### PR TITLE
General | v6.2 polishing

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,7 @@ DietPi-Software | PiJuice: Available for installation: http://dietpi.com/phpbb/v
 DietPi-Software | Grasshopper: Removed, no longer available for installation: https://github.com/Fourdee/DietPi/issues/1491
 DietPi-Software | Raspcontrol: Removed, no longer available for installation: https://github.com/Fourdee/DietPi/issues/1491
 DietPi-Software | NetData: Updated to latest version (v1.9.0, previously v1.6.0): https://github.com/Fourdee/DietPi/issues/1494#issuecomment-364504645
+DietPi-Software | MariaDB: Installation does now automatically migrate existing databases in /mnt/dietpi_userdata/mysql or /var/lib/mysql, which would be not easily possible afterwards: https://github.com/Fourdee/DietPi/pull/1475
 DietPi-Sync | Rsync: Error control now handled by G_RUN_CMD
 G_AGP | Will now only remove packages which are installed. Non matching items will be ignored. Supports wildcards. Prevents APT failure if the package is simply not installed.
 G_DIETPI-NOTIFY | Added initiating program name, to start of line print.

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -71,7 +71,7 @@
 
 	#Setup locale
 	# - Remove exisiting settings that will break dpkg-reconfigure
-	rm /etc/environment &> /dev/null
+	echo '' > /etc/environment
 	rm /etc/default/locale &> /dev/null
 
 	#	NB: DEV, any changes here must be also rolled into function '/DietPi/dietpi/func/dietpi-set_software locale', for future script use
@@ -88,11 +88,10 @@
 	fi
 
 	# - Update /etc/default/locales with new values (not effective until next load of bash session, eg: logout/in)
-	update-locale LANG="$INPUT_MODE_VALUE"
-	update-locale LANGUAGE="$INPUT_MODE_VALUE"
-	update-locale LC_CTYPE="$INPUT_MODE_VALUE"
-	update-locale LC_TIME="$INPUT_MODE_VALUE"
-	update-locale LC_ALL="$INPUT_MODE_VALUE"
+	update-locale LANG=en_GB.UTF-8
+	update-locale LC_CTYPE=en_GB.UTF-8
+	update-locale LC_TIME=en_GB.UTF-8
+	update-locale LC_ALL=en_GB.UTF-8
 
 	#Force en_GB Locale for rest of script. Prevents incorrect parsing with non-english locales.
 	export LC_ALL=en_GB.UTF-8
@@ -410,7 +409,7 @@
 	#	NB: Apt sources will get overwritten during 1st run, via boot script and dietpi.txt entry
 
 	#rm /etc/apt/sources.list.d/* &> /dev/null #Probably a bad idea
-	rm /etc/apt/sources.list.d/deb-multimedia.list &> /dev/null #meveric
+	#rm /etc/apt/sources.list.d/deb-multimedia.list &> /dev/null #meveric, already done above
 	rm /etc/apt/sources.list.d/openmediavault.list &> /dev/null #http://dietpi.com/phpbb/viewtopic.php?f=11&t=2772&p=10646#p10594
 	#rm /etc/apt/sources.list.d/armbian.list
 
@@ -580,8 +579,6 @@ _EOF_
 		(( $G_HW_MODEL != 20 )) && G_AGI firmware-linux-nonfree
 		grep 'vendor_id' /proc/cpuinfo | grep -qi 'intel' && G_AGI intel-microcode
 		grep 'vendor_id' /proc/cpuinfo | grep -qi 'amd' && G_AGI amd64-microcode
-		#aPACKAGES_REQUIRED_INSTALL+=('firmware-misc-nonfree')
-		#aPACKAGES_REQUIRED_INSTALL+=('dmidecode')
 
 		#	Grub EFI
 		if (( $(dpkg --get-selections | grep -ci -m1 '^grub-efi-amd64[[:space:]]') )) ||

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3881,7 +3881,7 @@ _EOF_
 			else
 
 				local datadir="$(grep -m1 '^[[:blank:]]*SOFTWARE_NEXTCLOUD_DATADIR=' /DietPi/dietpi.txt | sed 's/^.*=//')"
-				[ -n "$datadir" ] || datadir="$G_FP_DIETPI_USERDATA/nextcloudcloud_data"
+				[ -n "$datadir" ] || datadir="$G_FP_DIETPI_USERDATA/nextcloud_data"
 				if [ -f "$datadir"/dietpi-nextcloud-installation-backup/occ ]; then
 
 					G_DIETPI-NOTIFY 2 'Nextcloud installation backup found, starting recovery...'

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9506,8 +9506,7 @@ _EOF_
 			cat << _EOF_ > /etc/systemd/system/vncserver.service
 [Unit]
 Description=Manage VNC Server
-After=dietpi-service.service
-After=rc.local.service
+After=dietpi-ramdisk.service rc.local.service
 
 [Service]
 Type=idle

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -78,16 +78,12 @@ _EOF_
 			fi
 
 			# - Remove exisiting settings that will break dpkg-reconfigure
-			cp /etc/environment /mnt/dietpi_userdata/environment.bak &> /dev/null
-			rm /etc/environment &> /dev/null
-			cp /etc/default/locale /mnt/dietpi_userdata/locale.bak &> /dev/null
 			rm /etc/default/locale &> /dev/null
 
 			G_RUN_CMD dpkg-reconfigure -f noninteractive locales
 
 			# - Update /etc/default/locales with new values (not effective until next load of bash session, eg: logout/in)
 			update-locale LANG="$INPUT_MODE_VALUE"
-			update-locale LANGUAGE="$INPUT_MODE_VALUE"
 			update-locale LC_CTYPE="$INPUT_MODE_VALUE"
 			update-locale LC_TIME="$INPUT_MODE_VALUE"
 			update-locale LC_ALL="$INPUT_MODE_VALUE"

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -126,10 +126,12 @@
 		#-------------------------------------------------------------------------------
 		#locale rework/reset: https://github.com/Fourdee/DietPi/issues/1430#issuecomment-364763302
 		rm /etc/profile.d/99-dietpi-force-locale.sh &> /dev/null
+		mv /etc/environment /mnt/dietpi_userdata/environment.bak &> /dev/null
+		echo '' > /etc/environment
 
 		/DietPi/dietpi/func/dietpi-set_software locale en_GB.UTF-8
 
-		export G_WHIP_MSG_TEXT="Notice (locale):\n\nTo resolve broken Locales, they have been reset to en_GB.UTF-8.\n\nIf you had a different locale configured on this system, please use dietpi-config at a later date to re-configure."
+		export G_WHIP_MSG_TEXT="Notice (locale):\n\nTo resolve broken Locales, they have been reset to en_GB.UTF-8.\n\nIf you had a different locale configured on this system, please use dietpi-config at a later date to re-configure.\n\nIn relation to that, DietPi does not use "/etc/environment" anymore, thus it is cleaned. In case you manually edited it, a backup was created: /mnt/dietpi_userdata/environment.bak"
 		G_WHIP_MSG
 		#------------------------------------------------------------------------------
 		#Removed control from DietPi-Services: https://github.com/Fourdee/DietPi/issues/1501


### PR DESCRIPTION
+ DietPi-Prep | `update-locale` needs hardcoded string here ;).
_____________________
```
Feb 14 12:09:01 DietPi CRON[19691]: pam_unix(cron:session): session opened for user root by (uid=0)
Feb 14 12:09:01 DietPi CRON[19691]: pam_env(cron:session): Unable to open env file: /etc/environment: No such file or directory
```
+ Thus just clean, but do not remove /etc/environment.
+ Clean and create backup just once, to allow usage by user.
+ /etc/default/locale does not need backup, it was and is anyway never possible to select multiple locales with DietPi 😉.
_____________________
+Do not set update-locale LANGUAGE: It behaves a bid different than the others, is used as kind of priority, if first language is not available, then choose second etc. I am also not sure what kind of strings are allowed there and it does not fit to the clear/easy solution we want to provide: One locale + en_GB in case.
+ Further info about locale variables: https://wiki.debian.org/Locale
_____________________
+ Tiny spelling in Nextcloud installation, whoopsie 😄, at least there should have been no case of empty dietpi.txt entry.
_____________________
