### PR TITLE
DietPi-Software | Pi-hole: Enable support for FTLDNS

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ v6.8
 Changes / Improvements / Optimizations:
 DietPi-Software | AmiBerry (Amiga Emulator): Updated to v2.19, contains bug fixes and improvements: https://github.com/Fourdee/DietPi/issues/1707#issue-314377609
 DietPi-Software | Readymedia (MiniDLNA): Remove ALSA pre-req as it is not required. Many thanks to @bokiroki: https://github.com/Fourdee/DietPi/issues/1712
+DietPi-Software | Pi-hole: Enabled support for FTLDNS: https://github.com/Fourdee/DietPi/issues/1696
 PREP | G_HW_MODEL: Added for 'OrangePi PC Plus'. Many thanks to @SuBLiNeR: https://github.com/Fourdee/DietPi/pull/1704
 
 Bug Fixes:

--- a/dietpi/dietpi-logclear
+++ b/dietpi/dietpi-logclear
@@ -24,21 +24,17 @@
 	#Import DietPi-Globals ---------------------------------------------------------------
 
 	INPUT=-1
-	if G_CHECK_VALIDINT $1; then
-
-		INPUT=$1
-
-	fi
+	G_CHECK_VALIDINT $1 && INPUT=$1
 
 	#////////////////////////////////////////////////////////////////
 	# Global
 	#////////////////////////////////////////////////////////////////
-	TEMP_FILE="/tmp/dietpi-logclear"
+	TEMP_FILE='/tmp/dietpi-logclear'
 
-	FILEPATH_LOGFOLDER="/var/log"
+	FILEPATH_LOGFOLDER='/var/log'
 	FILEPATH_BACKUPFOLDER="$HOME/logfile_storage"
 
-	FILE_NAME=""
+	FILE_NAME=''
 	#0=text log, 1=compressed
 	FILE_TYPE=0
 	FILESIZE_BYTES=0
@@ -47,7 +43,7 @@
 	#////////////////////////////////////////////////////////////////
 	#Excluded log files (user created)
 	#////////////////////////////////////////////////////////////////
-	FP_EXCLUDED_LOGFILES="/DietPi/dietpi/.dietpi-logclear_exclude"
+	FP_EXCLUDED_LOGFILES='/DietPi/dietpi/.dietpi-logclear_exclude'
 	INFO_EXCLUDED_LOGFILES=0
 
 	#////////////////////////////////////////////////////////////////
@@ -85,13 +81,13 @@
 
 			#Special Filetypes
 			#PiHole logs (contains dns stats) | FILE_TYPE 2
-			if [ "${ARRAY_LOG_FILEPATH[$i]}" = "/var/log/pihole.log" ]; then
+			if [ "${ARRAY_LOG_FILEPATH[$i]}" = '/var/log/pihole.log' ]; then
 
 				FILE_TYPE=2
 
 			#Compessed files (zip etc) | FILE_TYPE 1
-			elif [[ ${FILE_NAME: -4} == ".zip" ]] ||
-				[[ ${FILE_NAME: -3} == ".gz" ]]; then
+			elif [[ ${FILE_NAME: -4} == '.zip' ]] ||
+				[[ ${FILE_NAME: -3} == '.gz' ]]; then
 
 				FILE_TYPE=1
 
@@ -112,16 +108,15 @@
 
 					#Find all non-matching lines with todays date
 					#	 NB: day is space padded without trailling 0 (eg: Sep  1, Sep 11)
-					#	 NB: Force english dates to match english dates that dnsmasq always logs with: https://github.com/Fourdee/DietPi/issues/233#issuecomment-196407135
-					local month_day_today=$(LC_ALL=en_GB.UTF-8 date +'%b %e')
+					local month_day_today="$(date +'%b %e')"
 
 					# - Check for at least 1 non-matching line before applying. Remove all lines in logfile for all other days, excluding today.
-					if (( $(grep -v -ci -m1 "$month_day_today" /var/log/pihole.log) == 1 )); then
+					if grep -vqi "$month_day_today" /var/log/pihole.log; then
 
 						#	RAMlog mode 2:
 						if (( $INPUT == 0 )); then
 
-							cat "${ARRAY_LOG_FILEPATH[$i]}" | sed '/'"$month_day_today"'/d' >> "$FILEPATH_BACKUPFOLDER"/"$FILE_NAME"
+							cat "${ARRAY_LOG_FILEPATH[$i]}" | sed "/$month_day_today/d" >> "$FILEPATH_BACKUPFOLDER/$FILE_NAME"
 							((INFO_BACKUPS_MADE++))
 
 						fi
@@ -144,12 +139,12 @@
 						#	RAMlog mode 2:
 						if (( $INPUT == 0 )); then
 
-							cat "${ARRAY_LOG_FILEPATH[$i]}" >> "$FILEPATH_BACKUPFOLDER"/"$FILE_NAME"
+							cat "${ARRAY_LOG_FILEPATH[$i]}" >> "$FILEPATH_BACKUPFOLDER/$FILE_NAME"
 							((INFO_BACKUPS_MADE++))
 
 						fi
 
-						echo -e "" > "${ARRAY_LOG_FILEPATH[$i]}"
+						> "${ARRAY_LOG_FILEPATH[$i]}"
 						((INFO_LOGS_CLEARED++))
 
 						pihole_restart_required=1
@@ -166,9 +161,12 @@
 
 						G_DIETPI-NOTIFY 2 'PiHole logs have been changed, restarting, please wait...'
 						systemctl stop pihole-FTL
-						systemctl stop dnsmasq
+						# Handle dnsmasq only, if enabled (+installed), otherwise assume FTLDNS, which would be broken by dnsmasq start: https://github.com/Fourdee/DietPi/issues/1696
+						systemctl is-enabled dnsmasq 2> /dev/null | grep -q '^enabled$' && systemctl stop dnsmasq
+						systemctl stop resolvconf
 						sleep 1
-						systemctl start dnsmasq
+						systemctl start resolvconf
+						systemctl is-enabled dnsmasq 2> /dev/null | grep -q '^enabled$' && systemctl start dnsmasq
 						systemctl start pihole-FTL
 
 						#	Reapply DietPi-Process_Tool
@@ -201,13 +199,13 @@
 					((INFO_BACKUPS_MADE++))
 
 					#Clear logfile contents
-					echo -e "" > "${ARRAY_LOG_FILEPATH[$i]}"
+					> "${ARRAY_LOG_FILEPATH[$i]}"
 					((INFO_LOGS_CLEARED++))
 
 				#Clear logfile contents
 				elif (( $INPUT == 1 )); then
 
-					echo -e "" > "${ARRAY_LOG_FILEPATH[$i]}"
+					> "${ARRAY_LOG_FILEPATH[$i]}"
 					((INFO_LOGS_CLEARED++))
 
 				#Hard delete log files
@@ -244,16 +242,16 @@
 	if (( $INPUT == -1 )); then
 
 		G_DIETPI-NOTIFY 2 'Available commands:'
-		echo -e ""
-		echo -e "\e[1m dietpi-logclear 0\e[0m"
+		echo ''
+		echo -e '\e[1m dietpi-logclear 0\e[0m'
 		echo -e "\e[38;5;244m Backup contents of all log files from $FILEPATH_LOGFOLDER to $FILEPATH_BACKUPFOLDER/*.\n Also clears the contents of all logs files in $FILEPATH_LOGFOLDER.\e[0m"
-		echo -e ""
-		echo -e "\e[1m dietpi-logclear 1\e[0m"
+		echo ''
+		echo -e '\e[1m dietpi-logclear 1\e[0m'
 		echo -e "\e[38;5;244m Clear contents of all logs files in $FILEPATH_LOGFOLDER.\e[0m"
-		echo -e ""
-		echo -e "\e[1m dietpi-logclear 2\e[0m"
+		echo ''
+		echo -e '\e[1m dietpi-logclear 2\e[0m'
 		echo -e "\e[38;5;244m Physically delete all files in $FILEPATH_LOGFOLDER and backups in $FILEPATH_BACKUPFOLDER/*.\n May prevent log files from being updated, restart services or reboot. \e[0m"
-		echo -e ""
+		echo ''
 
 	#----------------------------------------------------------------
 	#Process log files
@@ -294,14 +292,14 @@
 		#Backups
 		if (( $INPUT == 0 )); then
 
-			echo -e ""
-			echo -e " \e[38;5;244mBackup Info:\e[0m"
+			echo ''
+			echo -e ' \e[38;5;244mBackup Info:\e[0m'
 			echo -e " - Backup directory        \e[90m|\e[0m $FILEPATH_BACKUPFOLDER"
 			echo -e " - Updated log files       \e[90m|\e[0m $INFO_BACKUPS_MADE"
 
 		fi
 
-		echo -e ""
+		echo ''
 
 	fi
 

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -157,7 +157,7 @@
 		# - Network
 		'noip2'
 		'virtualhere'
-		'pihole-FTL'
+		#'pihole-FTL' #: https://github.com/Fourdee/DietPi/issues/1696
 		'hostapd'
 
 		# - System stats
@@ -182,6 +182,7 @@
 
 		# - Misc
 		aSERVICE_NAME+=('dnsmasq') 					#: https://github.com/Fourdee/DietPi/issues/1501
+		aSERVICE_NAME+=('pihole-FTL')					#: https://github.com/Fourdee/DietPi/issues/1696
 		aSERVICE_NAME+=('openvpn') 					#: https://github.com/Fourdee/DietPi/issues/1501
 		aSERVICE_NAME+=('vncserver') 				#: DietPi vnc server service/script
 		aSERVICE_NAME+=('amiberry') 				#: DietPi AmiBerry run service
@@ -235,7 +236,7 @@
 				aSERVICE_AVAILABLE[$i]=1
 
 			# - Check dpkg for matching packages.
-			elif (( $(grep -ci -m1 "^${aSERVICE_NAME[$i]}$" "$FP_TEMP") )); then
+			elif grep -qi "^${aSERVICE_NAME[$i]}$" "$FP_TEMP"; then
 
 				aSERVICE_AVAILABLE[$i]=1
 
@@ -309,6 +310,7 @@
 			'lighttpd'
 			'php5-fpm'
 			'php7.0-fpm'
+			'php7.2-fpm'
 			'mysql'
 			'avahi-daemon'
 		)
@@ -338,7 +340,7 @@
 
 		#Linux: installed services
 		# - STOP: Reverse service order
-		if [ "$target_state" = "stop" ]; then
+		if [ "$target_state" = 'stop' ]; then
 
 			for ((i=$(( ${#aSERVICE_NAME[@]} - 1 )); i>=0; i--))
 			do
@@ -376,8 +378,8 @@
 		fi
 
 		#Apply process tool settings
-		if [ "$target_state" = "start" ] ||
-			[ "$target_state" = "restart" ]; then
+		if [ "$target_state" = 'start' ] ||
+			[ "$target_state" = 'restart' ]; then
 
 			/DietPi/dietpi/dietpi-process_tool 1
 
@@ -535,7 +537,7 @@
 			if [ -n "$INPUT_S2" ]; then
 
 				systemctl $INPUT_MODE $INPUT_S2 &> /dev/null
-				if (( $? == 0 )); then
+				if (( ! $? )); then
 
 					G_DIETPI-NOTIFY 0 "$INPUT_MODE $INPUT_S2"
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -630,6 +630,9 @@ _EOF_
 			#	AmiBerry 2.19: https://github.com/Fourdee/DietPi/issues/1707
 			/DietPi/dietpi/dietpi-software reinstall 108
 			#-------------------------------------------------------------------------------
+			#	Pi-hole: Enable FTLDNS support by removing pihole-FTL from DietPi control: https://github.com/Fourdee/DietPi/pull/1714
+			systemctl enable pihole-FTL 2> /dev/null
+			#-------------------------------------------------------------------------------
 
 		fi
 


### PR DESCRIPTION
https://github.com/Fourdee/DietPi/issues/1696
+ DietPi-Services | Remove pihole-FTL from DietPi control, to enable support for integrated dnsmasq (FTLDNS).
+ DietPi-Services | Minor code enhancements
+ DietPi-Logclear | Pi-hole: Restart dnsmasq only, if enabled, otherwise assume FTLDNS, which conflicts dnsmasq
+ DietPi-Logclear | Minor code enhencements
+ DietPi-Patchfile | Pi-hole: Enable "pihole-FTL", which is removed from DietPi-Services control