### PR TITLE
Update to blynserver install script

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9375,8 +9375,7 @@ _EOF_
 			mkdir -p "$FP_DIETPI_USERDATA_DIRECTORY"/blynk
 			CONFIG_FILE_URL_ADDRESS='https://raw.githubusercontent.com/blynkkk/blynk-server/master/server/core/src/main/resources/server.properties'
 			wget "$CONFIG_URL_ADDRESS" -O "$FP_DIETPI_USERDATA_DIRECTORY"/blynk/server.properties
-			#TODO: Please check the following line
-			sed -i "/data.folder=/c\data.folder=$(FP_DIETPI_USERDATA_DIRECTORY)/blynk" "$FP_DIETPI_USERDATA_DIRECTORY"/blynk/server.properties
+			sed -i "/data.folder=/c\data.folder=$FP_DIETPI_USERDATA_DIRECTORY/blynk" "$FP_DIETPI_USERDATA_DIRECTORY"/blynk/server.properties
 
 			cat << _EOF_ > /etc/systemd/system/blynkserver.service
 [Unit]

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4205,7 +4205,7 @@ _EOF_
 
 				mkdir -p /etc/blynkserver
 
-				INSTALL_URL_ADDRESS='https://github.com/blynkkk/blynk-server/releases/download/v0.22.3/server-0.22.3.jar'
+				INSTALL_URL_ADDRESS='https://github.com/blynkkk/blynk-server/releases/download/v0.23.2/server-0.23.2.jar'
 				wget "$INSTALL_URL_ADDRESS" -O /etc/blynkserver/server.jar
 
 				# - Install Blynk JS Libary
@@ -9373,6 +9373,10 @@ _EOF_
 			local fp_java_binary=$(which java)
 
 			mkdir -p "$FP_DIETPI_USERDATA_DIRECTORY"/blynk
+			CONFIG_FILE_URL_ADDRESS='https://raw.githubusercontent.com/blynkkk/blynk-server/master/server/core/src/main/resources/server.properties'
+			wget "$CONFIG_URL_ADDRESS" -O "$FP_DIETPI_USERDATA_DIRECTORY"/blynk/server.properties
+			#TODO: Please check the following line
+			sed -i "/data.folder=/c\data.folder=$(FP_DIETPI_USERDATA_DIRECTORY)/blynk" "$FP_DIETPI_USERDATA_DIRECTORY"/blynk/server.properties
 
 			cat << _EOF_ > /etc/systemd/system/blynkserver.service
 [Unit]
@@ -9381,7 +9385,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=$fp_java_binary -jar /etc/blynkserver/server.jar -dataFolder $FP_DIETPI_USERDATA_DIRECTORY/blynk
+ExecStart=$fp_java_binary -jar /etc/blynkserver/server.jar -serverConfig $FP_DIETPI_USERDATA_DIRECTORY/blynk/server.properties
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
By not providing a config file to blynkserver, we get default configurations, which do not allow clients to access the admin page of blynkserver (at port 7443).
I edited the script so that it grabs a detailed configuration file from blynk's repo, edit the data folder path, and use the server config file as an argument to the service (instead of the data folder).

I only left the TO DO, so one can check one line of code there. I'm not sure if those are the best practices.

I also updated the blynk download link to the latest version.