### PR TITLE
DietPi-Config | Allow changing display resolution for VMs by adjusting GRUB GFX values

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ v6.5
 (xx/03/18)
 
 Changes / Improvements / Optimizations:
+DietPi-Config | Enabled possibility to adjust display resolution for VMs, but max guest display resolution might need to be adjusted within VM software as well: https://github.com/Fourdee/DietPi/issues/1227
 DietPi-Process_Tool | Added ability to add custom process entries to "/DietPi/dietpi/.dietpi-process_tool_include". Add one process each line with the format <chosenName>:<executableFileName>. Check via htop, e.g. "DHCP client:dhclient"
 
 Bug Fixes:

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -116,13 +116,6 @@
 
 				TARGETMENUID=1
 
-				if (( $G_HW_MODEL == 20 )); then
-
-					TARGETMENUID=0
-					Info_HW_OptionNotSupported
-
-				fi
-
 			 elif (( $OPTION == 2 )); then
 
 				TARGETMENUID=14
@@ -281,14 +274,19 @@
 		else
 
 			whiptail_menu_array+=("1" "Change Resolution")
-			whiptail_menu_array+=("2" "GPU/RAM Memory Split")
+			
+			# Just offer resolution option for VMs
+			if (( $G_HW_MODEL != 20 )); then
 
-			local lcdpanel_text=$(cat /DietPi/dietpi.txt | grep -m1 '^CONFIG_LCDPANEL=' | sed 's/.*=//')
-			whiptail_menu_array+=("3" "LCD Panel addon: $lcdpanel_text")
+				whiptail_menu_array+=("2" "GPU/RAM Memory Split")
+				local lcdpanel_text=$(cat /DietPi/dietpi.txt | grep -m1 '^CONFIG_LCDPANEL=' | sed 's/.*=//')
+				whiptail_menu_array+=("3" "LCD Panel addon: $lcdpanel_text")
+
+			fi
 
 		fi
 
-		whiptail_menu_array+=("14" "LED Control")
+		(( $G_HW_MODEL != 20 )) && whiptail_menu_array+=("14" "LED Control")
 
 		#RPi only
 		if (( $G_HW_MODEL < 10 )); then
@@ -786,8 +784,45 @@
 		#Return to Display Options Menu
 		TARGETMENUID=1
 
-		#Native PC
-		if (( $G_HW_MODEL == 21 )); then
+		#VM
+		if (( $G_HW_MODEL == 20 )); then
+
+			local current="$(grep '^[[:blank:]]*GRUB_GFXMODE=' /etc/default/grub | sed 's/^.*=//')"
+			[ -z $current ] && current='System default'
+
+			local array=(
+
+				'1' '1600x1200'
+				'2' '1280x1024'
+				'3' '1152x864'
+				'4' '1024x768'
+				'5' '800x600'
+				'6' 'System default'
+
+			)
+
+			G_WHIP_MENU_ARRAY=("${array[@]}")
+			G_WHIP_MENU "Please select a display resolution. Current: $current\n\nNote: This only affects the virtual screen resolution, not the SSH session.\n      You might need to increase the maximum guest screen resolution within your VM software."
+                        if (( $? == 0 )); then
+
+				if (( $G_WHIP_RETURNED_VALUE == 6 )); then
+
+					sed -i 's/^[[:blank:]]*GRUB_GFXMODE=/#GRUB_GFXMODE=/' /etc/default/grub
+					sed -i 's/^[[:blank:]]*GRUB_GFXPAYLOAD_LINUX=/#GRUB_GFXPAYLOAD_LINUX=/' /etc/default/grub
+
+				else
+
+					G_CONFIG_INJECT 'GRUB_GFXMODE=' "GRUB_GFXMODE=${array[(( $G_WHIP_RETURNED_VALUE * 2 - 1 ))]}" /etc/default/grub
+					G_CONFIG_INJECT 'GRUB_GFXPAYLOAD_LINUX=' 'GRUB_GFXPAYLOAD_LINUX=keep' /etc/default/grub
+
+				fi
+
+				update-grub
+
+			fi
+
+                #Native PC
+		elif (( $G_HW_MODEL == 21 )); then
 
 			local whiptail_menu_array=()
 


### PR DESCRIPTION
https://github.com/Fourdee/DietPi/issues/1227
- Allow a fix set of resolutions that are supported by VMware and VirtualBox.
- It can't break anything in case, as a wrong value results just in default resolution.