### PR TITLE
Add "status" argument to dietpi-services

### DIFF
--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -207,6 +207,24 @@
 		systemctl daemon-reload &> /dev/null
 
 		echo -e ""
+		
+	#-----------------------------------------------------------------------------------
+	#status
+	elif [ "$INPUT_MODE" = "status" ]; then
+
+		for ((i=0; i<${#aSERVICE_NAME[@]}; i++))
+		do
+
+			#Apply
+			if (( ${aSERVICE_AVAILABLE[$i]} == 1 )); then
+
+				echo -e "${aSERVICE_NAME[$i]}\t$(systemctl status "${aSERVICE_NAME[$i]}" | grep Active)"
+
+			fi
+
+		done
+
+		echo -e ""
 
 	#-----------------------------------------------------------------------------------
 	#start/stop/restart


### PR DESCRIPTION
Very often I find useful to know which of my dietpi services are actually running. systemctl provides this functionalities, but they are way too verbosed, and also show many other services along. For that I decided to code this very simple patch with the propose of showing the status of dietpi services.

There may be improvements to make, but it works fine for now, and useful somehow.