### PR TITLE
V116 IP_ADDRESS parse fix

### DIFF
--- a/dietpi/func/obtain_network_details
+++ b/dietpi/func/obtain_network_details
@@ -77,7 +77,7 @@
 
 	#-----------------------------------------------------------------------------------
 	#IP address
-	IP_ADDRESS=$(ifconfig "$ACTIVE_DEVICE" | grep -m1 'inet' | awk '{ print $2 }' | sed 's/addr://g')
+	IP_ADDRESS=$(ifconfig "$ACTIVE_DEVICE" | grep -m1 'inet' | awk '{ print $2 }' | cut -d: -f2 )
 
 	#-----------------------------------------------------------------------------------
 	#Output to file


### PR DESCRIPTION
corrected a parsing error when getting ipaddress for ifconfig on non-english systems.
