### PR TITLE
DietPi-Services | Start/Stop order is now based on service dependencies

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ DietPi-Environment | Move sysctl adjustments to "/etc/sysctl.d/dietpi.conf" to a
 DietPi-Config | Enabled possibility to adjust display resolution for VMs, but max guest display resolution might need to be adjusted within VM software as well: https://github.com/Fourdee/DietPi/issues/1227
 DietPi-Config | Advanced options: You can now define the swapfile location: https://github.com/Fourdee/DietPi/issues/1602
 DietPi-Config | Soundcards (RPi): Added option for ApplePi DAC: https://github.com/Fourdee/DietPi/issues/1626
+DietPi-Services | Start/Stop order is now based on service dependencies: https://github.com/Fourdee/DietPi/issues/1462
 DietPi-Process_Tool | Added ability to add custom process entries to "/DietPi/dietpi/.dietpi-process_tool_include". Add one process each line with the format <chosenName>:<executableFileName>. Check via htop, e.g. "DHCP client:dhclient"
 DietPi-Software | NoMachine: Installation updated to 6.0.78 (new installations only): https://github.com/Fourdee/DietPi/issues/1340#issuecomment-372845397
 DietPi-Software | Squeezebox server: Updated to systemd native service: https://github.com/Fourdee/DietPi/issues/1613

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -33,119 +33,140 @@
 
 	aSERVICE_NAME=(
 
-		'cron'
-		'docker'
-		### Webserver dependents
-		'koel'
-		'raspimjpeg'
-		### Webservers
+		#Core ------------------------------------------------------------------
+		# - Network
+		'fail2ban'
+		'avahi-daemon'
+		'isc-dhcp-server'
+		'haproxy'
+
+		# - File servers
+		'proftpd'
+		'vsftpd'
+		'smbd'
+			'nmbd'
+		'nfs-kernel-server'
+		#Core ------------------------------------------------------------------
+
+		#Backends --------------------------------------------------------------
+		# - Webservers
 		'apache2'
-		'lighttpd'
 		'nginx'
+		'lighttpd'
 		'tomcat8'
-		### PHP
+
+		# - MySQL/Databases
+		'redis-server'
+		'mysql'
+		#'mariadb' #: https://github.com/Fourdee/DietPi/issues/1000#issuecomment-307760517
+
+		# - PHP
 		'php5-fpm'
 		'php7.0-fpm'
 		'php7.2-fpm'
-		### Database dependents
-		'gitea'
-		'gogs'
-		### Databases
-		#'mariadb' #: https://github.com/Fourdee/DietPi/issues/1000#issuecomment-307760517
-		'mysql'
-		'redis-server'
-		### Network dependents
-		'htpc-manager'
-		## Media streaming
-		'airsonic'
-		'emby-server'
-		'gmrender'
-		'icecast2'
-			'darkice'
+
+		# - Media
+		'alsa-init'
+		'mpd'
 		'minidlna'
-		'mopidy'
+		'shairport-sync'
+		'squeezeboxserver'
+		'squeezelite'
+		'gmrender'
 		'mumble-server'
 		'networkaudiod'
-		'plexpy'
-			'plexmediaserver'
-		'raspotify'
 		'roonbridge'
-			'roonserver'
-		'shairport-sync'
-		'spotify-connect-web'
-		'squeezelite'
-		'squeezeboxserver'
-		'subsonic'
-		'ympd'
-		## BitTorrent / Download Tools
-		'jackett'
-		'aria2'
-		'couchpotato'
-		'nzbget'
-		'qbittorrent'
-		'radarr'
-		'rtorrent'
-		'sabnzbd'
-		'sickrage'
-		'sonarr'
+		'roonserver'
+		'icecast2'
+			'darkice'
+		'voice-recognizer'
+
+		# - Download/BitTorrent
 		'transmission-daemon'
-		## Emulation & Gaming
-		'cuberite'
-		'nukkit'
-		'supervisor'
-		## Camera / Surveillance
-		'motioneye'
-		## Cloud / Backups
+		'qbittorrent'
+		'rtorrent'
+		'nzbget'
+		#Backends --------------------------------------------------------------
+
+		#Frontends / Misc ------------------------------------------------------
+		# - Media
+		'ympd'
+		'subsonic'
+		'airsonic'
+		'mopidy'
+		'koel'
+		'raspotify'
+		'plexpy'
+		'plexmediaserver'
+		'emby-server'
+		'spotify-connect-web'
+		#'moode-worker'
+
+		# - Download/BitTorrent
+		'sickrage'
+		'aria2'
+		'sabnzbd'
+		'couchpotato'
+		'jackett'
+		'sonarr'
+		'radarr'
+		'htpc-manager'
+
+		# - Cloud/Backups
 		'bdd'
 		'minio'
-		'syncthing-inotify'
-			'syncthing'
-		'tonido'
+		'syncthing'
+			'syncthing-inotify'
 		'urbackupsrv'
-		## Social / Search
-		'openbazaar'
-		'yacy'
-		## WiFi HotSpot
-		'hostapd'
-		## Home Automation
-		'home-assistant'
-		## Hardware Projects
-		'blynkserver'
-		'node-red'
-		'webiopi'
-		## Remote Access
-		'virtualhere'
-		## System Stats / Management
-		'netdata'
-		'rpimonitor'
-		## File Servers
-		'nfs-kernel-server'
-		'proftpd'
-		'smbd'
-			'nmbd'
-		'vsftpd'
-		## Network Load Balancing
-		'haproxy'
-		## Website USL's
-		'noip2'
-		## Printing
+		'tonido'
+		'gogs'
+		'gitea'
+
+		# - Emulation/Gaming
+		'supervisor'
+		'nukkit'
+		'cuberite'
+
+		# - Camera/Surveillance
+		'motioneye'
+		'raspimjpeg'
+
+		# - Printing
 		'cups'
 			'cloudprintd'
 		'octoprint'
-		### Network
-		'avahi-daemon'
-		'pihole-FTL'
-		'isc-dhcp-server'
-		'fail2ban'
-		### Hardware/non-network dependents
-		'alsa-init'
-		'emonhub'
-		#'moode-worker'
-		'mosquitto'
-		'mpd'
+
+		# - Social/Search
+		'yacy'
+		'openbazaar'
+
+		# - Hardware Projects
 		'pi-spc'
 		'pijuice'
-		'voice-recognizer'
+		'mosquitto'
+		'node-red'
+		'blynkserver'
+		'webiopi'
+		'emonhub'
+
+		# - Home Automation
+		'home-assistant'
+
+		# - Network
+		'noip2'
+		'virtualhere'
+		'pihole-FTL'
+		'hostapd'
+
+		# - System stats
+		'netdata'
+		'rpimonitor'
+
+		# - Misc
+		#'openmediavault-engined'
+		'docker'
+		'cron'
+		#Frontends / Misc ------------------------------------------------------
 
 	)
 
@@ -312,7 +333,7 @@
 		# - STOP: Reverse service order
 		if [ "$target_state" = "stop" ]; then
 
-			for ((i=0; i<${#aSERVICE_NAME[@]}; i++))
+			for ((i=$(( ${#aSERVICE_NAME[@]} - 1 )); i>=0; i--))
 			do
 
 				if (( ${aSERVICE_AVAILABLE[$i]} == 1 )); then
@@ -330,7 +351,7 @@
 		# - EG: START/RESTART: Standard service order
 		else
 
-			for ((i=$(( ${#aSERVICE_NAME[@]} - 1 )); i>=0; i--))
+			for ((i=0; i<${#aSERVICE_NAME[@]}; i++))
 			do
 
 				if (( ${aSERVICE_AVAILABLE[$i]} == 1 )); then

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -34,96 +34,118 @@
 	aSERVICE_NAME=(
 
 		'cron'
-		'proftpd'
-		'smbd'
-		'nmbd'
-		'nfs-kernel-server'
-		'vsftpd'
+		'docker'
+		### Webserver dependents
+		'koel'
+		'raspimjpeg'
+		### Webservers
 		'apache2'
-		'nginx'
 		'lighttpd'
+		'nginx'
+		'tomcat8'
+		### PHP
 		'php5-fpm'
 		'php7.0-fpm'
 		'php7.2-fpm'
-		'mysql'
-		#'mariadb' #: https://github.com/Fourdee/DietPi/issues/1000#issuecomment-307760517
-		'redis-server'
-		'mpd'
-		'ympd'
-		'minidlna'
-		'noip2'
-		'pihole-FTL'
-		'subsonic'
-		'airsonic'
-		'webiopi'
-		'haproxy'
-		'fail2ban'
-		'isc-dhcp-server'
-		'hostapd'
-		'avahi-daemon'
-		'shairport-sync'
-		'squeezeboxserver'
-		'squeezelite'
-		'mopidy'
-		'emonhub'
-		'netdata'
-		'mumble-server'
-		'emby-server'
-		'plexmediaserver'
-		'cuberite'
-		'supervisor'
+		### Database dependents
+		'gitea'
 		'gogs'
-		'transmission-daemon'
-		'qbittorrent'
-		'syncthing'
-		'syncthing-inotify'
-		'rtorrent'
-		'urbackupsrv'
-		'sickrage'
-		'roonbridge'
-		'mosquitto'
-		'networkaudiod'
-		'node-red'
-		'tomcat8'
-		'rpimonitor'
-		#'openmediavault-engined'
-		'blynkserver'
-		'aria2'
-		'yacy'
-		'tonido'
-		'icecast2'
-		'darkice'
-		'motioneye'
-		'cups'
-		'cloudprintd'
-		'virtualhere'
-		'sabnzbd'
-		'spotify-connect-web'
-		'couchpotato'
-		'koel'
-		'sonarr'
-		'radarr'
-		'plexpy'
-		'jackett'
-		'nzbget'
-		'octoprint'
-		'roonserver'
+		### Databases
+		#'mariadb' #: https://github.com/Fourdee/DietPi/issues/1000#issuecomment-307760517
+		'mysql'
+		'redis-server'
+		### Network dependents
 		'htpc-manager'
-		'home-assistant'
-		'openbazaar'
-		'docker'
+		## Media streaming
+		'airsonic'
+		'emby-server'
+		'gmrender'
+		'icecast2'
+			'darkice'
+		'minidlna'
+		'mopidy'
+		'mumble-server'
+		'networkaudiod'
+		'plexpy'
+			'plexmediaserver'
+		'raspotify'
+		'roonbridge'
+			'roonserver'
+		'shairport-sync'
+		'spotify-connect-web'
+		'squeezelite'
+		'squeezeboxserver'
+		'subsonic'
+		'ympd'
+		## BitTorrent / Download Tools
+		'jackett'
+		'aria2'
+		'couchpotato'
+		'nzbget'
+		'qbittorrent'
+		'radarr'
+		'rtorrent'
+		'sabnzbd'
+		'sickrage'
+		'sonarr'
+		'transmission-daemon'
+		## Emulation & Gaming
+		'cuberite'
+		'nukkit'
+		'supervisor'
+		## Camera / Surveillance
+		'motioneye'
+		## Cloud / Backups
 		'bdd'
 		'minio'
-		'gmrender'
-		'nukkit'
-		'gitea'
-		'pi-spc'
-		'raspotify'
-		#'moode-worker'
-		'voice-recognizer'
+		'syncthing-inotify'
+			'syncthing'
+		'tonido'
+		'urbackupsrv'
+		## Social / Search
+		'openbazaar'
+		'yacy'
+		## WiFi HotSpot
+		'hostapd'
+		## Home Automation
+		'home-assistant'
+		## Hardware Projects
+		'blynkserver'
+		'node-red'
+		'webiopi'
+		## Remote Access
+		'virtualhere'
+		## System Stats / Management
+		'netdata'
+		'rpimonitor'
+		## File Servers
+		'nfs-kernel-server'
+		'proftpd'
+		'smbd'
+			'nmbd'
+		'vsftpd'
+		## Network Load Balancing
+		'haproxy'
+		## Website USL's
+		'noip2'
+		## Printing
+		'cups'
+			'cloudprintd'
+		'octoprint'
+		### Network
+		'avahi-daemon'
+		'pihole-FTL'
+		'isc-dhcp-server'
+		'fail2ban'
+		### Hardware/non-network dependents
 		'alsa-init'
+		'emonhub'
+		#'moode-worker'
+		'mosquitto'
+		'mpd'
+		'pi-spc'
 		'pijuice'
-		'raspimjpeg'
+		'voice-recognizer'
 
 	)
 
@@ -290,7 +312,7 @@
 		# - STOP: Reverse service order
 		if [ "$target_state" = "stop" ]; then
 
-			for ((i=$(( ${#aSERVICE_NAME[@]} - 1 )); i>=0; i--))
+			for ((i=0; i<${#aSERVICE_NAME[@]}; i++))
 			do
 
 				if (( ${aSERVICE_AVAILABLE[$i]} == 1 )); then
@@ -308,7 +330,7 @@
 		# - EG: START/RESTART: Standard service order
 		else
 
-			for ((i=0; i<${#aSERVICE_NAME[@]}; i++))
+			for ((i=$(( ${#aSERVICE_NAME[@]} - 1 )); i>=0; i--))
 			do
 
 				if (( ${aSERVICE_AVAILABLE[$i]} == 1 )); then


### PR DESCRIPTION
https://github.com/Fourdee/DietPi/issues/1462
- Added service categories (based more/less on dietpi-software categories) for sorting, better overview and review of start/stop order reason.
- Indented services are direct dependencies of the prior ones.
- I hope I allocated all services correctly 😉.
- Can be a basis for uninstall order as well (install order is solved by dependencies).