### PR TITLE
DietPi-Software | Nginx: Fix for fix for non-IPv6 installation

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3547,6 +3547,7 @@ _EOF_
 			if [ ! -d /proc/sys/net/ipv6 ]; then
 
 				[ -d /etc/nginx ] || mkdir /etc/nginx
+				cp /DietPi/dietpi/conf/nginx.conf /etc/nginx/nginx.conf
 				[ -d /etc/nginx/sites-available ] || mkdir /etc/nginx/sites-available
 				cp /DietPi/dietpi/conf/nginx.site-available-default /etc/nginx/sites-available/default
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12527,7 +12527,7 @@ _EOF_
 
 		elif (( $index == 85 )); then
 
-			G_AGP nginx
+			G_AGP nginx nginx-light
 
 		elif (( $index == 84 )); then
 


### PR DESCRIPTION
+ Whoopsie, of course without `upstream php` from our `nginx.conf`, our default page, using `fastcgi_pass php` must fail.