### PR TITLE
DietPi-Globals | G_CONFIG_INJECT: Final fixes

### DIFF
--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -1709,14 +1709,14 @@ $print_logfile_info
 
 			else
 
-				sed -Ei "0,/^[[:blank:]]*$pattern/s/^[[:blank:]]*$pattern.*$/$setting/" "$file"
+				sed -Ei "0,/^[[:blank:]]*$pattern/s|^[[:blank:]]*$pattern.*$|$setting|" "$file"
 				G_DIETPI-NOTIFY 0 "Edit existing setting \e[33m$setting\e[0m in \e[33m$file\e[0m"
 
 			fi
 
 		elif grep -qE "^[[:blank:]#;]*$pattern" "$file"; then
 
-			sed -Ei "0,/^[[:blank:]#;]*$pattern/s/^[[:blank:]#;]*$pattern.*$/$setting/" "$file"
+			sed -Ei "0,/^[[:blank:]#;]*$pattern/s|^[[:blank:]#;]*$pattern.*$|$setting|" "$file"
 			G_DIETPI-NOTIFY 0 "Turn comment into setting \e[33m$setting\e[0m in \e[33m$file\e[0m"
 
 		else
@@ -1725,7 +1725,7 @@ $print_logfile_info
 
 				if grep -qE "^[[:blank:]]*$after" "$file"; then
 
-					sed -Ei "0,/^[[:blank:]]*$after/s/^[[:blank:]]*$after.*$/&\n$setting/" "$file"
+					sed -Ei "0,/^[[:blank:]]*$after/s|^[[:blank:]]*$after.*$|&\n$setting|" "$file"
 					G_DIETPI-NOTIFY 0 "Add setting \e[33m$setting\e[0m after \e[33m$(grep -Em1 "$after" "$file")\e[0m in \e[33m$file\e[0m"
 
 				else

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -27,8 +27,7 @@
 	cd "$HOME"
 	#-----------------------------------------------------------------------------------
 	#Exit script for unsupported terminal and set dumb: https://github.com/Fourdee/DietPi/issues/1703#issue-314330405
-	if [ -z "$TERM" ] ||
-		[ "$TERM" = 'unknown' ]; then
+	if [[ -z $TERM || $TERM == unknown ]]; then
 
 		export TERM='dumb'
 		exit
@@ -49,7 +48,7 @@
 	# - Affects:
 	#	G_ERROR_HANDLER whiptail display
 	#	NB: You can export G_USER_INPUTS=0 to force non-interactive (eg: .bashrc) Must run 'unset G_USER_INPUTS' after to return to auto detection.
-	if [ -z $G_USER_INPUTS ]; then
+	if [[ -z $G_USER_INPUTS ]]; then
 
 		G_USER_INPUTS=0
 
@@ -71,7 +70,7 @@
 
 	#DietPi First-Run Stage | -2 = PREP_SYSTEM/Unknown | -1 = first boot | 0 = run dietpi-software at login | 1 = completed
 	G_DIETPI_INSTALL_STAGE=-2
-	if [ -f /DietPi/dietpi/.install_stage ]; then
+	if [[ -f /DietPi/dietpi/.install_stage ]]; then
 
 		G_DIETPI_INSTALL_STAGE=$(cat /DietPi/dietpi/.install_stage)
 
@@ -92,7 +91,7 @@
 
 	# - Update
 	#	NB: dietpi-boot service launches dietpi-obtain_hw_model to create the following file
-	if [ -f /DietPi/dietpi/.hw_model ]; then
+	if [[ -f /DietPi/dietpi/.hw_model ]]; then
 
 		G_HW_MODEL=$(sed -n 1p /DietPi/dietpi/.hw_model)
 		G_HW_MODEL_DESCRIPTION=$(sed -n 2p /DietPi/dietpi/.hw_model)
@@ -122,7 +121,7 @@
 		export LC_ALL=en_GB.UTF-8
 
 		# - HIERARCHY system for G_DIETPI-NOTIFY 3
-		[ -n "$HIERARCHY" ] && export HIERARCHY=$((HIERARCHY+1)) || export HIERARCHY=0
+		[[ $HIERARCHY ]] && export HIERARCHY=$((HIERARCHY+1)) || export HIERARCHY=0
 
 		# - Auto print init header for all scripts
 		# G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Init'
@@ -155,7 +154,7 @@
 		local status_text_error="\e[31mFAILED\e[0m"
 		local status_text_info="\e[0m INFO \e[0m"
 		local status_subfunction="\e[33m SUBF \e[0m"
-		if [ -n "$HIERARCHY" ]; then
+		if [[ $HIERARCHY ]]; then
 
 			# - >=10 should never occur, however, if it is, lets make it line up regardless
 			if (( $HIERARCHY < 10 )); then
@@ -198,7 +197,7 @@
 			for (( i=0; i<=${#aprocess_string[@]}; i++ )); do
 
 				(( i == 11 )) && i=1
-				[ -f /tmp/dietpi-process.pid ] && echo -ne "\r$bracket_string_l${aprocess_string[i]}$bracket_string_r " || break
+				[[ -w /tmp/dietpi-process.pid ]] && echo -ne "\r$bracket_string_l${aprocess_string[i]}$bracket_string_r " || break
 				sleep 0.15
 
 			done
@@ -207,10 +206,10 @@
 
 		Clean_Process_Animation(){
 
-			if [ -f /tmp/dietpi-process.pid ]; then
+			if [[ -w /tmp/dietpi-process.pid ]]; then
 
 				kill "$(</tmp/dietpi-process.pid)" &> /dev/null
-				rm /tmp/dietpi-process.pid &> /dev/null || sudo rm /tmp/dietpi-process.pid &> /dev/null
+				rm /tmp/dietpi-process.pid &> /dev/null
 				# In case, the output took more than one line, clean from cursor (animation position) until end of terminal.
 				tput ed
 
@@ -257,16 +256,17 @@
 		# - $1 = start printing from word number $1
 		Print_Input_String(){
 
-			if (( $1 == 1 )) && [ -n "$G_PROGRAM_NAME" ]; then
+			if (( $1 == 1 )) && [[ -n $G_PROGRAM_NAME ]]; then
 
 				echo -ne "\e[90m$G_PROGRAM_NAME | \e[0m"
 
 			fi
 
 			local i=0
-			for (( i=$1;i<${#ainput_string[@]} ;i++))
-			do
+			for (( i=$1; i<${#ainput_string[@]}; i++ )); do
+
 				echo -ne "${ainput_string[$i]}"
+
 			done
 
 		}
@@ -279,7 +279,7 @@
 		# - Use this at end of DietPi scripts, EG: G_DIETPI-NOTIFY -1 ${EXIT_CODE:=0}
 		if (( $1 == -1 )); then
 
-			if [ "$2" = "0" ]; then
+			if [[ $2 == 0 ]]; then
 
 				ainput_string+=(" Completed")
 				Print_Ok
@@ -312,7 +312,7 @@
 				(( lines-- ))
 
 			done
-			[ ! -f /tmp/dietpi-process.pid ] && touch /tmp/dietpi-process.pid && ( Print_Process_Animation & echo $! > /tmp/dietpi-process.pid )
+			[[ ! -e /tmp/dietpi-process.pid ]] && > /tmp/dietpi-process.pid && ( Print_Process_Animation & echo $! > /tmp/dietpi-process.pid )
 
 		#Status Ok
 		#$@ = txt desc
@@ -344,7 +344,7 @@
 		#$3 = txt mode
 		elif (( $1 == 3 )); then
 
-			if [ -n "$HIERARCHY" ] && (( $HIERARCHY > 0 )); then
+			if [[ $HIERARCHY ]] && (( $HIERARCHY > 0 )); then
 
 					Print_Subfunction
 					echo -e "$2 > $(Print_Input_String 2)"
@@ -379,7 +379,7 @@
 	G_CHECK_ROOT_USER(){
 
 		local input=0
-		if [ -n $1 ]; then
+		if [[ $1 ]]; then
 
 			input=$1
 
@@ -389,7 +389,7 @@
 
 			G_DIETPI-NOTIFY -2 'Checking for (elevated) root access'
 
-			if (( $UID != 0 )); then
+			if (( $UID )); then
 
 				G_DIETPI-NOTIFY 1 'Root privileges required. Please run the command with "G_SUDO", or, "sudo -i".'
 
@@ -466,20 +466,20 @@
 	alias dietpi-software='/DietPi/dietpi/dietpi-software'
 	alias dietpi-update='/DietPi/dietpi/dietpi-update'
 	alias dietpi-drive_manager='/DietPi/dietpi/dietpi-drive_manager'
-	alias emulationstation='/opt/retropie/supplementary/emulationstation/emulationstation'
 
 	alias cpu='/DietPi/dietpi/dietpi-cpuinfo'
 	alias dietpi-logclear='/DietPi/dietpi/dietpi-logclear'
 
 	# - Optional DietPi software aliases/functions
-	[ -f /usr/local/games/opentyrian/run ] && alias opentyrian='/usr/local/games/opentyrian/run'
-	[ -f /DietPi/dietpi/misc/dietpi-justboom ] && alias dietpi-justboom='/DietPi/dietpi/misc/dietpi-justboom'
-	[ -f "$G_FP_DIETPI_USERDATA"/dxx-rebirth/run.sh ] && alias dxx-rebirth="$G_FP_DIETPI_USERDATA/dxx-rebirth/run.sh"
-	[ -f /usr/share/applications/kodi.desktop ] && alias startkodi='/DietPi/dietpi/misc/start_kodi'
-	[ -f /etc/systemd/system/dietpi-cloudshell.service ] && alias dietpi-cloudshell='/DietPi/dietpi/dietpi-cloudshell'
+	[[ -f /opt/retropie/supplementary/emulationstation/emulationstation ]] && alias emulationstation='/opt/retropie/supplementary/emulationstation/emulationstation'
+	[[ -f /usr/local/games/opentyrian/run ]] && alias opentyrian='/usr/local/games/opentyrian/run'
+	[[ -f /DietPi/dietpi/misc/dietpi-justboom ]] && alias dietpi-justboom='/DietPi/dietpi/misc/dietpi-justboom'
+	[[ -f $G_FP_DIETPI_USERDATA/dxx-rebirth/run.sh ]] && alias dxx-rebirth="$G_FP_DIETPI_USERDATA/dxx-rebirth/run.sh"
+	[[ -f /usr/share/applications/kodi.desktop ]] && alias startkodi='/DietPi/dietpi/misc/start_kodi'
+	[[ -f /etc/systemd/system/dietpi-cloudshell.service ]] && alias dietpi-cloudshell='/DietPi/dietpi/dietpi-cloudshell'
 	# occ/ncc need to be global function, as aliases are not accessible from non-interactive scripts:
-	[ -f /var/www/owncloud/occ ] && occ(){ sudo -u www-data php /var/www/owncloud/occ "$@"; }
-	[ -f /var/www/nextcloud/occ ] && ncc(){ sudo -u www-data php /var/www/nextcloud/occ "$@"; }
+	[[ -f /var/www/owncloud/occ ]] && occ(){ sudo -u www-data php /var/www/owncloud/occ "$@"; }
+	[[ -f /var/www/nextcloud/occ ]] && ncc(){ sudo -u www-data php /var/www/nextcloud/occ "$@"; }
 
 	#-----------------------------------------------------------------------------------
 	# Whiptail (Whippy-da-whip-whip-whip tail!)
@@ -536,7 +536,7 @@
 
 		#Update backtitle
 		WHIP_BACKTITLE="$G_PROGRAM_NAME | $G_HW_MODEL_DESCRIPTION"
-		if [ -f /DietPi/dietpi/.network ]; then
+		if [[ -f /DietPi/dietpi/.network ]]; then
 
 			WHIP_BACKTITLE+=" | IP: $(sed -n 4p /DietPi/dietpi/.network)"
 
@@ -583,19 +583,17 @@
 		# - This can then be used to increase/decrease size of WHIP_SIZE_Z automatically.
 		else
 
-			if [ -n "$WHIP_MESSAGE" ]; then
+			if [[ $WHIP_MESSAGE ]]; then
 
 				local character_count_per_line=$(echo -e "$WHIP_MESSAGE" | awk '{ print length }')
 
 				# - Calculate lines required
-				while read -r line
-				do
+				while read -r line; do
 
 					((lines_required_whip_y++))
 
 					# - Calculate for addition required lines, if the text is longer than X
-					while (( $line > ( $WHIP_SIZE_X - $whip_x_internal_margin ) ))
-					do
+					while (( $line > ( $WHIP_SIZE_X - $whip_x_internal_margin ) ));	do
 
 						line=$(( $line - ( $WHIP_SIZE_X - $whip_x_internal_margin ) ))
 						((lines_required_whip_y++))
@@ -654,8 +652,7 @@
 
 				local lines_max_whip_z=$lines_required_whip_z
 
-				while (( ( $lines_max_whip_z + $lines_required_whip_y ) > $WHIP_SIZE_Y ))
-				do
+				while (( ( $lines_max_whip_z + $lines_required_whip_y ) > $WHIP_SIZE_Y )); do
 
 					((lines_max_whip_z--))
 
@@ -830,7 +827,7 @@
 		if (( $G_USER_INPUTS )); then
 
 			G_WHIP_YESNO "Would you like to view the contents of the following logfile?\n - $fp_log\n\nThis will contain further additional information, that may be required by the user."
-			if (( $? == 0 )); then
+			if (( ! $? )); then
 
 				#???
 				#G_FILE_EXISTS "$fp_log"
@@ -879,10 +876,10 @@
 	#	Usage: G_RUN_CMD dothis
 	G_ERROR_HANDLER(){
 
-		[ -n "$l_message" ] || local l_message="$G_ERROR_HANDLER_COMMAND"
+		[[ $l_message ]] || local l_message="$G_ERROR_HANDLER_COMMAND"
 
 		#Ok
-		if (( $G_ERROR_HANDLER_EXITCODE == 0 )); then
+		if (( ! $G_ERROR_HANDLER_EXITCODE )); then
 
 			G_DIETPI-NOTIFY 0 "$l_message"
 
@@ -892,7 +889,7 @@
 			local print_hw_info="DietPi version: v$(sed -n 1p /DietPi/dietpi/.version).$(sed -n 2p /DietPi/dietpi/.version) | HW_MODEL:$G_HW_MODEL | HW_ARCH:$G_HW_ARCH | DISTRO:$G_DISTRO"
 			local image_creator=''
 			local preimage_name=''
-			if [ -f '/DietPi/dietpi/.prep_info' ]; then
+			if [[ -f '/DietPi/dietpi/.prep_info' ]]; then
 
 				image_creator="$(sed -n 1p /DietPi/dietpi/.prep_info)"
 				preimage_name="$(sed -n 2p /DietPi/dietpi/.prep_info)"
@@ -905,7 +902,7 @@
 			G_DIETPI-NOTIFY 1 "$G_ERROR_HANDLER_COMMAND"
 
 			#	Display "please report to dietpi", if its one of our programs
-			if [ -n "$G_PROGRAM_NAME" ]; then
+			if [[ $G_PROGRAM_NAME ]]; then
 
 				G_DIETPI-NOTIFY 2 "$print_report_to_dietpi_info"
 
@@ -915,7 +912,7 @@
 			if (( $G_USER_INPUTS )); then
 
 				local whip_msg=()
-				if [ -n "$G_PROGRAM_NAME" ]; then
+				if [[ $G_PROGRAM_NAME ]]; then
 
 					whip_msg+="$G_PROGRAM_NAME: $G_ERROR_HANDLER_COMMAND"
 
@@ -936,7 +933,7 @@
 				whip_msg+='\n\n'
 
 				#	Display optional logfile?
-				if [ -n "$G_ERROR_HANDLER_ONERROR_FPLOGFILE" ]; then
+				if [[ $G_ERROR_HANDLER_ONERROR_FPLOGFILE ]]; then
 
 					whip_msg+="$print_logfile_info"
 					whip_msg+='\n\n'
@@ -944,7 +941,7 @@
 				fi
 
 				#	Display "please report to dietpi", if its one of our programs
-				if [ -n "$G_PROGRAM_NAME" ]; then
+				if [[ $G_PROGRAM_NAME ]]; then
 
 					whip_msg+="$print_report_to_dietpi_info"
 
@@ -1035,7 +1032,7 @@ $print_logfile_info
 
 		G_ERROR_HANDLER_COMMAND="$@"
 
-		[ -n "$l_message" ] || local l_message="$G_ERROR_HANDLER_COMMAND"
+		[[ $l_message ]] || local l_message="$G_ERROR_HANDLER_COMMAND"
 		G_DIETPI-NOTIFY -2 "$l_message"
 
 		$G_ERROR_HANDLER_COMMAND &> /tmp/G_ERROR_HANDLER_COMMAND
@@ -1064,8 +1061,7 @@ $print_logfile_info
 		G_ERROR_HANDLER_COMMAND="Connection test: $string"
 		G_ERROR_HANDLER_ONERROR_FPLOGFILE='/tmp/G_CHECK_URL'
 
-		while true
-		do
+		while true; do
 
 			#Allow user choice to configure network on failure
 			if (( $G_USER_INPUTS )); then
@@ -1076,7 +1072,7 @@ $print_logfile_info
 
 					#Ask to check settings,
 					whiptail --title "URL Connection Test Failed" --yesno "DietPi was unable to establish a connection:\n - $string\n\nIf problems persist, the URL may be offline/unreachable.\n\nWould you like to configure network settings and try again?" --yes-button "Ok" --no-button "Exit" --defaultno --backtitle "$WHIP_BACKTITLE" 15 80
-					if (( $? == 0 )); then
+					if (( ! $? )); then
 
 						whiptail --title "Launching DietPi-Config" --msgbox "DietPi-Config will now be started.\nUse the Network Options menu to change and test your network settings.\n\nWhen completed, exit DietPi-Config to resume." --backtitle "Launching DietPi-Config" 14 60
 						/DietPi/dietpi/dietpi-config 8 1
@@ -1102,15 +1098,14 @@ $print_logfile_info
 			fi
 
 			local i=0
-			for ((i=1; i<=$retry_max; i++))
-			do
+			for ((i=1; i<=$retry_max; i++)); do
 
 				G_DIETPI-NOTIFY -2 "($i/$retry_max) Testing connection to $string, please wait..."
 
 				wget --spider --timeout=$timeout --tries=1 "$string" &> /tmp/G_CHECK_URL
 				G_ERROR_HANDLER_EXITCODE=$?
 				#	Valid
-				if (( $G_ERROR_HANDLER_EXITCODE == 0 )); then
+				if (( ! $G_ERROR_HANDLER_EXITCODE )); then
 
 					break
 
@@ -1129,7 +1124,7 @@ $print_logfile_info
 			#https://github.com/Fourdee/DietPi/issues/352#issuecomment-221013166
 
 			G_ERROR_HANDLER
-			if (( $G_ERROR_HANDLER_EXITCODE == 0 )); then
+			if (( ! $G_ERROR_HANDLER_EXITCODE )); then
 
 				break
 
@@ -1153,11 +1148,11 @@ $print_logfile_info
 
 		local string=''
 
-		if [ -f "$G_ERROR_HANDLER_COMMAND" ]; then
+		if [[ -f $G_ERROR_HANDLER_COMMAND ]]; then
 
 			string='File exists'
 
-		elif [ -d "$G_ERROR_HANDLER_COMMAND" ]; then
+		elif [[ -d $G_ERROR_HANDLER_COMMAND ]]; then
 
 			string='Folder exists'
 
@@ -1251,8 +1246,7 @@ $print_logfile_info
 		local packages_to_remove=''
 		dpkg --get-selections > "$fp_temp"
 		local i=0
-		for i in "${string[@]}"
-		do
+		for i in "${string[@]}"; do
 
 			if (( $(grep -ci -m1 "^$i[[:space:]|:]" "$fp_temp") ||
 				( $(echo -e "$i" | grep -ci -m1 '*') && $(grep -ci -m1 "^$i" "$fp_temp") ) )); then #wildcard check
@@ -1271,7 +1265,7 @@ $print_logfile_info
 		rm "$fp_temp"
 		unset string #habbit :)
 
-		if [ -n "$packages_to_remove" ]; then
+		if [[ $packages_to_remove ]]; then
 
 			G_DIETPI-NOTIFY 0 "APT removal for: \e[33m$packages_to_remove\e[0m, please wait..."
 			echo -ne "\e[90m"
@@ -1301,7 +1295,7 @@ $print_logfile_info
 		G_ERROR_HANDLER_COMMAND="G_AGA"
 		G_ERROR_HANDLER_ONERROR_FPLOGFILE="$G_FP_LOG_APT"
 
-		G_DIETPI-NOTIFY 0 "APT autoremove + purge, please wait..."
+		G_DIETPI-NOTIFY 0 'APT autoremove + purge, please wait...'
 
 		echo -ne "\e[90m"
 		DEBIAN_FRONTEND=noninteractive apt-get autoremove --purge -y 2>&1 | tee "$G_FP_LOG_APT"
@@ -1324,7 +1318,7 @@ $print_logfile_info
 		G_ERROR_HANDLER_COMMAND="G_AGF"
 		G_ERROR_HANDLER_ONERROR_FPLOGFILE="$G_FP_LOG_APT"
 
-		G_DIETPI-NOTIFY 0 "APT fix, please wait..."
+		G_DIETPI-NOTIFY 0 'APT fix, please wait...'
 
 		echo -ne "\e[90m"
 		DEBIAN_FRONTEND=noninteractive apt-get install -f -y 2>&1 | tee "$G_FP_LOG_APT"
@@ -1347,7 +1341,7 @@ $print_logfile_info
 		G_ERROR_HANDLER_COMMAND="G_AGUP"
 		G_ERROR_HANDLER_ONERROR_FPLOGFILE="$G_FP_LOG_APT"
 
-		G_DIETPI-NOTIFY 0 "APT update, please wait..."
+ 		G_DIETPI-NOTIFY 0 'APT update, please wait...'
 
 		echo -ne "\e[90m"
 		DEBIAN_FRONTEND=noninteractive apt-get clean 2>&1 | tee "$G_FP_LOG_APT"
@@ -1371,7 +1365,7 @@ $print_logfile_info
 		G_ERROR_HANDLER_COMMAND="G_AGUG"
 		G_ERROR_HANDLER_ONERROR_FPLOGFILE="$G_FP_LOG_APT"
 
-		G_DIETPI-NOTIFY 0 "APT upgrade, please wait..."
+		G_DIETPI-NOTIFY 0 'APT upgrade, please wait...'
 
 		local options=''
 		if (( $G_DISTRO >= 4 )); then
@@ -1411,7 +1405,7 @@ $print_logfile_info
 
 		fi
 
-		G_DIETPI-NOTIFY 0 "APT dist-upgrade, please wait..."
+		G_DIETPI-NOTIFY 0 'APT dist-upgrade, please wait...'
 
 		echo -ne "\e[90m"
 		DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y $force_options 2>&1 | tee "$G_FP_LOG_APT"
@@ -1440,8 +1434,7 @@ $print_logfile_info
 
 		dpkg --get-selections > "$fp_temp"
 		local i=0
-		for i in "${string[@]}"
-		do
+		for i in "${string[@]}"; do
 
 			if ! grep -qi "^$i[[:space:]]" "$fp_temp"; then
 
@@ -1452,7 +1445,7 @@ $print_logfile_info
 
 		done
 
-		if [ -n "$packages_to_install" ]; then
+		if [[ $packages_to_install ]]; then
 
 			G_DIETPI-NOTIFY -2 "Installing pre-req APT packages"
 			G_AGI $packages_to_install
@@ -1531,10 +1524,9 @@ $print_logfile_info
 		)
 
 		local i=0
-		for ((i=0; i<${#afp_temperature[@]}; i++))
-		do
+		for ((i=0; i<${#afp_temperature[@]}; i++)); do
 
-			if [ -f "${afp_temperature[$i]}" ]; then
+			if [[ -f ${afp_temperature[$i]} ]]; then
 
 				#	Sparky/asus, special case:
 				if (( $G_HW_MODEL == 70 || $G_HW_MODEL == 52 )); then
@@ -1567,7 +1559,6 @@ $print_logfile_info
 
 				fi
 
-
 				break
 
 			fi
@@ -1587,8 +1578,7 @@ $print_logfile_info
 		local cpu_usage=0
 		local fp_temp='/tmp/.cpu_usage_cpuinfo'
 		ps -axo %cpu | sed '1d' | sed 's/ //' > "$fp_temp"
-		while read line
-		do
+		while read line; do
 
 			cpu_usage=$( echo "scale=1;$cpu_usage + $line" | bc -l )
 
@@ -1709,14 +1699,14 @@ $print_logfile_info
 
 			else
 
-				sed -Ei "0,/^[[:blank:]]*$pattern/s|^[[:blank:]]*$pattern.*$|$setting|" "$file"
+				sed -Ei "0,/^[[:blank:]]*$pattern.*$/s||$setting|" "$file"
 				G_DIETPI-NOTIFY 0 "Edit existing setting \e[33m$setting\e[0m in \e[33m$file\e[0m"
 
 			fi
 
 		elif grep -qE "^[[:blank:]#;]*$pattern" "$file"; then
 
-			sed -Ei "0,/^[[:blank:]#;]*$pattern/s|^[[:blank:]#;]*$pattern.*$|$setting|" "$file"
+			sed -Ei "0,/^[[:blank:]#;]*$pattern.*$/s||$setting|" "$file"
 			G_DIETPI-NOTIFY 0 "Turn comment into setting \e[33m$setting\e[0m in \e[33m$file\e[0m"
 
 		else
@@ -1725,7 +1715,7 @@ $print_logfile_info
 
 				if grep -qE "^[[:blank:]]*$after" "$file"; then
 
-					sed -Ei "0,/^[[:blank:]]*$after/s|^[[:blank:]]*$after.*$|&\n$setting|" "$file"
+					sed -Ei "0,/^[[:blank:]]*$after.*$/s||&\n$setting|" "$file"
 					G_DIETPI-NOTIFY 0 "Add setting \e[33m$setting\e[0m after \e[33m$(grep -Em1 "$after" "$file")\e[0m in \e[33m$file\e[0m"
 
 				else


### PR DESCRIPTION
+ DietPi-Globals | G_CONFIG_INJECT: Use `|` as delimiter to allow file paths without escaping `\`

@Fourdee 
This `sed` is driving me crazy. Was no problem, until used with double matches. This is rare, but some settings files allow multiple time the same setting, adding the values (e.g. /etc/ntp.conf server/pool). Also if you use much wildcards within pattern 😉. Then G_CONFIG_INJECT shall only apply to first match to avoid double entries.

`/c` and `/a` apply to every match and I didn't find a way to only apply them to first match. Theoretically `s/^.*pattern.*$/replacement/` or `s/^.*pattern.*$/&\n addition/` should work instead, but somehow they also apply to every match, even they should not. `s/.../.../1` also does not work as every man page or guide says 😠:
```
root@DietPi:~# cat TEST
test1 = 1
test2 = 2
test3 = 3
test3 = again
test1 = jep
root@DietPi:~# sed -i 's/test3 = .*/test3 = changed/' TEST
root@DietPi:~# cat TEST
test1 = 1
test2 = 2
test3 = changed
test3 = changed
test1 = jep
root@DietPi:~# sed -i 's/test1 = .*/test1 = changed_as_well/1' TEST
root@DietPi:~# cat TEST
test1 = changed_as_well
test2 = 2
test3 = changed
test3 = changed
test1 = changed_as_well
root@DietPi:~# sed -i '0,/test3 =/s/test3 = .*/test3 = changed_at_last/' TEST
root@DietPi:~# cat TEST
test1 = changed_as_well
test2 = 2
test3 = changed_at_last
test3 = changed
test1 = changed_as_well
root@DietPi:~# ^C
root@DietPi:~# sed -i '0,/test3 =/s/test3 = .*/&\ntest4 = mal_sehen/' TEST
root@DietPi:~# cat TEST
test1 = changed_as_well
test2 = 2
test3 = changed_at_last
test4 = mal_sehen
test3 = changed
test1 = changed_as_well
```
- The last ones shows the only ugly solution I could find.
- Problem with `s/` is also that you need to escape the delimiter, which didn't matter after `/c` or `/a`. Thus this PR to allow paths without the need to escape all slashes 😉.

Do you know any cleaner `awk` solutions? The one here is quite ugly for me and I somehow lost trust in `sed` 🤣.