### PR TITLE
DietPi | Fix Buster issues

### DIFF
--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -1009,6 +1009,7 @@ _EOF_
 
 	systemctl disable systemd-timesyncd
 	rm /etc/init.d/ntp &> /dev/null
+	(( $G_DISTRO > 4 )) && systemctl mask ntp
 
 	G_DIETPI-NOTIFY 2 "Configuring regional settings (TZdata):"
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4697,51 +4697,59 @@ _EOF_
 
 			Banner_Installing
 
-			# - ARMv8
-			if (( $G_HW_ARCH == 3 )); then
+			if (( $G_DISTRO > 4 )); then
 
-				dpkg --add-architecture armhf
-				G_AGUP
+				# On Buster, we can use current APT package from Debian repo
+				G_AGI mosquitto
 
+			else
+
+				# - ARMv8
+				if (( $G_HW_ARCH == 3 )); then
+
+					dpkg --add-architecture armhf
+					G_AGUP
+
+				fi
+
+				#Pre-Req
+				# - libssl1.0.0 no longer available: https://github.com/Fourdee/DietPi/issues/1299
+				INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/'
+
+				# - ARMv6/7/8
+				if (( $G_HW_ARCH >= 1 && $G_HW_ARCH <= 3 )); then
+
+					INSTALL_URL_ADDRESS+='libssl1.0.0_1.0.1t-1+deb8u7_armhf.deb'
+
+				# - x86_64
+				elif (( $G_HW_ARCH == 10 )); then
+
+					INSTALL_URL_ADDRESS+='libssl1.0.0_1.0.1t-1+deb8u7_amd64.deb'
+
+				fi
+				G_CHECK_URL "$INSTALL_URL_ADDRESS"
+
+				wget "$INSTALL_URL_ADDRESS" -O package.deb
+				dpkg -i package.deb
+				rm package.deb
+
+				INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/mosquitto_1.4.14-0mosquitto1_nows1_armhf.deb'
+				if (( $G_HW_ARCH == 10 )); then
+
+					INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/mosquitto_1.4.14-0mosquitto1_nows1_amd64.deb'
+
+				fi
+				G_CHECK_URL "$INSTALL_URL_ADDRESS"
+
+				wget "$INSTALL_URL_ADDRESS" -O package.deb
+
+				#Install deb
+				#	Allow error, so we can install additional required packages automatically
+				dpkg -i package.deb
+				G_AGF
+				rm package.deb
+	
 			fi
-
-			#Pre-Req
-			# - libssl1.0.0 no longer available: https://github.com/Fourdee/DietPi/issues/1299
-			INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/'
-
-			# - ARMv6/7/8
-			if (( $G_HW_ARCH >= 1 && $G_HW_ARCH <= 3 )); then
-
-				INSTALL_URL_ADDRESS+='libssl1.0.0_1.0.1t-1+deb8u7_armhf.deb'
-
-			# - x86_64
-			elif (( $G_HW_ARCH == 10 )); then
-
-				INSTALL_URL_ADDRESS+='libssl1.0.0_1.0.1t-1+deb8u7_amd64.deb'
-
-			fi
-
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-
-			wget "$INSTALL_URL_ADDRESS" -O package.deb
-			dpkg -i package.deb
-			rm package.deb
-
-			INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/mosquitto_1.4.14-0mosquitto1_nows1_armhf.deb'
-			if (( $G_HW_ARCH == 10 )); then
-
-				INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/mosquitto_1.4.14-0mosquitto1_nows1_amd64.deb'
-
-			fi
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-
-			wget "$INSTALL_URL_ADDRESS" -O package.deb
-
-			#Install deb
-			#	Allow error, so we can install additional required packages automatically
-			dpkg -i package.deb
-			G_AGF
-			rm package.deb
 
 		fi
 
@@ -12635,8 +12643,16 @@ _EOF_
 
 		elif (( $index == 123 )); then
 
-			#apt-mark auto libssl1.0.0
-			G_AGP mosquitto
+			if (( $G_DISTRO > 4 )); then
+	
+				G_AGP mosquitto
+
+			else
+
+				#apt-mark auto libssl1.0.0
+				dpkg -P mosquitto
+
+			fi
 
 		elif (( $index == 124 )); then
 


### PR DESCRIPTION
https://github.com/Fourdee/DietPi/issues/1286
- Debian Buster repo Mosquitto package is current and resolves all the dependency quirks.
- libssl1.0.0 installation failed because of missing pre-dependencies:
```
Selecting previously unselected package libssl1.0.0:amd64.
dpkg: regarding package.deb containing libssl1.0.0:amd64, pre-dependency problem:
 libssl1.0.0 pre-depends on multiarch-support
  multiarch-support is not installed.

dpkg: error processing archive package.deb (--install):
 pre-dependency problem - not installing libssl1.0.0:amd64
Errors were encountered while processing:
 package.deb
```
- **But further installation went on fine, Mosquitto starting in the end: Thus is libssl1.0.0 still necessary for current v4.14?**