### PR TITLE
DietPi-Set_Software | Fix locales?

### DIFF
--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -75,9 +75,9 @@ _EOF_
 			# - and force locale for remote access, especially dropbear, where receiving locale from client can't be suppressed:
 			cat << _EOF_ > /etc/profile.d/99-dietpi-force-locale.sh
 # To force server locales on SSH access, as dropbear does automatically overwrite them by client values:
-export LANG="$INPUT_MODE_VALUE"
-export LC_ALL="$INPUT_MODE_VALUE"
-export LANGUAGE="$( echo $INPUT_MODE_VALUE | sed 's/\..*//' ):$( echo $INPUT_MODE_VALUE | sed 's/_.*//' )"
+export LANG=$INPUT_MODE_VALUE
+export LC_ALL=$INPUT_MODE_VALUE
+export LANGUAGE=$( echo $INPUT_MODE_VALUE | sed 's/\..*//' ):$( echo $INPUT_MODE_VALUE | sed 's/_.*//' )
 _EOF_
 			chmod +x /etc/profile.d/99-dietpi-force-locale.sh
 

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -72,18 +72,6 @@ en_GB.UTF-8 UTF-8
 _EOF_
 			G_RUN_CMD dpkg-reconfigure -f noninteractive locales
 
-			# - Pump default locale into sys env: https://github.com/Fourdee/DietPi/issues/825
-			cat << _EOF_ > /etc/environment
-LC_ALL=$INPUT_MODE_VALUE
-LANG=$INPUT_MODE_VALUE
-_EOF_
-
-			# - and default locale (jessie?)
-			cat << _EOF_ > /etc/default/locale
-LC_ALL=$INPUT_MODE_VALUE
-LANG=$INPUT_MODE_VALUE
-_EOF_
-
 			# - and force locale for remote access, especially dropbear, where receiving locale from client can't be suppressed:
 			cat << _EOF_ > /etc/profile.d/99-dietpi-force-locale.sh
 # To force server locales on SSH access, as dropbear does automatically overwrite them by client values:
@@ -92,10 +80,6 @@ export LC_ALL="$INPUT_MODE_VALUE"
 export LANGUAGE="$( echo $INPUT_MODE_VALUE | sed 's/\..*//' ):$( echo $INPUT_MODE_VALUE | sed 's/_.*//' )"
 _EOF_
 			chmod +x /etc/profile.d/99-dietpi-force-locale.sh
-
-
-			#??? Is this still required?
-			localectl set-locale LANG="$INPUT_MODE_VALUE"
 
 			sed -i "/AUTO_SETUP_LOCALE=/c\AUTO_SETUP_LOCALE=$INPUT_MODE_VALUE" /DietPi/dietpi.txt
 


### PR DESCRIPTION
Fixes https://github.com/Fourdee/DietPi/issues/1385#issuecomment-358089280

But I still would consider the following:

- Keep all additional user selected languages, just add `en_GB.UTF-8`, if it was missing.
Move `LANG=en_GB.UTF-8` out of `dietpi-globals` (into all dedicated scripts again), as we source it on every login which might affect also desktop/software languages? We can assure on the other hand that `dietpi-globals` itself is parsed correctly, if we set `LANG=en_GB.UTF-8` in the dedicated scripts **before** sourcing it. Just at boot/dietpi-login script, we might need to test, if everything behaves as expected. I am not sure how all this is handled before user login.
**€:** Ah, we also would need to set LANG in all global functions as local variable I guess 🤔.