### PR TITLE
DietPi-LetsEncrypt | Lighttpd: Renewal fix and HSTS support + cleanup

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ v6.3
 Changes / Improvements / Optimizations:
 General | DietPi now uses its own "dietpi-postboot.service" to initiate dietpi-services, instead of /etc/rc.local. The latter will be reset on update, but in case of manual adjustments, a backup is safed to dietpi_userdata. The initiating "rc-local.service" will stay in place as well, so /etc/rc.local can be used as before: https://github.com/Fourdee/DietPi/issues/1376
 General | Additional getty's (2-6) are now disabled via mask. This reduces resource usage for unneeded screens: https://github.com/Fourdee/DietPi/issues/1541
+General | Skip and autoremove APT recommends on all devices: https://github.com/Fourdee/DietPi/issues/1482#issuecomment-367655376
 DietPi-Automation | dietpi.txt entries and support added for WPA2 Enterprise (WPA-EAP). Many thanks to @symo for implementing this feature!: https://github.com/Fourdee/DietPi/pull/1547
 DietPi-Backup | Once backup is completed, you will be asked if you wish to view the log file, for the full rsync log.
 DietPi-Globals | G_WHIP*: Further additions and improvements: https://github.com/Fourdee/DietPi/issues/1546
@@ -17,6 +18,7 @@ General | Resolved POSIX issues with dropbear (limitation) and SSH sessions. We 
 DietPi-Software | Desktops: USB drive removed from .gtk-bookmarks as no longer used in DietPi.
 DietPi-Software | Shairport-Sync: Resolved ARMv6 binary Illegal instruction: https://github.com/Fourdee/DietPi/issues/1548
 DietPi-Update | Resolved an issue where .update_available would exist during reboot, causing banner to display update available incorrectly: https://github.com/Fourdee/DietPi/issues/1535
+DietPi-LetsEncrypt | Lighttpd: Fixed auto renewal and added support for HSTS: https://github.com/Fourdee/DietPi/pull/1553
 
 -----------------------------------------------------------------------------------------------------------
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,13 +16,16 @@ DietPi-Software | Shairport-sync: Updated to 3.1.7 for all devices. Also enabled
 DietPi-Software | Proftp: Now defaults to dietpi user with root login off: https://github.com/Fourdee/DietPi/issues/1529#issuecomment-367644593
 DietPi-Sync | Once sync is completed, you will be asked if you wish to view the log file, for the full rsync log.
 DietPi-Update | G_AGUP/G_AGUG: Now runs prior to our patch system. Ensuring APT is upto date during our updates: http://dietpi.com/phpbb/viewtopic.php?f=11&t=2894&p=11150#p11149
+DietPi-LetsEncrypt | Lighttpd: Added support for HSTS (HTTP Strict Transport Security): https://github.com/Fourdee/DietPi/pull/1553
+DietPi-LetsEncrypt | Minor rework and cleaning, using now /etc/systemd/system/certbot.service.d/dietpi-script.conf for web server specific renewal hooks: https://github.com/Fourdee/DietPi/pull/1553
 
 Bug Fixes:
 General | Resolved POSIX issues with dropbear (limitation) and SSH sessions. We now detect for presence of POSIX and set user selected locale during session load: https://github.com/Fourdee/DietPi/issues/1540
 DietPi-Software | Desktops: USB drive removed from .gtk-bookmarks as no longer used in DietPi.
 DietPi-Software | Shairport-Sync: Resolved ARMv6 binary Illegal instruction: https://github.com/Fourdee/DietPi/issues/1548
 DietPi-Update | Resolved an issue where .update_available would exist during reboot, causing banner to display update available incorrectly: https://github.com/Fourdee/DietPi/issues/1535
-DietPi-LetsEncrypt | Lighttpd: Fixed auto renewal and added support for HSTS: https://github.com/Fourdee/DietPi/pull/1553
+DietPi-LetsEncrypt | Lighttpd/Minio: Fixed auto renewal: https://github.com/Fourdee/DietPi/pull/1553
+DietPi-LetsEncrypt | Minio: Fixed an issue, where port 443 listening would fail due to missing libcap2-bin/setcap package: https://github.com/Fourdee/DietPi/pull/1553#issuecomment-368261474
 
 -----------------------------------------------------------------------------------------------------------
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,7 +8,7 @@ Native PC BIOS | Image now available: http://dietpi.com/download
 Changes / Improvements / Optimizations:
 General | DietPi now uses its own "dietpi-postboot.service" to initiate dietpi-services, instead of /etc/rc.local. The latter will be reset on update, but in case of manual adjustments, a backup is safed to dietpi_userdata. The initiating "rc-local.service" will stay in place as well, so /etc/rc.local can be used as before: https://github.com/Fourdee/DietPi/issues/1376
 General | Additional getty's (2-6) are now disabled via mask. This reduces resource usage for unneeded screens: https://github.com/Fourdee/DietPi/issues/1541
-General | Skip and autoremove APT recommends on all devices: https://github.com/Fourdee/DietPi/issues/1482#issuecomment-367655376
+General | APT: 'Disabled install recommends' is now standard and default across all DietPi images: https://github.com/Fourdee/DietPi/issues/1482#issuecomment-368031044
 DietPi-Automation | dietpi.txt entries and support added for WPA2 Enterprise (WPA-EAP). Many thanks to @symo for implementing this feature!: https://github.com/Fourdee/DietPi/pull/1547
 DietPi-Backup | Once backup is completed, you will be asked if you wish to view the log file, for the full rsync log.
 DietPi-Globals | G_WHIP*: Further additions and improvements: https://github.com/Fourdee/DietPi/issues/1546
@@ -19,7 +19,6 @@ DietPi-Update | G_AGUP/G_AGUG: Now runs prior to our patch system. Ensuring APT 
 
 Bug Fixes:
 General | Resolved POSIX issues with dropbear (limitation) and SSH sessions. We now detect for presence of POSIX and set user selected locale during session load: https://github.com/Fourdee/DietPi/issues/1540
-General | APT: 'Disabled install recommends' is now standard and default across all DietPi images: https://github.com/Fourdee/DietPi/issues/1482#issuecomment-368031044
 DietPi-Software | Desktops: USB drive removed from .gtk-bookmarks as no longer used in DietPi.
 DietPi-Software | Shairport-Sync: Resolved ARMv6 binary Illegal instruction: https://github.com/Fourdee/DietPi/issues/1548
 DietPi-Update | Resolved an issue where .update_available would exist during reboot, causing banner to display update available incorrectly: https://github.com/Fourdee/DietPi/issues/1535

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -483,10 +483,7 @@ _EOF_
 	G_RUN_CMD apt-mark auto $(apt-mark showmanual)
 
 	# - @MichaIng https://github.com/Fourdee/DietPi/pull/1266/files
-	G_DIETPI-NOTIFY 2 "Disable automatic recommends/suggests installation and allow them to be autoremoved:"
-
-	# - - Remove other similar configurations first:
-	rm /etc/apt/apt.conf.d/*recommends*
+	G_DIETPI-NOTIFY 2 "Temporary disable automatic recommends/suggests installation and allow them to be autoremoved:"
 
 	#	Remove any existing apt recommends settings
 	rm /etc/apt/apt.conf.d/*recommends*

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -421,9 +421,6 @@
 	#rm /etc/apt/sources.list.d/deb-multimedia.list &> /dev/null #meveric, already done above
 	rm /etc/apt/sources.list.d/openmediavault.list &> /dev/null #http://dietpi.com/phpbb/viewtopic.php?f=11&t=2772&p=10646#p10594
 
-	#	Remove any existing apt recommends settings, defaults to "yes", allows us to manually --no-install-recommends as needed: https://github.com/Fourdee/DietPi/issues/1482#issuecomment-366971700
-	rm /etc/apt/apt.conf.d/*recommends*
-
 	G_DIETPI-NOTIFY 2 "Setting APT sources.list: $DISTRO_TARGET_NAME $DISTRO_TARGET"
 
 	# - Set raspbian
@@ -476,7 +473,10 @@ _EOF_
 	G_RUN_CMD apt-mark auto $(apt-mark showmanual)
 
 	# - @MichaIng https://github.com/Fourdee/DietPi/pull/1266/files
-	G_DIETPI-NOTIFY 2 "Temporary disable automatic recommends/suggests installation and allow them to be autoremoved:"
+	G_DIETPI-NOTIFY 2 "Disable automatic recommends/suggests installation and allow them to be autoremoved:"
+
+	# - - Remove other similar configurations first:
+	rm /etc/apt/apt.conf.d/*recommends*
 
 	export G_ERROR_HANDLER_COMMAND='/etc/apt/apt.conf.d/99-dietpi-norecommends'
 	cat << _EOF_ > $G_ERROR_HANDLER_COMMAND
@@ -758,11 +758,6 @@ _EOF_
 	G_DIETPI-NOTIFY 2 "Installing core DietPi pre-req APT packages"
 
 	G_AGI $INSTALL_PACKAGES
-
-	# - @MichaIng https://github.com/Fourdee/DietPi/pull/1266/files
-	G_DIETPI-NOTIFY 2 "Returning installation of recommends back to default"
-
-	G_RUN_CMD rm /etc/apt/apt.conf.d/99-dietpi-norecommends
 
 	G_DIETPI-NOTIFY 2 "Purging APT with autoremoval (in case of DISTRO upgrade/downgrade):"
 

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -1024,12 +1024,7 @@ _EOF_
 
 	G_DIETPI-NOTIFY 2 "Reducing getty count and resource usage:"
 
-	for ((i=2; i<=6; i++))
-	do
-
-		systemctl mask getty@tty$i
-
-	done
+	systemctl mask getty-static
 
 	G_DIETPI-NOTIFY 2 "Configuring ntpd:"
 

--- a/dietpi/dietpi-letsencrypt
+++ b/dietpi/dietpi-letsencrypt
@@ -34,7 +34,6 @@
 	#Globals
 	#/////////////////////////////////////////////////////////////////////////////////////
 	DP_LOGFILE="/var/log/dietpi-letsencrypt.log"
-	DP_WEBSERVER_INDEX=0 #0=apache2 1=lighttpd 2=nginx 3=minio
 
 	DP_CRON='/etc/systemd/system/certbot.service'
 	(( $G_DISTRO < 4 )) && DP_CRON='/etc/cron.weekly/dietpi-letsencrypt'
@@ -53,58 +52,13 @@
 
 	Run_Lets_Encrypt(){
 
-		G_DIETPI-NOTIFY 3 "$PROGRAM_NAME" "Running cert"
+		G_DIETPI-NOTIFY 3 "$PROGRAM_NAME" "Running CertBot"
 
-		#Conditions that must be met before allowing run
-		local run_conditions_met=1
+		#------------------------------------------------------------------------------------------------------
+		#ALL | Create cron job for cert renewal on Jessie only, as on Stretch+ it will be done via systemd service:
+		if (( $G_DISTRO < 4 )); then
 
-		/DietPi/dietpi/dietpi-services start
-
-		# - Obtain installed and running webserver index
-		if (( $(ps aux | grep -ci -m1 '[a]pache') )); then
-
-			DP_WEBSERVER_INDEX=0
-			G_DIETPI-NOTIFY 0 "Apache2 webserver detected"
-
-		elif (( $(ps aux | grep -ci -m1 '[l]ighttpd') )); then
-
-			DP_WEBSERVER_INDEX=1
-			G_DIETPI-NOTIFY 0 "Lighttpd webserver detected"
-
-		elif (( $(ps aux | grep -ci -m1 '[n]ginx') )); then
-
-			DP_WEBSERVER_INDEX=2
-			G_DIETPI-NOTIFY 0 "Nginx webserver detected"
-
-		elif (( $(ps aux | grep -ci -m1 '[m]inio') )); then
-
-			DP_WEBSERVER_INDEX=3
-			G_DIETPI-NOTIFY 0 "Minio S3 server detected"
-
-		else
-
-			run_conditions_met=0
-
-		fi
-
-		#Failed. No compatible webserver is currently running
-		if (( ! $run_conditions_met )); then
-
-			echo -e "Error: No compatible and/or active webserver was found. Aborting." >> "$DP_LOGFILE"
-			if (( $INPUT == 0 )); then
-
-				whiptail --title "Error" --msgbox "Error: No compatible and/or active webserver was found. Aborting." --backtitle "$PROGRAM_NAME" 8 60
-
-			fi
-
-		#Cert up
-		else
-
-			#------------------------------------------------------------------------------------------------------
-			#ALL | Create cron job for cert renewal on Jessie only, as on Stretch+ it will be done via systemd service:
-			if (( $G_DISTRO < 4 )); then
-
-				cat << _EOF_ > "$DP_CRON"
+			cat << _EOF_ > "$DP_CRON"
 #!/bin/bash
 {
 	#////////////////////////////////////
@@ -121,63 +75,85 @@
 	# Main Loop
 	#----------------------------------------------------------------
 
-	/etc/certbot_scripts/certbot-auto -q renew &>> $DP_LOGFILE &&
-	[ -f /home/minio-user/.minio/dietpi-cert-renewl.sh ] && /home/minio-user/.minio/dietpi-cert-renewl.sh
+	/etc/certbot_scripts/certbot-auto -q renew &>> $DP_LOGFILE
+	[ -f /home/minio-user/.minio/dietpi-cert-renewl.sh ] && /home/minio-user/.minio/dietpi-cert-renewl.sh &>> $DP_LOGFILE
+	[ -f /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/combined.pem ] &&
+	cat /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/privkey.pem /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/combined.pem/cert.pem > /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/combined.pem &>> $DP_LOGFILE
 
 	#----------------------------------------------------------------
 	exit
 	#----------------------------------------------------------------
 }
 _EOF_
+			chmod +x "$DP_CRON"
+
+		fi
+
+		#------------------------------------------------------------------------------------------------------
+		#apache2
+		if (( $(ps aux | grep -ci -m1 '[a]pache') )); then
+
+			G_DIETPI-NOTIFY 0 "Apache2 webserver detected"
+			local dp_defaultsite="/etc/apache2/sites-available/000-default.conf"
+
+			#Add ServerName if it doesnt exist. This is required to prevent letsencrypt compaining about vhost with no domain.
+			if (( ! $(cat "$dp_defaultsite" | grep -ci -m1 'ServerName') )); then
+
+				sed -i "/ServerAdmin /a ServerName" "$dp_defaultsite"
+
+				#log
+				echo -e "ServerName entry not found in $dp_defaultsite. Adding it now." >> "$DP_LOGFILE"
+
+			fi
+
+			#Apply domain name
+			sed -i "/ServerName/c\        ServerName $LETSENCRYPT_DOMAIN" "$dp_defaultsite"
+
+			#Restart apache2 to apply ServerName changes.
+			systemctl restart apache2
+
+			local options='--apache'
+			#Use webroot authentication on Stretch+ for now: https://github.com/Fourdee/DietPi/issues/734#issuecomment-361774084
+			(( $G_DISTRO > 3 )) && options='-a webroot -w /var/www/ -i apache'
+			(( $LETSENCRYPT_REDIRECT )) && options+=' --redirect' || options+=' --no-redirect'
+			(( $LETSENCRYPT_HSTS )) && options+=' --hsts'
+
+			#Cert me up Apache2
+			$DP_LETSENCRYPT_BINARY $options --agree-tos --rsa-key-size "$LETSENCRYPT_KEYSIZE" -m "$LETSENCRYPT_EMAIL" -d "$LETSENCRYPT_DOMAIN"
+
+		#------------------------------------------------------------------------------------------------------
+		#Lighttpd
+		elif (( $(ps aux | grep -ci -m1 '[l]ighttpd') )); then
+
+			G_DIETPI-NOTIFY 0 "Lighttpd webserver detected"
+			# - Cert me up
+			/DietPi/dietpi/dietpi-services stop
+
+			$DP_LETSENCRYPT_BINARY certonly --standalone --agree-tos --rsa-key-size "$LETSENCRYPT_KEYSIZE" -m "$LETSENCRYPT_EMAIL" -d "$LETSENCRYPT_DOMAIN"
+
+			# - Create combined key
+			cd /etc/letsencrypt/live/"$LETSENCRYPT_DOMAIN"
+			cat privkey.pem cert.pem > combined.pem
+
+			# Add Lighttpd renewal to certbot system service:
+			if (( $G_DISTRO > 3 )); then
+
+				cat << _EOF_ > "$DP_CRON"
+[Unit]
+Description=Certbot
+Documentation=file:///usr/share/doc/python-certbot-doc/html/index.html
+Documentation=https://letsencrypt.readthedocs.io/en/latest/
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/certbot -q renew && cat /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/privkey.pem /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/combined.pem/cert.pem > /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/combined.pem &>> $DP_LOGFILE
+PrivateTmp=true
+_EOF_
+
 				chmod +x "$DP_CRON"
 
 			fi
 
-			#------------------------------------------------------------------------------------------------------
-			#apache2
-			if (( $DP_WEBSERVER_INDEX == 0 )); then
-
-				local dp_defaultsite="/etc/apache2/sites-available/000-default.conf"
-
-				#Add ServerName if it doesnt exist. This is required to prevent letsencrypt compaining about vhost with no domain.
-				if (( ! $(cat "$dp_defaultsite" | grep -ci -m1 'ServerName') )); then
-
-					sed -i "/ServerAdmin /a ServerName" "$dp_defaultsite"
-
-					#log
-					echo -e "ServerName entry not found in $dp_defaultsite. Adding it now." >> "$DP_LOGFILE"
-
-				fi
-
-				#Apply domain name
-				sed -i "/ServerName/c\        ServerName $LETSENCRYPT_DOMAIN" "$dp_defaultsite"
-
-				#Restart apache2 to apply ServerName changes.
-				systemctl restart apache2
-
-				local options='--apache'
-				#Use webroot authentication on Stretch+ for now: https://github.com/Fourdee/DietPi/issues/734#issuecomment-361774084
-				(( $G_DISTRO > 3 )) && options='-a webroot -w /var/www/ -i apache'
-				(( $LETSENCRYPT_REDIRECT )) && options+=' --redirect' || options+=' --no-redirect'
-				(( $LETSENCRYPT_HSTS )) && options+=' --hsts'
-
-				#Cert me up Apache2
-				$DP_LETSENCRYPT_BINARY $options --agree-tos --rsa-key-size "$LETSENCRYPT_KEYSIZE" -m "$LETSENCRYPT_EMAIL" -d "$LETSENCRYPT_DOMAIN"
-
-			#------------------------------------------------------------------------------------------------------
-			#Lighttpd
-			elif (( $DP_WEBSERVER_INDEX == 1 )); then
-
-				# - Cert me up
-				/DietPi/dietpi/dietpi-services stop
-
-				$DP_LETSENCRYPT_BINARY certonly --standalone --agree-tos --rsa-key-size "$LETSENCRYPT_KEYSIZE" -m "$LETSENCRYPT_EMAIL" -d "$LETSENCRYPT_DOMAIN"
-
-				# - Create combined key
-				cd /etc/letsencrypt/live/"$LETSENCRYPT_DOMAIN"
-				cat privkey.pem cert.pem > combined.pem
-
-				cat << _EOF_ > /etc/lighttpd/conf-enabled/letsencrypt.conf
+			cat << _EOF_ > /etc/lighttpd/conf-enabled/letsencrypt.conf
 \$SERVER["socket"] == ":443" {
 		ssl.engine = "enable"
 		ssl.pemfile = "/etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/combined.pem"
@@ -190,11 +166,11 @@ _EOF_
 }
 _EOF_
 
-				#Redirect
-				rm /etc/lighttpd/conf-enabled/redirect.conf
-				if (( $LETSENCRYPT_REDIRECT )); then
+			# Redirect
+			rm /etc/lighttpd/conf-enabled/redirect.conf
+			if (( $LETSENCRYPT_REDIRECT )); then
 
-					cat << _EOF_ > /etc/lighttpd/conf-enabled/redirect.conf
+				cat << _EOF_ > /etc/lighttpd/conf-enabled/redirect.conf
 \$HTTP["scheme"] == "http" {
 	# capture vhost name with regex conditiona -> %0 in redirect pattern
 	# must be the most inner block to the redirect rule
@@ -204,63 +180,78 @@ _EOF_
 }
 _EOF_
 
-				fi
+			fi
 
-				/etc/init.d/lighttpd force-reload
+			# HSTS
+			if (( $LETSENCRYPT_HSTS )); then
 
+				G_CONFIG_INJECT '"mod_setenv"' '\t"mod_setenv",' /etc/lighttpd/lighttpd.conf 'server.modules = ('
+				cat << _EOF_ > /etc/lighttpd/conf-available/99-dietpi-hsts.conf
+$HTTP["scheme"] == "https" {
+	setenv.add-response-header = ( "Strict-Transport-Security" => "max-age=31536000; includeSubdomains; preload;" )
+}
+_EOF_
 
-			#------------------------------------------------------------------------------------------------------
-			# Nginx
+			fi
+			lighttpd-enable-mod dietpi-hsts
 
-			elif (( $DP_WEBSERVER_INDEX == 2 )); then
-
-				local nginx_defaultsite="/etc/nginx/sites-available/default"
-
-				# Apply domain name
-				sed -i "/server_name/c\        server_name $LETSENCRYPT_DOMAIN;" "$nginx_defaultsite"
-
-				#Restart nginx to apply ServerName changes.
-				systemctl restart nginx
-
-				local options='--nginx'
-				#Use webroot authentication on Stretch+ for now: https://github.com/Fourdee/DietPi/issues/734#issuecomment-361774084
-				(( $G_DISTRO > 3 )) && options='-a webroot -w /var/www/ -i nginx'
-				(( $LETSENCRYPT_REDIRECT )) && options+=' --redirect' || options+=' --no-redirect'
-				(( $LETSENCRYPT_HSTS )) && options+=' --hsts'
-
-				#Cert me up Nginx
-				$DP_LETSENCRYPT_BINARY $options --agree-tos --rsa-key-size "$LETSENCRYPT_KEYSIZE" -m "$LETSENCRYPT_EMAIL" -d "$LETSENCRYPT_DOMAIN"
+			/etc/init.d/lighttpd force-reload
 
 
-			#------------------------------------------------------------------------------------------------------
-			#Minio
-			elif (( $DP_WEBSERVER_INDEX == 3 )); then
-				# - Cert me up
-				/DietPi/dietpi/dietpi-services stop
+		#------------------------------------------------------------------------------------------------------
+		# Nginx
+		elif (( $(ps aux | grep -ci -m1 '[n]ginx') )); then
 
-				$DP_LETSENCRYPT_BINARY certonly --standalone --staple-ocsp --agree-tos --rsa-key-size "$LETSENCRYPT_KEYSIZE" -m "$LETSENCRYPT_EMAIL" -d "$LETSENCRYPT_DOMAIN"
+			G_DIETPI-NOTIFY 0 "Nginx webserver detected"
+			local nginx_defaultsite="/etc/nginx/sites-available/default"
 
-				# Ensure strict permissions at all time:
-				umask 077
+			# Apply domain name
+			sed -i "/server_name/c\        server_name $LETSENCRYPT_DOMAIN;" "$nginx_defaultsite"
 
-				# Locate them correctly (THIS didn't work as symlinks)
-				cp /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/fullchain.pem /home/minio-user/.minio/certs/public.crt
-				cp /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/privkey.pem /home/minio-user/.minio/certs/private.key
+			#Restart nginx to apply ServerName changes.
+			systemctl restart nginx
 
-				# Own those certs!
-				chown minio-user:minio-user /home/minio-user/.minio/certs/public.crt \
-					/home/minio-user/.minio/certs/private.key
-				chmod 400 /home/minio-user/.minio/certs/public.crt \
-					/home/minio-user/.minio/certs/private.key
+			local options='--nginx'
+			#Use webroot authentication on Stretch+ for now: https://github.com/Fourdee/DietPi/issues/734#issuecomment-361774084
+			(( $G_DISTRO > 3 )) && options='-a webroot -w /var/www/ -i nginx'
+			(( $LETSENCRYPT_REDIRECT )) && options+=' --redirect' || options+=' --no-redirect'
+			(( $LETSENCRYPT_HSTS )) && options+=' --hsts'
 
-				# Add SSL to config file
-				G_CONFIG_INJECT 'MINIO_OPTS="' 'MINIO_OPTS="--address :443"' /etc/default/minio
+			#Cert me up Nginx
+			$DP_LETSENCRYPT_BINARY $options --agree-tos --rsa-key-size "$LETSENCRYPT_KEYSIZE" -m "$LETSENCRYPT_EMAIL" -d "$LETSENCRYPT_DOMAIN"
 
-				# Allow SSL binding for non root user
-				setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/minio
 
-				# Create renewl script
-				cat << _EOF_ > /home/minio-user/.minio/dietpi-cert-renewl.sh
+		#------------------------------------------------------------------------------------------------------
+		#Minio
+		elif (( $(ps aux | grep -ci -m1 '[m]inio') )); then
+
+			G_DIETPI-NOTIFY 0 "Minio S3 server detected"
+			# - Cert me up
+			/DietPi/dietpi/dietpi-services stop
+
+			$DP_LETSENCRYPT_BINARY certonly --standalone --staple-ocsp --agree-tos --rsa-key-size "$LETSENCRYPT_KEYSIZE" -m "$LETSENCRYPT_EMAIL" -d "$LETSENCRYPT_DOMAIN"
+
+			# Ensure strict permissions at all time:
+			umask 077
+
+			# Locate them correctly (THIS didn't work as symlinks)
+			cp /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/fullchain.pem /home/minio-user/.minio/certs/public.crt
+			cp /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/privkey.pem /home/minio-user/.minio/certs/private.key
+
+			# Own those certs!
+			chown minio-user:minio-user /home/minio-user/.minio/certs/public.crt \
+				/home/minio-user/.minio/certs/private.key
+			chmod 400 /home/minio-user/.minio/certs/public.crt \
+				/home/minio-user/.minio/certs/private.key
+
+			# Add SSL to config file
+			G_CONFIG_INJECT 'MINIO_OPTS="' 'MINIO_OPTS="--address :443"' /etc/default/minio
+
+			# Allow SSL binding for non root user
+			setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/minio
+
+			# Create renewl script
+			cat << _EOF_ > /home/minio-user/.minio/dietpi-cert-renewl.sh
 # Minio only works with copied and owned certs. Upon renewal the new certs needs to be copied and re-owned
 systemctl stop minio.service
 
@@ -280,43 +271,50 @@ chmod 400 /home/minio-user/.minio/certs/public.crt \
 systemctl start minio.service
 _EOF_
 
-				# Change permissions on renewal script
-				chmod +x /home/minio-user/.minio/dietpi-cert-renewl.sh
+			# Change permissions on renewal script
+			chmod +x /home/minio-user/.minio/dietpi-cert-renewl.sh
 
-				# Add Minio renewal to certbot system service:
-				if (( $G_DISTRO > 3 )); then
+			# Add Minio renewal to certbot system service:
+			if (( $G_DISTRO > 3 )); then
 
-					cat << _EOF_ > "$DP_CRON"
+				cat << _EOF_ > "$DP_CRON"
 [Unit]
 Description=Certbot
 Documentation=file:///usr/share/doc/python-certbot-doc/html/index.html
 Documentation=https://letsencrypt.readthedocs.io/en/latest/
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/certbot -q renew && /home/minio-user/.minio/dietpi-cert-renewl.sh
+ExecStart=/usr/bin/certbot -q renew && /home/minio-user/.minio/dietpi-cert-renewl.sh &>> $DP_LOGFILE
 PrivateTmp=true
 _EOF_
 
-					chmod +x "$DP_CRON"
-
-				fi
+				chmod +x "$DP_CRON"
 
 			fi
 
-			#------------------------------------------------------------------------------------------------------
+		else
 
+			echo -e "Error: No compatible and/or active webserver was found. Aborting." >> "$DP_LOGFILE"
 			if (( $INPUT == 0 )); then
 
-				echo -e ""
-				read -p "Press any key to continue..."
-				echo -e ""
+				whiptail --title "Error" --msgbox "Error: No compatible and/or active webserver was found. Aborting." --backtitle "$PROGRAM_NAME" 8 60
 
 			fi
 
-			#Restart services
-			/DietPi/dietpi/dietpi-services restart
+		fi
+
+		#------------------------------------------------------------------------------------------------------
+
+		if (( $INPUT == 0 )); then
+
+			echo -e ""
+			read -p "Press any key to continue..."
+			echo -e ""
 
 		fi
+
+		#Restart services
+		/DietPi/dietpi/dietpi-services restart
 
 	}
 

--- a/dietpi/dietpi-letsencrypt
+++ b/dietpi/dietpi-letsencrypt
@@ -78,7 +78,7 @@
 	/etc/certbot_scripts/certbot-auto -q renew &>> $DP_LOGFILE
 	[ -f /home/minio-user/.minio/dietpi-cert-renewl.sh ] && /home/minio-user/.minio/dietpi-cert-renewl.sh &>> $DP_LOGFILE
 	[ -f /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/combined.pem ] &&
-	cat /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/privkey.pem /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/cert.pem > /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/combined.pem &>> $DP_LOGFILE
+	cat /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/privkey.pem /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/cert.pem > /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/combined.pem
 
 	#----------------------------------------------------------------
 	exit
@@ -141,7 +141,7 @@ _EOF_
 				[ -d "$DP_CRON" ] || mkdir "$DP_CRON"
 				cat << _EOF_ > "$DP_CRON"/dietpi-lighttpd.conf
 [Service]
-ExecStartPost=/bin/cat /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/privkey.pem /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/cert.pem > /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/combined.pem &>> $DP_LOGFILE
+ExecStartPost=/bin/bash -c '/bin/cat /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/privkey.pem /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/cert.pem > /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/combined.pem'
 _EOF_
 
 			fi

--- a/dietpi/dietpi-letsencrypt
+++ b/dietpi/dietpi-letsencrypt
@@ -35,7 +35,7 @@
 	#/////////////////////////////////////////////////////////////////////////////////////
 	DP_LOGFILE="/var/log/dietpi-letsencrypt.log"
 
-	DP_CRON='/etc/systemd/system/certbot.service'
+	DP_CRON='/etc/systemd/system/certbot.service.d'
 	(( $G_DISTRO < 4 )) && DP_CRON='/etc/cron.weekly/dietpi-letsencrypt'
 
 	DP_LETSENCRYPT_BINARY="/usr/bin/certbot"
@@ -78,7 +78,7 @@
 	/etc/certbot_scripts/certbot-auto -q renew &>> $DP_LOGFILE
 	[ -f /home/minio-user/.minio/dietpi-cert-renewl.sh ] && /home/minio-user/.minio/dietpi-cert-renewl.sh &>> $DP_LOGFILE
 	[ -f /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/combined.pem ] &&
-	cat /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/privkey.pem /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/combined.pem/cert.pem > /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/combined.pem &>> $DP_LOGFILE
+	cat /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/privkey.pem /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/cert.pem > /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/combined.pem &>> $DP_LOGFILE
 
 	#----------------------------------------------------------------
 	exit
@@ -138,18 +138,11 @@ _EOF_
 			# Add Lighttpd renewal to certbot system service:
 			if (( $G_DISTRO > 3 )); then
 
-				cat << _EOF_ > "$DP_CRON"
-[Unit]
-Description=Certbot
-Documentation=file:///usr/share/doc/python-certbot-doc/html/index.html
-Documentation=https://letsencrypt.readthedocs.io/en/latest/
+				[ -d "$DP_CRON" ] || mkdir "$DP_CRON"
+				cat << _EOF_ > "$DP_CRON"/dietpi-lighttpd.conf
 [Service]
-Type=oneshot
-ExecStart=/usr/bin/certbot -q renew && cat /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/privkey.pem /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/combined.pem/cert.pem > /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/combined.pem &>> $DP_LOGFILE
-PrivateTmp=true
+ExecStartPost=/bin/cat /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/privkey.pem /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/cert.pem > /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/combined.pem &>> $DP_LOGFILE
 _EOF_
-
-				chmod +x "$DP_CRON"
 
 			fi
 
@@ -187,13 +180,13 @@ _EOF_
 
 				G_CONFIG_INJECT '"mod_setenv"' '\t"mod_setenv",' /etc/lighttpd/lighttpd.conf 'server.modules = ('
 				cat << _EOF_ > /etc/lighttpd/conf-available/99-dietpi-hsts.conf
-$HTTP["scheme"] == "https" {
+\$HTTP["scheme"] == "https" {
 	setenv.add-response-header = ( "Strict-Transport-Security" => "max-age=31536000; includeSubdomains; preload;" )
 }
 _EOF_
+				lighttpd-enable-mod dietpi-hsts
 
 			fi
-			lighttpd-enable-mod dietpi-hsts
 
 			/etc/init.d/lighttpd force-reload
 
@@ -277,18 +270,11 @@ _EOF_
 			# Add Minio renewal to certbot system service:
 			if (( $G_DISTRO > 3 )); then
 
-				cat << _EOF_ > "$DP_CRON"
-[Unit]
-Description=Certbot
-Documentation=file:///usr/share/doc/python-certbot-doc/html/index.html
-Documentation=https://letsencrypt.readthedocs.io/en/latest/
+				[ -d "$DP_CRON" ] || mkdir "$DP_CRON"
+				cat << _EOF_ > "$DP_CRON"/dietpi-minio.conf
 [Service]
-Type=oneshot
-ExecStart=/usr/bin/certbot -q renew && /home/minio-user/.minio/dietpi-cert-renewl.sh &>> $DP_LOGFILE
-PrivateTmp=true
+ExecStartPost=/home/minio-user/.minio/dietpi-cert-renewl.sh &>> $DP_LOGFILE
 _EOF_
-
-				chmod +x "$DP_CRON"
 
 			fi
 

--- a/dietpi/dietpi-letsencrypt
+++ b/dietpi/dietpi-letsencrypt
@@ -241,6 +241,8 @@ _EOF_
 			G_CONFIG_INJECT 'MINIO_OPTS="' 'MINIO_OPTS="--address :443"' /etc/default/minio
 
 			# Allow SSL binding for non root user
+			# - Install libcap2-bin, which provides setcap command, not installed by default on DietPi:
+			G_AGI libcap2-bin
 			setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/minio
 
 			# Create renewl script

--- a/dietpi/dietpi-letsencrypt
+++ b/dietpi/dietpi-letsencrypt
@@ -224,7 +224,7 @@ _EOF_
 
 			$DP_LETSENCRYPT_BINARY certonly --standalone --staple-ocsp --agree-tos --rsa-key-size "$LETSENCRYPT_KEYSIZE" -m "$LETSENCRYPT_EMAIL" -d "$LETSENCRYPT_DOMAIN"
 
-			# Ensure strict permissions at all time:
+			# Ensure strict permissions while copying:
 			umask 077
 
 			# Locate them correctly (THIS didn't work as symlinks)
@@ -232,10 +232,11 @@ _EOF_
 			cp /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/privkey.pem /home/minio-user/.minio/certs/private.key
 
 			# Own those certs!
-			chown minio-user:minio-user /home/minio-user/.minio/certs/public.crt \
-				/home/minio-user/.minio/certs/private.key
-			chmod 400 /home/minio-user/.minio/certs/public.crt \
-				/home/minio-user/.minio/certs/private.key
+			chown minio-user:minio-user /home/minio-user/.minio/certs/public.crt /home/minio-user/.minio/certs/private.key
+			chmod 400 /home/minio-user/.minio/certs/public.crt /home/minio-user/.minio/certs/private.key
+
+			# Creation permissions back to default:
+			umask 022
 
 			# Add SSL to config file
 			G_CONFIG_INJECT 'MINIO_OPTS="' 'MINIO_OPTS="--address :443"' /etc/default/minio
@@ -247,10 +248,11 @@ _EOF_
 
 			# Create renewl script
 			cat << _EOF_ > /home/minio-user/.minio/dietpi-cert-renewl.sh
+#!/bin/bash
 # Minio only works with copied and owned certs. Upon renewal the new certs needs to be copied and re-owned
 systemctl stop minio.service
 
-# Ensure strict permissions at all time:
+# Ensure strict permissions while copying:
 umask 077
 
 # Copy to correct Location
@@ -258,10 +260,8 @@ cp /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/fullchain.pem /home/minio-user/.min
 cp /etc/letsencrypt/live/$LETSENCRYPT_DOMAIN/privkey.pem /home/minio-user/.minio/certs/private.key
 
 # Re-Own those certs!
-chown minio-user:minio-user /home/minio-user/.minio/certs/public.crt \
-	/home/minio-user/.minio/certs/private.key
-chmod 400 /home/minio-user/.minio/certs/public.crt \
-	/home/minio-user/.minio/certs/private.key
+chown minio-user:minio-user /home/minio-user/.minio/certs/public.crt /home/minio-user/.minio/certs/private.key
+chmod 400 /home/minio-user/.minio/certs/public.crt /home/minio-user/.minio/certs/private.key
 
 systemctl start minio.service
 _EOF_

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8415,8 +8415,8 @@ _EOF_
 					local dbpass=$(grep -m1 "^[[:blank:]]*'dbpassword'" $config_php | awk '{print $3}' | sed "s/[',]//g")
 					/DietPi/dietpi/func/create_mysql_db nextcloud "$dbuser" "$dbpass"
 					mysql nextcloud < "$datadir"/dietpi-nextcloud-database-backup.sql
-+					# Adjust database data directory entry, in case it changed due to server migration:
-+					mysql -e "update nextcloud.oc_storages set id='local::$datadir/' where id rlike 'local::'"
+					# Adjust database data directory entry, in case it changed due to server migration:
+					mysql -e "update nextcloud.oc_storages set id='local::$datadir/' where id rlike 'local::'"
 
 				else
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12417,6 +12417,11 @@ _EOF_
 
 			G_AGP lighttpd
 
+			# Remove certbot renewal hook:
+			rm /etc/systemd/system/certbot.service.d/dietpi-lighttpd.conf &> /dev/null
+			# Remove hook directory only, if empty:
+			rmdir /etc/systemd/system/certbot.service.d &> /dev/null
+
 		elif (( $index == 88 )); then
 
 			G_AGP mariadb-server
@@ -12907,6 +12912,7 @@ _EOF_
 
 				G_AGP python-certbot-apache python-certbot-nginx certbot
 				[ -f /etc/systemd/system/certbot.service ] && rm /etc/systemd/system/certbot.service
+				[ -d /etc/systemd/system/certbot.service.d ] && rm -R /etc/systemd/system/certbot.service.d
 
 			else
 
@@ -13251,7 +13257,9 @@ _EOF_
 			userdel -r -f minio-user
 
 			# Remove certbot renewal hook:
-			rm /etc/systemd/system/certbot.service &> /dev/null
+			rm /etc/systemd/system/certbot.service.d/dietpi-minio.conf &> /dev/null
+			# Remove hook directory only, if empty:
+			rmdir /etc/systemd/system/certbot.service.d &> /dev/null
 
 		elif (( $index == 161 )); then
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -286,8 +286,8 @@ _EOF_
 			PRESERVE=1 G_CONFIG_INJECT 'LETSENCRYPT_HSTS=' 'LETSENCRYPT_HSTS=0' /DietPi/dietpi/.dietpi-letsencrypt 'LETSENCRYPT_REDIRECT='
 			grep -q '^aSOFTWARE_INSTALL_STATE\[84\]=2' /DietPi/dietpi/.installed && dietpi-letsencrypt 1
 
-    fi
-    #-------------------------------------------------------------------------------
+		fi
+		#-------------------------------------------------------------------------------
 		#Microcode Native PC BIOS: https://github.com/Fourdee/DietPi/issues/1448
 		# - Install intel microcode if required on system. Due to PREP only installing detected (nice), me forgetting (not nice).
 		if (( $G_HW_MODEL == 21 )); then

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -280,9 +280,13 @@ _EOF_
 		#-------------------------------------------------------------------------------
 		#Add certificate combining for Lighttpd to CertBot auto renewal: https://github.com/Fourdee/DietPi/pull/1553
 		# - Replace old setting as well, which was forgotten on 6.2 patch:
-		sed -i '/LETSENCRYPT_AUTORENEW/d' /DietPi/dietpi/.dietpi-letsencrypt
-		PRESERVE=1 G_CONFIG_INJECT 'LETSENCRYPT_HSTS=' 'LETSENCRYPT_HSTS=0' /DietPi/dietpi/.dietpi-letsencrypt 'LETSENCRYPT_REDIRECT='
-		grep -q '^aSOFTWARE_INSTALL_STATE\[84\]=2' /DietPi/dietpi/.installed && dietpi-letsencrypt 1
+		if [ -f /DietPi/dietpi/.dietpi-letsencrypt ]; then
+
+			sed -i '/LETSENCRYPT_AUTORENEW/d' /DietPi/dietpi/.dietpi-letsencrypt
+			PRESERVE=1 G_CONFIG_INJECT 'LETSENCRYPT_HSTS=' 'LETSENCRYPT_HSTS=0' /DietPi/dietpi/.dietpi-letsencrypt 'LETSENCRYPT_REDIRECT='
+			grep -q '^aSOFTWARE_INSTALL_STATE\[84\]=2' /DietPi/dietpi/.installed && dietpi-letsencrypt 1
+
+		fi
 		#-------------------------------------------------------------------------------
 
 	fi

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -149,15 +149,15 @@
 
 			if (( $G_DISTRO > 3 )); then
 
-				if (( $(cat /DietPi/dietpi/.installed | grep -ci -m1 '^aSOFTWARE_INSTALL_STATE\[83\]=2') )); then
+				if grep -q '^aSOFTWARE_INSTALL_STATE\[83\]=2' /DietPi/dietpi/.installed; then
 
 					certbot renew --force-renewal -a webroot -w /var/www/ -i apache
 
-				elif (( $(cat /DietPi/dietpi/.installed | grep -ci -m1 '^aSOFTWARE_INSTALL_STATE\[85\]=2') )); then
+				elif grep -q '^aSOFTWARE_INSTALL_STATE\[85\]=2' /DietPi/dietpi/.installed; then
 
 					certbot renew --force-renewal -a webroot -w /var/www/ -i nginx
 
-				elif (( $(cat /DietPi/dietpi/.installed | grep -ci -m1 '^aSOFTWARE_INSTALL_STATE\[158\]=2') )); then
+				elif grep -q '^aSOFTWARE_INSTALL_STATE\[158\]=2' /DietPi/dietpi/.installed; then
 
 					certbot renew --force-renewal --preferred-challenges http
 
@@ -240,7 +240,7 @@ _EOF_
 
 		/DietPi/dietpi/func/dietpi-set_core_environment
 
-		if (( $(cat /DietPi/dietpi/.installed | grep -ci -m1 '^aSOFTWARE_INSTALL_STATE\[168\]=2') )); then
+		if grep -q '^aSOFTWARE_INSTALL_STATE\[168\]=2' /DietPi/dietpi/.installed; then
 
 			[ -d /var/lib/dietpi/postboot.d ] || mkdir /var/lib/dietpi/postboot.d
 			cat << _EOF_ > /var/lib/dietpi/postboot.d/moode
@@ -259,16 +259,16 @@ _EOF_
 		fi
 		#-------------------------------------------------------------------------------
 		G_DIETPI-NOTIFY 2 "Reducing getty count and resource usage:"
-
-		for ((i=2; i<=6; i++))
-		do
-
-			systemctl mask getty@tty$i
-
-		done
+		systemctl mask getty-static
 		#-------------------------------------------------------------------------------
-		#Remove any existing apt recommends settings, defaults to "yes", allows us to manually --no-install-recommends as needed: https://github.com/Fourdee/DietPi/issues/1482#issuecomment-366971700
+		#Remove any existing apt recommends settings, and bring our own norecommands in place:
 		rm /etc/apt/apt.conf.d/*recommends*
+		cat << _EOF_ > /etc/apt/apt.conf.d/99-dietpi-norecommends
+APT::Install-Recommends "false";
+APT::Install-Suggests "false";
+APT::AutoRemove::RecommendsImportant "false";
+APT::AutoRemove::SuggestsImportant "false";
+_EOF_
 		#-------------------------------------------------------------------------------
 		#Reinstalls:
 		#	Shairport-sync 3.1.7
@@ -277,6 +277,12 @@ _EOF_
 			/DietPi/dietpi/dietpi-software reinstall 37
 
 		fi
+		#-------------------------------------------------------------------------------
+		#Add certificate combining for Lighttpd to CertBot auto renewal: https://github.com/Fourdee/DietPi/pull/1553
+		# - Replace old setting as well, which was forgotten on 6.2 patch:
+		sed -i '/LETSENCRYPT_AUTORENEW/d' /DietPi/dietpi/.dietpi-letsencrypt
+		PRESERVE=1 G_CONFIG_INJECT 'LETSENCRYPT_HSTS=' 'LETSENCRYPT_HSTS=0' /DietPi/dietpi/.dietpi-letsencrypt 'LETSENCRYPT_REDIRECT='
+		grep -q '^aSOFTWARE_INSTALL_STATE\[84\]=2' /DietPi/dietpi/.installed && dietpi-letsencrypt 1
 		#-------------------------------------------------------------------------------
 
 	fi

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -279,11 +279,18 @@ _EOF_
 		fi
 		#-------------------------------------------------------------------------------
 		#Add certificate combining for Lighttpd to CertBot auto renewal: https://github.com/Fourdee/DietPi/pull/1553
-		# - Replace old setting as well, which was forgotten on 6.2 patch:
 		if [ -f /DietPi/dietpi/.dietpi-letsencrypt ]; then
 
+			# - Replace old setting as well, which was forgotten on 6.2 patch:
 			sed -i '/LETSENCRYPT_AUTORENEW/d' /DietPi/dietpi/.dietpi-letsencrypt
 			PRESERVE=1 G_CONFIG_INJECT 'LETSENCRYPT_HSTS=' 'LETSENCRYPT_HSTS=0' /DietPi/dietpi/.dietpi-letsencrypt 'LETSENCRYPT_REDIRECT='
+			# - Switch Minio to new certbot.service hook:
+			if (( $G_DISTRO > 3 )) && grep -q '^aSOFTWARE_INSTALL_STATE\[158\]=2' /DietPi/dietpi/.installed; then
+
+				[ -f /etc/systemd/system/certbot.service] && rm /etc/systemd/system/certbot.service
+				dietpi-letsencrypt 1
+
+			fi
 			grep -q '^aSOFTWARE_INSTALL_STATE\[84\]=2' /DietPi/dietpi/.installed && dietpi-letsencrypt 1
 
 		fi

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -281,9 +281,6 @@ _EOF_
 		#Add certificate combining for Lighttpd to CertBot auto renewal: https://github.com/Fourdee/DietPi/pull/1553
 		if [ -f /DietPi/dietpi/.dietpi-letsencrypt ]; then
 
-			# - Replace old setting as well, which was forgotten on 6.2 patch:
-			sed -i '/LETSENCRYPT_AUTORENEW/d' /DietPi/dietpi/.dietpi-letsencrypt
-			PRESERVE=1 G_CONFIG_INJECT 'LETSENCRYPT_HSTS=' 'LETSENCRYPT_HSTS=0' /DietPi/dietpi/.dietpi-letsencrypt 'LETSENCRYPT_REDIRECT='
 			# - Switch Minio to new certbot.service hook:
 			if (( $G_DISTRO > 3 )) && grep -q '^aSOFTWARE_INSTALL_STATE\[158\]=2' /DietPi/dietpi/.installed; then
 


### PR DESCRIPTION
https://github.com/Fourdee/DietPi/issues/1544
+ DietPi-LetsEncrypt | Lighttpd: Fix missing renewal due to necessary key+cert combining
+ DietPi-LetsEncrypt | Lighttpd: Add HSTS support
+ DietPi-LetsEncrypt | Minor cleanup
+ DietPi-LetsEncrypt | Switch certbot.service hooks to `certbot.service.d/dietpi-script.conf` and `ExecStartPost=`
+ General | Reduce getty count by just mask getty-static instead of every single getty service.