### PR TITLE
The following commit contains additions to dietpi-software for multip…

### DIFF
--- a/dietpi/dietpi-autostart
+++ b/dietpi/dietpi-autostart
@@ -91,7 +91,7 @@ _EOF_
 			"4" "OpenTyrian"
 			"5" "DietPi-Cloudshell"
 			"6" "MATE: Desktop"
-			"7" "GNUStep: Desktop"
+			"8" "GNUStep: Desktop"
 		)
 
 		OPTION=$(whiptail --title "$WHIP_TITLE" --menu "Current AutoStart Option: $AUTO_START_INDEX\n\nNB: If your choice is not \"Console:\", please ensure your choice is also installed (or selected for install) in DietPi-Software." --cancel-button "Back" --backtitle "$WHIP_BACKTITLE" --default-item "$AUTO_START_INDEX" 17 70 6 "${option_name[@]}" 3>&1 1>&2 2>&3)

--- a/dietpi/dietpi-autostart
+++ b/dietpi/dietpi-autostart
@@ -90,6 +90,8 @@ _EOF_
 			"3" "RetroPie"
 			"4" "OpenTyrian"
 			"5" "DietPi-Cloudshell"
+			"6" "MATE: Desktop"
+			"7" "GNUStep: Desktop"
 		)
 
 		OPTION=$(whiptail --title "$WHIP_TITLE" --menu "Current AutoStart Option: $AUTO_START_INDEX\n\nNB: If your choice is not \"Console:\", please ensure your choice is also installed (or selected for install) in DietPi-Software." --cancel-button "Back" --backtitle "$WHIP_BACKTITLE" --default-item "$AUTO_START_INDEX" 17 70 6 "${option_name[@]}" 3>&1 1>&2 2>&3)

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -219,6 +219,8 @@ USBDRIVE=${USBDRIVE:=0}
 #DietPi Software
 GRASSHOPPER=${GRASSHOPPER:=0}
 DESKTOP_LXDE=${DESKTOP_LXDE:=0}
+DESKTOP_MATE=${DESKTOP_MATE:=0}
+DESKTOP_GNUSTEP=${DESKTOP_GNUSTEP:=0}
 
 WEBSERVER_LAMP=${WEBSERVER_LAMP:=0}
 WEBSERVER_LASP=${WEBSERVER_LASP:=0}
@@ -241,6 +243,9 @@ WEBSERVER_SQLITE=${WEBSERVER_SQLITE:=0}
 WEBSERVER_PHP=${WEBSERVER_PHP:=0}
 WEBSERVER_MYADMINPHP=${WEBSERVER_MYADMINPHP:=0}
 WEBSERVER_REDIS=${WEBSERVER_REDIS:=0}
+
+NOMACHINE=${NOMACHINE:=0}
+XRDP=${XRDP:=0}
 
 OWNCLOUD=${OWNCLOUD:=0}
 TRANSMISSION=${TRANSMISSION:=0}
@@ -295,10 +300,12 @@ PLEXMEDIASERVER=${PLEXMEDIASERVER:=0}
 #Additional Linux Software
 VIMFULL=${VIMFULL:=0}
 VIMTINY=${VIMTINY:=0}
+QUITERSS=${QUITERSS:=0}
 GNUEMACS=${GNUEMACS:=0}
 SSHCLIENT=${SSHCLIENT:=0}
 SMBCLIENT=${SMBCLIENT:=0}
 MIDNIGHTCOMMANDER=${MIDNIGHTCOMMANDER:=0}
+VIFM=${VIFM:=0}
 JED=${JED:=0}
 IFTOP=${IFTOP:=0}
 IPTRAF=${IPTRAF:=0}
@@ -533,22 +540,135 @@ INDEX_WEBSERVER_TARGET=${INDEX_WEBSERVER_TARGET:=-2}
 		#--------------------------------------------------------------
 		#Install Software
 
-		#Installs that require DESKTOP_LXDE
+		#Installs that require a DESKTOP
 		if (( $TIGHTVNCSERVER == 1 )); then
-			DESKTOP_LXDE=1
+			if (( $DESKTOP_LXDE == 0 )) && (( $DESKTOP_MATE == 0 )) && (( $DESKTOP_GNUSTEP == 0 )); then
+				# Default to LXDE
+				DESKTOP_LXDE=1
+			elif (( $DESKTOP_MATE == 1 )) && (( $DESKTOP_GNUSTEP == 0 )); then
+				DESKTOP_LXDE=0
+				DESKTOP_MATE=1
+				DESKTOP_GNUSTEP=0
+			elif (( $DESKTOP_MATE == 0 )) && (( $DESKTOP_GNUSTEP == 1 )); then
+				DESKTOP_LXDE=0
+				DESKTOP_MATE=0
+				DESKTOP_GNUSTEP=1
+			fi
 		elif (( $VNC4SERVER == 1 )); then
-			DESKTOP_LXDE=1
+                        if (( $DESKTOP_LXDE == 0 )) && (( $DESKTOP_MATE == 0 )) && (( $DESKTOP_GNUSTEP == 0 )); then
+                                # Default to LXDE
+                                DESKTOP_LXDE=1
+                        elif (( $DESKTOP_LXDE == 1 )) && (( $DESKTOP_MATE == 0 )) && (( $DESKTOP_GNUSTEP == 0 )); then
+                                DESKTOP_LXDE=1
+                                DESKTOP_MATE=0
+                                DESKTOP_GNUSTEP=0
+                        elif (( $DESKTOP_LXDE == 0 )) && (( $DESKTOP_MATE == 1 )) && (( $DESKTOP_GNUSTEP == 0 )); then
+                                DESKTOP_LXDE=0
+                                DESKTOP_MATE=1
+                                DESKTOP_GNUSTEP=0
+                        elif (( $DESKTOP_LXDE == 0 )) && (( $DESKTOP_MATE == 0 )) && (( $DESKTOP_GNUSTEP == 1 )); then
+                                DESKTOP_LXDE=0
+                                DESKTOP_MATE=0
+                                DESKTOP_GNUSTEP=1
+			fi
 		fi
+
+		#Installs that require a DESKTOP
+		if (( $XRDP == 1 )); then
+                        if (( $DESKTOP_LXDE == 0 )) && (( $DESKTOP_MATE == 0 )) && (( $DESKTOP_GNUSTEP == 0 )); then
+                                # Default to LXDE
+                                DESKTOP_LXDE=1
+                        elif (( $DESKTOP_MATE == 1 )) && (( $DESKTOP_GNUSTEP == 0 )); then
+                                DESKTOP_LXDE=0
+                                DESKTOP_MATE=1
+                                DESKTOP_GNUSTEP=0
+                        elif (( $DESKTOP_MATE == 0 )) && (( $DESKTOP_GNUSTEP == 1 )); then
+                                DESKTOP_LXDE=0
+                                DESKTOP_MATE=0
+                                DESKTOP_GNUSTEP=1
+                        fi
+		fi
+
+                #Installs that require a DESKTOP
+                if (( $QUITERSS == 1 )); then
+                        if (( $DESKTOP_LXDE == 0 )) && (( $DESKTOP_MATE == 0 )) && (( $DESKTOP_GNUSTEP == 0 )); then
+                                # Default to LXDE
+                                DESKTOP_LXDE=1
+                        elif (( $DESKTOP_MATE == 1 )) && (( $DESKTOP_GNUSTEP == 0 )); then
+                                DESKTOP_LXDE=0
+                                DESKTOP_MATE=1
+                                DESKTOP_GNUSTEP=0
+                        elif (( $DESKTOP_MATE == 0 )) && (( $DESKTOP_GNUSTEP == 1 )); then
+                                DESKTOP_LXDE=0
+                                DESKTOP_MATE=0
+                                DESKTOP_GNUSTEP=1
+                        fi
+                fi
 
 		#Desktop LXDE
 		if (( $DESKTOP_LXDE == 1 )); then
-
 			INSTALL_DESCRIPTION='Desktop (LXDE)'
 			Banner_Installing
 
 			AGI lxde upower policykit-1 iceweasel p7zip-full --no-install-recommends
 			#upower policykit-1. Needed for LXDE logout menu item to show shutdown/restart ......
+		fi
 
+		#Desktop MATE
+		if (( $DESKTOP_MATE == 1 )); then
+			INSTALL_DESCRIPTION="Desktop (MATE)"
+			Banner_Installing
+
+			AGI mate-desktop-environment-extras upower policykit-1 iceweasel p7zip-full --no-install-recommends
+		fi
+
+		#Desktop GNUStep
+                if (( $DESKTOP_GNUSTEP == 1 )); then
+                        INSTALL_DESCRIPTION="Desktop (GNUStep)"
+                        Banner_Installing
+
+                        AGI x-window-system-core wmaker gnustep gnustep-devel gnustep-games libc-dbg upower policykit-1 iceweasel p7zip-full --no-install-recommends
+                fi
+
+		#QuiteRSS
+                if (( $QUITERSS == 1 )); then
+                        INSTALL_DESCRIPTION="QuiteRSS"
+                        Banner_Installing
+
+                        AGI quiterss
+                fi
+
+		#XRDP
+		if (( $XRDP == 1 )); then
+                        INSTALL_DESCRIPTION="XRDP (Remote Desktop Server)"
+                        Banner_Installing
+
+                        AGI xrdp
+                fi
+
+		#NOMACHINE
+		if (( $NOMACHINE == 1 )); then
+			INSTALL_DESCRIPTION="NoMachine (Remote Desktop Server/Client)"
+			Banner_Installing
+
+			## HW MODELS NEED TO BE CONSIDERED
+			## http://download.nomachine.com/download/5.1/Linux/nomachine_5.1.26_1_amd64.deb
+			## http://download.nomachine.com/download/5.1/Linux/nomachine_5.1.26_6_armv6hf.deb
+			## http://download.nomachine.com/download/5.1/Linux/nomachine_5.1.26_5_armhf.deb
+
+			INSTALL_URL_ADDRESS='http://download.nomachine.com/download/5.1/Linux/nomachine_5.1.26_1_amd64.deb'
+                        /DietPi/dietpi/func/check_connection "$INSTALL_URL_ADDRESS"
+                        if (( $? == 0 )); then
+
+                                #Install NoMachine for amd64 
+                                wget "$INSTALL_URL_ADDRESS" -O package.deb
+                                dpkg -i package.deb
+                                rm package.deb
+
+                        else
+                                Error_NoConnection_NoInstall
+                                NOMACHINE=0
+                        fi
 		fi
 
 		#BitTorrent Transmission
@@ -2034,6 +2154,14 @@ INDEX_WEBSERVER_TARGET=${INDEX_WEBSERVER_TARGET:=-2}
 		# Stop Services
 		/DietPi/dietpi/dietpi-services stop
 
+		if (( $VIFM == 1 )); then
+			INSTALL_DESCRIPTION='ViFM (File Manager with Vi Bindings)'
+			Banner_Installing
+			AGI vifm
+
+			VIFM=2
+		fi
+
 		if (( $VIMFULL == 1 )); then
 			INSTALL_DESCRIPTION='Vim'
 			Banner_Installing
@@ -2169,6 +2297,10 @@ INDEX_WEBSERVER_TARGET=${INDEX_WEBSERVER_TARGET:=-2}
 		#DietPi software that requires Alsa-base
 		if (( $DESKTOP_LXDE == 1 )); then
 			ALSABASE=1
+		elif (( $DESKTOP_MATE == 1 )); then
+			ALSABASE=1
+		elif (( $DESKTOP_GNUSTEP == 1 )); then
+			ALSABASE=1
 		elif (( $HIFI == 1 )); then
 			ALSABASE=1
 		elif (( $KODI == 1 )); then
@@ -2184,6 +2316,10 @@ INDEX_WEBSERVER_TARGET=${INDEX_WEBSERVER_TARGET:=-2}
 		elif (( $TIGHTVNCSERVER == 1 )); then
 			ALSABASE=1
 		elif (( $VNC4SERVER == 1 )); then
+			ALSABASE=1
+		elif (( $NOMACINE == 1 )); then
+			ALSABASE=1
+		elif (( $XRDP == 1 )); then
 			ALSABASE=1
 		elif (( $SQUEEZEBOXSERVER == 1 )); then
 			ALSABASE=1
@@ -2245,6 +2381,10 @@ _EOF_
 		#DietPi software that requires Xserver - Xorg
 		if (( $DESKTOP_LXDE == 1 )); then
 			XSERVERXORG=1
+		elif (( $DESKTOP_MATE == 1 )); then
+			XSERVERXORG=1
+		elif (( $DESKTOP_GNUSTEP == 1 )); then
+			XSERVERXORG=1
 		elif (( $KODI == 1 )); then
 			XSERVERXORG=1
 		elif (( $OPENTYRIAN == 1 )); then
@@ -2252,6 +2392,12 @@ _EOF_
 		elif (( $TIGHTVNCSERVER == 1 )); then
 			XSERVERXORG=1
 		elif (( $VNC4SERVER == 1 )); then
+			XSERVERXORG=1
+		elif (( $NOMACHINE == 1 )); then
+			XSERVERXORG=1
+		elif (( $XRDP == 1 )); then
+			XSERVERXORG=1
+		elif (( $QUITERSS == 1 )); then
 			XSERVERXORG=1
 		fi
 
@@ -2738,7 +2884,7 @@ _EOF_
 		# Copy/Set optimised Software settings.
 		# Set install states to 2 (installed).
 
-		#Destop
+		#Destop LXDE
 		if (( $DESKTOP_LXDE == 1 )); then
 
 			#Odroid C1/C2 - Fix for broken/laggy transparency
@@ -2801,7 +2947,70 @@ _EOF_
 			DESKTOP_LXDE=2
 		fi
 
-		#WEBSERVER_LAMP
+		#Desktop MATE
+                if (( $DESKTOP_MATE == 1 )); then
+
+                        #Copy DietPi pcmanfm favourite links
+                        cp /DietPi/dietpi/conf/desktop/.gtk-bookmarks "$HOME"/.gtk-bookmarks
+
+			#Create Desktop SymLinks
+                        mkdir -p "$HOME"/Desktop
+                        ln -sf /usr/share/applications/pcmanfm.desktop "$HOME"/Desktop/pcmanfm.desktop
+                        ln -sf /usr/share/applications/htop.desktop "$HOME"/Desktop/htop.desktop
+
+                        #DietPi Desktop symlinks
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-software.desktop "$HOME"/Desktop/dietpi-software.desktop
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-config.desktop "$HOME"/Desktop/dietpi-config.desktop
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-launcher.desktop "$HOME"/Desktop/dietpi-launcher.desktop
+
+                        #DietPi Menu symlinks
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-software.desktop /usr/share/applications/dietpi-software.desktop
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-update.desktop /usr/share/applications/dietpi-update.desktop
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-config.desktop /usr/share/applications/dietpi-config.desktop
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-uninstall.desktop /usr/share/applications/dietpi-uninstall.desktop
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-backup.desktop /usr/share/applications/dietpi-backup.desktop
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-sync.desktop /usr/share/applications/dietpi-sync.desktop
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-bugreport.desktop /usr/share/applications/dietpi-bugreport.desktop
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-process_tool.desktop /usr/share/applications/dietpi-process_tool.desktop
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-cleaner.desktop /usr/share/applications/dietpi-cleaner.desktop
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-cron.desktop /usr/share/applications/dietpi-cron.desktop
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-launcher.desktop /usr/share/applications/dietpi-launcher.desktop
+
+                        DESKTOP_MATE=2
+                fi
+
+                #Desktop GNUStep
+                if (( $DESKTOP_GNUSTEP == 1 )); then
+
+                        #Copy DietPi pcmanfm favourite links
+                        cp /DietPi/dietpi/conf/desktop/.gtk-bookmarks "$HOME"/.gtk-bookmarks
+
+                        #Create Desktop SymLinks
+                        mkdir -p "$HOME"/Desktop
+                        ln -sf /usr/share/applications/pcmanfm.desktop "$HOME"/Desktop/pcmanfm.desktop
+                        ln -sf /usr/share/applications/htop.desktop "$HOME"/Desktop/htop.desktop
+
+                        #DietPi Desktop symlinks
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-software.desktop "$HOME"/Desktop/dietpi-software.desktop
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-config.desktop "$HOME"/Desktop/dietpi-config.desktop
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-launcher.desktop "$HOME"/Desktop/dietpi-launcher.desktop
+
+                        #DietPi Menu symlinks
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-software.desktop /usr/share/applications/dietpi-software.desktop
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-update.desktop /usr/share/applications/dietpi-update.desktop
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-config.desktop /usr/share/applications/dietpi-config.desktop
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-uninstall.desktop /usr/share/applications/dietpi-uninstall.desktop
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-backup.desktop /usr/share/applications/dietpi-backup.desktop
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-sync.desktop /usr/share/applications/dietpi-sync.desktop
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-bugreport.desktop /usr/share/applications/dietpi-bugreport.desktop
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-process_tool.desktop /usr/share/applications/dietpi-process_tool.desktop
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-cleaner.desktop /usr/share/applications/dietpi-cleaner.desktop
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-cron.desktop /usr/share/applications/dietpi-cron.desktop
+                        ln -sf /DietPi/dietpi/conf/desktop/dietpi-launcher.desktop /usr/share/applications/dietpi-launcher.desktop
+
+                        DESKTOP_GNUSTEP=2
+                fi
+
 		if (( $WEBSERVER_LAMP == 1 )); then
 
 			WEBSERVER_LAMP=2
@@ -4680,6 +4889,10 @@ _EOF_
 		#Mode 2 (Desktop / LOW GPU RAM)
 		elif (( $DESKTOP_LXDE == 2 )); then
 			memory_split_mode=2
+		elif (( $DESKTOP_MATE == 2 )); then
+			memory_split_mode=2
+		elif (( $DESKTOP_GNUSTEP == 2 )); then
+			memory_split_mode=2
 		elif (( $OPENTYRIAN == 2 )); then
 			memory_split_mode=2
 
@@ -5697,14 +5910,23 @@ _EOF_
 			fi
 		fi
 
-		local desktop_w="off"
+		local desktop_lxde_w="off"
 		if (( $DESKTOP_LXDE > 0 )); then
-			desktop_w="on"
+			desktop_lxde_w="on"
 			#Reset to 0. Menu checklists will apply back to 1
 			if (( $DESKTOP_LXDE == 1 )); then
 				DESKTOP_LXDE=0
 			fi
 		fi
+
+                local desktop_mate_w="off"
+                if (( $DESKTOP_MATE > 0 )); then
+                        desktop_matew="on"
+                        #Reset to 0. Menu checklists will apply back to 1
+                        if (( $DESKTOP_MATE == 1 )); then
+                                DESKTOP_MATE=0
+                        fi
+                fi
 
 		local transmission_w="off"
 		if (( $TRANSMISSION > 0 )); then
@@ -6244,6 +6466,36 @@ _EOF_
 			fi
 		fi
 
+		#Desktop GNUSetp
+                local gnustep_w="off"
+                if (( $DESKTOP_GNUSTEP > 0 )); then
+                        gnustep_w="on"
+                        #Reset to 0.  Menu checklists will apply back to 1
+                        if (( $DESKTOP_GNUSTEP == 1 )); then
+                                DESKTOP_GNUSTEP=0
+                        fi
+                fi
+
+                #Remote Desktop: XRDP
+                local xrdp_w="off"
+                if (( $XRDP > 0 )); then
+                        xrdp_w="on"
+                        #Reset to 0.  Menu checklists will apply back to 1
+                        if (( $XRDP == 1 )); then
+                                XRDP=0
+                        fi
+                fi
+
+                #Remote Desktop: No Machine
+                local nomachine_w="off"
+                if (( $NOMACHINE > 0 )); then
+                        nomachine_w="on"
+                        #Reset to 0.  Menu checklists will apply back to 1
+                        if (( $NOMACHINE == 1 )); then
+                                NOMACHINE=0
+                        fi
+                fi
+
 
 		#-----------------------------------------------------------------------------
 		WHIP_TITLE='DietPi Optimized Software Selection'
@@ -6253,8 +6505,12 @@ _EOF_
 		if (( $HW_MODEL >= 40 )) && (( $HW_MODEL < 50 )); then
 			whiptail --title "$WHIP_TITLE" --checklist --separate-output "Please use the spacebar to select the software you wish to install.\nSoftware details: http://dietpi.com/software" --backtitle "$WHIP_BACKTITLE" 20 82 12 \
 			"" "────Desktops────────────────────────────────" "off" \
-			"LXDE: Desktop" "Ultra lightweight desktop." $desktop_w \
+			"LXDE: Desktop" "Ultra lightweight desktop." $desktop_lxde_w \
 			"LXDE: VNC4 Server" "LXDE Desktop for remote connection." $vnc4server_w \
+			"GNUStep" "Lightweight Desktop basedon OpenStep." $gnustep_w \
+                        "" "────Remote Desktop Access──────────────────" "off" \
+                        "XRDP" "Remote Desktop Protocol (RDP) server." $xrdp_w \
+                        "NoMachine" "Multi-Platform Server and Client Access." $nomachine_w \
 			"" "────Media Systems───────────────────────────" "off" \
 			"Kodi" "Your very own media centre / player. **WIP**" $kodi_w \
 			"SubSonic 5" "Web interface media streaming server." $subsonic5_w \
@@ -6317,9 +6573,13 @@ _EOF_
 		elif (( $HW_MODEL == 30 || $HW_MODEL == 50 )); then
 			whiptail --title "$WHIP_TITLE" --checklist --separate-output "Please use the spacebar to select the software you wish to install.\nSoftware details: http://dietpi.com/software" --backtitle "$WHIP_BACKTITLE" 20 82 12 \
 			"" "────Desktops────────────────────────────────" "off" \
-			"LXDE: Desktop" "Ultra lightweight desktop." $desktop_w \
+			"LXDE: Desktop" "Ultra lightweight desktop." $desktop_lxde_w \
 			"LXDE: TightVNC Server" "LXDE Desktop for remote connection." $tightvncserver_w \
 			"LXDE: VNC4 Server" "LXDE Desktop for remote connection." $vnc4server_w \
+			"GNUStep" "Lightweight Desktop basedon OpenStep." $gnustep_w \
+                        "" "────Remote Desktop Access──────────────────" "off" \
+                        "XRDP" "Remote Desktop Protocol (RDP) server." $xrdp_w \
+                        "NoMachine" "Multi-Platform Server and Client Access." $nomachine_w \
 			"" "────Media Systems───────────────────────────" "off" \
 			"HiFi" "Web interface music / radio player." $hifi_w \
 			"SubSonic 5" "Web interface media streaming server." $subsonic5_w \
@@ -6380,9 +6640,13 @@ _EOF_
 		elif (( $HW_MODEL == 20 )); then
 			whiptail --title "$WHIP_TITLE" --checklist --separate-output "Please use the spacebar to select the software you wish to install.\nSoftware details: http://dietpi.com/software" --backtitle "$WHIP_BACKTITLE" 20 82 12 \
 			"" "────Desktops───────────────────────────────" "off" \
-			"LXDE: Desktop" "Ultra lightweight desktop." $desktop_w \
+			"LXDE: Desktop" "Ultra lightweight desktop." $desktop_lxde_w \
 			"LXDE: TightVNC Server" "LXDE Desktop for remote connection." $tightvncserver_w \
 			"LXDE: VNC4 Server" "LXDE Desktop for remote connection." $vnc4server_w \
+			"GNUStep" "Lightweight Desktop basedon OpenStep." $gnustep_w \
+			"" "────Remote Desktop Access──────────────────" "off" \
+			"XRDP" "Remote Desktop Protocol (RDP) server." $xrdp_w \
+			"NoMachine" "Multi-Platform Server and Client Access." $nomachine_w \
 			"" "────Media Systems──────────────────────────" "off" \
 			"SubSonic 5" "Web interface media streaming server." $subsonic5_w \
 			"SubSonic 6" "(NEW) Web interface media streaming server." $subsonic6_w \
@@ -6439,8 +6703,12 @@ _EOF_
 		elif (( $HW_MODEL == 12 )); then
 			whiptail --title "$WHIP_TITLE" --checklist --separate-output "Please use the spacebar to select the software you wish to install.\nSoftware details: http://dietpi.com/software" --backtitle "$WHIP_BACKTITLE" 20 82 12 \
 			"" "────Desktops────────────────────────────────" "off" \
-			"LXDE: Desktop" "Ultra lightweight desktop." $desktop_w \
+			"LXDE: Desktop" "Ultra lightweight desktop." $desktop_lxde_w \
 			"LXDE: VNC4 Server" "LXDE Desktop for remote connection." $vnc4server_w \
+			"GNUStep" "Lightweight Desktop basedon OpenStep." $gnustep_w \
+                        "" "────Remote Desktop Access──────────────────" "off" \
+                        "XRDP" "Remote Desktop Protocol (RDP) server." $xrdp_w \
+                        "NoMachine" "Multi-Platform Server and Client Access." $nomachine_w \
 			"" "────Media Systems───────────────────────────" "off" \
 			"Kodi" "Your very own media centre / player." $kodi_w \
 			"SubSonic 5" "Web interface media streaming server." $subsonic5_w \
@@ -6503,9 +6771,13 @@ _EOF_
 		elif (( $HW_MODEL == 10 || $HW_MODEL == 11 )); then
 			whiptail --title "$WHIP_TITLE" --checklist --separate-output "Please use the spacebar to select the software you wish to install.\nSoftware details: http://dietpi.com/software" --backtitle "$WHIP_BACKTITLE" 20 82 12 \
 			"" "────Desktops────────────────────────────────" "off" \
-			"LXDE: Desktop" "Ultra lightweight desktop." $desktop_w \
+			"LXDE: Desktop" "Ultra lightweight desktop." $desktop_lxde_w \
 			"LXDE: TightVNC Server" "LXDE Desktop for remote connection." $tightvncserver_w \
 			"LXDE: VNC4 Server" "LXDE Desktop for remote connection." $vnc4server_w \
+			"GNUStep" "Lightweight Desktop basedon OpenStep." $gnustep_w \
+                        "" "────Remote Desktop Access──────────────────" "off" \
+                        "XRDP" "Remote Desktop Protocol (RDP) server." $xrdp_w \
+                        "NoMachine" "Multi-Platform Server and Client Access." $nomachine_w \
 			"" "────Media Systems───────────────────────────" "off" \
 			"Kodi" "Your very own media centre / player." $kodi_w \
 			"SubSonic 5" "Web interface media streaming server." $subsonic5_w \
@@ -6574,9 +6846,13 @@ _EOF_
 
 				whiptail --title "$WHIP_TITLE" --checklist --separate-output "Please use the spacebar to select the software you wish to install.\nSoftware details: http://dietpi.com/software" --backtitle "$WHIP_BACKTITLE" 20 82 12 \
 				"" "────Desktops────────────────────────────────" "off" \
-				"LXDE: Desktop" "Ultra lightweight desktop." $desktop_w \
+				"LXDE: Desktop" "Ultra lightweight desktop." $desktop_lxde_w \
 				"LXDE: TightVNC Server" "LXDE Desktop for remote connection." $tightvncserver_w \
 				"LXDE: VNC4 Server" "LXDE Desktop for remote connection." $vnc4server_w \
+				"GNUStep" "Lightweight Desktop basedon OpenStep." $gnustep_w \
+                        	"" "────Remote Desktop Access──────────────────" "off" \
+                        	"XRDP" "Remote Desktop Protocol (RDP) server." $xrdp_w \
+                        	"NoMachine" "Multi-Platform Server and Client Access." $nomachine_w \
 				"" "────Media Systems───────────────────────────" "off" \
 				"Kodi" "Your very own media centre / player." $kodi_w \
 				"HiFi" "Web interface music / radio player." $hifi_w \
@@ -6659,8 +6935,12 @@ _EOF_
 
 				whiptail --title "$WHIP_TITLE" --checklist --separate-output "Please use the spacebar to select the software you wish to install.\nSoftware details: http://dietpi.com/software" --backtitle "$WHIP_BACKTITLE" 20 82 12 \
 				"" "────Desktops────────────────────────────────" "off" \
-				"LXDE: Desktop" "Ultra lightweight desktop." $desktop_w \
+				"LXDE: Desktop" "Ultra lightweight desktop." $desktop_lxde_w \
 				"LXDE: TightVNC Server" "LXDE Desktop for remote connection." $tightvncserver_w \
+				"GNUStep" "Lightweight Desktop basedon OpenStep." $gnustep_w \
+	                        "" "────Remote Desktop Access──────────────────" "off" \
+        	                "XRDP" "Remote Desktop Protocol (RDP) server." $xrdp_w \
+                	        "NoMachine" "Multi-Platform Server and Client Access." $nomachine_w \
 				"" "────Media Systems───────────────────────────" "off" \
 				"Kodi" "Your very own media centre / player." $kodi_w \
 				"HiFi" "Web interface music / radio player." $hifi_w \
@@ -6731,6 +7011,18 @@ _EOF_
 		do
 			case $choice in
 
+                        "XRDP")
+                                if (( $XRDP == 0 )); then
+                                        XRDP=1
+                                        INSTALL_DIETPI_CHOICESMADE=1
+                                fi
+                        ;;
+                        "NoMachine")
+                                if (( $NOMACHINE == 0 )); then
+                                        NOMACHINE=1
+                                        INSTALL_DIETPI_CHOICESMADE=1
+                                fi
+                        ;;
 			"Plex Server")
 				if (( $PLEXMEDIASERVER == 0 )); then
 					PLEXMEDIASERVER=1
@@ -6887,6 +7179,12 @@ _EOF_
 					INSTALL_DIETPI_CHOICESMADE=1
 				fi
 			;;
+                        "GNUStep")
+                                if (( $DESKTOP_GNUSTEP == 0 )); then
+                                        DESKTOP_GNUSTEP=1
+                                        INSTALL_DIETPI_CHOICESMADE=1
+                                fi
+                        ;;
 			Wordpress)
 				if (( $WORDPRESS == 0 )); then
 					WORDPRESS=1
@@ -7332,6 +7630,10 @@ _EOF_
 		local bootchoices_available=0
 		if (( $DESKTOP_LXDE == 1 )); then
 			bootchoices_available=1
+		elif (( $DESKTOP_MATE == 1 )); then
+			bootchoices_available=1
+		elif (( $DESKTOP_GNUSTEP == 1 )); then
+			bootchoices_available=1
 		elif (( $KODI == 1 )); then
 			bootchoices_available=1
 		elif (( $OPENTYRIAN == 1 )); then
@@ -7407,6 +7709,15 @@ _EOF_
                         #Reset to 0. Menu checklists will apply back to 1
                         if (( $MIDNIGHTCOMMANDER == 1 )); then
                                 MIDNIGHTCOMMANDER=0
+                        fi
+                fi
+
+                local vimfm_w="off"
+                if (( $VIFM > 0 )); then
+                        vifm_w="on"
+                        #Reset to 0. Menu checklists will apply back to 1
+                        if (( $VIFM == 1 )); then
+                                VIFM=0
                         fi
                 fi
 
@@ -7558,9 +7869,29 @@ _EOF_
 			fi
 		fi
 
+                local desktop_mate_w="off"
+                if (( $DESKTOP_MATE > 0 )); then
+                        desktop_mate_w="on"
+                        #Reset to 0. Menu checklists will apply back to 1
+                        if (( $DESKTOP_MATE == 1 )); then
+                                DESKTOP_MATE=0
+                        fi
+                fi
+
+                local quiterss_w="off"
+                if (( $QUITERSS > 0 )); then
+                        quiterss_w="on"
+                        #Reset to 0. Menu checklists will apply back to 1
+                        if (( $QUITERSS == 1 )); then
+                                QUITERSS=0
+                        fi
+                fi
 
 		WHIP_TITLE='Linux - Software Selection'
 		whiptail --title "$WHIP_TITLE" --checklist --separate-output "Press the spacebar to select additional software for installation." --backtitle "$WHIP_BACKTITLE" 19 71 12 \
+		"" "────Desktops and Utilities───────────────────" "off" \
+		"MATE" "MATE Desktop Enviroment" $desktop_mate_w \
+		"QuiteRSS" "Cross-Platform, Free RSS Reader" $quiterss_w \
 		"" "────Editors──────────────────────────────────" "off" \
 		"Emacs" "GNU Emacs editor." $gnuemacs_w \
 		"Jed" "Editor for programmers." $jed_w \
@@ -7568,6 +7899,7 @@ _EOF_
 		"Vim-Tiny" "Compact release of Vim." $vimtiny_w \
 		"" "────File Managers────────────────────────────" "off" \
 		"MC" "Midnight Commander - a powerful file manager." $midnightcommander_w \
+		"ViFM" "File Manager with Vi bindings." $vimfm_w \
 		"" "────SSH Clients──────────────────────────────" "off" \
 		"OpenSSH" "SSH Client: OpenSSH." $sshclient_w \
 		"" "────Fileserver Clients───────────────────────" "off" \
@@ -7594,6 +7926,24 @@ _EOF_
 		while read choice
 		do
 			case $choice in
+				"QuiteRSS")
+                                        if (( $QUITERSS == 0 )); then
+                                                QUITERSS=1
+                                                INSTALL_LINUX_CHOICESMADE=1
+                                        fi
+                                ;;
+				"ViFM")
+					if (( $VIFM == 0 )); then
+						VIFM=1
+						INSTALL_LINUX_CHOICESMADE=1
+					fi
+				;;
+				MATE)
+					if (( $DESKTOP_MATE == 0 )); then
+						DESKTOP_MATE=1
+						INSTALL_LINUX_CHOICESMADE=1
+					fi
+				;;
 				Iperf)
 					if (( $IPERF == 0 )); then
 						IPERF=1

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -542,66 +542,58 @@ INDEX_WEBSERVER_TARGET=${INDEX_WEBSERVER_TARGET:=-2}
 
 		#Installs that require a DESKTOP
 		if (( $TIGHTVNCSERVER == 1 )); then
-			if (( $DESKTOP_LXDE == 0 )) && (( $DESKTOP_MATE == 0 )) && (( $DESKTOP_GNUSTEP == 0 )); then
-				# Default to LXDE
+			if (( $DESKTOP_LXDE > 0 )); then
 				DESKTOP_LXDE=1
-			elif (( $DESKTOP_MATE == 1 )) && (( $DESKTOP_GNUSTEP == 0 )); then
-				DESKTOP_LXDE=0
+			elif (( $DESKTOP_MATE > 0 )); then 
 				DESKTOP_MATE=1
-				DESKTOP_GNUSTEP=0
-			elif (( $DESKTOP_MATE == 0 )) && (( $DESKTOP_GNUSTEP == 1 )); then
-				DESKTOP_LXDE=0
-				DESKTOP_MATE=0
+			elif (( $DESKTOP_GNUSTEP > 0 )); then
 				DESKTOP_GNUSTEP=1
+			elif (( $DESKTOP_LXDE == 0 && $DESKTOP_MATE == 0 && $DESKTOP_GNUSTEP == 0 )); then
+	                        WHIP_TITLE='Desktop Environment Selection'
+        	                whiptail --title "$WHIP_TITLE" --msgbox "The software packages you have selected requires a Graphical Desktop Environment.  One was not selected. \n \nTo continue the installation process LXDE will be chosen for you. \n \nPress Enter to continue." 14 70
+				DESKTOP_LXDE=1
 			fi
 		elif (( $VNC4SERVER == 1 )); then
-                        if (( $DESKTOP_LXDE == 0 )) && (( $DESKTOP_MATE == 0 )) && (( $DESKTOP_GNUSTEP == 0 )); then
-                                # Default to LXDE
+                        if (( $DESKTOP_LXDE > 0 )); then
                                 DESKTOP_LXDE=1
-                        elif (( $DESKTOP_LXDE == 1 )) && (( $DESKTOP_MATE == 0 )) && (( $DESKTOP_GNUSTEP == 0 )); then
-                                DESKTOP_LXDE=1
-                                DESKTOP_MATE=0
-                                DESKTOP_GNUSTEP=0
-                        elif (( $DESKTOP_LXDE == 0 )) && (( $DESKTOP_MATE == 1 )) && (( $DESKTOP_GNUSTEP == 0 )); then
-                                DESKTOP_LXDE=0
+                        elif (( $DESKTOP_MATE > 0 )); then 
                                 DESKTOP_MATE=1
-                                DESKTOP_GNUSTEP=0
-                        elif (( $DESKTOP_LXDE == 0 )) && (( $DESKTOP_MATE == 0 )) && (( $DESKTOP_GNUSTEP == 1 )); then
-                                DESKTOP_LXDE=0
-                                DESKTOP_MATE=0
+                        elif (( $DESKTOP_GNUSTEP > 0 )); then
                                 DESKTOP_GNUSTEP=1
-			fi
+                        elif (( $DESKTOP_LXDE == 0 && $DESKTOP_MATE == 0 && $DESKTOP_GNUSTEP == 0 )); then
+                                WHIP_TITLE='Desktop Environment Selection'
+                                whiptail --title "$WHIP_TITLE" --msgbox "The software packages you have selected requires a Graphical Desktop Environment.  One was not selected. \n \nTo continue the installation process LXDE will be chosen for you. \n \nPress Enter to continue." 14 70
+                                DESKTOP_LXDE=1
+                        fi
 		fi
 
 		#Installs that require a DESKTOP
 		if (( $XRDP == 1 )); then
-                        if (( $DESKTOP_LXDE == 0 )) && (( $DESKTOP_MATE == 0 )) && (( $DESKTOP_GNUSTEP == 0 )); then
-                                # Default to LXDE
+                        if (( $DESKTOP_LXDE > 0 )); then
                                 DESKTOP_LXDE=1
-                        elif (( $DESKTOP_MATE == 1 )) && (( $DESKTOP_GNUSTEP == 0 )); then
-                                DESKTOP_LXDE=0
+                        elif (( $DESKTOP_MATE > 0 )); then 
                                 DESKTOP_MATE=1
-                                DESKTOP_GNUSTEP=0
-                        elif (( $DESKTOP_MATE == 0 )) && (( $DESKTOP_GNUSTEP == 1 )); then
-                                DESKTOP_LXDE=0
-                                DESKTOP_MATE=0
+                        elif (( $DESKTOP_GNUSTEP > 0 )); then
                                 DESKTOP_GNUSTEP=1
+                        elif (( $DESKTOP_LXDE == 0 && $DESKTOP_MATE == 0 && $DESKTOP_GNUSTEP == 0 )); then
+                                WHIP_TITLE='Desktop Environment Selection'
+                                whiptail --title "$WHIP_TITLE" --msgbox "The software packages you have selected requires a Graphical Desktop Environment.  One was not selected. \n \nTo continue the installation process LXDE will be chosen for you. \n \nPress Enter to continue." 14 70
+                                DESKTOP_LXDE=1
                         fi
 		fi
 
                 #Installs that require a DESKTOP
                 if (( $QUITERSS == 1 )); then
-                        if (( $DESKTOP_LXDE == 0 )) && (( $DESKTOP_MATE == 0 )) && (( $DESKTOP_GNUSTEP == 0 )); then
-                                # Default to LXDE
+                        if (( $DESKTOP_LXDE > 0 )); then
                                 DESKTOP_LXDE=1
-                        elif (( $DESKTOP_MATE == 1 )) && (( $DESKTOP_GNUSTEP == 0 )); then
-                                DESKTOP_LXDE=0
+                        elif (( $DESKTOP_MATE > 0 )); then 
                                 DESKTOP_MATE=1
-                                DESKTOP_GNUSTEP=0
-                        elif (( $DESKTOP_MATE == 0 )) && (( $DESKTOP_GNUSTEP == 1 )); then
-                                DESKTOP_LXDE=0
-                                DESKTOP_MATE=0
+                        elif (( $DESKTOP_GNUSTEP > 0 )); then
                                 DESKTOP_GNUSTEP=1
+                        elif (( $DESKTOP_LXDE == 0 && $DESKTOP_MATE == 0 && $DESKTOP_GNUSTEP == 0 )); then
+                                WHIP_TITLE='Desktop Environment Selection'
+                                whiptail --title "$WHIP_TITLE" --msgbox "The software packages you have selected requires a Graphical Desktop Environment.  One was not selected. \n \nTo continue the installation process LXDE will be chosen for you. \n \nPress Enter to continue." 14 70
+                                DESKTOP_LXDE=1
                         fi
                 fi
 
@@ -648,25 +640,39 @@ INDEX_WEBSERVER_TARGET=${INDEX_WEBSERVER_TARGET:=-2}
 
 		#NOMACHINE
 		if (( $NOMACHINE == 1 )); then
-			INSTALL_DESCRIPTION="NoMachine (Remote Desktop Server/Client)"
+			# NoMachine Supports many, many architectures and operating systems
+			# The following link can be used as a reference:
+			# 	https://www.nomachine.com/download/linux&id=1
+			INSTALL_DESCRIPTION="NoMachine (Secure RDP Server & Client)"
 			Banner_Installing
 
-			## HW MODELS NEED TO BE CONSIDERED
-			## http://download.nomachine.com/download/5.1/Linux/nomachine_5.1.26_1_amd64.deb
-			## http://download.nomachine.com/download/5.1/Linux/nomachine_5.1.26_6_armv6hf.deb
-			## http://download.nomachine.com/download/5.1/Linux/nomachine_5.1.26_5_armhf.deb
+			#x86_32 - As was said (you never know)
+			if (( $HW_ARCH == 20 )); then
+				INSTALL_URL_ADDRESS="http://download.nomachine.com/download/5.1/Linux/nomachine_5.1.26_1_i386.deb"
+			#x86_64
+			elif (( $HW_ARCH == 21 )); then
+				INSTALL_URL_ADDRESS="http://download.nomachine.com/download/5.1/Linux/nomachine_5.1.26_1_amd64.deb"
+			#arm6/7 hf (RPi2/RPi1)
+			elif (( $HW_ARCH >= 1 && $HW_ARCH <= 2 )); then
+				INSTALL_URL_ADDRESS="http://download.nomachine.com/download/5.1/Linux/nomachine_5.1.26_6_armv6hf.deb"
+			#arm8 hf (RPi 3)
+			elif (( $HW_ARCH == 3 )); then
+				INSTALL_URL_ADDRESS="http://download.nomachine.com/download/5.1/Linux/nomachine_5.1.26_5_armhf.deb"
+			fi
 
-			INSTALL_URL_ADDRESS='http://download.nomachine.com/download/5.1/Linux/nomachine_5.1.26_1_amd64.deb'
+			# Now, check that the links are legitimate	
                         /DietPi/dietpi/func/check_connection "$INSTALL_URL_ADDRESS"
+
                         if (( $? == 0 )); then
 
-                                #Install NoMachine for amd64 
                                 wget "$INSTALL_URL_ADDRESS" -O package.deb
                                 dpkg -i package.deb
                                 rm package.deb
 
                         else
                                 Error_NoConnection_NoInstall
+
+				# ABORT INSTALLATION
                                 NOMACHINE=0
                         fi
 		fi
@@ -1116,6 +1122,7 @@ INDEX_WEBSERVER_TARGET=${INDEX_WEBSERVER_TARGET:=-2}
 			fi
 		fi
 
+		#DietPi Cam
 		if (( $DIETPICAM == 1 )); then
 			INSTALL_DESCRIPTION='RPi Camera / Web Interface Surveillance (DietPi-Cam)'
 			Banner_Installing
@@ -2317,7 +2324,7 @@ INDEX_WEBSERVER_TARGET=${INDEX_WEBSERVER_TARGET:=-2}
 			ALSABASE=1
 		elif (( $VNC4SERVER == 1 )); then
 			ALSABASE=1
-		elif (( $NOMACINE == 1 )); then
+		elif (( $NOMACHINE == 1 )); then
 			ALSABASE=1
 		elif (( $XRDP == 1 )); then
 			ALSABASE=1
@@ -3011,6 +3018,7 @@ _EOF_
                         DESKTOP_GNUSTEP=2
                 fi
 
+		#WEBSERVER_LAMP
 		if (( $WEBSERVER_LAMP == 1 )); then
 
 			WEBSERVER_LAMP=2
@@ -3945,6 +3953,16 @@ _EOF_
 
 
 			DIETPICLOUDSHELL=2
+		fi
+
+		#XRDP
+		if (( $XRDP == 1 )); then
+			XRDP=2
+		fi
+
+		#NOMACHINE
+		if (( $NOMACHINE == 1 )); then
+			NOMACHINE=2
 		fi
 
 		#HAPROXY

--- a/dietpi/login
+++ b/dietpi/login
@@ -96,7 +96,16 @@
 				#Launch DietPi-Cloudshell (+thread)
 				/DietPi/dietpi/dietpi-cloudshell 1 &
 
+			#MATE - Desktop
+			elif (( $AUTO_START_INDEX == 6 )); then
+				startx
+			
+			#GNUStep - Desktop
+			elif (( $AUTO_START_INDEX == 8 )); then
+				startx
+			
 			fi
+
 
 		fi
 


### PR DESCRIPTION
The following pull request has several tickets-worth of updates.

363 - Stub | ViFM to Software Additional
Added option to install ViFM - a CLI-based file manager with Vi bindings under
Software Additional

357 - DietPi-Software | GNUStep Desktop Environment #357
Added option under Software Optimized to install GNUStep -
a lightweight, from-the-ground-up desktop environment.

347 - No Machine & stock configs
191 - DietPi-Software | Add xrdp installation option
Added an new Category under Software Optimized called Remote Desktop
I added the code necessary to pull No Machine's deb package and to run
this multi-platform, secure, very efficient Remote Desktop Server.
It also acts as a client - looking for hosts running No Machine servers
with port 4000 open

For XRDP, it simply installs and works.  Both packages follow previous
examples for ALSA, X components, and if no Desktop environment is selected,
the default goes to LXDE

195 - DietPi-Software | Add QuiteRSS installation option
I have added QuiteRSS under Desktops and Utilities (Software Additional)
I have also ensured that it install X dependencies, such as VNC Server does

151 - DietPi-Software | Add MATE desktop installation option
I added, under Software Additional as it is not optimized, the full MATE
Desktop environment with IceWeasel, etc.

If/Then conditions for Desktops/Software that require X, ALSA, and a
Desktop environment were added to the original section that checks
for these types of installations.
