### PR TITLE
DietPi-Set_Hardware | Install allo Piano firmware on demand

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,7 +9,7 @@ DietPi-Config | Native PC > Soundcard: 'firmware-intel-sound' is now installed a
 DietPi-Software | AmiBerry (Amiga Emulator): Updated to v2.19, contains bug fixes and improvements: https://github.com/Fourdee/DietPi/issues/1707#issue-314377609
 DietPi-Software | Readymedia (MiniDLNA): Remove ALSA pre-req as it is not required. Many thanks to @bokiroki: https://github.com/Fourdee/DietPi/issues/1712
 DietPi-Software | Pi-hole: Enabled support for FTLDNS: https://github.com/Fourdee/DietPi/issues/1696
-DietPi-Software | Allo: Piano allo firmware is now installed on demand and will be removed on update, if allo web ui is not installed: https://github.com/Fourdee/DietPi/issues/1656
+DietPi-Set_Hardware | Allo Piano firmware is now installed on demand and will be removed on update, if not chosen as soundcard: https://github.com/Fourdee/DietPi/issues/1656
 PREP | G_HW_MODEL: Added for 'OrangePi PC Plus'. Many thanks to @SuBLiNeR: https://github.com/Fourdee/DietPi/pull/1704
 
 Bug Fixes:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ Changes / Improvements / Optimizations:
 DietPi-Software | AmiBerry (Amiga Emulator): Updated to v2.19, contains bug fixes and improvements: https://github.com/Fourdee/DietPi/issues/1707#issue-314377609
 DietPi-Software | Readymedia (MiniDLNA): Remove ALSA pre-req as it is not required. Many thanks to @bokiroki: https://github.com/Fourdee/DietPi/issues/1712
 DietPi-Software | Pi-hole: Enabled support for FTLDNS: https://github.com/Fourdee/DietPi/issues/1696
+DietPi-Software | Allo: Piano allo firmware is now installed on demand and will be removed on update, if allo web ui is not installed: https://github.com/Fourdee/DietPi/issues/1656
 PREP | G_HW_MODEL: Added for 'OrangePi PC Plus'. Many thanks to @SuBLiNeR: https://github.com/Fourdee/DietPi/pull/1704
 
 Bug Fixes:

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -1201,11 +1201,6 @@ _EOF_
 		G_RUN_CMD wget https://raw.githubusercontent.com/sparky-sbc/sparky-test/master/dsd-marantz/snd-usb-audio.ko -O /lib/modules/3.10.38/kernel/sound/usb/snd-usb-audio.ko
 		G_RUN_CMD wget https://raw.githubusercontent.com/sparky-sbc/sparky-test/master/dsd-marantz/snd-usbmidi-lib.ko -O /lib/modules/3.10.38/kernel/sound/usb/snd-usbmidi-lib.ko
 
-		#	Firmware
-		G_RUN_CMD wget https://raw.githubusercontent.com/sparky-sbc/sparky-test/master/piano-firmware/piano-firmware.tar
-		tar -xvf piano-firmware.tar -C /lib/
-		rm piano-firmware.tar
-
 		cat << _EOF_ > /DietPi/uEnv.txt
 uenvcmd=setenv os_type linux;
 bootargs=earlyprintk clk_ignore_unused selinux=0 scandelay console=tty0 loglevel=1 real_rootflag=rw root=/dev/mmcblk0p2 rootwait init=/lib/systemd/systemd aotg.urb_fix=1 aotg.aotg1_speed=0
@@ -1236,13 +1231,6 @@ _EOF_
 
 	# - RPI:
 	elif (( $G_HW_MODEL < 10 )); then
-
-		# - RPI Piano allo firmware:
-		G_RUN_CMD wget https://github.com/allocom/piano-firmware/archive/master.zip -O package.zip
-		unzip -o package.zip
-		rm package.zip
-		cp -R piano-firmware-master/lib/firmware/allo /lib/firmware/
-		rm -R piano-firmware-master
 
 		# - Scroll lock fix for RPi by Midwan: https://github.com/Fourdee/DietPi/issues/474#issuecomment-243215674
 		cat << _EOF_ > /etc/udev/rules.d/50-leds.rules

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6624,7 +6624,7 @@ _EOF_
 
 			Banner_Installing
 
-			# - RPi Piano allo firmware:
+			# - RPi Piano allo firmware
 			if (( $G_HW_MODEL < 10 )); then
 
 				INSTALL_URL_ADDRESS='https://github.com/allocom/piano-firmware/archive/master.zip'
@@ -6634,6 +6634,14 @@ _EOF_
 				rm package.zip
 				cp -R piano-firmware-master/lib/firmware/allo /lib/firmware/
 				rm -R piano-firmware-master
+
+			# - Sparky Piano allo firmware
+			elif (( $G_HW_MODEL == 70 )); then
+
+				INSTALL_URL_ADDRESS='https://raw.githubusercontent.com/sparky-sbc/sparky-test/master/piano-firmware/piano-firmware.tar'
+				G_CHECK_URL "$INSTALL_URL_ADDRESS"
+				tar -xvf piano-firmware.tar -C /lib/
+				rm piano-firmware.tar
 
 			fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -14016,7 +14016,6 @@ _EOF_
 
 			Banner_Uninstalling
 			rm -R /var/www/allo
-			rm -R /lib/firmware/allo &> /dev/null
 			systemctl start mysql
 			mysqladmin drop allo_db -f
 			mysql -e "drop user allo_db@localhost"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6624,6 +6624,20 @@ _EOF_
 
 			Banner_Installing
 
+			# - RPi Piano allo firmware:
+			if (( $G_HW_MODEL < 10 )); then
+
+				INSTALL_URL_ADDRESS='https://github.com/allocom/piano-firmware/archive/master.zip'
+				G_CHECK_URL "$INSTALL_URL_ADDRESS"
+				wget "$INSTALL_URL_ADDRESS" -O package.zip
+				unzip -o package.zip
+				rm package.zip
+				cp -R piano-firmware-master/lib/firmware/allo /lib/firmware/
+				rm -R piano-firmware-master
+
+			fi
+
+			# - Web interface
 			INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/allo_web_interface_v6.7z'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
@@ -14016,6 +14030,7 @@ _EOF_
 
 			Banner_Uninstalling
 			rm -R /var/www/allo
+			rm -R /lib/firmware/allo &> /dev/null
 			systemctl start mysql
 			mysqladmin drop allo_db -f
 			mysql -e "drop user allo_db@localhost"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6624,28 +6624,6 @@ _EOF_
 
 			Banner_Installing
 
-			# - RPi Piano allo firmware
-			if (( $G_HW_MODEL < 10 )); then
-
-				INSTALL_URL_ADDRESS='https://github.com/allocom/piano-firmware/archive/master.zip'
-				G_CHECK_URL "$INSTALL_URL_ADDRESS"
-				wget "$INSTALL_URL_ADDRESS" -O package.zip
-				unzip -o package.zip
-				rm package.zip
-				cp -R piano-firmware-master/lib/firmware/allo /lib/firmware/
-				rm -R piano-firmware-master
-
-			# - Sparky Piano allo firmware
-			elif (( $G_HW_MODEL == 70 )); then
-
-				INSTALL_URL_ADDRESS='https://raw.githubusercontent.com/sparky-sbc/sparky-test/master/piano-firmware/piano-firmware.tar'
-				G_CHECK_URL "$INSTALL_URL_ADDRESS"
-				tar -xvf piano-firmware.tar -C /lib/
-				rm piano-firmware.tar
-
-			fi
-
-			# - Web interface
 			INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/allo_web_interface_v6.7z'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -1927,27 +1927,34 @@ _EOF_
 			#	snd-soc-allo-piano-dac-plus (2.1)
 			*allo-piano-dac*)
 
-				# - enable dtoverlay
-				echo -e "\ndtoverlay=$INPUT_DEVICE_VALUE" >> "$FP_RPI_CONFIG"
-
-				# - RPi Piano allo firmware
+				# - RPi
 				if (( $G_HW_MODEL < 10 )); then
 
-					INSTALL_URL_ADDRESS='https://github.com/allocom/piano-firmware/archive/master.zip'
-					G_CHECK_URL "$INSTALL_URL_ADDRESS"
-					wget "$INSTALL_URL_ADDRESS" -O package.zip
-					unzip -o package.zip
-					rm package.zip
-					cp -R piano-firmware-master/lib/firmware/allo /lib/firmware/
-					rm -R piano-firmware-master
+					if [ ! -d /lib/firmware/allo ]; then
 
-				# - Sparky Piano allo firmware
+						INSTALL_URL_ADDRESS='https://github.com/allocom/piano-firmware/archive/master.zip'
+						G_CHECK_URL "$INSTALL_URL_ADDRESS"
+						wget "$INSTALL_URL_ADDRESS" -O package.zip
+						unzip -o package.zip
+						rm package.zip
+						cp -R piano-firmware-master/lib/firmware/allo /lib/firmware/
+						rm -R piano-firmware-master
+
+					fi
+
+					echo -e "\ndtoverlay=$INPUT_DEVICE_VALUE" >> "$FP_RPI_CONFIG"
+
+				# - Sparky
 				elif (( $G_HW_MODEL == 70 )); then
 
-					INSTALL_URL_ADDRESS='https://raw.githubusercontent.com/sparky-sbc/sparky-test/master/piano-firmware/piano-firmware.tar'
-					G_CHECK_URL "$INSTALL_URL_ADDRESS"
-					tar -xvf piano-firmware.tar -C /lib/
-					rm piano-firmware.tar
+					if [ ! -d /lib/firmware/allo ]; then
+
+						INSTALL_URL_ADDRESS='https://raw.githubusercontent.com/sparky-sbc/sparky-test/master/piano-firmware/piano-firmware.tar'
+						G_CHECK_URL "$INSTALL_URL_ADDRESS"
+						tar -xvf piano-firmware.tar -C /lib/
+						rm piano-firmware.tar
+
+					fi
 
 					echo -e "$INPUT_DEVICE_VALUE" >> /etc/modules
 					SOUNDCARD_TARGET_CARD=1

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -1930,8 +1930,24 @@ _EOF_
 				# - enable dtoverlay
 				echo -e "\ndtoverlay=$INPUT_DEVICE_VALUE" >> "$FP_RPI_CONFIG"
 
-				# + Sparky SBC
-				if (( $G_HW_MODEL == 70 )); then
+				# - RPi Piano allo firmware
+				if (( $G_HW_MODEL < 10 )); then
+
+					INSTALL_URL_ADDRESS='https://github.com/allocom/piano-firmware/archive/master.zip'
+					G_CHECK_URL "$INSTALL_URL_ADDRESS"
+					wget "$INSTALL_URL_ADDRESS" -O package.zip
+					unzip -o package.zip
+					rm package.zip
+					cp -R piano-firmware-master/lib/firmware/allo /lib/firmware/
+					rm -R piano-firmware-master
+
+				# - Sparky Piano allo firmware
+				elif (( $G_HW_MODEL == 70 )); then
+
+					INSTALL_URL_ADDRESS='https://raw.githubusercontent.com/sparky-sbc/sparky-test/master/piano-firmware/piano-firmware.tar'
+					G_CHECK_URL "$INSTALL_URL_ADDRESS"
+					tar -xvf piano-firmware.tar -C /lib/
+					rm piano-firmware.tar
 
 					echo -e "$INPUT_DEVICE_VALUE" >> /etc/modules
 					SOUNDCARD_TARGET_CARD=1

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -124,7 +124,7 @@
 			#locale rework/reset: https://github.com/Fourdee/DietPi/issues/1430#issuecomment-364763302
 			rm /etc/profile.d/99-dietpi-force-locale.sh &> /dev/null
 			mv /etc/environment /mnt/dietpi_userdata/environment.bak &> /dev/null
-			echo '' > /etc/environment
+			> /etc/environment
 
 			/DietPi/dietpi/func/dietpi-set_software locale en_GB.UTF-8
 
@@ -512,22 +512,6 @@ _EOF_
 				G_RUN_CMD wget https://raw.githubusercontent.com/sparky-sbc/sparky-test/master/dsd-marantz/snd-usb-audio.ko -O /lib/modules/3.10.38/kernel/sound/usb/snd-usb-audio.ko
 				G_RUN_CMD wget https://raw.githubusercontent.com/sparky-sbc/sparky-test/master/dsd-marantz/snd-usbmidi-lib.ko -O /lib/modules/3.10.38/kernel/sound/usb/snd-usbmidi-lib.ko
 
-				#	Firmware
-				G_RUN_CMD wget https://raw.githubusercontent.com/sparky-sbc/sparky-test/master/piano-firmware/piano-firmware.tar
-				tar -xvf piano-firmware.tar -C /lib/
-				rm piano-firmware.tar
-
-			fi
-			#-------------------------------------------------------------------------------
-			#RPI Piano allo firmware:
-			if (( $G_HW_MODEL < 10 )); then
-
-				G_RUN_CMD wget https://github.com/allocom/piano-firmware/archive/master.zip -O package.zip
-				unzip -o package.zip
-				rm package.zip
-				cp -R piano-firmware-master/lib/firmware/allo /lib/firmware/
-				rm -R piano-firmware-master
-
 			fi
 			#-------------------------------------------------------------------------------
 
@@ -630,9 +614,12 @@ _EOF_
 			#	AmiBerry 2.19: https://github.com/Fourdee/DietPi/issues/1707
 			/DietPi/dietpi/dietpi-software reinstall 108
 			#-------------------------------------------------------------------------------
-			#	Pi-hole: Enable FTLDNS support by removing pihole-FTL from DietPi control: https://github.com/Fourdee/DietPi/pull/1714
+			#Pi-hole: Enable FTLDNS support by removing pihole-FTL from DietPi control: https://github.com/Fourdee/DietPi/pull/1714
 			systemctl enable pihole-FTL 2> /dev/null
 			#-------------------------------------------------------------------------------
+			#Remove Piano allo firmware, if no allo web ui is installed, as it will be installed on demand now: https://github.com/Fourdee/DietPi/issues/1656
+			grep -q '^aSOFTWARE_INSTALL_STATE\[159\]=2' /DietPi/dietpi/.installed && rm -R /lib/firmware/allo &> /dev/null
+			#-------------------------------------------------------------------------------			
 
 		fi
 


### PR DESCRIPTION
https://github.com/Fourdee/DietPi/issues/1656

@Fourdee 
Was creating PR a bid too fast. Actually the allo web ui is not needed for using their DAC modules, right? So firmware on demand installation needs to be done (just) via `dietpi-set_hardware` and not `dietpi-software`?
Also then firmware should be removed only (within patchfile), when `dtoverlay=*allo-piano-dac*` can be found within `config.txt` (btw. this is used by Sparky as well? https://github.com/Fourdee/DietPi/blob/allo_firmware_ondemand/dietpi/func/dietpi-set_hardware#L1931) or `/etc/modules` and not on dietpi-software uninstall.

- [x] Clarification allo web ui vs DACs / firmware => Remove firmware install/uninstall from dietpi-software?