### PR TITLE
DietPi-Set_Software | Use "pool" directive for NTPD

### DIFF
--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -214,11 +214,23 @@ _EOF_
 				fi
 
 				# - Set NTPD mirror
-				sed -i '/^server [0-9]/d' /etc/ntp.conf
-				for ((i=0; i<4; i++))
-				do
+				#   - Remove obsolete 'server' entries.
+				sed -i '/^[[:blank:]#;]*server [0-9]/d' /etc/ntp.conf
+				for ((i=0; i<4; i++)) do
 
-					echo -e "server $i.$ntpd_mirror iburst" >> /etc/ntp.conf
+					if grep "^[[:blank:]]*pool $i" /etc/ntp.conf; then
+
+						sed -i "s/^[[:blank:]]*pool $i.*/pool $i.$ntpd_mirror iburst/" /etc/ntp.conf
+
+					elif grep "^[[:blank:]#;]*pool $i" /etc/ntp.conf; then
+
+						sed -i "s/^[[:blank:]#;]*pool $i.*/pool $i.$ntpd_mirror iburst/" /etc/ntp.conf
+
+					else
+
+						echo -e "pool $i.$ntpd_mirror iburst" >> /etc/ntp.conf
+
+					fi
 
 				done
 


### PR DESCRIPTION
@Fourdee 
Hehe, was not yet finished 😋:
+ Switch NTP config to "pool" directive: https://serverfault.com/a/773234 and it's default on Debian.
+ Use sed to leave directives in place.

On master, current ntpd mirror was read from /etc/ntp.conf 'server 0' entry. But this changed in testing, so I don't need to adjust this directive somewhere else, right?