### PR TITLE
DietPi-Globals | Standardize/Shorten output

### DIFF
--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -9,12 +9,12 @@
 	#////////////////////////////////////
 	#
 	# Info:
-	# - Allows export of shared DietPi global variables/funcs into current bash session, and, other scripts
+	# - Allows export of shared DietPi global variables/funcs into current bash session, and other scripts
 	#
 	# Excluded scripts, which do NOT load these globals
 	# - dietpi-ramlog
 	# - dietpi-ramdisk
-	# - dietpi.txt (and all other .txt .ini files)
+	# - dietpi.txt (and all other .txt .ini or config files)
 	#
 	#////////////////////////////////////
 
@@ -57,23 +57,33 @@
 		#header_line="\e[38;5;154m─────────────────────────────────────────────────────\e[0m"
 		local header_line="\e[90m─────────────────────────────────────────────────────\e[0m"
 
-		local status_text_ok="\e[32mOk\e[0m"
-		local status_text_failed="\e[31mFailed:\e[0m"
+		#Line overwriting string:
+		local overwrite_string="\\r\\033[K"
+
+		local status_text_process="\e[33mProcessing\e[0m"
+		local status_text_ok="\e[32m    Ok    \e[0m"
+		local status_text_error="\e[31m  Error   \e[0m"
 
 		local bracket_string_l="\e[90m[\e[0m"
 		local bracket_string_r="\e[90m]\e[0m"
 
 		#Funcs
 
+		Print_Process(){
+
+			echo -ne "$overwrite_string $bracket_string_l$status_text_process$bracket_string_r"
+
+		}
+
 		Print_Ok(){
 
-			echo -ne " $bracket_string_l\e[32mOk\e[0m$bracket_string_r"
+			echo -ne "$overwrite_string $bracket_string_l$status_text_ok$bracket_string_r"
 
 		}
 
 		Print_Failed(){
 
-			echo -ne " $bracket_string_l\e[31mError\e[0m$bracket_string_r"
+			echo -ne "$overwrite_string $bracket_string_l$status_text_error$bracket_string_r"
 
 		}
 
@@ -87,7 +97,7 @@
 				echo -ne " ${ainput_string[$i]}"
 			done
 
-			echo -e ""
+			#echo -e ""
 
 			# echo -e "SIZE = ${#ainput_string}"
 
@@ -125,12 +135,20 @@
 			fi
 
 		#--------------------------------------------------------------------------------------
+		#Status Processing
+		#$@ = txt desc
+		elif (( $1 == -2 )); then
+
+			Print_Process
+			Print_Input_String 1
+
 		#Status Ok
 		#$@ = txt desc
 		elif (( $1 == 0 )); then
 
 			Print_Ok
 			Print_Input_String 1
+			echo -e ''
 
 		#Status failed
 		#$@ = txt desc
@@ -138,25 +156,27 @@
 
 			Print_Failed
 			Print_Input_String 1
+			echo -e ''
 
 		#Status Info
 		#$@ = txt desc
 		elif (( $1 == 2 )); then
 
-			echo -ne " $bracket_string_l\e[0mInfo\e[0m$bracket_string_r"
+			echo -ne "$overwrite_string $bracket_string_l\e[0m   Info   \e[0m$bracket_string_r"
 			echo -ne "\e[90m"
 			Print_Input_String 1
-			echo -ne "\e[0m"
+			echo -e "\e[0m"
 
 		#DietPi banner style
 		#$2 = txt program name
 		#$3 = txt mode
 		elif (( $1 == 3 )); then
 
-			echo -e "\n \e[38;5;154m$2\e[0m"
+			echo -e "$overwrite_string\n \e[38;5;154m$2\e[0m"
 			echo -e "$header_line"
 			echo -e " \e[90mMode:\e[0m$(Print_Input_String 2)"
 			echo -e " \e[90mPlease wait...\e[0m\n"
+			#Print_Process
 
 		fi
 		#-----------------------------------------------------------------------------------
@@ -170,11 +190,11 @@
 
 		if (( ! $G_CHECK_ROOT_USER_VERIFIED )); then
 
-			G_DIETPI-NOTIFY 2 'Checking for (elevated) root access, please wait..'
+			G_DIETPI-NOTIFY -2 'Checking for (elevated) root access, please wait..'
 
 			if (( $UID != 0 )); then
 
-				G_DIETPI-NOTIFY 1 'Error: Root privileges required. Please run the command with "sudo"\n'
+				G_DIETPI-NOTIFY 1 'Root privileges required. Please run the command with "sudo"\n'
 				exit 1
 
 			else
@@ -197,7 +217,7 @@
 			/DietPi/dietpi/dietpi-drive_manager 3
 			if (( $? != 0 )); then
 
-				G_DIETPI-NOTIFY 1 'Error: RootFS is currently Read Only, unable to continue.\n'
+				G_DIETPI-NOTIFY 1 'RootFS is currently Read Only, unable to continue.\n'
 				exit 1
 
 			else
@@ -425,8 +445,7 @@ $print_logfile_info
 
 		G_ERROR_HANDLER_COMMAND="$@"
 
-		G_DIETPI-NOTIFY 2 "Running command: $G_ERROR_HANDLER_COMMAND"
-		G_DIETPI-NOTIFY 2 'Please wait...'
+		G_DIETPI-NOTIFY -2 "Running command: $G_ERROR_HANDLER_COMMAND, please wait..."
 
 		$G_ERROR_HANDLER_COMMAND &> /tmp/G_ERROR_HANDLER_COMMAND
 		G_ERROR_HANDLER_EXITCODE=$?
@@ -445,8 +464,7 @@ $print_logfile_info
 		G_ERROR_HANDLER_COMMAND="$@"
 		G_ERROR_HANDLER_EXITCODE=0
 
-		G_DIETPI-NOTIFY 2 "Checking file/folder exists: $G_ERROR_HANDLER_COMMAND"
-		G_DIETPI-NOTIFY 2 'Please wait...'
+		G_DIETPI-NOTIFY -2 "Checking file/folder exists: $G_ERROR_HANDLER_COMMAND, please wait..."
 
 		local string=''
 
@@ -632,8 +650,7 @@ $print_logfile_info
 		G_ERROR_HANDLER_EXITCODE=0
 		G_ERROR_HANDLER_COMMAND="Connection test: $string"
 
-		G_DIETPI-NOTIFY 2 "Testing connection to $string"
-		G_DIETPI-NOTIFY 2 "Max duration of $(($timeout * $retry)) seconds, please wait..."
+		G_DIETPI-NOTIFY -2 "Testing connection to $string for max $(($timeout * $retry)) seconds, please wait..."
 
 		wget -q --spider --timeout=$timeout --tries=$retry "$string"
 		G_ERROR_HANDLER_EXITCODE=$?
@@ -684,8 +701,7 @@ $print_logfile_info
 
 
 		#-qq can add a slight period of appearing nothing is happening, lets inform user
-		G_DIETPI-NOTIFY 2 "APT installation for: $string"
-		G_DIETPI-NOTIFY 2 "APT is processing, please wait...\n"
+		G_DIETPI-NOTIFY -2 "APT installation for: $string, please wait..."
 
 		DEBIAN_FRONTEND=noninteractive apt-get install -y -qq $force_options $string 2>&1 | tee "$G_FP_LOG_APT"
 		G_ERROR_HANDLER_EXITCODE=${PIPESTATUS[0]}
@@ -712,7 +728,7 @@ $print_logfile_info
 		G_ERROR_HANDLER_COMMAND="G_AGP: $string"
 		G_ERROR_HANDLER_ONERROR_FPLOGFILE="$G_FP_LOG_APT"
 
-		G_DIETPI-NOTIFY 2 "APT removal for: $string"
+		G_DIETPI-NOTIFY -2 "APT removal for: $string, please wait"
 
 		DEBIAN_FRONTEND=noninteractive apt-get purge -y $string $options 2>&1 | tee "$G_FP_LOG_APT"
 		G_ERROR_HANDLER_EXITCODE=${PIPESTATUS[0]}
@@ -731,7 +747,7 @@ $print_logfile_info
 		G_ERROR_HANDLER_COMMAND="G_AGA:"
 		G_ERROR_HANDLER_ONERROR_FPLOGFILE="$G_FP_LOG_APT"
 
-		G_DIETPI-NOTIFY 2 "APT autoremove + purge"
+		G_DIETPI-NOTIFY -2 "APT autoremove + purge, please wait"
 
 		DEBIAN_FRONTEND=noninteractive apt-get autoremove --purge -y  2>&1 | tee "$G_FP_LOG_APT"
 		G_ERROR_HANDLER_EXITCODE=${PIPESTATUS[0]}
@@ -750,7 +766,7 @@ $print_logfile_info
 		G_ERROR_HANDLER_COMMAND="G_AGF:"
 		G_ERROR_HANDLER_ONERROR_FPLOGFILE="$G_FP_LOG_APT"
 
-		G_DIETPI-NOTIFY 2 "APT fix"
+		G_DIETPI-NOTIFY -2 "APT fix, please wait..."
 
 		DEBIAN_FRONTEND=noninteractive apt-get install -f -y 2>&1 | tee "$G_FP_LOG_APT"
 		G_ERROR_HANDLER_EXITCODE=${PIPESTATUS[0]}
@@ -769,7 +785,7 @@ $print_logfile_info
 		G_ERROR_HANDLER_COMMAND="G_AGUP:"
 		G_ERROR_HANDLER_ONERROR_FPLOGFILE="$G_FP_LOG_APT"
 
-		G_DIETPI-NOTIFY 2 "APT update"
+		G_DIETPI-NOTIFY -2 "APT update, please wait..."
 
 		DEBIAN_FRONTEND=noninteractive apt-get update 2>&1 | tee "$G_FP_LOG_APT"
 		G_ERROR_HANDLER_EXITCODE=${PIPESTATUS[0]}
@@ -788,7 +804,7 @@ $print_logfile_info
 		G_ERROR_HANDLER_COMMAND="G_AGUG:"
 		G_ERROR_HANDLER_ONERROR_FPLOGFILE="$G_FP_LOG_APT"
 
-		G_DIETPI-NOTIFY 2 "APT upgrade"
+		G_DIETPI-NOTIFY -2 "APT upgrade, please wait..."
 
 		DEBIAN_FRONTEND=noninteractive apt-get upgrade -y 2>&1 | tee "$G_FP_LOG_APT"
 		G_ERROR_HANDLER_EXITCODE=${PIPESTATUS[0]}
@@ -817,7 +833,7 @@ $print_logfile_info
 
 		fi
 
-		G_DIETPI-NOTIFY 2 "APT dist-upgrade"
+		G_DIETPI-NOTIFY -2 "APT dist-upgrade, please wait..."
 
 		DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y 2>&1 | tee "$G_FP_LOG_APT"
 		G_ERROR_HANDLER_EXITCODE=${PIPESTATUS[0]}
@@ -859,7 +875,7 @@ $print_logfile_info
 
 		if [ -n "$packages_to_install" ]; then
 
-			G_DIETPI-NOTIFY 2 "Installing pre-req APT packages, please wait..."
+			G_DIETPI-NOTIFY -2 "Installing pre-req APT packages, please wait..."
 			G_AGI $packages_to_install
 			exit_code=$?
 


### PR DESCRIPTION
+ Introduce processing messages, that will be overwritten by any kind of success/failure/info message.
+ Needs testing and further adjustment, also within other scripts.
+ One problem still is: If SSH window is to small to show processing message, internally some line break or what happens, so the next message will be printed onto the next line instead of over processing message. However this is not the case, if the message fits into the whole window.