### PR TITLE
Problem: when "hard re-booted" (e.g. power loss), dietpi suffers a lo…

### DIFF
--- a/dietpi/dietpi-ramdisk
+++ b/dietpi/dietpi-ramdisk
@@ -27,6 +27,7 @@
 	fi
 
 	FILEPATH_RAM="/DietPi"
+	FILEPATH_BAK="/bootbak"
 	FILEPATH_DISK="/boot"
 	
 	#List of ini files located in /boot (files that users may wish to manually edit)
@@ -53,15 +54,32 @@
 			mkdir -p "$FILEPATH_RAM"/dietpi/func
 			mkdir -p "$FILEPATH_RAM"/dietpi/misc
 
+			mkdir -p "$FILEPATH_BAK"
+			
 			#Copy array of /boot/* files (config/ini etc)
+			copyMsg="DietPi-Ramdisk: Copy from boot partition ..."
 			for ((i=0; i<${#aFILE_BOOT_INI[@]}; i++))
 			do
-				cp "$FILEPATH_DISK"/${aFILE_BOOT_INI[$i]} "$FILEPATH_RAM"/
+				currFile="$FILEPATH_DISK"/${aFILE_BOOT_INI[$i]}
+				PREFIX="This file has been moved to DietPi-Ramdisk."
+				result=$( grep -c "$PREFIX" $currFile )
+
+				# the file has no content (only the "has moved" remark) - perhaps the system went down				
+				if [ $result -gt 0 ]; then
+					currFile="$FILEPATH_BAK"/${aFILE_BOOT_INI[$i]}
+					copyMsg="DietPi-Ramdisk: Copy from backup folder ..."
+				else
+					# create a backup
+					cp "$currFile" "$FILEPATH_BAK/"
+				fi
+				cp "$currFile" "$FILEPATH_RAM/"
 
 				#Inform user of new ini file locations (cant use symlinks on FAT fs)
-				echo -e "This file has been moved to DietPi-Ramdisk.\nNew location = /DietPi/${aFILE_BOOT_INI[$i]}" > "$FILEPATH_DISK"/${aFILE_BOOT_INI[$i]}
+				echo -e $PREFIX"\nNew location = /DietPi/${aFILE_BOOT_INI[$i]}" > "$FILEPATH_DISK"/${aFILE_BOOT_INI[$i]}
 
 			done
+
+			echo "$copyMsg"
 
 			#/boot/dietpi folder
 			cp -Rf "$FILEPATH_DISK"/dietpi "$FILEPATH_RAM"/


### PR DESCRIPTION
…ss of it's configuration files dietpi.txt, config.txt, boot.ini

When DietPi is restartet with a "power cut" (meaning unplug the power [usb] cord and re-plug it again), DietPi copies at boottime the empty config files dietpi.txt, config.txt, boot.ini into the ramdisk, because these hasn't been rewritten on shutdown before. So in the /boot partition and in the ramdisk there a now simple text files with the text "This file has been moved to DietPi-Ramdisk.\nNew location = ..." in it, and a lot of configuration info is gone.

I changed the script so that when the correct files are copied to the ramdisk, another copy will be created in a backup directory. On next boot, the script will detect that the config file(s) is(are) corrupt and copy a backup version instead. The only problem is: while booting, the empty config file is used though. So after a reboot caused by power loss one must reboot again a second time correctly (via shell command), after this step, the backuped files a recovered in the /boot partition and the ramdisk as well.

TODO: change the boot process, so there already will the loss of config files be detected and the backup files used instead.
