### PR TITLE
A few nextcloud install fixes

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8495,7 +8495,7 @@ _EOF_
 
 			#Nginx
 			if (( ${aSOFTWARE_INSTALL_STATE[85]} >= 1 )); then
-				cat << _EOF_ > /etc/nginx/sites-available/nextcloud.conf
+				cat << _EOF_ > /etc/nginx/sites-dietpi/nextcloud.conf
     location = /.well-known/carddav {
       return 301 $scheme://$host/nextcloud/remote.php/dav;
     }
@@ -8604,8 +8604,6 @@ _EOF_
 	fastcgi_param PHP_ADMIN_VALUE $php_value;
     }
 _EOF_
-
-				ln -s /etc/nginx/sites-available/nextcloud.conf /etc/nginx/sites-enabled/
 
 			fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8524,7 +8524,7 @@ _EOF_
         #pagespeed off;
 
         location /nextcloud {
-            rewrite ^ /nextcloud/index.php$uri;
+            rewrite ^ /nextcloud/index.php$request_uri;
         }
 
         location ~ ^/nextcloud/(?:build|tests|config|lib|3rdparty|templates|data)/ {

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8495,7 +8495,7 @@ _EOF_
 
 			#Nginx
 			if (( ${aSOFTWARE_INSTALL_STATE[85]} >= 1 )); then
-				cat << _EOF_ > /etc/nginx/sites-dietpi/nextcloud.conf
+				cat << _EOF_ > /etc/nginx/sites-dietpi/nextcloud.config
     location = /.well-known/carddav {
       return 301 $scheme://$host/nextcloud/remote.php/dav;
     }
@@ -8545,7 +8545,8 @@ _EOF_
             fastcgi_param front_controller_active true;
             fastcgi_pass php-handler;
             fastcgi_intercept_errors on;
-            fastcgi_request_buffering off;
+            # Disable because Jessie Nginx does not support that parameter
+	    #fastcgi_request_buffering off;
         }
 
         location ~ ^/nextcloud/(?:updater|ocs-provider)(?:$|/) {

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8435,7 +8435,12 @@ _EOF_
 			fi
 
 			#Make sure all necessary PHP modules are enabled: https://docs.nextcloud.com/server/12/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
-			AGI "$php_package_name"-intl
+			if (( $DISTRO == 4 ));then
+				AGI php-intl
+			else
+				AGI php5-intl
+			fi
+		
 			${php_package_name}enmod ctype curl dom fileinfo gd iconv intl json mbstring posix simplexml xmlwriter xmlreader zip pdo_mysql exif opcache apcu
 
 			#Create Nextcloud specific webserver + PHP config.


### PR DESCRIPTION
Ref: https://github.com/Fourdee/DietPi/pull/1142

---

( In Progress )

- [X] php-intl installation _( Fixed )_
- [X] Nginx configuration rechecked and working _( Working )_
- [X] HTST not set correctly _( Not nextcloud centric )_
- [X] HTTP-Splitting vulnerability _( Fixed )_
- [X] Opcache error on nextcloud admin page _( Fix available )_

 
Nextcloud installation failed because of `AGI "$php_package_version"-intl` was interpreted as an installation with the argument `-intl`.

I corrected the install process by splitting the installation

- If Stretch -> `AGI php-intl`
- If Jessie -> `AGI php5-intl`

For the nextcloud nginx configuration file I assume that most users want their instance to be available at `theirdomainname.com/nextcloud` so instead of creating a virtualhost in `sites-available` it's more useful to put the `nextcloud.conf` in _sites-dietpi_ directory.