### PR TITLE
DietPi-Software | MariaDB as new default and remove MySQL option on Stretch

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1910,6 +1910,12 @@ _EOF_
 			aSOFTWARE_CATEGORY_INDEX[$index_current]=13
 					  aSOFTWARE_TYPE[$index_current]=0
 			 aSOFTWARE_ONLINEDOC_URL[$index_current]='f=8&t=5&start=10#p52'
+		# - Stretch only
+		if (( $DISTRO < 4 )); then
+
+			aSOFTWARE_AVAIL_HW_MODEL[$index_current,$HW_MODEL]=0
+
+		fi
 
 		#------------------
 		index_current=75
@@ -1937,6 +1943,12 @@ _EOF_
 			aSOFTWARE_CATEGORY_INDEX[$index_current]=13
 					  aSOFTWARE_TYPE[$index_current]=0
 			 aSOFTWARE_ONLINEDOC_URL[$index_current]='f=8&t=5#p5'
+		# - Stretch only
+		if (( $DISTRO < 4 )); then
+
+			aSOFTWARE_AVAIL_HW_MODEL[$index_current,$HW_MODEL]=0
+
+		fi
 
 		#------------------
 		index_current=78
@@ -1964,6 +1976,12 @@ _EOF_
 			aSOFTWARE_CATEGORY_INDEX[$index_current]=13
 					  aSOFTWARE_TYPE[$index_current]=0
 			 aSOFTWARE_ONLINEDOC_URL[$index_current]='f=8&t=5&p=1335#p1335'
+		# - Stretch only
+		if (( $DISTRO < 4 )); then
+
+			aSOFTWARE_AVAIL_HW_MODEL[$index_current,$HW_MODEL]=0
+
+		fi
 
 		#------------------
 		index_current=81
@@ -2018,6 +2036,12 @@ _EOF_
 			aSOFTWARE_CATEGORY_INDEX[$index_current]=13
 					  aSOFTWARE_TYPE[$index_current]=-1
 			 aSOFTWARE_ONLINEDOC_URL[$index_current]='f=8&t=5&p=1335#p1335'
+		# - Stretch only
+		if (( $DISTRO < 4 )); then
+
+			aSOFTWARE_AVAIL_HW_MODEL[$index_current,$HW_MODEL]=0
+
+		fi
 
 		#------------------
 		index_current=87
@@ -2957,10 +2981,10 @@ _EOF_
 				if (( ! ${aSOFTWARE_INSTALL_STATE[86]} &&
 					! ${aSOFTWARE_INSTALL_STATE[88]} )); then
 
-					#WEBSERVER_MYSQL
-					aSOFTWARE_INSTALL_STATE[86]=1
+					#WEBSERVER_MARIADB as new default
+					aSOFTWARE_INSTALL_STATE[88]=1
 
-					/DietPi/dietpi/func/dietpi-notify 2 "MySQL will be installed"
+					/DietPi/dietpi/func/dietpi-notify 2 "MariaDB will be installed"
 
 				fi
 
@@ -3092,8 +3116,8 @@ _EOF_
 			#	Both selected for install, disable Maria
 			else
 
-				aSOFTWARE_INSTALL_STATE[88]=0
-				/DietPi/dietpi/func/dietpi-notify 2 "MySQL and MariaDB are selected for install. MariaDB has been de-selected to prevent incompatible MySQL + MariaDB installation"
+				aSOFTWARE_INSTALL_STATE[86]=0
+				/DietPi/dietpi/func/dietpi-notify 2 "MySQL and MariaDB are selected for install. MySQL has been de-selected to prevent incompatible MySQL + MariaDB installation"
 
 			fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3113,7 +3113,7 @@ _EOF_
 				aSOFTWARE_INSTALL_STATE[86]=0
 				/DietPi/dietpi/func/dietpi-notify 2 "MariaDB is already installed, MySQL install has been disabled"
 
-			#	Both selected for install, disable Maria
+			#	Both selected for install, disable MySQL
 			else
 
 				aSOFTWARE_INSTALL_STATE[86]=0

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1910,8 +1910,8 @@ _EOF_
 			aSOFTWARE_CATEGORY_INDEX[$index_current]=13
 					  aSOFTWARE_TYPE[$index_current]=0
 			 aSOFTWARE_ONLINEDOC_URL[$index_current]='f=8&t=5&start=10#p52'
-		# - Stretch only
-		if (( $DISTRO < 4 )); then
+		# - disable on Stretch
+		if (( $DISTRO >= 4 )); then
 
 			aSOFTWARE_AVAIL_HW_MODEL[$index_current,$HW_MODEL]=0
 
@@ -1943,8 +1943,8 @@ _EOF_
 			aSOFTWARE_CATEGORY_INDEX[$index_current]=13
 					  aSOFTWARE_TYPE[$index_current]=0
 			 aSOFTWARE_ONLINEDOC_URL[$index_current]='f=8&t=5#p5'
-		# - Stretch only
-		if (( $DISTRO < 4 )); then
+		# - disable on Stretch
+		if (( $DISTRO >= 4 )); then
 
 			aSOFTWARE_AVAIL_HW_MODEL[$index_current,$HW_MODEL]=0
 
@@ -1976,8 +1976,8 @@ _EOF_
 			aSOFTWARE_CATEGORY_INDEX[$index_current]=13
 					  aSOFTWARE_TYPE[$index_current]=0
 			 aSOFTWARE_ONLINEDOC_URL[$index_current]='f=8&t=5&p=1335#p1335'
-		# - Stretch only
-		if (( $DISTRO < 4 )); then
+		# - disable on Stretch
+		if (( $DISTRO >= 4 )); then
 
 			aSOFTWARE_AVAIL_HW_MODEL[$index_current,$HW_MODEL]=0
 
@@ -2036,8 +2036,8 @@ _EOF_
 			aSOFTWARE_CATEGORY_INDEX[$index_current]=13
 					  aSOFTWARE_TYPE[$index_current]=-1
 			 aSOFTWARE_ONLINEDOC_URL[$index_current]='f=8&t=5&p=1335#p1335'
-		# - Stretch only
-		if (( $DISTRO < 4 )); then
+		# - disable on Stretch
+		if (( $DISTRO >= 4 )); then
 
 			aSOFTWARE_AVAIL_HW_MODEL[$index_current,$HW_MODEL]=0
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3797,9 +3797,6 @@ _EOF_
 
 			Banner_Installing
 
-			debconf-set-selections <<< "mysql-server mysql-server/root_password password $GLOBAL_PW"
-			debconf-set-selections <<< "mysql-server mysql-server/root_password_again password $GLOBAL_PW"
-
 			AGI mariadb-server
 
 		fi
@@ -13056,7 +13053,7 @@ _EOF_
 
 		elif (( $1 == 86 || $i == 88 )); then
 
-			AGP mysql-server
+			AGP mysql-server mysql-client
 
 			AGP mariadb-server mariadb-client
 


### PR DESCRIPTION
https://github.com/Fourdee/DietPi/issues/1269
https://github.com/Fourdee/DietPi/issues/1032#issuecomment-312274155
https://github.com/Fourdee/DietPi/issues/894

We could think about force migration via patchfile or encourage people to do it. It is still easily possible (did it by myself some months ago) and should be harmless: https://mariadb.com/de/node/546