### PR TITLE
DietPi-Environment | Some service-, config- and code adjustments

### DIFF
--- a/dietpi/func/dietpi-set_core_environment
+++ b/dietpi/func/dietpi-set_core_environment
@@ -27,7 +27,7 @@
 
 	fi
 	#Import DietPi-Globals -------------------------------------------------------------
-	. $FP_SCRIPTS/dietpi/func/dietpi-globals # NB: HW_* info are init only, not detected.
+	. "$FP_SCRIPTS"/dietpi/func/dietpi-globals # NB: HW_* info are init only, not detected.
 	G_CHECK_ROOT_USER
 	export G_PROGRAM_NAME='DietPi-Set_core_environment'
 	G_INIT
@@ -49,18 +49,14 @@
 		cp /root/.bashrc /home/"$DIETPI_USERNAME"/
 
 		#	Sudo up dietpi login script
-		sed -i '/^\/DietPi\/dietpi\/login/c\sudo \/DietPi\/dietpi\/login' /home/$DIETPI_USERNAME/.bashrc
+		sed -i '/^\/DietPi\/dietpi\/login/c\sudo \/DietPi\/dietpi\/login' /home/"$DIETPI_USERNAME"/.bashrc
 
 		chown -R "$DIETPI_USERNAME":"$DIETPI_USERNAME" /home/"$DIETPI_USERNAME"
 
 		#	Allow sudo without pw
-		if (( ! $(cat /etc/sudoers | grep -ci -m1 "^$DIETPI_USERNAME[[:space:]]") )); then
-
-			cat << _EOF_ >> /etc/sudoers
+		cat << _EOF_ > /etc/sudoers.d/dietpi
 $DIETPI_USERNAME ALL=NOPASSWD: ALL
 _EOF_
-
-		fi
 
 		#	Same groups as user pi
 		local group_array=()
@@ -86,7 +82,7 @@ _EOF_
 		for ((i=0; i<${#group_array[@]}; i++))
 		do
 
-			usermod -a -G ${group_array[$i]} $DIETPI_USERNAME &> /dev/null
+			usermod -a -G "${group_array[$i]}" "$DIETPI_USERNAME" &> /dev/null
 
 		done
 
@@ -232,7 +228,7 @@ _EOF_
 Description=DietPi-PostBoot
 Requires=dietpi-boot.service dietpi-ramdisk.service
 After=dietpi-boot.service dietpi-ramdisk.service dietpi-ramlog.service
-Before=rc-local.service
+Before=rc-local.service rc.local.service
 
 [Service]
 Type=idle
@@ -265,11 +261,11 @@ _EOF_
 
 	cat << _EOF_ > /var/lib/dietpi/dietpi-software/services/kill-ssh-user-sessions-before-network.sh
 #!/bin/bash
-if (( \$(ps x | grep -ci -m1 '[s]shd' ) )); then
+if ps x | grep -qi '[s]shd'; then
 
     killall -w sshd
 
-elif (( \$(ps x | grep -ci -m1 '[d]ropbear' ) )); then
+elif ps x | grep -qi '[d]ropbear'; then
 
     killall -w dropbear
 
@@ -279,60 +275,14 @@ exit 0
 _EOF_
 	chmod +x /var/lib/dietpi/dietpi-software/services/kill-ssh-user-sessions-before-network.sh
 
-	G_DIETPI-NOTIFY 2 'Configuring rc-local service:'
-
-	#	Remove all previous known rc-local services, replace with our own to avoid conflict.
-	update-rc.d -f rc.local remove &> /dev/null
-	rm /etc/init.d/rc.local &> /dev/null
-	rm -R /lib/systemd/system/rc-local.service* &> /dev/null #* for .d/x.conf
-	rm -R /lib/systemd/system/rc.local.service* &> /dev/null
-	rm -R /etc/systemd/system/rc-local.service* &> /dev/null
-	rm -R /etc/systemd/system/rc.local.service* &> /dev/null
-
-	cat << _EOF_ > /etc/systemd/system/rc-local.service
-[Unit]
-Description=rc.local backwards compatibility
-Requires=dietpi-boot.service dietpi-ramdisk.service
-After=dietpi-boot.service dietpi-ramdisk.service dietpi-ramlog.service dietpi-postboot.service
-
-[Service]
-Type=idle
-RemainAfterExit=yes
-ExecStart=/bin/bash -c '/etc/rc.local'
-StandardOutput=tty
-
-[Install]
-WantedBy=multi-user.target
-_EOF_
-	systemctl daemon-reload
-	systemctl enable rc-local.service
-
-	cp -a /etc/rc.local /etc/rc.local.bak
-	cat << _EOF_ > /etc/rc.local
-#!/bin/sh -e
-#
-#
-# This script is executed at the end of each multiuser runlevel.
-# Make sure that the script will "exit 0" on success or any other
-# value on error.
-#
-# In order to disable this script please use systemd to control the service:
-# systemctl disable rc-local.service
-#
-# By default this script does nothing.
-
-exit 0
-_EOF_
-	chmod +x /etc/rc.local
-
 	#-----------------------------------------------------------------------------------
 	#Cron Jobs
 
 	G_DIETPI-NOTIFY 2 "Configuring Cron:"
 
-	cp $FP_SCRIPTS/dietpi/conf/cron.daily_dietpi /etc/cron.daily/dietpi
+	cp "$FP_SCRIPTS"/dietpi/conf/cron.daily_dietpi /etc/cron.daily/dietpi
 	chmod +x /etc/cron.daily/dietpi
-	cp $FP_SCRIPTS/dietpi/conf/cron.hourly_dietpi /etc/cron.hourly/dietpi
+	cp "$FP_SCRIPTS"/dietpi/conf/cron.hourly_dietpi /etc/cron.hourly/dietpi
 	chmod +x /etc/cron.hourly/dietpi
 
 	mkdir -p /etc/cron.minutely #: https://github.com/Fourdee/DietPi/pull/1578
@@ -378,6 +328,10 @@ _EOF_
 
 	if (( $G_DISTRO > 3 )); then
 
+		systemctl disable apt-daily.service &> /dev/null
+		systemctl disable apt-daily.timer &> /dev/null
+		systemctl disable apt-daily-upgrade.service &> /dev/null
+		systemctl disable apt-daily-upgrade.timer &> /dev/null
 		systemctl mask apt-daily.service &> /dev/null
 		systemctl mask apt-daily.timer &> /dev/null
 		systemctl mask apt-daily-upgrade.service &> /dev/null
@@ -387,19 +341,17 @@ _EOF_
 
 	G_DIETPI-NOTIFY 2 "Setting vm.swappiness=1:"
 
-	sed -i '/^[[:blank:]]*vm.swappiness=/d' /etc/sysctl.conf
-	echo -e "vm.swappiness=1" > /etc/sysctl.d/99-dietpi.conf
+	echo 'vm.swappiness=1' > /etc/sysctl.d/dietpi.conf
 
 	# - Workaround for setting user selected locale to session when POSIX is detected (eg: dropbear limitation/bug): https://github.com/Fourdee/DietPi/issues/1540#issuecomment-367066178
 	cat << _EOF_ > /etc/profile.d/99-dietpi-posix-set-locale.sh
 #!/bin/bash
 
 #Workaround for setting locale to session when POSIX is detected (eg: dropbear): https://github.com/Fourdee/DietPi/issues/1540#issuecomment-367066178
-if (( \$(locale | grep -ci -m1 'POSIX') )); then
-	CURRENT_LOCALE=\$(grep -m1 'AUTO_SETUP_LOCALE=' /DietPi/dietpi.txt | sed 's/.*=//')
+if locale | grep -qi 'POSIX'; then
+	CURRENT_LOCALE="\$(grep -m1 '^[[:blank:]]*AUTO_SETUP_LOCALE=' /DietPi/dietpi.txt | sed 's/^.*=//')"
 	export LANG="\$CURRENT_LOCALE"
 	export LC_ALL="\$CURRENT_LOCALE"
-	#export LANGUAGE="\$CURRENT_LOCALE"
 fi
 _EOF_
 	chmod +x /etc/profile.d/99-dietpi-posix-set-locale.sh

--- a/dietpi/func/dietpi-set_core_environment
+++ b/dietpi/func/dietpi-set_core_environment
@@ -54,7 +54,7 @@
 		chown -R "$DIETPI_USERNAME":"$DIETPI_USERNAME" /home/"$DIETPI_USERNAME"
 
 		#	Allow sudo without pw
-		if ! grep -q "$DIETPI_USERNAME" /etc/sudoers.d/dietpi; then
+		if ! grep -qi "^$DIETPI_USERNAME[[:blank:]]" /etc/sudoers.d/dietpi; then
 
 			cat << _EOF_ >> /etc/sudoers.d/dietpi
 $DIETPI_USERNAME ALL=NOPASSWD: ALL

--- a/dietpi/func/dietpi-set_core_environment
+++ b/dietpi/func/dietpi-set_core_environment
@@ -54,9 +54,13 @@
 		chown -R "$DIETPI_USERNAME":"$DIETPI_USERNAME" /home/"$DIETPI_USERNAME"
 
 		#	Allow sudo without pw
-		cat << _EOF_ > /etc/sudoers.d/dietpi
+		if ! grep -q "$DIETPI_USERNAME" /etc/sudoers.d/dietpi; then
+
+			cat << _EOF_ >> /etc/sudoers.d/dietpi
 $DIETPI_USERNAME ALL=NOPASSWD: ALL
 _EOF_
+
+		fi
 
 		#	Same groups as user pi
 		local group_array=()

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -314,22 +314,22 @@ _EOF_
 			# - Create $INPUT_MODE_VALUE
 
 			mkdir -p /home
-			useradd -m -s /bin/bash "$INPUT_MODE_VALUE"
-			chpasswd <<< "$INPUT_MODE_VALUE:$(cat /DietPi/dietpi.txt | grep -m1 '^AUTO_SETUP_GLOBAL_PASSWORD=' | sed 's/.*=//')"
+			useradd -m -s /bin/bash "$INPUT_MODE_VALUE" -p "$(grep -m1 '^[[:blank:]]*AUTO_SETUP_GLOBAL_PASSWORD=' /DietPi/dietpi.txt | sed 's/^.*=//')"
+			#chpasswd <<< "$INPUT_MODE_VALUE:$(grep -m1 '^[[:blank:]]*AUTO_SETUP_GLOBAL_PASSWORD=' /DietPi/dietpi.txt | sed 's/^.*=//')"
 
 			#	Copy existing profile/bashrc
-			cp /root/.profile /home/$INPUT_MODE_VALUE/
-			cp /root/.bashrc /home/$INPUT_MODE_VALUE/
+			cp /root/.profile /home/"$INPUT_MODE_VALUE"/
+			cp /root/.bashrc /home/"$INPUT_MODE_VALUE"/
 
 			#	Sudo up dietpi login script
 			sed -i '/^\/DietPi\/dietpi\/login/c\sudo \/DietPi\/dietpi\/login' /home/$INPUT_MODE_VALUE/.bashrc
 
-			chown -R $INPUT_MODE_VALUE:$INPUT_MODE_VALUE /home/$INPUT_MODE_VALUE
+			chown -R "$INPUT_MODE_VALUE":"$INPUT_MODE_VALUE" /home/"$INPUT_MODE_VALUE"
 
 			#	Allow sudo without pw
-			if (( ! $(cat /etc/sudoers | grep -ci -m1 "^$INPUT_MODE_VALUE[[:space:]]") )); then
+			if ! grep -q "^$INPUT_MODE_VALUE[[:space:]]" /etc/sudoers.d/dietpi; then
 
-				cat << _EOF_ >> /etc/sudoers
+				cat << _EOF_ >> /etc/sudoers.d/dietpi
 $INPUT_MODE_VALUE ALL=NOPASSWD: ALL
 _EOF_
 
@@ -359,7 +359,7 @@ _EOF_
 			for ((i=0; i<${#group_array[@]}; i++))
 			do
 
-				usermod -a -G ${group_array[$i]} $INPUT_MODE_VALUE
+				usermod -a -G "${group_array[$i]}" "$INPUT_MODE_VALUE"
 
 			done
 
@@ -378,11 +378,11 @@ _EOF_
 		if [ -n "$INPUT_MODE_VALUE" ]; then
 
 			# - Delete $INPUT_MODE_VALUE
-			userdel -f $INPUT_MODE_VALUE
-			rm -R /home/$INPUT_MODE_VALUE
+			userdel -f "$INPUT_MODE_VALUE"
+			rm -R /home/"$INPUT_MODE_VALUE"
 
 			# - Remove from sudoers
-			sed -i "/^$INPUT_MODE_VALUE[[:space:]]/d" /etc/sudoers
+			sed -i "/^$INPUT_MODE_VALUE[[:space:]]/d" /etc/sudoers.d/dietpi
 
 		else
 
@@ -422,16 +422,16 @@ _EOF_
 					entry=$(echo -e "${entry%%=*}") #X*
 
 					# - Patch new entry if required
-					if (( ! $(grep -ci -m1 "^$entry=" /DietPi/dietpi.txt) )); then
+					if ! grep -qi "^$entry=" /DietPi/dietpi.txt; then
 
 						G_DIETPI-NOTIFY 2 "Updating dietpi.txt with new entry: $entry=$value"
 						cat << _EOF_ >> /DietPi/dietpi.txt
 $entry=$value
 _EOF_
 
-					else
+					#else
 
-						G_DIETPI-NOTIFY 0 "Verified: $entry"
+						#G_DIETPI-NOTIFY 0 "Verified: $entry"
 
 					fi
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -93,7 +93,7 @@
 			#Core_ENV update: https://github.com/Fourdee/DietPi/pull/1419
 			#	IPv6 disable x86_64
 			#	consoleblank disable x86_64
-			/DietPi/dietpi/func/dietpi-set_core_environment
+			#/DietPi/dietpi/func/dietpi-set_core_environment # Done with v6.2 patch, avoid two executions!
 			#-------------------------------------------------------------------------------
 			#Remove -dev keyring
 			G_AGP debian-keyring
@@ -196,7 +196,7 @@ _EOF_
 
 				sed -i '/^aSOFTWARE_INSTALL_STATE\[100\]=/c\aSOFTWARE_INSTALL_STATE\[100\]=0' /DietPi/dietpi/.installed #grashopper (now pijuice)
 				sed -i '/^aSOFTWARE_INSTALL_STATE\[106\]=/c\aSOFTWARE_INSTALL_STATE\[106\]=0' /DietPi/dietpi/.installed #raspcontrol (now ntp)
-				if (( $(grep -ci -m1 '^aSOFTWARE_INSTALL_STATE\[170\]=2' /DietPi/dietpi/.installed) )); then
+				if grep -qi '^aSOFTWARE_INSTALL_STATE\[170\]=2' /DietPi/dietpi/.installed; then
 
 					sed -i '/^aSOFTWARE_INSTALL_STATE\[106\]=/c\aSOFTWARE_INSTALL_STATE\[106\]=2' /DietPi/dietpi/.installed #ntp (replaces raspcontrol)
 					sed -i '/^aSOFTWARE_INSTALL_STATE\[170\]=/c\aSOFTWARE_INSTALL_STATE\[170\]=0' /DietPi/dietpi/.installed #ntp (now 106)
@@ -206,7 +206,7 @@ _EOF_
 			fi
 			#-------------------------------------------------------------------------------
 			#Nodered lacks homedir, create it: https://github.com/Fourdee/DietPi/issues/1446#issuecomment-366370800
-			if (( $(grep -ci -m1 '^nodered:' /etc/passwd) )) &&
+			if grep -qi '^nodered:' /etc/passwd &&
 				[ ! -d /home/nodered ]; then
 
 				mkdir -p /home/nodered
@@ -228,7 +228,42 @@ _EOF_
 
 			#-------------------------------------------------------------------------------
 			#Switch from rc.local to own postboot script: https://github.com/Fourdee/DietPi/issues/1376
-			G_WHIP_MSG "DietPi will not use /etc/rc.local for its own scripts anymore.\n\nHowever, in case you've manually added something, we safe a backup to /etc/rc.local.bak, from where you can copy & paste back to the cleaned /etc/rc.local.\n\nIt will work as before."
+			G_WHIP_MSG "DietPi will not use /etc/rc.local for its own scripts anymore.\n\nHowever, in case you've manually added something, we safe a backup to /mnt/dietpi_userdata/rc.local.bak, from where you can copy & paste back to the cleaned /etc/rc.local.\n\nIt will work as before."
+			cat << _EOF_ > /etc/systemd/system/rc-local.service
+[Unit]
+Description=rc.local backwards compatibility
+Requires=dietpi-boot.service dietpi-ramdisk.service
+After=dietpi-boot.service dietpi-ramdisk.service dietpi-ramlog.service dietpi-postboot.service
+
+[Service]
+Type=idle
+RemainAfterExit=yes
+ExecStart=/bin/bash -c '/etc/rc.local'
+StandardOutput=tty
+
+[Install]
+WantedBy=multi-user.target
+_EOF_
+			systemctl daemon-reload
+			systemctl enable rc-local.service
+
+			cp -a /etc/rc.local /mnt/dietpi_userdata/rc.local.bak
+			cat << _EOF_ > /etc/rc.local
+#!/bin/sh -e
+#
+#
+# This script is executed at the end of each multiuser runlevel.
+# Make sure that the script will "exit 0" on success or any other
+# value on error.
+#
+# In order to disable this script please use systemd to control the service:
+# systemctl disable rc-local.service
+#
+# By default this script does nothing.
+
+exit 0
+_EOF_
+			chmod +x /etc/rc.local
 
 			/DietPi/dietpi/func/dietpi-set_core_environment
 
@@ -405,7 +440,7 @@ _EOF_
 			#Cron minutely support: https://github.com/Fourdee/DietPi/pull/1578
 			mkdir -p /etc/cron.minutely
 
-			if (( ! $(grep -ci -m1 'cron.minutely' /etc/crontab) )); then
+			if ! grep -qi 'cron.minutely' /etc/crontab; then
 
 				cat << _EOF_ >> /etc/crontab
 */30 * * * *   root    cd / && run-parts --report /etc/cron.minutely
@@ -427,7 +462,7 @@ _EOF_
 			if [ -f /etc/dphys-swapfile ]; then
 
 				swap_size=$(grep -m1 '^CONF_SWAPSIZE=' /etc/dphys-swapfile | sed 's/.*=//')
-				swap_location=$(grep -m1 '^CONF_SWAPFILE=' /etc/dphys-swapfile | sed 's/.*=//')
+				swap_location="$(grep -m1 '^CONF_SWAPFILE=' /etc/dphys-swapfile | sed 's/.*=//')"
 
 			fi
 
@@ -449,12 +484,20 @@ _EOF_
 			/DietPi/dietpi/dietpi-software reinstall 35 37
 			#-------------------------------------------------------------------------------
 			#RPi 3 B+: Set correct disabled clocks for B+ (scraped by dietpi-config > overclocking)
-			if (( $(grep -ci -m1 'RPi 3 Model B+' /DietPi/dietpi/.hw_model) )); then
+			if grep -qi 'RPi 3 Model B+' /DietPi/dietpi/.hw_model; then
 
 				sed -i '/arm_freq=/c\#arm_freq=1400' /DietPi/config.txt
 				sed -i '/sdram_freq=/c\#sdram_freq=500' /DietPi/config.txt
 
 			fi
+			#-------------------------------------------------------------------------------
+			#sudoers and sysctl adjustments moved to *.d/ files: https://github.com/Fourdee/DietPi/pull/1635
+			cat << _EOF_ > /etc/sudoers.d/dietpi
+dietpi ALL=NOPASSWD: ALL
+_EOF_
+			sed -i '/dietpi/d' /etc/sudoers
+			#Our config must not start with '99-' to assure priority higher than '99-sysctl.conf'
+			mv /etc/sysctl.d/99-dietpi.conf /etc/sysctl.d/dietpi.conf &> /dev/null
 			#-------------------------------------------------------------------------------
 
 		fi


### PR DESCRIPTION
+ DietPi-Environment | Move sudo adjustments to "/etc/sudoers.d/dietpi"
+ DietPi-Environment | Leave rc-local services unchanged from now on, prevent incompatibilities by DietPi-PostBoot by "Before=rc-local.service rc.local.service"
+ DietPi-Environment | Move sysctl adjustments to "/etc/sysctl.d/dietpi.conf" to assure higher priority than "/etc/sysctl.d/99-sysctl.conf"
+ DietPi-Set_core_environment/Patchfile/Set_Software | Minor code enhencements
+ DietPi-Patchfile | Avoid doubled running of DietPi-Set_core_environment
+ DietPi-Set_Software | "verify_dietpi.txt": Reduce output to only mention added entries

**Whoopsie: Accidentally added changelog entries to testing branch 😅: https://github.com/Fourdee/DietPi/commit/045701ad3162a858676bb9e144bd3a42c0d4ed31**