### PR TITLE
DietPi-Prep | Fix installation for XU3/4/HC1 + some adjustments

### DIFF
--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -556,8 +556,9 @@ _EOF_
 	#	Odroid XU3/4/HC1
 	elif (( $G_HW_MODEL == 11 )); then
 
-		G_AGI linux-image-4.9-armhf-odroid-xu3
-		#aPACKAGES_REQUIRED_INSTALL+=('linux-image-armhf-odroid-xu3')
+		#G_AGI linux-image-4.9-armhf-odroid-xu3
+		G_AGI $(dpkg --get-selections | grep "linux-image*" | awk '{print $1}')
+		[ ! -n "$(dpkg --get-selections | grep "linux-image*" ] && G_AGI linux-image-armhf-odroid-xu3
 
 	#	Odroid C1
 	elif (( $G_HW_MODEL == 10 )); then

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -94,7 +94,7 @@
 
 	else
 
-		echo -e 'Error: Unknown or unsupported distribution version, aborting...\n'
+		echo -e 'Error: Unknown or unsupported distribution version. Aborting...\n'
 		exit 1
 
 	fi
@@ -120,7 +120,7 @@
 
 	else
 
-		G_DIETPI-NOTIFY 1 "Error: Unknown or unsupported CPU architecture $G_HW_ARCH_DESCRIPTION, aborting..."
+		echo -e "Error: Unknown or unsupported CPU architecture $G_HW_ARCH_DESCRIPTION. Aborting..."
 		exit 1
 
 	fi
@@ -168,7 +168,7 @@
 
 		else
 
-			G_DIETPI-NOTIFY 1 'No choices detected, aborting'
+			G_DIETPI-NOTIFY 1 'No choices detected, aborting...'
 			exit 0
 
 		fi

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -682,7 +682,7 @@ _EOF_
 	# - @MichaIng https://github.com/Fourdee/DietPi/pull/1266/files
 	G_DIETPI-NOTIFY 2 "Returning installation of recommends back to default"
 
-	G_RUN_CMD rm /etc/apt/apt-conf.d/99-dietpi-norecommends
+	G_RUN_CMD rm /etc/apt/apt.conf.d/99-dietpi-norecommends
 
 	G_DIETPI-NOTIFY 2 "Purging APT with autoremoval (in case of DISTRO upgrade/downgrade):"
 

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -1096,9 +1096,6 @@ _EOF_
 	G_DIETPI-NOTIFY 2 'Disabling swapfile'
 
 	/DietPi/dietpi/func/dietpi-set_dphys-swapfile 0 /var/swap
-	# - Reset config
-	echo -e "CONF_SWAPSIZE=0" > /etc/dphys-swapfile
-	echo -e "CONF_SWAPFILE=/var/swap" >> /etc/dphys-swapfile
 
 	#	BBB disable swapfile gen
 	if (( $G_HW_MODEL == 71 )); then

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -338,7 +338,7 @@
 		#	G_DIETPI-NOTIFY 2 "Disabled Buster for RPi: index $temp_distro_index"
 		#	temp_distro_available=0
 
-		#fi
+		fi
 
 		# - Enable option
 		if (( $temp_distro_available )); then

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -558,7 +558,7 @@ _EOF_
 
 		#G_AGI linux-image-4.9-armhf-odroid-xu3
 		G_AGI $(dpkg --get-selections | grep "linux-image*" | awk '{print $1}')
-		[ ! -n "$(dpkg --get-selections | grep "linux-image*" ] && G_AGI linux-image-armhf-odroid-xu3
+		[ ! -n "$(dpkg --get-selections | grep "linux-image*") ] && G_AGI linux-image-armhf-odroid-xu3
 
 	#	Odroid C1
 	elif (( $G_HW_MODEL == 10 )); then

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -557,8 +557,8 @@ _EOF_
 	elif (( $G_HW_MODEL == 11 )); then
 
 		#G_AGI linux-image-4.9-armhf-odroid-xu3
-		G_AGI $(dpkg --get-selections | grep "linux-image*" | awk '{print $1}')
-		[ ! -n "$(dpkg --get-selections | grep "linux-image*") ] && G_AGI linux-image-armhf-odroid-xu3
+		G_AGI $(dpkg --get-selections | grep '^linux-image' | awk '{print $1}')
+		(( ! $(dpkg --get-selections | grep -ci -m1 '^linux-image') )) && G_AGI linux-image-armhf-odroid-xu3
 
 	#	Odroid C1
 	elif (( $G_HW_MODEL == 10 )); then

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -1167,7 +1167,7 @@ _EOF_
 
 	G_DIETPI-NOTIFY 2 'Resetting DietPi generated globals/files'
 
-	rm /DietPi/dietpi/.*
+	rm /DietPi/dietpi/.??*
 
 	G_DIETPI-NOTIFY 2 'Storing current image version /etc/.dietpi_image_version'
 

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -963,11 +963,10 @@ _EOF_
 
 	G_DIETPI-NOTIFY 2 "Configuring regional settings (Locale):"
 
-	sed -i 's/^\([^#]\)/#\1/g' /etc/locale.gen
-	sed -i '/en_GB.UTF-8 UTF-8/c\en_GB.UTF-8 UTF-8' /etc/locale.gen
+	echo 'en_GB.UTF-8 UTF-8' > /etc/locale.gen
+	G_RUN_CMD dpkg-reconfigure -f noninteractive locales # en_GB.UTF-8 as only installed locale
 	#locale-gen
-	update-locale
-	G_RUN_CMD dpkg-reconfigure -f noninteractive locales # en_GB.UTF8 as only installed locale
+	#update-locale
 
 	# - Pump default locale into sys env: https://github.com/Fourdee/DietPi/issues/825
 	export G_ERROR_HANDLER_COMMAND='/etc/environment'


### PR DESCRIPTION
DietPi-Prep
+ Adjust conf.d file naming to 99-dietpi-*, so we can easily find/reset/remove those in the future.
+ Make wget prefer IPv4 failure prove. Maybe we can build a script like this to savely adjust values inside config files, including to option to preserve or overwrite existing values, something like: G_EDIT_CONF -o "prefer-family =" "prefer-family = IPv4" "/etc/wgetrc"
+ Fix https://github.com/Fourdee/DietPi/issues/1285#issuecomment-354602594 by installing kernel/firmware/bootloader packages directly. This allows autoremove of older/different packages.
+ Some typos...