### PR TITLE
update info after exiting from ntpd failed to sync

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12743,7 +12743,7 @@ _EOF_
 	Error_NTPD_Failed(){
 
 		#Abort install
-		ERROR_TEXT="NTPD: System time has not been synced/updated correctly.\n\nTo prevent further issues with software installations, DietPi-Software will now exit.\n\nIf problems persist, check the NTPD log:\n   /var/log/ntpd.log\n\nTo override this error, run the following command:\n   echo 0 > /etc/dietpi/.ntpd_exit_status"
+		ERROR_TEXT="NTPD: System time has not been synced/updated correctly.\n\nTo prevent further issues with software installations, DietPi-Software will now exit.\n\nIf problems persist, check the NTPD log:\n   /var/log/ntpd.log\n\nTo override this error, run the following command:\n   echo 0 > /etc/dietpi/.ntpd_exit_status\n  To set time and date from the command line, run the following command:\n date -s \"27 JUN 2017 14:14:00\"\n "
 		Error_Display
 
 		Exit_Destroy


### PR DESCRIPTION
updated info after  failed to sync time message, giving example on how to set time manually 

n  To set time and date from the command line, run the following command:\n     date -s \"27 JUN 2017 14:14:00\"\n

<!-- Before submitting a pull request  -->
<!-- - Please ensure target branch is the testing (active dev) branch: https://github.com/Fourdee/DietPi/tree/testing  -->
<!-- - Please ensure changes have been tested and verified functional.  -->
