### PR TITLE
Fix warning when running scp over openssh-server

### DIFF
--- a/dietpi/login
+++ b/dietpi/login
@@ -38,7 +38,7 @@
 	if (( $DIETPI_INSTALL_STAGE == 1 )); then
 
 		#Boot to specific Program
-		if [ -z "$DISPLAY" ] && [ $(tty) == /dev/tty1 ]; then
+		if [ -z "$DISPLAY" ] && [ "$(tty)" == /dev/tty1 ]; then
 			#Kodi
 			if (( $AUTO_BOOT_INDEX == 1 )); then
 				#Debian


### PR DESCRIPTION
When running `scp` to copy a file to _dietpi_ I saw the following problem:

```
$ scp file root@dietpi
/boot/dietpi/login: line 41: [: too many arguments
```

Adding more debug information:

```
$ scp file root@dietpi
++ sed -n 1p /boot/dietpi/.hw_model
+ HW_MODEL=1
++ sed -n 2p /boot/dietpi/.hw_model
+ HW_MODEL_DESCRIPTION='Raspberry Pi 1 (512MB)'
++ sed -n 3p /boot/dietpi/.hw_model
+ DISTRO=1
++ cat /boot/dietpi/.install_stage
+ DIETPI_INSTALL_STAGE=1
++ cat /boot/dietpi/.auto_boot_index
+ AUTO_BOOT_INDEX=0
++ cat /boot/dietpi/.version
+ DIETPI_VERSION=51
+ ((  1 == 1  ))
+ '[' -z '' ']'
++ tty
+ '[' not a tty == /dev/tty1 ']'
/boot/dietpi/login: line 41: [: too many arguments
+ /boot/dietpi/dietpi-banner 1
```

The safe way to go is to use $(tty) inside double quotes.

Note: I'm using the `openssh-server` package, I haven't tested it with dropbear.
