### PR TITLE
DietPi-Software | FFmpeg: Fix backports dependency issues for all Odroids

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,7 @@ DietPi-Software | Proftp: Now defaults to dietpi user with root login off: https
 DietPi-Software | RPi Cam Web Interface (Previously DietPiCam): Updated to 6.4.17 and resolves previously failed installation. URL has also changed to http://ip/rpicam : https://github.com/Fourdee/DietPi/issues/1512
 DietPi-Software | Mono: Raspbian dist is now used for RPi devices: https://github.com/Fourdee/DietPi/issues/1566
 DietPi-Sync | Once sync is completed, you will be asked if you wish to view the log file, for the full rsync log.
+DietPi-Software | FFmpeg: Fix backports dependency issues for all Odroids: https://github.com/Fourdee/DietPi/issues/1556
 DietPi-Update | G_AGUP/G_AGUG: Now runs prior to our patch system. Ensuring APT is upto date during our updates: http://dietpi.com/phpbb/viewtopic.php?f=11&t=2894&p=11150#p11149
 DietPi-LetsEncrypt | Lighttpd: Added support for HSTS (HTTP Strict Transport Security): https://github.com/Fourdee/DietPi/pull/1553
 DietPi-LetsEncrypt | Minor rework and cleaning, using now /etc/systemd/system/certbot.service.d/dietpi-script.conf for web server specific renewal hooks: https://github.com/Fourdee/DietPi/pull/1553

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -1157,8 +1157,8 @@ tic terminfo.txt
 tput cnorm
 _EOF_
 
-	# - XU4 FFMPEG fix. Prefer debian.org over Meveric for backports: https://github.com/Fourdee/DietPi/issues/1273
-	elif (( $G_HW_MODEL == 11 )); then
+	# - Odroids FFMPEG fix. Prefer debian.org over Meveric for backports: https://github.com/Fourdee/DietPi/issues/1273 + https://github.com/Fourdee/DietPi/issues/1556#issuecomment-369463910
+	elif (( $G_HW_MODEL > 9 && $G_HW_MODEL < 15 )); then
 
 		cat << _EOF_ > /etc/apt/preferences.d/backports
 Package: *

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -324,6 +324,18 @@ _EOF_
 		# GNU key management required for some APT installs via additional repos: https://github.com/Fourdee/DietPi/issues/1388
 		G_AGI dirmngr
 		#-------------------------------------------------------------------------------
+		# Odroids FFmpeg decendency fix: https://github.com/Fourdee/DietPi/issues/1556#issuecomment-369463910
+		if (( $G_HW_MODEL > 9 && $G_HW_MODEL < 15 )); then
+ 
+			cat << _EOF_ > /etc/apt/preferences.d/backports
+Package: *
+Pin: release a=jessie-backports
+Pin: origin "fuzon.co.uk"
+Pin-Priority: 99
+_EOF_
+
+		fi
+		#-------------------------------------------------------------------------------
 
 	fi
 


### PR DESCRIPTION
https://github.com/Fourdee/DietPi/issues/1556#issuecomment-369463910

- This is more a quick dirty fix, that is "just" working. Actually on Odroids there seem to be more overlapping pins within `/etc/apt/preferences.d` and suggest we do some cleanup there at least.
- Best would be, if we could manage installation from Meveric backports, as ffmpeg version is newer and might be a bid optimized for Odroids?
- I have no idea what actually causes this dependency issues when installing from Meverics at the moment, as the dependencies seem to be the same and all necessary available on his repo. Needs investigation if we want to have a real "solution" instead of more workaround.