### PR TITLE
Enable Home Assistant service to load on startup

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11991,6 +11991,10 @@ WantedBy=multi-user.target
 
 _EOF_
 
+			# Enable startup on boot by default
+			systemctl daemon-reload
+			systemctl enable home-assistant.service
+
 			# Link to the default ha location for the homeassistant user, this makes
 			# the configuration avaliable for the user to edit. Configuration generated
 			# when service is started at /home/homeassistant/.homeassistant


### PR DESCRIPTION
The Home Assistant service was not enabled so didn't start automatically at startup.
This PR fixes this issue.

<!-- Before submitting a pull request  -->
<!-- - Please ensure target branch is the testing (active dev) branch: https://github.com/Fourdee/DietPi/tree/testing  -->
<!-- - Please ensure changes have been tested and verified functional.  -->
