### PR TITLE
DietPi-Software | Java: Switch from OracleJDK to OpenJDK

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2294,7 +2294,7 @@ _EOF_
 		index_current=8
 
 				 aSOFTWARE_WHIP_NAME[$index_current]='Java'
-				 aSOFTWARE_WHIP_DESC[$index_current]='oracle java 8 jdk/jre libary'
+				 aSOFTWARE_WHIP_DESC[$index_current]='OpenJDK 8 + JRE libary'
 			aSOFTWARE_CATEGORY_INDEX[$index_current]=4
 					  aSOFTWARE_TYPE[$index_current]=1
 		#------------------
@@ -3107,7 +3107,7 @@ _EOF_
 				# - Flag for install
 				aSOFTWARE_INSTALL_STATE[8]=1
 
-				G_DIETPI-NOTIFY 2 "Oracle Java will be installed"
+				G_DIETPI-NOTIFY 2 "OpenJDK 8 will be installed"
 
 				break
 
@@ -7326,28 +7326,20 @@ _EOF_
 
 			Banner_Installing
 
-			# - Raspbian
-			if (( $G_HW_MODEL < 10 )); then
+			# On Jessie use backports repo:
+			if (( $G_DISTRO == 3 )); then
 
-				G_AGI oracle-java8-jdk
-
-			# - Debian. Add repo
-			else
-
-				cat << _EOF_ > /etc/apt/sources.list.d/webupd8team-java.list
-deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main
-deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main
+				cat << _EOF_ > /etc/apt/preferences.d/99-dietpi-openjdk-8-jdk
+Package: openjdk-8-jdk
+Pin: release a=jessie-backports
+Pin-Priority: 990
 _EOF_
 
-				apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EEA14886
 				G_AGUP
 
-				# - Accept the license: https://github.com/Fourdee/DietPi/issues/298
-				debconf-set-selections <<< "oracle-java8-installer shared/accepted-oracle-license-v1-1 boolean true"
-
-				G_AGI oracle-java8-installer
-
 			fi
+
+			G_AGI openjdk-8-jdk
 
 		fi
 
@@ -8947,29 +8939,7 @@ _EOF_
 
 			Banner_Configuration
 
-			# - Possible locations for Java
-			#	sed -i "/JAVA_HOME=/c\JAVA_HOME=$(which java)" /etc/default/tomcat8 # This doesnt work... | c2=/usr/bin/java/bin/java (Not a directory) | RPi = /usr/bin/java/bin/java (Not a directory)
-			local afp_java=(
-
-				'/usr/lib/jvm/java-7-oracle'
-				'/usr/lib/jvm/java-8-oracle'
-				'/usr/lib/jvm/jdk-8-oracle-arm32-vfp-hflt' #Rasbian
-
-			)
-
-			for ((i=0; i<${#afp_java[@]}; i++))
-			do
-
-				if [ -d "${afp_java[$i]}" ]; then
-
-					sed -i "/JAVA_HOME=/c\JAVA_HOME=${afp_java[$i]}" /etc/default/tomcat8
-					break
-
-				fi
-
-			done
-
-			unset afp_java
+			sed -i "/JAVA_HOME=/c\JAVA_HOME=$(find \/usr\/lib\/jvm\/ -name java-8-openjdk*)" /etc/default/tomcat8
 
 		fi
 
@@ -13571,9 +13541,8 @@ _EOF_
 
 		elif (( $index == 8 )); then
 
-			G_AGP oracle-java8-*
-			rm /etc/apt/sources.list.d/webupd8team-java.list
-			G_AGUP
+			G_AGP openjdk-8-jdk
+			rm /etc/apt/preferences.d/99-dietpi-openjdk-8-jdk &> /dev/null
 
 		elif (( $index == 104 )); then
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7335,11 +7335,13 @@ Pin: release a=jessie-backports
 Pin-Priority: 990
 _EOF_
 
-				G_AGUP
+				G_AGI openjdk-8-jdk -t jessie-backports
+
+			else
+
+				G_AGI openjdk-8-jdk
 
 			fi
-
-			G_AGI openjdk-8-jdk
 
 		fi
 


### PR DESCRIPTION
https://github.com/Fourdee/DietPi/issues/1401
+ On Jessie use backports: https://packages.debian.org/jessie-backports/openjdk-8-jdk
+ Also available on Raspbian, so we can handle all devices the same.

ToDo:
- Test with JDK relying software, especially tomcat, as this needed special adjustment: Java home dir is `/usr/lib/jvm/java-8-openjdk-<cpu_arch>`: https://packages.debian.org/jessie-backports/armhf/openjdk-8-jdk/filelist