### PR TITLE
Fix missing nginx support installation for Certbot

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5420,7 +5420,7 @@ _EOF_
 
 				if (( $DISTRO == 4 )); then
 
-				AGI certbot
+				AGI certbot python-certbot-nginx
 
 				else
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8612,15 +8612,6 @@ _EOF_
 			#Nginx
 			if (( ${aSOFTWARE_INSTALL_STATE[85]} >= 1 )); then
 				cat << _EOF_ > /etc/nginx/sites-dietpi/nextcloud.config
-    location = /.well-known/carddav {
-      return 301 $scheme://$host/nextcloud/remote.php/dav;
-    }
-    location = /.well-known/caldav {
-      return 301 $scheme://$host/nextcloud/remote.php/dav;
-    }
-
-    location /.well-known/acme-challenge { }
-
     location ^~ /nextcloud {
 
         # set max upload size


### PR DESCRIPTION
- Add missing `python-certbot-nginx` package on Stretch

<!-- Before submitting a pull request  -->
<!-- - Please ensure target branch is the testing (active dev) branch: https://github.com/Fourdee/DietPi/tree/testing  -->
<!-- - Please ensure changes have been tested and verified functional.  -->
