### PR TITLE
DietPi-Software | Minio: Installation and CertBot enhancements + new globals function

### DIFF
--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -63,11 +63,19 @@
 	unset a_MIN_APT_PREREQS
 
 	# - Wget prefer IPv4
-	grep -q '^[[:blank:]]*prefer-family =' /etc/wgetrc &&
-	sed -i '/^[[:blank:]]*prefer-family =/c\prefer-family = IPv4' /etc/wgetrc ||
-	grep -q '^[[:blank:]#;]*prefer-family =' /etc/wgetrc &&
-	sed -i '/^[[:blank:]#;]*prefer-family =/c\prefer-family = IPv4' /etc/wgetrc ||
-	echo 'prefer-family = IPv4' >> /etc/wgetrc
+	if grep -q '^[[:blank:]]*prefer-family =' /etc/wgetrc; then
+
+		sed -i '/^[[:blank:]]*prefer-family =/c\prefer-family = IPv4' /etc/wgetrc
+
+	elif grep -q '^[[:blank:]#;]*prefer-family =' /etc/wgetrc; then
+
+		sed -i '/^[[:blank:]#;]*prefer-family =/c\prefer-family = IPv4' /etc/wgetrc
+
+	else
+
+		echo 'prefer-family = IPv4' >> /etc/wgetrc
+
+	fi
 
 	#Setup locale
 	# - Remove exisiting settings that will break dpkg-reconfigure

--- a/dietpi/dietpi-letsencrypt
+++ b/dietpi/dietpi-letsencrypt
@@ -255,10 +255,6 @@ _EOF_
 
 				# Add SSL to config file
 				G_CONFIG_INJECT 'MINIO_OPTS="' 'MINIO_OPTS="--address :443"' /etc/default/minio
-				cat << _EOF_ >> /etc/default/minio
-# Use if you want to run Minio on a custom port.
-MINIO_OPTS="--address :443"
-_EOF_
 
 				# Allow SSL binding for non root user
 				setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/minio

--- a/dietpi/dietpi-letsencrypt
+++ b/dietpi/dietpi-letsencrypt
@@ -240,19 +240,21 @@ _EOF_
 
 				$DP_LETSENCRYPT_BINARY certonly --standalone --staple-ocsp --agree-tos --rsa-key-size "$LETSENCRYPT_KEYSIZE" -m "$LETSENCRYPT_EMAIL" -d "$LETSENCRYPT_DOMAIN"
 
+				# Ensure strict permissions at all time:
+				umask 077
+
 				# Locate them correctly (THIS didn't work as symlinks)
 				cp /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/fullchain.pem /home/minio-user/.minio/certs/public.crt
 				cp /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/privkey.pem /home/minio-user/.minio/certs/private.key
 
 				# Own those certs!
-				chown minio-user:minio-user /home/minio-user/.minio/certs/public.crt
-				chown minio-user:minio-user /home/minio-user/.minio/certs/private.key
+				chown minio-user:minio-user /home/minio-user/.minio/certs/public.crt \
+					/home/minio-user/.minio/certs/private.key
+				chmod 400 /home/minio-user/.minio/certs/public.crt \
+					/home/minio-user/.minio/certs/private.key
 
 				# Add SSL to config file
-				grep -v "MINIO_OPTS" /etc/default/minio > /etc/default/minio.temp1
-				grep -v "port" /etc/default/minio.temp1 > /etc/default/minio.temp2
-				rm /etc/default/minio.temp1
-				mv /etc/default/minio.temp2 /etc/default/minio
+				G_CONFIG_INJECT 'MINIO_OPTS="' 'MINIO_OPTS="--address :443"' /etc/default/minio
 				cat << _EOF_ >> /etc/default/minio
 # Use if you want to run Minio on a custom port.
 MINIO_OPTS="--address :443"
@@ -266,13 +268,18 @@ _EOF_
 # Minio only works with copied and owned certs. Upon renewal the new certs needs to be copied and re-owned
 systemctl stop minio.service
 
+# Ensure strict permissions at all time:
+umask 077
+
 # Copy to correct Location
 cp /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/fullchain.pem /home/minio-user/.minio/certs/public.crt
 cp /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/privkey.pem /home/minio-user/.minio/certs/private.key
 
 # Re-Own those certs!
-chown minio-user:minio-user /home/minio-user/.minio/certs/public.crt
-chown minio-user:minio-user /home/minio-user/.minio/certs/private.key
+chown minio-user:minio-user /home/minio-user/.minio/certs/public.crt \
+	/home/minio-user/.minio/certs/private.key
+chmod 400 /home/minio-user/.minio/certs/public.crt \
+	/home/minio-user/.minio/certs/private.key
 
 systemctl start minio.service
 _EOF_

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6404,6 +6404,7 @@ _EOF_
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			#Download executable
+			[ -d /usr/local/bin ] || mkdir /usr/local/bin
 			wget -O /usr/local/bin/minio $INSTALL_URL_ADDRESS
 			chmod +x /usr/local/bin/minio
 
@@ -11669,8 +11670,8 @@ _EOF_
 
 			Banner_Configuration
 
-			# Create simple mandatory default configuration file
-			cat << _EOF_ >> /etc/default/minio
+			# Create simple mandatory default configuration file, if not already existent:
+			[ -f /etc/default/minio ] || cat << _EOF_ > /etc/default/minio
 # Default file path
 MINIO_VOLUMES="$G_FP_DIETPI_USERDATA/minio-data"
 # Use if you want to run Minio on a custom port.

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -1244,6 +1244,51 @@ _EOF_
 
 	}
 
+	# Inject setting into config file.
+	#	First tries to replace old setting, else commented setting and otherwise adds it to end of file.
+	#	Optionally adds argument to new line after speficied pattern $4.
+	#	PRESERVE=1 G_CONFIG_INJECT allows to keep current setting, if present.
+	#	Example: G_CONFIG_INJECT 'prefer-family =' 'prefer-family = IPv4' '/etc/wgetrc'
+	G_CONFIG_INJECT(){
+
+		local pattern="$1"
+		local setting="$2"
+		local file="$3"
+		local after="$4"
+
+		if grep -q "^[[:blank:]]*$pattern" "$file"; then
+
+			(( $PRESERVE )) && G_DIETPI-NOTIFY 2 "Preserve existing setting '$(grep $pattern $file)' in '$file'" && exit 0
+			sed -i "/^[[:blank:]]*$pattern/c\\$setting" "$file" && G_DIETPI-NOTIFY 2 "Overwrite existing setting '$setting' in '$file'"
+
+		elif grep -q "^[[:blank:]#;]*$pattern" "$file"; then
+
+			sed -i "/^[[:blank:]#;]*$pattern/c\\$setting" "$file" && G_DIETPI-NOTIFY 2 "Turn comment into setting '$setting' in '$file'"
+
+		else
+
+			if [ -n "$after" ]; then
+
+				if grep -q "^[[:blank:]]*$after" "$file"; then
+
+					sed -i "/^[[:blank:]]*$after/a\\$setting" "$file" && G_DIETPI-NOTIFY 2 "Add setting '$setting' after '$after' in '$file'"
+
+				else
+
+					G_WHIP_MSG_TEXT="The pattern '$after' couldn't be found in '$file', thus the setting '$setting' couldn't be added to it's desired position.\n\nYou can ignore this, if the setting is not needed, or add it manually to an appropriate position." G_WHIP_MSG
+
+				fi
+
+			else
+
+				echo "$setting" >> "$file" && G_DIETPI-NOTIFY 2 "Add setting '$setting' to '$file'"
+
+			fi
+
+		fi
+
+	}
+
 	#-----------------------------------------------------------------------------------
 	#G_DIETPI-NOTIFY 2 'DietPi-Globals loaded\n'
 	#-----------------------------------------------------------------------------------


### PR DESCRIPTION
+ Should not be the case, but installation failed on my test system due to missing `/usr/local/bin/`. Create now on demand.
+ Do not "add" Minio defaults to existing defaults file, causing doubled entries. Preserving existing config file now.
+ Enhance security during Minio cert copy.
+ Introduce new dietpi-globals function to carefully add setting to config file.
+ As result of experiments and shellcheck.net, `<check> && <command> || <command>` does not necessarily work as "if then else", thus should be replaced by `if <check>; then <command> else`, respectively the new `[ PRESERVE=1 ] G_CONFIG_INJECT <setting_pattern> <setting_value_string> <file_name> [ <after_line_pattern> ]`.