### PR TITLE
DietPi-Software | Blynk: Update to Java 8 version and config typo fix

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4754,7 +4754,7 @@ _EOF_
 
 			mkdir -p /etc/blynkserver
 
-			INSTALL_URL_ADDRESS='https://github.com/blynkkk/blynk-server/releases/download/v0.29.2/server-0.29.2.jar'
+			INSTALL_URL_ADDRESS='https://github.com/blynkkk/blynk-server/releases/download/v0.29.7/server-0.29.7-java8.jar'
 			wget "$INSTALL_URL_ADDRESS" -O /etc/blynkserver/server.jar
 
 			# - Install Blynk JS Libary

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11359,7 +11359,7 @@ _EOF_
 
 			mkdir -p "$G_FP_DIETPI_USERDATA"/blynk
 			CONFIG_FILE_URL_ADDRESS='https://raw.githubusercontent.com/blynkkk/blynk-server/master/server/core/src/main/resources/server.properties'
-			wget "$CONFIG_URL_ADDRESS" -O "$G_FP_DIETPI_USERDATA"/blynk/server.properties
+			wget "$CONFIG_FILE_URL_ADDRESS" -O "$G_FP_DIETPI_USERDATA"/blynk/server.properties
 			sed -i "/data.folder=/c\data.folder=$G_FP_DIETPI_USERDATA/blynk" "$G_FP_DIETPI_USERDATA"/blynk/server.properties
 
 			cat << _EOF_ > /etc/systemd/system/blynkserver.service


### PR DESCRIPTION
+ Update Blynk to Java8 version: https://github.com/Fourdee/DietPi/pull/1405#issuecomment-358740228
+ Fix typo, which leaded to empty config file.