### PR TITLE
DietPi-Software | Pydio: Add PHP module 'intl' on installation, as requested via web ui warning

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ DietPi-Backup | Rsync: Error control now handled by G_RUN_CMD
 DietPi-Sync | Rsync: Error control now handled by G_RUN_CMD
 G_AGP | Will now only remove packages which are installed. Non matching items will be ignored. Supports wildcards. Prevents APT failure if the package is simply not installed.
 G_DIETPI-NOTIFY | Added initiating program name, to start of line print.
+DietPi-Software | Pydio: Add PHP module 'intl' on installation, as requested via web ui warning: https://github.com/Fourdee/DietPi/issues/1240
 
 Bug Fixes:
 DietPi-Config | AudioPhonics I-Sabre-K2M: Resolved issue with failed installation. This is now a source build ondemand: https://github.com/Fourdee/DietPi/issues/1437

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5347,6 +5347,9 @@ _EOF_
 
 			Banner_Installing
 
+			#Pre-reqs: Web ui warning: "PHP INTL extension missing. English month names will be used for all languages."
+			G_AGI $PHP_APT_PACKAGE_NAME-intl
+
 			#check folder is online
 			INSTALL_URL_ADDRESS='https://download.pydio.com/pub/core/archives/pydio-core-8.0.2.zip'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"


### PR DESCRIPTION
https://github.com/Fourdee/DietPi/issues/1240