### PR TITLE
DietPi-Process_Tool | Add ability to read custom processes from include file

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ v6.5
 (xx/03/18)
 
 Changes / Improvements / Optimizations:
+DietPi-Process_Tool | Added ability to add custom process entries to "/DietPi/dietpi/.dietpi-process_tool_include". Add one process each line with the format <chosenName>:<executableFileName>. Check via htop, e.g. "DHCP client:dhclient"
 
 Bug Fixes:
 General | dphys-swapfile: Has been removed and replace with our own swapfile generation system. Uses fallocate to quickly create the swapfile of any size (1-2 seconds): https://github.com/Fourdee/DietPi/issues/1602

--- a/dietpi/dietpi-process_tool
+++ b/dietpi/dietpi-process_tool
@@ -311,6 +311,21 @@
 		aNAME[$index]='WiFi Monitor';aPROCESS_NAME[$index]='dietpi-wifi-monitor.sh';((index++))
 		aNAME[$index]='VirtualHere';aPROCESS_NAME[$index]='vhusbd';((index++))
 		aNAME[$index]='YaCy search engine';aPROCESS_NAME[$index]='yacy';((index++))
+		# Add processes from include file:
+		# - File lines must have the format: <aNAME>[[:blank:]]<aPROCESS_NAME>
+		local fp_include='/DietPi/dietpi/.dietpi-process_tool_include'
+		if [ -f "$fp_include" ]; then
+
+			while read line
+			do
+
+				aNAME[$index]="$(awk '{print $1}' <<< $line)"
+				aPROCESS_NAME[$index]="$(awk '{print $2}' <<< $line)"
+				((index++))
+
+			done < "$fp_include"
+
+		fi
 		MAX_PROGRAMS=${#aNAME[@]}
 
 		# - Find out which programs are running (impies installed) | exclude kernel threads ([])

--- a/dietpi/dietpi-process_tool
+++ b/dietpi/dietpi-process_tool
@@ -319,8 +319,8 @@
 			while read line
 			do
 
-				aNAME[$index]="$(awk '{print $1}' <<< $line)"
-				aPROCESS_NAME[$index]="$(awk '{print $2}' <<< $line)"
+				aNAME[$index]="$(sed 's/:.*$//' <<< $line)"
+				aPROCESS_NAME[$index]="$(sed 's/^.*://' <<< $line)"
 				((index++))
 
 			done < "$fp_include"


### PR DESCRIPTION
https://github.com/Fourdee/DietPi/issues/944

🈯️ **Test:**
```
root@DietPi:~# cat /DietPi/dietpi/.dietpi-process_tool_include
DBus Daemon:dbus-daemon
```
Adding just `dbus-daemon` (without `:`) also works, resulting in outputName=processName 😉.
```
root@DietPi:~# dietpi-process_tool 1
[  OK  ] Root access verified.

 DietPi-Process_tool
─────────────────────────────────────────────────────
 Mode: Apply

[  OK  ] DietPi-Process_tool | Cron (13383) : Nice      0
[  OK  ] DietPi-Process_tool | Cron (13383) : Affinity  0,1
[  OK  ] DietPi-Process_tool | Cron (13383) : Scheduler SCHED_OTHER 0
[  OK  ] DietPi-Process_tool | DHCP Client (635) : Nice      0
[  OK  ] DietPi-Process_tool | DHCP Client (635) : Affinity  0,1
[  OK  ] DietPi-Process_tool | DHCP Client (635) : Scheduler SCHED_OTHER 0
[  OK  ] DietPi-Process_tool | Dropbear (318) : Nice      0
[  OK  ] DietPi-Process_tool | Dropbear (318) : Affinity  0,1
[  OK  ] DietPi-Process_tool | Dropbear (318) : Scheduler SCHED_OTHER 0
[  OK  ] DietPi-Process_tool | Dropbear (1800) : Nice      0
[  OK  ] DietPi-Process_tool | Dropbear (1800) : Affinity  0,1
[  OK  ] DietPi-Process_tool | Dropbear (1800) : Scheduler SCHED_OTHER 0
[  OK  ] DietPi-Process_tool | DBus Daemon (10699) : Nice      0
[  OK  ] DietPi-Process_tool | DBus Daemon (10699) : Affinity  0,1
[  OK  ] DietPi-Process_tool | DBus Daemon (10699) : Scheduler SCHED_OTHER 0
[  OK  ] DietPi-Process Tool | Completed
```
```
          ┌──────────────────────┤ DietPi-Process Tool ├───────────────────────┐
          │ Select a program:                                                  │
          │                                                                    │
          │                Cron        : Nice 0 | Affinity 0,1                 │
          │                DHCP Client : Nice 0 | Affinity 0,1                 │
          │                Dropbear    : Nice 0 | Affinity 0,1                 │
          │                DBus Daemon : Nice -3 | Affinity 0,1                │

```
```
root@DietPi:~# ps ax -o pid,ni,cmd | grep dbus
10699  -3 /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation
```