### PR TITLE
DietPi-Software |  Fix HAProxy installation on Stretch+

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5398,7 +5398,7 @@ _EOF_
 				cd haproxy-*
 
 				#Pre-reqs
-				AGI_ERROR_HANDLED libpcre3-dev libssl-dev
+				AGI_ERROR_HANDLED libpcre3-dev libssl-dev zlib1g-dev
 				#Compile and install
 				make -j $G_HW_CPU_CORES TARGET=linux2628 CPU=generic USE_PCRE=1 USE_OPENSSL=1 USE_ZLIB=1 USE_LINUX_SPLICE=1
 				make install


### PR DESCRIPTION
+ DietPi-Software |  Fix HAProxy installation on Stretch+

HAProxy build depends on `zlib1g-dev`, which is not dependency of `libssl-dev` anymore since Stretch: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=844888#10

Solution is, other than mention in the link, not to install `libssl1.0-dev`, which also does not depend on zlib anymore on Stretch. Install `zlib1g-dev` directly does the trick.