### PR TITLE
DietPi-Software | ownCloud/Nextcloud: Enable auto backup & recovery & other enhancements

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3854,33 +3854,33 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS="https://download.owncloud.org/download/repositories/stable/Debian_$(( $G_DISTRO + 5 )).0/Release.key"
-			# No repository available yet after Stretch, thus we choose archive here:
-			(( $G_DISTRO > 4 )) && INSTALL_URL_ADDRESS='https://download.owncloud.org/community/owncloud-latest.zip'
-
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-
-			# Install necessary PHP modules: https://doc.owncloud.org/server/latest/admin_manual/installation/source_installation.html#php-extensions
+			G_DIETPI-NOTIFY 2 'Installing needed PHP modules: https://doc.owncloud.org/server/latest/admin_manual/installation/source_installation.html#php-extensions'
 			G_AGI "$PHP_APT_PACKAGE_NAME"-intl "$PHP_APT_PACKAGE_NAME"-redis
 
-			if [ ! -f /etc/apt/sources.list.d/owncloud.list ] && [ ! -f /var/www/owncloud/occ ]; then
+			if [ -f /var/www/owncloud/occ ]; then
 
-				wget "$INSTALL_URL_ADDRESS" -O owncloud.key_or_zip
-				if (( $G_DISTRO < 5 )); then
+				G_DIETPI-NOTIFY 2 'Existing ownCloud installation found, will NOT overwrite...'
 
-					echo -e "deb https://download.owncloud.org/download/repositories/stable/Debian_$(( $G_DISTRO + 5 )).0/ /" > /etc/apt/sources.list.d/owncloud.list
-					apt-key add - < owncloud.key_or_zip && G_AGUP
+			else
+
+				local datadir="$(grep -m1 '^[[:blank:]]*SOFTWARE_OWNCLOUD_DATADIR=' /DietPi/dietpi.txt | sed 's/^.*=//')"
+				[ -n "$datadir" ] || datadir="$G_FP_DIETPI_USERDATA/owncloud_data"
+				if [ -f "$datadir"/dietpi-owncloud-installation-backup/occ ]; then
+
+					G_DIETPI-NOTIFY 2 'ownCloud installation backup found, starting recovery...'
+					G_RUN_CMD cp -a "$datadir"/dietpi-owncloud-installation-backup/. /var/www/owncloud
 
 				else
 
-					unzip -o owncloud.key_or_zip -d /var/www
+					INSTALL_URL_ADDRESS='https://download.owncloud.org/community/owncloud-latest.zip'
+					G_CHECK_URL "$INSTALL_URL_ADDRESS"
+					G_RUN_CMD wget "$INSTALL_URL_ADDRESS" -O package.zip
+					G_RUN_CMD unzip -o package.zip -d /var/www
+					rm package.zip
 
 				fi
-				rm owncloud.key_or_zip
 
 			fi
-
-			[ -f /etc/apt/sources.list.d/owncloud.list ] && G_AGI owncloud-files
 
 		fi
 
@@ -3890,18 +3890,31 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://download.nextcloud.com/server/releases/latest.zip'
-
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-
-			# Install necessary PHP modules: https://docs.nextcloud.com/server/12/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
+			G_DIETPI-NOTIFY 2 'Installing needed PHP modules: https://docs.nextcloud.com/server/12/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation'
 			G_AGI "$PHP_APT_PACKAGE_NAME"-intl "$PHP_APT_PACKAGE_NAME"-redis
 
-			if [ ! -f /var/www/nextcloud/occ ]; then
+			if [ -f /var/www/nextcloud/occ ]; then
 
-				wget "$INSTALL_URL_ADDRESS" -O package.zip
-				unzip -o package.zip -d /var/www
-				rm package.zip
+				G_DIETPI-NOTIFY 2 'Existing Nextcloud installation found, will NOT overwrite...'
+
+			else
+
+				local datadir="$(grep -m1 '^[[:blank:]]*SOFTWARE_NEXTCLOUD_DATADIR=' /DietPi/dietpi.txt | sed 's/^.*=//')"
+				[ -n "$datadir" ] || datadir="$G_FP_DIETPI_USERDATA/nextcloudcloud_data"
+				if [ -f "$datadir"/dietpi-nextcloud-installation-backup/occ ]; then
+
+					G_DIETPI-NOTIFY 2 'Nextcloud installation backup found, starting recovery...'
+					G_RUN_CMD cp -a "$datadir"/dietpi-nextcloud-installation-backup/. /var/www/nextcloud
+
+				else
+
+					INSTALL_URL_ADDRESS='https://download.nextcloud.com/server/releases/latest.zip'
+					G_CHECK_URL "$INSTALL_URL_ADDRESS"
+					G_RUN_CMD wget "$INSTALL_URL_ADDRESS" -O package.zip
+					G_RUN_CMD unzip -o package.zip -d /var/www
+					rm package.zip
+
+				fi
 
 			fi
 
@@ -8238,7 +8251,7 @@ _EOF_
 
 			Banner_Configuration
 
-			# Enable necessary PHP modules: https://doc.owncloud.org/server/latest/admin_manual/installation/source_installation.html#php-extensions
+			G_DIETPI-NOTIFY 2 'Enabling needed PHP modules: https://doc.owncloud.org/server/latest/admin_manual/installation/source_installation.html#php-extensions'
 			"$PHP_APT_PACKAGE_NAME"enmod curl gd intl json pdo_mysql opcache apcu redis
 			# Following modules are switchable since Stretch:
 			if (( $G_DISTRO > 3 )); then
@@ -8250,33 +8263,32 @@ _EOF_
 			# APCu configuration: To prevent cli (cron.php) producing ownCloud log entries.
 			grep -q 'apc.enable_cli=' $FP_PHP_BASE_DIR/mods-available/apcu.ini && sed -i '/apc.enable_cli=/c\apc.enable_cli=1' $FP_PHP_BASE_DIR/mods-available/apcu.ini || echo 'apc.enable_cli=1' >> $FP_PHP_BASE_DIR/mods-available/apcu.ini
 
-			# Create ownCloud specific webserver config.
-			# Apache: https://doc.owncloud.org/server/latest/admin_manual/installation/source_installation.html#configure-apache-web-server
 			if (( ${aSOFTWARE_INSTALL_STATE[83]} >= 1 )); then
 
+				G_DIETPI-NOTIFY 2 'Apache webserver found, enable ownCloud specific configuration: "https://doc.owncloud.org/server/latest/admin_manual/installation/source_installation.html#configure-apache-web-server"'
 				a2enmod rewrite headers env dir mime 1> /dev/null
 				local owncloud_conf='/etc/apache2/sites-available/owncloud.conf'
-				# Do not overwrite existing config.
 				if [ -f $owncloud_conf ]; then
 
+					G_DIETPI-NOTIFY 2 'Existing ownCloud configuration found, will save the new one for review and comparison to: /etc/apache2/sites-available/owncloud.conf.dietpi-new'
 					owncloud_conf='/etc/apache2/sites-available/owncloud.conf.dietpi-new'
 
 				fi
 				cp /DietPi/dietpi/conf/apache.ownnextcloud.conf $owncloud_conf
 				sed -i 's/nextcloud/owncloud/g' $owncloud_conf
-				# OPcache adjustment is just asked by Nextcloud
+				# OPcache adjustment is just needed by Nextcloud
 				sed -i 's/php_admin_value/#php_admin_value/' $owncloud_conf
 				a2ensite owncloud 1> /dev/null
 
 			fi
 
-			# NGINX: https://doc.owncloud.org/server/latest/admin_manual/installation/nginx_configuration.html#owncloud-in-a-subdir-of-nginx
 			if (( ${aSOFTWARE_INSTALL_STATE[85]} >= 1 )); then
 
+				G_DIETPI-NOTIFY 2 'Nginx webserver found, enable ownCloud specific configuration: "https://doc.owncloud.org/server/latest/admin_manual/installation/nginx_configuration.html#owncloud-in-a-subdir-of-nginx"'
 				local owncloud_config='/etc/nginx/sites-dietpi/owncloud.config'
-				# Do not overwrite existing config.
 				if [ -f $owncloud_config ]; then
 
+					G_DIETPI-NOTIFY 2 'Existing ownCloud configuration found, will save the new one for review and comparison to: /etc/nginx/sites-dietpi/owncloud.config.dietpi-new'
 					owncloud_config='/etc/nginx/sites-dietpi/owncloud.config.dietpi-new'
 
 				fi
@@ -8300,48 +8312,56 @@ _EOF_
 
 			fi
 
-			# Enable MySQL 4-byte support: https://doc.owncloud.org/server/latest/admin_manual/configuration/database/linux_database_configuration.html#configure-mysql-for-4-byte-unicode-support
+			# Enable 4-byte support for MariaDB: https://doc.owncloud.org/server/latest/admin_manual/configuration/database/linux_database_configuration.html#configure-mysql-for-4-byte-unicode-support
 			cat << _EOF_ > /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf
 [mysqld]
 innodb_large_prefix=1
 innodb_file_format=barracuda
 innodb_file_per_table=1
 _EOF_
-			# Check if we really do fresh installation:
-			local oc_is_fresh=1
-			if [ -d "$G_FP_DIETPI_USERDATA"/mysql/owncloud ]; then
+			G_RUN_CMD systemctl restart mysql
 
-				oc_is_fresh=0
-
-			fi
-
-			# Re-source dietpi-globals to load occ command shortcut:
+			# Reload dietpi-globals to enable occ command shortcut:
 			. /DietPi/dietpi/func/dietpi-globals
 
 			# Adjusting config file:
 			local config_php='/var/www/owncloud/config/config.php'
 
-			# Terminal installation:
-			local datadir=$(cat /DietPi/dietpi.txt | grep -m1 '^SOFTWARE_OWNCLOUD_DATADIR=' | sed 's/.*=//')
-			[ ! -n "$datadir" ] && datadir="$G_FP_DIETPI_USERDATA/owncloud_data"
+			local datadir="$(grep -m1 '^[[:blank:]]*SOFTWARE_OWNCLOUD_DATADIR=' /DietPi/dietpi.txt | sed 's/^.*=//')"
+			[ -n "$datadir" ] || datadir="$G_FP_DIETPI_USERDATA/owncloud_data"
 			mkdir -p "$datadir"
 			Install_Apply_Permissions &> /dev/null
 
-			local username=$(cat /DietPi/dietpi.txt | grep -m1 '^SOFTWARE_OWNCLOUD_NEXTCLOUD_USERNAME=' | sed 's/.*=//')
-			[ ! -n "$username" ] && username='admin'
+			if [ -d "$G_FP_DIETPI_USERDATA"/mysql/owncloud ]; then
 
-			systemctl start mysql
-			# For MariaDB, temporary database admin user needs to be created, as 'root' uses unix_socket login, which cannot be accessed by sudo -u www-data.
-			mysql -uroot -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
-			grep -q "'installed' => true," $config_php 2>/dev/null || occ maintenance:install --no-interaction --database "mysql" --database-name "owncloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$datadir"
-			mysql -uroot -e "drop user 'tmp_root'@'localhost'"
+				G_DIETPI-NOTIFY 2 'ownCloud database found, will NOT overwrite.'
 
-			# Enable MySQL 4-byte support for new installations only, to prevent risky database conversion tasks:
-			if (( $oc_is_fresh == 1 )); then
+			else
 
-				grep -q "^[[:blank:]]*'mysql.utf8mb4'" $config_php || sed -i "/^[[:blank:]]*'dbpassword'/a \ \ 'mysql.utf8mb4' => true," $config_php
+				if [ -f "$datadir"/dietpi-owncloud-database-backup.sql ]; then
+
+					G_DIETPI-NOTIFY 2 'ownCloud database backup found, starting recovery...'
+					local dbuser=$(grep -m1 "^[[:blank:]]*'dbuser'" $config_php | awk '{print $3}' | sed "s/[',]//g")
+					local dbpass=$(grep -m1 "^[[:blank:]]*'dbpassword'" $config_php | awk '{print $3}' | sed "s/[',]//g")
+					/DietPi/dietpi/func/create_mysql_db owncloud "$dbuser" "$dbpass"
+					mysql -uroot owncloud < "$datadir"/dietpi-owncloud-database-backup.sql
+
+				else
+
+					local username="$(cat /DietPi/dietpi.txt | grep -m1 '^[[:blank:]]*SOFTWARE_OWNCLOUD_NEXTCLOUD_USERNAME=' | sed 's/^.*=//')"
+					[ -n "$username" ] || username='admin'
+
+					# For MariaDB, temporary database admin user needs to be created, as 'root' uses unix_socket login, which cannot be accessed by sudo -u www-data.
+					mysql -uroot -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
+					grep -q "'installed' => true," $config_php 2>/dev/null || occ maintenance:install --no-interaction --database "mysql" --database-name "owncloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$datadir"
+					mysql -uroot -e "drop user 'tmp_root'@'localhost'"
+
+				fi
 
 			fi
+
+			# Enable ownCloud to use 4-byte database
+			grep -q "^[[:blank:]]*'mysql.utf8mb4'" $config_php || sed -i "/^[[:blank:]]*'dbpassword'/a \ \ 'mysql.utf8mb4' => true," $config_php
 
 			# Add local IP and hostname to trusted domains.
 			# If "1 => '" does not exist, the config.php is not copied e.g. from older instance, so we add entries.
@@ -8386,16 +8406,6 @@ _EOF_
 
 			fi
 
-			# ownCloud/Nextcloud ignores system wide php.ini settings. Use their own config.
-			# Set max upload size
-			local php_max_upload_size="$(( $(php -r 'print(PHP_INT_MAX);') / 1024 / 1024))M"
-			sed -i "/upload_max_filesize=/c\upload_max_filesize=$php_max_upload_size" /var/www/owncloud/.user.ini
-			sed -i "/post_max_size=/c\post_max_size=$php_max_upload_size" /var/www/owncloud/.user.ini
-
-			# Set memory limit: total / 4
-			local memory_limit_max="$(( $RAM_TOTAL / 4 ))M"
-			sed -i "/memory_limit=/c\memory_limit=$memory_limit_max" /var/www/owncloud/.user.ini
-
 			# Enable ownCloud background cron job:
 			crontab -u www-data -l 2>/dev/null | grep -q '/var/www/owncloud/cron.php' || ( crontab -u www-data -l 2>/dev/null ; echo "*/15 * * * * php /var/www/owncloud/cron.php" ) | crontab -u www-data -
 			occ background:cron
@@ -8411,7 +8421,7 @@ _EOF_
 
 			Banner_Configuration
 
-			# Enable necessary PHP modules: https://docs.nextcloud.com/server/12/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
+			G_DIETPI-NOTIFY 2 'Enabling needed PHP modules: https://docs.nextcloud.com/server/12/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation'
 			"$PHP_APT_PACKAGE_NAME"enmod curl gd intl json pdo_mysql opcache apcu redis
 			# Following modules are switchable since Stretch:
 			if (( $G_DISTRO > 3 )); then
@@ -8431,15 +8441,14 @@ _EOF_
 			grep -q 'opcache.save_comments=' $FP_PHP_BASE_DIR/mods-available/opcache.ini && sed -i '/opcache.save_comments=/c\opcache.save_comments=1' $FP_PHP_BASE_DIR/mods-available/opcache.ini || echo 'opcache.save_comments=1' >> $FP_PHP_BASE_DIR/mods-available/opcache.ini
 			grep -q 'opcache.revalidate_freq=' $FP_PHP_BASE_DIR/mods-available/opcache.ini && sed -i '/opcache.revalidate_freq=/c\opcache.revalidate_freq=1' $FP_PHP_BASE_DIR/mods-available/opcache.ini || echo 'opcache.revalidate_freq=1' >> $FP_PHP_BASE_DIR/mods-available/opcache.ini
 
-			# Create Nextcloud specific webserver config.
-			# Apache: https://docs.nextcloud.com/server/12/admin_manual/installation/source_installation.html#apache-web-server-configuration
 			if (( ${aSOFTWARE_INSTALL_STATE[83]} >= 1 )); then
 
+				G_DIETPI-NOTIFY 2 'Apache webserver found, enable Nextcloud specific configuration: "https://docs.nextcloud.com/server/12/admin_manual/installation/source_installation.html#apache-web-server-configuration"'
 				a2enmod rewrite headers env dir mime 1> /dev/null
 				local nextcloud_conf='/etc/apache2/sites-available/nextcloud.conf'
-				# Do not overwrite existing config.
 				if [ -f $nextcloud_conf ]; then
-
+	
+					G_DIETPI-NOTIFY 2 'Existing Nextcloud configuration found, will save the new one for review and comparison to: /etc/apache2/sites-available/nextcloud.conf.dietpi-new'
 					nextcloud_conf='/etc/apache2/sites-available/nextcloud.conf.dietpi-new'
 
 				fi
@@ -8448,13 +8457,13 @@ _EOF_
 
 			fi
 
-			# Nginx: https://docs.nextcloud.com/server/12/admin_manual/installation/nginx.html#nextcloud-in-a-subdir-of-nginx
 			if (( ${aSOFTWARE_INSTALL_STATE[85]} >= 1 )); then
 
+				G_DIETPI-NOTIFY 2 'Nginx webserver found, enable Nextcloud specific configuration: "https://docs.nextcloud.com/server/12/admin_manual/installation/nginx.html#nextcloud-in-a-subdir-of-nginx"'
 				local nextcloud_config='/etc/nginx/sites-dietpi/nextcloud.config'
-				# Do not overwrite existing config.
 				if [ -f $nextcloud_config ]; then
 
+					G_DIETPI-NOTIFY 2 'Existing Nextcloud configuration found, will save the new one for review and comparison to: /etc/nginx/sites-dietpi/nextcloud.config.dietpi-new'
 					nextcloud_config='/etc/nginx/sites-dietpi/nextcloud.config.dietpi-new'
 
 				fi
@@ -8478,9 +8487,9 @@ _EOF_
 
 			fi
 
-			# Lighttpd: So far just to solve OPcache warning on admin panel
 			if (( ${aSOFTWARE_INSTALL_STATE[84]} >= 1 )); then
 
+				G_DIETPI-NOTIFY 2 'Lighttpd webserver found, enable Nextcloud specific configuration.'
 				local lighttpd_conf='/etc/lighttpd/lighttpd.conf'
 
 				# Enable mod_setenv
@@ -8494,52 +8503,58 @@ _EOF_
 				lighttpd-enable-mod dietpi-nextcloud
 				service lighttpd force-reload
 
-				unset lighttpd_conf
-
 			fi
 
-			# Enable MySQL 4-byte support: https://docs.nextcloud.com/server/12/admin_manual/configuration_database/mysql_4byte_support.html
+			# Enable 4-byte support for MariaDB: https://docs.nextcloud.com/server/12/admin_manual/configuration_database/mysql_4byte_support.html
 			cat << _EOF_ > /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf
 [mysqld]
 innodb_large_prefix=1
 innodb_file_format=barracuda
 innodb_file_per_table=1
 _EOF_
-			# Check if we really do fresh installation:
-			local nc_is_fresh=1
-			if [ -d "$G_FP_DIETPI_USERDATA"/mysql/nextcloud ]; then
+			G_RUN_CMD systemctl restart mysql
 
-				nc_is_fresh=0
-
-			fi
-
-			# Re-source dietpi-globals to load ncc command shortcut:
+			# Reload dietpi-globals to enable ncc command shortcut:
 			. /DietPi/dietpi/func/dietpi-globals
 
 			# Adjusting config file:
 			local config_php='/var/www/nextcloud/config/config.php'
 
-			# Terminal installation:
-			local datadir=$(grep -m1 '^SOFTWARE_NEXTCLOUD_DATADIR=' /DietPi/dietpi.txt | sed 's/.*=//')
-			[ ! -n "$datadir" ] && datadir="$G_FP_DIETPI_USERDATA/nextcloud_data"
+			local datadir="$(grep -m1 '^[[:blank:]]*SOFTWARE_NEXTCLOUD_DATADIR=' /DietPi/dietpi.txt | sed 's/^.*=//')"
+			[ -n "$datadir" ] || datadir="$G_FP_DIETPI_USERDATA/nextcloud_data"
 			mkdir -p "$datadir"
 			Install_Apply_Permissions &> /dev/null
 
-			local username=$(grep -m1 '^SOFTWARE_OWNCLOUD_NEXTCLOUD_USERNAME=' /DietPi/dietpi.txt | sed 's/.*=//')
-			[ ! -n "$username" ] && username='admin'
+			if [ -d "$G_FP_DIETPI_USERDATA"/mysql/nextcloud ]; then
 
-			systemctl start mysql
-			# For MariaDB, temporary database admin user needs to be created, as 'root' uses unix_socket login, which cannot be accessed by sudo -u www-data.
-			mysql -uroot -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
-			grep -q "'installed' => true," $config_php 2>/dev/null || ncc maintenance:install --no-interaction --database "mysql" --database-name "nextcloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$datadir"
-			mysql -uroot -e "drop user 'tmp_root'@'localhost'"
+				G_DIETPI-NOTIFY 2 'Nextcloud database found, will NOT overwrite.'
 
-			# Enable MySQL 4-byte support for new installations only, to prevent risky database conversion tasks:
-			if (( $nc_is_fresh == 1 )); then
+			else
 
-				grep -q "^[[:blank:]]*'mysql.utf8mb4'" $config_php || sed -i "/^[[:blank:]]*'dbpassword'/a \ \ 'mysql.utf8mb4' => true," $config_php
+				if [ -f "$datadir"/dietpi-nextcloud-database-backup.sql ]; then
+
+					G_DIETPI-NOTIFY 2 'Nextcloud database backup found, starting recovery...'
+					local dbuser=$(grep -m1 "^[[:blank:]]*'dbuser'" $config_php | awk '{print $3}' | sed "s/[',]//g")
+					local dbpass=$(grep -m1 "^[[:blank:]]*'dbpassword'" $config_php | awk '{print $3}' | sed "s/[',]//g")
+					/DietPi/dietpi/func/create_mysql_db nextcloud "$dbuser" "$dbpass"
+					mysql -uroot nextcloud < "$datadir"/dietpi-nextcloud-database-backup.sql
+
+				else
+
+					local username="$(grep -m1 '^[[:blank:]]*SOFTWARE_OWNCLOUD_NEXTCLOUD_USERNAME=' /DietPi/dietpi.txt | sed 's/^.*=//')"
+					[ -n "$username" ] || username='admin'
+
+					# For MariaDB, temporary database admin user needs to be created, as 'root' uses unix_socket login, which cannot be accessed by sudo -u www-data.
+					mysql -uroot -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
+					grep -q "'installed' => true," $config_php 2>/dev/null || ncc maintenance:install --no-interaction --database "mysql" --database-name "nextcloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$datadir"
+					mysql -uroot -e "drop user 'tmp_root'@'localhost'"
+
+				fi
 
 			fi
+
+			# Enable Nextcloud to use 4-byte database
+			grep -q "^[[:blank:]]*'mysql.utf8mb4'" $config_php || sed -i "/^[[:blank:]]*'dbpassword'/a \ \ 'mysql.utf8mb4' => true," $config_php
 
 			# Disable trusted_domains.
 			if (( ! $(cat $config_php | grep -ci -m1 "1 => '*'") )); then
@@ -8581,16 +8596,6 @@ _EOF_
     )," $config_php
 
 			fi
-
-			# ownCloud/Nextcloud ignores system wide php.ini settings. Use their own config.
-			# Set max upload size
-			local php_max_upload_size="$(( $(php -r 'print(PHP_INT_MAX);') / 1024 / 1024))M"
-			sed -i "/upload_max_filesize=/c\upload_max_filesize=$php_max_upload_size" /var/www/nextcloud/.user.ini
-			sed -i "/post_max_size=/c\post_max_size=$php_max_upload_size" /var/www/nextcloud/.user.ini
-
-			# Set memory limit: total / 4
-			local memory_limit_max="$(( $RAM_TOTAL / 4 ))M"
-			sed -i "/memory_limit=/c\memory_limit=$memory_limit_max" /var/www/nextcloud/.user.ini
 
 			# Enable Nextcloud background cron job:
 			crontab -u www-data -l 2>/dev/null | grep -q '/var/www/nextcloud/cron.php' || ( crontab -u www-data -l 2>/dev/null ; echo "*/15 * * * * php /var/www/nextcloud/cron.php" ) | crontab -u www-data -
@@ -12495,6 +12500,53 @@ _EOF_
 			rm /etc/init.d/transmission-daemon &> /dev/null
 			rm /etc/systemd/system/transmission-daemon.service &> /dev/null
 
+		elif (( $index == 47 )); then
+			#ownCloud
+			# Remove background cron job
+			crontab -u www-data -l | grep -v '/var/www/owncloud/cron.php'  | crontab -u www-data -
+			# Disable and remove webserver configs
+			a2dissite owncloud 2>/dev/null
+			rm /etc/apache2/sites-available/owncloud.conf 2>/dev/null
+			rm /etc/nginx/sites-dietpi/owncloud.config 2>/dev/null
+			# Find datadir for backups
+			G_DIETPI-NOTIFY 2 "DietPi will perform an automated backup of your ownCloud database and installation directory, which will be stored inside your ownCloud data directory.\nThe data directory won't be removed. So you can at any time recover your whole ownCloud instance.\nRemove the data directory manually, if you don't need it anymore."
+			local datadir=$(grep -m1 "'datadirectory'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/[',]//g")
+			[ -n "$datadir" ] || datadir="$G_FP_DIETPI_USERDATA/owncloud_data"
+			# Drop MariaDB user and database
+			G_RUN_CMD systemctl start mysql
+			mysql -uroot -e "drop user $(grep -m1 "'dbuser'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")@$(grep -m1 "'dbhost'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")"
+			mysql -uroot -e "drop user $(grep -m1 "'dbuser'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")"
+			mysqldump -uroot --lock-tables owncloud > "$datadir"/dietpi-owncloud-database-backup.sql
+			mysqladmin -uroot drop owncloud -f
+			# Backup ownCloud installation folder
+			cp -a /var/www/owncloud/. "$datadir"/dietpi-owncloud-installation-backup
+			# Remove ownCloud installation folder
+			rm -R /var/www/owncloud
+
+		elif (( $index == 114 )); then
+			#Nextcloud
+			crontab -u www-data -l | grep -v '/var/www/nextcloud/cron.php'  | crontab -u www-data -
+			# Disable and remove webserver configs
+			a2dissite nextcloud 2>/dev/null
+			rm /etc/apache2/sites-available/nextcloud.conf 2>/dev/null
+			rm /etc/nginx/sites-dietpi/nextcloud.config 2>/dev/null
+			lighttpd-disable-mod dietpi-nextcloud 2>/dev/null
+			rm /etc/lighttpd/conf-available/99-dietpi-nextcloud.conf 2>/dev/null
+			# Find datadir for backups
+			G_DIETPI-NOTIFY 2 "DietPi will perform an automated backup of your Nextcloud database and installation directory, which will be stored inside your Nextcloud data directory.\nThe data directory won't be removed. So you can at any time recover your whole Nextcloud instance.\nRemove the data directory manually, if you don't need it anymore."
+			local datadir=$(grep -m1 "'datadirectory'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/[',]//g")
+			[ -n "$datadir" ] || datadir="$G_FP_DIETPI_USERDATA/nextcloud_data"
+			# Drop MariaDB user and database
+			G_RUN_CMD systemctl start mysql
+			mysql -uroot -e "drop user $(grep -m1 "'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")@$(grep -m1 "'dbhost'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")"
+			mysql -uroot -e "drop user $(grep -m1 "'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")"
+			mysqldump -uroot --lock-tables nextcloud > "$datadir"/dietpi-nextcloud-database-backup.sql
+			mysqladmin -uroot drop nextcloud -f
+			# Backup Nextcloud installation folder
+			cp -a /var/www/nextcloud/. "$datadir"/dietpi-nextcloud-installation-backup
+			# Remove Nextcloud installation folder
+			rm -R /var/www/nextcloud
+
 		elif (( $index == 83 )); then
 
 			G_AGP apache2
@@ -12547,46 +12599,6 @@ _EOF_
 			systemctl start mysql
 			mysqladmin -u root -p"$GLOBAL_PW" drop phpbb3 -f
 			rm -R /var/www/phpBB3
-
-		elif (( $index == 47 )); then
-			#ownCloud
-			# Remove background cron job
-			crontab -u www-data -l | grep -v '/var/www/owncloud/cron.php'  | crontab -u www-data -
-			# Disable and remove webservier configs
-			a2dissite owncloud 2>/dev/null
-			rm /etc/apache2/sites-available/owncloud.conf 2>/dev/null
-			rm /etc/nginx/sites-dietpi/owncloud.config 2>/dev/null
-			# Drop MariaDB user and database
-			systemctl start mysql
-			mysql -uroot -e "drop user $(grep -m1 "'dbuser'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")@$(grep -m1 "'dbhost'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")"
-			mysql -uroot -e "drop user $(grep -m1 "'dbuser'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")"
-			mysqldump -uroot --lock-tables owncloud > "$G_FP_DIETPI_USERDATA"/owncloud_data/mysql_backup.sql
-			mysqladmin -uroot drop owncloud -f
-			# Purge APT package
-			G_AGP owncloud-files owncloud owncloud-deps
-			# Remove ownCloud installation folder
-			rm -R /var/www/owncloud
-			# Remove ownCloud repo
-			rm /etc/apt/sources.list.d/owncloud.list 2> /dev/null
-
-		elif (( $index == 114 )); then
-			#Nextcloud
-			# Remove background cron job
-			crontab -u www-data -l | grep -v '/var/www/nextcloud/cron.php'  | crontab -u www-data -
-			# Disable and remove webservier configs
-			a2dissite nextcloud 2>/dev/null
-			rm /etc/apache2/sites-available/nextcloud.conf 2>/dev/null
-			rm /etc/nginx/sites-dietpi/nextcloud.config 2>/dev/null
-			lighttpd-disable-mod dietpi-nextcloud 2>/dev/null
-			rm /etc/lighttpd/conf-available/99-dietpi-nextcloud.conf 2>/dev/null
-			# Drop MariaDB user and database
-			systemctl start mysql
-			mysql -uroot -e "drop user $(grep -m1 "'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")@$(grep -m1 "'dbhost'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")"
-			mysql -uroot -e "drop user $(grep -m1 "'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")"
-			mysqldump -uroot --lock-tables nextcloud > "$G_FP_DIETPI_USERDATA"/nextcloud_data/mysql_backup.sql
-			mysqladmin -uroot drop nextcloud -f
-			# Remove Nextcloud installation folder
-			rm -R /var/www/nextcloud
 
 		elif (( $index == 115 )); then
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12513,10 +12513,10 @@ _EOF_
 			local datadir=$(grep -m1 "'datadirectory'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/[',]//g")
 			[ -n "$datadir" ] || datadir="$G_FP_DIETPI_USERDATA/owncloud_data"
 			# Drop MariaDB user and database
-			G_RUN_CMD systemctl start mysql
+			systemctl start mysql
 			mysql -uroot -e "drop user $(grep -m1 "'dbuser'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")@$(grep -m1 "'dbhost'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")"
-			mysql -uroot -e "drop user $(grep -m1 "'dbuser'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")"
-			mysqldump -uroot --lock-tables owncloud > "$datadir"/dietpi-owncloud-database-backup.sql
+			mysql -uroot -e "drop user $(grep -m1 "'dbuser'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")" 2> /dev/null
+			[ -d "$G_FP_DIETPI_USERDATA"/mysql/owncloud ] && mysqldump -uroot --lock-tables owncloud > "$datadir"/dietpi-owncloud-database-backup.sql
 			mysqladmin -uroot drop owncloud -f
 			# Backup ownCloud installation folder
 			cp -a /var/www/owncloud/. "$datadir"/dietpi-owncloud-installation-backup
@@ -12537,10 +12537,10 @@ _EOF_
 			local datadir=$(grep -m1 "'datadirectory'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/[',]//g")
 			[ -n "$datadir" ] || datadir="$G_FP_DIETPI_USERDATA/nextcloud_data"
 			# Drop MariaDB user and database
-			G_RUN_CMD systemctl start mysql
+			systemctl start mysql
 			mysql -uroot -e "drop user $(grep -m1 "'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")@$(grep -m1 "'dbhost'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")"
-			mysql -uroot -e "drop user $(grep -m1 "'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")"
-			mysqldump -uroot --lock-tables nextcloud > "$datadir"/dietpi-nextcloud-database-backup.sql
+			mysql -uroot -e "drop user $(grep -m1 "'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")" 2> /dev/null
+			[ -d "$G_FP_DIETPI_USERDATA"/mysql/nextcloud ] && mysqldump -uroot --lock-tables nextcloud > "$datadir"/dietpi-nextcloud-database-backup.sql
 			mysqladmin -uroot drop nextcloud -f
 			# Backup Nextcloud installation folder
 			cp -a /var/www/nextcloud/. "$datadir"/dietpi-nextcloud-installation-backup


### PR DESCRIPTION
+ DietPi-Software | ownCloud/Nextcloud: Enable auto backup & recovery from and to data directory
  - This includes migration by script from v159: https://github.com/Fourdee/DietPi/blob/dietpi-cloud-migration/dietpi-cloud-migration
+ DietPi-Software | ownCloud/Nextcloud: Remove initial adjustment of max upload size, which caused integrity check errors and was overwritten by updater and other occ commands
+ DietPi-Software | ownCloud/Nextcloud: Uninstallation will be now done before webservers and databases, to ensure database backups can be done
+ DietPi-Software | ownCloud: Switch to archive based installation
  - The package does nothing more than syncing the archive to `/var/www/owncloud`. We can do this easier by ourself, skip all the repository stuff and handle it similar than Nextcloud.
  - According to ownCloud manual, the internal web based updater is the preferred update method: https://doc.owncloud.org/server/latest/admin_manual/maintenance/upgrade.html#upgrade-options
  - This makes sense, as it automates many reasonable steps, such as maintenance mode, backup etc.
