### PR TITLE
DietPi-Software | Pi-hole: Dependency and uninstall enhencements

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2022,6 +2022,7 @@ _EOF_
 					  aSOFTWARE_TYPE[$index_current]=0
 			  aSOFTWARE_REQUIRES_GIT[$index_current]=1
 		aSOFTWARE_REQUIRES_WEBSERVER[$index_current]=1
+		aSOFTWARE_REQUIRES_SQLITE[$index_current]=1
 			 aSOFTWARE_ONLINEDOC_URL[$index_current]='f=8&t=5&start=20#p174'
 		aSOFTWARE_REQUIRES_USERINPUT[$index_current]=1
 
@@ -4395,9 +4396,6 @@ _EOF_
 			INSTALL_URL_ADDRESS='http://install.pi-hole.net'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
-			# - Pre-reqs: https://github.com/Fourdee/DietPi/issues/1282#issuecomment-350490524
-			G_AGI "$PHP_APT_PACKAGE_NAME"-cgi "$PHP_APT_PACKAGE_NAME"-sqlite*
-
 			# - Check free available memory. Increase swapfile size to prevent gravity running out of mem.
 			if (( $(free -m | grep -m1 'Mem:' | awk '{print $4}') < 512 &&
 				$(grep -m1 '^[[:blank:]]*AUTO_SETUP_SWAPFILE_SIZE=' /DietPi/dietpi.txt | sed 's/.*=//') < 512 )); then
@@ -4429,7 +4427,7 @@ _EOF_
 
 			./install.sh $commandline_options
 			local exit_code=$?
-			if (( $exit_code != 0 )); then
+			if (( $exit_code )); then
 
 				G_WHIP_MSG "Pi-Hole exited with code ($exit_code) and is not installed."
 				aSOFTWARE_INSTALL_STATE[$INSTALLING_INDEX]=0
@@ -9331,7 +9329,7 @@ Blocked by Pi-hole.
 _EOF_
 
 			# - Generate pihole.log , set permissions to www-data
-			echo -e "" > /var/log/pihole.log
+			>> /var/log/pihole.log
 			chown www-data:www-data /var/log/pihole.log
 			chmod 775 /var/log/pihole.log
 
@@ -13248,6 +13246,7 @@ _EOF_
 
 			Banner_Uninstalling
 			G_AGP dnsmasq
+			rm -R /etc/dnsmasq*
 			pihole uninstall
 
 			#https://github.com/Fourdee/DietPi/issues/753
@@ -13256,10 +13255,16 @@ _EOF_
 			rm -R /etc/pihole
 			rm -R /etc/.pihole
 			rm -R /var/www/html/admin
+			rm -R /opt/pihole
 
 			# - symlinks
-			rm /var/www/pihole
-			rm /var/www/admin
+			rm /var/www/pihole &> /dev/null
+			rm /var/www/admin &> /dev/null
+
+			# - pihole-FTL service
+			systemctl disable pihole-FTL &> /dev/null
+			systemctl stop pihole-FTL &> /dev/null
+			rm /etc/init.d/pihole-FTL &> /dev/null
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -13245,26 +13245,28 @@ _EOF_
 		if (( aSOFTWARE_INSTALL_STATE[$UNINSTALLING_INDEX] == -1 )); then
 
 			Banner_Uninstalling
-			G_AGP dnsmasq
-			rm -R /etc/dnsmasq*
 			pihole uninstall
 
-			#https://github.com/Fourdee/DietPi/issues/753
-			chmod 774 /etc/lighttpd/lighttpd.conf &> /dev/null
-
-			rm -R /etc/pihole
-			rm -R /etc/.pihole
-			rm -R /var/www/html/admin
-			rm -R /opt/pihole
+			rm -R /etc/pihole &> /dev/null
+			rm -R /etc/.pihole &> /dev/null
+			rm -R /opt/pihole &> /dev/null
+			rm -R /var/www/html/admin &> /dev/null
 
 			# - symlinks
 			rm /var/www/pihole &> /dev/null
 			rm /var/www/admin &> /dev/null
 
-			# - pihole-FTL service
+			# - pihole-FTL service+binary
 			systemctl disable pihole-FTL &> /dev/null
 			systemctl stop pihole-FTL &> /dev/null
 			rm /etc/init.d/pihole-FTL &> /dev/null
+			rm /usr/bin/pihole-FTL &> /dev/null
+
+			G_AGP dnsmasq
+			rm -R /etc/dnsmasq* &> /dev/null
+
+			#https://github.com/Fourdee/DietPi/issues/753
+			chmod 774 /etc/lighttpd/lighttpd.conf &> /dev/null
 
 		fi
 


### PR DESCRIPTION
+ https://github.com/Fourdee/DietPi/issues/1696#issuecomment-385215123
- Add SQLite to deps, to have php-sqlite installed as well before Pi-hole installer. Allows better overview and uninstall of web stack after Pi-hole uninstall.
- `php-cgi` is used by Pi-hole installer as Lighttpd connector, thus not necessary, if `php-fpm`/mod-php is used with our webserver installation.
- Remove all leftovers on Pi-hole uninstall, especially the still active pihole-FTL service.