### PR TITLE
DietPi-Software | Non-APT software updates

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -311,7 +311,7 @@ _EOF_
 	aSOFTWARE_WHIP_NAME=0				#Item name eg: Kodi
 	aSOFTWARE_WHIP_DESC=0				#Blah blah
 
-	FP_ONLINEDOC_URL='http://dietpi.com/phpbb/viewtopic.php?'
+	FP_ONLINEDOC_URL='https://dietpi.com/phpbb/viewtopic.php?'
 	aSOFTWARE_ONLINEDOC_URL=0
 
 	# - Disable software installation, if user input is required for automated installs
@@ -2094,7 +2094,7 @@ _EOF_
 			aSOFTWARE_CATEGORY_INDEX[$index_current]=16
 					  aSOFTWARE_TYPE[$index_current]=0
 		  aSOFTWARE_REQUIRES_RSYSLOG[$index_current]=1
-			 aSOFTWARE_ONLINEDOC_URL[$index_current]='http://dietpi.com/phpbb/viewtopic.php?f=8&t=5&p=3469#p3469'
+			 aSOFTWARE_ONLINEDOC_URL[$index_current]='https://dietpi.com/phpbb/viewtopic.php?f=8&t=5&p=3469#p3469'
 		aSOFTWARE_REQUIRES_USERINPUT[$index_current]=1
 
 		#------------------
@@ -3124,7 +3124,7 @@ _EOF_
 	Create_Desktop_Shared_Items(){
 
 		#Copy DietPi favourite links
-		wget http://dietpi.com/downloads/conf/desktop/.gtk-bookmarks -O "$HOME"/.gtk-bookmarks
+		wget https://dietpi.com/downloads/conf/desktop/.gtk-bookmarks -O "$HOME"/.gtk-bookmarks
 
 		#Create Desktop SymLinks
 		mkdir -p "$HOME"/Desktop
@@ -3132,17 +3132,17 @@ _EOF_
 
 		#DietPi Menu symlinks
 		mkdir -p /usr/share/applications
-		wget http://dietpi.com/downloads/conf/desktop/dietpi-software.desktop -O /usr/share/applications/dietpi-software.desktop
-		wget http://dietpi.com/downloads/conf/desktop/dietpi-update.desktop -O /usr/share/applications/dietpi-update.desktop
-		wget http://dietpi.com/downloads/conf/desktop/dietpi-config.desktop -O /usr/share/applications/dietpi-config.desktop
-		wget http://dietpi.com/downloads/conf/desktop/dietpi-backup.desktop -O /usr/share/applications/dietpi-backup.desktop
-		wget http://dietpi.com/downloads/conf/desktop/dietpi-sync.desktop -O /usr/share/applications/dietpi-sync.desktop
-		wget http://dietpi.com/downloads/conf/desktop/dietpi-bugreport.desktop -O /usr/share/applications/dietpi-bugreport.desktop
-		wget http://dietpi.com/downloads/conf/desktop/dietpi-process_tool.desktop -O /usr/share/applications/dietpi-process_tool.desktop
-		wget http://dietpi.com/downloads/conf/desktop/dietpi-cleaner.desktop -O /usr/share/applications/dietpi-cleaner.desktop
-		wget http://dietpi.com/downloads/conf/desktop/dietpi-cron.desktop -O /usr/share/applications/dietpi-cron.desktop
-		wget http://dietpi.com/downloads/conf/desktop/dietpi-launcher.desktop -O /usr/share/applications/dietpi-launcher.desktop
-		wget http://dietpi.com/downloads/conf/desktop/dietpi-justboom.desktop -O /usr/share/applications/dietpi-justboom.desktop
+		wget https://dietpi.com/downloads/conf/desktop/dietpi-software.desktop -O /usr/share/applications/dietpi-software.desktop
+		wget https://dietpi.com/downloads/conf/desktop/dietpi-update.desktop -O /usr/share/applications/dietpi-update.desktop
+		wget https://dietpi.com/downloads/conf/desktop/dietpi-config.desktop -O /usr/share/applications/dietpi-config.desktop
+		wget https://dietpi.com/downloads/conf/desktop/dietpi-backup.desktop -O /usr/share/applications/dietpi-backup.desktop
+		wget https://dietpi.com/downloads/conf/desktop/dietpi-sync.desktop -O /usr/share/applications/dietpi-sync.desktop
+		wget https://dietpi.com/downloads/conf/desktop/dietpi-bugreport.desktop -O /usr/share/applications/dietpi-bugreport.desktop
+		wget https://dietpi.com/downloads/conf/desktop/dietpi-process_tool.desktop -O /usr/share/applications/dietpi-process_tool.desktop
+		wget https://dietpi.com/downloads/conf/desktop/dietpi-cleaner.desktop -O /usr/share/applications/dietpi-cleaner.desktop
+		wget https://dietpi.com/downloads/conf/desktop/dietpi-cron.desktop -O /usr/share/applications/dietpi-cron.desktop
+		wget https://dietpi.com/downloads/conf/desktop/dietpi-launcher.desktop -O /usr/share/applications/dietpi-launcher.desktop
+		wget https://dietpi.com/downloads/conf/desktop/dietpi-justboom.desktop -O /usr/share/applications/dietpi-justboom.desktop
 
 		#DietPi Desktop symlinks
 		ln -sf /usr/share/applications/dietpi-software.desktop "$HOME"/Desktop/dietpi-software.desktop
@@ -3151,10 +3151,10 @@ _EOF_
 
 		#Download icons
 		mkdir -p /var/lib/dietpi/dietpi-software/installed/desktop_icons
-		wget http://dietpi.com/downloads/conf/desktop/dietpi-icon.png -O /var/lib/dietpi/dietpi-software/installed/desktop_icons/dietpi-icon.png
-		wget http://dietpi.com/downloads/conf/desktop/grey_16x16.png -O /var/lib/dietpi/dietpi-software/installed/desktop_icons/grey_16x16.png
-		wget http://dietpi.com/downloads/conf/desktop/kodi-icon.png -O /var/lib/dietpi/dietpi-software/installed/desktop_icons/kodi-icon.png
-		wget http://dietpi.com/downloads/conf/desktop/justboom.png -O /var/lib/dietpi/dietpi-software/installed/desktop_icons/justboom.png
+		wget https://dietpi.com/downloads/conf/desktop/dietpi-icon.png -O /var/lib/dietpi/dietpi-software/installed/desktop_icons/dietpi-icon.png
+		wget https://dietpi.com/downloads/conf/desktop/grey_16x16.png -O /var/lib/dietpi/dietpi-software/installed/desktop_icons/grey_16x16.png
+		wget https://dietpi.com/downloads/conf/desktop/kodi-icon.png -O /var/lib/dietpi/dietpi-software/installed/desktop_icons/kodi-icon.png
+		wget https://dietpi.com/downloads/conf/desktop/justboom.png -O /var/lib/dietpi/dietpi-software/installed/desktop_icons/justboom.png
 
 		# - Replace icon dir in .desktop from /etc/dietpi/desktop_icons
 		sed -i 's#^Icon=/etc/dietpi/desktop_icons#Icon=/var/lib/dietpi/dietpi-software/installed/desktop_icons#g' /usr/share/applications/*.desktop
@@ -3179,8 +3179,8 @@ _EOF_
 		if [ ! -f "$G_FP_DIETPI_USERDATA/$FOLDER_MUSIC"/fourdee_tech.ogg ]; then
 
 			#Grab My test music
-			wget http://dietpi.com/downloads/audio/fourdee_tech.ogg -O "$G_FP_DIETPI_USERDATA/$FOLDER_MUSIC"/fourdee_tech.ogg
-			#wget http://dietpi.com/downloads/audio/fourdee_space.mp3 -O "$G_FP_DIETPI_USERDATA/$FOLDER_MUSIC"/fourdee_space.mp3
+			wget https://dietpi.com/downloads/audio/fourdee_tech.ogg -O "$G_FP_DIETPI_USERDATA/$FOLDER_MUSIC"/fourdee_tech.ogg
+			#wget https://dietpi.com/downloads/audio/fourdee_space.mp3 -O "$G_FP_DIETPI_USERDATA/$FOLDER_MUSIC"/fourdee_space.mp3
 
 			#Grab Absolute Radio Streams
 			wget http://network.absoluteradio.co.uk/core/audio/ogg/live.pls?service=vrbb -O "$G_FP_DIETPI_USERDATA/$FOLDER_MUSIC"/Absolute-Radio.pls
@@ -3336,7 +3336,7 @@ _EOF_
 			Banner_Installing
 
 			# - For desktop entries/icons hosted on dietpi.com
-			INSTALL_URL_ADDRESS='http://dietpi.com/downloads/conf/desktop'
+			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/conf/desktop'
 
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
@@ -3352,7 +3352,7 @@ _EOF_
 			Banner_Installing
 
 			# - For desktop entries/icons hosted on dietpi.com
-			INSTALL_URL_ADDRESS='http://dietpi.com/downloads/conf/desktop'
+			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/conf/desktop'
 
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
@@ -3367,7 +3367,7 @@ _EOF_
 			Banner_Installing
 
 			# - For desktop entries/icons hosted on dietpi.com
-			INSTALL_URL_ADDRESS='http://dietpi.com/downloads/conf/desktop'
+			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/conf/desktop'
 
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
@@ -3382,7 +3382,7 @@ _EOF_
 			Banner_Installing
 
 			# - For desktop entries/icons hosted on dietpi.com
-			INSTALL_URL_ADDRESS='http://dietpi.com/downloads/conf/desktop'
+			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/conf/desktop'
 
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
@@ -3406,22 +3406,22 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/nomachine_6.0.78_1_'
+			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/nomachine_6.1.6_'
 
 			#x86_64
 			if (( $G_HW_ARCH == 10 )); then
 
-				INSTALL_URL_ADDRESS+='amd64.deb'
+				INSTALL_URL_ADDRESS+='9_amd64.deb'
 
 			#arm6 (RPi1)
 			elif (( $G_HW_ARCH == 1 )); then
 
-				INSTALL_URL_ADDRESS+='armv6hf.deb'
+				INSTALL_URL_ADDRESS+='4_armv6hf.deb'
 
 			#arm7+ (RPi 2/3)
 			elif (( $G_HW_ARCH == 2 )); then
 
-				INSTALL_URL_ADDRESS+='armhf.deb'
+				INSTALL_URL_ADDRESS+='4_armhf.deb'
 
 			fi
 
@@ -3689,7 +3689,7 @@ _EOF_
 				#MPD not available in Jessie Repo for ARMv8
 				if (( $G_HW_ARCH == 3 )); then
 
-					INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/mpd_0.19.21_arm64.deb'
+					INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/mpd_0.19.21_arm64.deb'
 					G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 					#libupnp6 for net discov with upnp/avahi
@@ -3709,31 +3709,29 @@ _EOF_
 			#Stretch+
 			else
 
-				INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/mpd_0.20.18-1_'
+				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/mpd_0.20.18-1_'
 
 				#armv6
 				if (( $G_HW_ARCH == 1 )); then
 
-					INSTALL_URL_ADDRESS+='armv6'
+					INSTALL_URL_ADDRESS+='armv6.deb'
 
 				#armv7+
 				elif (( $G_HW_ARCH == 2 )); then
 
-					INSTALL_URL_ADDRESS+='armv7'
+					INSTALL_URL_ADDRESS+='armv7.deb'
 
 				#ARMv8
 				elif (( $G_HW_ARCH == 3 )); then
 
-					INSTALL_URL_ADDRESS+='armv8'
+					INSTALL_URL_ADDRESS+='armv8.deb'
 
 				#x86_64
 				elif (( $G_HW_ARCH == 10 )); then
 
-					INSTALL_URL_ADDRESS+='amd64'
+					INSTALL_URL_ADDRESS+='amd64.deb'
 
 				fi
-
-				INSTALL_URL_ADDRESS+='.deb'
 
 				G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
@@ -3918,7 +3916,7 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/ympd_1.2.3.7z'
+			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/ympd_1.2.3.7z'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			wget "$INSTALL_URL_ADDRESS" -O package.7z
@@ -4004,17 +4002,17 @@ _EOF_
 			# - armv6
 			if (( $G_HW_ARCH == 1 )); then
 
-				INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/cava_0.4.2_armv6.deb'
+				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/cava_0.4.2_armv6.deb'
 
 			# - armv7
 			elif (( $G_HW_ARCH == 2 )); then
 
-				INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/cava_0.4.2_armv7.deb'
+				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/cava_0.4.2_armv7.deb'
 
 			# - arm64
 			elif (( $G_HW_ARCH == 3 )); then
 
-				INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/cava_0.4.2_arm64.deb'
+				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/cava_0.4.2_arm64.deb'
 
 			fi
 
@@ -4027,7 +4025,7 @@ _EOF_
 			rm package.deb
 
 			# + Font for cava, nice bars
-			wget http://dietpi.com/downloads/binaries/all/cava.psf -O "$HOME"/cava.psf
+			wget https://dietpi.com/downloads/binaries/all/cava.psf -O "$HOME"/cava.psf
 
 		fi
 
@@ -4127,17 +4125,17 @@ _EOF_
 			#x32 x64
 			if (( $G_HW_MODEL == 20 || $G_HW_MODEL == 21 )); then
 
-				INSTALL_URL_ADDRESS="http://dietpi.com/downloads/binaries/all/noip_x32_x64.zip"
+				INSTALL_URL_ADDRESS="https://dietpi.com/downloads/binaries/all/noip_x32_x64.zip"
 
 			#ARMv8
 			elif (( ( $G_HW_MODEL == 12 ) || ( $G_HW_MODEL >=40 && $G_HW_MODEL < 50 ) )); then
 
-				INSTALL_URL_ADDRESS="http://dietpi.com/downloads/binaries/all/noip_arm64.zip"
+				INSTALL_URL_ADDRESS="https://dietpi.com/downloads/binaries/all/noip_arm64.zip"
 
 			#armv6+
 			else
 
-				INSTALL_URL_ADDRESS="http://dietpi.com/downloads/binaries/all/noip_armhf.zip"
+				INSTALL_URL_ADDRESS="https://dietpi.com/downloads/binaries/all/noip_armhf.zip"
 
 			fi
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
@@ -4157,7 +4155,7 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/amiberry_v2.19.7z'
+			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/amiberry_v2.19.7z'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			# - Backup existing autostart.uae for user
@@ -4178,7 +4176,7 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/rpi/dxx-rebirth.7z'
+			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/rpi/dxx-rebirth.7z'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			G_AGI libsdl-mixer1.2 libsdl1.2debian libphysfs1
@@ -4197,16 +4195,16 @@ _EOF_
 
 			if (( $G_HW_ARCH == 10 )); then
 
-				INSTALL_URL_ADDRESS='https://hndl.urbackup.org/Server/2.2.8/urbackup-server_2.2.8_amd64.deb'
+				INSTALL_URL_ADDRESS='https://hndl.urbackup.org/Server/2.2.11/urbackup-server_2.2.11_amd64.deb'
 
 			elif (( $G_HW_ARCH == 2 )); then
 
-				INSTALL_URL_ADDRESS='https://hndl.urbackup.org/Server/2.2.8/urbackup-server_2.2.8_armhf.deb'
+				INSTALL_URL_ADDRESS='https://hndl.urbackup.org/Server/2.2.11/urbackup-server_2.2.11_armhf.deb'
 
 			#ARMv8 sourcebuild
 			elif (( $G_HW_ARCH == 3 )); then
 
-				INSTALL_URL_ADDRESS='http://hndl.urbackup.org/Server/2.2.8/urbackup-server-2.2.8.tar.gz'
+				INSTALL_URL_ADDRESS='https://hndl.urbackup.org/Server/2.2.11/urbackup-server-2.2.11.tar.gz'
 
 			fi
 
@@ -4258,7 +4256,7 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS="http://dietpi.com/downloads/binaries/rpi/opentyrian_armhf.zip"
+			INSTALL_URL_ADDRESS="https://dietpi.com/downloads/binaries/rpi/opentyrian_armhf.zip"
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			G_AGI ibsdl1.2debian libsdl-net1.2
@@ -4277,7 +4275,7 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://github.com/silvanmelchior/RPi_Cam_Web_Interface/archive/ab16e7619df5cb0fad8eb34d876d3686c5162482.zip'
+			INSTALL_URL_ADDRESS='https://github.com/silvanmelchior/RPi_Cam_Web_Interface/archive/master.zip'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			#Install pre-reqs
@@ -4452,7 +4450,7 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/airsonic.7z'
+			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/airsonic.7z'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			mkdir -p "$G_FP_DIETPI_USERDATA"/airsonic
@@ -4468,7 +4466,7 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/subsonic-6.1.3.deb'
+			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/subsonic-6.1.3.deb'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			#G_AGI lame #conflicts with our ffmpeg package: https://github.com/Fourdee/DietPi/issues/946#issuecomment-300738228
@@ -4486,7 +4484,7 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://github.com/weaved/installer/raw/master/Raspbian%20deb/1.3-07/weavedconnectd_1.3-07v_armhf.deb'
+			INSTALL_URL_ADDRESS='https://github.com/weaved/installer/raw/master/Raspbian%20deb/1.3-07/weavedconnectd_1.3-07z1_armhf.deb'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			#Install WEAVED
@@ -4611,12 +4609,12 @@ _EOF_
 				#ARMv6
 				if (( $G_HW_ARCH == 1 )); then
 
-					INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/mosquitto_1.4.14_armv6.deb'
+					INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/mosquitto_1.4.14_armv6.deb'
 
 				#ARMv7/8
 				elif (( $G_HW_ARCH == 2 || $G_HW_ARCH == 3 )); then
 
-					INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/mosquitto_1.4.14-0mosquitto1_nows1_armhf.deb'
+					INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/mosquitto_1.4.14-0mosquitto1_nows1_armhf.deb'
 
 					# - ARMv8
 					if (( $G_HW_ARCH == 3 )); then
@@ -4629,7 +4627,7 @@ _EOF_
 				#x86_64
 				elif (( $G_HW_ARCH == 10 )); then
 
-					INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/mosquitto_1.4.14-0mosquitto1_nows1_amd64.deb'
+					INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/mosquitto_1.4.14-0mosquitto1_nows1_amd64.deb'
 
 				fi
 				G_CHECK_URL "$INSTALL_URL_ADDRESS"
@@ -4658,7 +4656,7 @@ _EOF_
 
 			mkdir -p /etc/blynkserver
 
-			INSTALL_URL_ADDRESS='https://github.com/blynkkk/blynk-server/releases/download/v0.29.7/server-0.29.7-java8.jar'
+			INSTALL_URL_ADDRESS='https://github.com/blynkkk/blynk-server/releases/download/v0.36.2/server-0.36.2-java8.jar'
 			wget "$INSTALL_URL_ADDRESS" -O /etc/blynkserver/server.jar
 
 			# - Install Blynk JS Libary
@@ -4687,8 +4685,8 @@ _EOF_
 			#	Jessie - requires stretch packages
 			if (( $G_DISTRO == 3 )); then
 
-				apackages+=('http://dietpi.com/downloads/binaries/all/gcc-6-base_6.3.0-6_armhf.deb')
-				apackages+=('http://dietpi.com/downloads/binaries/all/libstdc++6_6.3.0-6_armhf.deb')
+				apackages+=('https://dietpi.com/downloads/binaries/all/gcc-6-base_6.3.0-6_armhf.deb')
+				apackages+=('https://dietpi.com/downloads/binaries/all/libstdc++6_6.3.0-6_armhf.deb')
 
 			fi
 
@@ -4795,7 +4793,7 @@ _EOF_
 			Banner_Installing
 
 
-			INSTALL_URL_ADDRESS='https://www.haproxy.org/download/1.8/src/haproxy-1.8.2.tar.gz'
+			INSTALL_URL_ADDRESS='https://www.haproxy.org/download/1.8/src/haproxy-1.8.8.tar.gz'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			#Download HAPROXY
@@ -4840,7 +4838,7 @@ _EOF_
 
 			fi
 
-			INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/logitechmediaserver_7.9.1_all.deb'
+			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/logitechmediaserver_7.9.1_all.deb'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 			wget "$INSTALL_URL_ADDRESS" -O package.deb
 			dpkg -i package.deb
@@ -4854,11 +4852,11 @@ _EOF_
 
 				if (( $G_DISTRO == 3 )); then
 
-					INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/DietPi-LMS7.9-CPAN_arm64.zip'
+					INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/DietPi-LMS7.9-CPAN_arm64.zip'
 
 				else
 
-					INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/logitechmediaserver_7.9.1_CPAN-armv8-stretch.zip'
+					INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/logitechmediaserver_7.9.1_CPAN-armv8-stretch.zip'
 
 				fi
 
@@ -4971,7 +4969,7 @@ _EOF_
 			Banner_Installing
 
 
-			INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/Single_File_PHP_Gallery_4.6.1.zip'
+			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/Single_File_PHP_Gallery_4.7.0.zip'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			wget "$INSTALL_URL_ADDRESS" -O package.zip
@@ -5118,7 +5116,7 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/hostapd_2.5_all.zip'
+			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/hostapd_2.5_all.zip'
 
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
@@ -5210,7 +5208,7 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/shairport-sync_3.1.7_'
+			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/shairport-sync_3.1.7_'
 
 			# - ARMv6
 			if (( $G_HW_ARCH == 1 )); then
@@ -5249,7 +5247,7 @@ _EOF_
 			#Jessie: https://github.com/Fourdee/DietPi/issues/1620#issuecomment-373086888
 			if (( $G_DISTRO == 3 )); then
 
-				INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/libssl1.1_1.1.0f-3+deb9u1_'
+				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/libssl1.1_1.1.0f-3+deb9u1_'
 
 				# - ARMv7
 				if (( $G_HW_ARCH == 2 )); then
@@ -5284,7 +5282,7 @@ _EOF_
 			Banner_Installing
 
 			#check folder is online
-			INSTALL_URL_ADDRESS='http://dietpi.com/downloads/conf/BruteFIR/'
+			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/conf/BruteFIR/'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			# - Prereqs
@@ -5321,7 +5319,7 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/squeezelite-1.8_all.7z'
+			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/squeezelite-1.8_all.7z'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			# - Prereqs
@@ -5413,7 +5411,7 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/netdata_1.9.0_'
+			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/netdata_1.9.0_'
 
 			#armv6
 			if (( $G_HW_ARCH == 1 )); then
@@ -5568,7 +5566,7 @@ _EOF_
 			#x86_64
 			if (( $G_HW_ARCH == 10 )); then
 
-				INSTALL_URL_ADDRESS='https://downloads.plex.tv/plex-media-server/1.10.1.4602-f54242b6b/plexmediaserver_1.10.1.4602-f54242b6b_amd64.deb'
+				INSTALL_URL_ADDRESS='https://downloads.plex.tv/plex-media-server/1.13.0.5023-31d3c0c65/plexmediaserver_1.13.0.5023-31d3c0c65_amd64.deb'
 
 			#ARM
 			else
@@ -5675,7 +5673,7 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/gogs_'
+			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/gogs_'
 
 			#armv6
 			if (( $G_HW_ARCH == 1 )); then
@@ -5740,7 +5738,7 @@ _EOF_
 
 				#G_AGI unrar-free #https://github.com/Fourdee/DietPi/issues/176#issuecomment-240101365
 
-				INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/unrar_5.3.2-1+deb9u1_armhf.deb'
+				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/unrar_5.3.2-1+deb9u1_armhf.deb'
 				G_CHECK_URL "$INSTALL_URL_ADDRESS"
 				wget "$INSTALL_URL_ADDRESS" -O package.deb
 				dpkg -i package.deb
@@ -5767,7 +5765,7 @@ _EOF_
 			else
 
 				#aria2 binary
-				INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/aria2_'
+				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/aria2_'
 
 				# - armv6
 				if (( $G_HW_ARCH == 1 )); then
@@ -5844,7 +5842,7 @@ _EOF_
 
 				#G_AGI unrar-free #https://github.com/Fourdee/DietPi/issues/176#issuecomment-240101365
 
-				INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/unrar_5.3.2-1+deb9u1_armhf.deb'
+				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/unrar_5.3.2-1+deb9u1_armhf.deb'
 				G_CHECK_URL "$INSTALL_URL_ADDRESS"
 				wget "$INSTALL_URL_ADDRESS" -O package.deb
 				dpkg -i package.deb
@@ -5867,17 +5865,17 @@ _EOF_
 			# - armv6+
 			if (( $G_HW_ARCH == 1 || $G_HW_ARCH == 2 )); then
 
-				INSTALL_URL_ADDRESS='https://github.com/syncthing/syncthing/releases/download/v0.14.42/syncthing-linux-arm-v0.14.42.tar.gz'
+				INSTALL_URL_ADDRESS='https://github.com/syncthing/syncthing/releases/download/v0.14.47/syncthing-linux-arm-v0.14.47.tar.gz'
 
 			# - arm64
 			elif (( $G_HW_ARCH == 3 )); then
 
-				INSTALL_URL_ADDRESS='https://github.com/syncthing/syncthing/releases/download/v0.14.42/syncthing-linux-arm64-v0.14.42.tar.gz'
+				INSTALL_URL_ADDRESS='https://github.com/syncthing/syncthing/releases/download/v0.14.47/syncthing-linux-arm64-v0.14.47.tar.gz'
 
 			# - x86_64
 			elif (( $G_HW_ARCH == 10 )); then
 
-				INSTALL_URL_ADDRESS='https://github.com/syncthing/syncthing/releases/download/v0.14.42/syncthing-linux-amd64-v0.14.42.tar.gz'
+				INSTALL_URL_ADDRESS='https://github.com/syncthing/syncthing/releases/download/v0.14.47/syncthing-linux-amd64-v0.14.47.tar.gz'
 
 			fi
 
@@ -5909,14 +5907,14 @@ _EOF_
 			# - armv6/7
 			if (( $G_HW_ARCH == 1 || $G_HW_ARCH == 2 )); then
 
-				INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/libjpeg8_8d1-2_armhf.deb'
+				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/libjpeg8_8d1-2_armhf.deb'
 				G_AGI libpng12-0
 
 			# - x86_64
 			elif (( $G_HW_ARCH == 10 )); then
 
-				INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/libjpeg8_8d1-2_amd64.deb'
-				(( $G_DISTRO > 3 )) && INSTALL_URL_ADDRESS2='http://dietpi.com/downloads/binaries/all/libpng12-0_1.2.50-2+deb8u3_amd64.deb' || AGI libpng12-0
+				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/libjpeg8_8d1-2_amd64.deb'
+				(( $G_DISTRO > 3 )) && INSTALL_URL_ADDRESS2='https://dietpi.com/downloads/binaries/all/libpng12-0_1.2.50-2+deb8u3_amd64.deb' || AGI libpng12-0
 
 			fi
 
@@ -5986,12 +5984,12 @@ _EOF_
 				#armv6+
 				if (( $G_HW_ARCH == 1 || $G_HW_ARCH == 2 )); then
 
-					INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/chromium_52.0.2743.116-1-deb8u1.1_armhf.deb'
+					INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/chromium_52.0.2743.116-1-deb8u1.1_armhf.deb'
 
 				#ARMv8
 				elif (( $G_HW_ARCH == 3 )); then
 
-					INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/chromium_52.0.2743.116-1-deb8u1.1_arm64.deb'
+					INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/chromium_52.0.2743.116-1-deb8u1.1_arm64.deb'
 
 				fi
 
@@ -6012,19 +6010,19 @@ _EOF_
 
 				fi
 
-				wget http://dietpi.com/downloads/binaries/all/chromium-l10n_52.0.2743.116-1-deb8u1.1_all.deb -O package.deb
+				wget https://dietpi.com/downloads/binaries/all/chromium-l10n_52.0.2743.116-1-deb8u1.1_all.deb -O package.deb
 				dpkg -i package.deb
 
 				#	armv6+
 				if (( $G_HW_ARCH == 1 || $G_HW_ARCH == 2 )); then
 
-					wget http://dietpi.com/downloads/binaries/all/chromedriver_52.0.2743.116-1-deb8u1.1_armhf.deb -O package.deb
+					wget https://dietpi.com/downloads/binaries/all/chromedriver_52.0.2743.116-1-deb8u1.1_armhf.deb -O package.deb
 					dpkg -i package.deb
 
 				#	arm64
 				elif (( $G_HW_ARCH == 3 )); then
 
-					wget http://dietpi.com/downloads/binaries/all/chromedriver_52.0.2743.116-1-deb8u1.1_arm64.deb -O package.deb
+					wget https://dietpi.com/downloads/binaries/all/chromedriver_52.0.2743.116-1-deb8u1.1_arm64.deb -O package.deb
 					dpkg -i package.deb
 
 				fi
@@ -6147,7 +6145,7 @@ _EOF_
 
 			Banner_Installing
 
-			local version='2.3.2'
+			local version='2.3.3'
 
 			INSTALL_URL_ADDRESS="https://github.com/sabnzbd/sabnzbd/archive/$version.zip"
 
@@ -6169,7 +6167,7 @@ _EOF_
 
 				#G_AGI unrar-free #https://github.com/Fourdee/DietPi/issues/176#issuecomment-240101365
 
-				INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/unrar_5.3.2-1+deb9u1_armhf.deb'
+				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/unrar_5.3.2-1+deb9u1_armhf.deb'
 				G_CHECK_URL "$INSTALL_URL_ADDRESS"
 				wget "$INSTALL_URL_ADDRESS" -O package.deb
 				dpkg -i package.deb
@@ -6194,7 +6192,7 @@ _EOF_
 			INSTALL_URL_ADDRESS='https://github.com/Fornoth/spotify-connect-web/releases' #full path fails wget spider test...
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
-			INSTALL_URL_ADDRESS+='/download/0.0.3-alpha/spotify-connect-web_0.0.3-alpha.tar.gz'
+			INSTALL_URL_ADDRESS+='/download/0.0.4-alpha/spotify-connect-web_0.0.4-alpha.tar.gz'
 
 			wget "$INSTALL_URL_ADDRESS" -O package.tar
 			tar zxvf package.tar -C "$G_FP_DIETPI_USERDATA"/
@@ -6230,7 +6228,7 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://github.com/phanan/koel/archive/v3.7.0.zip'
+			INSTALL_URL_ADDRESS='https://github.com/phanan/koel/archive/v3.7.2.zip'
 
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
@@ -6607,7 +6605,7 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/allo_web_interface_v7.7z'
+			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/allo_web_interface_v7.7z'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			wget "$INSTALL_URL_ADDRESS" -O package.7z
@@ -6622,7 +6620,7 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/gmrender_1_'
+			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/gmrender_1_'
 			if (( $G_HW_ARCH == 10 )); then
 
 				INSTALL_URL_ADDRESS+='amd64.deb'
@@ -6684,7 +6682,7 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/moode/moode_rel-stretch-r40.zip'
+			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/moode/moode_rel-stretch-r41.zip'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			cd "$HOME"
@@ -6842,7 +6840,7 @@ libusb-dev libglib2.0-dev libudev-dev libical-dev libreadline-dev libsbc1 libsbc
 			# - Stretch, libssl1.0.0 no longer available: https://github.com/Fourdee/DietPi/issues/1299
 			if (( $G_DISTRO >= 4 )); then
 
-				INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/'
+				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/'
 
 				# - ARMv6/7
 				if (( $G_HW_ARCH == 1 || $G_HW_ARCH == 2 )); then
@@ -6942,13 +6940,13 @@ _EOF_
 			#Pine64
 			elif (( $G_HW_MODEL == 40 )); then
 
-				INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/libump_1-1_arm64.deb'
+				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/libump_1-1_arm64.deb'
 				G_CHECK_URL "$INSTALL_URL_ADDRESS"
 				wget "$INSTALL_URL_ADDRESS" -O package.deb
 				dpkg -i package.deb
 				rm package.deb
 
-				INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/xf86-video-fbturbo_1-1_arm64.deb'
+				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/xf86-video-fbturbo_1-1_arm64.deb'
 				G_CHECK_URL "$INSTALL_URL_ADDRESS"
 				wget "$INSTALL_URL_ADDRESS" -O package.deb
 				dpkg -i package.deb
@@ -7256,7 +7254,7 @@ _EOF_
 			#RPi + OpenMAX HW Encoding: https://github.com/Fourdee/DietPi/issues/869
 			if (( $G_HW_MODEL < 10 )); then
 
-				INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/rpi/ffmpeg_rpi.7z'
+				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/rpi/ffmpeg_rpi.7z'
 
 				G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
@@ -7347,18 +7345,18 @@ _EOF_
 			if (( $G_HW_ARCH == 10 )); then
 
 				# G_AGI libsdl2-2.0-0 libsdl2-image-2.0-0 libsdl2-ttf-2.0-0 libsdl2-net-2.0-0 libsdl2-mixer-2.0-0
-				INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/sdl2-x86_64_stretch.7z'
+				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/sdl2-x86_64_stretch.7z'
 
 			#ARMv6
 			elif (( $G_HW_ARCH == 1 )); then
 
-				INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/sdl2-armv6_stretch.7z'
+				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/sdl2-armv6_stretch.7z'
 
 			#ARMv7 FKMS:
 			#	./configure --disable-video-rpi --enable-video-kmsdrm
 			elif (( $G_HW_ARCH == 2 )); then
 
-				INSTALL_URL_ADDRESS='http://dietpi.com/downloads/binaries/all/sdl2-armv7_stretch.7z'
+				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/sdl2-armv7_stretch.7z'
 
 				# - RPi 2/3 Enable fkms OpenGL
 				if (( $G_HW_MODEL < 10 )); then
@@ -7728,19 +7726,19 @@ _EOF_
 
 			#Copy PCmanFM configs
 			mkdir -p "$HOME"/.config/pcmanfm/LXDE
-			wget http://dietpi.com/downloads/conf/desktop/pcmanfm.conf -O "$HOME"/.config/pcmanfm/LXDE/pcmanfm.conf
-			wget http://dietpi.com/downloads/conf/desktop/pcmanfm-desktopitems.conf -O "$HOME"/.config/pcmanfm/LXDE/desktop-items-0.conf
+			wget https://dietpi.com/downloads/conf/desktop/pcmanfm.conf -O "$HOME"/.config/pcmanfm/LXDE/pcmanfm.conf
+			wget https://dietpi.com/downloads/conf/desktop/pcmanfm-desktopitems.conf -O "$HOME"/.config/pcmanfm/LXDE/desktop-items-0.conf
 
 			#Disable Trash
 			sed -i '/use_trash=/c\use_trash=0' /etc/xdg/libfm/libfm.conf
 
 			#Copy DietPi Panel config
 			mkdir -p "$HOME"/.config/lxpanel/LXDE/panels
-			wget http://dietpi.com/downloads/conf/desktop/panel -O "$HOME"/.config/lxpanel/LXDE/panels/panel
+			wget https://dietpi.com/downloads/conf/desktop/panel -O "$HOME"/.config/lxpanel/LXDE/panels/panel
 
 			#Openbox config
 			mkdir -p "$HOME"/.config/openbox
-			wget http://dietpi.com/downloads/conf/desktop/lxde-rc.xml -O "$HOME"/.config/openbox/lxde-rc.xml
+			wget https://dietpi.com/downloads/conf/desktop/lxde-rc.xml -O "$HOME"/.config/openbox/lxde-rc.xml
 
 			# - file manager desktop icon
 			ln -sf /usr/share/applications/pcmanfm.desktop "$HOME"/Desktop/pcmanfm.desktop
@@ -8124,7 +8122,7 @@ _EOF_
 
 			# Due to MariaDB unix_socket authentication, "root" cannot be used to login the web ui.
 			# Thus default "phpmyadmin" user need to be used, who on Jessie does not have all privileges:
-			# http://dietpi.com/phpbb/viewtopic.php?f=8&t=5&p=54#p54
+			# https://dietpi.com/phpbb/viewtopic.php?f=8&t=5&p=54#p54
 			systemctl start mysql
 			mysql -e "grant all privileges on *.* to phpmyadmin@localhost with grant option"
 
@@ -9013,7 +9011,7 @@ _EOF_
 			#Create .desktop SymLinks
 			mkdir -p "$HOME"/Desktop
 			rm /usr/share/applications/kodi.desktop &> /dev/null
-			wget http://dietpi.com/downloads/conf/desktop/kodi.desktop -O /usr/share/applications/kodi.desktop
+			wget https://dietpi.com/downloads/conf/desktop/kodi.desktop -O /usr/share/applications/kodi.desktop
 			ln -sf /usr/share/applications/kodi.desktop "$HOME"/Desktop/kodi.desktop
 
 		fi
@@ -9194,7 +9192,7 @@ _EOF_
 			#Create .Desktop SymLinks
 			mkdir -p "$HOME"/Desktop
 			rm /usr/share/applications/opentyrian.desktop &> /dev/null
-			wget http://dietpi.com/downloads/conf/desktop/pcmanfm.conf -O /usr/share/applications/opentyrian.desktop
+			wget https://dietpi.com/downloads/conf/desktop/pcmanfm.conf -O /usr/share/applications/opentyrian.desktop
 			ln -s /usr/share/applications/opentyrian.desktop "$HOME"/Desktop/opentyrian.desktop
 
 		fi
@@ -9868,7 +9866,7 @@ _EOF_
 
 			#Get test images
 			mkdir -p /var/www/gallery/DietPi
-			wget http://dietpi.com/images/dietpi-logo_256.png -O /var/www/gallery/DietPi/logo_256.png
+			wget https://dietpi.com/images/dietpi-logo_256.png -O /var/www/gallery/DietPi/logo_256.png
 
 			mkdir -p /var/www/gallery/Tr-Zero
 			wget http://media.indiedb.com/images/games/1/25/24673/SS_0.jpg -O /var/www/gallery/Tr-Zero/SS_0.jpg
@@ -9892,7 +9890,7 @@ _EOF_
 			Download_Test_Media
 
 			#create/insert our pre-made ampache sql db
-			G_RUN_CMD wget http://dietpi.com/downloads/mysql_databases/ampache_mysql_3.8.2-v6.0.zip -O sql.zip
+			G_RUN_CMD wget https://dietpi.com/downloads/mysql_databases/ampache_mysql_3.8.2-v6.0.zip -O sql.zip
 			unzip -o sql.zip
 			rm sql.zip
 
@@ -9901,7 +9899,7 @@ _EOF_
 			rm ampache.sql
 
 			#Grab config
-			G_RUN_CMD wget http://dietpi.com/downloads/conf/ampache.cfg.php_3.8.2-v6.0 -O /var/www/ampache/config/ampache.cfg.php
+			G_RUN_CMD wget https://dietpi.com/downloads/conf/ampache.cfg.php_3.8.2-v6.0 -O /var/www/ampache/config/ampache.cfg.php
 
 		fi
 
@@ -10477,7 +10475,7 @@ _EOF_
 			#Disable DB logging
 			sed -i '/logdays=/c\logdays=-1' /etc/mumble-server.ini
 
-			#Set Superuser passwd: http://dietpi.com/phpbb/viewtopic.php?f=11&t=2024#p8084
+			#Set Superuser passwd: https://dietpi.com/phpbb/viewtopic.php?f=11&t=2024#p8084
 			murmurd -ini /etc/mumble-server.ini -supw "$GLOBAL_PW"
 
 		fi
@@ -11205,7 +11203,7 @@ _EOF_
 			systemctl stop sickrage
 
 			cp "$G_FP_DIETPI_USERDATA"/sickrage/config.ini "$G_FP_DIETPI_USERDATA"/sickrage/config.ini.default
-			wget http://dietpi.com/downloads/conf/sickrage_dietpi_config.ini -O "$G_FP_DIETPI_USERDATA"/sickrage/config.ini
+			wget https://dietpi.com/downloads/conf/sickrage_dietpi_config.ini -O "$G_FP_DIETPI_USERDATA"/sickrage/config.ini
 
 		fi
 
@@ -11548,7 +11546,7 @@ _EOF_
 
 			systemctl stop sabnzbd
 
-			sleep 2 #additional wait, config being overwritten after below changes: http://dietpi.com/phpbb/viewtopic.php?f=11&t=1848&p=7085#p7082
+			sleep 2 #additional wait, config being overwritten after below changes: https://dietpi.com/phpbb/viewtopic.php?f=11&t=1848&p=7085#p7082
 
 			sed -i "/^download_dir =/c\download_dir = $G_FP_DIETPI_USERDATA/downloads/incomplete" /etc/sabnzbd/sabnzbd.ini
 			sed -i "/^complete_dir =/c\complete_dir = $G_FP_DIETPI_USERDATA/downloads/complete" /etc/sabnzbd/sabnzbd.ini
@@ -15122,7 +15120,7 @@ _EOF_
 
 		G_WHIP_SIZE_X_MAX=80
 		G_WHIP_BUTTON_CANCEL_TEXT='Back'
-		G_WHIP_CHECKLIST "Please use the spacebar to select the software you wish to install.\nSoftware details: http://dietpi.com/software"
+		G_WHIP_CHECKLIST "Please use the spacebar to select the software you wish to install.\nSoftware details: https://dietpi.com/software"
 
 		#Reset Choices made flag
 		# - dietpi
@@ -15352,7 +15350,7 @@ _EOF_
 
 					G_WHIP_DEFAULT_ITEM="$index_fileserver_text"
 					G_WHIP_BUTTON_CANCEL_TEXT='Back'
-					G_WHIP_MENU "Please select desired fileserver:\n\n- None: Select this option if you do NOT require a method of accessing files and folders on this device, over a network.\n\n- ProFTP (Recommended for RPi v1): Allows you to access/share files on this device efficiently with minimal cpu usage. Uses FTP protocol.\n\n- Samba (Recommended for RPi v2): Allows you to easily access/share files on this device, at the cost of higher cpu usage.\n\nMore info: http://dietpi.com/phpbb/viewtopic.php?f=8&t=15#p19"
+					G_WHIP_MENU "Please select desired fileserver:\n\n- None: Select this option if you do NOT require a method of accessing files and folders on this device, over a network.\n\n- ProFTP (Recommended for RPi v1): Allows you to access/share files on this device efficiently with minimal cpu usage. Uses FTP protocol.\n\n- Samba (Recommended for RPi v2): Allows you to easily access/share files on this device, at the cost of higher cpu usage.\n\nMore info: https://dietpi.com/phpbb/viewtopic.php?f=8&t=15#p19"
 					if (( $? == 0 )); then
 
 						# - Assign target index
@@ -15464,7 +15462,7 @@ _EOF_
 					)
 
 					G_WHIP_BUTTON_CANCEL_TEXT='Back'
-					G_WHIP_MENU "Choose where to store your user data. User data includes software such as Owncloud data store, BitTorrent downloads etc.\n\nMore information on user data in DietPi:\n- http://dietpi.com/phpbb/viewtopic.php?f=8&t=478&p=2087\n\n- DietPi-Drive Manager: Launch DietPi-Drive Manager to setup external drives, and, move user data to different locations."
+					G_WHIP_MENU "Choose where to store your user data. User data includes software such as Owncloud data store, BitTorrent downloads etc.\n\nMore information on user data in DietPi:\n- https://dietpi.com/phpbb/viewtopic.php?f=8&t=478&p=2087\n\n- DietPi-Drive Manager: Launch DietPi-Drive Manager to setup external drives, and, move user data to different locations."
 					if (( $? == 0 )); then
 
 						# - DriveMan
@@ -15543,7 +15541,7 @@ _EOF_
 
 					G_WHIP_DEFAULT_ITEM="$index_webserver_text"
 					G_WHIP_BUTTON_CANCEL_TEXT='Back'
-					G_WHIP_MENU "Please select a Webserver preference, more info http://dietpi.com/phpbb/viewtopic.php?f=8&t=5&p=1549#p1549:\n\n- Apache2: Feature-rich and popular. Recommended for beginners and users who are looking to follow Apache2 based guides.\n\n- Nginx: Lightweight alternative to Apache2. Nginx claims faster webserver performance compared to Apache2.\n\n- Lighttpd: Extremely lightweight and is generally considered to offer the \"best\" webserver performance for SBC's. Recommended for users who expect low webserver traffic."
+					G_WHIP_MENU "Please select a Webserver preference, more info https://dietpi.com/phpbb/viewtopic.php?f=8&t=5&p=1549#p1549:\n\n- Apache2: Feature-rich and popular. Recommended for beginners and users who are looking to follow Apache2 based guides.\n\n- Nginx: Lightweight alternative to Apache2. Nginx claims faster webserver performance compared to Apache2.\n\n- Lighttpd: Extremely lightweight and is generally considered to offer the \"best\" webserver performance for SBC's. Recommended for users who expect low webserver traffic."
 
 					if (( $? == 0 )); then
 
@@ -15647,10 +15645,10 @@ _EOF_
 					string+='Press ESC, or TAB then enter to exit this help screen.\n'
 					string+='\n'
 					string+='Easy to follow, step by step guides for installing DietPi:\n'
-					string+='http://dietpi.com/phpbb/viewtopic.php?f=8&t=9\n'
+					string+='https://dietpi.com/phpbb/viewtopic.php?f=8&t=9\n'
 					string+='\n'
 					string+='For a list of all installation options and their details:\n'
-					string+='http://dietpi.com/software\n'
+					string+='https://dietpi.com/software\n'
 					string+='\n'
 					string+='───────────────────────────────────────────────────────────────\n'
 					string+='List of installed software and their URL links for online docs:\n'
@@ -15752,7 +15750,7 @@ _EOF_
 		done
 
 		#Confirm Software install
-		G_WHIP_YESNO "DietPi is now ready to install your software choices: $string_output\n\nSoftware details, usernames, passwords etc:\n - http://dietpi.com/software\n\nNB: Software services will be temporarily controlled (stopped) by DietPi during this process. Please inform connected users, before continuing. SSH is not affected.\n\nWould you like to begin?"
+		G_WHIP_YESNO "DietPi is now ready to install your software choices: $string_output\n\nSoftware details, usernames, passwords etc:\n - https://dietpi.com/software\n\nNB: Software services will be temporarily controlled (stopped) by DietPi during this process. Please inform connected users, before continuing. SSH is not affected.\n\nWould you like to begin?"
 		if (( $? == 0 )); then
 
 			#exit menu system
@@ -16004,14 +16002,14 @@ _EOF_
 		#Weaved
 		if (( ${aSOFTWARE_INSTALL_STATE[68]} == 1 )); then
 
-			G_WHIP_MSG 'Remot3.it requires you to create an online account, and, link it this device.\n\nOnce DietPi has completed your software installations, and rebooted, please follow the First Run tutorial link below:\nhttp://dietpi.com/phpbb/viewtopic.php?f=8&t=5&p=188#p188'
+			G_WHIP_MSG 'Remot3.it requires you to create an online account, and, link it this device.\n\nOnce DietPi has completed your software installations, and rebooted, please follow the First Run tutorial link below:\nhttps://dietpi.com/phpbb/viewtopic.php?f=8&t=5&p=188#p188'
 
 		fi
 
 		#LetsEncrypt
 		if (( ${aSOFTWARE_INSTALL_STATE[92]} == 1 )); then
 
-			G_WHIP_MSG 'The DietPi installation of CertBot supports all offered web servers.\n\nOnce the installation has finished, you can setup your free SSL cert with:\n - DietPi-LetsEncrypt\n\nThis is a easy to use frontend for CertBot and allows integration into DietPi systems.\n\nMore information:\n - http://dietpi.com/phpbb/viewtopic.php?f=8&t=5&p=1061#p1062'
+			G_WHIP_MSG 'The DietPi installation of CertBot supports all offered web servers.\n\nOnce the installation has finished, you can setup your free SSL cert with:\n - DietPi-LetsEncrypt\n\nThis is a easy to use frontend for CertBot and allows integration into DietPi systems.\n\nMore information:\n - https://dietpi.com/phpbb/viewtopic.php?f=8&t=5&p=1061#p1062'
 
 		fi
 
@@ -16020,7 +16018,7 @@ _EOF_
 		#NoIp
 		if (( ${aSOFTWARE_INSTALL_STATE[67]} == 1 )); then
 
-			G_WHIP_YESNO 'NoIp can be setup and configured by using DietPi-Config. Would you like to complete this now? \n\n- Once finished, exit DietPi-Config to resume setup. \n\n- More information:\nhttp://dietpi.com/phpbb/viewtopic.php?f=8&t=5&start=10#p58'
+			G_WHIP_YESNO 'NoIp can be setup and configured by using DietPi-Config. Would you like to complete this now? \n\n- Once finished, exit DietPi-Config to resume setup. \n\n- More information:\nhttps://dietpi.com/phpbb/viewtopic.php?f=8&t=5&start=10#p58'
 			if (( $? == 0 )); then
 
 				#Write installed states to temp


### PR DESCRIPTION
https://github.com/Fourdee/DietPi/issues/1340
+ DietPi-Software | Non-APT software updates, including binary/package uploads to https://dietpi.com/downloads, excluding where source builds are needed
+ DietPi-Software | Switch to httpS://dietpi.com

Affected software:
- NoMachine
- UrBackup
- RPi Cam Control
- Weaved
- Blynk
- HAProxy
- Single File PHP Gallery
- Plex Media Server
- Syncthing
- Spotify Connect Web
- Koel
- moOde (currently inactive anyway) 