### PR TITLE
DietPi-RAMdisk/log | Systemd want's absolute command paths

### DIFF
--- a/rootfs/etc/systemd/system/dietpi-ramdisk.service
+++ b/rootfs/etc/systemd/system/dietpi-ramdisk.service
@@ -7,7 +7,7 @@ Before=rsyslog.service syslog.service
 Type=forking
 RemainAfterExit=yes
 StandardOutput=tty
-ExecStartPre=$(which mkdir) -p /var/tmp/dietpi/logs
+ExecStartPre=/bin/mkdir -p /var/tmp/dietpi/logs
 ExecStart=/bin/bash -c '/boot/dietpi/dietpi-ramdisk 0 &>> /var/tmp/dietpi/logs/dietpi-ramdisk.log'
 ExecStop=/bin/bash -c '/DietPi/dietpi/dietpi-ramdisk 1 &>> /var/tmp/dietpi/logs/dietpi-ramdisk.log'
 

--- a/rootfs/etc/systemd/system/dietpi-ramlog.service
+++ b/rootfs/etc/systemd/system/dietpi-ramlog.service
@@ -7,7 +7,7 @@ Before=rsyslog.service syslog.service
 Type=forking
 RemainAfterExit=yes
 StandardOutput=tty
-ExecStartPre=$(which mkdir) -p /var/tmp/dietpi/logs
+ExecStartPre=/bin/mkdir -p /var/tmp/dietpi/logs
 ExecStart=/bin/bash -c '/boot/dietpi/dietpi-ramlog 0 &>> /var/tmp/dietpi/logs/dietpi-ramlog.log'
 ExecStop=/bin/bash -c '/DietPi/dietpi/dietpi-ramlog 1 &>> /var/tmp/dietpi/logs/dietpi-ramlog.log'
 


### PR DESCRIPTION
- I suddenly faced an error, not starting RAMlog and RAMdisk on boot. Found that the systemd unit's fail because `$(which mkdir)` does not contain the full command path.
- Seems like this was not consequently asked for until now. Of course `which` itself would need the absolute path here: `$(/bin/which mkdir)`
- But instead of guessing/assuming certain `which` location here to estimate `mkdir` location, better take the always available `/bin/mkdir` 😉.
______________
I think I saw the use of which more often, possibly within DietPi-Software systemd unit installation? I just faced this on Buster, but we should take care of this now, before a sudden update breaks half DietPi 😉.