### PR TITLE
DietPi-Software | PHP: Add support for Buster default PHP7.2

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -234,6 +234,10 @@ _EOF_
 		FP_PHP_BASE_DIR='/etc/php5'
 		PHP_APT_PACKAGE_NAME='php5'
 
+	elif (( $G_DISTRO > 4 )); then
+
+		FP_PHP_BASE_DIR='/etc/php/7.2'
+
 	fi
 
 	#
@@ -3622,12 +3626,19 @@ _EOF_
 			fi
 
 			#php-common modules, used by most web software
-			G_AGI "$PHP_APT_PACKAGE_NAME"-curl "$PHP_APT_PACKAGE_NAME"-gd "$PHP_APT_PACKAGE_NAME"-apcu "$PHP_APT_PACKAGE_NAME"-mcrypt
+			G_AGI "$PHP_APT_PACKAGE_NAME"-curl "$PHP_APT_PACKAGE_NAME"-gd "$PHP_APT_PACKAGE_NAME"-apcu
 
 			# + stretch extras
 			if (( $G_DISTRO >= 4 )); then
 
 				G_AGI "$PHP_APT_PACKAGE_NAME"-mbstring "$PHP_APT_PACKAGE_NAME"-zip "$PHP_APT_PACKAGE_NAME"-xml
+
+			fi
+
+			# PHP7.2/Buster dropped support for mcrypt: https://liorkaplan.wordpress.com/2017/09/10/php-7-2-is-coming-mcrypt-extension-isnt/
+			if (( $G_DISTRO < 5 )); then
+
+				G_AGI "$PHP_APT_PACKAGE_NAME"-mcrypt
 
 			fi
 


### PR DESCRIPTION
As I just moved my RPi to generally good working Buster:
- Default PHP version there is now 7.2: https://packages.debian.org/buster/php
- Also `php-apcu` and `php-redis` finally support it: https://packages.debian.org/buster/php-apcu
<s>This changed in between the last few days and did not yet arrive to Raspbian repo.
- I needed to grab those packages from Debian repo, as well as `libsodium23`, which is needed by (also Raspbian) `libapache2-mod-php7.2` but not (yet) available in Raspbian repo: https://packages.debian.org/buster/libapache2-mod-php7.2

https://packages.debian.org/buster/armhf/libsodium23/download
https://packages.debian.org/buster/armhf/php-redis/download
https://packages.debian.org/buster/armhf/php-igbinary/download
https://packages.debian.org/de/buster/armhf/php-apcu/download

- I could add those to PHP/Redis installation part, but since it should be available in Raspbian repo soon as well and Buster is in early testing state, I think this is really not necessary.</s>
- `php-mcrypt` was dropped for PHP7.2: https://liorkaplan.wordpress.com/2017/09/10/php-7-2-is-coming-mcrypt-extension-isnt/
- I don't know if any of our software relies on it. ownCloud/Nextcloud somehow "recommend" it for better encryption performance (if one uses it), but I also remember some topics, that this is obsolete. Especially with today release Nextcloud 13, encryption was totally rewritten and client side encryption introduced and they will never ported mcrypt support, at least I hope, since library is >10 years old now.