### PR TITLE
DietPi-Software | MPD: Resolved an issue where "libwrap0" (libwrap.so.0) was missing to start MPD service

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,7 @@ DietPi-Software | NoMachine: Installation updated to 6.0.78 (new installations o
 DietPi-Software | Squeezebox server: Updated to systemd native service: https://github.com/Fourdee/DietPi/issues/1613
 DietPi-Software | AmiBerry: Updated to 2.18. Improved audio latency, Unique new feature: WHDLoad booter! (check the wiki for details), bug fixes: https://github.com/Fourdee/DietPi/issues/1410#issuecomment-374060452
 DietPi-Software | RPi: For all software titles which require unrar, unrar-nonfree is now installed via Debian package (previously unrar-free): https://github.com/Fourdee/DietPi/issues/865#issuecomment-375315827
+DietPi-Software | MPD: Resolved an issue where "libwrap0" (libwrap.so.0) was missing to start MPD service: http://dietpi.com/phpbb/viewtopic.php?f=9&t=2779
 
 Bug Fixes:
 General | dphys-swapfile: Has been removed and replace with our own swapfile generation system. Uses fallocate to quickly create the swapfile of any size (1-2 seconds): https://github.com/Fourdee/DietPi/issues/1602

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3716,7 +3716,7 @@ _EOF_
 
 					#libupnp6 for net discov with upnp/avahi
 					G_AGI libupnp6
-					G_AGI libmpdclient2 libao-common libao4 libasound2 libasound2-data libasyncns0 libaudiofile1 libavahi-client3 libavahi-common-data libavahi-common3 libavcodec56 libavformat56 libavresample2 libavutil54 libbinio1ldbl libcaca0 libcdio-cdda1 libcdio-paranoia1 libcdio13 libcups2 libcurl3-gnutls libdirectfb-1.2-9 libdnet libfaad2 libflac8 libfluidsynth1 libgme0 libgomp1 libgsm1 libice6 libid3tag0 libiso9660-8 libjack-jackd2-0 libjson-c2 libldb1 libmad0 libmikmod3 libmms0 libmodplug1 libmp3lame0 libmpcdec6 libmpg123-0 libnfs4 libntdb1 libogg0 libopenal-data libopenal1 libopenjpeg5 libopus0 liborc-0.4-0 libpulse0 libresid-builder0c2a libroar2 libsamplerate0 libschroedinger-1.0-0 libsdl1.2debian libshout3 libsidplay2 libsidutils0 libslp1 libsm6 libsmbclient libsndfile1 libsoxr0 libspeex1 libspeexdsp1 libsqlite3-0 libtalloc2 libtdb1 libtevent0 libtheora0 libupnp6 libva1 libvorbis0a libvorbisenc2 libvorbisfile3 libvpx1 libwavpack1 libwbclient0 libwildmidi-config libwildmidi1 libx11-6 libx11-data libx11-xcb1 libx264-142 libxau6 libxcb1 libxdmcp6 libxext6 libxi6 libxtst6 libxvidcore4 libyajl2 libzzip-0-13 mime-support python python-talloc python2.7 samba-libs x11-common file
+					G_AGI libwrap0 libmpdclient2 libao-common libao4 libasound2 libasound2-data libasyncns0 libaudiofile1 libavahi-client3 libavahi-common-data libavahi-common3 libavcodec56 libavformat56 libavresample2 libavutil54 libbinio1ldbl libcaca0 libcdio-cdda1 libcdio-paranoia1 libcdio13 libcups2 libcurl3-gnutls libdirectfb-1.2-9 libdnet libfaad2 libflac8 libfluidsynth1 libgme0 libgomp1 libgsm1 libice6 libid3tag0 libiso9660-8 libjack-jackd2-0 libjson-c2 libldb1 libmad0 libmikmod3 libmms0 libmodplug1 libmp3lame0 libmpcdec6 libmpg123-0 libnfs4 libntdb1 libogg0 libopenal-data libopenal1 libopenjpeg5 libopus0 liborc-0.4-0 libpulse0 libresid-builder0c2a libroar2 libsamplerate0 libschroedinger-1.0-0 libsdl1.2debian libshout3 libsidplay2 libsidutils0 libslp1 libsm6 libsmbclient libsndfile1 libsoxr0 libspeex1 libspeexdsp1 libsqlite3-0 libtalloc2 libtdb1 libtevent0 libtheora0 libupnp6 libva1 libvorbis0a libvorbisenc2 libvorbisfile3 libvpx1 libwavpack1 libwbclient0 libwildmidi-config libwildmidi1 libx11-6 libx11-data libx11-xcb1 libx264-142 libxau6 libxcb1 libxdmcp6 libxext6 libxi6 libxtst6 libxvidcore4 libyajl2 libzzip-0-13 mime-support python python-talloc python2.7 samba-libs x11-common file
 
 					wget "$INSTALL_URL_ADDRESS" -O package.deb
 					dpkg -i package.deb
@@ -3760,7 +3760,7 @@ _EOF_
 				G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 				#Prereqs
-				G_AGI libmpdclient2 libflac8 libyajl2 libavahi-client3 libvorbisfile3 libwavpack1 libmad0 libmpg123-0 libopus0 libavformat57 libfaad2 libcdio-paranoia1 libiso9660-8 libshout3 libid3tag0
+				G_AGI libwrap0 libmpdclient2 libflac8 libyajl2 libavahi-client3 libvorbisfile3 libwavpack1 libmad0 libmpg123-0 libopus0 libavformat57 libfaad2 libcdio-paranoia1 libiso9660-8 libshout3 libid3tag0
 
 				apt-mark unhold mpd &> /dev/null #??? Not required for dpkg -i installs
 
@@ -8687,29 +8687,35 @@ _EOF_
 
 			Banner_Configuration
 
-			#Create MPD env (based on moOde)
-			#useradd mpd
+			# Create MPD env (based on moOde)
+			# - useradd mpd
 			useradd -r -M mpd -G audio -s /usr/bin/nologin
-			mkdir -p /var/lib/mpd
+
+			# - Add files/folders
 			mkdir -p /var/run/mpd
 			mkdir -p /var/lib/mpd/music
 			mkdir -p /var/lib/mpd/playlists
-			touch /var/lib/mpd/state
-
-			#	Link /mnt to MPD defaults: https://github.com/Fourdee/DietPi/issues/1223#issuecomment-346955040
+			> /var/lib/mpd/state
+			#	- Link /mnt to MPD defaults: https://github.com/Fourdee/DietPi/issues/1223#issuecomment-346955040
 			rm /var/lib/mpd/music/MNT &> /dev/null # Always recreate (reinstalls), else,  mnt -> /mnt
 			ln -sf /mnt /var/lib/mpd/music/MNT
 
-			chown -R mpd:audio /var/lib/mpd
+			#	- log
 			mkdir -p /var/log/mpd
-			touch /var/log/mpd/mpd.log
+			> /var/log/mpd/mpd.log
 			chmod 644 /var/log/mpd/mpd.log
-			chown -R mpd:audio /var/log/mpd
 
-			#	cache
+			#	- cache
 			mkdir -p "$G_FP_DIETPI_USERDATA"/.mpd_cache
 
-			#MPD service/confs
+			#	- default config
+			cp /DietPi/dietpi/conf/mpd.conf /etc/mpd.conf
+			chmod 0666 /etc/mpd.conf
+
+			# - chown everything
+			chown -R mpd:audio /var/lib/mpd /var/log/mpd /etc/mpd.conf "$G_FP_DIETPI_USERDATA"/.mpd_cache
+
+			# - MPD service/confs
 			cat << _EOF_ > /etc/default/mpd
 #Even though we declare the conf location in our service, MPD will fail to start if this file does not exist.
 ## The configuration file location for mpd:
@@ -8733,29 +8739,23 @@ WantedBy=multi-user.target
 
 _EOF_
 
-			#Copy default config
-			cp /DietPi/dietpi/conf/mpd.conf /etc/mpd.conf
-
-			chown mpd:audio /etc/mpd.conf
-			chmod 0666 /etc/mpd.conf
-
 			#JustBoom specials
-			if (( $(cat /DietPi/dietpi.txt | grep -ci -m1 '^CONFIG_SOUNDCARD=justboom') )); then
+			if grep -qi '^[[:blank:]]*CONFIG_SOUNDCARD=justboom' /DietPi/dietpi.txt; then
 
 				# - Name displayed in YMPD sound button
 				local justboom_soundcard_desc='JustBoom DietPi'
-				sed -i "/^name \"/c\name \"$justboom_soundcard_desc\"" /etc/mpd.conf
-				sed -i "/^zeroconf_name \"/c\zeroconf_name \"$justboom_soundcard_desc\"" /etc/mpd.conf
+				G_CONFIG_INJECT 'name "' "name \"$justboom_soundcard_desc\"" /etc/mpd.conf
+				G_CONFIG_INJECT 'zeroconf_name "' "zeroconf_name \"$justboom_soundcard_desc\"" /etc/mpd.conf
 
 				# - Output (192khz 32bit)
 				local target_bitdepth=32
 				local target_rate=192000
-				sed -i '/^format "/c\format "'$target_rate':'$target_bitdepth':2"' /etc/mpd.conf
-				sed -i '/audio_output_format "/c\audio_output_format "'$target_rate':'$target_bitdepth':2"' /etc/mpd.conf
+				G_CONFIG_INJECT 'format "' "format \"$target_rate:$target_bitdepth:2\"" /etc/mpd.conf
+				G_CONFIG_INJECT 'audio_output_format "' "audio_output_format \"$target_rate:$target_bitdepth:2\"" /etc/mpd.conf
 
 				# - Set SOXR quality
 				#	All RPi's can handle SOXR VH @ 192khz 32bit: https://github.com/Fourdee/DietPi/issues/581#issuecomment-256643079
-				sed -i '/samplerate_converter "/c\samplerate_converter "soxr very high"' /etc/mpd.conf #highest
+				G_CONFIG_INJECT 'samplerate_converter "' 'samplerate_converter "soxr very high"' /etc/mpd.conf #highest
 
 			fi
 


### PR DESCRIPTION
Just faced the issue on VM and found open topic on our forum via search machine 😃: http://dietpi.com/phpbb/viewtopic.php?f=9&t=2779
Dependency can be also verified via Debian package: https://packages.debian.org/de/stretch/mpd
+ DietPi-Software | MPD: Resolved an issue where "libwrap0" (libwrap.so.0) was missing to start MPD service
+ DietPi-Software | MPD: Minor configuration code reordering/globals use
  - Yey had fun to implement G_CONFIG_INJECT and watch how output fits into dietpi-software run.