### PR TITLE
DietPi-Software | Redis: Minor un/installation/activation fixes of PHP module

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8984,7 +8984,7 @@ _EOF_
 		INSTALLING_INDEX=91
 		if (( ${aSOFTWARE_INSTALL_STATE[$INSTALLING_INDEX]} == 1 )); then
 
-			#Enable resdis extensions for all webstacks:
+			#Enable redis extension for all webstacks:
 			"$PHP_APT_PACKAGE_NAME"enmod redis
 
 		fi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3795,6 +3795,12 @@ _EOF_
 
 			Banner_Installing
 			AGI redis-server
+			#Redis php module | == 2 to check for existing installs, if == 1, then module will be installed together with PHP, to prevent dependency installations
+			if (( ${aSOFTWARE_INSTALL_STATE[89]} == 2 )); then
+
+				AGI "$PHP_APT_PACKAGE_NAME"-redis
+
+			fi
 
 		fi
 
@@ -8979,8 +8985,7 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$INSTALLING_INDEX]} == 1 )); then
 
 			#Enable resdis extensions for all webstacks:
-			echo -e "extension=redis.so" > "$FP_PHP_BASE_DIR"/cli/conf.d/20-redis.ini &> /dev/null
-			echo -e "extension=redis.so" > "$FP_PHP_BASE_DIR"/apache2/conf.d/20-redis.ini &> /dev/null
+			"$PHP_APT_PACKAGE_NAME"enmod redis
 
 		fi
 
@@ -13052,7 +13057,7 @@ _EOF_
 
 		elif (( $1 == 91 )); then
 
-			AGP redis-server
+			AGP redis-server "$PHP_APT_PACKAGE_NAME"-redis
 
 		elif (( $1 == 89 )); then
 


### PR DESCRIPTION
- Auto installation of PHP module, if PHP stack is installed. Just do this, if PHP state == 2, otherwise this leads to dependency PHP installations. If PHP install state == 1, then redis module will be installed together with PHP afterwards.
- Correctly use the phpenmod command to activate the PHP module. Otherwise this command will show errors later, I even got empty .ini files, leading to inactive module.
- Uninstall PHP module together with redis-server.