### PR TITLE
DietPi-Prep | Remove minutely running "make_nas_processes_faster" cron job

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ v6.6
 (xx/03/18)
 
 Changes / Improvements / Optimizations:
+General | Removed minutely running "make_nas_processes_faster" cron job, which is present on some device base images, without any effect on raw DietPi: https://github.com/Fourdee/DietPi/issues/1654 
 
 Bug Fixes:
 General | RPi: Resolved issue with updating 'raspberrypi-sys-mods', where the patch would incorrectly apply a new apt mirror, breaking the ability to update: https://github.com/Fourdee/DietPi/issues/1659#issuecomment-377297103

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -929,6 +929,9 @@ _EOF_
 	# - RPi specific https://github.com/Fourdee/DietPi/issues/1631#issuecomment-373965406
 	rm /etc/profile.d/wifi-country.sh &> /dev/null
 
+	# - make_nas_processes_faster cron job on Rock64 + NanoPi + Pine64(?) images
+	rm /etc/cron.d/make_nas_processes_faster &> /dev/null
+
 	G_DIETPI-NOTIFY 2 "Creating DietPi core environment"
 
 	G_RUN_CMD /boot/dietpi/func/dietpi-set_core_environment

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -589,6 +589,9 @@ _EOF_
 
 			fi
 			#-------------------------------------------------------------------------------
+			#Remove minutely running "make_nas_processes_faster" cron job, present on images with preinstalled OMV: https://github.com/Fourdee/DietPi/issues/1654
+			rm /etc/cron.d/make_nas_processes_faster &> /dev/null
+			#-------------------------------------------------------------------------------
 
 		fi
 


### PR DESCRIPTION
https://github.com/Fourdee/DietPi/issues/1654