### PR TITLE
DietPi-Software | Mosquitto: Allow apt-get -f auto dependency installation for all architectures

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4716,28 +4716,19 @@ _EOF_
 			rm package.deb
 
 			INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/mosquitto_1.4.14-0mosquitto1_nows1_armhf.deb'
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 			if (( $G_HW_ARCH == 10 )); then
 
 				INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/mosquitto_1.4.14-0mosquitto1_nows1_amd64.deb'
 
 			fi
+			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			wget "$INSTALL_URL_ADDRESS" -O package.deb
 
 			#Install deb
-			#	ARMv8, allow error, so we can install additional required packages automatically
-			if (( $G_HW_ARCH == 3 )); then
-
-				dpkg -i package.deb
-				G_AGF
-
-			else
-
-				G_RUN_CMD dpkg -i package.deb
-
-			fi
-
+			#	Allow error, so we can install additional required packages automatically
+			dpkg -i package.deb
+			G_AGF
 			rm package.deb
 
 		fi
@@ -12630,9 +12621,8 @@ _EOF_
 
 		elif (( $index == 123 )); then
 
-			#apt-mark auto libssl1.0.0 libwebsockets3 &> /dev/null
+			#apt-mark auto libssl1.0.0
 			G_AGP mosquitto
-			#rm /etc/apt/sources.list.d/mosquitto-*.list
 
 		elif (( $index == 124 )); then
 


### PR DESCRIPTION
`libwrap0` was missing on Jessie VirtualBox. `G_AGF` worked here as well like a charm. We should use this after every `dpkg -i` to handle dependencies automatically 😄. Also nice is, that they will be autoremoved, if not needed anymore.