### PR TITLE
DietPi-Software | Fix Tonido installation on Stretch

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6055,7 +6055,7 @@ _EOF_
 			elif (( $G_HW_ARCH == 10 )); then
 
 				INSTALL_URL_ADDRESS1='http://dietpi.com/downloads/binaries/all/libjpeg8_8d1-2_amd64.deb'
-				(( $G_DISTRO > 3 )) && INSTALL_URL_ADDRESS2='http://deb.debian.org/debian/pool/main/libp/libpng/libpng12-0_1.2.50-2+deb8u3_amd64.deb' || AGI libpng12-0
+				(( $G_DISTRO > 3 )) && INSTALL_URL_ADDRESS2='http://dietpi.com/downloads/binaries/all/libpng12-0_1.2.50-2+deb8u3_amd64.deb' || AGI libpng12-0
 
 			fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6041,24 +6041,42 @@ _EOF_
 
 			Banner_Installing
 
+			### Pre-reqs
+			## libjpeg8, libpng12, libssl1.0.0
+			# https://github.com/Fourdee/DietPi/issues/1428#issuecomment-361099496
 			# - armv6/7
 			if (( $G_HW_ARCH == 1 || $G_HW_ARCH == 2 )); then
 
-				INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/libjpeg8_8d1-2_armhf.deb'
+				INSTALL_URL_ADDRESS1='http://dietpi.com/downloads/binaries/all/libjpeg8_8d1-2_armhf.deb'
+				(( $G_DISTRO > 3 )) && INSTALL_URL_ADDRESS2='http://dietpi.com/downloads/binaries/all/libssl1.0.0_1.0.2l-1_bpo8+1_armhf.deb'
+				AGI libpng12-0
 
 			# - x86_64
 			elif (( $G_HW_ARCH == 10 )); then
 
-				INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/libjpeg8_8d1-2_amd64.deb'
+				INSTALL_URL_ADDRESS1='http://dietpi.com/downloads/binaries/all/libjpeg8_8d1-2_amd64.deb'
+				(( $G_DISTRO > 3 )) && INSTALL_URL_ADDRESS2='http://deb.debian.org/debian/pool/main/libp/libpng/libpng12-0_1.2.50-2+deb8u3_amd64.deb' || AGI libpng12-0
 
 			fi
 
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-
-			wget "$INSTALL_URL_ADDRESS" -O package.deb
+			G_CHECK_URL "$INSTALL_URL_ADDRESS1"
+			wget "$INSTALL_URL_ADDRESS1" -O package.deb
 			dpkg -i package.deb
 			rm package.deb
 
+			if (( $G_DISTRO > 3 )); then
+
+				G_CHECK_URL "$INSTALL_URL_ADDRESS2"
+				wget "$INSTALL_URL_ADDRESS2" -O package.deb
+				dpkg -i package.deb
+				rm package.deb
+
+			fi
+
+			## libfontconfig1
+			G_AGI libfontconfig1
+
+			### Tonido
 			# - armv6+
 			if (( $G_HW_ARCH == 1 || $G_HW_ARCH == 2 )); then
 
@@ -6072,8 +6090,6 @@ _EOF_
 			fi
 
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-
-			G_AGI libpng12-0 libfontconfig1
 
 			wget "$INSTALL_URL_ADDRESS" -O package.tar
 			mkdir /etc/tonido
@@ -12702,7 +12718,7 @@ _EOF_
 
 		elif (( $index == 134 )); then
 
-			#apt-mark auto libjpeg8 libpng12-0 libfontconfig1 &> /dev/null
+			#apt-mark auto libjpeg8 libpng12-0 libfontconfig1 libssl1.0.0 &> /dev/null
 
 			rm /etc/systemd/system/tonido.service
 


### PR DESCRIPTION
https://github.com/Fourdee/DietPi/issues/1432

- amd64 Tonido brings internal `libssl.so` + `libcrypto.so`, but Debian Stretch repo is missing libpng12-0 instead.
- arm Tonido comes as way older version, missing included libraries, but Raspbian Stretch repo has libpng12-0 instead.