### PR TITLE
DietPi-Prep | Force purging of dhcpcd5, as this will not be autoremoved in all cases

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ General | Resolved issues with swapfile being disabled by default due to image b
 General | Resolved incorrect scaling with G_WHIP_VIEWLOG: http://dietpi.com/phpbb/viewtopic.php?f=9&t=2882&p=11317#p11317
 General | Resolved issues with G_AGDUG missing the additional distro specific command line options: https://github.com/Fourdee/DietPi/issues/1594
 General | Resolved an issue with DietPi-RAMdisk/log, where /var/tmp/dietpi/logs would not be generated if removed, causing the service to fail: http://dietpi.com/phpbb/viewtopic.php?f=11&t=1148&p=11322#p11322
+General | Resolved an issue where 'dhcpcd' and 'dhclient' were active side-by-side: https://github.com/Fourdee/DietPi/issues/1560#issuecomment-370136642
 
 -----------------------------------------------------------------------------------------------------------
 

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -751,6 +751,10 @@ _EOF_
 	G_DIETPI-NOTIFY 2 "Purging APT with autoremoval:"
 
 	G_AGA
+	
+	# Purging additional packages, that in some cases do not get autoremoved:
+	# - dhcpcd5: https://github.com/Fourdee/DietPi/issues/1560#issuecomment-370136642
+	G_AGP dhcpcd5
 
 
 	#------------------------------------------------------------------------------------------------

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -391,6 +391,9 @@ _EOF_
 			systemctl daemon-reload
 			systemctl enable dietpi-ramlog.service
 			#-------------------------------------------------------------------------------
+			#Assure absence of dhcpcd5, if dhclient (isc-dhcp-client) is active: https://github.com/Fourdee/DietPi/issues/1560#issuecomment-370136642
+			ps aux | grep -q 'dhclient'  && G_AGP dhcpcd5
+			#-------------------------------------------------------------------------------
 
 		fi
 


### PR DESCRIPTION
+ As of: https://github.com/Fourdee/DietPi/issues/1560#issuecomment-370136642
+ Purge on patch only, if `dhclient` is active, thus we can be sure that user did not actively decide to use dhcpcd.