### PR TITLE
Update dietpi-set_hardware

### DIFF
--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -1307,6 +1307,7 @@ update_config=1
 
 network={
     ssid="$Wifi_SSID"
+    scan_ssid=1
 _EOF_
 
 				# - Add KEY and type


### PR DESCRIPTION
add scan_ssid=1, in order to connect to hidden SSID wifi network

<!-- Before submitting a pull request  -->
<!-- - Please ensure target branch is the testing (active dev) branch: https://github.com/Fourdee/DietPi/tree/testing  -->
<!-- - Please ensure changes have been tested and verified functional.  -->
