### PR TITLE
DietPi-Software | CertBot: Also Minio challenge needs to be patched, as we actively preferred 'tls-sni' here.

### DIFF
--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -158,6 +158,10 @@
 
 					certbot renew --force-renewal -a webroot -w /var/www/ -i nginx
 
+				elif (( $(cat /DietPi/dietpi/.installed | grep -ci -m1 '^aSOFTWARE_INSTALL_STATE\[158\]=2') )); then
+
+					certbot renew --force-renewal --preferred-challenges http
+
 				fi
 
 			else


### PR DESCRIPTION
+ Is fixed for new certificates, but forgot to add to patch_file: https://github.com/Fourdee/DietPi/pull/1459/commits/a6867fd905496984259bbbb1e58e349a8306a2a6