### PR TITLE
DietPi-Software | ownCloud/Nextcloud: Fix HTTPS check for Nginx

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9228,7 +9228,7 @@ _EOF_
 			# Apache: https://doc.owncloud.org/server/latest/admin_manual/installation/source_installation.html#configure-apache-web-server
 			if (( ${aSOFTWARE_INSTALL_STATE[83]} >= 1 )); then
 
-				a2enmod rewrite headers env dir mime &> /dev/null
+				a2enmod rewrite headers env dir mime 1> /dev/null
 				local owncloud_conf='/etc/apache2/sites-available/owncloud.conf'
 				# Do not overwrite existing config.
 				if [ -f $owncloud_conf ]; then
@@ -9240,7 +9240,7 @@ _EOF_
 				sed -i 's/nextcloud/owncloud/g' $owncloud_conf
 				# OPcache adjustment is just asked by Nextcloud
 				sed -i 's/php_admin_value/#php_admin_value/' $owncloud_conf
-				a2ensite owncloud &> /dev/null
+				a2ensite owncloud 1> /dev/null
 
 			fi
 
@@ -9265,7 +9265,7 @@ _EOF_
 				fi
 
 				# Set HTTPS on, if SSL connection is available, even with self-signed/untrusted certificate.
-				DietPi/dietpi/func/check_connection https://localhost &> /dev/null
+				wget -q --spider --timeout=10 --tries=2 https://localhost &> /dev/null
 				if (( $? == 0 || $? == 5)); then
 
 					sed -i 's/#fastcgi_param HTTPS on;/fastcgi_param HTTPS on;/g' $owncloud_config
@@ -9316,7 +9316,7 @@ _EOF_
 			# Enable MySQL 4-byte support for new installations only, to prevent risky database conversion tasks:
 			if (( $oc_is_fresh == 1 )); then
 
-				grep -q "'mysql.utf8mb4' => " $config_php || sed -i "/'dbpassword'/a \ \ 'mysql.utf8mb4' => true," $config_php
+				grep -q "^[[:blank:]]*'mysql.utf8mb4'" $config_php || sed -i "/^[[:blank:]]*'dbpassword'/a \ \ 'mysql.utf8mb4' => true," $config_php
 
 			fi
 
@@ -9335,25 +9335,21 @@ _EOF_
 			# Set pretty URLs (without /index.php/) on Apache:
 			if (( ${aSOFTWARE_INSTALL_STATE[83]} >= 1 )); then
 
-				grep -q "^\s*'htaccess.RewriteBase' => '" $config_php || sed -i "/^\s*'overwrite.cli.url' => '/a \ \ 'htaccess.RewriteBase' => '/owncloud'," $config_php
+				grep -q "^[[:blank:]]*'htaccess.RewriteBase'" $config_php || sed -i "/^[[:blank:]]*'overwrite.cli.url'/a \ \ 'htaccess.RewriteBase' => '/owncloud'," $config_php
 				occ maintenance:update:htaccess
 
 			fi
 
 			# APCu Memcache
-			if (( ! $(cat $config_php | grep -ci -m1 "'memcache.local'") )); then
-
-				sed -i "/'version'/a 'memcache.local' => '\\\OC\\\Memcache\\\APCu'," $config_php
-
-			fi
+			grep -q "^[[:blank:]]*'memcache.local'" $config_php || sed -i "/^[[:blank:]]*'version'/a \ \ 'memcache.local' => '\\\OC\\\Memcache\\\APCu'," $config_php
 
 			# Redis for transactional file locking:
 			# https://doc.owncloud.org/server/latest/admin_manual/configuration/server/caching_configura$
 			# - Enable Redis socket and grant www-data access to it:
 			local redis_conf="/etc/redis/redis*.conf"
-			grep -q "^\s*unixsocket /" $redis_conf || grep -q '#unixsocket /' $redis_conf && sed -i 's|#unixsocket /|unixsocket /|' $redis_conf || echo 'unixsocket /var/run/redis/redis.sock' >> $redis_conf
-			grep -q "^\s*#?unixsocketperm " $redis_conf && sed -i "/^\s*#?unixsocketperm /c\unixsocketperm 770" $redis_conf || echo 'unixsocketperm 770' >> $redis_conf
-			local redis_sock=$(grep "^\s*unixsocket " $redis_conf | sed "s/\s*unixsocket //")
+			grep -q "^[[:blank:]]*unixsocket /" $redis_conf || grep -q '^[[:blank:]]*#unixsocket /' $redis_conf && sed -i 's|^[[:blank:]]*#unixsocket /|unixsocket /|' $redis_conf || echo 'unixsocket /var/run/redis/redis.sock' >> $redis_conf
+			grep -q "^[[:blank:]]*#?unixsocketperm " $redis_conf && sed -i "/^[[:blank:]]*#?unixsocketperm /c\unixsocketperm 770" $redis_conf || echo 'unixsocketperm 770' >> $redis_conf
+			local redis_sock=$(grep "^[[:blank:]]*unixsocket /" $redis_conf | sed "s/^[[:blank:]]*unixsocket //")
 			usermod -a -G redis www-data
 			# - Enable ownCloud to use Redis socket:
 			if (( ! $(cat $config_php | grep -ci -m1 "'memcache.locking'") )); then
@@ -9382,7 +9378,7 @@ _EOF_
 			occ background:cron
 
 			# Enable maintenance mode to allow handling by dietpi-services:
-			grep -q "'maintenance' => true," $config_php || occ maintenance:mode --on
+			grep -q "^[[:blank:]]*'maintenance' => true," $config_php || occ maintenance:mode --on
 
 		fi
 
@@ -9414,7 +9410,7 @@ _EOF_
 			# Apache: https://docs.nextcloud.com/server/12/admin_manual/installation/source_installation.html#apache-web-server-configuration
 			if (( ${aSOFTWARE_INSTALL_STATE[83]} >= 1 )); then
 
-				a2enmod rewrite headers env dir mime &> /dev/null
+				a2enmod rewrite headers env dir mime 1> /dev/null
 				local nextcloud_conf='/etc/apache2/sites-available/nextcloud.conf'
 				# Do not overwrite existing config.
 				if [ -f $nextcloud_conf ]; then
@@ -9423,7 +9419,7 @@ _EOF_
 
 				fi
 				cp /DietPi/dietpi/conf/apache.ownnextcloud.conf $nextcloud_conf
-				a2ensite nextcloud &> /dev/null
+				a2ensite nextcloud 1> /dev/null
 
 			fi
 
@@ -9448,7 +9444,7 @@ _EOF_
 				fi
 
 				# Set HTTPS on, if SSL connection is available, even with self-signed/untrusted certificate.
-				DietPi/dietpi/func/check_connection https://localhost &> /dev/null
+				wget -q --spider --timeout=10 --tries=2 https://localhost &> /dev/null
 				if (( $? == 0 || $? == 5)); then
 
 					sed -i 's/#fastcgi_param HTTPS on;/fastcgi_param HTTPS on;/g' $nextcloud_config
@@ -9499,7 +9495,7 @@ _EOF_
 			# Enable MySQL 4-byte support for new installations only, to prevent risky database conversion tasks:
 			if (( $nc_is_fresh == 1 )); then
 
-				grep -q "'mysql.utf8mb4' => " $config_php || sed -i "/'dbpassword'/a \ \ 'mysql.utf8mb4' => true," $config_php
+				grep -q "^[[:blank:]]*'mysql.utf8mb4'" $config_php || sed -i "/^[[:blank:]]*'dbpassword'/a \ \ 'mysql.utf8mb4' => true," $config_php
 
 			fi
 
@@ -9516,25 +9512,21 @@ _EOF_
 			# Set pretty URLs (without /index.php/) on Apache:
 			if (( ${aSOFTWARE_INSTALL_STATE[83]} >= 1 )); then
 
-				grep -q "^\s*'htaccess.RewriteBase' => '" $config_php || sed -i "/^\s*'overwrite.cli.url' => '/a \ \ 'htaccess.RewriteBase' => '/nextcloud'," $config_php
+				grep -q "^[[:blank:]]*'htaccess.RewriteBase'" $config_php || sed -i "/^[[:blank:]]*'overwrite.cli.url'/a \ \ 'htaccess.RewriteBase' => '/nextcloud'," $config_php
 				ncc maintenance:update:htaccess
 
 			fi
 
 			# APCu Memcache
-			if (( ! $(cat $config_php | grep -ci -m1 "'memcache.local'") )); then
-
-				sed -i "/'version'/a 'memcache.local' => '\\\OC\\\Memcache\\\APCu'," $config_php
-
-			fi
+			grep -q "^[[:blank:]]*'memcache.local'" $config_php || sed -i "/^[[:blank:]]*'version'/a \ \ 'memcache.local' => '\\\OC\\\Memcache\\\APCu'," $config_php
 
 			# Redis for transactional file locking:
 			# https://docs.nextcloud.com/server/12/admin_manual/configuration_files/files_locking_transactional.html
 			# - Enable Redis socket and grant www-data access to it:
 			local redis_conf="/etc/redis/redis*.conf"
-			grep -q "^\s*unixsocket /" $redis_conf || grep -q '#unixsocket /' $redis_conf && sed -i 's|#unixsocket /|unixsocket /|' $redis_conf || echo 'unixsocket /var/run/redis/redis.sock' >> $redis_conf
-			grep -q "^\s*#?unixsocketperm " $redis_conf && sed -i "/^\s*#?unixsocketperm /c\unixsocketperm 770" $redis_conf || echo 'unixsocketperm 770' >> $redis_conf
-			local redis_sock=$(grep "^\s*unixsocket " $redis_conf | sed "s/\s*unixsocket //")
+			grep -q "^[[:blank:]]*unixsocket /" $redis_conf || grep -q '^[[:blank:]]*#unixsocket /' $redis_conf && sed -i 's|^[[:blank:]]*#unixsocket /|unixsocket /|' $redis_conf || echo 'unixsocket /var/run/redis/redis.sock' >> $redis_conf
+			grep -q "^[[:blank:]]*#?unixsocketperm " $redis_conf && sed -i "/^[[:blank:]]*#?unixsocketperm /c\unixsocketperm 770" $redis_conf || echo 'unixsocketperm 770' >> $redis_conf
+			local redis_sock=$(grep "^[[:blank:]]*unixsocket /" $redis_conf | sed "s/^[[:blank:]]*unixsocket //")
 			usermod -a -G redis www-data
 			# - Enable Nextloud to use Redis socket:
 			if (( ! $(cat $config_php | grep -ci -m1 "'memcache.locking'") )); then
@@ -9563,7 +9555,7 @@ _EOF_
 			ncc background:cron
 
 			# Enable maintenance mode to allow handling by dietpi-services:
-			grep -q "'maintenance' => true," $config_php || ncc maintenance:mode --on
+			grep -q "^[[:blank:]]*'maintenance' => true," $config_php || ncc maintenance:mode --on
 
 		fi
 


### PR DESCRIPTION
+ Fix HTTPS check for Nginx, as old script does not exist any more and G_CHECK_URL terminates installation on $? != 0.
+ Some grep/sed hardening, consequently using [[:blank:]] for horizontal spaces.
+ Show errors on enabling Apache modules and sites, if something is missing/not installed, just hide the unnecessary "already enabled" messages.