### PR TITLE
DietPi-dphys-swapfile | Remove entry from fstab when disabling + reorder/cleanup

### DIFF
--- a/dietpi/func/dietpi-set_dphys-swapfile
+++ b/dietpi/func/dietpi-set_dphys-swapfile
@@ -39,17 +39,19 @@
 
 	fi
 
-	SWAP_LOCATION_TARGET=$SWAP_LOCATION
+	SWAP_LOCATION_TARGET="$SWAP_LOCATION"
 	if [ -n "$2" ]; then
 
-		SWAP_LOCATION_TARGET=$2
+		SWAP_LOCATION_TARGET="$2"
 
 	fi
 
 	Delete_Swapfile(){
 
+		G_RUN_CMD swapoff -a
 		G_DIETPI-NOTIFY 2 "Deleting existing swapfile ($SWAP_LOCATION)"
 		rm "$SWAP_LOCATION" &> /dev/null
+		sed -i '/[[:blank:]]swap[[:blank:]]/d' /etc/fstab
 
 	}
 
@@ -65,26 +67,32 @@ _EOF_
 
 	}
 
+	Update_Tmp(){
+
+		#Set /tmp to 50% of RAM+SWAP: https://github.com/Fourdee/DietPi/issues/1027#issuecomment-369373082
+		local mem_total=$(free -m | grep -m1 'Mem:' | awk '{print $2}')
+		local swap_size=$(free -m | grep -im1 'Swap:' | awk '{print $2}')
+		local tmp_target_size="$(( ( $mem_total + $swap_size ) / 2 ))M"
+
+		G_DIETPI-NOTIFY 2 "Setting /tmp tmpfs size: $tmp_target_size"
+
+		sed -i -e "/[[:blank:]]\/tmp[[:blank:]]/ctmpfs \/tmp tmpfs defaults,size=$tmp_target_size,noatime,nodev,nosuid,mode=1777 0 0" /etc/fstab
+		systemctl daemon-reload
+		mount -a
+		G_RUN_CMD mount -o remount,size=$tmp_target_size tmpfs /tmp
+
+	}
+
 	Swap_Disable(){
 
 		G_DIETPI-NOTIFY 3 'DietPi-Swapfile' 'Disable swapfile'
 
-		G_RUN_CMD swapoff -a
 		Delete_Swapfile
 
 		SWAP_SIZE=0
 		Update_Conf
 
-		#Set /tmp to 50% of RAM: https://github.com/Fourdee/DietPi/issues/1027#issuecomment-369373082
-		local mem_total=$(free -m | grep -m1 'Mem:' | awk '{print $2}')
-		local tmp_target_size="$(( $mem_total / 2 ))M"
-
-		G_DIETPI-NOTIFY 2 "Setting /tmp tmpfs size: $tmp_target_size"
-
-		sed -i -e "/[[:space:]]\/tmp[[:space:]]/ctmpfs \/tmp tmpfs defaults,size=$tmp_target_size,noatime,nodev,nosuid,mode=1777 0 0" /etc/fstab
-		systemctl daemon-reload
-		mount -a
-		G_RUN_CMD mount -o remount,size=$tmp_target_size tmpfs /tmp
+		Update_Tmp
 
 	}
 
@@ -99,7 +107,6 @@ _EOF_
 
 		fi
 
-		G_RUN_CMD swapoff -a
 		Delete_Swapfile
 
 		SWAP_SIZE=$SWAP_SIZE_TARGET
@@ -117,22 +124,11 @@ _EOF_
 
 		G_RUN_CMD swapon $SWAP_LOCATION
 
-		sed -i '/[[:space:]]swap[[:space:]]/d' /etc/fstab
 		cat << _EOF_ >> /etc/fstab
 $SWAP_LOCATION    none    swap    sw    0   0
 _EOF_
-		systemctl daemon-reload
 
-		#Set /tmp to 50% of RAM+SWAP: https://github.com/Fourdee/DietPi/issues/1027#issuecomment-369373082
-		local mem_total=$(free -m | grep -m1 'Mem:' | awk '{print $2}')
-		local tmp_target_size="$(( ( $mem_total + $SWAP_SIZE_TARGET ) / 2 ))M"
-
-		G_DIETPI-NOTIFY 2 "Setting /tmp tmpfs size: $tmp_target_size"
-
-		sed -i -e "/[[:space:]]\/tmp[[:space:]]/ctmpfs \/tmp tmpfs defaults,size=$tmp_target_size,noatime,nodev,nosuid,mode=1777 0 0" /etc/fstab
-		systemctl daemon-reload
-		mount -a
-		G_RUN_CMD mount -o remount,size=$tmp_target_size tmpfs /tmp
+		Update_Tmp
 
 	}
 

--- a/dietpi/func/dietpi-set_dphys-swapfile
+++ b/dietpi/func/dietpi-set_dphys-swapfile
@@ -52,6 +52,7 @@
 		G_DIETPI-NOTIFY 2 "Deleting existing swapfile ($SWAP_LOCATION)"
 		rm "$SWAP_LOCATION" &> /dev/null
 		sed -i '/[[:blank:]]swap[[:blank:]]/d' /etc/fstab
+		systemctl daemon-reload
 
 	}
 


### PR DESCRIPTION
+ When removing swap file, the fstab entry should be removed as well: https://askubuntu.com/a/969297
+ Minor reorder to reduce redundant/doubled code