### PR TITLE
DietPi-Software | Minor code improvements

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12,14 +12,14 @@
 	# - filename /DietPi/dietpi/dietpi-software
 	# - Installs "ready to run" software with optimizations unique to the device.
 	# - Runs dietpi-update during 1st run setup.
-	# - Generates and uses /DietPi/dietpi/.installed (software list) # 0=not installed, 1=selected for install, 2=installed
+	# - Generates and uses /DietPi/dietpi/.installed (software list) # -1=selected for uninstall, 0=not installed, 1=selected for install, 2=installed
 	#
 	# Usage:
 	# - dietpi-software
-	# - /DietPi/dietpi/dietpi-software install			iUNIQUEID (OR) sINDEX_{SSHSERVER,FILESERVER,LOGGING,WEBSERVER}_TARGET=-int
+	# - /DietPi/dietpi/dietpi-software install		iUNIQUEID (OR) sINDEX_{SSHSERVER,FILESERVER,LOGGING,WEBSERVER}_TARGET=-int
 	# - /DietPi/dietpi/dietpi-software reinstall		#Same as installed, however, only reinstalls if state =2. Does not uninstall due to package removal danger (eg: xserver removes kodi), simply flags to be installed (=1).
 	# - /DietPi/dietpi/dietpi-software uninstall		iUNIQUEID
-	# - /DietPi/dietpi/dietpi-software list				#Lists UNIQUEIDs for software.
+	# - /DietPi/dietpi/dietpi-software list			#Lists UNIQUEIDs for software.
 	# - /DietPi/dietpi/dietpi-software setpermissions	#Sets shared permissions for /var/www and userdata folders.
 	#////////////////////////////////////
 	#Import DietPi-Globals ---------------------------------------------------------------
@@ -51,7 +51,7 @@
 
 		local fp_target="$FP_INSTALLED_FILE"
 
-		if [ "$1" = "temp" ]; then
+		if [ "$1" = 'temp' ]; then
 
 			fp_target="$FP_INSTALLED_FILE_TEMP"
 			write_software_in_pending_state=1
@@ -103,14 +103,14 @@ _EOF_
 
 		local fp_target="$FP_INSTALLED_FILE"
 
-		if [ "$1" = "temp" ]; then
+		if [ "$1" = 'temp' ]; then
 
 			fp_target="$FP_INSTALLED_FILE_TEMP"
 
 		fi
 
 		#Load Software states
-		G_DIETPI-NOTIFY 2 "Reading database, please wait..."
+		G_DIETPI-NOTIFY 2 'Reading database, please wait...'
 
 		#Load
 		if [ -f "$fp_target" ]; then
@@ -158,7 +158,7 @@ _EOF_
 		do
 
 			/DietPi/dietpi/func/run_ntpd status
-			if (( $? != 0 )); then
+			if (( $? )); then
 
 				#	Endless retry
 				if (( ! $G_USER_INPUTS )); then
@@ -178,7 +178,7 @@ _EOF_
 					)
 
 					G_WHIP_MENU "NTPD timesync has not yet completed, or, failed to update.\nTo prevent issues with outdated system time during installations, please select an option below.\n\nNB: We highly recommend choosing 'Retry' first. Failing that, 'mirror' then 'mode'.\n'Override' is a last resort and may cause future issues due to incorrect system clock time."
-					if (( $? == 0 )); then
+					if (( ! $? )); then
 
 						if [ "$G_WHIP_RETURNED_VALUE" = 'Retry' ]; then
 
@@ -224,7 +224,7 @@ _EOF_
 
 	#Global Password: Exception to AUTO first run init.
 	GLOBAL_PW="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_GLOBAL_PASSWORD=' /DietPi/dietpi.txt | sed 's/^.*=//')"
-	if [ ! -n "$GLOBAL_PW" ]; then
+	if [ -z "$GLOBAL_PW" ]; then
 
 		GLOBAL_PW='dietpi'
 
@@ -2524,6 +2524,7 @@ _EOF_
 		#Installed software on DietPi image by default.
 		aSOFTWARE_INSTALL_STATE[103]=2
 		aSOFTWARE_INSTALL_STATE[104]=2
+		aSOFTWARE_INSTALL_STATE[106]=2
 		#--------------------------------------------------------------------------------
 
 	}
@@ -2888,17 +2889,13 @@ _EOF_
 		do
 
 			if (( ${aSOFTWARE_REQUIRES_MYSQL[$i]} &&
-				${aSOFTWARE_INSTALL_STATE[$i]} == 1 )); then
+				${aSOFTWARE_INSTALL_STATE[$i]} == 1 &&
+				! ${aSOFTWARE_INSTALL_STATE[88]} )); then
 
-				# - Check for existing MariaDB installations
-				if (( ! ${aSOFTWARE_INSTALL_STATE[88]} )); then
+				#WEBSERVER_MARIADB
+				aSOFTWARE_INSTALL_STATE[88]=1
 
-					#WEBSERVER_MARIADB as new default
-					aSOFTWARE_INSTALL_STATE[88]=1
-
-					G_DIETPI-NOTIFY 2 'MariaDB will be installed'
-
-				fi
+				G_DIETPI-NOTIFY 2 'MariaDB will be installed'
 
 				break
 
@@ -2911,7 +2908,8 @@ _EOF_
 		do
 
 			if (( ${aSOFTWARE_REQUIRES_SQLITE[$i]} &&
-				${aSOFTWARE_INSTALL_STATE[$i]} == 1 )); then
+				${aSOFTWARE_INSTALL_STATE[$i]} == 1 &&
+				! ${aSOFTWARE_INSTALL_STATE[87]} )); then
 
 				#WEBSERVER_SQLITE
 				aSOFTWARE_INSTALL_STATE[87]=1
@@ -3250,7 +3248,7 @@ _EOF_
 
 			output=2
 
-			# - Bump up for VM's
+			# - Bump up for x86
 			if (( $G_HW_MODEL == 20 || $G_HW_MODEL == 21 )); then
 
 				output=3
@@ -3262,7 +3260,7 @@ _EOF_
 
 			output=20
 
-			# - Bump up for VM's
+			# - Bump up for x86
 			if (( $G_HW_MODEL == 20 || $G_HW_MODEL == 21 )); then
 
 				output=40
@@ -3295,7 +3293,7 @@ _EOF_
 
 			output=3
 
-			# - Bump up for VM's
+			# - Bump up for x86
 			if (( $G_HW_MODEL == 20 || $G_HW_MODEL == 21 )); then
 
 				output=5
@@ -3376,7 +3374,7 @@ _EOF_
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			G_AGI lxde upower policykit-1 iceweasel
-			#upower policykit-1. Needed for LXDE logout menu item to show shutdown/restart ......
+			#upower policykit-1. Needed for LXDE logout menu item to show shutdown/restart ...
 
 		fi
 
@@ -3493,7 +3491,7 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$INSTALLING_INDEX]} == 1 )); then
 
 			Banner_Installing
-			G_AGI samba samba-common-bin
+			G_AGI samba
 
 		fi
 
@@ -3502,7 +3500,6 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$INSTALLING_INDEX]} == 1 )); then
 
 			Banner_Installing
-
 			G_AGI vsftpd
 
 		fi
@@ -3512,8 +3509,7 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$INSTALLING_INDEX]} == 1 )); then
 
 			Banner_Installing
-
-			G_AGI nfs-kernel-server nfs-common ucf rpcbind
+			G_AGI nfs-kernel-server rpcbind
 
 		fi
 
@@ -3532,7 +3528,7 @@ _EOF_
 
 			Banner_Installing
 			# If IPv6 is disabled, nginx service fails to start up due to IPv6 part in default site.
-			# This leads to AGP failure, thus we copy our IPv6-less site in place first:
+			# This leads to APT failure, thus we copy our non-IPv6 config in place first:
 			if [ ! -d /proc/sys/net/ipv6 ]; then
 
 				[ -d /etc/nginx ] || mkdir /etc/nginx
@@ -3891,7 +3887,7 @@ _EOF_
 					G_DIETPI-NOTIFY 2 'ownCloud installation backup found, starting recovery...'
 					G_RUN_CMD cp -a "$datadir"/dietpi-owncloud-installation-backup/. /var/www/owncloud
 					# Correct config.php data directory entry, in case it changed due to server migration:
-					sed -i "\|^[[:blank:]]*'datadirectory'|c\ \ 'datadirectory' => '$datadir'," /var/www/owncloud/config/config.php
+					G_CONFIG_INJECT "'datadirectory'" "\ \ 'datadirectory' => '$datadir'," /var/www/owncloud/config/config.php "'dbtype'"
 
 				else
 
@@ -3929,7 +3925,7 @@ _EOF_
 					G_DIETPI-NOTIFY 2 'Nextcloud installation backup found, starting recovery...'
 					G_RUN_CMD cp -a "$datadir"/dietpi-nextcloud-installation-backup/. /var/www/nextcloud
 					# Correct config.php data directory entry, in case it changed due to server migration:
-					sed -i "\|^[[:blank:]]*'datadirectory'|c\ \ 'datadirectory' => '$datadir'," /var/www/nextcloud/config/config.php
+					G_CONFIG_INJECT "'datadirectory'" "\ \ 'datadirectory' => '$datadir'," /var/www/nextcloud/config/config.php "'dbtype'"
 
 				else
 
@@ -8249,23 +8245,23 @@ _EOF_
 			fi
 
 			# APCu configuration: To prevent cli (cron.php) producing ownCloud log entries.
-			grep -q 'apc.enable_cli=' "$FP_PHP_BASE_DIR/mods-available/apcu.ini" && sed -i '/apc.enable_cli=/c\apc.enable_cli=1' $FP_PHP_BASE_DIR/mods-available/apcu.ini || echo 'apc.enable_cli=1' >> $FP_PHP_BASE_DIR/mods-available/apcu.ini
+			G_CONFIG_INJECT 'apc.enable_cli=' 'apc.enable_cli=1' "$FP_PHP_BASE_DIR/mods-available/apcu.ini"
 
 			if (( ${aSOFTWARE_INSTALL_STATE[83]} >= 1 )); then
 
 				G_DIETPI-NOTIFY 2 'Apache webserver found, enable ownCloud specific configuration: "https://doc.owncloud.org/server/latest/admin_manual/installation/source_installation.html#configure-apache-web-server"'
 				a2enmod rewrite headers env dir mime 1> /dev/null
 				local owncloud_conf='/etc/apache2/sites-available/owncloud.conf'
-				if [ -f $owncloud_conf ]; then
+				if [ -f "$owncloud_conf" ]; then
 
-					G_DIETPI-NOTIFY 2 'Existing ownCloud configuration found, will save the new one for review and comparison to: /etc/apache2/sites-available/owncloud.conf.dietpi-new'
-					owncloud_conf='/etc/apache2/sites-available/owncloud.conf.dietpi-new'
+					owncloud_conf=+'.dietpi-new'
+					G_DIETPI-NOTIFY 2 "Existing ownCloud configuration found, will save the new one for review and comparison to: $owncloud_conf"
 
 				fi
-				cp /DietPi/dietpi/conf/apache.ownnextcloud.conf $owncloud_conf
-				sed -i 's/nextcloud/owncloud/g' $owncloud_conf
+				cp /DietPi/dietpi/conf/apache.ownnextcloud.conf "$owncloud_conf"
+				sed -i 's/nextcloud/owncloud/g' "$owncloud_conf"
 				# OPcache adjustment is just needed by Nextcloud
-				sed -i 's/php_admin_value/#php_admin_value/' $owncloud_conf
+				sed -i 's/php_admin_value/#php_admin_value/' "$owncloud_conf"
 				a2ensite owncloud 1> /dev/null
 
 			fi
@@ -8274,18 +8270,18 @@ _EOF_
 
 				G_DIETPI-NOTIFY 2 'Nginx webserver found, enable ownCloud specific configuration: "https://doc.owncloud.org/server/latest/admin_manual/installation/nginx_configuration.html#owncloud-in-a-subdir-of-nginx"'
 				local owncloud_config='/etc/nginx/sites-dietpi/owncloud.config'
-				if [ -f $owncloud_config ]; then
+				if [ -f "$owncloud_config" ]; then
 
-					G_DIETPI-NOTIFY 2 'Existing ownCloud configuration found, will save the new one for review and comparison to: /etc/nginx/sites-dietpi/owncloud.config.dietpi-new'
-					owncloud_config='/etc/nginx/sites-dietpi/owncloud.config.dietpi-new'
+					owncloud_config=+'.dietpi-new'
+					G_DIETPI-NOTIFY 2 "Existing ownCloud configuration found, will save the new one for review and comparison to: $owncloud_config"
 
 				fi
-				cp /DietPi/dietpi/conf/nginx.sites-dietpi.owncloud.config $owncloud_config
+				cp /DietPi/dietpi/conf/nginx.sites-dietpi.owncloud.config "$owncloud_config"
 
 				# Stretch: Set 'fastcgi_request_buffering off';
 				if (( $G_DISTRO > 3 )); then
 
-					sed -i 's/#fastcgi_request_buffering off;/fastcgi_request_buffering off;/g' $owncloud_config
+					sed -i 's/#fastcgi_request_buffering off;/fastcgi_request_buffering off;/g' "$owncloud_config"
 
 				fi
 
@@ -8293,14 +8289,14 @@ _EOF_
 				wget -q --spider --timeout=10 --tries=2 https://localhost &> /dev/null
 				if (( $? == 0 || $? == 5)); then
 
-					sed -i 's/#fastcgi_param HTTPS on;/fastcgi_param HTTPS on;/g' $owncloud_config
+					sed -i 's/#fastcgi_param HTTPS on;/fastcgi_param HTTPS on;/g' "$owncloud_config"
 
 				fi
 
-				# Disable pretty URLs (front controller), if ownCloud version is lower 10.
+				# Disable pretty URLs (front controller), if ownCloud version is lower than 10:
 				if (( $(grep '$OC_VersionString' /var/www/owncloud/version.php | sed "s/^.*= '//" | sed "s/\..*$//") < 10 )); then
 
-					sed -i 's/^[[:blank:]]*fastcgi_param front_controller_active true;/\t#fastcgi_param front_controller_active true;/g' $owncloud_config
+					sed -i 's/^[[:blank:]]*fastcgi_param front_controller_active true;/\t#fastcgi_param front_controller_active true;/g' "$owncloud_config"
 
 				fi
 
@@ -8315,8 +8311,8 @@ innodb_file_per_table=1
 _EOF_
 			G_RUN_CMD systemctl restart mysql
 
-			# Reload dietpi-globals to enable occ command shortcut:
-			. /DietPi/dietpi/func/dietpi-globals
+			# Initially add occ command shortcut, will be done by Dietpi-Globals automatically, if occ file exist:
+			occ(){ sudo -u www-data php /var/www/owncloud/occ "$@"; }
 
 			# Adjusting config file:
 			local config_php='/var/www/owncloud/config/config.php'
@@ -8349,7 +8345,7 @@ _EOF_
 
 					# For MariaDB, temporary database admin user needs to be created, as 'root' uses unix_socket login, which cannot be accessed by sudo -u www-data.
 					mysql -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
-					grep -q "'installed' => true," $config_php 2>/dev/null || occ maintenance:install --no-interaction --database "mysql" --database-name "owncloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$datadir"
+					grep -q "'installed' => true," "$config_php" 2>/dev/null || occ maintenance:install --no-interaction --database "mysql" --database-name "owncloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$datadir"
 					mysql -e "drop user 'tmp_root'@'localhost'"
 
 				fi
@@ -8357,48 +8353,48 @@ _EOF_
 			fi
 
 			# Enable ownCloud to use 4-byte database
-			grep -q "^[[:blank:]]*'mysql.utf8mb4'" $config_php || sed -i "/^[[:blank:]]*'dbpassword'/a \ \ 'mysql.utf8mb4' => true," $config_php
+			G_CONFIG_INJECT "'mysql.utf8mb4'" "\ \ 'mysql.utf8mb4' => true," "$config_php" "'dbpassword'"
 
 			# Add local IP and hostname to trusted domains.
 			# If "1 => '" does not exist, the config.php is not copied e.g. from older instance, so we add entries.
-			if (( ! $(grep -ci -m1 "1 => '" $config_php) )); then
+			if ! grep -q "1 => '" "$config_php"; then
 
-				sed -i "/0 => 'localhost'/a     1 => '$(sed -n 4p /DietPi/dietpi/.network)'," $config_php
-				sed -i "/1 => '/a     2 => '$(cat /etc/hostname)'," $config_php
+				sed -i "/0 => 'localhost'/a     1 => '$(sed -n 4p /DietPi/dietpi/.network)'," "$config_php"
+				sed -i "/1 => '/a     2 => '$(cat /etc/hostname)'," "$config_php"
 
 			fi
 
 			# Set CLI URL to ownCloud sub directory:
-			sed -i "s|'http://localhost'|'http://localhost/owncloud'|g" $config_php
+			sed -i "s|'http://localhost'|'http://localhost/owncloud'|g" "$config_php"
 
 			# Set pretty URLs (without /index.php/) on Apache:
 			if (( ${aSOFTWARE_INSTALL_STATE[83]} >= 1 )); then
 
-				grep -q "^[[:blank:]]*'htaccess.RewriteBase'" $config_php || sed -i "/^[[:blank:]]*'overwrite.cli.url'/a \ \ 'htaccess.RewriteBase' => '/owncloud'," $config_php
+				PRESERVE=1 G_CONFIG_INJECT "'htaccess.RewriteBase'" "\ \ 'htaccess.RewriteBase' => '/owncloud'," "$config_php" "'overwrite.cli.url'"
 				occ maintenance:update:htaccess
 
 			fi
 
 			# APCu Memcache
-			grep -q "^[[:blank:]]*'memcache.local'" $config_php || sed -i "/^[[:blank:]]*'version'/a \ \ 'memcache.local' => '\\\OC\\\Memcache\\\APCu'," $config_php
+			PRESERVE=1 G_CONFIG_INJECT "'memcache.local'" "\ \ 'memcache.local' => '\\\OC\\\Memcache\\\APCu'," "$config_php" "'version'"
 
 			# Redis for transactional file locking:
 			# https://doc.owncloud.org/server/latest/admin_manual/configuration/server/caching_configuration.html#configuring-transactional-file-locking
 			# - Enable Redis socket and grant www-data access to it:
 			local redis_conf="/etc/redis/redis*.conf"
-			grep -q "^[[:blank:]]*unixsocket /" $redis_conf || grep -q '^[[:blank:]]*#unixsocket /' $redis_conf && sed -i 's|^[[:blank:]]*#unixsocket /|unixsocket /|' $redis_conf || echo 'unixsocket /var/run/redis/redis.sock' >> $redis_conf
-			grep -q "^[[:blank:]]*#?unixsocketperm " $redis_conf && sed -i "/^[[:blank:]]*#?unixsocketperm /c\unixsocketperm 770" $redis_conf || echo 'unixsocketperm 770' >> $redis_conf
-			local redis_sock=$(grep "^[[:blank:]]*unixsocket /" $redis_conf | sed "s/^[[:blank:]]*unixsocket //")
+			PRESERVE=1 G_CONFIG_INJECT 'unixsocket /' 'unixsocket /var/run/redis/redis-server.sock' "$redis_conf"
+			G_CONFIG_INJECT 'unixsocketperm ' 'unixsocketperm 770' "$redis_conf"
+			local redis_sock="$(grep -m1 '^[[:blank:]]*unixsocket /' $redis_conf | sed 's/^[[:blank:]]*unixsocket //')"
 			usermod -a -G redis www-data
-			# - Enable ownCloud to use Redis socket:
-			if (( ! $(grep -ci -m1 "'memcache.locking'" $config_php) )); then
+			# - Enable ownCloud to use Redis socket for transactional file locking:
+			if ! grep -q "'memcache.locking'" "$config_php"; then
 
 				sed -i "\#'memcache.local'#a \ \ 'filelocking.enabled' => true,\n\
   'memcache.locking' => '\\\OC\\\Memcache\\\Redis',\n\
   'redis' => [\n\
     'host' => '$redis_sock',\n\
     'port' => 0,\n\
-  ]," $config_php
+  ]," "$config_php"
 
 			fi
 
@@ -8407,7 +8403,7 @@ _EOF_
 			occ background:cron
 
 			# Enable maintenance mode to allow handling by dietpi-services:
-			grep -q "^[[:blank:]]*'maintenance' => true," $config_php || occ maintenance:mode --on
+			grep -q "^[[:blank:]]*'maintenance' => true," "$config_php" || occ maintenance:mode --on
 
 		fi
 
@@ -8427,28 +8423,28 @@ _EOF_
 			fi
 
 			# APCu configuration: To prevent cli (cron.php) producing Nextcloud log [info] entries.
-			grep -q 'apc.enable_cli=' "$FP_PHP_BASE_DIR/mods-available/apcu.ini" && sed -i '/apc.enable_cli=/c\apc.enable_cli=1' $FP_PHP_BASE_DIR/mods-available/apcu.ini || echo 'apc.enable_cli=1' >> $FP_PHP_BASE_DIR/mods-available/apcu.ini
+			G_CONFIG_INJECT 'apc.enable_cli=' 'apc.enable_cli=1' "$FP_PHP_BASE_DIR/mods-available/apcu.ini"
 
 			# OPCache configuration: https://docs.nextcloud.com/server/12/admin_manual/configuration_server/server_tuning.html?highlight=opcache#enable-php-opcache
-			grep -q 'opcache.enable=' "$FP_PHP_BASE_DIR/mods-available/opcache.ini" && sed -i '/opcache.enable=/c\opcache.enable=1' $FP_PHP_BASE_DIR/mods-available/opcache.ini || echo 'opcache.enable=1' >> $FP_PHP_BASE_DIR/mods-available/opcache.ini
-			grep -q 'opcache.enable_cli=' "$FP_PHP_BASE_DIR/mods-available/opcache.ini" && sed -i '/opcache.enable_cli=/c\opcache.enable_cli=1' $FP_PHP_BASE_DIR/mods-available/opcache.ini || echo 'opcache.enable_cli=1' >> $FP_PHP_BASE_DIR/mods-available/opcache.ini
-			grep -q 'opcache.interned_strings_buffer=' "$FP_PHP_BASE_DIR/mods-available/opcache.ini" && sed -i '/opcache.interned_strings_buffer=/c\opcache.interned_strings_buffer=8' $FP_PHP_BASE_DIR/mods-available/opcache.ini || echo 'opcache.interned_strings_buffer=8' >> $FP_PHP_BASE_DIR/mods-available/opcache.ini
-			grep -q 'opcache.max_accelerated_files=' "$FP_PHP_BASE_DIR/mods-available/opcache.ini" && sed -i '/opcache.max_accelerated_files=/c\opcache.max_accelerated_files=10000' $FP_PHP_BASE_DIR/mods-available/opcache.ini || echo 'opcache.max_accelerated_files=10000' >> $FP_PHP_BASE_DIR/mods-available/opcache.ini
-			grep -q 'opcache.save_comments=' "$FP_PHP_BASE_DIR/mods-available/opcache.ini" && sed -i '/opcache.save_comments=/c\opcache.save_comments=1' $FP_PHP_BASE_DIR/mods-available/opcache.ini || echo 'opcache.save_comments=1' >> $FP_PHP_BASE_DIR/mods-available/opcache.ini
-			grep -q 'opcache.revalidate_freq=' "$FP_PHP_BASE_DIR/mods-available/opcache.ini" && sed -i '/opcache.revalidate_freq=/c\opcache.revalidate_freq=1' $FP_PHP_BASE_DIR/mods-available/opcache.ini || echo 'opcache.revalidate_freq=1' >> $FP_PHP_BASE_DIR/mods-available/opcache.ini
+			G_CONFIG_INJECT 'opcache.enable=' 'opcache.enable=1' "$FP_PHP_BASE_DIR/mods-available/opcache.ini"
+			G_CONFIG_INJECT 'opcache.enable_cli=' 'opcache.enable_cli=1' "$FP_PHP_BASE_DIR/mods-available/opcache.ini"
+			G_CONFIG_INJECT 'opcache.interned_strings_buffer=' 'opcache.interned_strings_buffer=8' "$FP_PHP_BASE_DIR/mods-available/opcache.ini"
+			G_CONFIG_INJECT 'opcache.max_accelerated_files=' 'opcache.max_accelerated_files=10000' "$FP_PHP_BASE_DIR/mods-available/opcache.ini"
+			G_CONFIG_INJECT 'opcache.save_comments=' 'opcache.save_comments=1' "$FP_PHP_BASE_DIR/mods-available/opcache.ini"
+			G_CONFIG_INJECT 'opcache.revalidate_freq=' 'opcache.revalidate_freq=1' "$FP_PHP_BASE_DIR/mods-available/opcache.ini"
 
 			if (( ${aSOFTWARE_INSTALL_STATE[83]} >= 1 )); then
 
 				G_DIETPI-NOTIFY 2 'Apache webserver found, enable Nextcloud specific configuration: "https://docs.nextcloud.com/server/12/admin_manual/installation/source_installation.html#apache-web-server-configuration"'
 				a2enmod rewrite headers env dir mime 1> /dev/null
 				local nextcloud_conf='/etc/apache2/sites-available/nextcloud.conf'
-				if [ -f $nextcloud_conf ]; then
+				if [ -f "$nextcloud_conf" ]; then
 
-					G_DIETPI-NOTIFY 2 'Existing Nextcloud configuration found, will save the new one for review and comparison to: /etc/apache2/sites-available/nextcloud.conf.dietpi-new'
-					nextcloud_conf='/etc/apache2/sites-available/nextcloud.conf.dietpi-new'
+					nextcloud_conf=+'.dietpi-new'
+					G_DIETPI-NOTIFY 2 "Existing Nextcloud configuration found, will save the new one for review and comparison to: $nextcloud_conf"
 
 				fi
-				cp /DietPi/dietpi/conf/apache.ownnextcloud.conf $nextcloud_conf
+				cp /DietPi/dietpi/conf/apache.ownnextcloud.conf "$nextcloud_conf"
 				a2ensite nextcloud 1> /dev/null
 
 			fi
@@ -8457,18 +8453,18 @@ _EOF_
 
 				G_DIETPI-NOTIFY 2 'Nginx webserver found, enable Nextcloud specific configuration: "https://docs.nextcloud.com/server/12/admin_manual/installation/nginx.html#nextcloud-in-a-subdir-of-nginx"'
 				local nextcloud_config='/etc/nginx/sites-dietpi/nextcloud.config'
-				if [ -f $nextcloud_config ]; then
+				if [ -f "$nextcloud_config" ]; then
 
-					G_DIETPI-NOTIFY 2 'Existing Nextcloud configuration found, will save the new one for review and comparison to: /etc/nginx/sites-dietpi/nextcloud.config.dietpi-new'
-					nextcloud_config='/etc/nginx/sites-dietpi/nextcloud.config.dietpi-new'
+					nextcloud_config=+'.dietpi-new'
+					G_DIETPI-NOTIFY 2 "Existing Nextcloud configuration found, will save the new one for review and comparison to: $nextcloud_config"
 
 				fi
-				cp /DietPi/dietpi/conf/nginx.sites-dietpi.nextcloud.config $nextcloud_config
+				cp /DietPi/dietpi/conf/nginx.sites-dietpi.nextcloud.config "$nextcloud_config"
 
 				# Stretch: Set 'fastcgi_request_buffering off';
 				if (( $G_DISTRO > 3 )); then
 
-					sed -i 's/#fastcgi_request_buffering off;/fastcgi_request_buffering off;/g' $nextcloud_config
+					sed -i 's/#fastcgi_request_buffering off;/fastcgi_request_buffering off;/g' "$nextcloud_config"
 
 				fi
 
@@ -8476,14 +8472,14 @@ _EOF_
 				wget -q --spider --timeout=10 --tries=2 https://localhost &> /dev/null
 				if (( $? == 0 || $? == 5)); then
 
-					sed -i 's/#fastcgi_param HTTPS on;/fastcgi_param HTTPS on;/g' $nextcloud_config
+					sed -i 's/#fastcgi_param HTTPS on;/fastcgi_param HTTPS on;/g' "$nextcloud_config"
 
 				fi
 
-				# Disable pretty URLs (front controller), if Nextcloud version is lower 13.
+				# Disable pretty URLs (front controller), if Nextcloud version is lower than 13:
 				if (( $(grep '$OC_VersionString' /var/www/nextcloud/version.php | sed "s/^.*= '//" | sed "s/\..*$//") < 13 )); then
 
-					sed -i 's/^[[:blank:]]*fastcgi_param front_controller_active true;/\t#fastcgi_param front_controller_active true;/g' $nextcloud_config
+					sed -i 's/^[[:blank:]]*fastcgi_param front_controller_active true;/\t#fastcgi_param front_controller_active true;/g' "$nextcloud_config"
 
 				fi
 
@@ -8495,10 +8491,7 @@ _EOF_
 				local lighttpd_conf='/etc/lighttpd/lighttpd.conf'
 
 				# Enable mod_setenv
-				grep -q '^[[:blank:]]*"mod_setenv",' $lighttpd_conf ||
-				grep -q '^[[:blank:]#;]*"mod_setenv",' $lighttpd_conf &&
-				sed -i '/^[[:blank:]#;]*"mod_setenv",/c\	"mod_setenv",' $lighttpd_conf ||
-				sed -i '/^[[:blank:]]*server.modules = (/a\	"mod_setenv",' $lighttpd_conf
+				G_CONFIG_INJECT '"mod_setenv",' '	"mod_setenv",' "$lighttpd_conf" 'server.modules = ('
 
 				# Move Nextcloud configuration file in place and activate it
 				[ ! -f /etc/lighttpd/conf-available/99-dietpi-nextcloud.conf ] && cp /DietPi/dietpi/conf/lighttpd.nextcloud.conf /etc/lighttpd/conf-available/99-dietpi-nextcloud.conf
@@ -8516,8 +8509,8 @@ innodb_file_per_table=1
 _EOF_
 			G_RUN_CMD systemctl restart mysql
 
-			# Reload dietpi-globals to enable ncc command shortcut:
-			. /DietPi/dietpi/func/dietpi-globals
+			# Initially add occ command shortcut, will be done by Dietpi-Globals automatically, if occ file exist:
+			ncc(){ sudo -u www-data php /var/www/nextcloud/occ "$@"; }
 
 			# Adjusting config file:
 			local config_php='/var/www/nextcloud/config/config.php'
@@ -8550,7 +8543,7 @@ _EOF_
 
 					# For MariaDB, temporary database admin user needs to be created, as 'root' uses unix_socket login, which cannot be accessed by sudo -u www-data.
 					mysql -e "grant all privileges on *.* to 'tmp_root'@'localhost' identified by '$GLOBAL_PW' with grant option"
-					grep -q "'installed' => true," $config_php 2>/dev/null || ncc maintenance:install --no-interaction --database "mysql" --database-name "nextcloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$datadir"
+					grep -q "'installed' => true," "$config_php" 2>/dev/null || ncc maintenance:install --no-interaction --database "mysql" --database-name "nextcloud" --database-user "tmp_root" --database-pass "$GLOBAL_PW" --admin-user "$username" --admin-pass "$GLOBAL_PW" --data-dir "$datadir"
 					mysql -e "drop user 'tmp_root'@'localhost'"
 
 				fi
@@ -8558,46 +8551,46 @@ _EOF_
 			fi
 
 			# Enable Nextcloud to use 4-byte database
-			grep -q "^[[:blank:]]*'mysql.utf8mb4'" $config_php || sed -i "/^[[:blank:]]*'dbpassword'/a \ \ 'mysql.utf8mb4' => true," $config_php
+			G_CONFIG_INJECT "'mysql.utf8mb4'" "\ \ 'mysql.utf8mb4' => true," "$config_php" "'dbpassword'"
 
 			# Disable trusted_domains.
-			if (( ! $(grep -ci -m1 "1 => '*'" $config_php) )); then
+			if ! grep -q "1 => '*'" "$config_php"; then
 
-				sed -i "/0 => 'localhost'/a     1 => '*'," $config_php
+				sed -i "/0 => 'localhost'/a     1 => '*'," "$config_php"
 
 			fi
 
 			# Set CLI URL to Nextcloud sub directory:
-			sed -i "s|'http://localhost'|'http://localhost/nextcloud'|g" $config_php
+			sed -i "s|'http://localhost'|'http://localhost/nextcloud'|g" "$config_php"
 
 			# Set pretty URLs (without /index.php/) on Apache:
 			if (( ${aSOFTWARE_INSTALL_STATE[83]} >= 1 )); then
 
-				grep -q "^[[:blank:]]*'htaccess.RewriteBase'" $config_php || sed -i "/^[[:blank:]]*'overwrite.cli.url'/a \ \ 'htaccess.RewriteBase' => '/nextcloud'," $config_php
+				PRESERVE=1 G_CONFIG_INJECT "'htaccess.RewriteBase'" "\ \ 'htaccess.RewriteBase' => '/nextcloud'," "$config_php" "'overwrite.cli.url'"
 				ncc maintenance:update:htaccess
 
 			fi
 
 			# APCu Memcache
-			grep -q "^[[:blank:]]*'memcache.local'" $config_php || sed -i "/^[[:blank:]]*'version'/a \ \ 'memcache.local' => '\\\OC\\\Memcache\\\APCu'," $config_php
+			PRESERVE=1 G_CONFIG_INJECT "'memcache.local'" "\ \ 'memcache.local' => '\\\OC\\\Memcache\\\APCu'," "$config_php" "'version'"
 
 			# Redis for transactional file locking:
 			# https://docs.nextcloud.com/server/12/admin_manual/configuration_files/files_locking_transactional.html
 			# - Enable Redis socket and grant www-data access to it:
 			local redis_conf="/etc/redis/redis*.conf"
-			grep -q "^[[:blank:]]*unixsocket /" $redis_conf || grep -q '^[[:blank:]]*#unixsocket /' $redis_conf && sed -i 's|^[[:blank:]]*#unixsocket /|unixsocket /|' $redis_conf || echo 'unixsocket /var/run/redis/redis.sock' >> $redis_conf
-			grep -q "^[[:blank:]]*#?unixsocketperm " $redis_conf && sed -i "/^[[:blank:]]*#?unixsocketperm /c\unixsocketperm 770" $redis_conf || echo 'unixsocketperm 770' >> $redis_conf
-			local redis_sock=$(grep "^[[:blank:]]*unixsocket /" $redis_conf | sed "s/^[[:blank:]]*unixsocket //")
+			PRESERVE=1 G_CONFIG_INJECT 'unixsocket /' 'unixsocket /var/run/redis/redis-server.sock' "$redis_conf"
+			G_CONFIG_INJECT 'unixsocketperm ' 'unixsocketperm 770' "$redis_conf"
+			local redis_sock="$(grep -m1 '^[[:blank:]]*unixsocket /' $redis_conf | sed 's/^[[:blank:]]*unixsocket //')"
 			usermod -a -G redis www-data
 			# - Enable Nextloud to use Redis socket:
-			if (( ! $(grep -ci -m1 "'memcache.locking'" $config_php) )); then
+			if ! grep -q "'memcache.locking'" "$config_php"; then
 
 				sed -i "\#'memcache.local'#a \ \ 'filelocking.enabled' => true,\n\
   'memcache.locking' => '\\\OC\\\Memcache\\\Redis',\n\
   'redis' => array(\n\
     'host' => '$redis_sock',\n\
     'port' => 0,\n\
-    )," $config_php
+    )," "$config_php"
 
 			fi
 
@@ -8606,7 +8599,7 @@ _EOF_
 			ncc background:cron
 
 			# Enable maintenance mode to allow handling by dietpi-services:
-			grep -q "^[[:blank:]]*'maintenance' => true," $config_php || ncc maintenance:mode --on
+			grep -q "^[[:blank:]]*'maintenance' => true," "$config_php" || ncc maintenance:mode --on
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8211,7 +8211,7 @@ _EOF_
 			fi
 
 			# APCu configuration: To prevent cli (cron.php) producing ownCloud log entries.
-			G_CONFIG_INJECT 'apc.enable_cli=' 'apc.enable_cli=1' "$FP_PHP_BASE_DIR/mods-available/apcu.ini"
+			G_CONFIG_INJECT 'apc.enable_cli[[:blank:]=]' 'apc.enable_cli=1' "$FP_PHP_BASE_DIR/mods-available/apcu.ini"
 
 			if (( ${aSOFTWARE_INSTALL_STATE[83]} >= 1 )); then
 
@@ -8286,7 +8286,7 @@ _EOF_
 			local datadir="$(grep -m1 '^[[:blank:]]*SOFTWARE_OWNCLOUD_DATADIR=' /DietPi/dietpi.txt | sed 's/^.*=//')"
 			[ -n "$datadir" ] || datadir="$G_FP_DIETPI_USERDATA/owncloud_data"
 			mkdir -p "$datadir"
-			Install_Apply_Permissions &> /dev/null
+			chown -R www-data:www-data "$datadir"
 
 			if [ -d "$G_FP_DIETPI_USERDATA"/mysql/owncloud ]; then
 
@@ -8347,10 +8347,11 @@ _EOF_
 			# Redis for transactional file locking:
 			# https://doc.owncloud.org/server/latest/admin_manual/configuration/server/caching_configuration.html#configuring-transactional-file-locking
 			# - Enable Redis socket and grant www-data access to it:
+			#	- NB: To allow wildcard expansion, do not use parentheses around $redis_conf!
 			local redis_conf="/etc/redis/redis*.conf"
-			PRESERVE=1 G_CONFIG_INJECT 'unixsocket /' 'unixsocket /var/run/redis/redis-server.sock' "$redis_conf"
-			G_CONFIG_INJECT 'unixsocketperm ' 'unixsocketperm 770' "$redis_conf"
-			local redis_sock="$(grep -m1 '^[[:blank:]]*unixsocket /' $redis_conf | sed 's/^[[:blank:]]*unixsocket //')"
+			PRESERVE=1 G_CONFIG_INJECT 'unixsocket[[:blank:]]' 'unixsocket /var/run/redis/redis-server.sock' $redis_conf
+			G_CONFIG_INJECT 'unixsocketperm[[:blank:]]' 'unixsocketperm 770' $redis_conf
+			local redis_sock=$(grep -m1 '^[[:blank:]]*unixsocket[[:blank:]]' $redis_conf | awk '{print $2}')
 			usermod -a -G redis www-data
 			# - Enable ownCloud to use Redis socket for transactional file locking:
 			if ! grep -q "'memcache.locking'" "$config_php"; then
@@ -8389,15 +8390,15 @@ _EOF_
 			fi
 
 			# APCu configuration: To prevent cli (cron.php) producing Nextcloud log [info] entries.
-			G_CONFIG_INJECT 'apc.enable_cli=' 'apc.enable_cli=1' "$FP_PHP_BASE_DIR/mods-available/apcu.ini"
+			G_CONFIG_INJECT 'apc.enable_cli[[:blank:]=]' 'apc.enable_cli=1' "$FP_PHP_BASE_DIR/mods-available/apcu.ini"
 
 			# OPCache configuration: https://docs.nextcloud.com/server/12/admin_manual/configuration_server/server_tuning.html?highlight=opcache#enable-php-opcache
-			G_CONFIG_INJECT 'opcache.enable=' 'opcache.enable=1' "$FP_PHP_BASE_DIR/mods-available/opcache.ini"
-			G_CONFIG_INJECT 'opcache.enable_cli=' 'opcache.enable_cli=1' "$FP_PHP_BASE_DIR/mods-available/opcache.ini"
-			G_CONFIG_INJECT 'opcache.interned_strings_buffer=' 'opcache.interned_strings_buffer=8' "$FP_PHP_BASE_DIR/mods-available/opcache.ini"
-			G_CONFIG_INJECT 'opcache.max_accelerated_files=' 'opcache.max_accelerated_files=10000' "$FP_PHP_BASE_DIR/mods-available/opcache.ini"
-			G_CONFIG_INJECT 'opcache.save_comments=' 'opcache.save_comments=1' "$FP_PHP_BASE_DIR/mods-available/opcache.ini"
-			G_CONFIG_INJECT 'opcache.revalidate_freq=' 'opcache.revalidate_freq=1' "$FP_PHP_BASE_DIR/mods-available/opcache.ini"
+			G_CONFIG_INJECT 'opcache.enable[[:blank:]=]' 'opcache.enable=1' "$FP_PHP_BASE_DIR/mods-available/opcache.ini"
+			G_CONFIG_INJECT 'opcache.enable_cli[[:blank:]=]' 'opcache.enable_cli=1' "$FP_PHP_BASE_DIR/mods-available/opcache.ini"
+			G_CONFIG_INJECT 'opcache.interned_strings_buffer[[:blank:]=]' 'opcache.interned_strings_buffer=8' "$FP_PHP_BASE_DIR/mods-available/opcache.ini"
+			G_CONFIG_INJECT 'opcache.max_accelerated_files[[:blank:]=]' 'opcache.max_accelerated_files=10000' "$FP_PHP_BASE_DIR/mods-available/opcache.ini"
+			G_CONFIG_INJECT 'opcache.save_comments[[:blank:]=]' 'opcache.save_comments=1' "$FP_PHP_BASE_DIR/mods-available/opcache.ini"
+			G_CONFIG_INJECT 'opcache.revalidate_freq[[:blank:]=]' 'opcache.revalidate_freq=1' "$FP_PHP_BASE_DIR/mods-available/opcache.ini"
 
 			if (( ${aSOFTWARE_INSTALL_STATE[83]} >= 1 )); then
 
@@ -8454,10 +8455,9 @@ _EOF_
 			if (( ${aSOFTWARE_INSTALL_STATE[84]} >= 1 )); then
 
 				G_DIETPI-NOTIFY 2 'Lighttpd webserver found, enable Nextcloud specific configuration.'
-				local lighttpd_conf='/etc/lighttpd/lighttpd.conf'
 
 				# Enable mod_setenv
-				G_CONFIG_INJECT '"mod_setenv",' '	"mod_setenv",' "$lighttpd_conf" 'server.modules = ('
+				G_CONFIG_INJECT '"mod_setenv",' '	"mod_setenv",' /etc/lighttpd/lighttpd.conf 'server.modules = ('
 
 				# Move Nextcloud configuration file in place and activate it
 				[ ! -f /etc/lighttpd/conf-available/99-dietpi-nextcloud.conf ] && cp /DietPi/dietpi/conf/lighttpd.nextcloud.conf /etc/lighttpd/conf-available/99-dietpi-nextcloud.conf
@@ -8484,7 +8484,7 @@ _EOF_
 			local datadir="$(grep -m1 '^[[:blank:]]*SOFTWARE_NEXTCLOUD_DATADIR=' /DietPi/dietpi.txt | sed 's/^.*=//')"
 			[ -n "$datadir" ] || datadir="$G_FP_DIETPI_USERDATA/nextcloud_data"
 			mkdir -p "$datadir"
-			Install_Apply_Permissions &> /dev/null
+			chown www-data:www-data "$datadir"
 
 			if [ -d "$G_FP_DIETPI_USERDATA"/mysql/nextcloud ]; then
 
@@ -8543,10 +8543,11 @@ _EOF_
 			# Redis for transactional file locking:
 			# https://docs.nextcloud.com/server/12/admin_manual/configuration_files/files_locking_transactional.html
 			# - Enable Redis socket and grant www-data access to it:
+			#	- NB: To allow wildcard expansion, do not use parentheses around $redis_conf!
 			local redis_conf="/etc/redis/redis*.conf"
-			PRESERVE=1 G_CONFIG_INJECT 'unixsocket /' 'unixsocket /var/run/redis/redis-server.sock' "$redis_conf"
-			G_CONFIG_INJECT 'unixsocketperm ' 'unixsocketperm 770' "$redis_conf"
-			local redis_sock="$(grep -m1 '^[[:blank:]]*unixsocket /' $redis_conf | sed 's/^[[:blank:]]*unixsocket //')"
+			PRESERVE=1 G_CONFIG_INJECT 'unixsocket[[:blank:]]' 'unixsocket /var/run/redis/redis-server.sock' $redis_conf
+			G_CONFIG_INJECT 'unixsocketperm[[:blank:]]' 'unixsocketperm 770' $redis_conf
+			local redis_sock=$(grep -m1 '^[[:blank:]]*unixsocket[[:blank:]]' $redis_conf | awk '{print $2}')
 			usermod -a -G redis www-data
 			# - Enable Nextloud to use Redis socket:
 			if ! grep -q "'memcache.locking'" "$config_php"; then

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2587,6 +2587,7 @@ _EOF_
 	}
 
 	#Work out which additional software we need to install
+	#	- We do reinstall =2 marked software as well, just to be sure.
 	Install_Flag_Prereq_Software(){
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" "Checking for prerequisite software"
@@ -2676,14 +2677,10 @@ _EOF_
 			${aSOFTWARE_INSTALL_STATE[163]} == 1 ||
 			${aSOFTWARE_INSTALL_STATE[168]} == 1 )); then
 
-			if (( ${aSOFTWARE_INSTALL_STATE[$index]} == 0 )); then
+			aSOFTWARE_INSTALL_STATE[$index]=1
 
-				aSOFTWARE_INSTALL_STATE[$index]=1
-
-				#aSOFTWARE_WHIP_NAME
-				G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$index]} will be installed"
-
-			fi
+			#aSOFTWARE_WHIP_NAME
+			G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$index]} will be installed"
 
 		fi
 
@@ -2695,14 +2692,10 @@ _EOF_
 			${aSOFTWARE_INSTALL_STATE[123]} == 1 ||
 			${aSOFTWARE_INSTALL_STATE[134]} == 1 )); then
 
-			if (( ${aSOFTWARE_INSTALL_STATE[$index]} == 0 )); then
+			aSOFTWARE_INSTALL_STATE[$index]=1
 
-				aSOFTWARE_INSTALL_STATE[$index]=1
-
-				#aSOFTWARE_WHIP_NAME
-				G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$index]} will be installed"
-
-			fi
+			#aSOFTWARE_WHIP_NAME
+			G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$index]} will be installed"
 
 		fi
 
@@ -2713,13 +2706,8 @@ _EOF_
 			${aSOFTWARE_INSTALL_STATE[145]} == 1 ||
 			${aSOFTWARE_INSTALL_STATE[147]} == 1 )); then
 
-			if (( ${aSOFTWARE_INSTALL_STATE[$index]} == 0 )); then
-
-				aSOFTWARE_INSTALL_STATE[$index]=1
-
-				G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$index]} will be installed"
-
-			fi
+			aSOFTWARE_INSTALL_STATE[$index]=1
+			G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$index]} will be installed"
 
 		fi
 
@@ -2727,13 +2715,8 @@ _EOF_
 		index=140
 		if (( ${aSOFTWARE_INSTALL_STATE[108]} == 1 )); then
 
-			if (( ${aSOFTWARE_INSTALL_STATE[$index]} == 0 )); then
-
-				aSOFTWARE_INSTALL_STATE[$index]=1
-
-				G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$index]} will be installed"
-
-			fi
+			aSOFTWARE_INSTALL_STATE[$index]=1
+			G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$index]} will be installed"
 
 		fi
 
@@ -2748,13 +2731,8 @@ _EOF_
 			${aSOFTWARE_INSTALL_STATE[153]} == 1 ||
 			${aSOFTWARE_INSTALL_STATE[169]} == 1 )); then
 
-			if (( ${aSOFTWARE_INSTALL_STATE[$index]} == 0 )); then
-
-				aSOFTWARE_INSTALL_STATE[$index]=1
-
-				G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$index]} will be installed"
-
-			fi
+			aSOFTWARE_INSTALL_STATE[$index]=1
+			G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$index]} will be installed"
 
 		fi
 
@@ -2767,13 +2745,8 @@ _EOF_
 			${aSOFTWARE_INSTALL_STATE[119]} == 1 ||
 			${aSOFTWARE_INSTALL_STATE[129]} == 1 )); then
 
-			if (( ${aSOFTWARE_INSTALL_STATE[$index]} == 0 )); then
-
-				aSOFTWARE_INSTALL_STATE[$index]=1
-
-				G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$index]} will be installed"
-
-			fi
+			aSOFTWARE_INSTALL_STATE[$index]=1
+			G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$index]} will be installed"
 
 		fi
 
@@ -2782,13 +2755,8 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[47]} == 1 ||
 			${aSOFTWARE_INSTALL_STATE[114]} == 1 )); then
 
-			if (( ${aSOFTWARE_INSTALL_STATE[$index]} == 0 )); then
-
-				aSOFTWARE_INSTALL_STATE[$index]=1
-
-				G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$index]} will be installed"
-
-			fi
+			aSOFTWARE_INSTALL_STATE[$index]=1
+			G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$index]} will be installed"
 
 		fi
 
@@ -2889,8 +2857,7 @@ _EOF_
 		do
 
 			if (( ${aSOFTWARE_REQUIRES_MYSQL[$i]} &&
-				${aSOFTWARE_INSTALL_STATE[$i]} == 1 &&
-				! ${aSOFTWARE_INSTALL_STATE[88]} )); then
+				${aSOFTWARE_INSTALL_STATE[$i]} == 1 )); then
 
 				#WEBSERVER_MARIADB
 				aSOFTWARE_INSTALL_STATE[88]=1
@@ -2908,8 +2875,7 @@ _EOF_
 		do
 
 			if (( ${aSOFTWARE_REQUIRES_SQLITE[$i]} &&
-				${aSOFTWARE_INSTALL_STATE[$i]} == 1 &&
-				! ${aSOFTWARE_INSTALL_STATE[87]} )); then
+				${aSOFTWARE_INSTALL_STATE[$i]} == 1 )); then
 
 				#WEBSERVER_SQLITE
 				aSOFTWARE_INSTALL_STATE[87]=1

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -1613,7 +1613,8 @@ $print_logfile_info
 	# - First tries to replace old setting, else commented setting and otherwise adds it to end of file.
 	# - Optionally adds argument to new line after speficied pattern $4.
 	# - PRESERVE=1 G_CONFIG_INJECT allows to keep current setting, if present.
-	# - Example: G_CONFIG_INJECT 'prefer-family =' 'prefer-family = IPv4' '/etc/wgetrc'
+	# - Example: G_CONFIG_INJECT 'prefer-family[[:blank:]]*=' 'prefer-family = IPv4' '/etc/wgetrc'
+	# - Extended regular expressions can be used for the identifying patterns $1 and $4.
 	G_CONFIG_INJECT(){
 
 		local pattern="$1"
@@ -1621,32 +1622,40 @@ $print_logfile_info
 		local file="$3"
 		local after="$4"
 
-		if grep -q "^[[:blank:]]*$pattern" "$file"; then
+		if [ ! -f "$file" ]; then
 
-			(( $PRESERVE )) && G_DIETPI-NOTIFY 2 "Preserve existing setting '$(grep $pattern $file)' in '$file'" && exit 0
-			sed -i "/^[[:blank:]]*$pattern/c\\$setting" "$file" && G_DIETPI-NOTIFY 2 "Overwrite existing setting '$setting' in '$file'"
+			G_DIETPI-NOTIFY 2 "File $file does not exists. Will try to create it:"
+			> "$file"
+			(( $? )) && G_WHIP_MSG "Could not create '$file' to add the setting '$setting'.\n\nYou can ignore this, if the setting is not needed, or create the file and add the setting manually." && return 1
 
-		elif grep -q "^[[:blank:]#;]*$pattern" "$file"; then
+		fi
 
-			sed -i "/^[[:blank:]#;]*$pattern/c\\$setting" "$file" && G_DIETPI-NOTIFY 2 "Turn comment into setting '$setting' in '$file'"
+		if grep -qE "^[[:blank:]]*$pattern" "$file"; then
+
+			(( $PRESERVE )) && G_DIETPI-NOTIFY 0 "Preserve existing setting '$(grep -E "$pattern" "$file")' in '$file'" && return 0
+			sed -iE "/^[[:blank:]]*$pattern/c\\$setting" "$file" && G_DIETPI-NOTIFY 0 "Overwrite existing setting '$setting' in '$file'"
+
+		elif grep -qE "^[[:blank:]#;]*$pattern" "$file"; then
+
+			sed -iE "/^[[:blank:]#;]*$pattern/c\\$setting" "$file" && G_DIETPI-NOTIFY 0 "Turn comment into setting '$setting' in '$file'"
 
 		else
 
 			if [ -n "$after" ]; then
 
-				if grep -q "^[[:blank:]]*$after" "$file"; then
+				if grep -qE "^[[:blank:]]*$after" "$file"; then
 
-					sed -i "/^[[:blank:]]*$after/a\\$setting" "$file" && G_DIETPI-NOTIFY 2 "Add setting '$setting' after '$after' in '$file'"
+					sed -iE "/^[[:blank:]]*$after/a\\$setting" "$file" && G_DIETPI-NOTIFY 0 "Add setting '$setting' after '$after' in '$file'"
 
 				else
 
-					G_WHIP_MSG "The pattern '$after' couldn't be found in '$file', thus the setting '$setting' couldn't be added to it's desired position.\n\nYou can ignore this, if the setting is not needed, or add it manually to an appropriate position." G_WHIP_MSG
+					G_WHIP_MSG "The pattern '$after' couldn't be found in '$file', thus the setting '$setting' couldn't be added to it's desired position.\n\nYou can ignore this, if the setting is not needed, or add it manually to an appropriate position." && return 1
 
 				fi
 
 			else
 
-				echo "$setting" >> "$file" && G_DIETPI-NOTIFY 2 "Add setting '$setting' to '$file'"
+				echo "$setting" >> "$file" && G_DIETPI-NOTIFY 0 "Add setting '$setting' to '$file'"
 
 			fi
 


### PR DESCRIPTION
+ DietPi-Software | ownCloud/Nextcloud: Minor install code improvements, use of G_CONFIG_INJECT
+ DietPi-Software | Minor code improvements
+ DietPi-Software | Mark NTP as installed on images by default
+ DietPi-Software | Assure all pre-req software being reinstalled

**WIP: Testing needed**

@Fourdee 
When checking for pre-req software, we do in most cases not check, if the dependency software title is already installed and set status =1 in every case. If I am not wrong, this leads to a reinstall of the related dependency. E.g. SQLite will be reinstalled every time, another title is installed that requires SQLite: https://github.com/Fourdee/DietPi/blob/testing/dietpi/dietpi-software#L2909-L2925

Could be desired, if configuration depends on the other installed titles, on the other hand in many cases we should be able to skip it, in some cases it might be even dangerous, if user made manual adjustments e.g.?