### PR TITLE
Coding | Replace remaining "clear" commands with "printf '\ec'"

### DIFF
--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -5664,7 +5664,7 @@ Custom     : Write = $CUSTOM_WRITE | Read = $CUSTOM_READ"
 
 					else
 
-						clear
+						printf '\ec' # clear current terminal screen
 						service noip2 stop
 						noip2 -C
 						read -p "Press any key to continue....."

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4775,7 +4775,7 @@ _EOF_
 
 			#Run setup script
 			./setup.sh
-			clear
+			printf '\ec' # clear current terminal screen
 
 			cd ..
 
@@ -16384,7 +16384,7 @@ _EOF_
 		#Start DietPi Menu
 		while (( $TARGETMENUID > -1 )); do
 
-			clear
+			printf '\ec' # clear current terminal screen
 
 			if (( $TARGETMENUID == 0 )); then
 


### PR DESCRIPTION
+ https://github.com/Fourdee/DietPi/issues/1615
+ Excluding `DietPi-Cloudshell`, as on LCD panel it makes sense to clear the whole terminal history as well.