### PR TITLE
DietPi-Software | Switch software titles to use separate MariaDB users

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -41,6 +41,7 @@ DietPi-Software | UrBackup: Installation updated to latest version 2.1.20. For n
 DietPi-Software | NodeRed: Corrected user which nodered runs under, now runs as its own user, created during install: https://github.com/Fourdee/DietPi/issues/1294#issuecomment-354314318
 DietPi-Software | SqueezeBox/LMS (Stretch): Installation resolved: https://github.com/Fourdee/DietPi/issues/1124
 DietPi-Software | MySQL: Completely remove MySQL from DietPi in favour of MariaDB: https://github.com/Fourdee/DietPi/issues/1397
+DietPi-Software | General: MySQL using software titles now have their own database user, instead of accessing as "root": https://github.com/Fourdee/DietPi/issues/1397#issuecomment-359655198
 run_ntpd | Added support for systemd-timesyncd completion/detection: https://github.com/Fourdee/DietPi/issues/1379
 
 Bug Fixes:

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2147,7 +2147,6 @@ _EOF_
 		      aSOFTWARE_REQUIRES_GIT[$index_current]=1
    aSOFTWARE_REQUIRES_BUILDESSENTIAL[$index_current]=1
 		   aSOFTWARE_REQUIRES_SQLITE[$index_current]=1
-		    aSOFTWARE_REQUIRES_MYSQL[$index_current]=1
 		   aSOFTWARE_REQUIRES_FFMPEG[$index_current]=1
 			 aSOFTWARE_ONLINEDOC_URL[$index_current]='f=8&t=5&start=20#p70'
 
@@ -7438,12 +7437,11 @@ _EOF_
 
             # Install needed libraries
             G_AGI libssl-dev git cmake libc-ares-dev uuid-dev daemon curl libgnutls28-dev libgnutlsxx28 nmap net-tools sudo libglib2.0-dev libudev-dev swig libssl-dev libusb-1.0-0 gcc libssl-dev libffi-dev libbz2-dev zlib1g-dev libreadline-dev libsqlite3-dev libncurses5-dev libncursesw5-dev
-			if (( $G_DISTRO == 3 )); then
+			if (( $G_DISTRO < 4 )); then
 
 				G_AGI libmysqlclient-dev
 
-			fi
-			if (( $G_DISTRO >= 4 )); then
+			else
 
 				G_AGI libmariadbclient-dev
 
@@ -8130,10 +8128,10 @@ _EOF_
 			if (( $G_DISTRO < 4 )); then
 
 				G_RUN_CMD systemctl start mysql
-				mysql -uroot -e "install plugin unix_socket soname 'auth_socket';" &> /dev/null
-				mysql -uroot -e "grant all privileges on *.* to 'root'@'localhost' identified via unix_socket with grant option;flush privileges"
+				mysql -e "install plugin unix_socket soname 'auth_socket';" &> /dev/null
+				mysql -e "grant all privileges on *.* to 'root'@'localhost' identified via unix_socket with grant option;flush privileges"
 				# Drop unnecessary root user children.
-				mysql -uroot -e "drop user 'root'@'dietpi';drop user 'root'@'127.0.0.1';drop user 'root'@'::1'" &> /dev/null
+				mysql -e "drop user 'root'@'dietpi';drop user 'root'@'127.0.0.1';drop user 'root'@'::1'" &> /dev/null
 
 			fi
 
@@ -8167,7 +8165,7 @@ _EOF_
 			# Due to MariaDB unix_socket authentication, "root" cannot be used to login the web ui.
 			# Thus default "phpmyadmin" user need to be used, who on Jessie does not have all privileges:
 			# http://dietpi.com/phpbb/viewtopic.php?f=8&t=5&p=54#p54
-			mysql -uroot -e "grant all privileges on *.* to phpmyadmin@localhost with grant option"
+			mysql -e "grant all privileges on *.* to phpmyadmin@localhost with grant option"
 
 		fi
 
@@ -8332,9 +8330,9 @@ _EOF_
 
 			systemctl start mysql
 			# For MariaDB, temporary database admin user needs to be created, as 'root' uses unix_socket login, which cannot be accessed by sudo -u www-data.
-			mysql -uroot -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
+			mysql -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
 			grep -q "'installed' => true," $config_php 2>/dev/null || occ maintenance:install --no-interaction --database "mysql" --database-name "owncloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$datadir"
-			mysql -uroot -e "drop user 'tmp_root'@'localhost'"
+			mysql -e "drop user 'tmp_root'@'localhost'"
 
 			# Enable MySQL 4-byte support for new installations only, to prevent risky database conversion tasks:
 			if (( $oc_is_fresh == 1 )); then
@@ -8530,9 +8528,9 @@ _EOF_
 
 			systemctl start mysql
 			# For MariaDB, temporary database admin user needs to be created, as 'root' uses unix_socket login, which cannot be accessed by sudo -u www-data.
-			mysql -uroot -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
+			mysql -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
 			grep -q "'installed' => true," $config_php 2>/dev/null || ncc maintenance:install --no-interaction --database "mysql" --database-name "nextcloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$datadir"
-			mysql -uroot -e "drop user 'tmp_root'@'localhost'"
+			mysql -e "drop user 'tmp_root'@'localhost'"
 
 			# Enable MySQL 4-byte support for new installations only, to prevent risky database conversion tasks:
 			if (( $nc_is_fresh == 1 )); then
@@ -8715,7 +8713,7 @@ _EOF_
 
 			Banner_Configuration
 
-			/DietPi/dietpi/func/create_mysql_db phpbb3 root "$GLOBAL_PW"
+			/DietPi/dietpi/func/create_mysql_db phpbb3 phpbb3 "$GLOBAL_PW"
 
 		fi
 
@@ -9624,7 +9622,7 @@ _EOF_
 			Banner_Configuration
 
 			#Create mysql DB
-			/DietPi/dietpi/func/create_mysql_db wordpress root "$GLOBAL_PW"
+			/DietPi/dietpi/func/create_mysql_db wordpress wordpress "$GLOBAL_PW"
 
 		fi
 
@@ -9907,8 +9905,8 @@ _EOF_
 			unzip -o sql.zip
 			rm sql.zip
 
-			/DietPi/dietpi/func/create_mysql_db ampache root "$GLOBAL_PW"
-			mysql -u root -p"$GLOBAL_PW" ampache < ampache.sql
+			/DietPi/dietpi/func/create_mysql_db ampache ampache "$GLOBAL_PW"
+			mysql ampache < ampache.sql
 			rm ampache.sql
 
 			#Grab config
@@ -10289,7 +10287,7 @@ _EOF_
 			a2enmod rewrite
 
 			#Create Mysql DB
-			/DietPi/dietpi/func/create_mysql_db pydio root "$GLOBAL_PW"
+			/DietPi/dietpi/func/create_mysql_db pydio pydio "$GLOBAL_PW"
 
 			#Setup Data directory
 			local target_data_dir="$G_FP_DIETPI_USERDATA/pydio_data"
@@ -10462,7 +10460,7 @@ _EOF_
 			cd ~/
 
 			# - Mysql DB
-			/DietPi/dietpi/func/create_mysql_db baikal root "$GLOBAL_PW"
+			/DietPi/dietpi/func/create_mysql_db baikal baikal "$GLOBAL_PW"
 
 		fi
 
@@ -10617,7 +10615,7 @@ _EOF_
 			mkdir -p "$G_FP_DIETPI_USERDATA"/gogs-repo
 
 			# - sqldb
-			/DietPi/dietpi/func/create_mysql_db gogs root "$GLOBAL_PW"
+			/DietPi/dietpi/func/create_mysql_db gogs gogs "$GLOBAL_PW"
 
 			# - service (couldnt get this to run as a new thread with systemD (&). so bash script ftw.
 			cat << _EOF_ > /etc/gogs/start.sh
@@ -11256,12 +11254,12 @@ _EOF_
 
 			Banner_Configuration
 
-			sed -i "/'mysqli_user'/c \$cfg[\'mysqli_user\']                 = \'root\';" /var/www/ompd/include/config.inc.php
+			sed -i "/'mysqli_user'/c \$cfg[\'mysqli_user\']                 = \'ompd\';" /var/www/ompd/include/config.inc.php
 			sed -i "/'mysqli_password'/c \$cfg[\'mysqli_password\']                 = \'$GLOBAL_PW\';" /var/www/ompd/include/config.inc.php
 			sed -i "/'media_dir'/c \$cfg[\'media_dir\']                 = \'/var/lib/mpd/music/\';" /var/www/ompd/include/config.inc.php
 			sed -i "/'ignore_media_dir_access_error'/c \$cfg[\'ignore_media_dir_access_error\']                 = \'true';" /var/www/ompd/include/config.inc.php
 
-			/DietPi/dietpi/func/create_mysql_db ompd root "$GLOBAL_PW"
+			/DietPi/dietpi/func/create_mysql_db ompd ompd "$GLOBAL_PW"
 
 		fi
 
@@ -11527,14 +11525,14 @@ _EOF_
 
 			Download_Test_Media
 
-			/DietPi/dietpi/func/create_mysql_db koel root "$GLOBAL_PW"
+			/DietPi/dietpi/func/create_mysql_db koel koel "$GLOBAL_PW"
 
 			cd /var/www/koel
 
 			sed -i '/DB_CONNECTION=/c\DB_CONNECTION=mysql' .env
 			sed -i '/DB_HOST=/c\DB_HOST=127.0.0.1' .env
 			sed -i '/DB_DATABASE=/c\DB_DATABASE=koel' .env
-			sed -i '/DB_USERNAME=/c\DB_USERNAME=root' .env
+			sed -i '/DB_USERNAME=/c\DB_USERNAME=koel' .env
 			sed -i "/DB_PASSWORD=/c\DB_PASSWORD=$GLOBAL_PW" .env
 
 			sed -i '/ADMIN_EMAIL=/c\ADMIN_EMAIL=dietpi@dietpi.com' .env
@@ -11937,7 +11935,7 @@ _EOF_
 			chown -R dietpi:dietpi /var/log/gitea
 
 			# - sqldb
-			/DietPi/dietpi/func/create_mysql_db gitea root "$GLOBAL_PW"
+			/DietPi/dietpi/func/create_mysql_db gitea gitae "$GLOBAL_PW"
 
 		fi
 
@@ -11950,7 +11948,7 @@ _EOF_
 			Banner_Configuration
 
 			/DietPi/dietpi/func/create_mysql_db allo_db root "$GLOBAL_PW"
-			mysql -u root -pdietpi allo_db < /var/www/allo_db.sql
+			mysql allo_db < /var/www/allo_db.sql
 			rm /var/www/allo_db.sql
 
 			# - Redirect to web interface by default:
@@ -12545,7 +12543,8 @@ _EOF_
 		elif (( $index == 54 )); then
 
 			systemctl start mysql
-			mysqladmin -u root -p"$GLOBAL_PW" drop phpbb3 -f
+			mysqladmin drop phpbb3 -f
+			mysql -e "drop user phpbb3@localhost"
 			rm -R /var/www/phpBB3
 
 		elif (( $index == 47 )); then
@@ -12558,10 +12557,10 @@ _EOF_
 			rm /etc/nginx/sites-dietpi/owncloud.config 2>/dev/null
 			# Drop MariaDB user and database
 			systemctl start mysql
-			mysql -uroot -e "drop user $(grep -m1 "'dbuser'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")@$(grep -m1 "'dbhost'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")"
-			mysql -uroot -e "drop user $(grep -m1 "'dbuser'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")"
-			mysqldump -uroot --lock-tables owncloud > "$G_FP_DIETPI_USERDATA"/owncloud_data/mysql_backup.sql
-			mysqladmin -uroot drop owncloud -f
+			mysql -e "drop user $(grep -m1 "'dbuser'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")@$(grep -m1 "'dbhost'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")"
+			mysql -e "drop user $(grep -m1 "'dbuser'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")"
+			mysqldump owncloud > "$G_FP_DIETPI_USERDATA"/owncloud_data/mysql_backup.sql
+			mysqladmin drop owncloud -f
 			# Purge APT package
 			G_AGP owncloud-files owncloud owncloud-deps
 			# Remove ownCloud installation folder
@@ -12581,10 +12580,10 @@ _EOF_
 			rm /etc/lighttpd/conf-available/99-dietpi-nextcloud.conf 2>/dev/null
 			# Drop MariaDB user and database
 			systemctl start mysql
-			mysql -uroot -e "drop user $(grep -m1 "'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")@$(grep -m1 "'dbhost'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")"
-			mysql -uroot -e "drop user $(grep -m1 "'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")"
-			mysqldump -uroot --lock-tables nextcloud > "$G_FP_DIETPI_USERDATA"/nextcloud_data/mysql_backup.sql
-			mysqladmin -uroot drop nextcloud -f
+			mysql -e "drop user $(grep -m1 "'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")@$(grep -m1 "'dbhost'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")"
+			mysql -e "drop user $(grep -m1 "'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")"
+			mysqldump nextcloud > "$G_FP_DIETPI_USERDATA"/nextcloud_data/mysql_backup.sql
+			mysqladmin drop nextcloud -f
 			# Remove Nextcloud installation folder
 			rm -R /var/www/nextcloud
 
@@ -12642,7 +12641,8 @@ _EOF_
 
 			rm -R /var/www/ompd
 			systemctl start mysql
-			mysqladmin -uroot drop ompd -f
+			mysqladmin drop ompd -f
+			mysql -e "drop user ompd@localhost"
 
 		elif (( $index == 130 )); then
 
@@ -12740,7 +12740,8 @@ _EOF_
 		elif (( $index == 143 )); then
 
 			systemctl start mysql
-			mysqladmin -uroot drop koel -f
+			mysqladmin drop koel -f
+			mysql -e "drop user koel@localhost"
 
 			rm -R /var/www/koel
 
@@ -13004,7 +13005,8 @@ _EOF_
 
 			#drop database
 			systemctl start mysql
-			mysqladmin -uroot drop ampache -f
+			mysqladmin drop ampache -f
+			mysql -e "drop user ampache@localhost"
 
 		elif (( $index == 117 )); then
 
@@ -13114,7 +13116,8 @@ _EOF_
 
 			#drop database
 			systemctl start mysql
-			mysqladmin -uroot drop pydio -f
+			mysqladmin drop pydio -f
+			mysql -e "drop user pydio@localhost"
 
 		elif (( $index == 36 )); then
 
@@ -13139,7 +13142,8 @@ _EOF_
 
 			#drop database
 			systemctl start mysql
-			mysqladmin -uroot drop baikal -f
+			mysqladmin drop baikal -f
+			mysql -e "drop user baikal@localhost"
 
 		elif (( $index == 65 )); then
 
@@ -13214,7 +13218,8 @@ _EOF_
 			rm /var/log/gogs.log
 
 			systemctl start mysql
-			mysqladmin -uroot drop gogs -f
+			mysqladmin drop gogs -f
+			mysql -e "drop user gogs@localhost"
 
 		elif (( $index == 46 )); then
 
@@ -13309,8 +13314,8 @@ _EOF_
 
 			# drop/delete database
 			systemctl start mysql
-			mysqladmin -uroot drop gitea -f
-			systemctl stop mysql
+			mysqladmin drop gitea -f
+			mysql -e "drop user gitea@localhost"
 
 		elif (( $index == 166 )); then
 
@@ -13400,9 +13405,7 @@ _EOF_
 
 			rm -R /var/www/allo
 			systemctl start mysql
-			mysqladmin -uroot drop allo_db -f
-			systemctl stop mysql
-
+			mysqladmin drop allo_db -f
 
 		#----------------------------------------------------------------------
 		#LINUX SOFTWARE


### PR DESCRIPTION
This was easier than expected. Everything done and tested, besides Allo web interface.

**ToDo:**

🈯️ Ampache:
Update http://dietpi.com/downloads/conf/ampache.cfg.php_3.8.2-v113 with database user "ampache"
Optional: update config version (can be done automatically after installation)

🈺 Allo:
Update some config file within http://dietpi.com/downloads/binaries/all/allo_web_interface_v4.7z ?
Didn't find the infos inside the config php files 🤔.
Can't test on VM of course 😉.

🈯️ Pydio:
Update dietpi.com documentation

🈯️ Gogs:
Update dietpi.com documentation

🈯️ Gitea:
Update dietpi.com documentation

🈯️ Baikal:
Update dietpi.com documentation

🈯️ Forum (phpBB3):
Update dietpi.com documentation

🈯️ Wordpress:
Update dietpi.com documentation

🈯️ phpMyAdmin:
Update dietpi.com documentation

🈯️ Home Assistant:
Missing on dietpi.com **(!!)**
Does not use MySQL, SQLite instead: https://home-assistant.io/docs/backend/database/

The infos on the forum can be adjusted with v6.0 release. Keep old info for users, that stay with v159: `MySQL user: root (since v6.0: ampache)`