### PR TITLE
DietPi-Globals | Tuning processing messages

### DIFF
--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -69,7 +69,7 @@
 
 		Print_Process(){
 
-			echo -ne " $bracket_string_l$status_text_process$bracket_string_r"
+			echo -ne "\033[K $bracket_string_l$status_text_process$bracket_string_r"
 
 		}
 

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -60,6 +60,7 @@
 		local status_text_process="\e[33mProcessing\e[0m"
 		local status_text_ok="\e[32m    Ok    \e[0m"
 		local status_text_error="\e[31m  Error   \e[0m"
+		local status_text_info="\e[0m   Info   \e[0m"
 
 		local bracket_string_l="\e[90m[\e[0m"
 		local bracket_string_r="\e[90m]\e[0m"
@@ -74,13 +75,19 @@
 
 		Print_Ok(){
 
-			echo -ne " $bracket_string_l$status_text_ok$bracket_string_r"
+			echo -ne "\033[K $bracket_string_l$status_text_ok$bracket_string_r"
 
 		}
 
 		Print_Failed(){
 
-			echo -ne " $bracket_string_l$status_text_error$bracket_string_r"
+			echo -ne "\033[K $bracket_string_l$status_text_error$bracket_string_r"
+
+		}
+		
+		Print_Info(){
+
+			echo -ne "\033[K $bracket_string_l$status_text_info$bracket_string_r"
 
 		}
 
@@ -160,7 +167,7 @@
 		#$@ = txt desc
 		elif (( $1 == 2 )); then
 
-			echo -ne " $bracket_string_l\e[0m   Info   \e[0m$bracket_string_r"
+			Print_Info
 			echo -ne "\e[90m"
 			Print_Input_String 1
 			echo -e "\e[0m"
@@ -188,7 +195,7 @@
 
 		if (( ! $G_CHECK_ROOT_USER_VERIFIED )); then
 
-			G_DIETPI-NOTIFY -2 'Checking for (elevated) root access, please wait..'
+			G_DIETPI-NOTIFY -2 'Checking for (elevated) root access'
 
 			if (( $UID != 0 )); then
 
@@ -462,7 +469,7 @@ $print_logfile_info
 		G_ERROR_HANDLER_COMMAND="$@"
 		G_ERROR_HANDLER_EXITCODE=0
 
-		G_DIETPI-NOTIFY -2 "Checking file/folder exists: $G_ERROR_HANDLER_COMMAND, please wait..."
+		G_DIETPI-NOTIFY -2 "Checking file/folder exists: $G_ERROR_HANDLER_COMMAND"
 
 		local string=''
 
@@ -648,7 +655,7 @@ $print_logfile_info
 		G_ERROR_HANDLER_EXITCODE=0
 		G_ERROR_HANDLER_COMMAND="Connection test: $string"
 
-		G_DIETPI-NOTIFY -2 "Testing connection to $string for max $(($timeout * $retry)) seconds, please wait..."
+		G_DIETPI-NOTIFY -2 "Testing connection to $string for max $(($timeout * $retry)) seconds"
 
 		wget -q --spider --timeout=$timeout --tries=$retry "$string"
 		G_ERROR_HANDLER_EXITCODE=$?
@@ -726,7 +733,7 @@ $print_logfile_info
 		G_ERROR_HANDLER_COMMAND="G_AGP: $string"
 		G_ERROR_HANDLER_ONERROR_FPLOGFILE="$G_FP_LOG_APT"
 
-		G_DIETPI-NOTIFY -2 "APT removal for: $string, please wait..."
+		G_DIETPI-NOTIFY -2 "APT removal for: $string"
 
 		DEBIAN_FRONTEND=noninteractive apt-get purge -y $string $options 2>&1 | tee "$G_FP_LOG_APT"
 		G_ERROR_HANDLER_EXITCODE=${PIPESTATUS[0]}
@@ -745,7 +752,7 @@ $print_logfile_info
 		G_ERROR_HANDLER_COMMAND="G_AGA:"
 		G_ERROR_HANDLER_ONERROR_FPLOGFILE="$G_FP_LOG_APT"
 
-		G_DIETPI-NOTIFY -2 "APT autoremove + purge, please wait..."
+		G_DIETPI-NOTIFY -2 "APT autoremove + purge"
 
 		DEBIAN_FRONTEND=noninteractive apt-get autoremove --purge -y  2>&1 | tee "$G_FP_LOG_APT"
 		G_ERROR_HANDLER_EXITCODE=${PIPESTATUS[0]}
@@ -764,7 +771,7 @@ $print_logfile_info
 		G_ERROR_HANDLER_COMMAND="G_AGF:"
 		G_ERROR_HANDLER_ONERROR_FPLOGFILE="$G_FP_LOG_APT"
 
-		G_DIETPI-NOTIFY -2 "APT fix, please wait..."
+		G_DIETPI-NOTIFY -2 "APT fix"
 
 		DEBIAN_FRONTEND=noninteractive apt-get install -f -y 2>&1 | tee "$G_FP_LOG_APT"
 		G_ERROR_HANDLER_EXITCODE=${PIPESTATUS[0]}
@@ -783,7 +790,7 @@ $print_logfile_info
 		G_ERROR_HANDLER_COMMAND="G_AGUP:"
 		G_ERROR_HANDLER_ONERROR_FPLOGFILE="$G_FP_LOG_APT"
 
-		G_DIETPI-NOTIFY -2 "APT update, please wait..."
+		G_DIETPI-NOTIFY -2 "APT update"
 
 		DEBIAN_FRONTEND=noninteractive apt-get update 2>&1 | tee "$G_FP_LOG_APT"
 		G_ERROR_HANDLER_EXITCODE=${PIPESTATUS[0]}
@@ -802,7 +809,7 @@ $print_logfile_info
 		G_ERROR_HANDLER_COMMAND="G_AGUG:"
 		G_ERROR_HANDLER_ONERROR_FPLOGFILE="$G_FP_LOG_APT"
 
-		G_DIETPI-NOTIFY -2 "APT upgrade, please wait..."
+		G_DIETPI-NOTIFY -2 "APT upgrade"
 
 		DEBIAN_FRONTEND=noninteractive apt-get upgrade -y 2>&1 | tee "$G_FP_LOG_APT"
 		G_ERROR_HANDLER_EXITCODE=${PIPESTATUS[0]}
@@ -831,7 +838,7 @@ $print_logfile_info
 
 		fi
 
-		G_DIETPI-NOTIFY -2 "APT dist-upgrade, please wait..."
+		G_DIETPI-NOTIFY -2 "APT dist-upgrade"
 
 		DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y 2>&1 | tee "$G_FP_LOG_APT"
 		G_ERROR_HANDLER_EXITCODE=${PIPESTATUS[0]}
@@ -873,7 +880,7 @@ $print_logfile_info
 
 		if [ -n "$packages_to_install" ]; then
 
-			G_DIETPI-NOTIFY -2 "Installing pre-req APT packages, please wait..."
+			G_DIETPI-NOTIFY -2 "Installing pre-req APT packages"
 			G_AGI $packages_to_install
 			exit_code=$?
 

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -177,7 +177,7 @@
 		#$3 = txt mode
 		elif (( $1 == 3 )); then
 
-			echo -e "\n \e[38;5;154m$2\e[0m"
+			echo -e "\033[K\n \e[38;5;154m$2\e[0m"
 			echo -e "$header_line"
 			echo -e " \e[90mMode:\e[0m$(Print_Input_String 2)\n"
 			Print_Process

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -57,9 +57,6 @@
 		#header_line="\e[38;5;154m─────────────────────────────────────────────────────\e[0m"
 		local header_line="\e[90m─────────────────────────────────────────────────────\e[0m"
 
-		#Line overwriting string:
-		local overwrite_string="\r\033[K"
-
 		local status_text_process="\e[33mProcessing\e[0m"
 		local status_text_ok="\e[32m    Ok    \e[0m"
 		local status_text_error="\e[31m  Error   \e[0m"
@@ -71,19 +68,19 @@
 
 		Print_Process(){
 
-			echo -ne "$overwrite_string $bracket_string_l$status_text_process$bracket_string_r"
+			echo -ne " $bracket_string_l$status_text_process$bracket_string_r"
 
 		}
 
 		Print_Ok(){
 
-			echo -ne "$overwrite_string $bracket_string_l$status_text_ok$bracket_string_r"
+			echo -ne " $bracket_string_l$status_text_ok$bracket_string_r"
 
 		}
 
 		Print_Failed(){
 
-			echo -ne "$overwrite_string $bracket_string_l$status_text_error$bracket_string_r"
+			echo -ne " $bracket_string_l$status_text_error$bracket_string_r"
 
 		}
 
@@ -141,6 +138,7 @@
 
 			Print_Process
 			Print_Input_String 1
+			echo -ne "\r"
 
 		#Status Ok
 		#$@ = txt desc
@@ -162,7 +160,7 @@
 		#$@ = txt desc
 		elif (( $1 == 2 )); then
 
-			echo -ne "$overwrite_string $bracket_string_l\e[0m   Info   \e[0m$bracket_string_r"
+			echo -ne " $bracket_string_l\e[0m   Info   \e[0m$bracket_string_r"
 			echo -ne "\e[90m"
 			Print_Input_String 1
 			echo -e "\e[0m"
@@ -172,11 +170,11 @@
 		#$3 = txt mode
 		elif (( $1 == 3 )); then
 
-			echo -e "$overwrite_string\n \e[38;5;154m$2\e[0m"
+			echo -e "\n \e[38;5;154m$2\e[0m"
 			echo -e "$header_line"
-			echo -e " \e[90mMode:\e[0m$(Print_Input_String 2)"
-			echo -e " \e[90mPlease wait...\e[0m\n"
-			#Print_Process
+			echo -e " \e[90mMode:\e[0m$(Print_Input_String 2)\n"
+			Print_Process
+			echo -ne " \e[90mPlease wait...\e[0m\r"
 
 		fi
 		#-----------------------------------------------------------------------------------


### PR DESCRIPTION
Just copying the method of other installation scripts lead to a complicated solution. "\r" is the command to move "cursor" position to beginning of line, thus just adding "\r" at the end of every processing message (leading -n also necessary) does the job.

Now every processing message will be overwritten by any other kind of output. In best cases it should be some ok or error from error handler, but if there are some other command outputs in between this is also okay and shows user what is going on/that something is going on.

If there is information we want users to keep/review, then use `G_DIETPI-NOTIFY 2 ...` for [Info].

Btw: Don't we want preparation script to use `G_DIETPI-NOTIFY 3 ...` for the installation step info? At the moment it uses info messages, thus leading [Info] string appears at the beginning of header+separation lines 😆.