### PR TITLE
Modified fstab to enable NTFS to work with Owncloud

### DIFF
--- a/dietpi/conf/fstab
+++ b/dietpi/conf/fstab
@@ -10,7 +10,7 @@ tmpfs 			/DietPi 		tmpfs 	defaults,size=10m,noatime,nodev,nosuid,mode=1777  0 0
 # - Try and use only ext4 for USB drives
 # - Faster performance than NTFS, espically on RPi v1
 #/dev/sda1       /mnt/usb_1      ext4    defaults,noatime,nofail  0       0
-#/dev/sda1       /mnt/usb_1      ntfs-3g    defaults,noatime,nofail       0       0
+#/dev/sda1       /mnt/usb_1      ntfs-3g    defaults,permissions,noatime,nofail       0       0
 
 #Samba Client------------------------------------------------------
 #/mnt/samba . Please use dietpi-config and the networking menu to setup this mount


### PR DESCRIPTION
Changed the mounting options of the NTFS drive. Added the permissions flag so "sudo chown -R www-data:www-data /var/lib/owncloud/data" can be issued to enable owncloud to work with NTFS drives.
