### PR TITLE
DietPi-Drive_Manager | Improved method of reading available dev drives

### DIFF
--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -124,7 +124,11 @@
 			for i in /dev/sd[a-z][0-9]
 			do
 
-				aDRIVE_MOUNT_SOURCE+=($i)
+				if [[ -b $i ]]; then
+				
+					aDRIVE_MOUNT_SOURCE+=($i)
+					
+				fi
 
 			done
 
@@ -132,7 +136,11 @@
 			for i in /dev/mmcblk[0-9]p[0-9]
 			do
 
-				aDRIVE_MOUNT_SOURCE+=($i)
+				if [[ -b $i ]]; then
+				
+					aDRIVE_MOUNT_SOURCE+=($i)
+					
+				fi
 
 			done
 

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -865,7 +865,7 @@
 			if (( ${aDRIVE_ISMOUNTED[$INDEX_DRIVE_BEING_EDITED]} )); then
 
 				local reserved_blocks_percent_info=''
-				local reserved_blocks_percent_current=''
+				local reserved_blocks_percent_current=0
 				# Show reserved blocks percentage for ext4 drives behind capacity:
 				if [ "${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]}" = 'ext4' ]; then
 
@@ -874,7 +874,9 @@
 					local block_count="$(grep -m1 '^Block count:' $fp_temp | awk '{print $3}')"
 					local reserved_block_count="$(grep -m1 '^Reserved block count:' $fp_temp | awk '{print $4}')"
 					rm "$fp_temp"
-					reserved_blocks_percent_current="$(bc -l <<< "scale=2;100*$reserved_block_count/$block_count+0.01" | sed 's/^\./0\./' | sed 's/0$//' | sed 's/\.0$//')"
+					reserved_blocks_percent_current="$(bc -l <<< "scale=3;(100*$reserved_block_count)/$block_count")"
+					# Correct rounding to final scale:
+					reserved_blocks_percent_current="$(bc -l <<< "scale=2;(($reserved_blocks_percent_current*100)+0.5)/100" | sed 's/^\./0\./' | sed '/.0$/s/0$//' | sed 's/\.0$//')"
 					reserved_blocks_percent_info=" (Reserved blocks: $reserved_blocks_percent_current%)"
 					G_WHIP_MENU_ARRAY+=('Reserved blocks' ': Adjust percentage of reserved blocks on this drive')
 
@@ -1011,7 +1013,11 @@
 
 					G_WHIP_DEFAULT_ITEM="$reserved_blocks_percent_current"
 					G_WHIP_INPUTBOX 'Ext4 formatted drives allow the reservation of drive space for the root user to assure system functionality, if filled by other users or processes, and to avoid fragmentation of large files.\n\nHowever, on modern drives, the default of 5% reserved blocks is often by orders of magnitude larger than necessary. You may want to reduce the percentage to an absolute reserved space of about 500 MiB, which should be enough, to enable root user starting and maintaining the system. Additionally, on non rootfs drives reserved blocks are not necessary at all.\n\nPlease enter the desired percentage of reserved blocks, e.g. "0.05" for 0.05% or "10" for 10%.\nNote: Only values between "0" and "50" are allowed.'
-					if (( ! $? )); then
+					if (( $? )); then
+
+						break
+
+					else
 
 						if grep -qE '^[0-9]*\.?[0-9]*$' <<< "$G_WHIP_RETURNED_VALUE" &&
 							[ "$G_WHIP_RETURNED_VALUE" != '.' ] &&

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -1241,22 +1241,33 @@
 				G_WHIP_MENU "Please select a filesystem type for this format:\n\nEXT4:\nHighly recommended if you plan to use this drive solely on this system (dedicated drive).\n\nNTFS:\nRecommended if you plan to use this drive on a Windows system. High CPU usage during transfers.\n\nFull list of different filesystem types:\nhttp://dietpi.com/phpbb/viewtopic.php?f=8&t=673&p=2898#p2898"
 				if (( ! $? )); then
 
-					# - HFS install packages
-					if (( $G_WHIP_RETURNED_VALUE == 3 )); then
+					# Install FS pre-reqs
+					# - NTFS
+					if (( $G_WHIP_RETURNED_VALUE == 1 )); then
+
+						G_AG_CHECK_INSTALL_PREREQ ntfs-3g
+
+					# - FAT32
+					elif (( $G_WHIP_RETURNED_VALUE == 2 )); then
+
+						G_AG_CHECK_INSTALL_PREREQ dosfstools
+
+					# - HFS+
+					elif (( $G_WHIP_RETURNED_VALUE == 3 )); then
 
 						G_AG_CHECK_INSTALL_PREREQ hfsplus hfsprogs hfsutils
 
-					# - btrfs install packages
+					# - Btrfs
 					elif (( $G_WHIP_RETURNED_VALUE == 4 )); then
 
 						G_AG_CHECK_INSTALL_PREREQ btrfs-tools
 
-					# - f2fs install packages
+ 					# - F2FS
 					elif (( $G_WHIP_RETURNED_VALUE == 5 )); then
 
 						G_AG_CHECK_INSTALL_PREREQ f2fs-tools
 
-					# - exfat install packages
+					# - exFAT
 					elif (( $G_WHIP_RETURNED_VALUE == 6 )); then
 
 						G_AG_CHECK_INSTALL_PREREQ exfat-utils exfat-fuse

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -130,6 +130,7 @@
 
 			# - /dev/mmcblkXpX
 			for i in /dev/mmcblk[0-9]p[0-9]
+			do
 
 				aDRIVE_MOUNT_SOURCE+=($i)
 

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -120,37 +120,18 @@
 			cp /etc/fstab "$FP_TEMP_FSTAB"
 
 			#Get list of available dev drives
-			local dev_detection_max_partitions=9
-			local dev_detection_max_drives=5
-			local string=''
-			for (( i=0; i<=$dev_detection_max_partitions; i++ ))
+			# - /dev/sdXX
+			for i in /dev/sd[a-z][0-9]
 			do
 
-				# - /dev/sdXX
-				for (( j=97; j<$(( 97 + $dev_detection_max_drives )); j++ ))
-				do
+				aDRIVE_MOUNT_SOURCE+=($i)
 
-					string="/dev/sd$(awk 'BEGIN{printf "%c", '$j'}')$i"
-					if [[ -b $string ]]; then
+			done
 
-						aDRIVE_MOUNT_SOURCE+=($string)
+			# - /dev/mmcblkXpX
+			for i in /dev/mmcblk[0-9]p[0-9]
 
-					fi
-
-				done
-
-				# - /dev/mmcblkXpX
-				for (( j=0; j<$dev_detection_max_drives; j++ ))
-				do
-
-					string="/dev/mmcblk${j}p${i}"
-					if [[ -b $string ]]; then
-
-						aDRIVE_MOUNT_SOURCE+=($string)
-
-					fi
-
-				done
+				aDRIVE_MOUNT_SOURCE+=($i)
 
 			done
 


### PR DESCRIPTION
- Didn't do performance test, but method works well and looks cleaner.

**€: Another addition:**
- DietPi-Drive_Manager | Also re-check for FAT32 and NTFS format tools, in case user removed it manually
- DietPi-Drive_Manager | ext4 reserved blocks: Correct rounding and allowing to cancel input box