### PR TITLE
DietPi-Update | Added option to rerun the current subversion patch: "dietpi-update -1"

### DIFF
--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -11,7 +11,7 @@
 	#
 	# Info:
 	# - Updates DietPi from Git
-	# - Uses patch_file for online pactching
+	# - Uses patch_file for online patching
 	#
 	# Usage:
 	# - dietpi-update    = Normal
@@ -243,7 +243,7 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 
 				#Run patch file
 				G_DIETPI-NOTIFY 2 "Patching $COREVERSION_CURRENT.$SUBVERSION_CURRENT to $COREVERSION_CURRENT.$(( $SUBVERSION_CURRENT + 1 ))"
-				/DietPi/dietpi/patch_file $SUBVERSION_CURRENT $SUBVERSION_SERVER
+				/DietPi/dietpi/patch_file $SUBVERSION_CURRENT
 
 				#Update Local Version ID
 				((SUBVERSION_CURRENT++))

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -14,17 +14,15 @@
 	# - Uses patch_file for online pactching
 	#
 	# Usage:
-	# - dietpi-update   = Normal
-	# - dietpi-update 1 = forced update
+	# - dietpi-update    = Normal
+	# - dietpi-update 1  = noninteractive update
 	# - dietpi-update 2 = Check for updates. print server_version to /DietPi/dietpi/.update_available (-1=new image required)
+	# - dietpi-update -1 = Include reapplying the current subversion patch, e.g. to update testing branch
 	#////////////////////////////////////
 
 	INPUT=0
-	if [[ $1 =~ ^-?[0-9]+$ ]]; then
+	[[ $1 =~ ^-?[0-9]+$ ]] && INPUT=$1
 
-		INPUT=$1
-
-	fi
 	#Import DietPi-Globals ---------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
 	G_CHECK_ROOT_USER
@@ -36,8 +34,8 @@
 	#/////////////////////////////////////////////////////////////////////////////////////
 	#GIT Branch | master / testing
 	#/////////////////////////////////////////////////////////////////////////////////////
-	GITBRANCH=$(grep -m1 '^DEV_GITBRANCH=' /DietPi/dietpi.txt | sed 's/.*=//')
-	GITFORKOWNER=$(grep -m1 '^DEV_GITOWNER=' /DietPi/dietpi.txt | sed 's/.*=//')
+	GITBRANCH="$(grep -m1 '^[[:blank:]]*DEV_GITBRANCH=' /DietPi/dietpi.txt | sed 's/^.*=//')"
+	GITFORKOWNER="$(grep -m1 '^[[:blank:]]*DEV_GITOWNER=' /DietPi/dietpi.txt | sed 's/^.*=//')"
 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	#UPDATE Vars
@@ -77,6 +75,22 @@
 
 		COREVERSION_CURRENT=$(sed -n 1p /DietPi/dietpi/.version)
 		SUBVERSION_CURRENT=$(sed -n 2p /DietPi/dietpi/.version)
+		# Reapply current subversion patch, e.g. when using testing branch.
+		if (( $INPUT == -1 )); then
+
+			if (( $SUBVERSION_CURRENT < 0 )); then
+
+				G_DIETPI-NOTIFY 1 'Repatch was requested: Update will skip the current subversion patch, as your device seems to be on lowest subversion already'
+
+			else
+
+				G_DIETPI-NOTIFY 0 'Repatch was requested: Update will reapply the current subversion patch'
+				SUBVERSION_CURRENT=$((SUBVERSION_CURRENT-1))
+				INPUT=1
+
+			fi
+
+		fi
 
 	}
 
@@ -89,7 +103,7 @@
 			URL_MIRROR_INDEX=$i
 
 			G_DIETPI-NOTIFY 2 "Checking Mirror : ${URL_MIRROR_SERVERVERSION[$i]}"
-			curl -k -L ${URL_MIRROR_SERVERVERSION[$i]} > "$FILEPATH_TEMP"/server_version
+			curl -k -L "${URL_MIRROR_SERVERVERSION[$i]}" > "$FILEPATH_TEMP"/server_version
 			if (( $? == 0 )); then
 
 				#Get server Version info
@@ -106,7 +120,7 @@
 
 				else
 
-					G_DIETPI-NOTIFY 2 "Invalid server version and/or update file unavailable"
+					G_DIETPI-NOTIFY 2 'Invalid server version and/or update file unavailable'
 
 				fi
 
@@ -132,14 +146,14 @@
 			if (( $DIETPIUPDATE_COREVERSION_CURRENT < $COREVERSION_SERVER )); then
 
 				UPDATE_REQUIRESNEWIMAGE=1
-				echo -e "-1" > /DietPi/dietpi/.update_available
+				echo '-1' > /DietPi/dietpi/.update_available
 
 			#Update available
 			elif (( $SUBVERSION_CURRENT < $SUBVERSION_SERVER )); then
 
 				UPDATE_AVAILABLE=1
-				echo -e ""
-				G_DIETPI-NOTIFY 0 "Update available"
+				echo ''
+				G_DIETPI-NOTIFY 0 'Update available'
 				G_DIETPI-NOTIFY 2 "Current Version : $COREVERSION_CURRENT.$SUBVERSION_CURRENT"
 				G_DIETPI-NOTIFY 2 "Server Version  : $COREVERSION_SERVER.$SUBVERSION_SERVER"
 
@@ -152,7 +166,7 @@ _EOF_
 
 		else
 
-			G_DIETPI-NOTIFY 1 "Unable to access update servers. Please check your connection, then run dietpi-update again."
+			G_DIETPI-NOTIFY 1 'Unable to access update servers. Please check your connection, then run dietpi-update again.'
 			exit 1
 
 		fi
@@ -163,7 +177,7 @@ _EOF_
 	# MENUS
 	#/////////////////////////////////////////////////////////////////////////////////////
 	WHIP_BACKTITLE='DietPi-Update'
-	WHIP_TITLE=$WHIP_BACKTITLE
+	WHIP_TITLE="$WHIP_BACKTITLE"
 	CHOICE=0
 	OPTION=0
 
@@ -182,13 +196,9 @@ You can create a system backup, by running:
  - dietpi-backup
 ----------------------------------------------------------------------------
 
-Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SERVER?" --yes-button "Ok" --no-button "Exit" --defaultno --backtitle "$WHIP_BACKTITLE" 24 80
+Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SERVER?" --yes-button 'Ok' --no-button 'Exit' --defaultno --backtitle "$WHIP_BACKTITLE" 24 80
 		CHOICE=$?
-		if (( $CHOICE == 0 )); then
-
-			RUN_UPDATE=1
-
-		fi
+		(( $CHOICE == 0 )) && RUN_UPDATE=1
 
 	}
 
@@ -199,10 +209,10 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 	Run_Update(){
 
 		#git clone Zip method (no need to install GIT)
-		curl -k -L ${URL_MIRROR_ZIP[$URL_MIRROR_INDEX]} > "$FILEPATH_TEMP"/update.zip
+		curl -k -L "${URL_MIRROR_ZIP[$URL_MIRROR_INDEX]}" > "$FILEPATH_TEMP"/update.zip
 		if (( $? == 0 )); then
 
-			unzip "$FILEPATH_TEMP"/update.zip -d "$FILEPATH_TEMP"/
+			l_message='Unpack update archieve' G_RUN_CMD unzip "$FILEPATH_TEMP"/update.zip -d "$FILEPATH_TEMP"/
 
 			#Remove setting files from git that are not to be updated on client
 			rm "$FILEPATH_TEMP"/DietPi-"$GITBRANCH"/dietpi/.* &> /dev/null
@@ -213,7 +223,7 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 			# rm -R /DietPi/dietpi/misc
 
 			#Copy downloaded DietPi to Ramdisk
-			cp -Rf "$FILEPATH_TEMP"/DietPi-"$GITBRANCH"/dietpi /DietPi/
+			l_message='Copy files in place' G_RUN_CMD cp -Rf "$FILEPATH_TEMP"/DietPi-"$GITBRANCH"/dietpi /DietPi/
 
 			#Allow execute of all DietPi scripts and patch file
 			chmod -R +x /DietPi
@@ -221,16 +231,15 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 			#Verify/update dietpi.txt entries:
 			/DietPi/dietpi/func/dietpi-set_software verify_dietpi.txt
 
+			G_AGUP
+			G_AGUG
+
 			#Run Patch file
 			while (( $SUBVERSION_CURRENT < $SUBVERSION_SERVER )); do
 
 				G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'DietPi-Update Updating DietPi'
 				G_DIETPI-NOTIFY 2 "Current Version : $COREVERSION_CURRENT.$SUBVERSION_CURRENT"
 				G_DIETPI-NOTIFY 2 "Server Version  : $COREVERSION_SERVER.$SUBVERSION_SERVER\n"
-
-				G_DIETPI-NOTIFY 2 "Upgrading APT, before DietPi patch system, please wait..."
-				G_AGUP
-				G_AGUG
 
 				#Run patch file
 				G_DIETPI-NOTIFY 2 "Patching $COREVERSION_CURRENT.$SUBVERSION_CURRENT to $COREVERSION_CURRENT.$(( $SUBVERSION_CURRENT + 1 ))"
@@ -245,8 +254,6 @@ _EOF_
 
 				G_DIETPI-NOTIFY 0 "Patch $COREVERSION_CURRENT.$SUBVERSION_CURRENT completed\n"
 
-				Get_Client_Version
-
 			done
 
 			#Remove Patch files.
@@ -259,7 +266,7 @@ _EOF_
 		#Unable to download file.
 		else
 
-			G_DIETPI-NOTIFY 1 "Download failed, unable to run update. Please try running dietpi-update again."
+			G_DIETPI-NOTIFY 1 'Download failed, unable to run update. Please try running dietpi-update again.'
 			exit 1
 
 		fi
@@ -287,7 +294,7 @@ _EOF_
 	#Check for updates only. Send result to global file for use by dietpi-banner.
 	if (( $INPUT == 2 )); then
 
-		echo -e "Do nothing, now contained within Check_Update_Available()" &> /dev/null
+		> /dev/null #exit normally for delete []
 
 	#----------------------------------------------------------------
 	#Run menus / prompts / updates
@@ -297,15 +304,15 @@ _EOF_
 		#Server offline
 		if (( $SERVER_ONLINE == 0 )); then
 
-			whiptail --title "Error - Server Offline" --msgbox "http://github.com is either offline, or, unable to connect \n \n No updates applied." 12 60
+			whiptail --title 'Error - Server Offline' --msgbox 'https://github.com is either offline, or, unable to connect \n \n No updates applied.' 12 60
 
 		#Update requires new DietPi image
 		elif (( $UPDATE_REQUIRESNEWIMAGE == 1 )); then
 
 			#Cannot update, Image required
-			whiptail --title "New image required" --msgbox " Your version of DietPi is now obsolete and cannot be updated. \n\n Please download the latest DietPi image:\n - http://dietpi.com/downloads/images \n\n - Current Version : $SUBVERSION_CURRENT \n - Server Version  : $SUBVERSION_SERVER \n " 13 70
+			whiptail --title 'New image required' --msgbox " Your version of DietPi is now obsolete and cannot be updated. \n\n Please download the latest DietPi image:\n - http://dietpi.com/downloads/images \n\n - Current Version : $SUBVERSION_CURRENT \n - Server Version  : $SUBVERSION_SERVER \n " 13 70
 
-			G_DIETPI-NOTIFY 1 "Your version of DietPi is now obsolete and cannot be updated."
+			G_DIETPI-NOTIFY 1 'Your version of DietPi is now obsolete and cannot be updated.'
 			echo -e "Please download the latest DietPi image:\n - http://dietpi.com/download \n\n - Current Version : $SUBVERSION_CURRENT \n - Server Version  : $SUBVERSION_SERVER \n "
 
 		#Update available
@@ -315,16 +322,13 @@ _EOF_
 			/DietPi/dietpi/dietpi-drive_manager 2
 			if (( $? != 0 )); then
 
-				echo 1 &> /dev/null #exit normally for delete []
+				> /dev/null #exit normally for delete []
 
-			#Forced update
+			#Noninteractive update
 			elif (( $INPUT == 1 )); then
 
-				G_DIETPI-NOTIFY 0 "Updates have been found and are being applied, please wait..."
-				G_DIETPI-NOTIFY 2 "Current Version : $COREVERSION_CURRENT.$SUBVERSION_CURRENT"
-				G_DIETPI-NOTIFY 2 "Server Version  : $COREVERSION_SERVER.$SUBVERSION_SERVER"
-
 				RUN_UPDATE=1
+				G_DIETPI-NOTIFY 0 'Update is being applied, please wait...'
 
 			#Ask for update
 			else
@@ -333,11 +337,11 @@ _EOF_
 
 			fi
 
-		#No Updates
+		#No updates
 		else
 
-			echo -e ""
-			G_DIETPI-NOTIFY 0 "No updates required, your DietPi installation is up to date.\n"
+			echo ''
+			G_DIETPI-NOTIFY 0 'No updates required, your DietPi installation is up to date.\n'
 			G_DIETPI-NOTIFY 2 "Current Version : $COREVERSION_CURRENT.$SUBVERSION_CURRENT"
 			G_DIETPI-NOTIFY 2 "Server Version  : $COREVERSION_SERVER.$SUBVERSION_SERVER"
 			sleep 2
@@ -369,28 +373,23 @@ _EOF_
 			G_DIETPI-NOTIFY 4 "$G_PROGRAM_NAME" "Completed"
 			G_DIETPI-NOTIFY 2 "Current Version : $COREVERSION_CURRENT.$SUBVERSION_CURRENT"
 			G_DIETPI-NOTIFY 2 "Server Version  : $COREVERSION_SERVER.$SUBVERSION_SERVER"
-			G_DIETPI-NOTIFY 0 "Update completed"
-			echo -e ""
-			echo -e "Please reboot your system now, using the command \e[31;49;1mreboot\e[0m"
+			G_DIETPI-NOTIFY 0 'Update completed'
+			echo -e "\nPlease reboot your system now, using the command \e[31;49;1mreboot\e[0m"
 
 		fi
 
 		#----------------------------------------------------------------
 		#Desktop Run, exit key prompt
-		if (( $(ps aux | grep -ci -m1 '[l]xpanel') == 1 )); then
+		if ps aux | grep -qi '[l]xpanel'; then
 
-			read -p "Press any key to exit DietPi-Update..."
+			read -p 'Press any key to exit DietPi-Update...'
 
 		fi
 
 	fi
-
 	#----------------------------------------------------------------
 	#Clear temp files and folders
 	rm -R "$FILEPATH_TEMP" &> /dev/null
-	#----------------------------------------------------------------
-	unset URL_MIRROR_SERVERVERSION
-	unset URL_MIRROR_ZIP
 	#----------------------------------------------------------------
 	exit 0
 	#----------------------------------------------------------------

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -13,12 +13,11 @@
 	# - Runs from dietpi-update
 	#
 	# Usage:
-	# - /DietPi/dietpi/patch_file $SUBVERSION_CURRENT $SUBVERSION_SERVER
+	# - /DietPi/dietpi/patch_file $SUBVERSION_CURRENT
 	#////////////////////////////////////
 
 	#Grab input
 	SUBVERSION_CURRENT=$1
-	SUBVERSION_SERVER=$2
 	#Import DietPi-Globals ---------------------------------------------------------------
 	/DietPi/dietpi/dietpi-obtain_hw_model # Always update
 	. /DietPi/dietpi/func/dietpi-globals


### PR DESCRIPTION
... e.g. to patch latest testing branch commits, and:
+ DietPi-Update | Run APT update+upgrade outside of incremental patch loop to avoid multiple execution
+ DietPi-Update | Minor code and output cleaning
