### PR TITLE
DietPi-Software | ownCloud/Nextcloud: Fix/Polish Phase II

### DIFF
--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -433,8 +433,8 @@
 			# Control ownCloud and Nextcloud maintenance mode:
 			if [ "$INPUT_MODE" = "stop" ] || [ "$INPUT_MODE" = "restart" ]; then
 
-				grep -q "'maintenance' => true," /var/www/owncloud/config/config.php || occ maintenance:mode --on 2> /dev/null
-				grep -q "'maintenance' => true," /var/www/nextcloud/config/config.php || ncc maintenance:mode --on 2> /dev/null
+				grep -q "'maintenance' => false," /var/www/owncloud/config/config.php &>/dev/null && occ maintenance:mode --on 2> /dev/null
+				grep -q "'maintenance' => false," /var/www/nextcloud/config/config.php &>/dev/null && ncc maintenance:mode --on 2> /dev/null
 
 			fi
 
@@ -443,8 +443,8 @@
 			# Control ownCloud and Nextcloud maintenance mode:
 			if [ "$INPUT_MODE" = "restart" ] || [ "$INPUT_MODE" = "start" ]; then
 
-				grep -q "'maintenance' => false," /var/www/owncloud/config/config.php || occ maintenance:mode --off 2> /dev/null
-				grep -q "'maintenance' => false," /var/www/nextcloud/config/config.php || ncc maintenance:mode --off 2> /dev/null
+				grep -q "'maintenance' => true," /var/www/owncloud/config/config.php &>/dev/null && occ maintenance:mode --off 2> /dev/null
+				grep -q "'maintenance' => true," /var/www/nextcloud/config/config.php &>/dev/null && ncc maintenance:mode --off 2> /dev/null
 
 			fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9265,6 +9265,9 @@ _EOF_
 			crontab -u www-data -l 2>/dev/null | grep -q '/var/www/owncloud/cron.php' || echo "*/15 * * * * php /var/www/owncloud/cron.php" | crontab -u www-data -
 			occ background:cron
 
+			# Enable maintenance mode to allow handling by dietpi-services:
+			grep -q "'maintenance' => true," $config_php &>/dev/null || occ maintenance:mode --on
+
 		fi
 
 		#Nextcloud
@@ -9430,6 +9433,9 @@ _EOF_
 			# Enable Nextcloud background cron job:
 			crontab -u www-data -l 2>/dev/null | grep -q '/var/www/nextcloud/cron.php' || echo "*/15 * * * * php /var/www/nextcloud/cron.php" | crontab -u www-data -
 			ncc background:cron
+
+			# Enable maintenance mode to allow handling by dietpi-services:
+			grep -q "'maintenance' => true," $config_php &>/dev/null || ncc maintenance:mode --on
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -13227,16 +13227,16 @@ _EOF_
 			a2dissite owncloud 2>/dev/null
 			rm /etc/apache2/sites-available/owncloud.conf 2>/dev/null
 			rm /etc/nginx/sites-dietpi/owncloud.config 2>/dev/null
-			# Purge APT package
-			AGP owncloud-files owncloud owncloud-deps
-			# Remove ownCloud installation folder
-			rm -R /var/www/owncloud
 			# Drop MySQL/MariaDB user and database
 			systemctl start mysql
 			mysql -uroot -p"$GLOBAL_PW" -e "drop user $(grep -m1 "'dbuser'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")@$(grep -m1 "'dbhost'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")"
 			mysql -uroot -p"$GLOBAL_PW" -e "drop user $(grep -m1 "'dbuser'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")"
 			mysqldump --lock-tables -uroot -p"$GLOBAL_PW" owncloud > "$FP_DIETPI_USERDATA_DIRECTORY"/owncloud_data/mysql_backup.sql
 			mysqladmin -u root -p"$GLOBAL_PW" drop owncloud -f
+			# Purge APT package
+			AGP owncloud-files owncloud owncloud-deps
+			# Remove ownCloud installation folder
+			rm -R /var/www/owncloud
 			# Remove ownCloud repo
 			rm /etc/apt/sources.list.d/owncloud.list 2> /dev/null
 
@@ -13250,14 +13250,14 @@ _EOF_
 			a2dissite nextcloud 2>/dev/null
 			rm /etc/apache2/sites-available/nextcloud.conf 2>/dev/null
 			rm /etc/nginx/sites-dietpi/nextcloud.config 2>/dev/null
-			# Remove Nextcloud installation folder
-			rm -R /var/www/nextcloud
 			# Drop MySQL/MariaDB user and database
 			systemctl start mysql
 			mysql -uroot -p"$GLOBAL_PW" -e "drop user $(grep -m1 "'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")@$(grep -m1 "'dbhost'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")"
 			mysql -uroot -p"$GLOBAL_PW" -e "drop user $(grep -m1 "'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")"
 			mysqldump --lock-tables -uroot -p"$GLOBAL_PW" nextcloud > "$FP_DIETPI_USERDATA_DIRECTORY"/nextcloud_data/mysql_backup.sql
 			mysqladmin -u root -p"$GLOBAL_PW" drop nextcloud -f
+			# Remove Nextcloud installation folder
+			rm -R /var/www/nextcloud
 
 		elif (( $1 == 115 )); then
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -13219,8 +13219,8 @@ _EOF_
 
 		elif (( $1 == 47 )); then
 			#ownCloud
-			# Remove occ command alias
-			sed -i '\|/var/www/owncloud/occ|d' /etc/bash.bashrc
+			# Remove occ command binary
+			rm /usr/local/bin/occ
 			# Remove background cron job
 			crontab -u www-data -l | grep -v '/var/www/owncloud/cron.php'  | crontab -u www-data -
 			# Disable and remove webservier configs
@@ -13242,8 +13242,8 @@ _EOF_
 
 		elif (( $1 == 114 )); then
 			#Nextcloud
-			# Remove occ command alias
-			sed -i '\|/var/www/nextcloud/occ|d' /etc/bash.bashrc
+			# Remove occ command binary
+			rm /usr/local/bin/ncc
 			# Remove background cron job
 			crontab -u www-data -l | grep -v '/var/www/nextcloud/cron.php'  | crontab -u www-data -
 			# Disable and remove webservier configs

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9202,7 +9202,7 @@ _EOF_
 
 			# Adjusting config file:
 			local config_php="/var/www/owncloud/config/config.php"
-			
+
 			# Enable MySQL 4-byte support for new installations only, to prevent risky database conversion tasks:
 			if (( $oc_is_fresh == 1 )); then
 
@@ -9247,7 +9247,6 @@ _EOF_
 
 			fi
 
-
 			# ownCloud/Nextcloud ignores system wide php.ini settings. Use their own config.
 			# Set max upload size
 			local php_max_upload_size="$(( $(php -r 'print(PHP_INT_MAX);') / 1024 / 1024))M"
@@ -9257,11 +9256,11 @@ _EOF_
 			# Set memory limit: total / 4
 			local memory_limit_max="$(( $RAM_TOTAL / 4 ))M"
 			sed -i "/memory_limit=/c\memory_limit=$memory_limit_max" /var/www/owncloud/.user.ini
-			
+
 			# Enable ownCloud background cron job:
 			crontab -u www-data -l 2>/dev/null | grep -q '/var/www/owncloud/cron.php' || echo "*/15 * * * * php /var/www/owncloud/cron.php" | crontab -u www-data -
 			sudo -u www-data php /var/www/owncloud/occ background:cron
-			
+
 			# Add occ command shortcut:
 			grep -q '/var/www/owncloud/occ' /etc/bash.bashrc || sed -i "\|alias sudo='sudo '|a alias occ='sudo -u www-data php /var/www/owncloud/occ'" /etc/bash.bashrc
 
@@ -9426,7 +9425,7 @@ _EOF_
 			# Enable Nextcloud background cron job:
 			crontab -u www-data -l 2>/dev/null | grep -q '/var/www/nextcloud/cron.php' || echo "*/15 * * * * php /var/www/nextcloud/cron.php" | crontab -u www-data -
 			sudo -u www-data php /var/www/nextcloud/occ background:cron
-			
+
 			# Add occ command shortcut, use 'ncc' as 'occ' is reserved for ownCloud:
 			grep -q '/var/www/nextcloud/occ' /etc/bash.bashrc || sed -i "\|alias sudo='sudo '|a alias ncc='sudo -u www-data php /var/www/nextcloud/occ'" /etc/bash.bashrc
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9185,6 +9185,9 @@ _EOF_
 
 			fi
 
+			# Add occ command shortcut:
+			echo -e '#!/bin/bash\nsudo -u www-data php /var/www/owncloud/occ $*' > /usr/local/bin/occ
+
 			# Terminal installation:
 			mkdir -p "$FP_DIETPI_USERDATA_DIRECTORY"/owncloud_data
 			Install_Apply_Permissions &> /dev/null
@@ -9197,7 +9200,7 @@ _EOF_
 			systemctl start mysql
 			# For MariaDB, temporary database admin user needs to be created, as 'root' uses unix_socket login, which cannot be accessed by sudo -u www-data.
 			mysql -uroot -p"$GLOBAL_PW" -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
-			sudo -u www-data php /var/www/owncloud/occ maintenance:install --no-interaction --database "mysql" --database-name "owncloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$FP_DIETPI_USERDATA_DIRECTORY/owncloud_data" 2> /dev/null
+			occ maintenance:install --no-interaction --database "mysql" --database-name "owncloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$FP_DIETPI_USERDATA_DIRECTORY/owncloud_data" 2> /dev/null
 			mysql -uroot -p"$GLOBAL_PW" -e "drop user 'tmp_root'@'localhost'"
 
 			# Adjusting config file:
@@ -9259,10 +9262,7 @@ _EOF_
 
 			# Enable ownCloud background cron job:
 			crontab -u www-data -l 2>/dev/null | grep -q '/var/www/owncloud/cron.php' || echo "*/15 * * * * php /var/www/owncloud/cron.php" | crontab -u www-data -
-			sudo -u www-data php /var/www/owncloud/occ background:cron
-
-			# Add occ command shortcut:
-			grep -q '/var/www/owncloud/occ' /etc/bash.bashrc || sed -i "\|alias sudo='sudo '|a alias occ='sudo -u www-data php /var/www/owncloud/occ'" /etc/bash.bashrc
+			occ background:cron
 
 		fi
 
@@ -9352,6 +9352,9 @@ _EOF_
 
 			fi
 
+			# Add occ command shortcut, use 'ncc' as 'occ' is reserved for ownCloud:
+			echo -e '#!/bin/bash\nsudo -u www-data php /var/www/nextcloud/occ $*' > /usr/local/bin/ncc
+
 			# Terminal installation:
 			mkdir -p "$FP_DIETPI_USERDATA_DIRECTORY"/nextcloud_data
 			Install_Apply_Permissions &> /dev/null
@@ -9364,7 +9367,7 @@ _EOF_
 			systemctl start mysql
 			# For MariaDB, temporary database admin user needs to be created, as 'root' uses unix_socket login, which cannot be accessed by sudo -u www-data.
 			mysql -uroot -p"$GLOBAL_PW" -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
-			sudo -u www-data php /var/www/nextcloud/occ maintenance:install --no-interaction --database "mysql" --database-name "nextcloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$FP_DIETPI_USERDATA_DIRECTORY/nextcloud_data" 2> /dev/null
+			occ maintenance:install --no-interaction --database "mysql" --database-name "nextcloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$FP_DIETPI_USERDATA_DIRECTORY/nextcloud_data" 2> /dev/null
 			mysql -uroot -p"$GLOBAL_PW" -e "drop user 'tmp_root'@'localhost'"
 
 			# Adjusting config file:
@@ -9424,10 +9427,7 @@ _EOF_
 
 			# Enable Nextcloud background cron job:
 			crontab -u www-data -l 2>/dev/null | grep -q '/var/www/nextcloud/cron.php' || echo "*/15 * * * * php /var/www/nextcloud/cron.php" | crontab -u www-data -
-			sudo -u www-data php /var/www/nextcloud/occ background:cron
-
-			# Add occ command shortcut, use 'ncc' as 'occ' is reserved for ownCloud:
-			grep -q '/var/www/nextcloud/occ' /etc/bash.bashrc || sed -i "\|alias sudo='sudo '|a alias ncc='sudo -u www-data php /var/www/nextcloud/occ'" /etc/bash.bashrc
+			occ background:cron
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9187,6 +9187,7 @@ _EOF_
 
 			# Add occ command shortcut:
 			echo -e '#!/bin/bash\nsudo -u www-data php /var/www/owncloud/occ $*' > /usr/local/bin/occ
+			chmod +x /usr/local/bin/occ
 
 			# Terminal installation:
 			mkdir -p "$FP_DIETPI_USERDATA_DIRECTORY"/owncloud_data
@@ -9354,6 +9355,7 @@ _EOF_
 
 			# Add occ command shortcut, use 'ncc' as 'occ' is reserved for ownCloud:
 			echo -e '#!/bin/bash\nsudo -u www-data php /var/www/nextcloud/occ $*' > /usr/local/bin/ncc
+			chmod +x /usr/local/bin/ncc
 
 			# Terminal installation:
 			mkdir -p "$FP_DIETPI_USERDATA_DIRECTORY"/nextcloud_data

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9124,7 +9124,7 @@ _EOF_
 			# Apache: https://doc.owncloud.org/server/latest/admin_manual/installation/source_installation.html#configure-apache-web-server
 			if (( ${aSOFTWARE_INSTALL_STATE[83]} >= 1 )); then
 
-				a2enmod rewrite headers env dir mime
+				a2enmod rewrite headers env dir mime &> /dev/null
 				local owncloud_conf='/etc/apache2/sites-available/owncloud.conf'
 				# Do not overwrite existing config.
 				if [ -f $owncloud_conf ]; then
@@ -9136,7 +9136,7 @@ _EOF_
 				sed -i "s/nextcloud/owncloud/g" $owncloud_conf
 				# OPCache adjustment is just forced by Nextcloud
 				sed -i "s/php_admin_value/#php_admin_value/" $owncloud_conf
-				a2ensite owncloud
+				a2ensite owncloud &> /dev/null
 
 			fi
 
@@ -9197,7 +9197,7 @@ _EOF_
 			systemctl start mysql
 			# For MariaDB, temporary database admin user needs to be created, as 'root' uses unix_socket login, which cannot be accessed by sudo -u www-data.
 			mysql -uroot -p"$GLOBAL_PW" -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
-			sudo -u www-data php /var/www/owncloud/occ maintenance:install --no-interaction --database "mysql" --database-name "owncloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$FP_DIETPI_USERDATA_DIRECTORY/owncloud_data"
+			sudo -u www-data php /var/www/owncloud/occ maintenance:install --no-interaction --database "mysql" --database-name "owncloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$FP_DIETPI_USERDATA_DIRECTORY/owncloud_data" 2> /dev/null
 			mysql -uroot -p"$GLOBAL_PW" -e "drop user 'tmp_root'@'localhost'"
 
 			# Adjusting config file:
@@ -9295,7 +9295,7 @@ _EOF_
 			# Apache: https://docs.nextcloud.com/server/12/admin_manual/installation/source_installation.html#apache-web-server-configuration
 			if (( ${aSOFTWARE_INSTALL_STATE[83]} >= 1 )); then
 
-				a2enmod rewrite headers env dir mime
+				a2enmod rewrite headers env dir mime &> /dev/null
 				local nextcloud_conf='/etc/apache2/sites-available/nextcloud.conf'
 				# Do not overwrite existing config.
 				if [ -f $nextcloud_conf ]; then
@@ -9304,7 +9304,7 @@ _EOF_
 
 				fi
 				cp /DietPi/dietpi/conf/apache.ownnextcloud.conf $nextcloud_conf
-				a2ensite nextcloud
+				a2ensite nextcloud &> /dev/null
 
 			fi
 
@@ -9365,7 +9365,7 @@ _EOF_
 			systemctl start mysql
 			# For MariaDB, temporary database admin user needs to be created, as 'root' uses unix_socket login, which cannot be accessed by sudo -u www-data.
 			mysql -uroot -p"$GLOBAL_PW" -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
-			sudo -u www-data php /var/www/nextcloud/occ maintenance:install --no-interaction --database "mysql" --database-name "nextcloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$FP_DIETPI_USERDATA_DIRECTORY/nextcloud_data"
+			sudo -u www-data php /var/www/nextcloud/occ maintenance:install --no-interaction --database "mysql" --database-name "nextcloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$FP_DIETPI_USERDATA_DIRECTORY/nextcloud_data" 2> /dev/null
 			mysql -uroot -p"$GLOBAL_PW" -e "drop user 'tmp_root'@'localhost'"
 
 			# Adjusting config file:
@@ -9428,7 +9428,7 @@ _EOF_
 			sudo -u www-data php /var/www/nextcloud/occ background:cron
 			
 			# Add occ command shortcut, use 'ncc' as 'occ' is reserved for ownCloud:
-			grep -q '/var/www/nextcloud/occ' /etc/bash.bashrc || sed -i "\|alias sudo='sudo '|a alias ncc='sudo -u www-data php /var/www/nextcloud/occ'" >> /etc/bash.bashrc
+			grep -q '/var/www/nextcloud/occ' /etc/bash.bashrc || sed -i "\|alias sudo='sudo '|a alias ncc='sudo -u www-data php /var/www/nextcloud/occ'" /etc/bash.bashrc
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9189,6 +9189,9 @@ _EOF_
 			echo -e '#!/bin/bash\nsudo -u www-data php /var/www/owncloud/occ $*' > /usr/local/bin/occ
 			chmod +x /usr/local/bin/occ
 
+			# Adjusting config file:
+			local config_php="/var/www/owncloud/config/config.php"
+
 			# Terminal installation:
 			mkdir -p "$FP_DIETPI_USERDATA_DIRECTORY"/owncloud_data
 			Install_Apply_Permissions &> /dev/null
@@ -9201,11 +9204,8 @@ _EOF_
 			systemctl start mysql
 			# For MariaDB, temporary database admin user needs to be created, as 'root' uses unix_socket login, which cannot be accessed by sudo -u www-data.
 			mysql -uroot -p"$GLOBAL_PW" -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
-			occ maintenance:install --no-interaction --database "mysql" --database-name "owncloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$FP_DIETPI_USERDATA_DIRECTORY/owncloud_data" 2> /dev/null
+			grep -q "'installed' => true," $config_php 2>/dev/null || occ maintenance:install --no-interaction --database "mysql" --database-name "owncloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$FP_DIETPI_USERDATA_DIRECTORY/owncloud_data"
 			mysql -uroot -p"$GLOBAL_PW" -e "drop user 'tmp_root'@'localhost'"
-
-			# Adjusting config file:
-			local config_php="/var/www/owncloud/config/config.php"
 
 			# Enable MySQL 4-byte support for new installations only, to prevent risky database conversion tasks:
 			if (( $oc_is_fresh == 1 )); then
@@ -9262,7 +9262,7 @@ _EOF_
 			sed -i "/memory_limit=/c\memory_limit=$memory_limit_max" /var/www/owncloud/.user.ini
 
 			# Enable ownCloud background cron job:
-			crontab -u www-data -l 2>/dev/null | grep -q '/var/www/owncloud/cron.php' || echo "*/15 * * * * php /var/www/owncloud/cron.php" | crontab -u www-data -
+			crontab -u www-data -l 2>/dev/null | grep -q '/var/www/owncloud/cron.php' || ( crontab -u www-data -l 2>/dev/null ; echo "*/15 * * * * php /var/www/owncloud/cron.php" ) | crontab -u www-data -
 			occ background:cron
 
 			# Enable maintenance mode to allow handling by dietpi-services:
@@ -9360,6 +9360,9 @@ _EOF_
 			echo -e '#!/bin/bash\nsudo -u www-data php /var/www/nextcloud/occ $*' > /usr/local/bin/ncc
 			chmod +x /usr/local/bin/ncc
 
+			# Adjusting config file:
+			local config_php="/var/www/nextcloud/config/config.php"
+
 			# Terminal installation:
 			mkdir -p "$FP_DIETPI_USERDATA_DIRECTORY"/nextcloud_data
 			Install_Apply_Permissions &> /dev/null
@@ -9372,11 +9375,8 @@ _EOF_
 			systemctl start mysql
 			# For MariaDB, temporary database admin user needs to be created, as 'root' uses unix_socket login, which cannot be accessed by sudo -u www-data.
 			mysql -uroot -p"$GLOBAL_PW" -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
-			ncc maintenance:install --no-interaction --database "mysql" --database-name "nextcloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$FP_DIETPI_USERDATA_DIRECTORY/nextcloud_data" 2> /dev/null
+			grep -q "'installed' => true," $config_php 2>/dev/null || ncc maintenance:install --no-interaction --database "mysql" --database-name "nextcloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$FP_DIETPI_USERDATA_DIRECTORY/nextcloud_data"
 			mysql -uroot -p"$GLOBAL_PW" -e "drop user 'tmp_root'@'localhost'"
-
-			# Adjusting config file:
-			local config_php="/var/www/nextcloud/config/config.php"
 
 			# Enable MySQL 4-byte support for new installations only, to prevent risky database conversion tasks:
 			if (( $nc_is_fresh == 1 )); then
@@ -9431,7 +9431,7 @@ _EOF_
 			sed -i "/memory_limit=/c\memory_limit=$memory_limit_max" /var/www/nextcloud/.user.ini
 
 			# Enable Nextcloud background cron job:
-			crontab -u www-data -l 2>/dev/null | grep -q '/var/www/nextcloud/cron.php' || echo "*/15 * * * * php /var/www/nextcloud/cron.php" | crontab -u www-data -
+			crontab -u www-data -l 2>/dev/null | grep -q '/var/www/nextcloud/cron.php' || ( crontab -u www-data -l 2>/dev/null ; echo "*/15 * * * * php /var/www/nextcloud/cron.php" ) | crontab -u www-data -
 			ncc background:cron
 
 			# Enable maintenance mode to allow handling by dietpi-services:

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9369,7 +9369,7 @@ _EOF_
 			systemctl start mysql
 			# For MariaDB, temporary database admin user needs to be created, as 'root' uses unix_socket login, which cannot be accessed by sudo -u www-data.
 			mysql -uroot -p"$GLOBAL_PW" -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
-			occ maintenance:install --no-interaction --database "mysql" --database-name "nextcloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$FP_DIETPI_USERDATA_DIRECTORY/nextcloud_data" 2> /dev/null
+			ncc maintenance:install --no-interaction --database "mysql" --database-name "nextcloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$FP_DIETPI_USERDATA_DIRECTORY/nextcloud_data" 2> /dev/null
 			mysql -uroot -p"$GLOBAL_PW" -e "drop user 'tmp_root'@'localhost'"
 
 			# Adjusting config file:
@@ -9429,7 +9429,7 @@ _EOF_
 
 			# Enable Nextcloud background cron job:
 			crontab -u www-data -l 2>/dev/null | grep -q '/var/www/nextcloud/cron.php' || echo "*/15 * * * * php /var/www/nextcloud/cron.php" | crontab -u www-data -
-			occ background:cron
+			ncc background:cron
 
 		fi
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -2788,6 +2788,10 @@ _EOF_
 		update-rc.d ympd remove &> /dev/null # switch to systemD
 		rm /etc/init.d/ympd &> /dev/null # switch to systemD
 
+		# Enable ownCloud/Nextcloud maintenance mode before reinstall:
+		sudo -u www-data php /var/www/owncloud/occ maintenance:mode --on &> /dev/null
+		sudo -u www-data php /var/www/nextcloud/occ maintenance:mode --on &> /dev/null
+
 		/DietPi/dietpi/dietpi-software reinstall 159 128 114 47 36 32
 		#-------------------------------------------------------------------------------
 		#RPi update DietPi kernel:


### PR DESCRIPTION
- Enable maintenance mode before reinstallation via patchfile to suppress error caused by stopped MySQL.
- Suppress Apache2 messaged about already enabled modules and sites.
- Suppress `occ maintenance:install` error message, if instance is already installed.
- Fixed typo about ncc command.
- Intelligent handling of maintenance mode during dietpi-services.
- Main folders should be removed after mysql user dropping, otherwise we can't find user names.
- Correctly "add" cronjob, instead of overwrite.