### PR TITLE
[Nextcloud] Fix database creation and Nginx config

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8967,9 +8967,6 @@ _EOF_
 
 			fi
 
-			# - Create DB v11: https://github.com/Fourdee/DietPi/issues/647#issuecomment-267019815
-			/DietPi/dietpi/func/create_mysql_db nextcloud "$GLOBAL_PW" root "$GLOBAL_PW"
-
 			sudo -u www-data php /var/www/nextcloud/occ maintenance:install --no-interaction --database "mysql" --database-name "nextcloud" --database-user "root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$FP_DIETPI_USERDATA_DIRECTORY/nextcloud_data"
 
 			#Disable trusted_domains.

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8987,6 +8987,9 @@ _EOF_
 
 			sudo -u www-data php /var/www/nextcloud/occ maintenance:install --no-interaction --database "mysql" --database-name "nextcloud" --database-user "root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$FP_DIETPI_USERDATA_DIRECTORY/nextcloud_data"
 
+			# Remove obsolete 'oc_admin'@'%' MySQL user:
+			mysql -uroot -p"$GLOBAL_PW" -e "drop user $(grep -m1 "'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")"
+
 			# Disable trusted_domains.
 			if (( ! $(cat /var/www/nextcloud/config/config.php | grep -ci -m1 "1 => '*'") )); then
 
@@ -12590,6 +12593,7 @@ _EOF_
 
 			systemctl start mysql
 			mysqladmin -u root -p"$GLOBAL_PW" drop nextcloud -f
+			mysql -uroot -p"$GLOBAL_PW" -e "drop user $(grep -m1 "'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")@$(grep -m1 "'dbhost'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")"
 			rm -R /var/www/nextcloud
 			a2dissite nextcloud &>/dev/null
 			rm /etc/apache2/sites-available/nextcloud.conf &>/dev/null

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8962,9 +8962,9 @@ _EOF_
 
 				fi
 				
-				# Set HTTPS on, if SSL connection is available.
+				# Set HTTPS on, if SSL connection is available, even with self-signed/untrusted certificate.
 				DietPi/dietpi/func/check_connection https://localhost &> /dev/null
-				if (( $? == 0 )); then
+				if (( $? == 0 || $? == 5)); then
 
 					sed -i "s#\#fastcgi_param HTTPS on;#fastcgi_param HTTPS on;#g" /etc/nginx/sites-dietpi/nextcloud.config
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3752,7 +3752,7 @@ _EOF_
 			# + stretch extras
 			if (( $DISTRO >= 4 )); then
 
-				AGI "$PHP_APT_PACKAGE_NAME"-opcache "$PHP_APT_PACKAGE_NAME"-mbstring "$PHP_APT_PACKAGE_NAME"-zip "$PHP_APT_PACKAGE_NAME"-xml
+				AGI "$PHP_APT_PACKAGE_NAME"-mbstring "$PHP_APT_PACKAGE_NAME"-zip "$PHP_APT_PACKAGE_NAME"-xml
 
 			fi
 
@@ -8871,6 +8871,8 @@ _EOF_
 				cat << _EOF_ > /etc/nginx/sites-dietpi/nextcloud.config
 location ^~ /nextcloud {
 
+	# Security headers
+	add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;";
 	add_header X-Content-Type-Options nosniff;
 	add_header X-XSS-Protection "1; mode=block";
 	add_header X-Robots-Tag none;
@@ -8977,14 +8979,17 @@ _EOF_
 
 			sudo -u www-data php /var/www/nextcloud/occ maintenance:install --no-interaction --database "mysql" --database-name "nextcloud" --database-user "root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$FP_DIETPI_USERDATA_DIRECTORY/nextcloud_data"
 
-			#Disable trusted_domains.
+			# Disable trusted_domains.
 			if (( ! $(cat /var/www/nextcloud/config/config.php | grep -ci -m1 "1 => '*'") )); then
 
 				sed -i "/0 => 'localhost'/a     1 => '*'," /var/www/nextcloud/config/config.php
 
 			fi
+			
+			# Set CLI URL to Nextcloud sub directory:
+			sed -i "s#'http://localhost'#'http://localhost/nextcloud'#g"
 
-			#Owncloud/Nextcloud ignores system wide php.ini settings. Use their own config.
+			# Owncloud/Nextcloud ignores system wide php.ini settings. Use their own config.
 			# - max upload size
 			local php_max_upload_size="$(( $(php -r 'print(PHP_INT_MAX);') / 1024 / 1024))M"
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8871,6 +8871,12 @@ _EOF_
 				cat << _EOF_ > /etc/nginx/sites-dietpi/nextcloud.config
 location ^~ /nextcloud {
 
+	add_header X-Content-Type-Options nosniff;
+	add_header X-XSS-Protection "1; mode=block";
+	add_header X-Robots-Tag none;
+	add_header X-Download-Options noopen;
+	add_header X-Permitted-Cross-Domain-Policies none;
+
 	# set max upload size
 	client_max_body_size $(( $(php -r 'print(PHP_INT_MAX);') / 1024 / 1024))M;
 	fastcgi_buffers 64 4K;
@@ -8894,27 +8900,31 @@ location ^~ /nextcloud {
 	location ~ ^/nextcloud/(?:build|tests|config|lib|3rdparty|templates|data)/ {
 		deny all;
 	}
+
 	location ~ ^/nextcloud/(?:\.|autotest|occ|issue|indie|db_|console) {
 		deny all;
 	}
 
 	location ~ ^/nextcloud/(?:index|remote|public|cron|core/ajax/update|status|ocs/v[12]|updater/.+|ocs-provider/.+)\.php(?:$|/) {
-	include fastcgi_params;
-	fastcgi_split_path_info ^(.+\.php)(/.+)$;
-	fastcgi_param SCRIPT_FILENAME \$request_filename;
-	fastcgi_param PATH_INFO \$fastcgi_path_info;
-	fastcgi_param HTTPS on;
-	# Avoid sending the security headers twice
-	fastcgi_param modHeadersAvailable true;
-	fastcgi_param REMOTE_USER \$remote_user;
-	fastcgi_pass unix:/var/run/php5-fpm.sock;
-	fastcgi_intercept_errors on;
-	# Disable because Jessie Nginx does not support that parameter
-	#fastcgi_request_buffering off;
+		include fastcgi_params;
+		fastcgi_split_path_info ^(.+\.php)(/.+)$;
+		fastcgi_param SCRIPT_FILENAME \$request_filename;
+		fastcgi_param PATH_INFO \$fastcgi_path_info;
+		# HTTPS forces redirection from http://, thus has to be enabled only on active HTTPS environment.
+		#fastcgi_param HTTPS on;
+		# Avoid sending the security headers twice
+		fastcgi_param modHeadersAvailable true;
+		fastcgi_param REMOTE_USER \$remote_user;
+		fastcgi_pass unix:/var/run/php5-fpm.sock;
+		fastcgi_intercept_errors on;
+		# Disable because Jessie Nginx does not support that parameter
+		#fastcgi_request_buffering off;
+		# Hard coding 128M OPCache size, only for /nextcloud, to suppress warning on nextcloud admin panel.
+		fastcgi_param PHP_ADMIN_VALUE "opcache.memory_consumption=128";
 	}
 
 	location ~ ^/nextcloud/(?:updater|ocs-provider)(?:$|/) {
-	try_files \$uri/ =404;
+		try_files \$uri/ =404;
 		index index.php;
 	}
 
@@ -8922,9 +8932,9 @@ location ^~ /nextcloud {
 	# Make sure it is BELOW the PHP block
 	location ~ \.(?:css|js|woff|svg|gif)$ {
 		try_files \$uri /nextcloud/index.php\$uri\$is_args\$args;
-    add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;";
+		add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;";
 		add_header Cache-Control "public, max-age=15778463";
-	  add_header X-Content-Type-Options nosniff;
+		add_header X-Content-Type-Options nosniff;
 		add_header X-XSS-Protection "1; mode=block";
 		add_header X-Robots-Tag none;
 		add_header X-Download-Options noopen;
@@ -8939,16 +8949,14 @@ location ^~ /nextcloud {
 		access_log off;
 	}
 
-	# Hard coding 128M OPCache size, only for /nextcloud, to suppress warning on nextcloud admin panel.
-	fastcgi_param PHP_ADMIN_VALUE "opcache.memory_consumption=128";
-
 }
 _EOF_
 
-				# - Stretch, set php7.0
+				# - Stretch, set php7.0 and set fastcgi_request_buffering off; 
 				if (( $DISTRO >= 4 )); then
 
 					sed -i "s#/run/php5-fpm.sock#/run/php/php7.0-fpm.sock#g" /etc/nginx/sites-dietpi/nextcloud.config
+					sed -i "s#\#fastcgi_request_buffering off;#fastcgi_request_buffering off;#g" /etc/nginx/sites-dietpi/nextcloud.config
 
 				fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -17,10 +17,10 @@
 	# Usage:
 	# - dietpi-software
 	# - /DietPi/dietpi/dietpi-software install		iUNIQUEID (OR) sINDEX_{SSHSERVER,FILESERVER,LOGGING,WEBSERVER}_TARGET=-int
-	# - /DietPi/dietpi/dietpi-software reinstall	Same as installed, however, only reinstalls if state =2. Does not uninstall due to package removal danger (eg: xserver removes kodi), simply flags to be installed (=1).
-	# - /DietPi/dietpi/dietpi-software uninstall	iUNIQUEID
-	# - /DietPi/dietpi/dietpi-software list			#Lists UNIQUEIDs for software
-	# - /DietPi/dietpi/dietpi-software setpermissions #Sets shared permissions for /var/www and userdata folders
+	# - /DietPi/dietpi/dietpi-software reinstall		#Same as installed, however, only reinstalls if state =2. Does not uninstall due to package removal danger (eg: xserver removes kodi), simply flags to be installed (=1).
+	# - /DietPi/dietpi/dietpi-software uninstall		iUNIQUEID
+	# - /DietPi/dietpi/dietpi-software list			#Lists UNIQUEIDs for software.
+	# - /DietPi/dietpi/dietpi-software setpermissions	#Sets shared permissions for /var/www and userdata folders.
 	#////////////////////////////////////
 
 	#Force en_GB Locale for whole script. Prevents incorrect parsing with non-english locales.
@@ -264,7 +264,7 @@ _EOF_
 	#PHP5/7 specific directories, apt package-, module- and command names
 	FP_PHP_BASE_DIR='/etc/php/7.0'
 	PHP_APT_PACKAGE_NAME='php'
-	if (( $DISTRO == 3 )); then
+	if (( $DISTRO < 4 )); then
 
 		FP_PHP_BASE_DIR='/etc/php5'
 		PHP_APT_PACKAGE_NAME='php5'
@@ -310,15 +310,15 @@ _EOF_
 	TOTAL_SOFTWARE_INDEXS=0
 	TOTAL_SOFTWARE_INDEXS_HARDLIMIT=168	#Increase as needed. Must be higher than TOTAL_SOFTWARE_INDEXS once calculated in Software_Arrays_Init
 
-	INSTALLING_INDEX=0					#Which software index is currently being installed?
+	INSTALLING_INDEX=0			#Which software index is currently being installed?
 
-	aSOFTWARE_CATEGORY_INDEX=0			#Category index
-	aSOFTWARE_TYPE=0					#0=DietPi 1=Linux | -1=Hidden from install menu, visible in uninstall menu | -2 Hidden from all menus
+	aSOFTWARE_CATEGORY_INDEX=0		#Category index
+	aSOFTWARE_TYPE=0			#0=DietPi 1=Linux | -1=Hidden from install menu, visible in uninstall menu | -2 Hidden from all menus
 
-	aSOFTWARE_INSTALL_STATE=0			#0=not / 1=tobe, or not tobe that is the... / 2=installed
+	aSOFTWARE_INSTALL_STATE=0		#0=not / 1=tobe, or not tobe that is the... / 2=installed
 
-	aSOFTWARE_WHIP_NAME=0				#Item name eg: Kodi
-	aSOFTWARE_WHIP_DESC=0				#Blah blah
+	aSOFTWARE_WHIP_NAME=0			#Item name eg: Kodi
+	aSOFTWARE_WHIP_DESC=0			#Blah blah
 
 	FP_ONLINEDOC_URL='http://dietpi.com/phpbb/viewtopic.php?'
 	aSOFTWARE_ONLINEDOC_URL=0
@@ -357,11 +357,11 @@ _EOF_
 	# Adding Software to the Install List:
 	# ------------------------------------
 	# - index_current:
-	#   This is the next number in the sequence, each software install has a unique number
+	#   This is the next number in the sequence. Each software install has a unique number,
 	#   so it can be referenced in all arrays. This has to be the same for install, uninstall
 	#   and setting up the service. Run "dietpi-software list | grep 'index Current'" to
-	#   get the next number in the sequence. Ensure you are running a testing build as
-	#   release may be behind the testing branch and avaliable software packages
+	#   get the next number in the sequence. Ensure that you are running a testing build, as
+	#   release may be behind the testing branch and avaliable software packages.
 	#
 	# - aSOFTWARE_WHIP_NAME:
 	#   This is the name to display in the UI.
@@ -370,27 +370,27 @@ _EOF_
 	#   This is the description to place next to the name in the UI.
 	#
 	# - aSOFTWARE_CATEGORY_INDEX:
-	#   If you are adding a new peice of software first choose the category it goes under
-	#   (aSOFTWARE_CATEGORIES_DIETPI or  aSOFTWARE_CATEGORIES_LINUX) this will give you
-	#   the aSOFTWARE_CATEGORY_INDEX to set, in the example belo this is 0.
+	#   If you are adding a new peice of software, first choose the category it belongs to
+	#   (see aSOFTWARE_CATEGORIES_DIETPI and aSOFTWARE_CATEGORIES_LINUX below), which will
+	#   give you the aSOFTWARE_CATEGORY_INDEX to set. In the example below this is 0.
 	#
 	# - aSOFTWARE_TYPE:
-	#   If this is aSOFTWARE_CATEGORIES_DIETPI then aSOFTWARE_TYPE = 0 if it is
+	#   If this is aSOFTWARE_CATEGORIES_DIETPI then aSOFTWARE_TYPE=0, if it is
 	#   aSOFTWARE_CATEGORIES_LINUX then it is 1. In the example it is 0.
 	#
 	# - aSOFTWARE_ONLINEDOC_URL:
 	#   This is appeneded to FP_ONLINEDOC_URL to make a URL for help on this software.
 	#
 	# Specifying other software as dependencies:
-	#   If you need other software to be avaliable for you look under the 'Requires software
+	#   If your software needs other software to be available, look under the 'Requires software
 	#   to be installed' heading and then add that to the section you create. In the example
-	#   below ALSA and XSERVERXORG are needed. The system will check to see if they are
-	#   installed and if not will install them for you.
+	#   below ALSA and XSERVERXORG are needed. The system will check their presence
+	#   and install as needed.
 	#
 	# Dealing with Hardware types:
-	#   If you have hardware requirements like must not/only be installed on a pi then you need
-	#   to add something like the following, look for other examples in the existing software
-	#   installations. Full list of models can be found in 'dietpi-obtain_hw_model'
+	#   If you have hardware requirements, like must not/only be installed on a Pi, then you need
+	#   to add something like below. Look for other examples in the existing software
+	#   installations. Full list of models can be found in 'dietpi-obtain_hw_model'.
 	#
 	#	# - Disabled for All non-rpi
 	#	for ((i=10; i<=$MAX_HW_MODEL; i++))
@@ -8825,7 +8825,7 @@ _EOF_
 
 			fi
 
-			# APCu configuration: To prevent cli (cron.php) producing Nextcloud log [info] entry.
+			# APCu configuration: To prevent cli (cron.php) producing Nextcloud log [info] entries.
 			grep -q 'apc.enable_cli=' $FP_PHP_BASE_DIR/mods-available/apcu.ini && sed -i '/apc.enable_cli=/c\apc.enable_cli=1' $FP_PHP_BASE_DIR/mods-available/apcu.ini || echo 'apc.enable_cli=1' >> $FP_PHP_BASE_DIR/mods-available/apcu.ini
 
 			# OPCache configuration: https://docs.nextcloud.com/server/12/admin_manual/configuration_server/server_tuning.html?highlight=opcache#enable-php-opcache
@@ -8954,11 +8954,19 @@ location ^~ /nextcloud {
 }
 _EOF_
 
-				# - Stretch, set php7.0 and set fastcgi_request_buffering off; 
+				# - Stretch, set php7.0 and fastcgi_request_buffering off; 
 				if (( $DISTRO >= 4 )); then
 
 					sed -i "s#/run/php5-fpm.sock#/run/php/php7.0-fpm.sock#g" /etc/nginx/sites-dietpi/nextcloud.config
 					sed -i "s#\#fastcgi_request_buffering off;#fastcgi_request_buffering off;#g" /etc/nginx/sites-dietpi/nextcloud.config
+
+				fi
+				
+				# Set HTTPS on, if SSL connection is available.
+				DietPi/dietpi/func/check_connection https://localhost &> /dev/null
+				if (( $? == 0 )); then
+
+					sed -i "s#\#fastcgi_param HTTPS on;#fastcgi_param HTTPS on;#g" /etc/nginx/sites-dietpi/nextcloud.config
 
 				fi
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -32,6 +32,14 @@
 	HW_MODEL_DESCRIPTION=$(sed -n 2p /DietPi/dietpi/.hw_model)
 	DISTRO=$(sed -n 3p /DietPi/dietpi/.hw_model)
 	HW_ARCH=$(sed -n 6p /DietPi/dietpi/.hw_model)
+	
+	#Global Password: Exception to AUTO first run init.
+	GLOBAL_PW=$(cat /DietPi/dietpi.txt | grep -m1 '^AUTO_Global_Password=' | sed 's/.*=//')
+	if [ ! -n "$GLOBAL_PW" ]; then
+
+		GLOBAL_PW='dietpi'
+
+	fi
 
 	ALLO_GUI_IMAGE=0
 	if [ -f /DietPi/dietpi/.installed ] && (( $(cat /DietPi/dietpi/.installed | grep -ci -m1 '^aSOFTWARE_INSTALL_STATE\[159\]=2') )); then
@@ -2780,7 +2788,12 @@ _EOF_
 		#	Squeezelite / Shairport-sync / Allo GUI (full)
 		/DietPi/dietpi/dietpi-software reinstall 36 37 159
 		#-------------------------------------------------------------------------------
-
+		#Nextcloud: Remove obsolete MySQL user
+		if ! [ "$(grep -m1 "'dbhost'" /var/www/nextcloud/config/config.php 2> /dev/null | awk '{print $3}' | sed "s/,//")" == "''" ]; then
+   		     mysql -uroot -p"$GLOBAL_PW" -e "drop user $(grep -m1 "'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")" &> /dev/null
+		fi
+		#-------------------------------------------------------------------------------
+		
 	fi
 
 		#-------------------------------------------------------------------------------


### PR DESCRIPTION
- [x] Fix MySQL database creation
- [x] Remove database user on uninstallation
- [x] Fix Nginx config for non-SSL environment
- [x] Check for SSL connectivity and adjust Nginx config
- [x] Allow self-signed certificates on SSL check
____________________
- Database was created with wrong privileges for user `root`, thus user `oc_admin` is not able to access.
- On top, `occ maintenance:install` creates the database and user automatically, thus if `create_mysql_db` is used to create database with correct user` oc_admin` (<prefix>_$username), Nextcloud will create `oc_admin1` as user via `occ maintenance:install` and use it.
=> Removing `create_mysql_db` works fine for me, Nextcloud is accessible.

Actually I would also like to remove the user on Nextcloud uninstallation, but I am not too good in creating the right command to get the right string from `nextcloud/config/config.php` 😅.