### PR TITLE
PREP_SYSTEM_FOR_DIETPI.sh | Split installed dependencies into individual lines

### DIFF
--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -121,7 +121,47 @@ apt-get dist-upgrade -y
 
 #install packages
 echo -e "CONF_SWAPSIZE=0" > /etc/dphys-swapfile
-apt-get install -y ethtool p7zip-full hfsplus iw debconf-utils xz-utils fbset wpasupplicant resolvconf bc dbus bzip2 psmisc bash-completion cron whiptail sudo ntp ntfs-3g dosfstools parted hdparm pciutils usbutils zip htop wput wget fake-hwclock dphys-swapfile curl unzip ca-certificates console-setup console-data console-common keyboard-configuration wireless-tools wireless-regdb crda --no-install-recommends
+apt-get install -y  --no-install-recommends \
+  ethtool \
+  p7zip-full \
+  hfsplus \
+  iw \
+  debconf-utils \
+  xz-utils \
+  fbset \
+  wpasupplicant \
+  resolvconf \
+  bc \
+  dbus \
+  bzip2 \
+  psmisc \
+  bash-completion \
+  cron \
+  whiptail \
+  sudo \
+  ntp \
+  ntfs-3g \
+  dosfstools \
+  parted \
+  hdparm \
+  pciutils \
+  usbutils \
+  zip \
+  htop \
+  wput \
+  wget \
+  fake-hwclock \
+  dphys-swapfile \
+  curl \
+  unzip \
+  ca-certificates \
+  console-setup \
+  console-data \
+  console-common \
+  keyboard-configuration \
+  wireless-tools \
+  wireless-regdb \
+  crda
 
 #??? NanoPi Neo Air, required for ap6212 bt firmware service: https://github.com/Fourdee/DietPi/issues/602#issuecomment-262806470
 apt-get install rfkill


### PR DESCRIPTION
This makes it easier to visualize the base dependencies that need to be installed.  It also makes it easier to diff when a dependency gets added or removed later.