### PR TITLE
DietPi-Drive_Manager | Check & Repair

### DIFF
--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -1143,25 +1143,58 @@
 
 				if (( ${aDRIVE_ISMOUNTED[$INDEX_DRIVE_BEING_EDITED]} )); then
 
-					G_WHIP_MSG 'Partition must be unmounted, before check and repair can be run.\n\nPlease unmount the partition, then try again.'
+					G_WHIP_YESNO 'For safe check and repair, the drive needs to be unmounted.\n\nDo you want to continue with the drive being unmounted automatically?'
+					(( $? )) && TARGETMENUID=1 && return
 
-				else
+					# - disable swap
+					G_RUN_CMD swapoff -a
 
-					G_WHIP_MSG "The following drive will now be checked for errors:\n${aDRIVE_MOUNT_SOURCE[$INDEX_DRIVE_BEING_EDITED]}\n\nNo repair will be completed during this process. An option to repair the drive, will be provided after the check."
-					fsck -n -f ${aDRIVE_MOUNT_SOURCE[$INDEX_DRIVE_BEING_EDITED]} &> /tmp/.dietpi-drive_manager_check.log
+					# - Unmount drive
+					G_RUN_CMD umount ${aDRIVE_MOUNT_SOURCE[$INDEX_DRIVE_BEING_EDITED]}
+
+				fi
+
+				# Do dry-run first for file systems supporting it:
+				if [[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == ext4 ||
+					${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == vfat ||
+					${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == ntfs ||
+					${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == btrfs ||
+					${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == f2fs ||
+					${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} =~ hfs ]]; then
+
+					G_WHIP_MSG "The following drive will now be checked for errors:\n${aDRIVE_MOUNT_SOURCE[$INDEX_DRIVE_BEING_EDITED]}\n\nNo repair will be completed during this process. An option to repair the drive$
+					local fsck_cmd='fsck -n -f'
+					[[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == vfat ]] && fsck_cmd='fsck.fat -n'
+					[[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == ntfs ]] && fsck_cmd='ntfsfix -n'
+					[[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == btrfs ]] && fsck_cmd='btrfs check --readonly'
+					[[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == f2fs ]] && fsck_cmd='fsck.f2fs'
+					$fsck_cmd ${aDRIVE_MOUNT_SOURCE[$INDEX_DRIVE_BEING_EDITED]} &> /tmp/.dietpi-drive_manager_check.log
 					G_WHIP_VIEWLOG /tmp/.dietpi-drive_manager_check.log
 					rm /tmp/.dietpi-drive_manager_check.log &> /dev/null
 
-					G_WHIP_YESNO "Would you like to run a repair on the following drive?\n${aDRIVE_MOUNT_SOURCE[$INDEX_DRIVE_BEING_EDITED]}"
-					if (( $? == 0 )); then
+				fi
 
-						fsck -y -f ${aDRIVE_MOUNT_SOURCE[$INDEX_DRIVE_BEING_EDITED]} &> /tmp/.dietpi-drive_manager_repair.log
-						G_WHIP_VIEWLOG /tmp/.dietpi-drive_manager_repair.log
-						rm /tmp/.dietpi-drive_manager_repair.log &> /dev/null
+				G_WHIP_YESNO "Would you like to run an automated repair on the following drive now?\n       ${aDRIVE_MOUNT_SOURCE[$INDEX_DRIVE_BEING_EDITED]}\n
+NB:
+- Automated repair steps potentially lead to data loss, which would have been able to recover by professional drive recovery services.
+- If the data is extremely important and you don't have any backup, you might want to hand the drive to a recovery service as is.
+- These services are usually very expensive, but might be able to recover more data than (after) this automated repair steps!"
+				if (( ! $? )); then
 
-					fi
+					local fsck_cmd='fsck -y -f'
+					[[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == vfat ]] && fsck_cmd='fsck.fat -y'
+					[[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == ntfs ]] && fsck_cmd='ntfsfix'
+					[[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == btrfs ]] && fsck_cmd='btrfs check --repair'
+					[[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == f2fs ]] && fsck_cmd='fsck.f2fs -f'
+					[[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == exfat ]] && fsck_cmd='exfatfsck'
+					$fsck_cmd ${aDRIVE_MOUNT_SOURCE[$INDEX_DRIVE_BEING_EDITED]} &> /tmp/.dietpi-drive_manager_repair.log
+					G_WHIP_VIEWLOG /tmp/.dietpi-drive_manager_repair.log
+					rm /tmp/.dietpi-drive_manager_repair.log &> /dev/null
 
 				fi
+
+				# - re-enable swap
+				G_RUN_CMD swapon -a
 
 			fi
 

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -1154,21 +1154,59 @@
 
 				fi
 
-				# Do dry-run first for file systems supporting it:
-				if [[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == ext4 ||
-					${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == vfat ||
-					${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == ntfs ||
-					${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == btrfs ||
-					${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == f2fs ||
-					${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} =~ hfs ]]; then
+				if [[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} =~ ext ]]; then
 
-					G_WHIP_MSG "The following drive will now be checked for errors:\n${aDRIVE_MOUNT_SOURCE[$INDEX_DRIVE_BEING_EDITED]}\n\nNo repair will be completed during this process. An option to repair the drive$
-					local fsck_cmd='fsck -n -f'
-					[[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == vfat ]] && fsck_cmd='fsck.fat -n'
-					[[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == ntfs ]] && fsck_cmd='ntfsfix -n'
-					[[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == btrfs ]] && fsck_cmd='btrfs check --readonly'
-					[[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == f2fs ]] && fsck_cmd='fsck.f2fs'
-					$fsck_cmd ${aDRIVE_MOUNT_SOURCE[$INDEX_DRIVE_BEING_EDITED]} &> /tmp/.dietpi-drive_manager_check.log
+					local fsck_dry='e2fsck -n -f'
+					local fsck_fix='e2fsck -y -f'
+
+				elif [[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == exfat ]]; then
+
+					G_AG_CHECK_INSTALL_PREREQ exfat-utils exfat-fuse
+					local fsck_fix='exfatfsck'
+
+				elif [[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} =~ fat ]]; then
+
+					G_AG_CHECK_INSTALL_PREREQ dosfstools
+					local fsck_dry='fsck.fat -n'
+					local fsck_fix='fsck.fat -y'
+
+				elif [[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == ntfs ]]; then
+
+					G_AG_CHECK_INSTALL_PREREQ ntfs-3g
+					local fsck_dry='ntfsfix -n'
+					local fsck_fix='ntfsfix'
+
+				elif [[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} =~ hfs ]]; then
+
+					G_AG_CHECK_INSTALL_PREREQ hfsplus hfsprogs hfsutils
+					local fsck_dry='fsck.hfsplus -n -f'
+					local fsck_fix='fsck.hfsplus -y -f'
+
+				elif [[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == f2fs ]]; then
+
+					G_AG_CHECK_INSTALL_PREREQ f2fs-tools
+					local fsck_dry='fsck.f2fs'
+					local fsck_fix='fsck.f2fs -f'
+
+				elif [[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == btrfs ]]; then
+
+					G_AG_CHECK_INSTALL_PREREQ btrfs-tools
+					local fsck_dry='btrfs check --readonly'
+					local fsck_fix='btrfs check --repair'
+
+				else
+
+					G_WHIP_MSG "File system checks are currently not supported for '${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]}'. Aborting..."
+					TARGETMENUID=1
+					return
+
+				fi
+
+				# Do dry-run first for file systems supporting it:
+				if [[ $fsck_dry ]]; then
+
+					G_WHIP_MSG "The following drive will now be checked for errors:\n${aDRIVE_MOUNT_SOURCE[$INDEX_DRIVE_BEING_EDITED]}\n\nNo repair will be completed during this process. An option to repair the drive, will be provided after the check."
+					$fsck_dry ${aDRIVE_MOUNT_SOURCE[$INDEX_DRIVE_BEING_EDITED]} &> /tmp/.dietpi-drive_manager_check.log
 					G_WHIP_VIEWLOG /tmp/.dietpi-drive_manager_check.log
 					rm /tmp/.dietpi-drive_manager_check.log &> /dev/null
 
@@ -1181,13 +1219,7 @@ NB:
 - These services are usually very expensive, but might be able to recover more data than (after) this automated repair steps!"
 				if (( ! $? )); then
 
-					local fsck_cmd='fsck -y -f'
-					[[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == vfat ]] && fsck_cmd='fsck.fat -y'
-					[[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == ntfs ]] && fsck_cmd='ntfsfix'
-					[[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == btrfs ]] && fsck_cmd='btrfs check --repair'
-					[[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == f2fs ]] && fsck_cmd='fsck.f2fs -f'
-					[[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == exfat ]] && fsck_cmd='exfatfsck'
-					$fsck_cmd ${aDRIVE_MOUNT_SOURCE[$INDEX_DRIVE_BEING_EDITED]} &> /tmp/.dietpi-drive_manager_repair.log
+					$fsck_fix ${aDRIVE_MOUNT_SOURCE[$INDEX_DRIVE_BEING_EDITED]} &> /tmp/.dietpi-drive_manager_repair.log
 					G_WHIP_VIEWLOG /tmp/.dietpi-drive_manager_repair.log
 					rm /tmp/.dietpi-drive_manager_repair.log &> /dev/null
 


### PR DESCRIPTION
+ DietPi-Drive_Manager | Enable Check & Repair for all FS types: https://github.com/Fourdee/DietPi/issues/1740#issuecomment-387882792
+ DietPi-Drive_Manager | Allow to automatically unmount the drive when doing Check & Repair and handle the swap file

🈯️ Checked on all supported FS types.
- [x] Install pre-reqs...

Recheck:
- 🈯️ HFS+
- 🈯️ ext4
- 🈯️ FAT including pre-reqs installation
- 🈯️ NTFS including pre-reqs
- 🈯️ F2FS
- 🈯️ BTRFS
- 🈯️ exFAT