### PR TITLE
DietPi-Software | Nginx: Fix installation with IPv6 disabled

### DIFF
--- a/dietpi/conf/nginx.site-available-default
+++ b/dietpi/conf/nginx.site-available-default
@@ -23,7 +23,7 @@ server {
 	location ~ \.php(?:$|/) {
 		fastcgi_split_path_info ^(.+\.php)(/.+)$;
 		fastcgi_param PATH_INFO $fastcgi_path_info;
-		fastcgi_pass unix:/run/php5-fpm.sock;
+		fastcgi_pass php;
 		fastcgi_index index.php;
 		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 		include fastcgi_params;

--- a/dietpi/conf/nginx.sites-dietpi.nextcloud.config
+++ b/dietpi/conf/nginx.sites-dietpi.nextcloud.config
@@ -49,10 +49,9 @@ location ^~ /nextcloud {
                 #fastcgi_param HTTPS on;
                 # Avoid sending the security headers twice
                 fastcgi_param modHeadersAvailable true;
-                # Front controller enables pretty URLs without /index.php/ but some icons are redirected wrong, thus don't show up!
-                # Will be fixed with Nextcloud 13!
-                #fastcgi_param front_controller_active true;
-                fastcgi_pass unix:/var/run/php5-fpm.sock;
+                # Front controller enables pretty URLs without /index.php/, which works fine since Nextcloud 13!
+                fastcgi_param front_controller_active true;
+                fastcgi_pass php;
                 fastcgi_intercept_errors on;
                 # Disable on Jessie, because Jessie Nginx does not support that parameter
                 #fastcgi_request_buffering off;

--- a/dietpi/conf/nginx.sites-dietpi.owncloud.config
+++ b/dietpi/conf/nginx.sites-dietpi.owncloud.config
@@ -54,9 +54,9 @@ location ^~ /owncloud {
         #fastcgi_param HTTPS on;
         fastcgi_param modHeadersAvailable true; #Avoid sending the security headers twice
         # EXPERIMENTAL: active the following if you need to get rid of the 'index.php' in the URLs
-        #fastcgi_param front_controller_active true;
+        fastcgi_param front_controller_active true;
         fastcgi_read_timeout 180; # increase default timeout e.g. for long running carddav/ caldav syncs with 1000+ entries
-        fastcgi_pass unix:/var/run/php5-fpm.sock;
+        fastcgi_pass php;
         fastcgi_intercept_errors on;
         #fastcgi_request_buffering off; #Available since NGINX 1.7.11
     }

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3545,6 +3545,15 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$INSTALLING_INDEX]} == 1 )); then
 
 			Banner_Installing
+			# If IPv6 is disabled, nginx service fails to start up due to IPv6 part in default site.
+			# This leads to AGP failure, thus we copy our IPv6-less site in place first:
+			if [ ! -d /proc/sys/net/ipv6 ]; then
+
+				[ -d /etc/nginx ] || mkdir /etc/nginx
+				[ -d /etc/nginx/sites-available ] || mkdir /etc/nginx/sites-available
+				cp /DietPi/dietpi/conf/nginx.site-available-default /etc/nginx/sites-available/default
+
+			fi
 			G_AGI nginx xml-core --no-install-recommends
 
 		fi
@@ -7924,10 +7933,6 @@ _EOF_
 
 			#Default site
 			cp /DietPi/dietpi/conf/nginx.site-available-default /etc/nginx/sites-available/default
-			# - Stretch , set php7.0
-			if (( $G_DISTRO >= 4 )); then
-				sed -i "s#/run/php5-fpm.sock#/run/php/php7.0-fpm.sock#g" /etc/nginx/sites-available/default
-			fi
 
 			# - Nginx index page
 			cp /usr/share/nginx/html/index.html /var/www/index.html

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8310,10 +8310,9 @@ _EOF_
 				fi
 				cp /DietPi/dietpi/conf/nginx.sites-dietpi.owncloud.config $owncloud_config
 
-				# Stretch: Use PHP7.0 socket and set 'fastcgi_request_buffering off';
+				# Stretch: Set 'fastcgi_request_buffering off';
 				if (( $G_DISTRO > 3 )); then
 
-					sed -i 's|/run/php5-fpm.sock|/run/php/php7.0-fpm.sock|g' $owncloud_config
 					sed -i 's/#fastcgi_request_buffering off;/fastcgi_request_buffering off;/g' $owncloud_config
 
 				fi
@@ -8323,6 +8322,13 @@ _EOF_
 				if (( $? == 0 || $? == 5)); then
 
 					sed -i 's/#fastcgi_param HTTPS on;/fastcgi_param HTTPS on;/g' $owncloud_config
+
+				fi
+
+				# Disable pretty URLs (front controller), if ownCloud version is lower 10.
+				if (( $(grep '$OC_VersionString' /var/www/owncloud/version.php | sed "s/^.*= '//" | sed "s/\..*$//") < 10 )); then
+
+					sed -i 's/^[[:blank:]]*fastcgi_param front_controller_active true;/\t#fastcgi_param front_controller_active true;/g' $owncloud_config
 
 				fi
 
@@ -8485,10 +8491,9 @@ _EOF_
 				fi
 				cp /DietPi/dietpi/conf/nginx.sites-dietpi.nextcloud.config $nextcloud_config
 
-				# Stretch: Use PHP7.0 socket and set 'fastcgi_request_buffering off';
+				# Stretch: Set 'fastcgi_request_buffering off';
 				if (( $G_DISTRO > 3 )); then
 
-					sed -i 's|/run/php5-fpm.sock|/run/php/php7.0-fpm.sock|g' $nextcloud_config
 					sed -i 's/#fastcgi_request_buffering off;/fastcgi_request_buffering off;/g' $nextcloud_config
 
 				fi
@@ -8498,6 +8503,13 @@ _EOF_
 				if (( $? == 0 || $? == 5)); then
 
 					sed -i 's/#fastcgi_param HTTPS on;/fastcgi_param HTTPS on;/g' $nextcloud_config
+
+				fi
+
+				# Disable pretty URLs (front controller), if Nextcloud version is lower 13.
+				if (( $(grep '$OC_VersionString' /var/www/nextcloud/version.php | sed "s/^.*= '//" | sed "s/\..*$//") < 13 )); then
+
+					sed -i 's/^[[:blank:]]*fastcgi_param front_controller_active true;/\t#fastcgi_param front_controller_active true;/g' $nextcloud_config
 
 				fi
 


### PR DESCRIPTION
+ Installation fails, if IPv6 is disabled, as the repo maintainers default site comes with an IPv6 string included. Solved by copy our own config in place before G_AGI, if IPv6 is disabled.
  - Another feature would be enable/disable the IPv6 string together with dietpi-config toggle, as otherwise our Nginx doesn't seems to be compatible with IPv6 by default?
+ DietPi-Software | ownCloud/Nextcloud: Enable pretty URLs without /index.php/ by default on Nginx
  - This works nice since NC 13 (will be released today) and OC 10
+ DietPi-Software | Nginx: Use defined upstream "php" within nginx.conf on all Nginx sites now
  - Wanted to define an upstream, then found the existing on in our config. And we define/overwrite the correct unix socket on each site separately until now 😆.