### PR TITLE
DietPi System Preparation | Add sysctl config values to our own .conf file

### DIFF
--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -333,7 +333,7 @@ systemctl mask apt-daily.service
 systemctl mask apt-daily-upgrade.timer
 
 #/etc/sysctl.conf | Check for a previous entry before adding this
-echo -e "vm.swappiness=1" >> /etc/sysctl.d/97-dietpi.conf
+echo -e "vm.swappiness=1" > /etc/sysctl.d/97-dietpi.conf
 
 #login,
 echo -e "\n/DietPi/dietpi/login" >> /root/.bashrc

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -333,7 +333,7 @@ systemctl mask apt-daily.service
 systemctl mask apt-daily-upgrade.timer
 
 #/etc/sysctl.conf | Check for a previous entry before adding this
-echo -e "vm.swappiness=1" >> /etc/sysctl.conf
+echo -e "vm.swappiness=1" >> /etc/sysctl.d/97-dietpi.conf
 
 #login,
 echo -e "\n/DietPi/dietpi/login" >> /root/.bashrc

--- a/dietpi/dietpi-bugreport
+++ b/dietpi/dietpi-bugreport
@@ -134,6 +134,7 @@ _EOF_
 			"/etc/fstab"
 			"/etc/dphys-swapfile"
 			"/etc/sysctl.conf"
+			"/etc/sysctl.d/*"
 
 			# - Services
 			"/etc/init.d/*"


### PR DESCRIPTION
- Generally we should try to add our values into our own files, if a '*.d/' folder exists. This enables package updates to overwrite the unchanged main .conf without overwriting our values.
- I chose "97-" prefix here as "99-" is used by systemd and "98-" by RPi raspberrypi-sys-mods.
- We could also check for/sed existing vm.swappiness entries, but I guess '/*.d' entries will overwrite anyway?