### PR TITLE
DietPi-Software | PHP: Fix php-xsl installation

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3809,7 +3809,9 @@ _EOF_
 
 			else
 
-				AGI_ERROR_CHECKED "$PHP_APT_PACKAGE_NAME"-fpm "$PHP_APT_PACKAGE_NAME"-cgi "$PHP_APT_PACKAGE_NAME"-xsl
+				AGI_ERROR_CHECKED "$PHP_APT_PACKAGE_NAME"-fpm "$PHP_APT_PACKAGE_NAME"-cgi
+				# 'php-xsl' does not exist for >= Stretch, 'php7.0-xsl' is just dummy for 'php7.0-xml': https://github.com/Fourdee/DietPi/issues/1286 
+				(( $DISTRO < 4 )) && AGI_ERROR_CHECKED php5-xsl
 
 			fi
 
@@ -3850,7 +3852,7 @@ _EOF_
 
 			fi
 
-			#Redis php module | >= 1 to check for existing installs (2)
+			#Redis php module
 			if (( ${aSOFTWARE_INSTALL_STATE[91]} >= 1 )); then
 
 				AGI_ERROR_CHECKED "$PHP_APT_PACKAGE_NAME"-redis


### PR DESCRIPTION
https://github.com/Fourdee/DietPi/issues/1286

Additional:
- Otherwise remove the package completely?
- Do we actually need php-cgi as it is superseded by php-fpm?
- Just checked, that PiHole e.g. seems to need it, but will install it on demand. 

=> In the end it is a bid similar to the nginx-light / xml-core question, so better leave it for now.
