### PR TITLE
Small improvement on printing dietpi-services status

### DIFF
--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -222,7 +222,7 @@
 			#Apply
 			if (( ${aSERVICE_AVAILABLE[$i]} == 1 )); then
 
-				echo -e "${aSERVICE_NAME[$i]}\t$(systemctl status "${aSERVICE_NAME[$i]}" | grep Active)"
+				echo -e "${aSERVICE_NAME[$i]}\t$(systemctl status "${aSERVICE_NAME[$i]}" | grep Active | cut -c12-)"
 
 			fi
 


### PR DESCRIPTION
Removed unnecessary "Active: " from the beginning of the line. 