### PR TITLE
DietPi-Software | Some locale handling improvements, based issue I faced

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -14532,7 +14532,8 @@ _EOF_
 			fi
 
 			#Apply Language (Locale)
-			if ! locale | grep -qE "(LANG|LC_ALL)=[\'\"]?$AUTOINSTALL_LANGUAGE[\'\"]?"; then
+			if ! locale | grep -qE "(LANG|LC_ALL)=[\'\"]?$AUTOINSTALL_LANGUAGE[\'\"]?" ||
+				! locale -a | grep -q 'en_GB.UTF-8'; then
 
 				G_DIETPI-NOTIFY 2 "Setting Locale $AUTOINSTALL_LANGUAGE. Please wait"
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -14521,7 +14521,7 @@ _EOF_
 			fi
 
 			#Apply Timezone
-			if [ "$AUTOINSTALL_TIMEZONE" != "Europe/London" ]; then
+			if [ "$AUTOINSTALL_TIMEZONE" != "$(cat /etc/timezone)" ]; then
 
 				echo -e "\nDietPi: Setting Timezone = $AUTOINSTALL_TIMEZONE"
 				rm /etc/timezone
@@ -14532,12 +14532,12 @@ _EOF_
 			fi
 
 			#Apply Language (Locale)
-			if [ "$AUTOINSTALL_LANGUAGE" != 'en_GB.UTF-8' ]; then
+			if ! locale | grep -qE "(LANG|LC_ALL)=[\'\"]?$AUTOINSTALL_LANGUAGE[\'\"]?"; then
 
 				G_DIETPI-NOTIFY 2 "Setting Locale $AUTOINSTALL_LANGUAGE. Please wait"
 
-				#	Sanity, No result, revert back to default
-				if [ -z "$AUTOINSTALL_LANGUAGE" ]; then
+				#	Sanity, wrong result, revert back to default
+				if [[ ! "$AUTOINSTALL_LANGUAGE" =~ 'UTF-8' ]]; then
 
 					AUTOINSTALL_LANGUAGE='en_GB.UTF-8'
 
@@ -14549,7 +14549,7 @@ _EOF_
 			fi
 
 			#Apply Keyboard
-			if [ "$AUTOINSTALL_KEYBOARD" != 'gb' ]; then
+			if ! grep -q "XKBLAYOUT=\"$AUTOINSTALL_KEYBOARD\"" /etc/default/keyboard; then
 
 				G_DIETPI-NOTIFY 2 "Setting Keyboard $AUTOINSTALL_KEYBOARD. Please wait...\n"
 				sed -i '/XKBLAYOUT=/c XKBLAYOUT="'"$AUTOINSTALL_KEYBOARD"'"' /etc/default/keyboard

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -63,7 +63,7 @@ $FP_SCRIPT			verify_dietpi.txt		verifies dietpi.txt entries, adds missing entrie
 	#/////////////////////////////////////////////////////////////////////////////////////
 	Locale_Main(){
 
-		if [ -n "$INPUT_MODE_VALUE" ]; then
+		if [[ "$INPUT_MODE_VALUE" =~ 'UTF-8' ]]; then
 
 			cat << _EOF_ > /etc/locale.gen
 $INPUT_MODE_VALUE UTF-8
@@ -82,15 +82,15 @@ _EOF_
 
 			G_RUN_CMD dpkg-reconfigure -f noninteractive locales
 
+			# - Reassign locale, as in case of error (wrong locale variables) update-locale command will produce ugly errors.
+			export LANG=en_GB.UTF8
+			export LC_ALL=en_GB.UTF8
+
 			# - Update /etc/default/locales with new values (not effective until next load of bash session, eg: logout/in)
 			update-locale LANG="$INPUT_MODE_VALUE"
 			update-locale LC_CTYPE="$INPUT_MODE_VALUE"
 			update-locale LC_TIME="$INPUT_MODE_VALUE"
 			update-locale LC_ALL="$INPUT_MODE_VALUE"
-
-			# - Failsafe, reset script to en_GB
-			export LANG=en_GB.UTF8
-			export LC_ALL=en_GB.UTF8
 
 			sed -i "/AUTO_SETUP_LOCALE=/c\AUTO_SETUP_LOCALE=$INPUT_MODE_VALUE" /DietPi/dietpi.txt
 


### PR DESCRIPTION
On fresh DietPi image, I switched from within first run dietpi-software to dietpi-config and changed NTP settings there, which triggered non-interactive dietpi-software execution. The non-interactive dietpi-software declares `AUTORUN_LANGUAGE=0` etc. variables, but does not read dietpi.txt for the actual chosen values. It then accordingly executes `dietpi-set_software locale 0 `, as the value "0" passes the [ -z ] checks, leading to invalid locales.
It is possible to rerun dietpi-config and reset the locales, but `update-locale` executions will produce ugly errors and reboot (relog) is needed.
- Actually there could/should be done some deeper fix by times, as this also effects keyboard and timezone, I made just last resort prevention here 🤔. I think dietpi-software should simply deny non-interactive execution on 1st run. All the automation is done twice, when doing related dietpi-config adjustments.

Another point, I accidentally uploaded VM image with de keyboard layout set. But dietpi-software on first run just applies dietpi.txt value, if not gb is chosen, assuming that the image definitely comes with gb layout. I switched to comparing actual system values with dietpi.txt chosen ones, to assure adjustments are done in every case.

+ DietPi-Automation | Apply 1st run timezone, locale and keyboard layout, if actual system values differ.
+ DietPi-Automation | Check for "UTF-8" to validate locale string, as initiated variable "0" passes "-z" check.
+ DietPi-Set_Software | Locales: Validate input value more carefully
+ DietPi-Set_Software | Locales: Reassign locale variables before executing update-locale to prevent error messages, if locales got messed up before.