### PR TITLE
dietpi-config Wi-Fi scan now properly captures weird SSIDs

### DIFF
--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -1934,7 +1934,7 @@
 		clear
 		echo -e "Scanning SSIDS, please wait...."
 		echo -e "-------------------------------"
-		iwlist wlan$WIFI_INDEX scan | grep ESSID: | sed 's/ESSID:"//g' | sed 's/"//g' | awk '{ print $1 }' > /tmp/dietpi-config_temp
+		iwlist wlan$WIFI_INDEX scan | grep ESSID: | sed 's/[ \t]*ESSID:"\(.*\)"/\1/' > /tmp/dietpi-config_temp
 
 		#read file to array
 		readarray wifi_ssid_array < /tmp/dietpi-config_temp


### PR DESCRIPTION
I noticed that the `dietpi-config` Wi-Fi scan utility wasn't properly grabbing my SSID since it has a space in it. I've addressed this and condensed the SSID wrangling into one `grep` and one `sed` call.

From Section 7.3.2.1 of the 802.11-2007 specification, the SSID character set is unrestricted - my implemented solution properly handles really weird SSIDs, like ones with spaces or quote `"` characters in them.

I've tested this by running the script locally on my own Pi and I can confirm it solves the original problem I was having. I don't foresee any potential edge cases that might still break it - but if you can think of any I'd be happy to try and figure it out.
