### PR TITLE
new dev setting to change target git fork

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,8 +2,10 @@ v118
 (xx/05/16)
 
 Changes / Improvements / Optimizations:
+DietPi-Update | Added GITFORKOWNER to aid in testing new releases on different forks
 
 Bug fixes:
+Odroid-XU4 | corrected typo in boot_xu4.ini file: https://github.com/Fourdee/DietPi/issues/314
 
 -----------------------------------------------------------------------------------------------------------
 

--- a/dietpi.txt
+++ b/dietpi.txt
@@ -256,3 +256,4 @@ dietpi_emonhub_apikey=
 # Dev settings
 #------------------------------------------------------------------------------------------------------
 gitbranch=master
+gitforkowner=Fourdee

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -43,6 +43,7 @@
 	#GIT Branch | master / testing
 	#/////////////////////////////////////////////////////////////////////////////////////
 	GITBRANCH=$(cat /DietPi/dietpi.txt | grep -m1 '^gitbranch=' | sed 's/.*=//')
+	GITFORKOWNER=$(cat /DietPi/dietpi.txt | grep -m1 '^gitforkowner=' | sed 's/.*=//')
 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	#UPDATE Vars
@@ -67,7 +68,7 @@
 	Get_Server_Version(){
 
 		#Get server version file
-		curl -k -L https://raw.githubusercontent.com/Fourdee/DietPi/"$GITBRANCH"/dietpi/server_version > "$FILEPATH_TEMP"/server_version
+		curl -k -L https://raw.githubusercontent.com/${GITFORKOWNER:-Fourdee}/DietPi/"$GITBRANCH"/dietpi/server_version > "$FILEPATH_TEMP"/server_version
 		if (( $? == 0 )); then
 			SERVER_ONLINE=1
 
@@ -124,7 +125,7 @@
 	Run_Update(){
 
 		#git clone Zip method (no need to install GIT)
-		curl -k -L https://github.com/Fourdee/DietPi/archive/"$GITBRANCH".zip > "$FILEPATH_TEMP"/update.zip
+		curl -k -L https://github.com/${GITFORKOWNER:-Fourdee}/DietPi/archive/"$GITBRANCH".zip > "$FILEPATH_TEMP"/update.zip
 		if (( $? == 0 )); then
 
 			unzip "$FILEPATH_TEMP"/update.zip -d "$FILEPATH_TEMP"/


### PR DESCRIPTION
This will let me override the update so that it pulls from my fork without having to edit dietpi-update every time.... And, more importantly, without having to remember to change it back before sending you a pull... :smile:   like last time

it still defaults to your repo... even if the setting is not in the dietpi.txt file.  But, if the setting is present, it will use that value.
