### PR TITLE
DietPi-Software | MySQL: Completely remove MySQL from DietPi in favour of MariaDB

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3567,7 +3567,7 @@ _EOF_
 
 			# In case remove old symlink, created by DietPi MariaDB installation, otherwise installation will fail.
 			# This will not remove the folder in case, without "-R".
-			rm /var/lib/mysql &> /dev/null
+			[ "$(readlink /var/lib/mysql)" ] && [ ! -d "$(readlink /var/lib/mysql)/mysql" ] && rm /var/lib/mysql
 			G_AGI mariadb-server
 
 		fi
@@ -3668,13 +3668,12 @@ _EOF_
 			Banner_Installing
 
 			#MySQL must be running during install to allow debconf setup.
-			systemctl start mysql
+			G_RUN_CMD systemctl start mysql
 
 			# Set password parameters before installing
 			debconf-set-selections <<< "phpmyadmin phpmyadmin/dbconfig-install boolean true"
-			debconf-set-selections <<< "phpmyadmin phpmyadmin/app-password-confirm password $GLOBAL_PW"
-			debconf-set-selections <<< "phpmyadmin phpmyadmin/mysql/admin-pass password $GLOBAL_PW"
 			debconf-set-selections <<< "phpmyadmin phpmyadmin/mysql/app-pass password $GLOBAL_PW"
+			debconf-set-selections <<< "phpmyadmin phpmyadmin/app-password-confirm password $GLOBAL_PW"
 
 			if (( ${aSOFTWARE_INSTALL_STATE[83]} == 1 )); then
 
@@ -8113,20 +8112,10 @@ _EOF_
 
 			Banner_Configuration
 
-			# On Jessie assure unix_socket authentication:
-			if (( $G_DISTRO < 4 )); then
-
-				mysql -uroot -e "install plugin unix_socket soname 'auth_socket';"
-				mysql -uroot -e "grant all privileges on *.* to 'root'@'localhost' identified via unix_socket with grant option;flush privileges"
-				# Drop unnecessary root user children.
-				mysql -uroot -e "drop user 'root'@'dietpi';drop user 'root'@'127.0.0.1';drop user 'root'@'::1'"
-
-			fi
-
 			# Move SQL store to userdata location: https://github.com/Fourdee/DietPi/issues/672
-			if [ "$(readlink /var/lib/mysql)" != "$G_FP_DIETPI_USERDATA/mysql" ]; then
+			if [ "$(readlink /var/lib/mysql)" != "$G_FP_DIETPI_USERDATA/mysql/" ]; then
 
-				systemctl stop mysql
+				G_RUN_CMD systemctl stop mysql
 
 				# - Create target dir
 				mkdir -p "$G_FP_DIETPI_USERDATA"/mysql
@@ -8140,7 +8129,7 @@ _EOF_
 
 				fi
 
-				rm -R /var/lib/mysql
+				rm -R /var/lib/mysql &> /dev/null || rm /var/lib/mysql &> /dev/null
 
 				# - Symlink
 				ln -sf "$G_FP_DIETPI_USERDATA"/mysql /var/lib/mysql
@@ -8152,9 +8141,20 @@ _EOF_
 
 			fi
 
+			# On Jessie assure unix_socket authentication:
+			if (( $G_DISTRO < 4 )); then
+
+				G_RUN_CMD systemctl start mysql
+				mysql -uroot -e "install plugin unix_socket soname 'auth_socket';" &> /dev/null
+				mysql -uroot -e "grant all privileges on *.* to 'root'@'localhost' identified via unix_socket with grant option;flush privileges"
+				# Drop unnecessary root user children.
+				mysql -uroot -e "drop user 'root'@'dietpi';drop user 'root'@'127.0.0.1';drop user 'root'@'::1'" &> /dev/null
+
+			fi
+
 			### Also for MariaDB?
-			#Optimize for reduced memory use: https://github.com/Fourdee/DietPi/issues/605#issue-188930987
-#			cat << _EOF_ > /etc/mysql/conf.d/reduce_resources.cnf
+			# Optimize for reduced memory use: https://github.com/Fourdee/DietPi/issues/605#issue-188930987
+			#cat << _EOF_ > /etc/mysql/conf.d/reduce_resources.cnf
 #[mysqld]
 #key_buffer_size=8M
 #max_connections=30
@@ -8178,6 +8178,11 @@ _EOF_
 				ln -sf /usr/share/phpmyadmin /var/www
 
 			fi
+
+			# Due to MariaDB unix_socket authentication, "root" cannot be used to login the web ui.
+			# Thus default "phpmyadmin" user need to be used, who on Jessie does not have all privileges:
+			# http://dietpi.com/phpbb/viewtopic.php?f=8&t=5&p=54#p54
+			mysql -uroot -e "grant all privileges on *.* to phpmyadmin@localhost with grant option"
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1865,21 +1865,6 @@ _EOF_
 
 		#Webserver stacks
 		#--------------------------------------------------------------------------------
-		index_current=74
-
-				 aSOFTWARE_WHIP_NAME[$index_current]='LAMP'
-				 aSOFTWARE_WHIP_DESC[$index_current]='apache2  | mysql   | php'
-			aSOFTWARE_CATEGORY_INDEX[$index_current]=13
-					  aSOFTWARE_TYPE[$index_current]=0
-			 aSOFTWARE_ONLINEDOC_URL[$index_current]='f=8&t=5&start=10#p52'
-		# - disable on Stretch
-		if (( $G_DISTRO >= 4 )); then
-
-			aSOFTWARE_AVAIL_G_HW_MODEL[$index_current,$G_HW_MODEL]=0
-
-		fi
-
-		#------------------
 		index_current=75
 
 				 aSOFTWARE_WHIP_NAME[$index_current]='LASP'
@@ -1898,21 +1883,6 @@ _EOF_
 			 aSOFTWARE_ONLINEDOC_URL[$index_current]='f=8&t=5&start=10#p52'
 
 		#------------------
-		index_current=77
-
-				 aSOFTWARE_WHIP_NAME[$index_current]='LEMP'
-				 aSOFTWARE_WHIP_DESC[$index_current]='nginx    | mysql   | php'
-			aSOFTWARE_CATEGORY_INDEX[$index_current]=13
-					  aSOFTWARE_TYPE[$index_current]=0
-			 aSOFTWARE_ONLINEDOC_URL[$index_current]='f=8&t=5#p5'
-		# - disable on Stretch
-		if (( $G_DISTRO >= 4 )); then
-
-			aSOFTWARE_AVAIL_G_HW_MODEL[$index_current,$G_HW_MODEL]=0
-
-		fi
-
-		#------------------
 		index_current=78
 
 				 aSOFTWARE_WHIP_NAME[$index_current]='LESP'
@@ -1929,21 +1899,6 @@ _EOF_
 			aSOFTWARE_CATEGORY_INDEX[$index_current]=13
 					  aSOFTWARE_TYPE[$index_current]=0
 			 aSOFTWARE_ONLINEDOC_URL[$index_current]='f=8&t=5#p5'
-
-		#------------------
-		index_current=80
-
-				 aSOFTWARE_WHIP_NAME[$index_current]='LLMP'
-				 aSOFTWARE_WHIP_DESC[$index_current]='lighttpd | mysql   | php'
-			aSOFTWARE_CATEGORY_INDEX[$index_current]=13
-					  aSOFTWARE_TYPE[$index_current]=0
-			 aSOFTWARE_ONLINEDOC_URL[$index_current]='f=8&t=5&p=1335#p1335'
-		# - disable on Stretch
-		if (( $G_DISTRO >= 4 )); then
-
-			aSOFTWARE_AVAIL_G_HW_MODEL[$index_current,$G_HW_MODEL]=0
-
-		fi
 
 		#------------------
 		index_current=81
@@ -1989,21 +1944,6 @@ _EOF_
 			aSOFTWARE_CATEGORY_INDEX[$index_current]=13
 					  aSOFTWARE_TYPE[$index_current]=-1
 			 aSOFTWARE_ONLINEDOC_URL[$index_current]='f=8&t=5#p5'
-
-		#------------------
-		index_current=86
-
-				 aSOFTWARE_WHIP_NAME[$index_current]='MySQL'
-				 aSOFTWARE_WHIP_DESC[$index_current]='database'
-			aSOFTWARE_CATEGORY_INDEX[$index_current]=13
-					  aSOFTWARE_TYPE[$index_current]=-1
-			 aSOFTWARE_ONLINEDOC_URL[$index_current]='f=8&t=5&p=1335#p1335'
-		# - disable on Stretch
-		if (( $G_DISTRO >= 4 )); then
-
-			aSOFTWARE_AVAIL_G_HW_MODEL[$index_current,$G_HW_MODEL]=0
-
-		fi
 
 		#------------------
 		index_current=87
@@ -2862,13 +2802,6 @@ _EOF_
 			aSOFTWARE_INSTALL_STATE[89]=1
 		fi
 
-		#LLMP
-		if (( ${aSOFTWARE_INSTALL_STATE[80]} == 1 )); then
-			aSOFTWARE_INSTALL_STATE[84]=1
-			aSOFTWARE_INSTALL_STATE[86]=1
-			aSOFTWARE_INSTALL_STATE[89]=1
-		fi
-
 		#LEAP
 		if (( ${aSOFTWARE_INSTALL_STATE[79]} == 1 )); then
 			aSOFTWARE_INSTALL_STATE[85]=1
@@ -2883,13 +2816,6 @@ _EOF_
 			aSOFTWARE_INSTALL_STATE[89]=1
 		fi
 
-		#LEMP
-		if (( ${aSOFTWARE_INSTALL_STATE[77]} == 1 )); then
-			aSOFTWARE_INSTALL_STATE[85]=1
-			aSOFTWARE_INSTALL_STATE[86]=1
-			aSOFTWARE_INSTALL_STATE[89]=1
-		fi
-
 		#LAAP
 		if (( ${aSOFTWARE_INSTALL_STATE[76]} == 1 )); then
 			aSOFTWARE_INSTALL_STATE[83]=1
@@ -2901,13 +2827,6 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[75]} == 1 )); then
 			aSOFTWARE_INSTALL_STATE[83]=1
 			aSOFTWARE_INSTALL_STATE[87]=1
-			aSOFTWARE_INSTALL_STATE[89]=1
-		fi
-
-		#LAMP
-		if (( ${aSOFTWARE_INSTALL_STATE[74]} == 1 )); then
-			aSOFTWARE_INSTALL_STATE[83]=1
-			aSOFTWARE_INSTALL_STATE[86]=1
 			aSOFTWARE_INSTALL_STATE[89]=1
 		fi
 
@@ -2964,9 +2883,8 @@ _EOF_
 			if (( ${aSOFTWARE_REQUIRES_MYSQL[$i]} &&
 				${aSOFTWARE_INSTALL_STATE[$i]} == 1 )); then
 
-				# - Check for existing mysql/mariaDB installations
-				if (( ! ${aSOFTWARE_INSTALL_STATE[86]} &&
-					! ${aSOFTWARE_INSTALL_STATE[88]} )); then
+				# - Check for existing MariaDB installations
+				if (( ! ${aSOFTWARE_INSTALL_STATE[88]} )); then
 
 					#WEBSERVER_MARIADB as new default
 					aSOFTWARE_INSTALL_STATE[88]=1
@@ -3003,14 +2921,6 @@ _EOF_
 		#WEBSERVER_APACHE
 		if (( ${aSOFTWARE_INSTALL_STATE[83]} >= 1 )); then
 
-			#MySQL
-			if (( ${aSOFTWARE_INSTALL_STATE[86]} >= 1 )); then
-
-				#WEBSERVER_LAMP
-				aSOFTWARE_INSTALL_STATE[74]=1
-
-			fi
-
 			#SQLite
 			if (( ${aSOFTWARE_INSTALL_STATE[87]} >= 1 )); then
 
@@ -3031,14 +2941,6 @@ _EOF_
 		#WEBSERVER_NGINX
 		elif (( ${aSOFTWARE_INSTALL_STATE[85]} >= 1 )); then
 
-			#MySQL
-			if (( ${aSOFTWARE_INSTALL_STATE[86]} >= 1 )); then
-
-				#WEBSERVER_LEMP
-				aSOFTWARE_INSTALL_STATE[77]=1
-
-			fi
-
 			#SQLite
 			if (( ${aSOFTWARE_INSTALL_STATE[87]} >= 1 )); then
 
@@ -3058,14 +2960,6 @@ _EOF_
 		#WEBSERVER_LIGHTTPD
 		elif (( ${aSOFTWARE_INSTALL_STATE[84]} >= 1 )); then
 
-			#MySQL
-			if (( ${aSOFTWARE_INSTALL_STATE[86]} >= 1 )); then
-
-				#WEBSERVER_LLMP
-				aSOFTWARE_INSTALL_STATE[80]=1
-
-			fi
-
 			#SQLite
 			if (( ${aSOFTWARE_INSTALL_STATE[87]} >= 1 )); then
 
@@ -3082,31 +2976,6 @@ _EOF_
 
 			fi
 
-
-		fi
-
-		#Prevent incompatible MySQL + MariaDB installation: https://github.com/Fourdee/DietPi/issues/761#issuecomment-280848758
-		if (( ${aSOFTWARE_INSTALL_STATE[86]} >= 1 && ${aSOFTWARE_INSTALL_STATE[88]} >= 1 )); then
-
-			#	MySQL installed
-			if (( ${aSOFTWARE_INSTALL_STATE[86]} == 2 )); then
-
-				aSOFTWARE_INSTALL_STATE[88]=0
-				G_DIETPI-NOTIFY 2 "MySQL is already installed, MariaDB install has been disabled"
-
-			#	MariaDB installed
-			elif (( ${aSOFTWARE_INSTALL_STATE[88]} == 2 )); then
-
-				aSOFTWARE_INSTALL_STATE[86]=0
-				G_DIETPI-NOTIFY 2 "MariaDB is already installed, MySQL install has been disabled"
-
-			#	Both selected for install, disable MySQL
-			else
-
-				aSOFTWARE_INSTALL_STATE[86]=0
-				G_DIETPI-NOTIFY 2 "MySQL and MariaDB are selected for install. MySQL has been de-selected to prevent incompatible MySQL + MariaDB installation"
-
-			fi
 
 		fi
 
@@ -3668,34 +3537,14 @@ _EOF_
 
 		fi
 
-		#WEBSERVER_MYSQL
-		INSTALLING_INDEX=86
-		if (( ${aSOFTWARE_INSTALL_STATE[$INSTALLING_INDEX]} == 1 )); then
-
-			Banner_Installing
-
-			debconf-set-selections <<< "mysql-server mysql-server/root_password password $GLOBAL_PW"
-			debconf-set-selections <<< "mysql-server mysql-server/root_password_again password $GLOBAL_PW"
-
-			# In case remove old symlink, created by DietPi MySQL/MariaDB installation, otherwise installation will fail.
-			rm /var/lib/mysql &> /dev/null
-			G_AGI mysql-server
-
-			# Fix depricated key_buffer -> key_buffer_size per MySQL 5.x notification
-			sed -i 's/^key_buffer[[:space:]]/key_buffer_size /g' /etc/mysql/my.cnf
-
-			# Restart service and leave it running (just incase another install requires SQL DB creation).
-			systemctl restart mysql
-
-		fi
-
 		#WEBSERVER_MARIADB
 		INSTALLING_INDEX=88
 		if (( ${aSOFTWARE_INSTALL_STATE[$INSTALLING_INDEX]} == 1 )); then
 
 			Banner_Installing
 
-			# In case remove old symlink, created by DietPi MySQL/MariaDB installation, otherwise installation will fail.
+			# In case remove old symlink, created by DietPi MariaDB installation, otherwise installation will fail.
+			# This will not remove the folder in case, without "-R".
 			rm /var/lib/mysql &> /dev/null
 			G_AGI mariadb-server
 
@@ -3796,7 +3645,7 @@ _EOF_
 
 			Banner_Installing
 
-			#Mysql must be running during install to allow debconf setup.
+			#MySQL must be running during install to allow debconf setup.
 			systemctl start mysql
 
 			# Set password parameters before installing
@@ -8236,46 +8085,23 @@ _EOF_
 
 		fi
 
-		#WEBSERVER_MYSQL
-		INSTALLING_INDEX=86
-		if (( ${aSOFTWARE_INSTALL_STATE[$INSTALLING_INDEX]} == 1 )); then
-
-			Banner_Configuration
-
-			#Optimize for reduced memory use: https://github.com/Fourdee/DietPi/issues/605#issue-188930987
-			cat << _EOF_ > /etc/mysql/conf.d/reduce_resources.cnf
-[mysqld]
-key_buffer_size=8M
-max_connections=30
-query_cache_size=8M
-query_cache_limit=512K
-thread_stack=128K
-_EOF_
-
-		fi
-
 		#WEBSERVER_MARIADB
 		INSTALLING_INDEX=88
 		if (( ${aSOFTWARE_INSTALL_STATE[$INSTALLING_INDEX]} == 1 )); then
+
+			Banner_Configuration
 
 			# On Jessie assure unix_socket authentication:
 			if (( $G_DISTRO < 4 )); then
 
 				mysql -uroot -e "install plugin unix_socket soname 'auth_socket';"
-				mysql -uroot -e "grant usage on *.* to 'root'@'localhost' identified via unix_socket;flush privileges;"
+				mysql -uroot -e "grant all privileges on *.* to 'root'@'localhost' identified via unix_socket with grant option;flush privileges"
 				# Drop unnecessary root user children.
-				mysql -uroot -e "drop user root@dietpi;drop user root@'127.0.0.1';drop user root@'::1';"
+				mysql -uroot -e "drop user 'root'@'dietpi';drop user 'root'@'127.0.0.1';drop user 'root'@'::1'"
 
 			fi
 
-		fi
-
-		#MariaDB + MySQL | Move SQL store to userdata location: https://github.com/Fourdee/DietPi/issues/672
-		if (( ${aSOFTWARE_INSTALL_STATE[86]} == 1 ||
-			${aSOFTWARE_INSTALL_STATE[88]} == 1 )); then
-
-			Banner_Configuration
-
+			# Move SQL store to userdata location: https://github.com/Fourdee/DietPi/issues/672
 			if [ "$(readlink /var/lib/mysql)" != "$G_FP_DIETPI_USERDATA/mysql" ]; then
 
 				systemctl stop mysql
@@ -8284,7 +8110,7 @@ _EOF_
 				mkdir -p "$G_FP_DIETPI_USERDATA"/mysql
 
 				# - copy
-				cp -R /var/lib/mysql/* "$G_FP_DIETPI_USERDATA"/mysql/
+				cp -a /var/lib/mysql/* "$G_FP_DIETPI_USERDATA"/mysql/
 				if (( $? != 0 )); then
 
 					G_DIETPI-NOTIFY 1 "Moving of MySQL data store failed to $G_FP_DIETPI_USERDATA/mysql. DietPi-Software will now exit"
@@ -8303,6 +8129,17 @@ _EOF_
 				Install_Apply_Permissions &> /dev/null
 
 			fi
+
+			### Also for MariaDB?
+			#Optimize for reduced memory use: https://github.com/Fourdee/DietPi/issues/605#issue-188930987
+#			cat << _EOF_ > /etc/mysql/conf.d/reduce_resources.cnf
+#[mysqld]
+#key_buffer_size=8M
+#max_connections=30
+#query_cache_size=8M
+#query_cache_limit=512K
+#thread_stack=128K
+#_EOF_
 
 		fi
 
@@ -8452,7 +8289,7 @@ _EOF_
 			fi
 
 			# Enable MySQL 4-byte support: https://doc.owncloud.org/server/latest/admin_manual/configuration/database/linux_database_configuration.html#configure-mysql-for-4-byte-unicode-support
-			cat << _EOF_ > /etc/mysql/conf.d/99-dietpi-4bit.cnf
+			cat << _EOF_ > /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf
 [mysqld]
 innodb_large_prefix=1
 innodb_file_format=barracuda
@@ -8483,11 +8320,9 @@ _EOF_
 
 			systemctl start mysql
 			# For MariaDB, temporary database admin user needs to be created, as 'root' uses unix_socket login, which cannot be accessed by sudo -u www-data.
-			local mysql_cmd='mysql -uroot'
-			(( ${aSOFTWARE_INSTALL_STATE[86]} >= 1 )) && mysql_cmd+=" -p$GLOBAL_PW"
-			$mysql_cmd -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
+			mysql -uroot -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
 			grep -q "'installed' => true," $config_php 2>/dev/null || occ maintenance:install --no-interaction --database "mysql" --database-name "owncloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$datadir"
-			$mysql_cmd -e "drop user 'tmp_root'@'localhost'"
+			mysql -uroot -e "drop user 'tmp_root'@'localhost'"
 
 			# Enable MySQL 4-byte support for new installations only, to prevent risky database conversion tasks:
 			if (( $oc_is_fresh == 1 )); then
@@ -8652,7 +8487,7 @@ _EOF_
 			fi
 
 			# Enable MySQL 4-byte support: https://docs.nextcloud.com/server/12/admin_manual/configuration_database/mysql_4byte_support.html
-			cat << _EOF_ > /etc/mysql/conf.d/99-dietpi-4bit.cnf
+			cat << _EOF_ > /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf
 [mysqld]
 innodb_large_prefix=1
 innodb_file_format=barracuda
@@ -8683,11 +8518,9 @@ _EOF_
 
 			systemctl start mysql
 			# For MariaDB, temporary database admin user needs to be created, as 'root' uses unix_socket login, which cannot be accessed by sudo -u www-data.
-			local mysql_cmd='mysql -uroot'
-			(( ${aSOFTWARE_INSTALL_STATE[86]} >= 1 )) && mysql_cmd+=" -p$GLOBAL_PW"
-			$mysql_cmd -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
+			mysql -uroot -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
 			grep -q "'installed' => true," $config_php 2>/dev/null || ncc maintenance:install --no-interaction --database "mysql" --database-name "nextcloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$datadir"
-			$mysql_cmd -e "drop user 'tmp_root'@'localhost'"
+			mysql -uroot -e "drop user 'tmp_root'@'localhost'"
 
 			# Enable MySQL 4-byte support for new installations only, to prevent risky database conversion tasks:
 			if (( $nc_is_fresh == 1 )); then
@@ -12684,17 +12517,13 @@ _EOF_
 
 			G_AGP lighttpd
 
-		elif (( $index == 86 || $index == 88 )); then
+		elif (( $index == 88 )); then
 
-			G_AGP mysql-server mysql-client
+			G_AGP mariadb-server
 
-			G_AGP mariadb-server mariadb-client
-
+			### Also for MariaDB?
 			# - custom confs
-			rm /etc/mysql/conf.d/reduce_resources.cnf
-
-			# - Remove debian flag generated by mariaDB install that prevents mysql 5.5 being installed.
-			rm /var/lib/mysql/debian-*
+			#rm /etc/mysql/conf.d/reduce_resources.cnf
 
 			# - SQL store
 			rm /var/lib/mysql &> /dev/null || rm -R /var/lib/mysql &> /dev/null #in case of symlink or folder
@@ -12737,14 +12566,12 @@ _EOF_
 			a2dissite owncloud 2>/dev/null
 			rm /etc/apache2/sites-available/owncloud.conf 2>/dev/null
 			rm /etc/nginx/sites-dietpi/owncloud.config 2>/dev/null
-			# Drop MySQL/MariaDB user and database
+			# Drop MariaDB user and database
 			systemctl start mysql
-			local mysql_auth='-uroot'
-			(( ${aSOFTWARE_INSTALL_STATE[86]} >= 1 )) && mysql_auth+=" -p$GLOBAL_PW"
-			mysql "$mysql_auth" -e "drop user $(grep -m1 "'dbuser'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")@$(grep -m1 "'dbhost'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")"
-			mysql "$mysql_auth" -e "drop user $(grep -m1 "'dbuser'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")"
-			mysqldump --lock-tables "$mysql_auth" owncloud > "$G_FP_DIETPI_USERDATA"/owncloud_data/mysql_backup.sql
-			mysqladmin "$mysql_auth" drop owncloud -f
+			mysql -uroot -e "drop user $(grep -m1 "'dbuser'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")@$(grep -m1 "'dbhost'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")"
+			mysql -uroot -e "drop user $(grep -m1 "'dbuser'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")"
+			mysqldump -uroot --lock-tables owncloud > "$G_FP_DIETPI_USERDATA"/owncloud_data/mysql_backup.sql
+			mysqladmin -uroot drop owncloud -f
 			# Purge APT package
 			G_AGP owncloud-files owncloud owncloud-deps
 			# Remove ownCloud installation folder
@@ -12762,14 +12589,12 @@ _EOF_
 			rm /etc/nginx/sites-dietpi/nextcloud.config 2>/dev/null
 			lighttpd-disable-mod dietpi-nextcloud 2>/dev/null
 			rm /etc/lighttpd/conf-available/99-dietpi-nextcloud.conf 2>/dev/null
-			# Drop MySQL/MariaDB user and database
+			# Drop MariaDB user and database
 			systemctl start mysql
-			local mysql_auth='-uroot'
-			(( ${aSOFTWARE_INSTALL_STATE[86]} >= 1 )) && mysql_auth+=" -p$GLOBAL_PW"
-			mysql "$mysql_auth" -e "drop user $(grep -m1 "'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")@$(grep -m1 "'dbhost'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")"
-			mysql "$mysql_auth" -e "drop user $(grep -m1 "'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")"
-			mysqldump --lock-tables "$mysql_auth" nextcloud > "$G_FP_DIETPI_USERDATA"/nextcloud_data/mysql_backup.sql
-			mysqladmin "$mysql_auth" drop nextcloud -f
+			mysql -uroot -e "drop user $(grep -m1 "'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")@$(grep -m1 "'dbhost'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")"
+			mysql -uroot -e "drop user $(grep -m1 "'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")"
+			mysqldump -uroot --lock-tables nextcloud > "$G_FP_DIETPI_USERDATA"/nextcloud_data/mysql_backup.sql
+			mysqladmin -uroot drop nextcloud -f
 			# Remove Nextcloud installation folder
 			rm -R /var/www/nextcloud
 
@@ -12828,7 +12653,7 @@ _EOF_
 
 			rm -R /var/www/ompd
 			systemctl start mysql
-			mysqladmin -u root -p"$GLOBAL_PW" drop ompd -f
+			mysqladmin -uroot drop ompd -f
 
 		elif (( $index == 130 )); then
 
@@ -12926,7 +12751,7 @@ _EOF_
 		elif (( $index == 143 )); then
 
 			systemctl start mysql
-			mysqladmin -u root -p"$GLOBAL_PW" drop koel -f
+			mysqladmin -uroot drop koel -f
 
 			rm -R /var/www/koel
 
@@ -13190,7 +13015,7 @@ _EOF_
 
 			#drop database
 			systemctl start mysql
-			mysqladmin -u root -p"$GLOBAL_PW" drop ampache -f
+			mysqladmin -uroot drop ampache -f
 
 		elif (( $index == 117 )); then
 
@@ -13300,7 +13125,7 @@ _EOF_
 
 			#drop database
 			systemctl start mysql
-			mysqladmin -u root -p"$GLOBAL_PW" drop pydio -f
+			mysqladmin -uroot drop pydio -f
 
 		elif (( $index == 36 )); then
 
@@ -13325,7 +13150,7 @@ _EOF_
 
 			#drop database
 			systemctl start mysql
-			mysqladmin -u root -p"$GLOBAL_PW" drop baikal -f
+			mysqladmin -uroot drop baikal -f
 
 		elif (( $index == 65 )); then
 
@@ -13400,7 +13225,7 @@ _EOF_
 			rm /var/log/gogs.log
 
 			systemctl start mysql
-			mysqladmin -u root -p"$GLOBAL_PW" drop gogs -f
+			mysqladmin -uroot drop gogs -f
 
 		elif (( $index == 46 )); then
 
@@ -13495,7 +13320,7 @@ _EOF_
 
 			# drop/delete database
 			systemctl start mysql
-			mysqladmin -u root -p"$GLOBAL_PW" drop gitea -f
+			mysqladmin -uroot drop gitea -f
 			systemctl stop mysql
 
 		elif (( $index == 166 )); then
@@ -13586,7 +13411,7 @@ _EOF_
 
 			rm -R /var/www/allo
 			systemctl start mysql
-			mysqladmin -u root -p"$GLOBAL_PW" drop allo_db -f
+			mysqladmin -uroot drop allo_db -f
 			systemctl stop mysql
 
 
@@ -15380,7 +15205,7 @@ _EOF_
 			( ${aSOFTWARE_INSTALL_STATE[80]} < 2 && ${aSOFTWARE_INSTALL_STATE[82]} < 2 ) )); then
 
 			WHIP_TITLE='PhpMyAdmin'
-			WHIP_QUESTION="Due to a apt-get installation issue with PhpMyAdmin, you must have a fully installed Lighttpd + Mysql/MaridaDB webserver stack, before PhpMyAdmin can be selected for install.\n\nYour selection for PhpMyAdmin has been removed."
+			WHIP_QUESTION="Due to a apt-get installation issue with PhpMyAdmin, you must have a fully installed Lighttpd + MaridaDB webserver stack, before PhpMyAdmin can be selected for install.\n\nYour selection for PhpMyAdmin has been removed."
 			whiptail --title "$WHIP_TITLE" --msgbox "$WHIP_QUESTION" --backtitle "$WHIP_BACKTITLE" 13 70
 
 			aSOFTWARE_INSTALL_STATE[90]=0

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2511,6 +2511,29 @@ _EOF_
 			 aSOFTWARE_ONLINEDOC_URL[$index_current]='f=8&t=5&start=10#p63'
 		#------------------
 
+		#--------------------------------------------------------------------------------
+		#Free indexes (due to removal of MySQL)
+		#--------------------------------------------------------------------------------
+		index_current=74
+			aSOFTWARE_WHIP_NAME[$index_current]='free index'
+			aSOFTWARE_WHIP_DESC[$index_current]=''
+			aSOFTWARE_CATEGORY_INDEX[$index_current]=0
+			aSOFTWARE_TYPE[$index_current]=-1
+		index_current=77
+			aSOFTWARE_WHIP_NAME[$index_current]='free index'
+			aSOFTWARE_WHIP_DESC[$index_current]=''
+			aSOFTWARE_CATEGORY_INDEX[$index_current]=0
+			aSOFTWARE_TYPE[$index_current]=-1
+		index_current=80
+			aSOFTWARE_WHIP_NAME[$index_current]='free index'
+			aSOFTWARE_WHIP_DESC[$index_current]=''
+			aSOFTWARE_CATEGORY_INDEX[$index_current]=0
+			aSOFTWARE_TYPE[$index_current]=-1
+		index_current=86
+			aSOFTWARE_WHIP_NAME[$index_current]='free index'
+			aSOFTWARE_WHIP_DESC[$index_current]=''
+			aSOFTWARE_CATEGORY_INDEX[$index_current]=0
+			aSOFTWARE_TYPE[$index_current]=-1
 
 		#--------------------------------------------------------------------------------
 		#Total software installations
@@ -2620,7 +2643,6 @@ _EOF_
 			aSOFTWARE_INSTALL_STATE[65]=1 # Netdata
 			aSOFTWARE_INSTALL_STATE[96]=1 # Samba
 
-			#aSOFTWARE_INSTALL_STATE[80]=1 # LLMP
 			aSOFTWARE_INSTALL_STATE[121]=1 # Roon Bridge
 			aSOFTWARE_INSTALL_STATE[124]=1 # NAA Daemon
 			#aSOFTWARE_INSTALL_STATE[128]=1 # MPD

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8703,7 +8703,7 @@ _EOF_
 
 			Banner_Configuration
 
-			/DietPi/dietpi/func/create_mysql_db phpbb3 "$GLOBAL_PW" root "$GLOBAL_PW"
+			/DietPi/dietpi/func/create_mysql_db phpbb3 root "$GLOBAL_PW"
 
 		fi
 
@@ -9634,7 +9634,7 @@ _EOF_
 			Banner_Configuration
 
 			#Create mysql DB
-			/DietPi/dietpi/func/create_mysql_db wordpress "$GLOBAL_PW" root "$GLOBAL_PW"
+			/DietPi/dietpi/func/create_mysql_db wordpress root "$GLOBAL_PW"
 
 		fi
 
@@ -9917,7 +9917,7 @@ _EOF_
 			unzip -o sql.zip
 			rm sql.zip
 
-			/DietPi/dietpi/func/create_mysql_db ampache "$GLOBAL_PW" root "$GLOBAL_PW"
+			/DietPi/dietpi/func/create_mysql_db ampache root "$GLOBAL_PW"
 			mysql -u root -p"$GLOBAL_PW" ampache < ampache.sql
 			rm ampache.sql
 
@@ -10299,7 +10299,7 @@ _EOF_
 			a2enmod rewrite
 
 			#Create Mysql DB
-			/DietPi/dietpi/func/create_mysql_db pydio "$GLOBAL_PW" root "$GLOBAL_PW"
+			/DietPi/dietpi/func/create_mysql_db pydio root "$GLOBAL_PW"
 
 			#Setup Data directory
 			local target_data_dir="$G_FP_DIETPI_USERDATA/pydio_data"
@@ -10472,7 +10472,7 @@ _EOF_
 			cd ~/
 
 			# - Mysql DB
-			/DietPi/dietpi/func/create_mysql_db baikal "$GLOBAL_PW" root "$GLOBAL_PW"
+			/DietPi/dietpi/func/create_mysql_db baikal root "$GLOBAL_PW"
 
 		fi
 
@@ -10627,7 +10627,7 @@ _EOF_
 			mkdir -p "$G_FP_DIETPI_USERDATA"/gogs-repo
 
 			# - sqldb
-			/DietPi/dietpi/func/create_mysql_db gogs "$GLOBAL_PW" root "$GLOBAL_PW"
+			/DietPi/dietpi/func/create_mysql_db gogs root "$GLOBAL_PW"
 
 			# - service (couldnt get this to run as a new thread with systemD (&). so bash script ftw.
 			cat << _EOF_ > /etc/gogs/start.sh
@@ -11271,7 +11271,7 @@ _EOF_
 			sed -i "/'media_dir'/c \$cfg[\'media_dir\']                 = \'/var/lib/mpd/music/\';" /var/www/ompd/include/config.inc.php
 			sed -i "/'ignore_media_dir_access_error'/c \$cfg[\'ignore_media_dir_access_error\']                 = \'true';" /var/www/ompd/include/config.inc.php
 
-			/DietPi/dietpi/func/create_mysql_db ompd "$GLOBAL_PW" root "$GLOBAL_PW"
+			/DietPi/dietpi/func/create_mysql_db ompd root "$GLOBAL_PW"
 
 		fi
 
@@ -11537,7 +11537,7 @@ _EOF_
 
 			Download_Test_Media
 
-			/DietPi/dietpi/func/create_mysql_db koel "$GLOBAL_PW" root "$GLOBAL_PW"
+			/DietPi/dietpi/func/create_mysql_db koel root "$GLOBAL_PW"
 
 			cd /var/www/koel
 
@@ -11947,7 +11947,7 @@ _EOF_
 			chown -R dietpi:dietpi /var/log/gitea
 
 			# - sqldb
-			/DietPi/dietpi/func/create_mysql_db gitea "$GLOBAL_PW" root "$GLOBAL_PW"
+			/DietPi/dietpi/func/create_mysql_db gitea root "$GLOBAL_PW"
 
 		fi
 
@@ -11959,7 +11959,7 @@ _EOF_
 
 			Banner_Configuration
 
-			/DietPi/dietpi/func/create_mysql_db allo_db dietpi root dietpi
+			/DietPi/dietpi/func/create_mysql_db allo_db root "$GLOBAL_PW"
 			mysql -u root -pdietpi allo_db < /var/www/allo_db.sql
 			rm /var/www/allo_db.sql
 

--- a/dietpi/func/create_mysql_db
+++ b/dietpi/func/create_mysql_db
@@ -2,21 +2,20 @@
 {
 	#////////////////////////////////////
 	# DietPi Function:
-	# - Creates a MySql database
+	# - Creates a MariaDB database
 	#////////////////////////////////////
 	# Created by Daniel Knight / daniel.knight@dietpi.com / dietpi.com
 	#////////////////////////////////////
 	# Usage:
-	# - /DietPi/dietpi/func/create_mysql_db DATABASE_NAME MYSQL_ROOT_PW DATABASE_USER DATABASE_PW
+	# - /DietPi/dietpi/func/create_mysql_db DATABASE_NAME DATABASE_USER DATABASE_PW
 	#
 	# Drop database:
-	# - mysqladmin -u root -pdietpi drop phpbb3 -f
+	# - mysqladmin -uroot drop phpbb3 -f
 	#////////////////////////////////////
 
 	DATABASE_NAME="$1"
-	MYSQL_ROOT_PW="$2"
-	DATABASE_USER="$3"
-	DATABASE_PW="$4"
+	DATABASE_USER="$2"
+	DATABASE_PW="$3"
 
 	#Import DietPi-Globals ---------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals

--- a/dietpi/func/create_mysql_db
+++ b/dietpi/func/create_mysql_db
@@ -31,18 +31,15 @@
 	#Start MySQL if not running.
 	service mysql start &> /dev/null
 
-	G_DIETPI-NOTIFY 2 "Creating MySQL database: $DATABASE_NAME"
+	G_DIETPI-NOTIFY 2 "Creating MariaDB database: $DATABASE_NAME"
 
-	# On MariaDB, unix_socket authentication is used, thus no root password is necessary + it breaks access on Jessie.
-	# If 'IDENTIFIED BY' is used on root user, it will overwrite unix_socket authentication, thus this part need to be left out on MariaDB.
 	#Generate DB
-	mysql_cmd='mysql -uroot'
-	grep -q 'aSOFTWARE_INSTALL_STATE\[86\]=0' /DietPi/dietpi/.installed || mysql_cmd+=" -p$MYSQL_ROOT_PW"
+	# 'identified by' can overwrite unix_socket authentication, thus just use this for non-root users.
 	grant_privileges=''
 	[ "$DATABASE_USER" == 'root' ] || grant_privileges="grant all privileges on \`$DATABASE_NAME\`.* to $DATABASE_USER@localhost identified by '$DATABASE_PW';flush privileges"
-	$mysql_cmd -e "create database \`$DATABASE_NAME\`;$grant_privileges"
+	mysql -uroot -e "create database \`$DATABASE_NAME\`;$grant_privileges"
 
-	G_DIETPI-NOTIFY -1 "$?" "Creating MySQL database: $DATABASE_NAME |"
+	G_DIETPI-NOTIFY -1 "$?" "Creating MariaDB database: $DATABASE_NAME |"
 
 	#-----------------------------------------------------------------------------------
 	exit

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -123,7 +123,7 @@ _EOF_
 
 				else
 
-					INPUT_MODE_VALUE='http://ftp.debian.org/debian/'
+					INPUT_MODE_VALUE='https://deb.debian.org/debian/'
 
 				fi
 


### PR DESCRIPTION
https://github.com/Fourdee/DietPi/issues/1397
- [x] create_mysql_db
- [x] Remove "-p" option from all mysql commands
- [x] Fix userdata symlink handling on installation/configuration
- [x] Test phpMyAdmin: Default database user "phpmyadmin" need to be used, full privileges set
- [x] Fixed a tiny bug regarding default repo, that I just faced during testing.