### PR TITLE
Switch to Nextcloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ Kodi / Xbmc
 Transmission
 - http://www.transmissionbt.com/download/
 
-OwnCloud
-- https://github.com/owncloud
+Nextcloud
+- https://github.com/nextcloud/server
 
 MiniDLNA
 - http://sourceforge.net/p/minidlna/git/ci/master/tree/


### PR DESCRIPTION
Nextcloud offers better performance and more features than ownCloud, so it would be logical to promote this Open Source private cloud platform in the README.