### PR TITLE
DietPi-Config | Fix reversed IPv6 grub adjustment

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,7 @@ General | DietPi RPi kernel, now reverted to stock RPi kernel: https://github.co
 General | We have completed much needed backbone work for DietPi, which will allow for improved expansion in source code. This includes the use of dietpi-globals.
 DietPi-Globals | New script which optimizes most used DietPi commands and vars, throughout our scripts. Also exported to bash session, please type 'G_' then press 'TAB' to see a full list of options: https://github.com/Fourdee/DietPi/issues/1311
 General | FHS compliance completed. /etc/dietpi has moved to /var/lib/dietpi. RAMlog store has moved to /var/tmp/dietpi: https://github.com/Fourdee/DietPi/issues/1297#issuecomment-352241193
+General | We have refreshed our terminal messages look & feel, oriented on RPi boot messages, and with process animation: https://github.com/Fourdee/DietPi/pull/1377
 General | wget: Now set to prefer IPv4 by default (generally faster, can be changed by 'CONFIG_PREFER_IPVERSION' in dietpi.txt): https://github.com/Fourdee/DietPi/issues/1285#issuecomment-353230187
 General | APT: Now set to force IPv4 by default (generally faster, can be changed by 'CONFIG_PREFER_IPVERSION' in dietpi.txt): https://github.com/Fourdee/DietPi/issues/1285#issuecomment-353230187
 General | SparkySBC: CPU gov default changed to Performance, reports of increased stability.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,8 +17,8 @@ General | DietPi RPi kernel, now reverted to stock RPi kernel: https://github.co
 General | We have completed much needed backbone work for DietPi, which will allow for improved expansion in source code. This includes the use of dietpi-globals.
 DietPi-Globals | New script which optimizes most used DietPi commands and vars, throughout our scripts. Also exported to bash session, please type 'G_' then press 'TAB' to see a full list of options: https://github.com/Fourdee/DietPi/issues/1311
 General | FHS compliance completed. /etc/dietpi has moved to /var/lib/dietpi. RAMlog store has moved to /var/tmp/dietpi: https://github.com/Fourdee/DietPi/issues/1297#issuecomment-352241193
-General | wget: Now set to prefer IPv4 by default (generally faster): https://github.com/Fourdee/DietPi/issues/1285#issuecomment-353230187
-General | APT: Now set to force IPv4 by default (generally faster): https://github.com/Fourdee/DietPi/issues/1285#issuecomment-353230187
+General | wget: Now set to prefer IPv4 by default (generally faster, can be changed by 'CONFIG_PREFER_IPVERSION' in dietpi.txt): https://github.com/Fourdee/DietPi/issues/1285#issuecomment-353230187
+General | APT: Now set to force IPv4 by default (generally faster, can be changed by 'CONFIG_PREFER_IPVERSION' in dietpi.txt): https://github.com/Fourdee/DietPi/issues/1285#issuecomment-353230187
 General | SparkySBC: CPU gov default changed to Performance, reports of increased stability.
 General | Swapfile generation is now completed during 1st run of dietpi-software (previously boot stage): https://github.com/Fourdee/DietPi/issues/1270#issue-278797206
 General | DietPi-Funtime: Removed from DietPi. Although it looked pretty, it did absolutely nothing (except slow down a program)
@@ -36,7 +36,9 @@ DietPi-Software | NAA Daemon: Updated to latest (3.5.2-36). Existing installs wi
 DietPi-Software | PHP-FPM: Increased from "$CPU_CORES_TOTAL" to "pm.max_children = $(( $CPU_CORES_TOTAL * 3 ))". This should avoid failed forking of PHP-FPM processes/requests : https://github.com/Fourdee/DietPi/issues/1298
 DietPi-Software | ownCloud/Nextcloud: Added option to choose data directory via dietpi.txt pre installation: https://github.com/Fourdee/DietPi/issues/1314#issuecomment-352782055
 DietPi-Software | ownCloud/Nextcloud: Switch to pretty URLs (without "index.php") on Apache
-DietPi-Software | Nextcloud: Resolve OPcache admin panel warnings on Lighttpd
+DietPi-Software | ownCloud/Nextcloud: Automated backup restoring on install and creation und uninstall to ownCloud/Nextcloud data directory
+DietPi-Software | ownCloud: Switch to non-package/archive installation. This allows usage of preferred web based updater.
+DietPi-Software | Nextcloud: Resolved OPcache admin panel warnings now also on Lighttpd
 DietPi-Software | UrBackup: Installation updated to latest version 2.1.20. For new installations only: https://github.com/Fourdee/DietPi/issues/1335
 DietPi-Software | NodeRed: Corrected user which nodered runs under, now runs as its own user, created during install: https://github.com/Fourdee/DietPi/issues/1294#issuecomment-354314318
 DietPi-Software | SqueezeBox/LMS (Stretch): Installation resolved: https://github.com/Fourdee/DietPi/issues/1124
@@ -49,6 +51,7 @@ General | Fixed two systemd error messages during shutdown and boot: https://git
 DietPi-Automation | Resolved an issue where AUTO_SETUP_TIMEZONE was not being applied correctly, thanks @k-plan: https://github.com/Fourdee/DietPi/issues/1285#issuecomment-356310496
 DietPi-Automation | dietpi.txt: CONFIG_NTP_MIRROR will now be applied to systemd-timesyncd configuration: https://github.com/Fourdee/DietPi/issues/1379
 DietPi-Config | Resolved an issue with WiFi Country code, failing to set on some devices: https://github.com/Fourdee/DietPi/issues/838
+DietPi-Config | Resolved an issue where disabling IPv6 didn't have an effect on AMD64 devices: https://github.com/Fourdee/DietPi/issues/1343#issuecomment-359652751
 DietPi-Services | dietpi-wifi-monitor: Is no longer controlled, to prevent WiFi drop during software installs/updates etc: https://github.com/Fourdee/DietPi/issues/1288#issuecomment-350653480
 DietPi-Software | General: MySQL using software titles now have their own database user, instead of accessing as "root": https://github.com/Fourdee/DietPi/issues/1397#issuecomment-359655198
 DietPi-Software | qBittorrent: Resolved an issue with inability to log into web interface: https://github.com/Fourdee/DietPi/issues/1366

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -3129,8 +3129,12 @@
 							if (( G_HW_ARCH == 10 )); then
 							# On amd64 images, IPv6 is no kernel module, but can be disabled via grub: https://github.com/Fourdee/DietPi/issues/1343#issuecomment-359652751
 
-								sed -i 's/ipv6.disable=1 //g' /etc/default/grub
-								update-grub
+								if (( ! $(grep -ci -m1 'ipv6.disable=1' /etc/default/grub) )); then
+								
+									sed -i 's/GRUB_CMDLINE_LINUX_DEFAULT=\"/GRUB_CMDLINE_LINUX_DEFAULT=\"ipv6.disable=1 /g' /etc/default/grub
+									update-grub
+								
+								fi
 
 							else
 							# On all other images, IPv6 is a kernel module, which can be blacklisted.
@@ -3160,12 +3164,8 @@
 
 							if (( G_HW_ARCH == 10 )); then
 
-								if (( ! $(grep -ci -m1 'ipv6.disable=1' /etc/default/grub) )); then
-								
-									sed -i 's/GRUB_CMDLINE_LINUX_DEFAULT=\"/GRUB_CMDLINE_LINUX_DEFAULT=\"ipv6.disable=1 /g' /etc/default/grub
-									update-grub
-								
-								fi
+								sed -i 's/ipv6.disable=1 //g' /etc/default/grub
+								update-grub
 
 							else
 


### PR DESCRIPTION
+ And hijacked PR to add missing changelogs 😉.