### PR TITLE
DietPi-Boot | Various enhencements

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,7 +3,12 @@ v6.6
 (xx/03/18)
 
 Changes / Improvements / Optimizations:
-General | Removed minutely running "make_nas_processes_faster" cron job, which is present on some device base images, without any effect on raw DietPi: https://github.com/Fourdee/DietPi/issues/1654 
+General | Removed minutely running "make_nas_processes_faster" cron job, which is present on some device base images, without any effect on raw DietPi: https://github.com/Fourdee/DietPi/issues/1654
+DietPi-Boot | Dropbear: Adding ecdsa and dss host keys as well on 1st boot, to avoid boot error messages: https://github.com/Fourdee/DietPi/issues/1670
+DietPi-Boot | Now executes "iw" and "amixer" only, if binaries exist, unhide command outputs instead.
+DietPi-Boot | Now executes "ifup/down wlan0" only, if interface is configured, to avoid error message about it.
+DietPi-Boot | Now adds sourcing of DietPi-Globals to /root/.bashrc, if missing, e.g. due to user edit.
+DietPi-Boot | Various code improvements according to: https://github.com/Fourdee/DietPi/issues/1510
 
 Bug Fixes:
 General | RPi: Resolved issue with updating 'raspberrypi-sys-mods', where the patch would incorrectly apply a new apt mirror, breaking the ability to update: https://github.com/Fourdee/DietPi/issues/1659#issuecomment-377297103

--- a/dietpi/boot
+++ b/dietpi/boot
@@ -109,14 +109,14 @@
 		sed -i "s/wlan0/wlan$index_wlan/g" /etc/network/interfaces
 
 		#Grab user requested settings from /dietpi.txt
-		local Ethernet_Enabled=$(cat /DietPi/dietpi.txt | grep -ci -m1 'AUTO_SETUP_NET_ETHERNET_ENABLED=1')
-		local Wifi_Enabled=$(cat /DietPi/dietpi.txt | grep -ci -m1 'AUTO_SETUP_NET_WIFI_ENABLED=1')
+		local Ethernet_Enabled=$(grep -ci -m1 '^[[:blank:]]*AUTO_SETUP_NET_ETHERNET_ENABLED=1' /DietPi/dietpi.txt)
+		local Wifi_Enabled=$(grep -ci -m1 '^[[:blank:]]*AUTO_SETUP_NET_WIFI_ENABLED=1' /DietPi/dietpi.txt)
 
-		local Use_Static=$(cat /DietPi/dietpi.txt | grep -ci -m1 '^AUTO_SETUP_NET_USESTATIC=1')
-		local Static_IP=$(cat /DietPi/dietpi.txt | grep -m1 '^AUTO_SETUP_NET_STATIC_IP=' | sed 's/.*=//')
-		local Static_Mask=$(cat /DietPi/dietpi.txt | grep -m1 '^AUTO_SETUP_NET_STATIC_MASK=' | sed 's/.*=//')
-		local Static_Gateway=$(cat /DietPi/dietpi.txt | grep -m1 '^AUTO_SETUP_NET_STATIC_GATEWAY=' | sed 's/.*=//')
-		local Static_Dns=$(cat /DietPi/dietpi.txt | grep -m1 '^AUTO_SETUP_NET_STATIC_DNS=' | sed 's/.*=//')
+		local Use_Static=$(grep -ci -m1 '^[[:blank:]]*AUTO_SETUP_NET_USESTATIC=1' /DietPi/dietpi.txt)
+		local Static_IP="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_NET_STATIC_IP=' /DietPi/dietpi.txt | sed 's/^.*=//')"
+		local Static_Mask="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_NET_STATIC_MASK=' /DietPi/dietpi.txt | sed 's/^.*=//')"
+		local Static_Gateway="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_NET_STATIC_GATEWAY=' /DietPi/dietpi.txt | sed 's/^.*=//')"
+		local Static_Dns="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_NET_STATIC_DNS=' /DietPi/dietpi.txt | sed 's/^.*=//')"
 
 		# - Wifi
 		if (( $Wifi_Enabled == 1 )); then
@@ -182,7 +182,7 @@
 		fi
 
 		#Apply forced eth speed if set in dietpi.txt
-		/DietPi/dietpi/func/dietpi-set_hardware eth-forcespeed $(cat /DietPi/dietpi.txt | grep -m1 '^AUTO_SETUP_NET_ETH_FORCE_SPEED=' | sed 's/.*=//' )
+		/DietPi/dietpi/func/dietpi-set_hardware eth-forcespeed $(grep -m1 '^[[:blank:]]*AUTO_SETUP_NET_ETH_FORCE_SPEED=' /DietPi/dietpi.txt | sed 's/^.*=//' )
 
 		#Wait for active connection, then update network details file
 		Wait_For_Valid_Network_Connection
@@ -243,7 +243,7 @@
 
 		#----------------------------------------------------------------
 		#WiFi Country | Additional fallback for (older kernel?) devices that fail with wpa_supplicant.conf https://github.com/Fourdee/DietPi/issues/838
-		iw reg set $(grep -m1 '^CONFIG_WIFI_COUNTRY_CODE=' /DietPi/dietpi.txt | sed 's/.*=//') &> /dev/null &
+		which iw &> /dev/null && iw reg set "$(grep -m1 '^[[:blank:]]*CONFIG_WIFI_COUNTRY_CODE=' /DietPi/dietpi.txt | sed 's/^.*=//')" &
 		#----------------------------------------------------------------
 		#Update NTP
 		/DietPi/dietpi/func/run_ntpd &
@@ -254,7 +254,7 @@
 		#RPi set volume to -0.1db | We have to do it here because sound card modules (dietpi-set_hardware) are not enabled on the fly, requires a reboot.
 		if (( $G_HW_MODEL < 10 )); then
 
-			amixer set PCM -- -010 &> /dev/null &
+			which amixer &> /dev/null && amixer set PCM -- -010 &
 
 		fi
 		#----------------------------------------------------------------
@@ -262,8 +262,8 @@
 		/DietPi/dietpi/dietpi-cpu_set &
 		#----------------------------------------------------------------
 		#Disable RPi hdmi output if set in dietpi.txt
-		if (( $G_HW_MODEL < 10 &&
-			$(cat /DietPi/dietpi.txt | grep -ci -m1 '^CONFIG_HDMI_OUTPUT=0'))); then
+		if (( $G_HW_MODEL < 10 )) &&
+			grep -q '^[[:blank:]]*CONFIG_HDMI_OUTPUT=0' /DietPi/dietpi.txt; then
 
 			#FBset value below allows for reduced memory bandwidth usage from VideoCore (eg: Faster RAM bandwidth/performance)
 			fbset -xres 16 -yres 16 -vxres 16 -vyres 16 -depth 8 &> /dev/null
@@ -274,12 +274,9 @@
 		#Find first index number for network devices (checks 0-9)
 		/DietPi/dietpi/func/obtain_network_details
 		#----------------------------------------------------------------
-		#Ensure DietPi login and banner scripts always exists (eg: if user disables it)
-		if (( $(grep -ci -m1 '^/DietPi/dietpi/login' /root/.bashrc) == 0 )); then
-
-			echo -e "/DietPi/dietpi/login" >> /root/.bashrc
-
-		fi
+		#Ensure DietPi-Globals, login and banner scripts always exists (eg: if user disables it)
+		grep -qE '^[[:blank:]]*(.|source)[[:blank:]]+/DietPi/dietpi/func/dietpi-globals' /root/.bashrc && echo '. /DietPi/dietpi/func/dietpi-globals' >> /root/.bashrc
+		grep -q '^[[:blank:]]*/DietPi/dietpi/login' /root/.bashrc && echo '/DietPi/dietpi/login' >> /root/.bashrc
 		#----------------------------------------------------------------
 		# - Lower dmesg print level (mostly for Odroid C2 where HiFi Shield prints info when starting/stopping stream on tty1)
 		dmesg -n 1
@@ -293,7 +290,8 @@
 
 		#Workaround: Wlan currently fails to connect during boot, so, manually drop and reconnect: https://github.com/Fourdee/DietPi/issues/602#issuecomment-262806470
 		#	OPi Zero 2 / Neo Air
-		if (( $G_HW_MODEL == 35 || $G_HW_MODEL == 64 )); then
+		if (( $G_HW_MODEL == 35 || $G_HW_MODEL == 64 ))
+			&& grep -qE '^[[:blank:]]*(allow-hotplug|auto)[[:blank:]]+wlan0' /etc/network/interfaces; then
 
 			ifdown wlan0
 			ifup wlan0
@@ -316,7 +314,7 @@
 
 		Wait_For_Valid_Network_Connection
 
-		if (( $( cat /DietPi/dietpi.txt | grep -ci -m1 '^CONFIG_CHECK_DIETPI_UPDATES=1') )); then
+		if grep -qi '^[[:blank:]]*CONFIG_CHECK_DIETPI_UPDATES=1' /DietPi/dietpi.txt; then
 
 			#Check for DietPi updates (+thread)
 			echo -e "$(date) | +Thread: checking for DietPi-Updates" >> "$FP_LOGFILE"
@@ -336,25 +334,25 @@
 		/DietPi/dietpi/dietpi-banner 0
 
 		#Set hostname
-		/DietPi/dietpi/func/change_hostname "$(cat /DietPi/dietpi.txt | grep -m1 '^AUTO_SETUP_NET_HOSTNAME=' | sed 's/.*=//')"
+		/DietPi/dietpi/func/change_hostname "$(grep -m1 '^[[:blank:]]*AUTO_SETUP_NET_HOSTNAME=' /DietPi/dietpi.txt | sed 's/^.*=//')"
 
 		#Automation
 		# - Set auto login for next bootup
-		if (( $(cat /DietPi/dietpi.txt | grep -m1 '^AUTO_SETUP_AUTOMATED=' | sed 's/.*=//') >= 1 )); then
+		if (( $(grep -m1 '^[[:blank:]]*AUTO_SETUP_AUTOMATED=' /DietPi/dietpi.txt | sed 's/^.*=//') >= 1 )); then
 
 			/DietPi/dietpi/dietpi-autostart 7
 
 		fi
 
 		# - Enable serial console?
-		if (( $(cat /DietPi/dietpi.txt | grep -ci -m1 '^CONFIG_SERIAL_CONSOLE_ENABLE=1') )); then
+		if grep -qi '^[[:blank:]]*CONFIG_SERIAL_CONSOLE_ENABLE=1' /DietPi/dietpi.txt; then
 
 			/DietPi/dietpi/func/dietpi-set_hardware serialconsole enable
 
 		fi
 
 		# - Set root password?
-		ROOT_PASSWORD=$(cat /DietPi/dietpi.txt | grep -m1 '^AUTO_SETUP_GLOBAL_PASSWORD=' | sed 's/.*=//')
+		ROOT_PASSWORD="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_GLOBAL_PASSWORD=' /DietPi/dietpi.txt | sed 's/^.*=//')"
 		if [ -n "$ROOT_PASSWORD" ]; then
 
 			chpasswd <<< "root:$ROOT_PASSWORD"
@@ -370,11 +368,13 @@
 
 		fi
 
-		/DietPi/dietpi/func/dietpi-set_software apt-mirror $(grep -m1 "^$TARGET_REPO=" /DietPi/dietpi.txt | sed 's/.*=//')
+		/DietPi/dietpi/func/dietpi-set_software apt-mirror "$(grep -m1 "^[[:blank:]]*$TARGET_REPO=" /DietPi/dietpi.txt | sed 's/^.*=//')"
 
 		#Generate unique Dropbear host-key:
 		rm /etc/dropbear/*key &> /dev/null
 		dropbearkey -t rsa -f /etc/dropbear/dropbear_rsa_host_key &> /dev/null
+		dropbearkey -t ecdsa -f /etc/dropbear/dropbear_ecdsa_host_key &> /dev/null
+		dropbearkey -t dss -f /etc/dropbear/dropbear_dss_host_key &> /dev/null
 
 		#Activate DietPi Boot Loader User Settings and bring up network (dietpi.txt)
 		Apply_DietPi_FirstRun_Settings
@@ -382,11 +382,11 @@
 		Workaround_WiFi
 
 		# - Set NTPD
-		/DietPi/dietpi/func/dietpi-set_software ntpd-mode $(grep -m1 '^CONFIG_NTP_MODE=' /DietPi/dietpi.txt | sed 's/.*=//')
+		/DietPi/dietpi/func/dietpi-set_software ntpd-mode $(grep -m1 '^[[:blank:]]*CONFIG_NTP_MODE=' /DietPi/dietpi.txt | sed 's/^.*=//')
 
 		#Finished
 		/DietPi/dietpi/dietpi-banner 0
-		echo -e " Default Login:\n Username = root\n Password = dietpi\n"
+		echo -e ' Default Login:\n Username = root\n Password = dietpi\n'
 
 		#Set Install Stage index to trigger DietPi-Software installation on login
 		echo 0 > /DietPi/dietpi/.install_stage

--- a/dietpi/boot
+++ b/dietpi/boot
@@ -275,8 +275,8 @@
 		/DietPi/dietpi/func/obtain_network_details
 		#----------------------------------------------------------------
 		#Ensure DietPi-Globals, login and banner scripts always exists (eg: if user disables it)
-		grep -qE '^[[:blank:]]*(.|source)[[:blank:]]+/DietPi/dietpi/func/dietpi-globals' /root/.bashrc && echo '. /DietPi/dietpi/func/dietpi-globals' >> /root/.bashrc
-		grep -q '^[[:blank:]]*/DietPi/dietpi/login' /root/.bashrc && echo '/DietPi/dietpi/login' >> /root/.bashrc
+		grep -qE '^[[:blank:]]*(.|source)[[:blank:]]+/DietPi/dietpi/func/dietpi-globals' /root/.bashrc || echo '. /DietPi/dietpi/func/dietpi-globals' >> /root/.bashrc
+		grep -q '^[[:blank:]]*/DietPi/dietpi/login' /root/.bashrc || echo '/DietPi/dietpi/login' >> /root/.bashrc
 		#----------------------------------------------------------------
 		# - Lower dmesg print level (mostly for Odroid C2 where HiFi Shield prints info when starting/stopping stream on tty1)
 		dmesg -n 1

--- a/dietpi/boot
+++ b/dietpi/boot
@@ -290,8 +290,8 @@
 
 		#Workaround: Wlan currently fails to connect during boot, so, manually drop and reconnect: https://github.com/Fourdee/DietPi/issues/602#issuecomment-262806470
 		#	OPi Zero 2 / Neo Air
-		if (( $G_HW_MODEL == 35 || $G_HW_MODEL == 64 ))
-			&& grep -qE '^[[:blank:]]*(allow-hotplug|auto)[[:blank:]]+wlan0' /etc/network/interfaces; then
+		if (( $G_HW_MODEL == 35 || $G_HW_MODEL == 64 )) &&
+			grep -qE '^[[:blank:]]*(allow-hotplug|auto)[[:blank:]]+wlan0' /etc/network/interfaces; then
 
 			ifdown wlan0
 			ifup wlan0

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -592,6 +592,14 @@ _EOF_
 			#Remove minutely running "make_nas_processes_faster" cron job, present on images with preinstalled OMV: https://github.com/Fourdee/DietPi/issues/1654
 			rm /etc/cron.d/make_nas_processes_faster &> /dev/null
 			#-------------------------------------------------------------------------------
+			#Add Dropbear ecdsa and dss host keys, if missing: https://github.com/Fourdee/DietPi/issues/1670
+			if grep -q '^aSOFTWARE_INSTALL_STATE\[104\]=2' /DietPi/dietpi/.installed; then
+
+				[ -f /etc/dropbear/dropbear_ecdsa_host_key ] || dropbearkey -t ecdsa -f /etc/dropbear/dropbear_ecdsa_host_key &> /dev/null
+				[ -f /etc/dropbear/dropbear_dss_host_key ] || dropbearkey -t dss -f /etc/dropbear/dropbear_dss_host_key &> /dev/null
+
+			fi
+			#-------------------------------------------------------------------------------
 
 		fi
 


### PR DESCRIPTION
+ DietPi-Boot | Dropbear: Add ecdsa and dss host keys as well on 1st boot + patch on v6.6: https://github.com/Fourdee/DietPi/issues/1670
+ DietPi-Boot | Execute iw and amixer only, if binary exist
+ DietPi-Boot | Execute ifup/down wlan0 only, if interface is configured
+ DietPi-Boot | Add sourcing DietPi-Globals as well, if missing in /root/.bashrc
+ DietPi-Boot | Various code improvements according to: https://github.com/Fourdee/DietPi/issues/1510

🈯️ Tested on VM Stretch + Jessie + Dropbear keys on RPi, resolving error message on service startup