### PR TITLE
DietPi-Software | ownCloud/Nextcloud: Jessie+MariaDB fix and optional datadir

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ DietPi-Globals | Global variables and functions are now exported during login. P
 DietPi-Set_Hardware | Sparky SBC: enable aotg.aotg1_speed compatibility setting for USB 1.1, when USB-DAC configured: https://github.com/Fourdee/DietPi/issues/1301
 DietPi-Software | NAA Daemon: Updated to latest (3.5.2-36). Existing installs will be patched automatically: https://github.com/Fourdee/DietPi/issues/1305
 DietPi-Software | PHP-FPM: Increased from "$CPU_CORES_TOTAL" to "pm.max_children = $(( $CPU_CORES_TOTAL * 3 ))". This should avoid failed forking of PHP-FPM processes/requests : https://github.com/Fourdee/DietPi/issues/1298
+DietPi-Software | ownCloud/Nextcloud: Added option to choose data directory via dietpi.txt pre installation: https://github.com/Fourdee/DietPi/issues/1314#issuecomment-352782055
 
 Bug Fixes:
 DietPi-Services | dietpi-wifi-monitor: Is no longer controlled, to prevent WiFi drop during software installs/updates etc: https://github.com/Fourdee/DietPi/issues/1288#issuecomment-350653480
@@ -20,6 +21,7 @@ DietPi-Software | Plex Media Server: Resolved uninstall to include /var/lib/plex
 DietPi-Software | MariaDB: Resolved an issue where MariaDB would fail to uninstall correctly: https://github.com/Fourdee/DietPi/pull/1280
 DietPi-Software | Aira2 (Stretch): Resolved installation, now used APT installation: https://github.com/Fourdee/DietPi/issues/1310
 DietPi-Software | Mosquitto (Stretch): Resolved issue with failed install, due to unavailable pre-req libs in Debian/Mosq repos: https://github.com/Fourdee/DietPi/issues/1306
+DietPi-Software | ownCloud/Nextcloud: Fixed an installation issue on Jessie with MariaDB: https://github.com/Fourdee/DietPi/pull/1319
 DietPi-Update | dietpi.txt is now checked for missing entries, and, will now be patched during the update: https://github.com/Fourdee/DietPi/issues/1292#issuecomment-350818969
 Sparky SBC | Kernel patch will be applied which resolves issues with HQPlayer playback: https://www.computeraudiophile.com/forums/topic/32132-allo-sparky-usbridge/?do=findComment&comment=753100
 

--- a/dietpi.txt
+++ b/dietpi.txt
@@ -210,8 +210,11 @@ dietpi_vncserver_shared_desktop=0
 #Optional username for ownCloud/Nextcloud admin account, default is 'admin'. Applied during installation.
 dietpi_ownnextcloud_username=admin
 
-#Optional data directory for ownCloud/Nextcloud, default is '/mnt/dietpi_userdata'. Applied during installation.
-dietpi_ownnextcloud_datadir=$FP_DIETPI_USERDATA
+#Optional data directory for ownCloud, default is '/mnt/dietpi_userdata/owncloud_data'. Applied during installation.
+dietpi_owncloud_datadir=$FP_DIETPI_USERDATA/owncloud_data
+
+#Optional data directory for Nextcloud, default is '/mnt/dietpi_userdata/nextcloud_data'. Applied during installation.
+dietpi_nextcloud_datadir=$FP_DIETPI_USERDATA/nextcloud_data
 
 #------------------------------------------------------------------------------------------------------
 # D I E T - P I

--- a/dietpi.txt
+++ b/dietpi.txt
@@ -207,8 +207,11 @@ dietpi_vncserver_depth=16
 dietpi_vncserver_display=1
 dietpi_vncserver_shared_desktop=0
 
-#Optional username for nextcloud admin account, default is admin. Applied during installation.
-dietpi_nextcloud_username=admin
+#Optional username for ownCloud/Nextcloud admin account, default is 'admin'. Applied during installation.
+dietpi_ownnextcloud_username=admin
+
+#Optional data directory for ownCloud/Nextcloud, default is '/mnt/dietpi_userdata'. Applied during installation.
+dietpi_ownnextcloud_datadir=$FP_DIETPI_USERDATA
 
 #------------------------------------------------------------------------------------------------------
 # D I E T - P I

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9303,20 +9303,21 @@ _EOF_
 			local config_php='/var/www/owncloud/config/config.php'
 
 			# Terminal installation:
-			mkdir -p "$FP_DIETPI_USERDATA"/owncloud_data
+			local datadir=$(cat /DietPi/dietpi.txt | grep -m1 '^dietpi_owncloud_datadir=' | sed 's/.*=//')
+			[ ! -n "$datadir" ] && datadir="$FP_DIETPI_USERDATA/owncloud_data"
+			mkdir -p "$datadir"
+			chown -R www-data:www-data "$datadir"
 			Install_Apply_Permissions &> /dev/null
-			local username=$(cat /DietPi/dietpi.txt | grep -m1 '^dietpi_nextcloud_username=' | sed 's/.*=//')
-			if [ ! -n "$username" ]; then
 
-				username='admin'
+			local username=$(cat /DietPi/dietpi.txt | grep -m1 '^dietpi_ownnextcloud_username=' | sed 's/.*=//')
+			[ ! -n "$username" ] && username='admin'
 
-			fi
 			systemctl start mysql
 			# For MariaDB, temporary database admin user needs to be created, as 'root' uses unix_socket login, which cannot be accessed by sudo -u www-data.
 			local mysql_cmd='mysql -uroot'
 			(( ${aSOFTWARE_INSTALL_STATE[86]} >= 1 )) && mysql_cmd+=" -p$GLOBAL_PW"
 			$mysql_cmd -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
-			grep -q "'installed' => true," $config_php 2>/dev/null || occ maintenance:install --no-interaction --database "mysql" --database-name "owncloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$FP_DIETPI_USERDATA/owncloud_data"
+			grep -q "'installed' => true," $config_php 2>/dev/null || occ maintenance:install --no-interaction --database "mysql" --database-name "owncloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$datadir"
 			$mysql_cmd -e "drop user 'tmp_root'@'localhost'"
 
 			# Enable MySQL 4-byte support for new installations only, to prevent risky database conversion tasks:
@@ -9478,20 +9479,21 @@ _EOF_
 			local config_php='/var/www/nextcloud/config/config.php'
 
 			# Terminal installation:
-			mkdir -p "$FP_DIETPI_USERDATA"/nextcloud_data
+			local datadir=$(cat /DietPi/dietpi.txt | grep -m1 '^dietpi_nextcloud_datadir=' | sed 's/.*=//')
+			[ ! -n "$datadir" ] && datadir="$FP_DIETPI_USERDATA/nextcloud_data"
+			mkdir -p "$datadir"
+			chown -R www-data:www-data "$datadir"
 			Install_Apply_Permissions &> /dev/null
-			local username=$(cat /DietPi/dietpi.txt | grep -m1 '^dietpi_nextcloud_username=' | sed 's/.*=//')
-			if [ ! -n "$username" ]; then
 
-				username='admin'
+			local username=$(cat /DietPi/dietpi.txt | grep -m1 '^dietpi_ownnextcloud_username=' | sed 's/.*=//')
+			[ ! -n "$username" ] && username='admin'
 
-			fi
 			systemctl start mysql
 			# For MariaDB, temporary database admin user needs to be created, as 'root' uses unix_socket login, which cannot be accessed by sudo -u www-data.
 			local mysql_cmd='mysql -uroot'
 			(( ${aSOFTWARE_INSTALL_STATE[86]} >= 1 )) && mysql_cmd+=" -p$GLOBAL_PW"
 			$mysql_cmd -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
-			grep -q "'installed' => true," $config_php 2>/dev/null || ncc maintenance:install --no-interaction --database "mysql" --database-name "nextcloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$FP_DIETPI_USERDATA/nextcloud_data"
+			grep -q "'installed' => true," $config_php 2>/dev/null || ncc maintenance:install --no-interaction --database "mysql" --database-name "nextcloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$datadir"
 			$mysql_cmd -e "drop user 'tmp_root'@'localhost'"
 
 			# Enable MySQL 4-byte support for new installations only, to prevent risky database conversion tasks:

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8702,8 +8702,14 @@ _EOF_
 		# - www-data
 		chown -R www-data:www-data "$FP_DIETPI_USERDATA"/dietpicam
 		chown -R www-data:www-data "$FP_DIETPI_USERDATA"/pydio_data
-		chown -R www-data:www-data "$FP_DIETPI_USERDATA"/owncloud_data
-		chown -R www-data:www-data "$FP_DIETPI_USERDATA"/nextcloud_data
+		
+		local datadir=$(cat /DietPi/dietpi.txt | grep -m1 '^dietpi_owncloud_datadir=' | sed 's/.*=//')
+		[ ! -n "$datadir" ] && datadir="$FP_DIETPI_USERDATA/owncloud_data"
+		chown -R www-data:www-data "$datadir"
+		
+		datadir=$(cat /DietPi/dietpi.txt | grep -m1 '^dietpi_nextcloud_datadir=' | sed 's/.*=//')
+		[ ! -n "$datadir" ] && datadir="$FP_DIETPI_USERDATA/nextcloud_data"
+		chown -R www-data:www-data "$datadir"
 
 		# - Home Assistant Permissions
 		#chown -R homeassistant:dietpi /home/homeassistant/.homeassistant
@@ -9306,7 +9312,6 @@ _EOF_
 			local datadir=$(cat /DietPi/dietpi.txt | grep -m1 '^dietpi_owncloud_datadir=' | sed 's/.*=//')
 			[ ! -n "$datadir" ] && datadir="$FP_DIETPI_USERDATA/owncloud_data"
 			mkdir -p "$datadir"
-			chown -R www-data:www-data "$datadir"
 			Install_Apply_Permissions &> /dev/null
 
 			local username=$(cat /DietPi/dietpi.txt | grep -m1 '^dietpi_ownnextcloud_username=' | sed 's/.*=//')
@@ -9482,7 +9487,6 @@ _EOF_
 			local datadir=$(cat /DietPi/dietpi.txt | grep -m1 '^dietpi_nextcloud_datadir=' | sed 's/.*=//')
 			[ ! -n "$datadir" ] && datadir="$FP_DIETPI_USERDATA/nextcloud_data"
 			mkdir -p "$datadir"
-			chown -R www-data:www-data "$datadir"
 			Install_Apply_Permissions &> /dev/null
 
 			local username=$(cat /DietPi/dietpi.txt | grep -m1 '^dietpi_ownnextcloud_username=' | sed 's/.*=//')

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9313,9 +9313,11 @@ _EOF_
 			fi
 			systemctl start mysql
 			# For MariaDB, temporary database admin user needs to be created, as 'root' uses unix_socket login, which cannot be accessed by sudo -u www-data.
-			mysql -uroot -p"$GLOBAL_PW" -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
+			local mysql_cmd='mysql -uroot'
+			(( ${aSOFTWARE_INSTALL_STATE[86]} >= 1 )) && mysql_cmd+=" -p$GLOBAL_PW"
+			$mysql_cmd -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
 			grep -q "'installed' => true," $config_php 2>/dev/null || occ maintenance:install --no-interaction --database "mysql" --database-name "owncloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$FP_DIETPI_USERDATA/owncloud_data"
-			mysql -uroot -p"$GLOBAL_PW" -e "drop user 'tmp_root'@'localhost'"
+			$mysql_cmd -e "drop user 'tmp_root'@'localhost'"
 
 			# Enable MySQL 4-byte support for new installations only, to prevent risky database conversion tasks:
 			if (( $oc_is_fresh == 1 )); then
@@ -9486,9 +9488,11 @@ _EOF_
 			fi
 			systemctl start mysql
 			# For MariaDB, temporary database admin user needs to be created, as 'root' uses unix_socket login, which cannot be accessed by sudo -u www-data.
-			mysql -uroot -p"$GLOBAL_PW" -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
+			local mysql_cmd='mysql -uroot'
+			(( ${aSOFTWARE_INSTALL_STATE[86]} >= 1 )) && mysql_cmd+=" -p$GLOBAL_PW"
+			$mysql_cmd -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
 			grep -q "'installed' => true," $config_php 2>/dev/null || ncc maintenance:install --no-interaction --database "mysql" --database-name "nextcloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$FP_DIETPI_USERDATA/nextcloud_data"
-			mysql -uroot -p"$GLOBAL_PW" -e "drop user 'tmp_root'@'localhost'"
+			$mysql_cmd -e "drop user 'tmp_root'@'localhost'"
 
 			# Enable MySQL 4-byte support for new installations only, to prevent risky database conversion tasks:
 			if (( $nc_is_fresh == 1 )); then
@@ -13370,10 +13374,12 @@ _EOF_
 			rm /etc/nginx/sites-dietpi/owncloud.config 2>/dev/null
 			# Drop MySQL/MariaDB user and database
 			systemctl start mysql
-			mysql -uroot -p"$GLOBAL_PW" -e "drop user $(grep -m1 "'dbuser'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")@$(grep -m1 "'dbhost'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")"
-			mysql -uroot -p"$GLOBAL_PW" -e "drop user $(grep -m1 "'dbuser'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")"
-			mysqldump --lock-tables -uroot -p"$GLOBAL_PW" owncloud > "$FP_DIETPI_USERDATA"/owncloud_data/mysql_backup.sql
-			mysqladmin -u root -p"$GLOBAL_PW" drop owncloud -f
+			local mysql_auth='-uroot'
+			(( ${aSOFTWARE_INSTALL_STATE[86]} >= 1 )) && mysql_auth+=" -p$GLOBAL_PW"
+			mysql "$mysql_auth" -e "drop user $(grep -m1 "'dbuser'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")@$(grep -m1 "'dbhost'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")"
+			mysql "$mysql_auth" -e "drop user $(grep -m1 "'dbuser'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")"
+			mysqldump --lock-tables "$mysql_auth" owncloud > "$FP_DIETPI_USERDATA"/owncloud_data/mysql_backup.sql
+			mysqladmin "$mysql_auth" drop owncloud -f
 			# Purge APT package
 			AGP_ERROR_CHECKED owncloud-files owncloud owncloud-deps
 			# Remove ownCloud installation folder
@@ -13393,10 +13399,12 @@ _EOF_
 			rm /etc/nginx/sites-dietpi/nextcloud.config 2>/dev/null
 			# Drop MySQL/MariaDB user and database
 			systemctl start mysql
-			mysql -uroot -p"$GLOBAL_PW" -e "drop user $(grep -m1 "'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")@$(grep -m1 "'dbhost'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")"
-			mysql -uroot -p"$GLOBAL_PW" -e "drop user $(grep -m1 "'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")"
-			mysqldump --lock-tables -uroot -p"$GLOBAL_PW" nextcloud > "$FP_DIETPI_USERDATA"/nextcloud_data/mysql_backup.sql
-			mysqladmin -u root -p"$GLOBAL_PW" drop nextcloud -f
+			local mysql_auth='-uroot'
+			(( ${aSOFTWARE_INSTALL_STATE[86]} >= 1 )) && mysql_auth+=" -p$GLOBAL_PW"
+			mysql "$mysql_auth" -e "drop user $(grep -m1 "'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")@$(grep -m1 "'dbhost'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")"
+			mysql "$mysql_auth" -e "drop user $(grep -m1 "'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")"
+			mysqldump --lock-tables "$mysql_auth" nextcloud > "$FP_DIETPI_USERDATA"/nextcloud_data/mysql_backup.sql
+			mysqladmin "$mysql_auth" drop nextcloud -f
 			# Remove Nextcloud installation folder
 			rm -R /var/www/nextcloud
 


### PR DESCRIPTION
... as on Jessie, MariaDB (with unix_socket authentication enabled) does not only ignore the password, but denies access, if password option is used.

We're any  going to drop Jessie support, but until that, this should be kept in mind, if other errors including mysql command appear.

We could also introduce a global `MYSQL_AUTH` variable for this, if the problem might occur on enough other software. Jessie + MariaDB seems to be rare at the moment, but could rise, as we chose MariaDB by default since v160!