### PR TITLE
DietPi-Set_Hardware | Adjust "preferipversion" behaviour

### DIFF
--- a/dietpi.txt
+++ b/dietpi.txt
@@ -182,7 +182,7 @@ CONFIG_SOUNDCARD=none
 #	NB: Do not modify, you must use dietpi-config to configure/set options
 CONFIG_LCDPANEL=none
 
-#Prefer IPversion (for: APT) | auto (let system decide) / ipv4 (force) / ipv6 (force) | eg: force IPv4 with CONFIG_PREFER_IPVERSION=ipv4
+#Prefer IPversion (for: APT, wget) | auto (let system decide) / ipv4 (force) / ipv6 (prefer) | eg: force IPv4 with CONFIG_PREFER_IPVERSION=ipv4
 CONFIG_PREFER_IPVERSION=ipv4
 
 #Apt mirrors which are applied to /etc/apt/sources.list | Values here will also be applied during 1st run setup

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -1108,15 +1108,33 @@ _EOF_
 
 		if [ "$INPUT_DEVICE_VALUE" = "ipv4" ]; then
 
+			# - APT force IPv4
 			echo 'Acquire::ForceIPv4 "true";' > /etc/apt/apt.conf.d/99-dietpi-force-ipv4
+			# - Wget prefer IPv4
+			grep -q '^[[:blank:]]*prefer-family =' /etc/wgetrc &&
+			sed -i '/^[[:blank:]]*prefer-family =/c\prefer-family = IPv4' /etc/wgetrc ||
+			grep -q '^[[:blank:]#;]*prefer-family =' /etc/wgetrc &&
+			sed -i '/^[[:blank:]#;]*prefer-family =/c\prefer-family = IPv4' /etc/wgetrc ||
+			echo 'prefer-family = IPv4' >> /etc/wgetrc
 
 		elif [ "$INPUT_DEVICE_VALUE" = "ipv6" ]; then
 
-			echo 'Acquire::ForceIPv6 "true";' > /etc/apt/apt.conf.d/99-dietpi-force-ipv4
+			# - APT allow IPv6
+			rm /etc/apt/apt.conf.d/99-dietpi-force-ipv4 &> /dev/null
+			# - Wget prefer IPv6
+			grep -q '^[[:blank:]]*prefer-family =' /etc/wgetrc &&
+			sed -i '/^[[:blank:]]*prefer-family =/c\prefer-family = IPv6' /etc/wgetrc ||
+			grep -q '^[[:blank:]#;]*prefer-family =' /etc/wgetrc &&
+			sed -i '/^[[:blank:]#;]*prefer-family =/c\prefer-family = IPv6' /etc/wgetrc ||
+			echo 'prefer-family = IPv6' >> /etc/wgetrc
 
 		elif [ "$INPUT_DEVICE_VALUE" = "auto" ]; then
 
+			# - APT allow IPv6
 			rm /etc/apt/apt.conf.d/99-dietpi-force-ipv4 &> /dev/null
+			# - Wget back to default
+			grep -q '^[[:blank:]]*prefer-family =' /etc/wgetrc &&
+			sed -i 's/^[[:blank:]]*prefer-family =/#prefer-family =/' /etc/wgetrc
 
 		else
 


### PR DESCRIPTION
...according to https://github.com/Fourdee/DietPi/issues/472#issuecomment-356444922, for consistency and compatibility, as force IPv6 would break many APT mirrors.
+ Ready to merge!