### PR TITLE
DietPi-Prep | RPi: Fix "--reinstall" not marking as "manual"

### DIFF
--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -599,9 +599,9 @@ _EOF_
 		apt-mark unhold libraspberrypi-bin libraspberrypi0 raspberrypi-bootloader raspberrypi-kernel raspberrypi-sys-mods raspi-copies-and-fills
 		rm -R /lib/modules/*
 		G_AGI libraspberrypi-bin libraspberrypi0 raspberrypi-bootloader raspberrypi-kernel raspberrypi-sys-mods
-		G_AGI --reinstall libraspberrypi-bin libraspberrypi0 raspberrypi-bootloader raspberrypi-kernel raspberrypi-sys-mods
+		G_AGI --reinstall libraspberrypi-bin libraspberrypi0 raspberrypi-bootloader raspberrypi-kernel
 		# Buster systemd-udevd doesn't support the current raspi-copies-and-fills: https://github.com/Fourdee/DietPi/issues/1286
-		(( $DISTRO_TARGET < 5 )) && G_AGI raspi-copies-and-fills && G_AGI --reinstall raspi-copies-and-fills
+		(( $DISTRO_TARGET < 5 )) && G_AGI raspi-copies-and-fills
 
 	#	Odroid C2
 	elif (( $G_HW_MODEL == 12 )); then

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -596,7 +596,9 @@ _EOF_
 	#	RPi
 	elif (( $G_HW_MODEL < 10 )); then
 
-		G_AGI libraspberrypi-bin libraspberrypi0 raspberrypi-bootloader raspberrypi-kernel raspberrypi-sys-mods raspi-copies-and-fills
+		G_AGI libraspberrypi-bin libraspberrypi0 raspberrypi-bootloader raspberrypi-kernel raspberrypi-sys-mods
+		# Buster systemd-udevd doesn't support the current raspi-copies-and-fills: https://github.com/Fourdee/DietPi/issues/1286
+		(( $DISTRO_TARGET < 5 )) && G_AGI raspi-copies-and-fills
 
 	#	Odroid C2
 	elif (( $G_HW_MODEL == 12 )); then

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -596,9 +596,11 @@ _EOF_
 	#	RPi
 	elif (( $G_HW_MODEL < 10 )); then
 
+		rm -R /lib/modules/*
 		G_AGI libraspberrypi-bin libraspberrypi0 raspberrypi-bootloader raspberrypi-kernel raspberrypi-sys-mods
+		G_AGI --reinstall libraspberrypi-bin libraspberrypi0 raspberrypi-bootloader raspberrypi-kernel raspberrypi-sys-mods
 		# Buster systemd-udevd doesn't support the current raspi-copies-and-fills: https://github.com/Fourdee/DietPi/issues/1286
-		(( $DISTRO_TARGET < 5 )) && G_AGI raspi-copies-and-fills
+		(( $DISTRO_TARGET < 5 )) && G_AGI raspi-copies-and-fills && G_AGI --reinstall raspi-copies-and-fills
 
 	#	Odroid C2
 	elif (( $G_HW_MODEL == 12 )); then

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -596,6 +596,7 @@ _EOF_
 	#	RPi
 	elif (( $G_HW_MODEL < 10 )); then
 
+		apt-mark unhold libraspberrypi-bin libraspberrypi0 raspberrypi-bootloader raspberrypi-kernel raspberrypi-sys-mods raspi-copies-and-fills
 		rm -R /lib/modules/*
 		G_AGI libraspberrypi-bin libraspberrypi0 raspberrypi-bootloader raspberrypi-kernel raspberrypi-sys-mods
 		G_AGI --reinstall libraspberrypi-bin libraspberrypi0 raspberrypi-bootloader raspberrypi-kernel raspberrypi-sys-mods

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -596,10 +596,7 @@ _EOF_
 	#	RPi
 	elif (( $G_HW_MODEL < 10 )); then
 
-		apt-mark unhold libraspberrypi-bin libraspberrypi0 raspberrypi-bootloader raspberrypi-kernel raspberrypi-sys-mods raspi-copies-and-fills
-		rm -R /lib/modules/*
-
-		G_AGI libraspberrypi-bin libraspberrypi0 raspberrypi-bootloader raspberrypi-kernel raspberrypi-sys-mods raspi-copies-and-fills --reinstall
+		G_AGI libraspberrypi-bin libraspberrypi0 raspberrypi-bootloader raspberrypi-kernel raspberrypi-sys-mods raspi-copies-and-fills
 
 	#	Odroid C2
 	elif (( $G_HW_MODEL == 12 )); then


### PR DESCRIPTION
Just tested script on my RPi. Worked well besides: apt install --reinstall does not change apt-mark flag. Thus RPi specific packages get autoremoved afterwards. The package unhold/rm modules/--reinstall was just for own to package kernel transition and should be not necessary anymore, right?