### PR TITLE
DietPi-Run_ntpd | Buster: Adjusted timedatectl status check, as output changed with latest systemd update

### DIFF
--- a/dietpi/func/run_ntpd
+++ b/dietpi/func/run_ntpd
@@ -128,7 +128,7 @@
 			do
 
 				#NB: Following will always report "Synced", once systemd has completed it once
-				TIME_SYNCED=$(timedatectl status --no-pager | grep -ci -m1 'NTP synchronized: yes')
+				TIME_SYNCED=$(timedatectl status --no-pager | grep -ci -m1 ' synchronized: yes')
 				if (( $CURRENT_LOOP >= $MAX_LOOPS )); then
 
 					G_DIETPI-NOTIFY 2 "NTPD: time out waiting for systemd-timesyncd"


### PR DESCRIPTION
+ https://github.com/Fourdee/DietPi/issues/1286#issuecomment-377347756
```
root@VM-Buster:~# timedatectl
                      Local time: Thu 2018-03-29 21:37:32 CEST
                  Universal time: Thu 2018-03-29 19:37:32 UTC
                        RTC time: Thu 2018-03-29 19:37:33
                       Time zone: Europe/Berlin (CEST, +0200)
       System clock synchronized: yes
systemd-timesyncd.service active: yes
                 RTC in local TZ: no
```