### PR TITLE
DietPi-Login | Completely remove sudo/root requirements

### DIFF
--- a/dietpi/func/obtain_network_details
+++ b/dietpi/func/obtain_network_details
@@ -48,17 +48,14 @@
 	# Main Loop
 	#/////////////////////////////////////////////////////////////////////////////////////
 
-	#grab content of ifconfig -a
-	ifconfig -a > "$FP_TEMP"
-
-	#clear previous
-	rm "$FP_NETFILE" &> /dev/null
+	#grab content of ip l
+	ip l > "$FP_TEMP"
 
 	#find eth[0-9]
 	for ((i=0; i<$MAX_DEVICE; i++))
 	do
 
-		if (( $(grep -ci -m1 "eth$i" "$FP_TEMP") )); then
+		if grep -qi "eth$i" "$FP_TEMP"; then
 
 			ETH_INDEX=$i
 			DEVICE_FOUND=1
@@ -72,7 +69,7 @@
 	for ((i=0; i<$MAX_DEVICE; i++))
 	do
 
-		if (( $(grep -ci -m1 "wlan$i" "$FP_TEMP") )); then
+		if grep -qi "wlan$i" "$FP_TEMP"; then
 
 			WLAN_INDEX=$i
 			DEVICE_FOUND=1
@@ -88,18 +85,18 @@
 		#Find active network device
 		# - eth takes priority, if both eth wlan are active.
 		ip r > "$FP_TEMP"
-		if (( $(grep -ci -m1 "eth$ETH_INDEX" "$FP_TEMP") )); then
+		if grep -qi "eth$ETH_INDEX" "$FP_TEMP"; then
 
 			ACTIVE_DEVICE="eth$ETH_INDEX"
 
-		elif (( $(grep -ci -m1 "wlan$WLAN_INDEX" "$FP_TEMP") )); then
+		elif grep -qi "wlan$WLAN_INDEX" "$FP_TEMP"; then
 
 			ACTIVE_DEVICE="wlan$WLAN_INDEX"
 
 		fi
 
 		#IP address
-		IP_ADDRESS=$(ifconfig "$ACTIVE_DEVICE" 2>&1 | grep -m1 'inet' | awk '{ print $2 }' | cut -d: -f2)
+		IP_ADDRESS="$(ip a show $ACTIVE_DEVICE | grep -m1 'inet' | awk '{ print $2 }' | sed -E 's/(:|\/).*$//')"
 
 	fi
 
@@ -111,6 +108,8 @@ $WLAN_INDEX
 $ACTIVE_DEVICE
 $IP_ADDRESS
 _EOF_
+	# Assure that non-root user can call this script:
+	chmod 666 "$FP_NETFILE" &> /dev/null
 
 	#Clean up tmp files used
 	rm "$FP_TEMP"

--- a/dietpi/login
+++ b/dietpi/login
@@ -16,7 +16,7 @@
 
 	#--------------------------------------------------------------------------------------
 	#Prevent sudo -i/G_SUDO from re-running this script due to profile.d/99-dietpi under sudo -i
-	if ps ax | grep -qi 'sudo -i'; then
+	if ps ax | grep -qi '[s]udo -i'; then
 
 		exit
 

--- a/dietpi/login
+++ b/dietpi/login
@@ -16,7 +16,7 @@
 
 	#--------------------------------------------------------------------------------------
 	#Prevent sudo -i/G_SUDO from re-running this script due to profile.d/99-dietpi under sudo -i
-	if ps ax | grep -qi '[s]udo -i'; then
+	if ps ax | grep -qi 'sudo -i'; then
 
 		exit
 
@@ -25,7 +25,6 @@
 
 	#Import DietPi-Globals ---------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
-	#G_CHECK_ROOT_USER # sudo must be used throughout this script
 	export G_PROGRAM_NAME='DietPi-Login'
 	#G_INIT
 	##Import DietPi-Globals ---------------------------------------------------------------
@@ -47,7 +46,7 @@
 
 		#Do we have a valid screen for autoboot?
 		local screen_valid=0
-		if [ -z "$DISPLAY" ] && [ "$(tty)" = "/dev/tty1" ]; then
+		if [[ -z $DISPLAY && $(tty) == '/dev/tty1' ]]; then
 
 			screen_valid=1
 
@@ -154,16 +153,16 @@
 	# Main Loop
 	#/////////////////////////////////////////////////////////////////////////////////////
 	#Precaution: Wait for DietPi Ramdisk to finish
-	while [ ! -f /DietPi/.ramdisk ]
+	while [[ ! -f /DietPi/.ramdisk ]]
 	do
 
-		G_DIETPI-NOTIFY 2 "Waiting for DietPi-RAMDISK to finish mounting DietPi to RAM..."
+		G_DIETPI-NOTIFY 2 'Waiting for DietPi-RAMDISK to finish mounting DietPi to RAM...'
 		sleep 1
 
 	done
 
 	#Update network details for banner IP address.
-	sudo /DietPi/dietpi/func/obtain_network_details
+	/DietPi/dietpi/func/obtain_network_details
 
 	#----------------------------------------------------------------
 	#Normal Login
@@ -184,14 +183,13 @@
 		/DietPi/dietpi/dietpi-banner 0
 
 		#Wait for DietPi-Software if already running, else run it
-		while ps aux | grep -qi '/DietPi/dietpi/[d]ietpi-software'
+		while pgrep -i 'dietpi-software' &> /dev/null
 		do
 
 			# - Automated
 			if grep -qi '^[[:blank:]]*AUTO_SETUP_AUTOMATED=1' /DietPi/dietpi.txt; then
 
 				G_DIETPI-NOTIFY 2 'DietPi is currently installing and configuring your system. Please wait for this to complete, check back later.'
-
 
 			else
 
@@ -226,14 +224,14 @@
 	elif (( $G_DIETPI_INSTALL_STAGE == -1 )); then
 
 		/DietPi/dietpi/dietpi-banner 0
-		echo -e " >> DietPi System prep is nearly completed: \n Please run /DietPi/dietpi/login after a few seconds"
+		echo -e ' >> DietPi System prep is nearly completed: \n Please run /DietPi/dietpi/login after a few seconds'
 
 	#----------------------------------------------------------------
 	#DietPi running filesystem prep
 	else
 
 		/DietPi/dietpi/dietpi-banner 0
-		echo -e " >> Filesystem prep has not yet completed: \n Please wait for the system to reboot "
+		echo -e ' >> Filesystem prep has not yet completed: \n Please wait for the system to reboot'
 
 	fi
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -747,6 +747,10 @@ _EOF_
 
 			fi
 			#-------------------------------------------------------------------------------
+			#Initially allow non-root users to obtain network details as well: https://github.com/Fourdee/DietPi/commit/15c0d495c33d3091e219c87bb2d09a22f8d27e9c
+			[[ -f /DietPi/dietpi/.network ]] && chmod 666 /DietPi/dietpi/.network
+			[[ -f /boot/dietpi/.network ]] && chmod 666 /boot/dietpi/.network
+			#-------------------------------------------------------------------------------
 
 		fi
 


### PR DESCRIPTION
+ DietPi-Obtain_network_details | Allow calling this script as non-root user
+ DietPi-Obtain_network_details | Minor code improvements
+ DietPi-Login | No need to call "obtain_network_details" with "sudo" any more
+ DietPi-Login | Minor code improvements
+ DietPi-Patch_file | For smooth transition to non-root login script, initially patch /DietPi/dietpi/.network to globally writeable. 

Allows login banner for users without sudo permissions or with password protected sudo rights, without breaking remote script due to additional password prompt: https://dietpi.com/phpbb/viewtopic.php?p=12535#p12535

🈯️ Tests with root, sudo (passwd+nopasswd) and non-sudo user