### PR TITLE
DietPi-Drive_Manager | Remove 'nofail' from RootFS

### DIFF
--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -216,7 +216,14 @@
 					sed -i "\@^${aDRIVE_MOUNT_SOURCE[$i]}[[:space:]]@d" "$FP_TEMP_FSTAB"
 					sed -i "\@^UUID=${aDRIVE_UUID[$i]}[[:space:]]@d" "$FP_TEMP_FSTAB"
 
-					local mount_options='defaults,noatime,nofail'
+					local mount_options='defaults,noatime'
+
+					#	Disable nofail for RootFS, which will be ignored, causing warning:
+					if [ "${aDRIVE_MOUNT_TARGET[$i]}" != '/' ]; then
+
+						mount_options+=',nofail'
+
+					fi
 
 					#	Disable x-systemd.automount for
 					#		RootFS, breaks FS_partition

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -222,16 +222,14 @@
 					if [ "${aDRIVE_MOUNT_TARGET[$i]}" != '/' ]; then
 
 						mount_options+=',nofail'
+						#	Disable x-systemd.automount for
+						#		RootFS, breaks FS_partition
+						#		Boot, breaks dietpi-ramdisk on ASUS TB
+						if [ "${aDRIVE_MOUNT_TARGET[$i]}" != '/boot' ]; then
 
-					fi
+							mount_options+=',x-systemd.automount'
 
-					#	Disable x-systemd.automount for
-					#		RootFS, breaks FS_partition
-					#		Boot, breaks dietpi-ramdisk on ASUS TB
-					if [ "${aDRIVE_MOUNT_TARGET[$i]}" != '/' ] &&
-						[ "${aDRIVE_MOUNT_TARGET[$i]}" != '/boot' ]; then
-
-						mount_options+=',x-systemd.automount'
+						fi
 
 					fi
 

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -216,20 +216,16 @@
 					sed -i "\@^${aDRIVE_MOUNT_SOURCE[$i]}[[:space:]]@d" "$FP_TEMP_FSTAB"
 					sed -i "\@^UUID=${aDRIVE_UUID[$i]}[[:space:]]@d" "$FP_TEMP_FSTAB"
 
-					local mount_options='defaults,noatime'
+					local mount_options='defaults,noatime,x-systemd.automount,nofail'
 
-					#	Disable nofail for RootFS, which will be ignored, causing warning:
-					if [ "${aDRIVE_MOUNT_TARGET[$i]}" != '/' ]; then
-
-						mount_options+=',nofail'
-						#	Disable x-systemd.automount for
-						#		RootFS, breaks FS_partition
-						#		Boot, breaks dietpi-ramdisk on ASUS TB
-						if [ "${aDRIVE_MOUNT_TARGET[$i]}" != '/boot' ]; then
-
-							mount_options+=',x-systemd.automount'
-
-						fi
+					#	Override rootFS/Boot options
+					#	- Disable nofail for RootFS & boot, which will be ignored, causing warning:
+					#	- x-systemd.automount RootFS, breaks FS_partition
+					#	- x-systemd.automount Boot, breaks dietpi-ramdisk on ASUS TB
+					if [ "${aDRIVE_MOUNT_TARGET[$i]}" == '/' ] || 
+						[ "${aDRIVE_MOUNT_TARGET[$i]}" == '/boot' ]; then
+					
+						mount_options='defaults,noatime'
 
 					fi
 


### PR DESCRIPTION
Due to: `systemd-fstab-generator[18421]: Ignoring "nofail" for root device`
Reference: https://lists.freedesktop.org/archives/systemd-devel/2015-May/031446.html