### PR TITLE
DietPi-Software | Koel: Workaround due to Node 10 incompatibility

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -960,6 +960,8 @@ _EOF_
 		   aSOFTWARE_REQUIRES_NODEJS[$index_current]=1
    aSOFTWARE_REQUIRES_BUILDESSENTIAL[$index_current]=1
 		   aSOFTWARE_REQUIRES_FFMPEG[$index_current]=1
+		# Currently user prompt asks for admin user credentials:
+		aSOFTWARE_REQUIRES_USERINPUT[$index_current]=1
 
 		#------------------
 		index_current=146
@@ -6321,7 +6323,6 @@ _EOF_
 			Banner_Installing
 
 			INSTALL_URL_ADDRESS='https://github.com/phanan/koel/archive/v3.7.2.zip'
-
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			G_THREAD_START wget "$INSTALL_URL_ADDRESS" -O $INSTALLING_INDEX.zip
@@ -6333,16 +6334,18 @@ _EOF_
 			rm $INSTALLING_INDEX.zip
 			mv koel-* /var/www/koel
 
+			# Install pre-req yarn and "n" to downgrade to Node 8, as Node 10 is not (yet) compatible with Koel build.
+			npm i yarn n -g --unsafe-perm
+			n 8
+
+			# Download and install Composer:
 			php -r "readfile('https://getcomposer.org/installer');" > composer-setup.php
 			php composer-setup.php
 			php -r "unlink('composer-setup.php');"
-
 			mv composer.phar /usr/local/bin/composer
 
 			cd /var/www/koel
-			npm install yarn -g --unsafe-perm
 			composer install
-
 			cd "$HOME"
 
 		fi
@@ -11742,9 +11745,10 @@ _EOF_
 			G_CONFIG_INJECT 'DB_DATABASE=' 'DB_DATABASE=koel' .env
 			G_CONFIG_INJECT 'DB_USERNAME=' 'DB_USERNAME=koel' .env
 			G_CONFIG_INJECT 'DB_PASSWORD=' "DB_PASSWORD=$GLOBAL_PW" .env
-			G_CONFIG_INJECT 'ADMIN_EMAIL=' 'ADMIN_EMAIL=dietpi@dietpi.com' .env
-			G_CONFIG_INJECT 'ADMIN_NAME=' 'ADMIN_NAME=admin' .env
-			G_CONFIG_INJECT 'ADMIN_PASSWORD=' "ADMIN_PASSWORD=$GLOBAL_PW" .env
+			# ADMIN env vars are not used any more, user prompt will ask for info.
+			#G_CONFIG_INJECT 'ADMIN_EMAIL=' 'ADMIN_EMAIL=dietpi@dietpi.com' .env
+			#G_CONFIG_INJECT 'ADMIN_NAME=' 'ADMIN_NAME=admin' .env
+			#G_CONFIG_INJECT 'ADMIN_PASSWORD=' "ADMIN_PASSWORD=$GLOBAL_PW" .env
 			G_CONFIG_INJECT 'DB_CONNECTION=' 'DB_CONNECTION=mysql' .env
 			G_CONFIG_INJECT 'FFMPEG_PATH=' "FFMPEG_PATH=$(which ffmpeg)" .env
 


### PR DESCRIPTION
Ref: https://github.com/Fourdee/DietPi/issues/1340#issuecomment-390359989

@Fourdee 
- Python is needed for what? Just installed and used Koel successfully without 🙂.