### PR TITLE
DietPi-Software | Gitea 1.3.2 -> 1.4.0

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6583,7 +6583,7 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://dl.gitea.io/gitea/1.3.2/gitea-1.3.2-'
+			INSTALL_URL_ADDRESS='https://dl.gitea.io/gitea/1.4.0/gitea-1.4.0-'
 
 			#armv6
 			if (( $G_HW_ARCH == 1 )); then


### PR DESCRIPTION
Very straightforward contribution: the download URL for the Gitea binary has been updated in `dietpi-software` to download 1.4.0 instead of 1.3.2. I've verified 1.4.0 on a fresh installation, and no issues have appeared when installing and dealing with Git repositories.

Testing has been done on DietPi 6.7 in a VM; however, further testing can be done on the RPi if necessary. I wouldn't worry too much about it as the [breaking changes from 1.3.2 to 1.4.0](https://blog.gitea.io/2018/03/gitea-1.4.0-is-released/) are minimal and so far irrelevant to the way Gitea is set up on DietPi.

Don't hesitate to let me know if there is something needs to be changed or considered!

| Screenshots                                                                                                                                    |
| ---------------------------------------------------------------------------------------------------------------------------------------------- |
| ![screen shot 2018-04-20 at 10 09 48 pm](https://user-images.githubusercontent.com/10241434/39055754-9254ba02-44e7-11e8-9f2d-a4d5e86a61dd.png) |
| ![screen shot 2018-04-20 at 10 07 29 pm](https://user-images.githubusercontent.com/10241434/39055652-565145fc-44e7-11e8-996a-32126a4edc88.png) |
| ![screen shot 2018-04-20 at 10 08 03 pm](https://user-images.githubusercontent.com/10241434/39055654-568aac84-44e7-11e8-8180-b1d996b019cf.png) |