### PR TITLE
DietPi-Login | Move DietPi-Globals and login scripts into new /etc/bashrc.d/ global custom interactive shell script directory

### DIFF
--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -1219,7 +1219,11 @@ _EOF_
 	# - PINE64 (and possibily others): Cursor fix for FB
 	elif (( $G_HW_MODEL == 40 )); then
 
-		cat << _EOF_ >> "$HOME"/.bashrc
+		mkdir -p /etc/bashrc.d
+		cat << _EOF_ > /etc/bashrc.d/dietpi-pine64-cursorfix.sh
+#!/bin/bash
+
+# DietPi: Cursor fix for FB
 infocmp > terminfo.txt
 sed -i -e 's/?0c/?112c/g' -e 's/?8c/?48;0;64c/g' terminfo.txt
 tic terminfo.txt

--- a/dietpi/dietpi-bugreport
+++ b/dietpi/dietpi-bugreport
@@ -134,7 +134,11 @@ _EOF_
 			# - confs
 			"/etc/X11/xorg.conf"
 			"/etc/bash.bashrc"
+			"/etc/bashrc.d/*"
 			"/root/.bashrc"
+			"/etc/profile"
+			"/etc/profile.d/*"
+			"/root/.profile"
 			"/etc/rc.local"
 			"/etc/asound.conf"
 			"/etc/network/interfaces"

--- a/dietpi/func/dietpi-set_core_environment
+++ b/dietpi/func/dietpi-set_core_environment
@@ -40,6 +40,7 @@
 	rm /etc/profile.d/99-dietpi* &> /dev/null
 
 	# - Enable /etc/bashrc.d/ support for custom interactive non-login shell scripts:
+	mkdir -p /etc/bashrc.d
 	G_CONFIG_INJECT 'for i in /etc/bashrc\.d/\*\.sh; do \[ -r "\$i" \] && \. \$i; done' 'for i in /etc/bashrc\.d/\*\.sh; do \[ -r "\$i" \] && \. \$i; done' /etc/bash.bashrc
 
 	# - Login | Global init and login script

--- a/dietpi/func/dietpi-set_core_environment
+++ b/dietpi/func/dietpi-set_core_environment
@@ -34,15 +34,26 @@
 	#-----------------------------------------------------------------------------------
 	# Bash Profiles
 
+	# - Pre v6.9 cleaning:
+	sed -i '/\/DietPi/d' /root/.bashrc
+	sed -i '/\/DietPi/d' /home/dietpi/.bashrc &> /dev/null
+	rm /etc/profile.d/99-dietpi* &> /dev/null
+
+	# - Enable /etc/bashrc.d/ support for custom interactive non-login shell scripts:
+	G_CONFIG_INJECT 'for i in /etc/bashrc\.d/\*\.sh; do \[ -r "\$i" \] && \. \$i; done' 'for i in /etc/bashrc\.d/\*\.sh; do \[ -r "\$i" \] && \. \$i; done' /etc/bash.bashrc
+
 	# - Login | Global init and login script
-	sed -i '/\/DietPi/d' /root/.bashrc #failsafe start clean
-	cat << _EOF_ >> /root/.bashrc
+	cat << _EOF_ > /etc/bashrc.d/99-dietpi-login.sh
+#!/bin/bash
+
+# dietpi-* and G_* functions
 . /DietPi/dietpi/func/dietpi-globals
+# login scripts and banner
 /DietPi/dietpi/login
 _EOF_
 
 	# - Workaround for setting user selected locale to session when POSIX is detected (eg: dropbear limitation/bug): https://github.com/Fourdee/DietPi/issues/1540#issuecomment-367066178
-	cat << _EOF_ > /etc/profile.d/99-dietpi-posix-set-locale.sh
+	cat << _EOF_ > /etc/bashrc.d/99-dietpi-posix-set-locale.sh
 #!/bin/bash
 
 #Workaround for setting locale to session when POSIX is detected (eg: dropbear): https://github.com/Fourdee/DietPi/issues/1540#issuecomment-367066178
@@ -52,7 +63,6 @@ if locale | grep -qi 'POSIX'; then
 	export LC_ALL="\$CURRENT_LOCALE"
 fi
 _EOF_
-	chmod +x /etc/profile.d/99-dietpi-posix-set-locale.sh
 
 	#-----------------------------------------------------------------------------------
 	#Create_DietPi_User

--- a/dietpi/func/dietpi-set_core_environment
+++ b/dietpi/func/dietpi-set_core_environment
@@ -65,6 +65,10 @@ if locale | grep -qi 'POSIX'; then
 fi
 _EOF_
 
+	# - Enable bash-completion for non-login shells:
+	#	- NB: It is called twice on login shells then, but breaks directly if called already once.
+	ln -sf /etc/profile.d/bash_completion.sh /etc/bashrc.d/dietpi-bash_completion.sh
+
 	#-----------------------------------------------------------------------------------
 	#Create_DietPi_User
 

--- a/dietpi/func/dietpi-set_core_environment
+++ b/dietpi/func/dietpi-set_core_environment
@@ -43,7 +43,7 @@
 	G_CONFIG_INJECT 'for i in /etc/bashrc\.d/\*\.sh; do \[ -r "\$i" \] && \. \$i; done' 'for i in /etc/bashrc\.d/\*\.sh; do \[ -r "\$i" \] && \. \$i; done' /etc/bash.bashrc
 
 	# - Login | Global init and login script
-	cat << _EOF_ > /etc/bashrc.d/99-dietpi-login.sh
+	cat << _EOF_ > /etc/bashrc.d/dietpi-login.sh
 #!/bin/bash
 
 # dietpi-* and G_* functions
@@ -53,7 +53,7 @@
 _EOF_
 
 	# - Workaround for setting user selected locale to session when POSIX is detected (eg: dropbear limitation/bug): https://github.com/Fourdee/DietPi/issues/1540#issuecomment-367066178
-	cat << _EOF_ > /etc/bashrc.d/99-dietpi-posix-set-locale.sh
+	cat << _EOF_ > /etc/bashrc.d/dietpi-posix-set-locale.sh
 #!/bin/bash
 
 #Workaround for setting locale to session when POSIX is detected (eg: dropbear): https://github.com/Fourdee/DietPi/issues/1540#issuecomment-367066178

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -675,19 +675,13 @@ _EOF_
 			sed -i '/^aSOFTWARE_INSTALL_STATE\[106\]=/c\aSOFTWARE_INSTALL_STATE\[106\]=0' /DietPi/dietpi/.installed &> /dev/null
 			/DietPi/dietpi/func/dietpi-set_software ntpd-mode $(grep -m1 '^CONFIG_NTP_MODE=' /DietPi/dietpi.txt | sed 's/.*=//')
 			#-------------------------------------------------------------------------------
-			#Revert back to .bashrc, due to issues with remote shell and desktop terms: https://github.com/Fourdee/DietPi/issues/1777#issuecomment-390248960
-			rm /etc/profile.d/99-dietpi-login.sh
+			#Move DietPi globals and login scripts into new /etc/bashrc.d location to load on all interactive shells:
+			mkdir -p /etc/bashrc.d
+			G_CONFIG_INJECT 'for i in /etc/bashrc\.d/\*\.sh; do \[ -r "\$i" \] && \. \$i; done' 'for i in /etc/bashrc\.d/\*\.sh; do \[ -r "\$i" \] && \. \$i; done' /etc/bash.bashrc
+			mv /etc/profile.d/99-dietpi-login.sh /etc/bashrc.d/dietpi-login.sh &> /dev/null
+			mv /etc/profile.d/99-dietpi-posix-set-locale.sh /etc/bashrc.d/dietpi-posix-set-locale.sh &> /dev/null
 			sed -i '/\/DietPi/d' /root/.bashrc #should already be removed, failsafe start clean
 			sed -i '/\/DietPi/d' /home/dietpi/.bashrc #should already be removed, failsafe start clean
-
-			cat << _EOF_ >> /root/.bashrc
-. /DietPi/dietpi/func/dietpi-globals
-/DietPi/dietpi/login
-_EOF_
-			cat << _EOF_ >> /home/dietpi/.bashrc
-. /DietPi/dietpi/func/dietpi-globals
-/DietPi/dietpi/login
-_EOF_
 			#-------------------------------------------------------------------------------
 			#Sparky unmute fix (re: @sudeep)
 			#	v2: https://github.com/Fourdee/DietPi/pull/1779

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -689,17 +689,17 @@ _EOF_
 . /DietPi/dietpi/func/dietpi-globals
 # login scripts and banner
 /DietPi/dietpi/login
- _EOF_
+_EOF_
  			cat << _EOF_ > /etc/bashrc.d/dietpi-posix-set-locale.sh
 #!/bin/bash
- 
- #Workaround for setting locale to session when POSIX is detected (eg: dropbear): https://github.com/Fourdee/DietPi/issues/1540#issuecomment-367066178
- if locale | grep -qi 'POSIX'; then
- 	CURRENT_LOCALE="\$(grep -m1 '^[[:blank:]]*AUTO_SETUP_LOCALE=' /DietPi/dietpi.txt | sed 's/^.*=//')"
- 	export LANG="\$CURRENT_LOCALE"
- 	export LC_ALL="\$CURRENT_LOCALE"
- fi
- _EOF_
+
+#Workaround for setting locale to session when POSIX is detected (eg: dropbear): https://github.com/Fourdee/DietPi/issues/1540#issuecomment-367066178
+if locale | grep -qi 'POSIX'; then
+	CURRENT_LOCALE="\$(grep -m1 '^[[:blank:]]*AUTO_SETUP_LOCALE=' /DietPi/dietpi.txt | sed 's/^.*=//')"
+	export LANG="\$CURRENT_LOCALE"
+	export LC_ALL="\$CURRENT_LOCALE"
+fi
+_EOF_
 			# - Enable bash-completion for non-login shells:
 			#	- NB: It is called twice on login shells then, but breaks directly if called already once.
 			ln -sf /etc/profile.d/bash_completion.sh /etc/bashrc.d/dietpi-bash_completion.sh

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -681,7 +681,7 @@ _EOF_
 			sed -i '/\/DietPi/d' /root/.bashrc #should already be removed, failsafe start clean
 			sed -i '/\/DietPi/d' /home/dietpi/.bashrc #should already be removed, failsafe start clean
 			[[ -f /etc/profile.d/99-dietpi-login.sh ]] && rm /etc/profile.d/99-dietpi-login.sh
-			[[ -f /etc/profile.d/99-dietpi-posix-set-locale.sh ]] rm /etc/profile.d/99-dietpi-posix-set-locale.sh
+			[[ -f /etc/profile.d/99-dietpi-posix-set-locale.sh ]] && rm /etc/profile.d/99-dietpi-posix-set-locale.sh
 			cat << _EOF_ > /etc/bashrc.d/dietpi-login.sh
 #!/bin/bash
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -678,10 +678,28 @@ _EOF_
 			#Move DietPi globals and login scripts into new /etc/bashrc.d location to load on all interactive shells:
 			mkdir -p /etc/bashrc.d
 			G_CONFIG_INJECT 'for i in /etc/bashrc\.d/\*\.sh; do \[ -r "\$i" \] && \. \$i; done' 'for i in /etc/bashrc\.d/\*\.sh; do \[ -r "\$i" \] && \. \$i; done' /etc/bash.bashrc
-			mv /etc/profile.d/99-dietpi-login.sh /etc/bashrc.d/dietpi-login.sh &> /dev/null
-			mv /etc/profile.d/99-dietpi-posix-set-locale.sh /etc/bashrc.d/dietpi-posix-set-locale.sh &> /dev/null
 			sed -i '/\/DietPi/d' /root/.bashrc #should already be removed, failsafe start clean
 			sed -i '/\/DietPi/d' /home/dietpi/.bashrc #should already be removed, failsafe start clean
+			[[ -f /etc/profile.d/99-dietpi-login.sh ]] && rm /etc/profile.d/99-dietpi-login.sh
+			[[ -f /etc/profile.d/99-dietpi-posix-set-locale.sh ]] rm /etc/profile.d/99-dietpi-posix-set-locale.sh
+			cat << _EOF_ > /etc/bashrc.d/dietpi-login.sh
+#!/bin/bash
+
+# dietpi-* and G_* functions
+. /DietPi/dietpi/func/dietpi-globals
+# login scripts and banner
+/DietPi/dietpi/login
+ _EOF_
+ 			cat << _EOF_ > /etc/bashrc.d/dietpi-posix-set-locale.sh
+#!/bin/bash
+ 
+ #Workaround for setting locale to session when POSIX is detected (eg: dropbear): https://github.com/Fourdee/DietPi/issues/1540#issuecomment-367066178
+ if locale | grep -qi 'POSIX'; then
+ 	CURRENT_LOCALE="\$(grep -m1 '^[[:blank:]]*AUTO_SETUP_LOCALE=' /DietPi/dietpi.txt | sed 's/^.*=//')"
+ 	export LANG="\$CURRENT_LOCALE"
+ 	export LC_ALL="\$CURRENT_LOCALE"
+ fi
+ _EOF_
 			# - Enable bash-completion for non-login shells:
 			#	- NB: It is called twice on login shells then, but breaks directly if called already once.
 			ln -sf /etc/profile.d/bash_completion.sh /etc/bashrc.d/dietpi-bash_completion.sh

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -680,8 +680,7 @@ _EOF_
 			G_CONFIG_INJECT 'for i in /etc/bashrc\.d/\*\.sh; do \[ -r "\$i" \] && \. \$i; done' 'for i in /etc/bashrc\.d/\*\.sh; do \[ -r "\$i" \] && \. \$i; done' /etc/bash.bashrc
 			sed -i '/\/DietPi/d' /root/.bashrc #should already be removed, failsafe start clean 
 			for i in /home/*/.bashrc; do sed -i '/\/DietPi/d' "$i"; done #should already be removed, failsafe start clean
-			[[ -f /etc/profile.d/99-dietpi-login.sh ]] && rm /etc/profile.d/99-dietpi-login.sh
-			[[ -f /etc/profile.d/99-dietpi-posix-set-locale.sh ]] && rm /etc/profile.d/99-dietpi-posix-set-locale.sh
+			rm /etc/profile.d/99-dietpi* &> /dev/null
 			cat << _EOF_ > /etc/bashrc.d/dietpi-login.sh
 #!/bin/bash
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -678,8 +678,8 @@ _EOF_
 			#Move DietPi globals and login scripts into new /etc/bashrc.d location to load on all interactive shells:
 			mkdir -p /etc/bashrc.d
 			G_CONFIG_INJECT 'for i in /etc/bashrc\.d/\*\.sh; do \[ -r "\$i" \] && \. \$i; done' 'for i in /etc/bashrc\.d/\*\.sh; do \[ -r "\$i" \] && \. \$i; done' /etc/bash.bashrc
-			sed -i '/\/DietPi/d' /root/.bashrc #should already be removed, failsafe start clean
-			sed -i '/\/DietPi/d' /home/dietpi/.bashrc #should already be removed, failsafe start clean
+			sed -i '/\/DietPi/d' /root/.bashrc #should already be removed, failsafe start clean 
+			for i in /home/*/.bashrc; do sed -i '/\/DietPi/d' "$i"; done #should already be removed, failsafe start clean
 			[[ -f /etc/profile.d/99-dietpi-login.sh ]] && rm /etc/profile.d/99-dietpi-login.sh
 			[[ -f /etc/profile.d/99-dietpi-posix-set-locale.sh ]] && rm /etc/profile.d/99-dietpi-posix-set-locale.sh
 			cat << _EOF_ > /etc/bashrc.d/dietpi-login.sh

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -682,6 +682,9 @@ _EOF_
 			mv /etc/profile.d/99-dietpi-posix-set-locale.sh /etc/bashrc.d/dietpi-posix-set-locale.sh &> /dev/null
 			sed -i '/\/DietPi/d' /root/.bashrc #should already be removed, failsafe start clean
 			sed -i '/\/DietPi/d' /home/dietpi/.bashrc #should already be removed, failsafe start clean
+			# - Enable bash-completion for non-login shells:
+			#	- NB: It is called twice on login shells then, but breaks directly if called already once.
+			ln -sf /etc/profile.d/bash_completion.sh /etc/bashrc.d/dietpi-bash_completion.sh
 			#-------------------------------------------------------------------------------
 			#Sparky unmute fix (re: @sudeep)
 			#	v2: https://github.com/Fourdee/DietPi/pull/1779


### PR DESCRIPTION
Should solve the following issues:
- Valid for all users automatically, no need to edit single /$HOME/.bashrc files for every new user.
- Valid for all bash shells, not just login shells, thus desktop terminal emulators show banners and offer globals as well.
- Not valid for non-interactive shells, where it can cause issues.

**TEST needed to check if samba/ftp/rsync remote access is working well without this being called, thus `[ -z "PS1" ] && return` is working well compared to `~/.bashrc`.**