### PR TITLE
DietPi-Prep | PREP_SYSTEM_FOR_DIETPI.sh fixes

### DIFF
--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -1244,18 +1244,19 @@ _EOF_
 systemctl disable dietpi-fs_partition_resize.service
 systemctl daemon-reload
 
-TARGET_PARTITION=\$(findmnt / -o source -n | sed 's/.*p//')
 TARGET_DEV=\$(findmnt / -o source -n)
 
 # - MMCBLK[0-9]p[0-9] scrape
 if [[ "\$TARGET_DEV" = *"mmcblk"* ]]; then
 
     TARGET_DEV=\$(findmnt / -o source -n | sed 's/p[0-9]\$//')
+    TARGET_PARTITION=\$(findmnt / -o source -n | sed 's/.*p//')
 
 # - Everything else scrape (eg: /dev/sdX[0-9])
 else
 
     TARGET_DEV=\$(findmnt / -o source -n | sed 's/[0-9]\$//')
+    TARGET_PARTITION=\$(findmnt / -o source -n | sed 's|/dev/sd.||')
 
 fi
 


### PR DESCRIPTION
https://github.com/Fourdee/DietPi/issues/1285#issuecomment-351830101
+ Add apt-transport-https as initial script dependency, as RPi uses already https sources.
+ Switched sources to new default debian https mirrordirector, but http for Jessie.
+ Fixed UEFI detection. In case stay with installed grub package, as this obviously works, otherwise install based on /boot/efi.
+ Check for cmdline.txt before edit. But better to put this into HW_MODEL dependent statement.
+ Could do the same for /etc/dietpi/.* but actually the whole folder is removed at the beginning, thus this can't even exist?
+ Fixed partition resizing for /dev/sdX drives.