### PR TITLE
Add "net-tools" to auto installed dependencies

### DIFF
--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -123,7 +123,7 @@ apt-get dist-upgrade -y
 
 #install packages
 echo -e "CONF_SWAPSIZE=0" > /etc/dphys-swapfile
-apt-get install -y cron rfkill ca-certificates locales apt-transport-https ethtool p7zip-full hfsplus iw debconf-utils xz-utils fbset wpasupplicant resolvconf bc dbus bzip2 psmisc bash-completion cron whiptail sudo ntp ntfs-3g dosfstools parted hdparm pciutils usbutils zip htop wput wget fake-hwclock dphys-swapfile curl unzip console-setup console-data console-common keyboard-configuration wireless-tools wireless-regdb crda --no-install-recommends
+apt-get install -y net-tools cron rfkill ca-certificates locales apt-transport-https ethtool p7zip-full hfsplus iw debconf-utils xz-utils fbset wpasupplicant resolvconf bc dbus bzip2 psmisc bash-completion cron whiptail sudo ntp ntfs-3g dosfstools parted hdparm pciutils usbutils zip htop wput wget fake-hwclock dphys-swapfile curl unzip console-setup console-data console-common keyboard-configuration wireless-tools wireless-regdb crda --no-install-recommends
 
 #??? bluetooth if onboard device / RPI
 apt-get install -y bluetooth bluez-firmware

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4715,8 +4715,6 @@ _EOF_
 
 			Banner_Installing
 
-			AGI net-tools
-
 			#LCD panels can be enabled in Dietpi-config > display options
 			#	XU4 enable cloudshell
 			if (( $HW_MODEL == 11 )); then


### PR DESCRIPTION
The package [net-tools](https://packages.debian.org/de/stretch/net-tools) is necessary to run all DietPi scripts without error:
- `dietpi/boot` uses provided command `route` to check for valid network connection: https://github.com/Fourdee/DietPi/blob/testing/dietpi/boot#L275
- The provided command `ifconfig` is used by many other scripts: https://github.com/Fourdee/DietPi/search?utf8=✓&q="ifconfig"&type=
- Separately pre-installing `net-tools` for any other dietpi-software package can be skipped then, which is indeed just done by dietpi-cloudshell `#62`