### PR TITLE
DietPi-Set_Software | Repository enhancements

### DIFF
--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -149,17 +149,17 @@ _EOF_
 				cat << _EOF_ > /etc/apt/sources.list
 deb $INPUT_MODE_VALUE $G_DISTRO_NAME main contrib non-free
 deb $INPUT_MODE_VALUE $G_DISTRO_NAME-updates main contrib non-free
-deb http://security.debian.org/debian-security/ $G_DISTRO_NAME/updates main contrib non-free
+deb https://deb.debian.org/debian-security/ $G_DISTRO_NAME/updates main contrib non-free
 deb $INPUT_MODE_VALUE $G_DISTRO_NAME-backports main contrib non-free
 _EOF_
 
-				#	Jessie, switch to http: https://github.com/Fourdee/DietPi/issues/1285#issuecomment-351830101
-				if (( $G_DISTRO == 3 )); then
+				#	Jessie, switch deb.debian.org to http: https://github.com/Fourdee/DietPi/issues/1285#issuecomment-351830101
+				if (( $G_DISTRO < 4 )); then
 
-					sed -i 's/https/http/g' /etc/apt/sources.list
+					sed -i 's|https://deb.debian.org|http://deb.debian.org|g' /etc/apt/sources.list
 
 				#	Buster, remove backports: https://github.com/Fourdee/DietPi/issues/1285#issuecomment-351830101
-				elif (( $G_DISTRO == 5 )); then
+				elif (( $G_DISTRO > 4 )); then
 
 					sed -i '/backports/d' /etc/apt/sources.list
 


### PR DESCRIPTION
+ Use deb.debian.org mirrordirector as default and hardcoded debian-security repo.
+ On Jessie, just revert deb.debian.org to http, as just here issues with https were observed.