### PR TITLE
DietPi-Software | ownCloud/Nextcloud: Enable pretty URLs (without index.php)  on Apache

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9328,6 +9328,14 @@ _EOF_
 
 			# Set CLI URL to ownCloud sub directory:
 			sed -i "s|'http://localhost'|'http://localhost/owncloud'|g" $config_php
+			
+			# Set pretty URLs (without /index.php/) on Apache:
+			if (( ${aSOFTWARE_INSTALL_STATE[83]} >= 1 )); then
+
+				grep -q "^\s*'htaccess.RewriteBase' => '" $config_php || sed -i "/^\s*'overwrite.cli.url' => '/a \ \ 'htaccess.RewriteBase' => '/owncloud'," $config_php
+				occ maintenance:update:htaccess
+
+			fi
 
 			# APCu Memcache
 			if (( ! $(cat $config_php | grep -ci -m1 "'memcache.local'") )); then
@@ -9371,7 +9379,7 @@ _EOF_
 			occ background:cron
 
 			# Enable maintenance mode to allow handling by dietpi-services:
-			grep -q "'maintenance' => true," $config_php &>/dev/null || occ maintenance:mode --on
+			grep -q "'maintenance' => true," $config_php || occ maintenance:mode --on
 
 		fi
 
@@ -9502,6 +9510,14 @@ _EOF_
 			# Set CLI URL to Nextcloud sub directory:
 			sed -i "s|'http://localhost'|'http://localhost/nextcloud'|g" $config_php
 
+			# Set pretty URLs (without /index.php/) on Apache:
+			if (( ${aSOFTWARE_INSTALL_STATE[83]} >= 1 )); then
+
+				grep -q "^\s*'htaccess.RewriteBase' => '" $config_php || sed -i "/^\s*'overwrite.cli.url' => '/a \ \ 'htaccess.RewriteBase' => '/nextcloud'," $config_php
+				ncc maintenance:update:htaccess
+
+			fi
+
 			# APCu Memcache
 			if (( ! $(cat $config_php | grep -ci -m1 "'memcache.local'") )); then
 
@@ -9544,7 +9560,7 @@ _EOF_
 			ncc background:cron
 
 			# Enable maintenance mode to allow handling by dietpi-services:
-			grep -q "'maintenance' => true," $config_php &>/dev/null || ncc maintenance:mode --on
+			grep -q "'maintenance' => true," $config_php || ncc maintenance:mode --on
 
 		fi
 


### PR DESCRIPTION
After Nextcloud 13 release, we can also do this on Nginx (and potentially Lighttpd).

Tested on RPi2 Stretch and VM Jessie, method well known and provided on OC/NC documentations: https://doc.owncloud.org/server/latest/admin_manual/configuration/server/index_php_less_urls.html