### PR TITLE
DietPi-Backup/Sync | Add free space check before run

### DIFF
--- a/dietpi/dietpi-backup
+++ b/dietpi/dietpi-backup
@@ -346,8 +346,8 @@
 	)
 
 	#rsync options
-	RSYNC_RUN_OPTIONS_SYSTEM_BACKUP="-alHpvP --delete --log-file=$LOGFILE --include-from=$FP_FILTER_INCLUDE_EXCLUDE_SYSTEM_BACKUP"
-	RSYNC_RUN_OPTIONS_USERDATA_BACKUP="-alHpvP --delete --log-file=$LOGFILE"
+	RSYNC_RUN_OPTIONS_SYSTEM_BACKUP="-aHv --delete --log-file=$LOGFILE --include-from=$FP_FILTER_INCLUDE_EXCLUDE_SYSTEM_BACKUP"
+	RSYNC_RUN_OPTIONS_USERDATA_BACKUP="-aHv --delete --log-file=$LOGFILE"
 
 	#Date format for logs
 	Print_Date(){
@@ -484,7 +484,23 @@ _EOF_
 
 					# - system
 					RSYNC_MODE_TEXT='Backup (system)'
+					mkdir -p "$FP_TARGET_BACKUP"/dietpi-backup_system
+					local old_backup_size=$(( $(du -s "$FP_TARGET_BACKUP"/dietpi-backup_system | awk '{print $1}') / 1024 ))
+					local new_backup_size=$(( $(rsync --dry-run $RSYNC_RUN_OPTIONS_SYSTEM_BACKUP "$FP_SOURCE_SYSTEM" "$FP_TARGET_BACKUP"/dietpi-backup_system/ | grep 'total size' | awk '{print $4}' | sed 's/,//g') / 1024**2 ))
+					local security_factor=12 # will be deviced by 10, thus results in factor 1.2
+					if G_CHECK_FREESPACE "$FP_TARGET_BACKUP"/dietpi-backup_system $(( $new_backup_size * $security_factor / 10 - $old_backup_size )); then
 
+						G_WHIP_BUTTON_OK_TEXT='Ignore'
+						G_WHIP_BUTTON_CANCEL_TEXT='Exit'
+						G_WHIP_YESNO 'Your system backup target location seems to have insufficient free space to successfully finish the backup.\nHowever, we can just do a rough estimation in reasonable time, thus it could fit closely.\n\nDo you want to ignore and go on with the backup process?'
+						if (( $? )); then
+
+							echo -e "$RSYNC_MODE_TEXT canceled due to insuffecient free space    : $(Print_Date)" >> "$FP_TARGET_BACKUP/$BACKUP_STATS_FILENAME_SYSTEM"
+							break
+
+						fi
+
+					fi
 					G_RUN_CMD rsync $RSYNC_RUN_OPTIONS_SYSTEM_BACKUP "$FP_SOURCE_SYSTEM" "$FP_TARGET_BACKUP"/dietpi-backup_system/
 					echo -e "$RSYNC_MODE_TEXT Completed    : $(Print_Date)" >> "$FP_TARGET_BACKUP/$BACKUP_STATS_FILENAME_SYSTEM"
 
@@ -493,6 +509,23 @@ _EOF_
 
 					if (( $BACKUP_MODE == 1 )); then
 
+						mkdir -p "$FP_TARGET_BACKUP"/dietpi-backup_userdata
+						local old_backup_size=$(( $(du -s "$FP_TARGET_BACKUP"/dietpi-backup_userdata | awk '{print $1}') / 1024 ))
+						local new_backup_size=$(( $(rsync --dry-run $RSYNC_RUN_OPTIONS_USERDATA_BACKUP "$G_FP_DIETPI_USERDATA_ACTUAL"/ "$FP_TARGET_BACKUP"/dietpi-backup_userdata/ | grep 'total size' | awk '{print $4}' | sed 's/,//g') / 1024**2 ))
+						local security_factor=12 # will be deviced by 10, thus results in factor 1.2
+						if G_CHECK_FREESPACE "$FP_TARGET_BACKUP"/dietpi-backup_userdata $(( $new_backup_size * $security_factor / 10 - $old_backup_size )); then
+
+							G_WHIP_BUTTON_OK_TEXT='Ignore'
+							G_WHIP_BUTTON_CANCEL_TEXT='Exit'
+							G_WHIP_YESNO 'Your userdata backup target location seems to have insufficient free space to successfully finish the backup.\nHowever, we can just do a rough estimation in reasonable time, thus it could fit closely.\n\nDo you want to ignore and go on with the backup process?'
+							if (( $? )); then
+
+								echo -e "$RSYNC_MODE_TEXT canceled due to insuffecient free space : $(Print_Date)" >> "$FP_TARGET_BACKUP/$BACKUP_STATS_FILENAME_USERDATA"
+								break
+
+							fi
+
+						fi
 						G_RUN_CMD rsync $RSYNC_RUN_OPTIONS_USERDATA_BACKUP "$G_FP_DIETPI_USERDATA_ACTUAL"/ "$FP_TARGET_BACKUP"/dietpi-backup_userdata/
 						echo -e "$RSYNC_MODE_TEXT Completed : $(Print_Date)" >> "$FP_TARGET_BACKUP/$BACKUP_STATS_FILENAME_USERDATA"
 


### PR DESCRIPTION
+ DietPi-Backup | Add free space check before running backup: https://github.com/Fourdee/DietPi/issues/1664
+ DietPi-Backup | Adjust rsync options: Remove "l" and "p" as included in "a" and "P" as we do not show direct output anymore

This is early **WIP** just to review the technique, do speed tests etc.
- Found `(( ))` not allow calculation with decimal values, nor does bash even support decimal variables? `bc` seems to be a solution for this, but I was a bid tired to learn it and found `* 12 / 10` as an easy replacement for `* 1.2`
- Found `G_CHECK_FREESPACE` and `G_CHECK_VALIDINT` a bid inconsistent currently in use. If `return $return_value` is used, the function cannot be used within arithmetic checks, but direct checks, as used within this PR are possible. But for this use, the output should be switched, as `0` returns as true and anything else (?) as false. `G_CHECK_VALIDINT` uses `echo` instead of `return`, which then can be used in arithmetic checks and `if (( $(G_CHECK_VALIDINT 10) )); then` executes code as expected, but I guess this is the slower method? Will do some benchmarking in the code performance issue 😋.
- [x] Currently rsync --dry-run also logs to logfile, which is not wanted I guess. 
- [x] If system backup is cancelled, userdata backup cancelled silently as well, but the other way round, if system backup is made, userdata backup can be still cancelled independently.
- [x] `G_WHIP_MSG` currently shows `completed`, even if backup was cancelled due to insufficient free space.
- [x] Should be integrated into DietPi-Sync as well, if method passes performance and reliability tests.

Indeed rsync `total size` result is always smaller than the `du` result afterwards, I guess as rsync shows theoretical file size (transferred bytes), while du shows actual used disc space based on e.g. 4k blocks. No idea if there is some better way to estimate this. Theoretically if a huge amount of 1 byte files is transferred, the actual used size will be 4000 times larger than what rsync shows 😆. But `1.2` security factor should work in most real cases at least. Good enough for the effort?