### PR TITLE
Home Assistant | Add FFMPEG as a requires

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2047,6 +2047,7 @@ _EOF_
 		      aSOFTWARE_REQUIRES_GIT[$index_current]=1
 		   aSOFTWARE_REQUIRES_SQLITE[$index_current]=1
 		    aSOFTWARE_REQUIRES_MYSQL[$index_current]=1
+		   aSOFTWARE_REQUIRES_FFMPEG[$index_current]=1
 			 aSOFTWARE_ONLINEDOC_URL[$index_current]='f=8&t=5&start=20#p70'
 
 		#------------------


### PR DESCRIPTION
Small change to add ffmpeg to requires so the ffmpeg component works out of the box without users having to remote in and install themselves.

<!-- Before submitting a pull request  -->
<!-- - Please ensure target branch is the testing (active dev) branch: https://github.com/Fourdee/DietPi/tree/testing  -->
<!-- - Please ensure changes have been tested and verified functional.  -->
