### PR TITLE
Create dietpi-recover

### DIFF
--- a/dietpi/dietpi-recover
+++ b/dietpi/dietpi-recover
@@ -1,0 +1,39 @@
+#!/bin/bash
+{
+	#////////////////////////////////////
+	# DietPi Boot Script
+	#
+	#////////////////////////////////////
+	# Created by Manfred Mueller-Spaeth / fms1961@gmail.com
+	#
+	#////////////////////////////////////
+	#
+	# Info:
+	# - filename /DietPi/dietpi/dietpi-recover
+	#////////////////////////////////////
+
+	FILEPATH_RAM="/DietPi"
+	FILEPATH_BAK="/boot/bak"
+	FILEPATH_DISK="/boot"
+
+	Recover_Config(){
+		#List of ini files located in /boot (files that users may wish to manually edit)
+		declare -a aFILE_BOOT_INI=(
+			"dietpi.txt"
+			"config.txt"
+			"boot.ini"
+		)
+		for ((i=0; i<${#aFILE_BOOT_INI[@]}; i++))
+		do
+			currFile="$FILEPATH_RAM"/${aFILE_BOOT_INI[$i]}
+			PREFIX="This file has been moved to DietPi-Ramdisk."
+			result=$( grep -c "$PREFIX" $currFile )
+			# the file has no content (only the "has moved" remark) - perhaps the system went down				
+			if [ $result -gt 0 ]; then
+				cp "$FILEPATH_BAK"/${aFILE_BOOT_INI[$i]} "$currFile"
+			fi 
+		done
+	}
+	
+	Recover_Config
+}


### PR DESCRIPTION
A script to recover erroneously deleted config files by the dietpi-ramdisk in conjunction with hard resets (power loss) of the Raspberry PI (in which case the current config files may not be re-written in the boot partition). The script should be called in the first line of the dietpi boot process to be sure, all depending scripts may use the recovered config files.
