### PR TITLE
DietPi-PREP | Fine tuning

### DIFF
--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -25,9 +25,9 @@
 	# Critical checks and pre-reqs, with exit, prior to initial run of script
 	#------------------------------------------------------------------------------------------------
 	#Exit path for non-root logins.
-	if (( $UID != 0 )); then
+	if (( $UID )); then
 
-		echo -e 'Error: Root privileges required. Please run the command with "sudo"\nIn case install the "sudo" package with root privileges: #apt-get install sudo\n'
+		echo -e 'Error: Root privileges required, please run the script with "sudo"\nIn case install the "sudo" package with root privileges:\n\t# apt-get install -y sudo\n'
 		exit 1
 
 	fi
@@ -53,12 +53,12 @@
 	for (( i=0; i<${#a_MIN_APT_PREREQS[@]}; i++))
 	do
 
-		if (( ! $(dpkg --get-selections | grep -ci -m1 "^${a_MIN_APT_PREREQS[$i]}[[:space:]]") )); then
+		if ! dpkg --get-selections | grep -qi "^${a_MIN_APT_PREREQS[$i]}[[:space:]]"; then
 
 			apt-get install -y ${a_MIN_APT_PREREQS[$i]}
-			if (( $? != 0 )); then
+			if (( $? )); then
 
-				echo -e "Error: Unable to install ${a_MIN_APT_PREREQS[$i]}, please try to install it manually with\n - apt-get install -y ${a_MIN_APT_PREREQS[$i]}"
+				echo -e "Error: Unable to install ${a_MIN_APT_PREREQS[$i]}, please try to install it manually:\n\t# apt-get install -y ${a_MIN_APT_PREREQS[$i]}"
 				exit 1
 
 			fi
@@ -86,7 +86,7 @@
 
 	#Setup locale
 	# - Remove exisiting settings that will break dpkg-reconfigure
-	echo '' > /etc/environment
+	> /etc/environment
 	rm /etc/default/locale &> /dev/null
 
 	#	NB: DEV, any changes here must be also rolled into function '/DietPi/dietpi/func/dietpi-set_software locale', for future script use
@@ -95,7 +95,7 @@
 	# dpkg-reconfigure includes:
 	#	- "locale-gen": Generate locale(s) based on "/etc/locale.gen" or interactive selection.
 	#	- "update-locale": Add $LANG to "/etc/default/locale" based on generated locale(s) or interactive default language selection.
-	if (( $? != 0 )); then
+	if (( $? )); then
 
 		echo -e 'Error: Locale generation failed. Aborting...\n'
 		exit 1
@@ -118,7 +118,7 @@
 	#Download DietPi-Globals
 	# - NB: we'll have to manually handle errors, until script is sucessfully loaded
 	wget https://raw.githubusercontent.com/Fourdee/DietPi/$GIT_BRANCH/dietpi/func/dietpi-globals -O dietpi-globals
-	if (( $? != 0 )); then
+	if (( $? )); then
 
 		echo -e 'Error: Unable to download dietpi-globals. Aborting...\n'
 		exit 1
@@ -128,7 +128,7 @@
 	# - load
 	chmod +x dietpi-globals
 	. ./dietpi-globals
-	if (( $? != 0 )); then
+	if (( $? )); then
 
 		echo -e 'Error: Unable to load dietpi-globals. Aborting...\n'
 		exit 1
@@ -169,26 +169,26 @@
 
 	#G_HW_MODEL # init from dietpi-globals
 	#G_HW_ARCH_DESCRIPTION # init from dietpi-globals
-	G_HW_ARCH_DESCRIPTION=$(uname -m)
-	if [ "$G_HW_ARCH_DESCRIPTION" = "armv6l" ]; then
+	G_HW_ARCH_DESCRIPTION="$(uname -m)"
+	if [ "$G_HW_ARCH_DESCRIPTION" = 'armv6l' ]; then
 
 		export G_HW_ARCH=1
 
-	elif [ "$G_HW_ARCH_DESCRIPTION" = "armv7l" ]; then
+	elif [ "$G_HW_ARCH_DESCRIPTION" = 'armv7l' ]; then
 
 		export G_HW_ARCH=2
 
-	elif [ "$G_HW_ARCH_DESCRIPTION" = "aarch64" ]; then
+	elif [ "$G_HW_ARCH_DESCRIPTION" = 'aarch64' ]; then
 
 		export G_HW_ARCH=3
 
-	elif [ "$G_HW_ARCH_DESCRIPTION" = "x86_64" ]; then
+	elif [ "$G_HW_ARCH_DESCRIPTION" = 'x86_64' ]; then
 
 		export G_HW_ARCH=10
 
 	else
 
-		echo -e "Error: Unknown or unsupported CPU architecture $G_HW_ARCH_DESCRIPTION. Aborting..."
+		echo -e "Error: Unknown or unsupported CPU architecture \"$G_HW_ARCH_DESCRIPTION\". Aborting...\n"
 		exit 1
 
 	fi
@@ -198,7 +198,7 @@
 
 	#Image creator flags
 	IMAGE_CREATOR=''
-	PREIMAGE_NAME=''
+	PREIMAGE_INFO=''
 
 	#Setup step, current (used in info)
 	SETUP_STEP=0
@@ -215,13 +215,13 @@
 	#------------------------------------------------------------------------------------------------
 
 	#------------------------------------------------------------------------------------------------
-	echo -e ''
+	echo ''
 	G_DIETPI-NOTIFY 2 '-----------------------------------------------------------------------------------'
 	G_DIETPI-NOTIFY 0 "Step $SETUP_STEP: Detecting existing DietPi system:"
 	((SETUP_STEP++))
 	G_DIETPI-NOTIFY 2 '-----------------------------------------------------------------------------------'
 	#------------------------------------------------------------------------------------------------
-	if (( $(systemctl is-active dietpi-ramdisk | grep -ci -m1 '^active') )); then
+	if systemctl is-active dietpi-ramdisk | grep -qi '^active'; then
 
 		G_DIETPI-NOTIFY 2 'DietPi system found, running pre-prep'
 
@@ -253,7 +253,7 @@
 	fi
 
 	#------------------------------------------------------------------------------------------------
-	echo -e ''
+	echo ''
 	G_DIETPI-NOTIFY 2 '-----------------------------------------------------------------------------------'
 	G_DIETPI-NOTIFY 0 "Step $SETUP_STEP: Initial prep to allow this script to function:"
 	((SETUP_STEP++))
@@ -269,9 +269,9 @@
 	G_AGI apt-transport-https unzip whiptail
 
 	#------------------------------------------------------------------------------------------------
-	echo -e ''
+	echo ''
 	G_DIETPI-NOTIFY 2 '-----------------------------------------------------------------------------------'
-	G_DIETPI-NOTIFY 0 "Step $SETUP_STEP (inputs): Image creator / Hardware / WiFi / Distro:"
+	G_DIETPI-NOTIFY 0 "Step $SETUP_STEP (inputs): Image info / Hardware / WiFi / Distro:"
 	((SETUP_STEP++))
 	G_DIETPI-NOTIFY 2 '-----------------------------------------------------------------------------------'
 	#------------------------------------------------------------------------------------------------
@@ -280,8 +280,8 @@
 	while true
 	do
 
-		G_WHIP_INPUTBOX 'Please enter your name. This will be used to identify the image creator.\n\nNB: An entry is required.'
-		if (( $? == 0 )) && [ -n "$G_WHIP_RETURNED_VALUE" ]; then
+		G_WHIP_INPUTBOX 'Please enter your name. This will be used to identify the image creator within credits banner.\n\nYou can add your contanct information as well for end users.\n\nNB: An entry is required.'
+		if (( ! $? )) && [ -n "$G_WHIP_RETURNED_VALUE" ]; then
 
 			#Disallowed:
 			DISALLOWED_NAME=0
@@ -314,7 +314,7 @@
 
 			if (( $DISALLOWED_NAME )); then
 
-				G_WHIP_MSG "$G_WHIP_RETURNED_VALUE is reserved and cannot be used. Please try again."
+				G_WHIP_MSG "\"$G_WHIP_RETURNED_VALUE\" is reserved and cannot be used. Please try again."
 
 			else
 
@@ -331,16 +331,15 @@
 	while true
 	do
 
-		G_WHIP_INPUTBOX 'Please enter the name of the pre-image you installed on this system, prior to running this script. This will be used to identify the pre-image credits.\n\nEG: Debian, Raspbian Lite, Meveric, FriendlyARM, etc\n\nNB: An entry is required.'
-		if (( $? == 0 )) && [ -n "$G_WHIP_RETURNED_VALUE" ]; then
+		G_WHIP_INPUTBOX 'Please enter the name or URL of the pre-image you installed on this system, prior to running this script. This will be used to identify the pre-image credits.\n\nEG: Debian, Raspbian Lite, Meveric, FriendlyARM, or "forum.odroid.com/viewtopic.php?f=ABC&t=XYZ" etc.\n\nNB: An entry is required.'
+		if (( ! $? )) && [ -n "$G_WHIP_RETURNED_VALUE" ]; then
 
-			PREIMAGE_NAME="$G_WHIP_RETURNED_VALUE"
+			PREIMAGE_INFO="$G_WHIP_RETURNED_VALUE"
 			break
 
 		fi
 
 	done
-
 
 	#Hardware selection
 	G_WHIP_DEFAULT_ITEM=22
@@ -392,9 +391,9 @@
 	)
 
 	G_WHIP_MENU 'Please select the current device this is being installed on:\n - NB: Select "Generic device" if not listed.\n - "Core devices": Are fully supported by DietPi, offering full GPU + Kodi support.\n - "Limited support devices": No GPU support, supported limited to DietPi specific issues only (eg: excludes Kernel/GPU/VPU related items).'
-	if (( $? != 0 )) || [ -z "$G_WHIP_RETURNED_VALUE" ]; then
+	if (( $? )) || [ -z "$G_WHIP_RETURNED_VALUE" ]; then
 
-		G_DIETPI-NOTIFY 1 'No choices detected, aborting...'
+		G_DIETPI-NOTIFY 1 'No choices detected. Aborting...'
 		exit 0
 
 	fi
@@ -408,7 +407,7 @@
 	echo -e "$G_HW_MODEL" > /etc/.dietpi_hw_model_identifier
 
 	#WiFi selection
-	G_DIETPI-NOTIFY 2 "WiFi selection"
+	G_DIETPI-NOTIFY 2 'WiFi selection'
 
 	G_WHIP_DEFAULT_ITEM=1
 	G_WHIP_MENU_ARRAY=(
@@ -421,8 +420,7 @@
 	G_WHIP_MENU 'Please select an option:'
 	if (( $? == 0 && $G_WHIP_RETURNED_VALUE == 1 )); then
 
-		G_DIETPI-NOTIFY 2 "Marking WiFi as needed"
-
+		G_DIETPI-NOTIFY 2 'Marking WiFi as needed'
 		WIFI_REQUIRED=1
 
 	fi
@@ -474,9 +472,9 @@
 	fi
 
 	G_WHIP_MENU "Please select a distro to install on this system. Selecting a distro that is older than the current installed on system, is not supported.\n\nCurrently installed:\n - $G_DISTRO $G_DISTRO_NAME"
-	if (( $? != 0 )) || [ -z "$G_WHIP_RETURNED_VALUE" ]; then
+	if (( $? )) || [ -z "$G_WHIP_RETURNED_VALUE" ]; then
 
-		G_DIETPI-NOTIFY 1 'No choices detected, aborting...'
+		G_DIETPI-NOTIFY 1 'No choices detected. Aborting...'
 		exit 0
 
 	fi
@@ -498,14 +496,14 @@
 
 
 	#------------------------------------------------------------------------------------------------
-	echo -e ''
+	echo ''
 	G_DIETPI-NOTIFY 2 '-----------------------------------------------------------------------------------'
 	G_DIETPI-NOTIFY 0 "Step $SETUP_STEP: APT configuration:"
 	((SETUP_STEP++))
 	G_DIETPI-NOTIFY 2 '-----------------------------------------------------------------------------------'
 	#------------------------------------------------------------------------------------------------
 
-	G_DIETPI-NOTIFY 2 'Removing conflicting apt sources.list.d'
+	G_DIETPI-NOTIFY 2 'Removing conflicting /etc/apt/sources.list.d entries'
 	#	NB: Apt sources will get overwritten during 1st run, via boot script and dietpi.txt entry
 
 	#rm /etc/apt/sources.list.d/* &> /dev/null #Probably a bad idea
@@ -567,7 +565,7 @@ _EOF_
 	G_RUN_CMD apt-mark auto $(apt-mark showmanual)
 
 	# - @MichaIng https://github.com/Fourdee/DietPi/pull/1266/files
-	G_DIETPI-NOTIFY 2 'Temporary disable automatic recommends/suggests installation and allow them to be autoremoved:'
+	G_DIETPI-NOTIFY 2 'Disable automatic recommends/suggests installation and allow them to be autoremoved:'
 
 	#	Remove any existing apt recommends settings
 	rm /etc/apt/apt.conf.d/*recommends*
@@ -582,7 +580,7 @@ _EOF_
 	export G_ERROR_HANDLER_EXITCODE=$?
 	G_ERROR_HANDLER
 
-	G_DIETPI-NOTIFY 2 "Forcing use of modified apt configs"
+	G_DIETPI-NOTIFY 2 'Forcing use of modified package configs'
 
 	export G_ERROR_HANDLER_COMMAND='/etc/apt/apt.conf.d/99-dietpi-forceconf'
 	cat << _EOF_ > $G_ERROR_HANDLER_COMMAND
@@ -641,14 +639,25 @@ _EOF_
 
 	if (( $WIFI_REQUIRED )); then
 
-		aPACKAGES_REQUIRED_INSTALL+=('crda')					# WiFi related
-		aPACKAGES_REQUIRED_INSTALL+=('firmware-atheros')		# WiFi dongle firmware
-		aPACKAGES_REQUIRED_INSTALL+=('firmware-brcm80211')		# WiFi dongle firmware
-		aPACKAGES_REQUIRED_INSTALL+=('firmware-misc-nonfree')	# Intel/Nvidia/WiFi (ralink) dongle firmware: https://github.com/Fourdee/DietPi/issues/1675#issuecomment-377806609
-		aPACKAGES_REQUIRED_INSTALL+=('iw')						# WiFi related
-		aPACKAGES_REQUIRED_INSTALL+=('rfkill')	 				# WiFi related: Used by some onboard WiFi chipsets
-		aPACKAGES_REQUIRED_INSTALL+=('wireless-tools')			# WiFi related
-		aPACKAGES_REQUIRED_INSTALL+=('wpasupplicant')			# WiFi related
+		aPACKAGES_REQUIRED_INSTALL+=('crda')			# WiFi related
+		aPACKAGES_REQUIRED_INSTALL+=('firmware-atheros')	# WiFi dongle firmware
+		aPACKAGES_REQUIRED_INSTALL+=('firmware-brcm80211')	# WiFi dongle firmware
+		aPACKAGES_REQUIRED_INSTALL+=('iw')			# WiFi related
+		aPACKAGES_REQUIRED_INSTALL+=('rfkill')	 		# WiFi related: Used by some onboard WiFi chipsets
+		aPACKAGES_REQUIRED_INSTALL+=('wireless-tools')		# WiFi related
+		aPACKAGES_REQUIRED_INSTALL+=('wpasupplicant')		# WiFi related
+
+		# Intel/Nvidia/WiFi (ralink) dongle firmware: https://github.com/Fourdee/DietPi/issues/1675#issuecomment-377806609
+		# On Jessie, firmware-misc-nonfree is not available, firmware-ralink instead as dedicated package.
+		if (( $G_DISTRO < 4 )); then
+
+			aPACKAGES_REQUIRED_INSTALL+=('firmware-ralink')
+
+		else
+
+			aPACKAGES_REQUIRED_INSTALL+=('firmware-misc-nonfree')
+
+		fi
 
 	fi
 
@@ -693,7 +702,7 @@ _EOF_
 
 		G_AGI linux-image-amd64
 		# Usually no firmware should be necessary for VMs. If user manually passes though some USB device, he might need to install the firmware then.
-		(( $G_HW_MODEL != 20 )) && G_AGI firmware-linux-nonfree firmware-misc-nonfree
+		(( $G_HW_MODEL != 20 )) && G_AGI firmware-linux-nonfree
 
 		#	Grub EFI
 		if dpkg --get-selections | grep -q '^grub-efi-amd64' ||
@@ -722,13 +731,8 @@ _EOF_
 	#	Odroid N1
 	elif (( $G_HW_MODEL == 14 )); then
 
-		#G_AGI libdrm-rockchip1 #Not currently on meveric's repo
-		echo 0
-
-	#	Odroid N1
-	elif (( $G_HW_MODEL == 14 )); then
-
 		G_AGI linux-image-arm64-odroid-n1
+		#G_AGI libdrm-rockchip1 #Not currently on meveric's repo
 
 	#	Odroid C2
 	elif (( $G_HW_MODEL == 12 )); then
@@ -740,7 +744,7 @@ _EOF_
 
 		#G_AGI linux-image-4.9-armhf-odroid-xu3
 		G_AGI $(dpkg --get-selections | grep '^linux-image' | awk '{print $1}')
-		(( $(dpkg --get-selections | grep -ci -m1 '^linux-image') )) || G_AGI linux-image-4.14-armhf-odroid-xu4
+		dpkg --get-selections | grep -qi '^linux-image' || G_AGI linux-image-4.14-armhf-odroid-xu4
 
 	#	Odroid C1
 	elif (( $G_HW_MODEL == 10 )); then
@@ -833,26 +837,26 @@ _EOF_
 
 
 	#------------------------------------------------------------------------------------------------
-	echo -e ''
+	echo ''
 	G_DIETPI-NOTIFY 2 '-----------------------------------------------------------------------------------'
 	G_DIETPI-NOTIFY 0 "Step $SETUP_STEP: APT installations:"
 	((SETUP_STEP++))
 	G_DIETPI-NOTIFY 2 '-----------------------------------------------------------------------------------'
 	#------------------------------------------------------------------------------------------------
 
-	G_DIETPI-NOTIFY 2 "Upgrading existing APT installed packages:"
+	G_DIETPI-NOTIFY 2 'Upgrading existing APT installed packages:'
 
 	G_AGDUG
 
 	# - Distro is now target (for APT purposes and G_AGX support due to installed binary, its here, instead of after G_AGUP)
 	export G_DISTRO=$DISTRO_TARGET
-	export G_DISTRO_NAME=$DISTRO_TARGET_NAME
+	export G_DISTRO_NAME="$DISTRO_TARGET_NAME"
 
-	G_DIETPI-NOTIFY 2 "Installing core DietPi pre-req APT packages"
+	G_DIETPI-NOTIFY 2 'Installing core DietPi pre-req APT packages'
 
 	G_AGI $INSTALL_PACKAGES
 
-	G_DIETPI-NOTIFY 2 "Applying default DietPi configuration for APT"
+	G_DIETPI-NOTIFY 2 'Applying default DietPi configuration for APT'
 
 	export G_ERROR_HANDLER_COMMAND='/etc/apt/apt.conf.d/99-dietpi-norecommends'
 	cat << _EOF_ > $G_ERROR_HANDLER_COMMAND
@@ -864,7 +868,7 @@ _EOF_
 	export G_ERROR_HANDLER_EXITCODE=$?
 	G_ERROR_HANDLER
 
-	G_DIETPI-NOTIFY 2 "Purging APT with autoremoval (in case of DISTRO upgrade/downgrade):"
+	G_DIETPI-NOTIFY 2 'Purging APT with autoremoval (in case of DISTRO upgrade/downgrade):'
 
 	G_AGA
 
@@ -876,7 +880,7 @@ _EOF_
 	fi
 
 	#------------------------------------------------------------------------------------------------
-	echo -e ''
+	echo ''
 	G_DIETPI-NOTIFY 2 '-----------------------------------------------------------------------------------'
 	G_DIETPI-NOTIFY 0 "Step $SETUP_STEP: Downloading and installing DietPi sourcecode:"
 	((SETUP_STEP++))
@@ -889,13 +893,13 @@ _EOF_
 
 	G_RUN_CMD wget "$INTERNET_ADDRESS" -O package.zip
 
-	G_DIETPI-NOTIFY 2 "Extracting DietPi sourcecode"
+	G_DIETPI-NOTIFY 2 'Extracting DietPi sourcecode'
 
 	G_RUN_CMD unzip -o package.zip
 
 	rm package.zip
 
-	G_DIETPI-NOTIFY 2 "Removing files not required"
+	G_DIETPI-NOTIFY 2 'Removing files not required'
 
 	#	Remove files we do not require, or want to overwrite in /boot
 	rm DietPi-*/CHANGELOG.txt
@@ -903,11 +907,11 @@ _EOF_
 	rm DietPi-*/TESTING-BRANCH.md
 	rm DietPi-*/uEnv.txt # Pine 64, use existing on system.
 
-	G_DIETPI-NOTIFY 2 "Creating /boot"
+	G_DIETPI-NOTIFY 2 'Creating /boot'
 
 	G_RUN_CMD mkdir -p /boot
 
-	G_DIETPI-NOTIFY 2 "Moving to /boot"
+	G_DIETPI-NOTIFY 2 'Moving to /boot'
 
 	# - HW specific boot.ini uEnv.txt
 	if (( $G_HW_MODEL == 10 )); then
@@ -927,23 +931,23 @@ _EOF_
 
 	G_RUN_CMD cp -R DietPi-*/* /boot/
 
-	G_DIETPI-NOTIFY 2 "Cleaning up extracted files"
+	G_DIETPI-NOTIFY 2 'Cleaning up extracted files'
 
 	G_RUN_CMD rm -R DietPi-*
 
-	G_DIETPI-NOTIFY 2 "Setting execute permissions for /boot/dietpi"
+	G_DIETPI-NOTIFY 2 'Setting execute permissions for /boot/dietpi'
 
 	G_RUN_CMD chmod -R +x /boot/dietpi
 
 	#------------------------------------------------------------------------------------------------
-	echo -e ''
+	echo ''
 	G_DIETPI-NOTIFY 2 '-----------------------------------------------------------------------------------'
 	G_DIETPI-NOTIFY 0 "Step $SETUP_STEP: Prep system for DietPi ENV:"
 	((SETUP_STEP++))
 	G_DIETPI-NOTIFY 2 '-----------------------------------------------------------------------------------'
 	#------------------------------------------------------------------------------------------------
 
-	G_DIETPI-NOTIFY 2 "Deleting list of known users, not required by DietPi"
+	G_DIETPI-NOTIFY 2 'Deleting list of known users, not required by DietPi'
 
 	userdel -f pi &> /dev/null
 	userdel -f test &> /dev/null #armbian
@@ -953,7 +957,7 @@ _EOF_
 	userdel -f dietpi &> /dev/null
 	userdel -f debian &> /dev/null #BBB
 
-	G_DIETPI-NOTIFY 2 "Removing misc files/folders/services, not required by DietPi"
+	G_DIETPI-NOTIFY 2 'Removing misc files/folders/services, not required by DietPi'
 
 	rm -R /home &> /dev/null
 	rm -R /media &> /dev/null
@@ -1015,27 +1019,27 @@ _EOF_
 	# - make_nas_processes_faster cron job on Rock64 + NanoPi + Pine64(?) images
 	rm /etc/cron.d/make_nas_processes_faster &> /dev/null
 
-	G_DIETPI-NOTIFY 2 "Creating DietPi core environment"
+	G_DIETPI-NOTIFY 2 'Creating DietPi core environment'
 
 	G_RUN_CMD /boot/dietpi/func/dietpi-set_core_environment
 
-	echo -e "Samba client can be installed and setup by DietPi-Config.\nSimply run: dietpi-config and select the Networking option: NAS/Misc menu" > /mnt/samba/readme.txt
-	echo -e "FTP client mount can be installed and setup by DietPi-Config.\nSimply run: dietpi-config and select the Networking option: NAS/Misc menu" > /mnt/ftp_client/readme.txt
-	echo -e "NFS client can be installed and setup by DietPi-Config.\nSimply run: dietpi-config and select the Networking option: NAS/Misc menu" > /mnt/nfs_client/readme.txt
+	echo -e 'Samba client can be installed and setup by DietPi-Config.\nSimply run: dietpi-config and select the Networking option: NAS/Misc menu' > /mnt/samba/readme.txt
+	echo -e 'FTP client mount can be installed and setup by DietPi-Config.\nSimply run: dietpi-config and select the Networking option: NAS/Misc menu' > /mnt/ftp_client/readme.txt
+	echo -e 'NFS client can be installed and setup by DietPi-Config.\nSimply run: dietpi-config and select the Networking option: NAS/Misc menu' > /mnt/nfs_client/readme.txt
 
-	G_DIETPI-NOTIFY 2 "Deleting all log files /var/log"
+	G_DIETPI-NOTIFY 2 'Deleting all log files /var/log'
 
 	/boot/dietpi/dietpi-logclear 2 &> /dev/null # As this will report missing vars, however, its fine, does not break functionality.
 
-	G_DIETPI-NOTIFY 2 "Generating DietPi /etc/fstab"
+	G_DIETPI-NOTIFY 2 'Generating DietPi /etc/fstab'
 
 	G_RUN_CMD /boot/dietpi/dietpi-drive_manager 4
 
-	G_DIETPI-NOTIFY 2 "Starting DietPi-RAMdisk service"
+	G_DIETPI-NOTIFY 2 'Starting DietPi-RAMdisk service'
 
 	G_RUN_CMD systemctl start dietpi-ramdisk.service
 
-	G_DIETPI-NOTIFY 2 "Starting DietPi-RAMlog service"
+	G_DIETPI-NOTIFY 2 'Starting DietPi-RAMlog service'
 
 	G_RUN_CMD systemctl start dietpi-ramlog.service
 
@@ -1043,7 +1047,7 @@ _EOF_
 
 	/DietPi/dietpi/dietpi-obtain_hw_model
 
-	G_DIETPI-NOTIFY 2 "Configuring Network:"
+	G_DIETPI-NOTIFY 2 'Configuring Network:'
 
 	rm -R /etc/network/interfaces &> /dev/null # armbian symlink for bulky network-manager
 
@@ -1060,7 +1064,7 @@ _EOF_
 
 	fi
 
-	G_DIETPI-NOTIFY 2 "Tweaking DHCP timeout:"
+	G_DIETPI-NOTIFY 2 'Tweaking DHCP timeout:'
 
 	# - Reduce DHCP request retry count and timeouts: https://github.com/Fourdee/DietPi/issues/711
 	sed -i '/^#timeout /d' /etc/dhcp/dhclient.conf
@@ -1072,7 +1076,7 @@ timeout 10;
 retry 4;
 _EOF_
 
-	G_DIETPI-NOTIFY 2 "Configuring hosts:"
+	G_DIETPI-NOTIFY 2 'Configuring hosts:'
 
 	export G_ERROR_HANDLER_COMMAND='/etc/hosts'
 	cat << _EOF_ > $G_ERROR_HANDLER_COMMAND
@@ -1092,39 +1096,39 @@ _EOF_
 	export G_ERROR_HANDLER_EXITCODE=$?
 	G_ERROR_HANDLER
 
-	G_DIETPI-NOTIFY 2 "Configuring htop:"
+	G_DIETPI-NOTIFY 2 'Configuring htop:'
 
 	mkdir -p /root/.config/htop
 	cp /DietPi/dietpi/conf/htoprc /root/.config/htop/htoprc
 
-	G_DIETPI-NOTIFY 2 "Configuring fakehwclock:"
+	G_DIETPI-NOTIFY 2 'Configuring fakehwclock:'
 
 	# - allow times in the past
-	sed -i "/FORCE=/c\FORCE=force" /etc/default/fake-hwclock
+	sed -i '/FORCE=/c\FORCE=force' /etc/default/fake-hwclock
 
-	G_DIETPI-NOTIFY 2 "Configuring serial consoles:"
+	G_DIETPI-NOTIFY 2 'Configuring serial consoles:'
 
 	# - Disable serial console
 	/DietPi/dietpi/func/dietpi-set_hardware serialconsole disable
 
-	G_DIETPI-NOTIFY 2 "Reducing getty count and resource usage:"
+	G_DIETPI-NOTIFY 2 'Reducing getty count and resource usage:'
 
 	systemctl mask getty-static
 
-	G_DIETPI-NOTIFY 2 "Configuring ntpd:"
+	G_DIETPI-NOTIFY 2 'Configuring ntpd:'
 
 	systemctl disable systemd-timesyncd
 	rm /etc/init.d/ntp &> /dev/null
 	(( $G_DISTRO > 4 )) && systemctl mask ntp
 
-	G_DIETPI-NOTIFY 2 "Configuring regional settings (TZdata):"
+	G_DIETPI-NOTIFY 2 'Configuring regional settings (TZdata):'
 
 	rm /etc/timezone &> /dev/null
 	rm /etc/localtime
 	ln -fs /usr/share/zoneinfo/Europe/London /etc/localtime
 	G_RUN_CMD dpkg-reconfigure -f noninteractive tzdata
 
-	G_DIETPI-NOTIFY 2 "Configuring regional settings (Keyboard):"
+	G_DIETPI-NOTIFY 2 'Configuring regional settings (Keyboard):'
 
 	dpkg-reconfigure -f noninteractive keyboard-configuration #Keyboard must be plugged in for this to work!
 
@@ -1133,7 +1137,7 @@ _EOF_
 	#Runs at start of script
 
 	#G_HW_ARCH specific
-	G_DIETPI-NOTIFY 2 "Applying G_HW_ARCH specific tweaks:"
+	G_DIETPI-NOTIFY 2 'Applying G_HW_ARCH specific tweaks:'
 
 	if (( $G_HW_ARCH == 10 )); then
 
@@ -1149,17 +1153,17 @@ options nouveau modeset=0
 alias nouveau off
 alias lbm-nouveau off
 _EOF_
-		echo -e "options nouveau modeset=0" > /etc/modprobe.d/nouveau-kms.conf
+		echo 'options nouveau modeset=0' > /etc/modprobe.d/nouveau-kms.conf
 		update-initramfs -u
 
 	fi
 
 	#G_HW_MODEL specific
-	G_DIETPI-NOTIFY 2 "Appling G_HW_MODEL specific tweaks:"
+	G_DIETPI-NOTIFY 2 'Appling G_HW_MODEL specific tweaks:'
 
 	if (( $G_HW_MODEL != 20 )); then
 
-		G_DIETPI-NOTIFY 2 "Configuring hdparm:"
+		G_DIETPI-NOTIFY 2 'Configuring hdparm:'
 
 		sed -i '/#DietPi/,$d' /etc/hdparm.conf #Prevent dupes
 		export G_ERROR_HANDLER_COMMAND='/etc/hdparm.conf'
@@ -1182,7 +1186,7 @@ _EOF_
 	# - ARMbian OPi Zero 2: https://github.com/Fourdee/DietPi/issues/876#issuecomment-294350580
 	if (( $G_HW_MODEL == 35 )); then
 
-		echo -e "blacklist bmp085" > /etc/modprobe.d/bmp085.conf
+		echo 'blacklist bmp085' > /etc/modprobe.d/bmp085.conf
 
 	# - Sparky SBC ONLY:
 	elif (( $G_HW_MODEL == 70 )); then
@@ -1227,7 +1231,7 @@ blacklist bc_example
 _EOF_
 
 		#	Use performance gov for stability.
-		sed -i "/^CONFIG_CPU_GOVERNOR=/c\CONFIG_CPU_GOVERNOR=performance" /DietPi/dietpi.txt
+		sed -i '/^[[:blank:]]*CONFIG_CPU_GOVERNOR=/c\CONFIG_CPU_GOVERNOR=performance' /DietPi/dietpi.txt
 		/DietPi/dietpi/dietpi-cpu_set
 
 	# - RPI:
@@ -1278,7 +1282,7 @@ _EOF_
 
 
 	#------------------------------------------------------------------------------------------------
-	echo -e ''
+	echo ''
 	G_DIETPI-NOTIFY 2 '-----------------------------------------------------------------------------------'
 	G_DIETPI-NOTIFY 0 "Step $SETUP_STEP: Finalise system for first run of DietPi:"
 	((SETUP_STEP++))
@@ -1321,7 +1325,7 @@ _EOF_
 	fi
 
 	# - Set Pi cmdline.txt back to normal
-	[ -f /boot/cmdline.txt ] && sed -i "s/ rootdelay=10//g" /boot/cmdline.txt
+	[ -f /boot/cmdline.txt ] && sed -i 's/ rootdelay=10//g' /boot/cmdline.txt
 
 	G_DIETPI-NOTIFY 2 'Generating default wpa_supplicant.conf'
 
@@ -1383,7 +1387,7 @@ _EOF_
 
 	cat << _EOF_ > /DietPi/dietpi/.prep_info
 $IMAGE_CREATOR
-$PREIMAGE_NAME
+$PREIMAGE_INFO
 _EOF_
 
 	G_DIETPI-NOTIFY 2 'Remove server_version / patch_file (downloads fresh from dietpi-update)'
@@ -1539,11 +1543,20 @@ _EOF_
 
 	sync
 
+	G_DIETPI-NOTIFY 2 "The used kernel version is: $(uname -r)"
+	kernel_apt_packages="$(dpkg --get-selections | grep '^linux-image-[0-9]')"
+	if [ -n "$kernel_apt_packages" ]; then
+
+		G_DIETPI-NOTIFY 2 'The following kernel APT packages have been found, please purge the outdated ones:'
+		echo "$kernel_apt_packages"
+
+	fi
+	
 	G_DIETPI-NOTIFY 2 'Please check and delete all non-required folders in /root/.xxxxxx'
-	G_DIETPI-NOTIFY 2 'Please delete outdated modules'
+	G_DIETPI-NOTIFY 2 'Please delete outdated non-APT kernel modules:'
 	ls -lha /lib/modules
 
-	G_DIETPI-NOTIFY 0 "Completed, disk can now be saved to .img for later use, or, reboot system to start first run of DietPi:"
+	G_DIETPI-NOTIFY 0 'Completed, disk can now be saved to .img for later use, or, reboot system to start first run of DietPi:'
 
 	# - Remove PREP files
 	rm dietpi-globals

--- a/dietpi/dietpi-banner
+++ b/dietpi/dietpi-banner
@@ -153,7 +153,7 @@
 
 		fi
 
-		echo -e "\e[90m Web                : http://DietPi.com | http://twitter.com/dietpi_\e[0m"
+		echo -e "\e[90m Web                : http://DietPi.com | https://twitter.com/dietpi_\e[0m"
 		echo -e "\e[90m Donate             : http://goo.gl/pzISt9 \e[0m"
 
 		if [ -n "$IMAGE_ADDITIONAL_CREDITS" ]; then


### PR DESCRIPTION
+ DietPi-PREP | Suggest adding contact/URL to image creator/pre-image info: https://github.com/Fourdee/DietPi/issues/1621
+ DietPi-PREP | Resolve "firmware-misc-nonfree" not being available on Jessie, but "firmware-ralink" instead, as well as "firmware-misc-nonfree" being dependency of "firmware-linux-nonfree" on Stretch and above
+ DietPi-PREP | Suggest purging outdated kernel APT packages, as they are protected from autoremove in most cases
+ DietPi-PREP | Minor code and text improvements