### PR TITLE
DietPi-Bugreport/Survey | Rework

### DIFF
--- a/dietpi/dietpi-bugreport
+++ b/dietpi/dietpi-bugreport
@@ -129,7 +129,8 @@
 		done
 		unset aCOMMAND_LIST
 
-		l_message='Packing upload archive' G_RUN_CMD 7z a -t7z -spf "$UPLOAD_FILENAME" ${aFILE_LIST[@]}
+		G_DIETPI-NOTIFY 2 'Packing upload archive, please wait...'
+		7z a -t7z -spf "$UPLOAD_FILENAME" ${aFILE_LIST[@]} &> /dev/null
 
 	}
 

--- a/dietpi/dietpi-bugreport
+++ b/dietpi/dietpi-bugreport
@@ -32,38 +32,72 @@
 	UPLOAD_FILESIZE_LIMIT=10000000
 	UPLOAD_FILESIZE=0
 
-	#DATE_CURRENT=$(date +"%d-%m-%Y")
-
 	UNIQUE_ID_HW=$(sed -n 5p /DietPi/dietpi/.hw_model)
-	UNIQUE_ID_BUGNUMBER=0
 
 	FTP_ADDR='dietpi.com'
 	FTP_USER='dietpi-survey'
 	FTP_PASS='inactive_tba'
 
 	FILEPATH_TEMP='/tmp/dietpi-bugreport'
-
-	FILE_GENERATED_ZIP='bugreport.zip'
-	FILE_BUG_NUMBER='/DietPi/dietpi/.bug_id'
+	FILE_GENERATED_ZIP='bugreport.7z'
 
 	Generate_Zip_File(){
 
 		#----------------------------------------------------------------
 		#Define zip settings (level 9 compression etc)
-		local zip_settings='-9'
-		FILE_GENERATED_ZIP="br_auto-$UNIQUE_ID_HW-$UNIQUE_ID_BUGNUMBER.zip"
-
+		FILE_GENERATED_ZIP="$UNIQUE_ID_HW.7z"
+		7z_settings='-spf -t7z'
 		#----------------------------------------------------------------
+		#List of commands we want to run and redirect to zip
+		acommand_list=(
+
+			'ls -lha /var/log'
+			'dpkg -l'
+			'ifconfig -a'
+			'ip a'
+			'lsusb'
+			'cat /proc/cpuinfo'
+			'ps aux'
+			'blkid'
+			'mount'
+			'df -h'
+			"ls /etc/rc*.d/"
+			'cut -d: -f1 /etc/passwd'
+			'locale'
+			'ls -lha /mnt' #dietpi userdata location
+			'dmesg'
+			'lsmod'
+			"systemctl status *.service -l"
+			"systemctl status *.mount -l"
+			'/DietPi/dietpi/dietpi-services status'
+
+		)
+
+		[[ -f br_cmd_out.txt ]] && rm br_cmd_out.txt
+
+		for ((i=0; i<${#acommand_list[@]}; i++))
+		do
+
+			echo -e "\n----------\n${acommand_list[$i]}:\n----------" >> br_cmd_out.txt
+			${acommand_list[$i]} >> br_cmd_out.txt
+
+		done
+
+		unset acommand_list
+
 		#list of files and/or folders we want to zip
 		local afile_list=(
+
+			# - command output file
+			'br_cmd_out.txt'
 
 			# - logs
 			"/var/log/*"
 
 			# - DietPi scripts / logs
 			"/DietPi/*"
-			"/boot/dietpi.txt"
-			"/boot/config.txt"
+			'/boot/dietpi.txt'
+			'/boot/config.txt'
 			"/boot/dietpi/*"
 			"/tmp/.G*"
 			"/var/tmp/dietpi/logs/*"
@@ -72,87 +106,42 @@
 			"/var/lib/dietpi/*"
 
 			# - confs
-			"/etc/X11/xorg.conf"
-			"/etc/bash.bashrc"
+			#	- bash shell
+			'/etc/bash.bashrc'
 			"/etc/bashrc.d/*"
-			"/root/.bashrc"
-			"/etc/profile"
+			'/root/.bashrc'
+			"/home/*/.bashrc"
+			#	- login shell
+			'/etc/profile'
 			"/etc/profile.d/*"
-			"/root/.profile"
-			"/etc/rc.local"
-			"/etc/asound.conf"
-			"/etc/network/interfaces"
-			"/etc/fstab"
-			"/etc/sysctl.conf"
+			'/root/.profile'
+			"/home/*/.profile"
+
+			'/etc/rc.local'
+			'/etc/X11/xorg.conf'
+			'/etc/asound.conf'
+			'/etc/network/interfaces'
+			'/etc/fstab'
+			'/etc/sysctl.conf'
 			"/etc/sysctl.d/*"
 
 			# - Services
 			"/etc/init.d/*"
-			"/etc/systemd/*"
-			"/lib/systemd/*"
+			"/etc/systemd/system/*"
+			"/lib/systemd/system/*"
 
 			# - APT
-			"/etc/apt/sources.list"
+			'/etc/apt/sources.list'
 			"/etc/apt/sources.list.d/*"
 
 		)
 
-		for ((i=0; i<${#afile_list[@]}; i++))
-		do
-
-			zip -r "$zip_settings" "$FILE_GENERATED_ZIP" ${afile_list[$i]}
-
-		done
-
-		unset afile_list
-
-		#List of commands we want to run and redirect to zip
-		local acommand_list=(
-
-			"ls -lha /var/log"
-			"dpkg -l"
-			"ifconfig -a"
-			"ip a"
-			"lsusb"
-			"cat /proc/cpuinfo"
-			"ps aux"
-			"blkid"
-			"mount"
-			"df -h"
-			"ls /etc/rc*.d/"
-			"cut -d: -f1 /etc/passwd"
-			"locale"
-			"ls -lha /mnt" #dietpi userdata location
-			"dmesg"
-			"lsmod"
-			"systemctl status *.service -l"
-			"systemctl status *.mount -l"
-			"/DietPi/dietpi/dietpi-services status"
-
-		)
-
-		for ((i=0; i<${#acommand_list[@]}; i++))
-		do
-
-			${acommand_list[$i]} > cmd_$i.txt
-			zip -r "$zip_settings" "$FILE_GENERATED_ZIP" cmd_$i.txt
-			rm cmd_$i.txt
-
-		done
-
-		unset acommand_list
+		[[ -f $FILE_GENERATED_ZIP ]] && rm "$FILE_GENERATED_ZIP"
+		7z a "$7z_settings" "$FILE_GENERATED_ZIP" ${afile_list[@]}
 
 	}
 
 	Create_Bug_Report(){
-
-		#----------------------------------------------------------------
-		#Load .bug_id
-		if [[ -f $FILE_BUG_NUMBER ]]; then
-
-			UNIQUE_ID_BUGNUMBER=$(cat "$FILE_BUG_NUMBER")
-
-		fi
 
 		#----------------------------------------------------------------
 		#Generate our zipped bugreport file
@@ -161,7 +150,7 @@
 		#----------------------------------------------------------------
 		#Check upload location is online
 		G_CHECK_URL "$FTP_ADDR"
-		if (( $? == 0 )); then
+		if (( ! $? )); then
 
 			#Limit filesize
 			UPLOAD_FILESIZE=$(stat -c%s "$FILE_GENERATED_ZIP")
@@ -171,22 +160,30 @@
 
 				G_DIETPI-NOTIFY 2 'Uploading bug report, please wait...'
 				wput --timeout=10th-4 --tries=1 --waitretry=2 -B -u "$FILE_GENERATED_ZIP" ftp://"$FTP_USER":"$FTP_PASS"@"$FTP_ADDR"
-				if (( $? == 0 )); then
-
-					((UNIQUE_ID_BUGNUMBER++))
-					echo $UNIQUE_ID_BUGNUMBER > $FILE_BUG_NUMBER
+				if (( ! $? )); then
 
 					G_DIETPI-NOTIFY 0 "Bug report sent, reference code: $FILE_GENERATED_ZIP"
 
+				else
+
+					G_DIETPI-NOTIFY 1 'An error appeared while trying to upload the bug report. Please try again later or report this to DietPi forum or GitHub repo in the first place.'
+
 				fi
+
+			else
+
+				G_DIETPI-NOTIFY 1 'The bug report upload archive appears to be unexpected large. The file list, that was to be uploaded, was saved to: /tmp/dietpi-bugreport-filelist\nPlease inspect and in case clean up those locations, as their size should never be that large.'
+				printf "%s\n" "${afile_list[@]}" > /tmp/dietpi-bugreport-filelist
 
 			fi
 
 		else
 
-			G_DIETPI-NOTIFY 1 'Failed to upload bugreport, URL offline or unreachable.'
+			G_DIETPI-NOTIFY 1 'Failed to upload bugreport, URL offline or unreachable. Please try again later or report this to DietPi forum or GitHub repo in the first place.'
 
 		fi
+
+		unset afile_list
 
 	}
 

--- a/dietpi/dietpi-bugreport
+++ b/dietpi/dietpi-bugreport
@@ -11,16 +11,16 @@
 	# Info:
 	# - Called from G_ERROR_HANDLER
 	# - filename /DietPi/dietpi/dietpi-bugreport
-	# - Generates UUID_BUGNUMBER.zip and uploads to dietpi.com
+	# - Generates $UNIQUE_ID_HW.7z and uploads to dietpi.com
 	# Usage:
 	# - /DietPi/dietpi/dietpi-bugreport 1				#Automated send of bug report
 	#////////////////////////////////////
 
 	#Import DietPi-Globals ---------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
+	export G_PROGRAM_NAME='DietPi-Bugreport'
 	G_CHECK_ROOT_USER
 	G_CHECK_ROOTFS_RW
-	export G_PROGRAM_NAME='DietPi-Bugreport'
 	G_INIT
 	G_USER_INPUTS=0
 	#Import DietPi-Globals ---------------------------------------------------------------
@@ -28,28 +28,26 @@
 	INPUT=0
 	G_CHECK_VALIDINT $1 && INPUT=$1
 
+	UNIQUE_ID_HW=$(sed -n 5p /DietPi/dietpi/.hw_model)
+	FP_TMP='/tmp/dietpi-bugreport'
+	UPLOAD_FILENAME="$UNIQUE_ID_HW.7z"
+
 	# - byte
 	UPLOAD_FILESIZE_LIMIT=10000000
 	UPLOAD_FILESIZE=0
 
-	UNIQUE_ID_HW=$(sed -n 5p /DietPi/dietpi/.hw_model)
+	SFTP_ADDR='dietpi.com'
+	SFTP_USER='dietpi-survey'
+	SFTP_PASS='upload2dietpi'
 
-	FTP_ADDR='dietpi.com'
-	FTP_USER='dietpi-survey'
-	FTP_PASS='inactive_tba'
-
-	FILEPATH_TEMP='/tmp/dietpi-bugreport'
-	FILE_GENERATED_ZIP='bugreport.7z'
-
-	Generate_Zip_File(){
+	Generate_Upload_File(){
 
 		#----------------------------------------------------------------
-		#Define zip settings (level 9 compression etc)
-		FILE_GENERATED_ZIP="$UNIQUE_ID_HW.7z"
-		7z_settings='-spf -t7z'
+		#Define 7zip settings: 7z archive, preserve absolute file paths
+		local 7z_settings='-t7z -spf'
 		#----------------------------------------------------------------
-		#List of commands we want to run and redirect to zip
-		acommand_list=(
+		#List of commands we want to run and redirect to upload archive
+		local acommand_list=(
 
 			'ls -lha /var/log'
 			'dpkg -l'
@@ -73,8 +71,6 @@
 
 		)
 
-		[[ -f br_cmd_out.txt ]] && rm br_cmd_out.txt
-
 		for ((i=0; i<${#acommand_list[@]}; i++))
 		do
 
@@ -86,7 +82,7 @@
 		unset acommand_list
 
 		#list of files and/or folders we want to zip
-		local afile_list=(
+		afile_list=(
 
 			# - command output file
 			'br_cmd_out.txt'
@@ -136,50 +132,49 @@
 
 		)
 
-		[[ -f $FILE_GENERATED_ZIP ]] && rm "$FILE_GENERATED_ZIP"
-		7z a "$7z_settings" "$FILE_GENERATED_ZIP" ${afile_list[@]}
+		7z a "$7z_settings" "$UPLOAD_FILENAME" ${afile_list[@]}
 
 	}
 
 	Create_Bug_Report(){
 
 		#----------------------------------------------------------------
-		#Generate our zipped bugreport file
-		Generate_Zip_File
+		#Generate our 7z bug report file
+		Generate_Upload_File
 
 		#----------------------------------------------------------------
 		#Check upload location is online
-		G_CHECK_URL "$FTP_ADDR"
+		G_CHECK_URL "$SFTP_ADDR"
 		if (( ! $? )); then
 
 			#Limit filesize
-			UPLOAD_FILESIZE=$(stat -c%s "$FILE_GENERATED_ZIP")
+			UPLOAD_FILESIZE=$(stat -c%s "$UPLOAD_FILENAME")
 
 			# - Upload
 			if (( $UPLOAD_FILESIZE <= $UPLOAD_FILESIZE_LIMIT )); then
 
 				G_DIETPI-NOTIFY 2 'Uploading bug report, please wait...'
-				wput --timeout=10th-4 --tries=1 --waitretry=2 -B -u "$FILE_GENERATED_ZIP" ftp://"$FTP_USER":"$FTP_PASS"@"$FTP_ADDR"
+				curl -m 20 --retry 1 --retry-delay 4 -sT "$UPLOAD_FILENAME" sftp://"$SFTP_USER":"$SFTP_PASS"@"$SFTP_ADDR"/bugreport/
 				if (( ! $? )); then
 
-					G_DIETPI-NOTIFY 0 "Bug report sent, reference code: $FILE_GENERATED_ZIP"
+					G_DIETPI-NOTIFY 0 "Bug report sent, reference code: $UNIQUE_ID_HW"
 
 				else
 
-					G_DIETPI-NOTIFY 1 'An error appeared while trying to upload the bug report. Please try again later or report this to DietPi forum or GitHub repo in the first place.'
+					G_DIETPI-NOTIFY 1 'Failed to upload bug report to SFTP server. Please try again later or report this to DietPi forum or GitHub repo in the first place.'
 
 				fi
 
 			else
 
-				G_DIETPI-NOTIFY 1 'The bug report upload archive appears to be unexpected large. The file list, that was to be uploaded, was saved to: /tmp/dietpi-bugreport-filelist\nPlease inspect and in case clean up those locations, as their size should never be that large.'
-				printf "%s\n" "${afile_list[@]}" > /tmp/dietpi-bugreport-filelist
+				G_DIETPI-NOTIFY 1 'The bug report upload archive appears to be unexpected large. Please inspect and in case clean up the locations to be uploaded, as their size should never be that large:'
+				printf "%s\n" "${afile_list[@]}"
 
 			fi
 
 		else
 
-			G_DIETPI-NOTIFY 1 'Failed to upload bugreport, URL offline or unreachable. Please try again later or report this to DietPi forum or GitHub repo in the first place.'
+			G_DIETPI-NOTIFY 1 'Failed to connect to "dietpi.com". Please try again later or report this to DietPi forum or GitHub repo in the first place.'
 
 		fi
 
@@ -195,15 +190,16 @@
 
 		#Make Directory
 		#	we need to work inside the directory as Wput cant accept /paths
-		mkdir -p $FILEPATH_TEMP
-		cd $FILEPATH_TEMP
+		rm -R "$FP_TMP"
+		mkdir -p "$FP_TMP"
+		cd "$FP_TMP"
 
 		#Automated bug report send
 		Create_Bug_Report
 
 		#remove temp folder and all generated temp files
 		cd "$HOME"
-		rm -R $FILEPATH_TEMP &> /dev/null
+		rm -R "$FP_TMP"
 
 	else
 

--- a/dietpi/dietpi-bugreport
+++ b/dietpi/dietpi-bugreport
@@ -11,26 +11,27 @@
 	# Info:
 	# - Called from G_ERROR_HANDLER
 	# - filename /DietPi/dietpi/dietpi-bugreport
-	# - Generates $UNIQUE_ID_HW.7z and uploads to dietpi.com
+	# - Generates $UNIQUE_ID.7z and uploads to dietpi.com
 	# Usage:
-	# - /DietPi/dietpi/dietpi-bugreport 1				#Automated send of bug report
+	# - /DietPi/dietpi/dietpi-bugreport	Interactively let user send or remove already uploaded bug report
+	# - /DietPi/dietpi/dietpi-bugreport 1	Automated send of bug report
+	# - /DietPi/dietpi/dietpi-bugreport -1	Automated remove of already uploaded bug report
 	#////////////////////////////////////
 
 	#Import DietPi-Globals ---------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
-	export G_PROGRAM_NAME='DietPi-Bugreport'
 	G_CHECK_ROOT_USER
 	G_CHECK_ROOTFS_RW
 	G_INIT
-	G_USER_INPUTS=0
+	export G_PROGRAM_NAME='DietPi-Bugreport'
 	#Import DietPi-Globals ---------------------------------------------------------------
 
 	INPUT=0
 	G_CHECK_VALIDINT $1 && INPUT=$1
 
-	UNIQUE_ID_HW=$(sed -n 5p /DietPi/dietpi/.hw_model)
+	UNIQUE_ID=$(sed -n 5p /DietPi/dietpi/.hw_model)
 	FP_TMP='/tmp/dietpi-bugreport'
-	UPLOAD_FILENAME="$UNIQUE_ID_HW.7z"
+	UPLOAD_FILENAME="$UNIQUE_ID.7z"
 
 	# - byte
 	UPLOAD_FILESIZE_LIMIT=10000000
@@ -40,124 +41,116 @@
 	SFTP_USER='dietpi-survey'
 	SFTP_PASS='upload2dietpi'
 
+	# List of commands we want to run and redirect to upload archive
+	aCOMMAND_LIST=(
+
+		'ls -lha /var/log'
+		'dpkg -l'
+		'ifconfig -a'
+		'ip a'
+		'lsusb'
+		'cat /proc/cpuinfo'
+		'ps aux'
+		'blkid'
+		'mount'
+		'df -h'
+		"ls /etc/rc*.d/"
+		'cut -d: -f1 /etc/passwd'
+		'locale'
+		'ls -lha /mnt' #dietpi userdata location
+		'dmesg'
+		'lsmod'
+		"systemctl status *.service -l"
+		"systemctl status *.mount -l"
+		'/DietPi/dietpi/dietpi-services status'
+
+	)
+
+	# List of files and folders we want to add to upload archive
+	aFILE_LIST=(
+
+		# - command output file
+		'CMD_OUT.txt'
+
+		# - logs
+		"/var/log/*"
+
+		# - DietPi scripts / logs
+		"/DietPi/*"
+		'/boot/dietpi.txt'
+		'/boot/config.txt'
+		"/boot/dietpi/*"
+		"/tmp/.G*"
+		"/var/tmp/dietpi/logs/*"
+
+		# - /var/lib/dietpi
+		"/var/lib/dietpi/*"
+
+		# - confs
+		#	- bash shell
+		'/etc/bash.bashrc'
+		"/etc/bashrc.d/*"
+		'/root/.bashrc'
+		"/home/*/.bashrc"
+		#	- login shell
+		'/etc/profile'
+		"/etc/profile.d/*"
+		'/root/.profile'
+		"/home/*/.profile"
+
+		'/etc/rc.local'
+		'/etc/X11/xorg.conf'
+		'/etc/asound.conf'
+		'/etc/network/interfaces'
+		'/etc/fstab'
+		'/etc/sysctl.conf'
+		"/etc/sysctl.d/*"
+
+		# - Services
+		"/etc/init.d/*"
+		"/etc/systemd/system/*"
+		"/lib/systemd/system/*"
+
+		# - APT
+		'/etc/apt/sources.list'
+		"/etc/apt/sources.list.d/*"
+
+	)
+
 	Generate_Upload_File(){
 
-		#----------------------------------------------------------------
-		#Define 7zip settings: 7z archive, preserve absolute file paths
-		local 7z_settings='-t7z -spf'
-		#----------------------------------------------------------------
-		#List of commands we want to run and redirect to upload archive
-		local acommand_list=(
-
-			'ls -lha /var/log'
-			'dpkg -l'
-			'ifconfig -a'
-			'ip a'
-			'lsusb'
-			'cat /proc/cpuinfo'
-			'ps aux'
-			'blkid'
-			'mount'
-			'df -h'
-			"ls /etc/rc*.d/"
-			'cut -d: -f1 /etc/passwd'
-			'locale'
-			'ls -lha /mnt' #dietpi userdata location
-			'dmesg'
-			'lsmod'
-			"systemctl status *.service -l"
-			"systemctl status *.mount -l"
-			'/DietPi/dietpi/dietpi-services status'
-
-		)
-
-		for ((i=0; i<${#acommand_list[@]}; i++))
+		# Generate command output file
+		for ((i=0; i<${#aCOMMAND_LIST[@]}; i++))
 		do
 
-			echo -e "\n----------\n${acommand_list[$i]}:\n----------" >> br_cmd_out.txt
-			${acommand_list[$i]} >> br_cmd_out.txt
+			echo -e "\n----------\n${aCOMMAND_LIST[$i]}:\n----------" >> CMD_OUT.txt
+			${aCOMMAND_LIST[$i]} >> CMD_OUT.txt
 
 		done
+		unset aCOMMAND_LIST
 
-		unset acommand_list
-
-		#list of files and/or folders we want to zip
-		afile_list=(
-
-			# - command output file
-			'br_cmd_out.txt'
-
-			# - logs
-			"/var/log/*"
-
-			# - DietPi scripts / logs
-			"/DietPi/*"
-			'/boot/dietpi.txt'
-			'/boot/config.txt'
-			"/boot/dietpi/*"
-			"/tmp/.G*"
-			"/var/tmp/dietpi/logs/*"
-
-			# - /var/lib/dietpi
-			"/var/lib/dietpi/*"
-
-			# - confs
-			#	- bash shell
-			'/etc/bash.bashrc'
-			"/etc/bashrc.d/*"
-			'/root/.bashrc'
-			"/home/*/.bashrc"
-			#	- login shell
-			'/etc/profile'
-			"/etc/profile.d/*"
-			'/root/.profile'
-			"/home/*/.profile"
-
-			'/etc/rc.local'
-			'/etc/X11/xorg.conf'
-			'/etc/asound.conf'
-			'/etc/network/interfaces'
-			'/etc/fstab'
-			'/etc/sysctl.conf'
-			"/etc/sysctl.d/*"
-
-			# - Services
-			"/etc/init.d/*"
-			"/etc/systemd/system/*"
-			"/lib/systemd/system/*"
-
-			# - APT
-			'/etc/apt/sources.list'
-			"/etc/apt/sources.list.d/*"
-
-		)
-
-		7z a "$7z_settings" "$UPLOAD_FILENAME" ${afile_list[@]}
+		# Pack everything into upload file
+		7z a -t7z -spf "$UPLOAD_FILENAME" ${aFILE_LIST[@]}
 
 	}
 
-	Create_Bug_Report(){
+	Upload_Bug_Report(){
 
-		#----------------------------------------------------------------
-		#Generate our 7z bug report file
-		Generate_Upload_File
-
-		#----------------------------------------------------------------
-		#Check upload location is online
+		# Check upload location is online
 		G_CHECK_URL "$SFTP_ADDR"
 		if (( ! $? )); then
 
-			#Limit filesize
+			# Limit filesize
 			UPLOAD_FILESIZE=$(stat -c%s "$UPLOAD_FILENAME")
 
 			# - Upload
 			if (( $UPLOAD_FILESIZE <= $UPLOAD_FILESIZE_LIMIT )); then
 
 				G_DIETPI-NOTIFY 2 'Uploading bug report, please wait...'
-				curl -m 20 --retry 1 --retry-delay 4 -sT "$UPLOAD_FILENAME" sftp://"$SFTP_USER":"$SFTP_PASS"@"$SFTP_ADDR"/bugreport/
+				curl --connect-timeout 4 --retry 1 --retry-delay 4 -sT "$UPLOAD_FILENAME" sftp://"$SFTP_USER":"$SFTP_PASS"@"$SFTP_ADDR"/bugreport/
 				if (( ! $? )); then
 
-					G_DIETPI-NOTIFY 0 "Bug report sent, reference code: $UNIQUE_ID_HW"
+					G_DIETPI-NOTIFY 0 "Bug report sent, reference code: $UNIQUE_ID"
 
 				else
 
@@ -168,7 +161,7 @@
 			else
 
 				G_DIETPI-NOTIFY 1 'The bug report upload archive appears to be unexpected large. Please inspect and in case clean up the locations to be uploaded, as their size should never be that large:'
-				printf "%s\n" "${afile_list[@]}"
+				printf "%s\n" "${aFILE_LIST[@]}"
 
 			fi
 
@@ -185,25 +178,68 @@
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Main Loop
 	#/////////////////////////////////////////////////////////////////////////////////////
-	#----------------------------------------------------------------
-	if (( $INPUT == 1 )); then
+	# Interactive menu
+	if (( $INPUT != 1 && $INPUT != -1 )); then
 
-		#Make Directory
-		#	we need to work inside the directory as Wput cant accept /paths
+		G_WHIP_MENU_ARRAY=(
+
+			'1' 'Send bug report archive to help the developers investigate your issue.'
+			'2' 'Remove my already uploaded bug report.'
+
+		)
+
+		G_WHIP_MENU "By sending a bug report file, you can help the developers to investigate you issue, in related to your report on GitHub or the DietPi forum. \
+The file is sent via secured connection to our SFTP server and is stored there unreadable to the public upload user. \
+The file will be removed after your issue is solved and you can remove it by yourself as well by running "dietpi-bugreport -1" or via this menu. \
+The upload will contain the following command outputs:
+$(printf "%s\n" "${aCOMMAND_LIST[@]}")
+
+It will contain as well the following file locations:
+$(printf "%s\n" "${aFILE_LIST[@]}")
+
+Would you like to send a bug report archive or remove an already uploaded one?"
+		if (( ! $? )); then
+
+			if (( G_WHIP_RETURNED_VALUE == 1 )); then
+
+				INPUT=1
+
+			elif (( G_WHIP_RETURNED_VALUE == 2 )); then
+
+				INPUT=-1
+
+			fi
+
+		fi
+
+	fi
+
+	if (( $INPUT == 1 && $INPUT == -1 )); then
+
+		# Clean, recreate and enter tmp ramfs
 		rm -R "$FP_TMP"
 		mkdir -p "$FP_TMP"
 		cd "$FP_TMP"
 
-		#Automated bug report send
-		Create_Bug_Report
 
-		#remove temp folder and all generated temp files
+		if (( $INPUT == 1 )); then
+
+			# Generate 7z bug report file
+			Generate_Upload_File
+
+		else
+
+			# Send empty file to clear already uploaded bug report
+			> "$UPLOAD_FILENAME"
+
+		fi
+
+		# Upload bug report file
+		Upload_Bug_Report
+
+		# Clean tmp ramfs
 		cd "$HOME"
 		rm -R "$FP_TMP"
-
-	else
-
-		G_DIETPI-NOTIFY 2 'This feature is no longer available. Now handled automatically by G_ERROR_HANDLER when an issue occurs'
 
 	fi
 

--- a/dietpi/dietpi-bugreport
+++ b/dietpi/dietpi-bugreport
@@ -150,7 +150,16 @@
 				curl --connect-timeout 4 --retry 1 --retry-delay 4 -sT "$UPLOAD_FILENAME" sftp://"$SFTP_USER":"$SFTP_PASS"@"$SFTP_ADDR"/bugreport/
 				if (( ! $? )); then
 
-					G_DIETPI-NOTIFY 0 "Bug report sent, reference code: $UNIQUE_ID"
+					# Bug report removal via empty file upload
+					if (( $UPLOAD_FILESIZE == 0 )); then
+
+						G_DIETPI-NOTIFY 0 "Bug report successfully purged"
+
+					else
+
+						G_DIETPI-NOTIFY 0 "Bug report sent, reference code: $UNIQUE_ID"
+
+					fi
 
 				else
 
@@ -171,7 +180,7 @@
 
 		fi
 
-		unset afile_list
+		unset aFILE_LIST
 
 	}
 
@@ -234,7 +243,7 @@ $(printf "%s\n\t- " "${aFILE_LIST[@]}")"
 	if (( $INPUT == 1 || $INPUT == -1 )); then
 
 		# Clean, recreate and enter tmp ramfs
-		rm -R "$FP_TMP"
+		[[ -d $FP_TMP ]] && rm -R "$FP_TMP"
 		mkdir -p "$FP_TMP"
 		cd "$FP_TMP"
 

--- a/dietpi/dietpi-bugreport
+++ b/dietpi/dietpi-bugreport
@@ -181,16 +181,16 @@
 	# Interactive menu
 	if (( $INPUT != 1 && $INPUT != -1 )); then
 
-		G_WHIP_MENU_ARRAY=(
-
-			'1' 'Send bug report archive to help the developers investigate your issue.'
-			'2' 'Remove my already uploaded bug report.'
-			'3' 'Show me what is included with the upload archive.'
-
-		)
-
 		while true
 		do
+
+			G_WHIP_MENU_ARRAY=(
+
+				'1' 'Send bug report archive to help the developers investigate your issue.'
+				'2' 'Remove my already uploaded bug report.'
+				'3' 'Show me what is included with the upload archive.'
+
+			)
 
 			G_WHIP_MENU "By sending a bug report file, you can help the developers to investigate your issue, in relation to your report on GitHub or the DietPi forum.
 The file is sent via secured connection to our SFTP server and is stored there unreadable to the public upload user.
@@ -212,10 +212,12 @@ Would you like to send a bug report archive or remove an already uploaded one?"
 				elif (( G_WHIP_RETURNED_VALUE == 3 )); then
 
 					G_WHIP_SCROLLBOX "The upload will contain the following command outputs:
-$(printf "%s\n" "${aCOMMAND_LIST[@]}")
+					
+$(printf "%s\n\t- " "${aCOMMAND_LIST[@]}")
 
 It will contain as well the following file locations:
-$(printf "%s\n" "${aFILE_LIST[@]}")"
+
+$(printf "%s\n\t- " "${aFILE_LIST[@]}")"
 
 				fi
 

--- a/dietpi/dietpi-bugreport
+++ b/dietpi/dietpi-bugreport
@@ -129,8 +129,7 @@
 		done
 		unset aCOMMAND_LIST
 
-		# Pack everything into upload file
-		7z a -t7z -spf "$UPLOAD_FILENAME" ${aFILE_LIST[@]}
+		l_message='Packing upload archive' G_RUN_CMD 7z a -t7z -spf "$UPLOAD_FILENAME" ${aFILE_LIST[@]}
 
 	}
 
@@ -146,7 +145,7 @@
 			# - Upload
 			if (( $UPLOAD_FILESIZE <= $UPLOAD_FILESIZE_LIMIT )); then
 
-				G_DIETPI-NOTIFY 2 'Uploading bug report, please wait...'
+				G_DIETPI-NOTIFY -2 'Running cURL'
 				curl --connect-timeout 4 --retry 1 --retry-delay 4 -sT "$UPLOAD_FILENAME" sftp://"$SFTP_USER":"$SFTP_PASS"@"$SFTP_ADDR"/bugreport/
 				if (( ! $? )); then
 
@@ -163,7 +162,7 @@
 
 				else
 
-					G_DIETPI-NOTIFY 1 'Failed to upload bug report to SFTP server. Please try again later or report this to DietPi forum or GitHub repo in the first place.'
+					G_DIETPI-NOTIFY 1 'Failed to connect to SFTP server. Please try again later or report this to DietPi forum or GitHub repo in the first place.'
 
 				fi
 

--- a/dietpi/dietpi-bugreport
+++ b/dietpi/dietpi-bugreport
@@ -185,36 +185,51 @@
 
 			'1' 'Send bug report archive to help the developers investigate your issue.'
 			'2' 'Remove my already uploaded bug report.'
+			'3' 'Show me what is included with the upload archive.'
 
 		)
 
-		G_WHIP_MENU "By sending a bug report file, you can help the developers to investigate you issue, in related to your report on GitHub or the DietPi forum. \
-The file is sent via secured connection to our SFTP server and is stored there unreadable to the public upload user. \
-The file will be removed after your issue is solved and you can remove it by yourself as well by running "dietpi-bugreport -1" or via this menu. \
-The upload will contain the following command outputs:
+		while true
+		do
+
+			G_WHIP_MENU "By sending a bug report file, you can help the developers to investigate your issue, in relation to your report on GitHub or the DietPi forum.
+The file is sent via secured connection to our SFTP server and is stored there unreadable to the public upload user.
+The file will be removed after your issue is solved and you can remove it by yourself as well by running \"dietpi-bugreport -1\" or via this menu.
+
+Would you like to send a bug report archive or remove an already uploaded one?"
+			if (( ! $? )); then
+
+				if (( G_WHIP_RETURNED_VALUE == 1 )); then
+
+					INPUT=1
+					break
+
+				elif (( G_WHIP_RETURNED_VALUE == 2 )); then
+
+					INPUT=-1
+					break
+
+				elif (( G_WHIP_RETURNED_VALUE == 3 )); then
+
+					G_WHIP_SCROLLBOX "The upload will contain the following command outputs:
 $(printf "%s\n" "${aCOMMAND_LIST[@]}")
 
 It will contain as well the following file locations:
-$(printf "%s\n" "${aFILE_LIST[@]}")
+$(printf "%s\n" "${aFILE_LIST[@]}")"
 
-Would you like to send a bug report archive or remove an already uploaded one?"
-		if (( ! $? )); then
+				fi
 
-			if (( G_WHIP_RETURNED_VALUE == 1 )); then
+			else
 
-				INPUT=1
-
-			elif (( G_WHIP_RETURNED_VALUE == 2 )); then
-
-				INPUT=-1
+				break
 
 			fi
 
-		fi
+		done
 
 	fi
 
-	if (( $INPUT == 1 && $INPUT == -1 )); then
+	if (( $INPUT == 1 || $INPUT == -1 )); then
 
 		# Clean, recreate and enter tmp ramfs
 		rm -R "$FP_TMP"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -16577,7 +16577,10 @@ _EOF_
 			FirstRun_Automation_Init
 
 			# - GPL compliance prompt
-			G_WHIP_MSG "DietPi - GPLv2 License:\n\nThis program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or any later version.\n\nThis program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.\n\nYou should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/"
+			G_WHIP_MSG 'DietPi - GPLv2 License:\n\nThis program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or any later version.\n\nThis program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.\n\nYou should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/'
+
+			# - DietPi-Survey opt in/out
+			/DietPi/dietpi/dietpi-survey
 
 			# - Change global password for root and dietpi users?
 			Change_Global_Password

--- a/dietpi/dietpi-survey
+++ b/dietpi/dietpi-survey
@@ -16,11 +16,11 @@
 	# - Runs on dietpi-update and when user installs software using dietpi-software
 	#
 	# Usage:
-	# - /DietPi/dietpi/dietpi-survey	Interactively asking user for opting in, out or even remove uploaded data
-	# - /DietPi/dietpi/dietpi-survey 1	Non-interactively send survey, if user opted in
+	# - /DietPi/dietpi/dietpi-survey	Interactively let user opt-in, opt-out or remove uploaded data
+	# - /DietPi/dietpi/dietpi-survey 1	Non-interactively send survey data, IF user opted in (!)
 	#
 	# File Sent format:
-	# $FILENAME_FORMAT.txt
+	# $(sed -n 5p /DietPi/dietpi/.hw_model).txt
 	#////////////////////////////////////
 
 	#Import DietPi-Globals ---------------------------------------------------------------
@@ -39,7 +39,7 @@
 	SURVEY_SENTCOUNT=1
 	SURVEY_VERSION=5
 
-	DIETPI_VERSION="$(sed -n 1p /DietPi/dietpi/.version).$(sed -n 2p /DietPi/dietpi/.version)"
+	DIETPI_VERSION="$(paste -sd '.' /DietPi/dietpi/.version)"
 	G_HW_MODEL=$(sed -n 1p /DietPi/dietpi/.hw_model)
 	UNIQUE_ID=$(sed -n 5p /DietPi/dietpi/.hw_model)
 
@@ -67,10 +67,10 @@ _EOF_
 	Send_File(){
 
 		#Check if we have a working internet connection beforehand
-		G_CHECK_URL "$FTP_ADDR"
+		G_CHECK_URL "$SFTP_ADDR"
 
 		#upload to server
-		curl -m 20 --retry 1 --retry-delay 4 -sT "$FILENAME_FORMAT" ftp://"$FTP_USER":"$FTP_PASS"@"$FTP_ADDR"/survey/
+		curl -m 20 --retry 1 --retry-delay 4 -sT "$FILENAME_FORMAT" sftp://"$SFTP_USER":"$SFTP_PASS"@"$SFTP_ADDR"/survey/
 
 		#Update .dietpi-survey file
 		((SURVEY_SENTCOUNT++))
@@ -110,8 +110,8 @@ DietPi Version : $DIETPI_VERSION
 Hardware Index : $G_HW_MODEL
 Hardware Name  : $G_HW_MODEL_DESCRIPTION
 Distro Index   : $G_DISTRO
-Autoboot Index : $(cat /DietPi/dietpi/.dietpi-autostart_index)
-Hostname       : $(cat /etc/hostname)
+Autoboot Index : $(</DietPi/dietpi/.dietpi-autostart_index)
+Hostname       : $(</etc/hostname)
 
 -------------------------
 DietPi-Software Installed
@@ -163,7 +163,7 @@ Would you like to opt in for DietPi-Survey?"
 			elif (( G_WHIP_RETURNED_VALUE == 3 )); then
 
 				OPTED_IN=0
-				# Send empty file to overwrite existing data
+				# Send empty file to overwrite existing data, rm is not possible due to missing file list permissions
 				> "$FILENAME_FORMAT"
 				((SURVEY_SENTCOUNT--)) # Compensate upcount by Send_File
 				Send_File

--- a/dietpi/dietpi-survey
+++ b/dietpi/dietpi-survey
@@ -19,7 +19,7 @@
 	# - /DietPi/dietpi/dietpi-survey	Interactively let user opt-in, opt-out or remove already uploaded data
 	# - /DietPi/dietpi/dietpi-survey 1	Non-interactively send survey data, IF user opted in (!)
 	#
-	# File Sent format:
+	# File sent format:
 	# $(sed -n 5p /DietPi/dietpi/.hw_model).txt
 	#////////////////////////////////////
 
@@ -70,7 +70,7 @@ _EOF_
 		G_CHECK_URL "$SFTP_ADDR"
 
 		#upload to server
-		curl --connect-timeout 4 --retry 1 --retry-delay 4 -sT "$FILENAME_FORMAT" sftp://"$SFTP_USER":"$SFTP_PASS"@"$SFTP_ADDR"/survey/
+		curl --connect-timeout 4 --retry 1 --retry-delay 4 -sT "$UPLOAD_FILENAME" sftp://"$SFTP_USER":"$SFTP_PASS"@"$SFTP_ADDR"/survey/
 
 		#Update .dietpi-survey file
 		((SURVEY_SENTCOUNT++))
@@ -83,7 +83,7 @@ _EOF_
 	#Enter ramfs
 	mkdir -p "$FP_TMP"
 	cd "$FP_TMP"
-	
+
 	#Read data from .dietpi-survey file
 	if [[ -f $FP_SETTINGS ]]; then
 
@@ -143,7 +143,7 @@ The data is sent via secured connection to our SFTP server and is stored there u
 If you agree, your uploaded data will be automatically updated on every DietPi-Update and whenever you install software via DietPi-Software. \
 We regularly publish results of the collected data at: https://dietpi.com/forum
 Your personal upload file would currently look like this:
-$(<$FILENAME_FORMAT)
+$(<$UPLOAD_FILENAME)
 
 Would you like to opt in for DietPi-Survey?"
 		if (( ! $? )); then
@@ -164,7 +164,7 @@ Would you like to opt in for DietPi-Survey?"
 				> "$UPLOAD_FILENAME"
 				((SURVEY_SENTCOUNT--)) # Compensate upcount by Send_File
 				Send_File
-				
+
 			fi
 
 		fi

--- a/dietpi/dietpi-survey
+++ b/dietpi/dietpi-survey
@@ -10,13 +10,14 @@
 	#
 	# Info:
 	# - http://dietpi.com/phpbb/viewtopic.php?f=8&t=20
-	# - Sends DietPi statistics to FTP server (eg: what programs are installed, hardware model)
+	# - Sends DietPi statistics to SFTP server (eg: what programs are installed, hardware model)
 	# - Allows the DietPi project to focus on areas based on popularity.
 	# - No private data is sent. Noone can indentify you.
-	# - Runs when user installs software using dietpi-software
+	# - Runs on dietpi-update and when user installs software using dietpi-software
 	#
-	# You can opt out of dietpi-survey by running:
-	# sed -i "1s/.*/0/" /DietPi/dietpi/.dietpi-survey
+	# Usage:
+	# - /DietPi/dietpi/dietpi-survey	Interactively asking user for opting in, out or even remove uploaded data
+	# - /DietPi/dietpi/dietpi-survey 1	Non-interactively send survey, if user opted in
 	#
 	# File Sent format:
 	# $FILENAME_FORMAT.txt
@@ -30,24 +31,21 @@
 	G_INIT
 	#Import DietPi-Globals ---------------------------------------------------------------
 
-	SURVEY_VERSION=4
-	SURVEY_SENTCOUNT=1
+	#Grab Input (valid interger)
+	INPUT=0
+	G_CHECK_VALIDINT $1 && INPUT=$1
 
-	OPTED_IN=1
+	OPTED_IN=0
+	SURVEY_SENTCOUNT=1
+	SURVEY_VERSION=5
 
 	DIETPI_VERSION="$(sed -n 1p /DietPi/dietpi/.version).$(sed -n 2p /DietPi/dietpi/.version)"
 	G_HW_MODEL=$(sed -n 1p /DietPi/dietpi/.hw_model)
 	UNIQUE_ID=$(sed -n 5p /DietPi/dietpi/.hw_model)
 
-	FTP_ADDR='dietpi.com'
-	FTP_USER='dietpi-survey'
-	FTP_PASS='inactive_tba'
-
-	Update_FileName_Format(){
-
-		FILENAME_FORMAT="$SURVEY_VERSION-$UNIQUE_ID-$DIETPI_VERSION-$G_HW_MODEL.txt"
-
-	}
+	SFTP_ADDR='dietpi.com'
+	SFTP_USER='dietpi-survey'
+	SFTP_PASS='upload2dietpi'
 
 	FP_SETTINGS='/DietPi/dietpi/.dietpi-survey'
 	Write_Settings(){
@@ -66,9 +64,26 @@ _EOF_
 
 	}
 
+	Send_File(){
+
+		#Check if we have a working internet connection beforehand
+		G_CHECK_URL "$FTP_ADDR"
+
+		#upload to server
+		curl -m 20 --retry 1 --retry-delay 4 -sT "$FILENAME_FORMAT" ftp://"$FTP_USER":"$FTP_PASS"@"$FTP_ADDR"/survey/
+
+		#Update .dietpi-survey file
+		((SURVEY_SENTCOUNT++))
+
+	}
+
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Main Loop
 	#/////////////////////////////////////////////////////////////////////////////////////
+	#Enter ramfs
+	mkdir -p /tmp/dietpi-survey
+	cd /tmp/dietpi-survey
+	
 	#Read data from .dietpi-survey file
 	if [[ -f $FP_SETTINGS ]]; then
 
@@ -81,21 +96,11 @@ _EOF_
 
 	fi
 
-	#-----------------------------------------------------------------------------------
-	#Opted in - Setup and send
-	if (( $OPTED_IN )); then
+	#Grab filename to use
+	FILENAME_FORMAT="$UNIQUE_ID.txt"
 
-		#Check if we have a working internet connection beforehand
-		G_CHECK_URL "$FTP_ADDR"
-
-		#Grab filename to use
-		Update_FileName_Format
-
-		#Generate text file for upload
-		# -  wput does not work with a filepath, so we must enter the directory and use a filename only.
-		cd /tmp
-
-		cat << _EOF_ > "$FILENAME_FORMAT"
+	#Generate text file for upload
+	cat << _EOF_ > "$FILENAME_FORMAT"
 -------------------------
 DietPi-Survey v$SURVEY_VERSION
 -------------------------
@@ -111,21 +116,67 @@ Hostname       : $(cat /etc/hostname)
 -------------------------
 DietPi-Software Installed
 -------------------------
-$(cat /DietPi/dietpi/.installed | grep ' =2 ')
+$(cat /DietPi/dietpi/.installed | grep '=2')
 
 _EOF_
 
-		#upload to server
-		wput --timeout=10th-4 --tries=1 --waitretry=4 -q -B -u "$FILENAME_FORMAT" ftp://"$FTP_USER":"$FTP_PASS"@"$FTP_ADDR"
+	#-----------------------------------------------------------------------------------
+	if (( $INPUT == 1 )); then
 
-		#clear generated temp file
-		rm "$FILENAME_FORMAT"
+		#Opted in - Setup and send
+		if (( $OPTED_IN )); then
 
-		#Update .dietpi-survey file
-		((SURVEY_SENTCOUNT++))
-		Write_Settings
+			Send_File
+
+		fi
+
+	else
+
+		G_WHIP_MENU_ARRAY=(
+
+			'1' 'Yes, I want to join DietPi-Survey.'
+			'2' 'No, do not send data from my device.'
+			'3' 'No, do not send data and remove my data, if already collected before.'
+
+		)
+
+		G_WHIP_MENU "DietPi-Survey would like to collect anonymous statistics about your device, version and installed software. \
+This allows us to focus development based on popularity. NO private data is sent and NOONE can identify you based on the data sent. \
+The data is sent via secured connection to our SFTP server and is stored there unreadable to the public upload user. \
+If you agree, your uploaded data will be automatically updated on every DietPi-Update and whenever you install software via DietPi-Software \
+We regularly publish results of the collected data at: https://dietpi.com/forum
+Your personal upload file would currently look like this:
+$(cat $FILENAME_FORMAT)
+
+Would you like to opt in for DietPi-Survey?"
+		if (( ! $? )); then
+
+			if (( G_WHIP_RETURNED_VALUE == 1 )); then
+
+				OPTED_IN=1
+				Send_File
+
+			elif (( G_WHIP_RETURNED_VALUE == 2 )); then
+
+				OPTED_IN=0
+
+			elif (( G_WHIP_RETURNED_VALUE == 3 )); then
+
+				OPTED_IN=0
+				# Send empty file to overwrite existing data
+				> "$FILENAME_FORMAT"
+				((SURVEY_SENTCOUNT--)) # Compensate upcount by Send_File
+				Send_File
+				
+			fi
+
+		fi
 
 	fi
+
+	Write_Settings
+	cd "$HOME"
+	rm -R /tmp/dietpi-survey
 
 	#-----------------------------------------------------------------------------------
 	exit 0

--- a/dietpi/dietpi-survey
+++ b/dietpi/dietpi-survey
@@ -16,7 +16,7 @@
 	# - Runs on dietpi-update and when user installs software using dietpi-software
 	#
 	# Usage:
-	# - /DietPi/dietpi/dietpi-survey	Interactively let user opt-in, opt-out or remove uploaded data
+	# - /DietPi/dietpi/dietpi-survey	Interactively let user opt-in, opt-out or remove already uploaded data
 	# - /DietPi/dietpi/dietpi-survey 1	Non-interactively send survey data, IF user opted in (!)
 	#
 	# File Sent format:
@@ -25,10 +25,9 @@
 
 	#Import DietPi-Globals ---------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
-	export G_PROGRAM_NAME='DietPi-Survey'
-	export G_USER_INPUTS=0
 	G_CHECK_ROOT_USER
 	G_INIT
+	export G_PROGRAM_NAME='DietPi-Survey'
 	#Import DietPi-Globals ---------------------------------------------------------------
 
 	#Grab Input (valid interger)
@@ -40,8 +39,9 @@
 	SURVEY_VERSION=5
 
 	DIETPI_VERSION="$(paste -sd '.' /DietPi/dietpi/.version)"
-	G_HW_MODEL=$(sed -n 1p /DietPi/dietpi/.hw_model)
 	UNIQUE_ID=$(sed -n 5p /DietPi/dietpi/.hw_model)
+	FP_TMP='/tmp/dietpi-survey'
+	UPLOAD_FILENAME="$UNIQUE_ID.txt"
 
 	SFTP_ADDR='dietpi.com'
 	SFTP_USER='dietpi-survey'
@@ -70,7 +70,7 @@ _EOF_
 		G_CHECK_URL "$SFTP_ADDR"
 
 		#upload to server
-		curl -m 20 --retry 1 --retry-delay 4 -sT "$FILENAME_FORMAT" sftp://"$SFTP_USER":"$SFTP_PASS"@"$SFTP_ADDR"/survey/
+		curl --connect-timeout 4 --retry 1 --retry-delay 4 -sT "$FILENAME_FORMAT" sftp://"$SFTP_USER":"$SFTP_PASS"@"$SFTP_ADDR"/survey/
 
 		#Update .dietpi-survey file
 		((SURVEY_SENTCOUNT++))
@@ -81,8 +81,8 @@ _EOF_
 	# Main Loop
 	#/////////////////////////////////////////////////////////////////////////////////////
 	#Enter ramfs
-	mkdir -p /tmp/dietpi-survey
-	cd /tmp/dietpi-survey
+	mkdir -p "$FP_TMP"
+	cd "$FP_TMP"
 	
 	#Read data from .dietpi-survey file
 	if [[ -f $FP_SETTINGS ]]; then
@@ -96,11 +96,8 @@ _EOF_
 
 	fi
 
-	#Grab filename to use
-	FILENAME_FORMAT="$UNIQUE_ID.txt"
-
 	#Generate text file for upload
-	cat << _EOF_ > "$FILENAME_FORMAT"
+	cat << _EOF_ > "$UPLOAD_FILENAME"
 -------------------------
 DietPi-Survey v$SURVEY_VERSION
 -------------------------
@@ -116,7 +113,7 @@ Hostname       : $(</etc/hostname)
 -------------------------
 DietPi-Software Installed
 -------------------------
-$(cat /DietPi/dietpi/.installed | grep '=2')
+$(grep '=2' /DietPi/dietpi/.installed)
 
 _EOF_
 
@@ -134,19 +131,19 @@ _EOF_
 
 		G_WHIP_MENU_ARRAY=(
 
-			'1' 'Yes, I want to join DietPi-Survey.'
-			'2' 'No, do not send data from my device.'
-			'3' 'No, do not send data and remove my data, if already collected before.'
+			'1' 'Yes, I want to opt in DietPi-Survey.'
+			'2' 'No, I want to opt out DietPi-Survey.'
+			'3' 'Opt me out and purge any existing survey data.'
 
 		)
 
 		G_WHIP_MENU "DietPi-Survey would like to collect anonymous statistics about your device, version and installed software. \
-This allows us to focus development based on popularity. NO private data is sent and NOONE can identify you based on the data sent. \
+This allows us to focus development based on popularity. NO private data will be collected and NO ONE ccan identify you based on the data. \
 The data is sent via secured connection to our SFTP server and is stored there unreadable to the public upload user. \
-If you agree, your uploaded data will be automatically updated on every DietPi-Update and whenever you install software via DietPi-Software \
+If you agree, your uploaded data will be automatically updated on every DietPi-Update and whenever you install software via DietPi-Software. \
 We regularly publish results of the collected data at: https://dietpi.com/forum
 Your personal upload file would currently look like this:
-$(cat $FILENAME_FORMAT)
+$(<$FILENAME_FORMAT)
 
 Would you like to opt in for DietPi-Survey?"
 		if (( ! $? )); then
@@ -164,7 +161,7 @@ Would you like to opt in for DietPi-Survey?"
 
 				OPTED_IN=0
 				# Send empty file to overwrite existing data, rm is not possible due to missing file list permissions
-				> "$FILENAME_FORMAT"
+				> "$UPLOAD_FILENAME"
 				((SURVEY_SENTCOUNT--)) # Compensate upcount by Send_File
 				Send_File
 				
@@ -176,7 +173,7 @@ Would you like to opt in for DietPi-Survey?"
 
 	Write_Settings
 	cd "$HOME"
-	rm -R /tmp/dietpi-survey
+	rm -R "$FP_TMP"
 
 	#-----------------------------------------------------------------------------------
 	exit 0

--- a/dietpi/dietpi-survey
+++ b/dietpi/dietpi-survey
@@ -71,6 +71,12 @@ _EOF_
 
 		#upload to server
 		curl --connect-timeout 4 --retry 1 --retry-delay 4 -sT "$UPLOAD_FILENAME" sftp://"$SFTP_USER":"$SFTP_PASS"@"$SFTP_ADDR"/survey/
+		if (( $? )); then
+
+			G_DIETPI-NOTIFY 1 'Failed to connect to SFTP server. Please try again later or report this to DietPi forum or GitHub repo in the first place.'
+			return 1
+
+		fi
 
 		#Update .dietpi-survey file
 		((SURVEY_SENTCOUNT++))
@@ -121,11 +127,7 @@ _EOF_
 	if (( $INPUT == 1 )); then
 
 		#Opted in - Setup and send
-		if (( $OPTED_IN )); then
-
-			Send_File
-
-		fi
+		(( $OPTED_IN )) && Send_File
 
 	else
 
@@ -152,6 +154,7 @@ Would you like to opt in for DietPi-Survey?"
 
 				OPTED_IN=1
 				Send_File
+				(( ! $? )) && G_DIETPI-NOTIFY 0 'Successfully sent survey data'
 
 			elif (( G_WHIP_RETURNED_VALUE == 2 )); then
 
@@ -162,8 +165,8 @@ Would you like to opt in for DietPi-Survey?"
 				OPTED_IN=0
 				# Send empty file to overwrite existing data, rm is not possible due to missing file list permissions
 				> "$UPLOAD_FILENAME"
-				((SURVEY_SENTCOUNT--)) # Compensate upcount by Send_File
 				Send_File
+				(( ! $? )) && G_DIETPI-NOTIFY 0 'Successfully purged survey data' && ((SURVEY_SENTCOUNT--)) # Compensate upcount by Send_File
 
 			fi
 

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -1958,6 +1958,8 @@ Please retry with valid parameter (\$4) or apply the setting manually:\n        
 
 			else
 
+				# The following sed does not work on empty files:
+				[[ ! -s $file ]] && echo '# Added by DietPi:' >> "$file"
 				sed -Ei "\$s|\$|\n$setting|" "$file"
 				(( $? )) && syntax_error && return 1
 				G_DIETPI-NOTIFY 0 "Added setting \e[33m$(sed -E "c$setting" <<< '' | sed 's|\\|\\\\|g')\e[0m to end of file \e[33m$file\e[0m"

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -710,6 +710,11 @@ _EOF_
 			rm /var/lib/dietpi/fs_partition_resize.sh &> /dev/null
 			rm /var/lib/dietpi/dietpi-software/services/kill-ssh-user-sessions-before-network.sh &> /dev/null
 			#-------------------------------------------------------------------------------
+			#Add dietpi.com SSH pub host key for survey and bug report uploads:
+			mkdir -p /root/.ssh
+			>> /root/.ssh/known_hosts
+			G_CONFIG_INJECT 'dietpi.com ' 'dietpi.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDE6aw3r6aOEqendNu376iiCHr9tGBIWPgfrLkzjXjEsHGyVSUFNnZt6pftrDeK7UX\+qX4FxOwQlugG4fymOHbimRCFiv6cf7VpYg1Ednquq9TLb7/cIIbX8a6AuRmX4fjdGuqwmBq3OG7ZksFcYEFKt5U4mAJIaL8hXiM2iXjgY02LqiQY/QWATsHI4ie9ZOnwrQE\+Rr6mASN1BVFuIgyHIbwX54jsFSnZ/7CdBMkuAd9B8JkxppWVYpYIFHE9oWNfjh/epdK8yv9Oo6r0w5Rb\+4qaAc5g\+RAaknHeV6Gp75d2lxBdCm5XknKKbGma2\+/DfoE8WZTSgzXrYcRlStYN' /root/.ssh/known_hosts
+			#-------------------------------------------------------------------------------
 			#Run DietPi-Survey interactively to allow user opt in or out:
 			/DietPi/dietpi/dietpi-survey
 			#-------------------------------------------------------------------------------

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -710,6 +710,9 @@ _EOF_
 			rm /var/lib/dietpi/fs_partition_resize.sh &> /dev/null
 			rm /var/lib/dietpi/dietpi-software/services/kill-ssh-user-sessions-before-network.sh &> /dev/null
 			#-------------------------------------------------------------------------------
+			#Run DietPi-Survey interactively to allow user opt in or out:
+			/DietPi/dietpi/dietpi-survey
+			#-------------------------------------------------------------------------------
 
 		fi
 


### PR DESCRIPTION
As this topic is kinda essential, I think we should have this done before v6.9 release.

- [x] Adjust upload method: SFTP
- [x] Adjust DietPi-Survey accordingly
- [x] Add 1st run and patch G_WHIP about DietPi-Survey opt-in/out

+ DietPi-Bugreport | Remove bug ID, to simply overwrite any old bug report on server, the content does not change based on the bug
+ DietPi-Bugreport | Write commands output to single file first, which will be added then to file list
+ DietPi-Bugreport | Add all files at once to archive, which should be faster and lead to smaller file
+ DietPi-Bugreport | Switch to 7z for smaller archive
+ DietPi-Bugreport | Add error handling/message to all checks being done around uploading

Testing:
🈯️ VM Jessie
🈯️ VM Stretch
🈯️ VM Buster