### PR TITLE
DietPi-Globals | G_RUN_CMD: Alternative output string

### DIFF
--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -318,7 +318,7 @@
 		if [ "$target_state" = "start" ] ||
 			[ "$target_state" = "restart" ]; then
 
-			text='Apply process tool settings' G_RUN_CMD /DietPi/dietpi/dietpi-process_tool 1
+			G_RUN_CMD /DietPi/dietpi/dietpi-process_tool 1
 
 		fi
 

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -318,7 +318,7 @@
 		if [ "$target_state" = "start" ] ||
 			[ "$target_state" = "restart" ]; then
 
-			/DietPi/dietpi/dietpi-process_tool 1
+			G_RUN_CMD /DietPi/dietpi/dietpi-process_tool 1
 
 		fi
 

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -318,7 +318,7 @@
 		if [ "$target_state" = "start" ] ||
 			[ "$target_state" = "restart" ]; then
 
-			G_RUN_CMD /DietPi/dietpi/dietpi-process_tool 1
+			text='Apply process tool settings' G_RUN_CMD /DietPi/dietpi/dietpi-process_tool 1
 
 		fi
 

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -318,7 +318,7 @@
 		if [ "$target_state" = "start" ] ||
 			[ "$target_state" = "restart" ]; then
 
-			G_RUN_CMD /DietPi/dietpi/dietpi-process_tool 1
+			/DietPi/dietpi/dietpi-process_tool 1
 
 		fi
 

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -403,12 +403,12 @@
 	#		G_ERROR_HANDLER
 	G_ERROR_HANDLER(){
 
-		[ -n "$L_MESSAGE" ] || local L_MESSAGE="$G_ERROR_HANDLER_COMMAND"
+		[ -n "$l_message" ] || local l_message="$G_ERROR_HANDLER_COMMAND"
 
 		#Ok
 		if (( $G_ERROR_HANDLER_EXITCODE == 0 )); then
 
-			G_DIETPI-NOTIFY 0 "$L_MESSAGE"
+			G_DIETPI-NOTIFY 0 "$l_message"
 
 		#Error
 		else
@@ -551,8 +551,8 @@ $print_logfile_info
 
 		G_ERROR_HANDLER_COMMAND="$@"
 
-		[ -n "$L_MESSAGE" ] || local L_MESSAGE="$G_ERROR_HANDLER_COMMAND"
-		G_DIETPI-NOTIFY -2 "$L_MESSAGE"
+		[ -n "$l_message" ] || local l_message="$G_ERROR_HANDLER_COMMAND"
+		G_DIETPI-NOTIFY -2 "$l_message"
 
 		$G_ERROR_HANDLER_COMMAND &> /tmp/G_ERROR_HANDLER_COMMAND
 		G_ERROR_HANDLER_EXITCODE=$?

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -406,7 +406,15 @@
 		#Ok
 		if (( $G_ERROR_HANDLER_EXITCODE == 0 )); then
 
-			G_DIETPI-NOTIFY 0 "$G_ERROR_HANDLER_COMMAND"
+			if [ -n "$text" ]; then
+
+				G_DIETPI-NOTIFY 0 "$text"
+
+			else
+
+				G_DIETPI-NOTIFY 0 "$G_ERROR_HANDLER_COMMAND"
+
+			fi
 
 		#Error
 		else
@@ -418,13 +426,21 @@
 			local print_unable_to_continue='Unable to continue, the program will now terminate.'
 
 			echo ''
-			if [ -n "$G_PROGRAM_NAME" ]; then
+			if [ -n "$text" ]; then
 
-				G_DIETPI-NOTIFY 1 "$G_PROGRAM_NAME: $G_ERROR_HANDLER_COMMAND"
+				G_DIETPI-NOTIFY 1 "$text"
 
 			else
 
-				G_DIETPI-NOTIFY 1 "$G_ERROR_HANDLER_COMMAND"
+				if [ -n "$G_PROGRAM_NAME" ]; then
+
+					G_DIETPI-NOTIFY 1 "$G_PROGRAM_NAME: $G_ERROR_HANDLER_COMMAND"
+
+				else
+
+					G_DIETPI-NOTIFY 1 "$G_ERROR_HANDLER_COMMAND"
+
+				fi
 
 			fi
 
@@ -559,7 +575,15 @@ $print_logfile_info
 
 		G_ERROR_HANDLER_COMMAND="$@"
 
-		G_DIETPI-NOTIFY -2 "Running command: $G_ERROR_HANDLER_COMMAND"
+		if [ -n "$text" ]; then
+
+			G_DIETPI-NOTIFY -2 "$text"
+
+		else
+
+			G_DIETPI-NOTIFY -2 "Running command: $G_ERROR_HANDLER_COMMAND"
+
+		fi
 
 		$G_ERROR_HANDLER_COMMAND &> /tmp/G_ERROR_HANDLER_COMMAND
 		G_ERROR_HANDLER_EXITCODE=$?

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -403,12 +403,7 @@
 	#		G_ERROR_HANDLER
 	G_ERROR_HANDLER(){
 
-		if [ ! -n "$L_MESSAGE" ]; then
-
-			local L_MESSAGE="$G_ERROR_HANDLER_COMMAND"
-			[ -n "$G_PROGRAM_NAME" ] && L_MESSAGE="$G_PROGRAM_NAME: $L_MESSAGE"
-
-		fi
+		[ -n "$L_MESSAGE" ] || local L_MESSAGE="$G_ERROR_HANDLER_COMMAND"
 
 		#Ok
 		if (( $G_ERROR_HANDLER_EXITCODE == 0 )); then
@@ -424,7 +419,7 @@
 			local print_report_to_dietpi_info='If problems persist, please report this to DietPi for investigation, including a screenshot of this error! (https://github.com/Fourdee/DietPi/issues).'
 			local print_unable_to_continue='Unable to continue, the program will now terminate.'
 
-			G_DIETPI-NOTIFY 1 "$L_MESSAGE"
+			G_DIETPI-NOTIFY 1 "$G_ERROR_HANDLER_COMMAND"
 			G_DIETPI-NOTIFY 2 "$print_exitcode_info"
 			G_DIETPI-NOTIFY 2 "$print_hw_info"
 
@@ -556,12 +551,7 @@ $print_logfile_info
 
 		G_ERROR_HANDLER_COMMAND="$@"
 
-		if [ ! -n "$L_MESSAGE" ]; then
-
-			local L_MESSAGE="$G_ERROR_HANDLER_COMMAND"
-			[ -n "$G_PROGRAM_NAME" ] && L_MESSAGE="$G_PROGRAM_NAME: $L_MESSAGE"
-
-		fi
+		[ -n "$L_MESSAGE" ] || local L_MESSAGE="$G_ERROR_HANDLER_COMMAND"
 		G_DIETPI-NOTIFY -2 "$L_MESSAGE"
 
 		$G_ERROR_HANDLER_COMMAND &> /tmp/G_ERROR_HANDLER_COMMAND

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -403,18 +403,12 @@
 	#		G_ERROR_HANDLER
 	G_ERROR_HANDLER(){
 
+		[ -n "$text" ] || text="$G_ERROR_HANDLER_COMMAND"
+
 		#Ok
 		if (( $G_ERROR_HANDLER_EXITCODE == 0 )); then
 
-			if [ -n "$text" ]; then
-
-				G_DIETPI-NOTIFY 0 "$text"
-
-			else
-
-				G_DIETPI-NOTIFY 0 "$G_ERROR_HANDLER_COMMAND"
-
-			fi
+			G_DIETPI-NOTIFY 0 "$text"
 
 		#Error
 		else
@@ -426,23 +420,10 @@
 			local print_unable_to_continue='Unable to continue, the program will now terminate.'
 
 			echo ''
-			if [ -n "$text" ]; then
 
-				G_DIETPI-NOTIFY 1 "$text"
-
-			else
-
-				if [ -n "$G_PROGRAM_NAME" ]; then
-
-					G_DIETPI-NOTIFY 1 "$G_PROGRAM_NAME: $G_ERROR_HANDLER_COMMAND"
-
-				else
-
-					G_DIETPI-NOTIFY 1 "$G_ERROR_HANDLER_COMMAND"
-
-				fi
-
-			fi
+			text="$G_ERROR_HANDLER_COMMAND"
+			[ -n "$G_PROGRAM_NAME" ] && text="$G_PROGRAM_NAME: $G_ERROR_HANDLER_COMMAND"
+			G_DIETPI-NOTIFY 1 "$text"
 
 			G_DIETPI-NOTIFY 2 "$print_exitcode_info"
 			G_DIETPI-NOTIFY 2 "$print_hw_info"
@@ -575,15 +556,8 @@ $print_logfile_info
 
 		G_ERROR_HANDLER_COMMAND="$@"
 
-		if [ -n "$text" ]; then
-
-			G_DIETPI-NOTIFY -2 "$text"
-
-		else
-
-			G_DIETPI-NOTIFY -2 "Running command: $G_ERROR_HANDLER_COMMAND"
-
-		fi
+		[ -n "$text" ] || text="Running command: $G_ERROR_HANDLER_COMMAND"
+		G_DIETPI-NOTIFY -2 "$text"
 
 		$G_ERROR_HANDLER_COMMAND &> /tmp/G_ERROR_HANDLER_COMMAND
 		G_ERROR_HANDLER_EXITCODE=$?

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -403,12 +403,17 @@
 	#		G_ERROR_HANDLER
 	G_ERROR_HANDLER(){
 
-		[ -n "$text" ] || text="$G_ERROR_HANDLER_COMMAND"
+		if [ ! -n "$L_MESSAGE" ]; then
+
+			local L_MESSAGE="$G_ERROR_HANDLER_COMMAND"
+			[ -n "$G_PROGRAM_NAME" ] && L_MESSAGE="$G_PROGRAM_NAME: $L_MESSAGE"
+
+		fi
 
 		#Ok
 		if (( $G_ERROR_HANDLER_EXITCODE == 0 )); then
 
-			G_DIETPI-NOTIFY 0 "$text"
+			G_DIETPI-NOTIFY 0 "$L_MESSAGE"
 
 		#Error
 		else
@@ -419,12 +424,7 @@
 			local print_report_to_dietpi_info='If problems persist, please report this to DietPi for investigation, including a screenshot of this error! (https://github.com/Fourdee/DietPi/issues).'
 			local print_unable_to_continue='Unable to continue, the program will now terminate.'
 
-			echo ''
-
-			text="$G_ERROR_HANDLER_COMMAND"
-			[ -n "$G_PROGRAM_NAME" ] && text="$G_PROGRAM_NAME: $G_ERROR_HANDLER_COMMAND"
-			G_DIETPI-NOTIFY 1 "$text"
-
+			G_DIETPI-NOTIFY 1 "$L_MESSAGE"
 			G_DIETPI-NOTIFY 2 "$print_exitcode_info"
 			G_DIETPI-NOTIFY 2 "$print_hw_info"
 
@@ -556,8 +556,13 @@ $print_logfile_info
 
 		G_ERROR_HANDLER_COMMAND="$@"
 
-		[ -n "$text" ] || text="Running command: $G_ERROR_HANDLER_COMMAND"
-		G_DIETPI-NOTIFY -2 "$text"
+		if [ ! -n "$L_MESSAGE" ]; then
+
+			local L_MESSAGE="$G_ERROR_HANDLER_COMMAND"
+			[ -n "$G_PROGRAM_NAME" ] && L_MESSAGE="$G_PROGRAM_NAME: $L_MESSAGE"
+
+		fi
+		G_DIETPI-NOTIFY -2 "$L_MESSAGE"
 
 		$G_ERROR_HANDLER_COMMAND &> /tmp/G_ERROR_HANDLER_COMMAND
 		G_ERROR_HANDLER_EXITCODE=$?


### PR DESCRIPTION
https://github.com/Fourdee/DietPi/issues/1384

What do you think? Would be most beautiful, if we could give a more meaningful output, like "DietPi process settings are applied", but for me, as DietPi-Process_Tool output can be very long, it is most important, that it is shortened, if not called manually/via dietpi-launcher, as services are started/restarted quite often during installation and other maintenance tasks.

G_RUN_CMD could get an optional output by times, like `G_RUN_CMD --text "DietPi process settings are applied" /DietPi/dietpi/dietpi-process_tool 1`