### PR TITLE
[RPi Stretch] Switch to new stretch repo on archive.raspberrypi.org

### DIFF
--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -2653,7 +2653,7 @@ _EOF_
 		apt purge -y pciutils
 		#-------------------------------------------------------------------------------
 		# RPi Stretch: Switch to new stretch repo on archive.raspberrypi.org: https://github.com/Fourdee/DietPi/issues/1077
-		if (( $HW_MODEL < 10 && DISTRO == 4 )); then # RPi + Stretch
+		if (( $HW_MODEL < 10 && $DISTRO == 4 )); then # RPi + Stretch
 			echo "deb https://archive.raspberrypi.org/debian/ stretch main ui" > /etc/apt/sources.list.d/raspi.list
 			apt update
 			AGU

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -2649,10 +2649,18 @@ _EOF_
 
 		fi
 		#-------------------------------------------------------------------------------
-                # Purge unnecessary pciutils package: https://github.com/Fourdee/DietPi/issues/1068
+		# Purge unnecessary pciutils package: https://github.com/Fourdee/DietPi/issues/1068
 		apt purge -y pciutils
 		#-------------------------------------------------------------------------------
-		
+		# RPi Stretch: Switch to new stretch repo on archive.raspberrypi.org: https://github.com/Fourdee/DietPi/issues/1077
+		if (( $HW_MODEL < 10 && DISTRO == 4 )); then # RPi + Stretch
+			echo "deb https://archive.raspberrypi.org/debian/ stretch main ui" > /etc/apt/sources.list.d/raspi.list
+			apt update
+			AGU
+			AGDU
+		fi
+		#-------------------------------------------------------------------------------
+
 	fi
 
 		#-------------------------------------------------------------------------------


### PR DESCRIPTION
...as it is finally available: https://github.com/Fourdee/DietPi/issues/1077

Use https in favour of the plan to switch all repos to https, where possible: https://github.com/Fourdee/DietPi/issues/1077#issuecomment-315606641
