### PR TITLE
General | Adjust and unify password handling to increase security

### DIFF
--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -2151,46 +2151,6 @@
 
 	}
 
-	Change_Password(){
-
-		local PasswordRecieved=0
-
-		#1st input
-		local passw1=$(whiptail --passwordbox "Please Enter Your New Password" 8 60 --title "Change PW" 3>&1 1>&2 2>&3)
-		if (( $? == 0 )); then
-
-			((PasswordRecieved++))
-
-		fi
-
-		#2nd input (confirm)
-		local passw2=$(whiptail --passwordbox "Please Confirm Your New Password" 8 60 --title "Confirm PW" 3>&1 1>&2 2>&3)
-		if (( $? == 0 )); then
-
-			((PasswordRecieved++))
-
-		fi
-
-		#Password Mismatch
-		if [ "$passw1" != "$passw2" ]; then
-
-			G_WHIP_MSG "Error - Password Mismatch:\n\nThe Passwords you have entered do not match, therefor, no changes have been applied. Please try again"
-
-		#Change password
-		elif (( $PasswordRecieved == 2 )); then
-
-			echo -e "$passw1\n$passw1" | passwd -q root
-			G_WHIP_MSG "New password has successfully been applied."
-
-		#Aborted
-		else
-
-			G_WHIP_MSG "Password change has been aborted. No changes have been applied"
-
-		fi
-
-	}
-
 	Change_Hostname(){
 
 		#Get existing Hostname
@@ -2225,17 +2185,17 @@
 
 		G_WHIP_MENU_ARRAY=(
 
-			'1' 'Change Root Password'
+			'1' 'Change Passwords'
 			'2' 'Change Hostname'
 
 		)
 
 		G_WHIP_MENU "Lock down your DietPi Install"
-		if (( $? == 0 )); then
+		if (( ! $? )); then
 
 			if (( $G_WHIP_RETURNED_VALUE == 1 )); then
 
-				Change_Password
+				/DietPi/dietpi/func/dietpi-set_software passwords
 				TARGETMENUID=5
 
 			elif (( $G_WHIP_RETURNED_VALUE == 2 )); then

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -16520,7 +16520,7 @@ _EOF_
 
 	#--------------------------------------------------------------------------------------
 	# - CLi input mode
-	if [[ -n $1 ]]; then
+	if [[ $1 ]]; then
 
 		# - Run input mode
 		Input_Modes "$@"
@@ -16538,8 +16538,8 @@ _EOF_
 			# - GPL compliance prompt
 			G_WHIP_MSG "DietPi - GPLv2 License:\n\nThis program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or any later version.\n\nThis program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.\n\nYou should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/"
 
-			# - Change global password for root and dietpi users?
-			/DietPi/dietpi/func/dietpi-set_software password
+			# - Change global password and login passwords for root and dietpi users
+			/DietPi/dietpi/func/dietpi-set_software passwords "$GLOBAL_PW"
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -16504,47 +16504,6 @@ _EOF_
 
 	}
 
-	Change_Global_Password(){
-
-		if (( $G_USER_INPUTS )); then
-
-			while true
-			do
-
-				G_WHIP_YESNO 'Change DietPi Global Password?:\n\nDietPi has two accounts by default "root" and "dietpi". Both accounts share and use the default password global password "dietpi".\n\nIt is recommended you change the default global password.\n\nWould you like to change the global password, which will affect "root" and "dietpi" login accounts, and, all future software installed by DietPi that requires a password?'
-				if (( $? == 0 )); then
-
-					G_WHIP_INPUTBOX "Please enter a new password:\nNB: the following characters are not supported \$'\\\""
-					local password_0="$G_WHIP_RETURNED_VALUE"
-					G_WHIP_INPUTBOX "Please enter the new password again:"
-					local password_1="$G_WHIP_RETURNED_VALUE"
-					if [[ -n $password_0 && $password_0 == $password_1 ]]; then
-
-						chpasswd <<< "root:$password_0"
-						chpasswd <<< "dietpi:$password_0"
-						sed -i "/^AUTO_SETUP_GLOBAL_PASSWORD=/c\AUTO_SETUP_GLOBAL_PASSWORD=$password_0" /DietPi/dietpi.txt
-						GLOBAL_PW="$password_0"
-						G_DIETPI-NOTIFY 2 "Global password changed to $password_0"
-						break
-
-					else
-
-						G_WHIP_MSG 'No password entered, or invalid match. Please try again'
-
-					fi
-
-				else
-
-					break
-
-				fi
-
-			done
-
-		fi
-
-	}
-
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Main Loop
 	#/////////////////////////////////////////////////////////////////////////////////////
@@ -16580,7 +16539,7 @@ _EOF_
 			G_WHIP_MSG "DietPi - GPLv2 License:\n\nThis program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or any later version.\n\nThis program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.\n\nYou should have received a copy of the GNU General Public License along with this program.  If not, see http://www.gnu.org/licenses/"
 
 			# - Change global password for root and dietpi users?
-			Change_Global_Password
+			/DietPi/dietpi/func/dietpi-set_software password
 
 		fi
 

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -99,10 +99,10 @@
 		G_HW_CPUID=$(sed -n 9p /DietPi/dietpi/.hw_model)
 
 		G_DISTRO=$(sed -n 3p /DietPi/dietpi/.hw_model)
-		G_DISTRO_NAME='jessie'
-		if (( $G_DISTRO == 4 )); then
+		G_DISTRO_NAME='stretch'
+		if (( $G_DISTRO == 3 )); then
 
-			G_DISTRO_NAME='stretch'
+			G_DISTRO_NAME='jessie'
 
 		elif (( $G_DISTRO == 5 )); then
 
@@ -147,13 +147,13 @@
 
 		local ainput_string=("$@")
 
-		#header_line="\e[38;5;154m─────────────────────────────────────────────────────\e[0m"
-		local header_line="\e[90m─────────────────────────────────────────────────────\e[0m"
+		#header_line='\e[38;5;154m─────────────────────────────────────────────────────\e[0m'
+		local header_line='\e[90m─────────────────────────────────────────────────────\e[0m'
 
-		local status_text_ok="\e[32m  OK  \e[0m"
-		local status_text_error="\e[31mFAILED\e[0m"
-		local status_text_info="\e[0m INFO \e[0m"
-		local status_subfunction="\e[33m SUBF \e[0m"
+		local status_text_ok='\e[32m  OK  \e[0m'
+		local status_text_error='\e[31mFAILED\e[0m'
+		local status_text_info='\e[0m INFO \e[0m'
+		local status_subfunction='\e[33m SUBF \e[0m'
 		if [[ $HIERARCHY ]]; then
 
 			# - >=10 should never occur, however, if it is, lets make it line up regardless
@@ -169,17 +169,17 @@
 
 		fi
 
-		local bracket_string_l="\e[90m[\e[0m"
-		local bracket_string_r="\e[90m]\e[0m"
+		local bracket_string_l='\e[90m[\e[0m'
+		local bracket_string_r='\e[90m]\e[0m'
 
 		#Funcs
 
 		Print_Process_Animation(){
 
-			local bright_dot="\e[1;93m.\e[0m"
-			local dimmed_dot="\e[2;33m.\e[0m"
+			local bright_dot='\e[1;93m.\e[0m'
+			local dimmed_dot='\e[2;33m.\e[0m'
+			# Alternative: \u23F9
 			local aprocess_string=(
-				#\u23F9
 				"$bright_dot     "
 				"$dimmed_dot$bright_dot    "
 				" $dimmed_dot$bright_dot   "
@@ -214,13 +214,13 @@
 				tput ed
 
 			fi
-			echo -ne "\r\e[K"
+			echo -ne '\r\e[K'
 
 		}
 
 		Print_Process(){
 
-			echo -ne "\r\e[9C"
+			echo -ne '\r\e[9C'
 
 		}
 
@@ -256,7 +256,7 @@
 		# - $1 = start printing from word number $1
 		Print_Input_String(){
 
-			if (( $1 == 1 )) && [[ -n $G_PROGRAM_NAME ]]; then
+			if (( $1 == 1 )) && [[ $G_PROGRAM_NAME ]]; then
 
 				echo -ne "\e[90m$G_PROGRAM_NAME | \e[0m"
 
@@ -279,16 +279,16 @@
 		# - Use this at end of DietPi scripts, EG: G_DIETPI-NOTIFY -1 ${EXIT_CODE:=0}
 		if (( $1 == -1 )); then
 
-			if [[ $2 == 0 ]]; then
+			if (( ! $2 )); then
 
-				ainput_string+=(" Completed")
+				ainput_string+=(' Completed')
 				Print_Ok
 				Print_Input_String 2
 				echo ''
 
 			else
 
-				ainput_string+=(" An issue has occured")
+				ainput_string+=(' An issue has occured')
 				Print_Failed
 				Print_Input_String 2
 				echo ''
@@ -335,9 +335,9 @@
 		elif (( $1 == 2 )); then
 
 			Print_Info
-			echo -ne "\e[90m"
+			echo -ne '\e[90m'
 			Print_Input_String 1
-			echo -e "\e[0m"
+			echo -e '\e[0m'
 
 		#DietPi banner style
 		#$2 = txt program name
@@ -379,11 +379,7 @@
 	G_CHECK_ROOT_USER(){
 
 		local input=0
-		if [[ $1 ]]; then
-
-			input=$1
-
-		fi
+		G_CHECK_VALIDINT $1 && input=$1
 
 		if (( ! $G_CHECK_ROOT_USER_VERIFIED )); then
 
@@ -779,13 +775,31 @@
 		if (( $G_USER_INPUTS )); then
 
 			G_WHIP_INIT 0
-			result=$(whiptail --title "$G_PROGRAM_NAME" --passwordbox "$WHIP_MESSAGE" --ok-button "$G_WHIP_BUTTON_OK_TEXT" --cancel-button "$G_WHIP_BUTTON_CANCEL_TEXT" --backtitle "$WHIP_BACKTITLE" $WHIP_SIZE_Y $WHIP_SIZE_X 3>&1 1>&2 2>&3)
+			local password_0=''
+			local password_1=''
+
+			while true
+			do
+
+				password_0=$(whiptail --title "$G_PROGRAM_NAME" --passwordbox "$WHIP_MESSAGE" --ok-button "$G_WHIP_BUTTON_OK_TEXT" --cancel-button "$G_WHIP_BUTTON_CANCEL_TEXT" --backtitle "$WHIP_BACKTITLE" $WHIP_SIZE_Y $WHIP_SIZE_X 3>&1 1>&2 2>&3)
+				password_1=$(whiptail --title "$G_PROGRAM_NAME" --passwordbox 'Please enter the new password again:' --ok-button "$G_WHIP_BUTTON_OK_TEXT" --cancel-button "$G_WHIP_BUTTON_CANCEL_TEXT" --backtitle "$WHIP_BACKTITLE" $WHIP_SIZE_Y $WHIP_SIZE_X 3>&1 1>&2 2>&3)
+				if [[ $password_0 && $password_0 == $password_1 ]]; then
+
+					result="$password_0"
+					break
+
+				else
+
+					G_WHIP_MSG 'No password entered, or invalid match. Please try again...'
+
+				fi
+
+			done
 
 		fi
 
 		G_WHIP_DESTROY
-
-		return $result
+		return "$result"
 
 	}
 

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -768,6 +768,27 @@
 
 	}
 
+	#G_WHIP_PASSWORD "message"
+	# - Prompt user to input password and return it. Do not export for security reasons!
+	# - No return value is considered as user cancel
+	G_WHIP_PASSWORD(){
+
+		local result=''
+		WHIP_MESSAGE=("$@")
+
+		if (( $G_USER_INPUTS )); then
+
+			G_WHIP_INIT 0
+			result=$(whiptail --title "$G_PROGRAM_NAME" --passwordbox "$WHIP_MESSAGE" --ok-button "$G_WHIP_BUTTON_OK_TEXT" --cancel-button "$G_WHIP_BUTTON_CANCEL_TEXT" --backtitle "$WHIP_BACKTITLE" $WHIP_SIZE_Y $WHIP_SIZE_X 3>&1 1>&2 2>&3)
+
+		fi
+
+		G_WHIP_DESTROY
+
+		return $result
+
+	}
+
 	#G_WHIP_MENU "message"
 	# - Prompt user to select option from G_WHIP_MENU_ARRAY and sets G_WHIP_RETURNED_VALUE
 	# - returns result 0=Ok, everything else considered a user canceled result

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -765,24 +765,21 @@
 	}
 
 	#G_WHIP_PASSWORD "message"
-	# - Prompt user to input password and return it. Do not export for security reasons!
-	# - No return value is considered as user cancel
+	# - Prompt user to input password and safe it in variable "result". Do not export for security reasons!
 	G_WHIP_PASSWORD(){
 
-		local result=''
+		result=''
 		WHIP_MESSAGE=("$@")
 
 		if (( $G_USER_INPUTS )); then
 
 			G_WHIP_INIT 0
-			local password_0=''
-			local password_1=''
 
 			while true
 			do
 
-				password_0=$(whiptail --title "$G_PROGRAM_NAME" --passwordbox "$WHIP_MESSAGE" --ok-button "$G_WHIP_BUTTON_OK_TEXT" --cancel-button "$G_WHIP_BUTTON_CANCEL_TEXT" --backtitle "$WHIP_BACKTITLE" $WHIP_SIZE_Y $WHIP_SIZE_X 3>&1 1>&2 2>&3)
-				password_1=$(whiptail --title "$G_PROGRAM_NAME" --passwordbox 'Please enter the new password again:' --ok-button "$G_WHIP_BUTTON_OK_TEXT" --cancel-button "$G_WHIP_BUTTON_CANCEL_TEXT" --backtitle "$WHIP_BACKTITLE" $WHIP_SIZE_Y $WHIP_SIZE_X 3>&1 1>&2 2>&3)
+				local password_0=$(whiptail --title "$G_PROGRAM_NAME" --passwordbox "$WHIP_MESSAGE" --ok-button "$G_WHIP_BUTTON_OK_TEXT" --nocancel --backtitle "$WHIP_BACKTITLE" $WHIP_SIZE_Y $WHIP_SIZE_X 3>&1 1>&2 2>&3)
+				local password_1=$(whiptail --title "$G_PROGRAM_NAME" --passwordbox 'Please enter the new password again:' --ok-button "$G_WHIP_BUTTON_OK_TEXT" --nocancel --backtitle "$WHIP_BACKTITLE" $WHIP_SIZE_Y $WHIP_SIZE_X 3>&1 1>&2 2>&3)
 				if [[ $password_0 && $password_0 == $password_1 ]]; then
 
 					result="$password_0"
@@ -790,7 +787,7 @@
 
 				else
 
-					G_WHIP_MSG 'No password entered, or invalid match. Please try again...'
+					whiptail --title "$G_PROGRAM_NAME" --msgbox '[FAILED] No password entered, or invalid match.\n\nPlease try again...' --ok-button 'Retry' --backtitle "$WHIP_BACKTITLE" 9 60
 
 				fi
 
@@ -799,7 +796,6 @@
 		fi
 
 		G_WHIP_DESTROY
-		return "$result"
 
 	}
 

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -21,7 +21,7 @@ $FP_SCRIPT			userdel					X=delete user with name X
 $FP_SCRIPT			apt-mirror				url / default
 $FP_SCRIPT			ntpd-mode				[0-4] configures NTPD mode (eg: ntp/systemd)
 $FP_SCRIPT			verify_dietpi.txt			verifies dietpi.txt entries, adds missing entries if required
-$FP_SCRIPT			password				X=set X as global password for users \"root\" and \"dietpi\"
+$FP_SCRIPT			passwords				optional X=set X as global password for dietpi-software installations, \"root\" and \"dietpi\" login passwords can be changed via additional secure user prompt
 "
 	#////////////////////////////////////
 
@@ -402,20 +402,19 @@ _EOF_
 
 	}
 
-	Password_Main(){
+	Passwords_Main(){
 
 		if [[ -z $INPUT_MODE_VALUE ]] && (( $G_USER_INPUTS )); then
 
 			while true
 			do
 
-				G_WHIP_YESNO 'Change DietPi Global Password?:\n\nDietPi has two accounts by default "root" and "dietpi". Both accounts share and use the default password global password "dietpi".\n\nIt is recommended you change the default global password.\n\nWould you like to change the global password, which will affect "root" and "dietpi" login accounts, and, all future software installed by DietPi that requires a password?'
+				G_WHIP_YESNO 'Do you want to adjust the default global password for DietPi-Software installations? This does not effect any unix user login.\n
+NB: This password will be saved as plain text within /DietPi/dietpi.txt to be useable by DietPi-Software for e.g. web application and database logins. We highly recommand to adjust all passwords for services, that are opened to the web.'
 				if (( ! $? )); then
 
-					G_WHIP_INPUTBOX "Please enter a new password:\nNB: the following characters are not supported \$'\\\""
-					local password_0="$G_WHIP_RETURNED_VALUE"
-					G_WHIP_INPUTBOX "Please enter the new password again:"
-					local password_1="$G_WHIP_RETURNED_VALUE"
+					local password_0=G_WHIP_PASSWORD "Please enter a new global password:\nNB: the following characters are not supported \$'\\\"\|"
+					local password_1=G_WHIP_PASSWORD "Please enter the new password again:"
 					if [[ -n $password_0 && $password_0 == $password_1 ]]; then
 
 						INPUT_MODE_VALUE="$password_0"
@@ -441,14 +440,16 @@ _EOF_
 
 			chpasswd <<< "root:$INPUT_MODE_VALUE"
 			chpasswd <<< "dietpi:$INPUT_MODE_VALUE"
-			G_CONFIG_INJECT 'AUTO_SETUP_GLOBAL_PASSWORD=' "AUTO_SETUP_GLOBAL_PASSWORD=$INPUT_MODE_VALUE" /DietPi/dietpi.txt
-			G_DIETPI-NOTIFY 2 "Global password changed to: $INPUT_MODE_VALUE"
+			G_CONFIG_INJECT 'AUTO_SETUP_GLOBAL_PASSWORD=' "AUTO_SETUP_GLOBAL_PASSWORD=$INPUT_MODE_VALUE" /DietPi/dietpi.txt &> /dev/null
+			G_DIETPI-NOTIFY 2 'Global password successfully changed'
 
 		else
 
 			Unknown_Input_Mode
 
 		fi
+
+		G_WHIP_YESNO 'Change DietPi Global Password?:\n\nDietPi has two accounts by default "root" and "dietpi". Both accounts share and use the default password global password "dietpi".\n\nIt is recommended you change the default global password.\n\nWould you like to change the global password, which will affect "root" and "dietpi" login accounts, and, all future software installed by DietPi that requires a password?'
 
 	}
 
@@ -493,9 +494,9 @@ _EOF_
 
 		Locale_Main
 
-	elif [[ $INPUT_MODE_NAME == 'password' ]]; then
+	elif [[ $INPUT_MODE_NAME == 'passwords' ]]; then
 
-		Password_Main
+		Passwords_Main
 
 	else
 

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -187,7 +187,7 @@ _EOF_
 			(( $INPUT_MODE_VALUE >= 0 && $INPUT_MODE_VALUE <= 4 )); then
 
 			# - Reset global to disabled, prevents run_ntpd in dietpi-software
-			G_CONFIG_INJECT 'CONFIG_NTP_MODE=' 'CONFIG_NTP_MODE=0' /DietPi/dietpi.txt
+			sed -i '/CONFIG_NTP_MODE=/c\CONFIG_NTP_MODE=0' /DietPi/dietpi.txt
 
 			#Kill current
 			killall -w /DietPi/dietpi/func/run_ntpd &> /dev/null
@@ -218,7 +218,7 @@ _EOF_
 
 				systemctl stop systemd-timesyncd
 				systemctl disable systemd-timesyncd
-				apt-mark auto dbus
+				#apt-mark auto dbus #???
 
 			fi
 

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -14,13 +14,14 @@
 	FP_SCRIPT='/DietPi/dietpi/func/dietpi-set_software'
 	AVAIABLE_COMMANDS="
 Available commands
-$FP_SCRIPT			locale					en_GB.UTF-8
+$FP_SCRIPT			locale					en_GB.UTF-8 / any other UTF-8 locale
 $FP_SCRIPT			allo					eth_dhcp / eth_static
 $FP_SCRIPT			useradd					X=create user with name X and default permissions, using global DietPi password (dietpi)
 $FP_SCRIPT			userdel					X=delete user with name X
-$FP_SCRIPT			apt-mirror				url/default
-$FP_SCRIPT			ntpd-mode				configures NTPD mode (eg: ntp/systemd)
-$FP_SCRIPT			verify_dietpi.txt		verifies dietpi.txt entries, adds missing entries if required
+$FP_SCRIPT			apt-mirror				url / default
+$FP_SCRIPT			ntpd-mode				[0-4] configures NTPD mode (eg: ntp/systemd)
+$FP_SCRIPT			verify_dietpi.txt			verifies dietpi.txt entries, adds missing entries if required
+$FP_SCRIPT			password				X=set X as global password for users \"root\" and \"dietpi\"
 "
 	#////////////////////////////////////
 
@@ -54,6 +55,7 @@ $FP_SCRIPT			verify_dietpi.txt		verifies dietpi.txt entries, adds missing entrie
 
 		EXIT_CODE=1
 		G_DIETPI-NOTIFY 2 "Unknown input value ($INPUT_MODE_VALUE). Nothing has been applied."
+		echo -e "$AVAIABLE_COMMANDS"
 
 	}
 
@@ -63,14 +65,14 @@ $FP_SCRIPT			verify_dietpi.txt		verifies dietpi.txt entries, adds missing entrie
 	#/////////////////////////////////////////////////////////////////////////////////////
 	Locale_Main(){
 
-		if [[ "$INPUT_MODE_VALUE" =~ 'UTF-8' ]]; then
+		if [[ $INPUT_MODE_VALUE =~ 'UTF-8' ]]; then
 
 			cat << _EOF_ > /etc/locale.gen
 $INPUT_MODE_VALUE UTF-8
 _EOF_
 
 			# - Add en_GB.UTF-8 back in, if its not the default
-			if [ "$INPUT_MODE_VALUE" != "en_GB.UTF-8" ]; then
+			if [[ $INPUT_MODE_VALUE != 'en_GB.UTF-8' ]]; then
 
 				cat << _EOF_ >> /etc/locale.gen
 en_GB.UTF-8 UTF-8
@@ -92,7 +94,7 @@ _EOF_
 			update-locale LC_TIME="$INPUT_MODE_VALUE"
 			update-locale LC_ALL="$INPUT_MODE_VALUE"
 
-			sed -i "/AUTO_SETUP_LOCALE=/c\AUTO_SETUP_LOCALE=$INPUT_MODE_VALUE" /DietPi/dietpi.txt
+			G_CONFIG_INJECT 'AUTO_SETUP_LOCALE=' "AUTO_SETUP_LOCALE=$INPUT_MODE_VALUE" /DietPi/dietpi.txt
 
 		else
 
@@ -107,10 +109,10 @@ _EOF_
 	#/////////////////////////////////////////////////////////////////////////////////////
 	AptMirror_Main(){
 
-		if [ -n "$INPUT_MODE_VALUE" ]; then
+		if [[ $INPUT_MODE_VALUE ]]; then
 
 			# - Set defaults?
-			if [ "$INPUT_MODE_VALUE" = "default" ]; then
+			if [[ $INPUT_MODE_VALUE = 'default' ]]; then
 
 				if (( $G_HW_MODEL < 10 )); then
 
@@ -138,7 +140,7 @@ _EOF_
 				(( $G_DISTRO > 4 )) && sed -i "s/$G_DISTRO_NAME/stretch/" /etc/apt/sources.list.d/raspi.list
 
 				#	Update dietpi.txt entry
-				sed -i "/CONFIG_APT_RASPBIAN_MIRROR=/c\CONFIG_APT_RASPBIAN_MIRROR=$INPUT_MODE_VALUE" /DietPi/dietpi.txt
+				G_CONFIG_INJECT 'CONFIG_APT_RASPBIAN_MIRROR=' "CONFIG_APT_RASPBIAN_MIRROR=$INPUT_MODE_VALUE" /DietPi/dietpi.txt
 
 			# - Set debian
 			else
@@ -163,7 +165,7 @@ _EOF_
 				fi
 
 				#	Update dietpi.txt entry
-				sed -i "/CONFIG_APT_DEBIAN_MIRROR=/c\CONFIG_APT_DEBIAN_MIRROR=$INPUT_MODE_VALUE" /DietPi/dietpi.txt
+				G_CONFIG_INJECT 'CONFIG_APT_DEBIAN_MIRROR=' "CONFIG_APT_DEBIAN_MIRROR=$INPUT_MODE_VALUE" /DietPi/dietpi.txt
 
 			fi
 
@@ -181,50 +183,47 @@ _EOF_
 	#/////////////////////////////////////////////////////////////////////////////////////
 	NtpdMode_Main(){
 
-		if [ -n "$INPUT_MODE_VALUE" ]; then
+		if G_CHECK_VALIDINT $INPUT_MODE_VALUE &&
+			(( $INPUT_MODE_VALUE >= 0 && $INPUT_MODE_VALUE <= 4 )); then
+
+			# - Reset global to disabled, prevents run_ntpd in dietpi-software
+			G_CONFIG_INJECT 'CONFIG_NTP_MODE=' 'CONFIG_NTP_MODE=0' /DietPi/dietpi.txt
 
 			#Kill current
 			killall -w /DietPi/dietpi/func/run_ntpd &> /dev/null
 
-			# - Reset global to disabled, prevents run_ntpd in dietpi-software
-			sed -i "/CONFIG_NTP_MODE=/c\CONFIG_NTP_MODE=0" /DietPi/dietpi.txt
-
-			local ntpd_mirror=$(grep -m1 '^CONFIG_NTP_MIRROR=' /DietPi/dietpi.txt | sed 's/.*=//')
+			local ntpd_mirror=$(grep -m1 '^[[:blank:]]*CONFIG_NTP_MIRROR=' /DietPi/dietpi.txt | sed 's/^.*=//')
 			# - Set defaults?
-			if [ "$ntpd_mirror" = 'default' ]; then
+			if [[ $ntpd_mirror == 'default' ]]; then
 
 				ntpd_mirror='debian.pool.ntp.org'
 
 			fi
 
-			#SystemD-timesyncd
-			if (( $INPUT_MODE_VALUE >= 1 && $INPUT_MODE_VALUE <= 4 )); then
-
-				# - Set mirror
-				cat << _EOF_ > /etc/systemd/timesyncd.conf
+			# - Set mirror
+			cat << _EOF_ > /etc/systemd/timesyncd.conf
 [Time]
 Servers=0.$ntpd_mirror 1.$ntpd_mirror 2.$ntpd_mirror 3.$ntpd_mirror
 _EOF_
 
-				# - Drift mode, dbus required for timedatectl, that users may require
-				if (( $INPUT_MODE_VALUE == 4 )); then
+			# - Daemon mode, dbus required for timedatectl, that users may require
+			if (( $INPUT_MODE_VALUE == 4 )); then
 
-					G_AG_CHECK_INSTALL_PREREQ dbus
+				G_AG_CHECK_INSTALL_PREREQ dbus
+				systemctl enable systemd-timesyncd
+				systemctl start systemd-timesyncd
 
-				fi
-
-			#Disable SystemD and allow "run_ntpd" script to take control
+			# - Else, disable systemd-timesyncd to let "run_ntpd" or other time sync system take control
 			else
 
 				systemctl stop systemd-timesyncd
 				systemctl disable systemd-timesyncd
-
-				#apt-mark auto dbus #???
+				apt-mark auto dbus
 
 			fi
 
 			# - Update DietPi.txt
-			sed -i "/CONFIG_NTP_MODE=/c\CONFIG_NTP_MODE=$INPUT_MODE_VALUE" /DietPi/dietpi.txt
+			G_CONFIG_INJECT 'CONFIG_NTP_MODE=' "CONFIG_NTP_MODE=$INPUT_MODE_VALUE" /DietPi/dietpi.txt
 
 			# - Update now
 			/DietPi/dietpi/func/run_ntpd
@@ -242,22 +241,18 @@ _EOF_
 	#/////////////////////////////////////////////////////////////////////////////////////
 	Allo_Main(){
 
-		if [ -n "$INPUT_MODE_VALUE" ]; then
+		if [[ $INPUT_MODE_VALUE == 'eth_dhcp' ]]; then
 
-			if [ "$INPUT_MODE_VALUE" = "eth_dhcp" ]; then
+			G_CONFIG_INJECT 'iface eth' 'iface eth0 inet dhcp' /etc/network/interfaces
+			sed -i "$(cat -n /etc/network/interfaces | grep 'dns-nameservers ' | sed -n 1p | awk '{print $1}')s/.*/#dns-nameservers 8.8.8.8/" /etc/network/interfaces
 
-				sed -i "/iface eth/c\iface eth0 inet dhcp" /etc/network/interfaces
-				sed -i "$(cat -n /etc/network/interfaces | grep 'dns-nameservers ' | sed -n 1p | awk '{print $1}')s/.*/#dns-nameservers 8.8.8.8/" /etc/network/interfaces
+		elif [[ $INPUT_MODE_VALUE == 'eth_static' ]]; then
 
-			elif [ "$INPUT_MODE_VALUE" = "eth_static" ]; then
-
-				sed -i "/iface eth/c\iface eth0 inet static" /etc/network/interfaces
-				sed -i "$(cat -n /etc/network/interfaces | grep 'address ' | sed -n 1p | awk '{print $1}')s/.*/address $INPUT_ADDITIONAL_1/" /etc/network/interfaces
-				sed -i "$(cat -n /etc/network/interfaces | grep 'gateway ' | sed -n 1p | awk '{print $1}')s/.*/gateway $INPUT_ADDITIONAL_2/" /etc/network/interfaces
-				sed -i "$(cat -n /etc/network/interfaces | grep 'netmask ' | sed -n 1p | awk '{print $1}')s/.*/netmask $INPUT_ADDITIONAL_3/" /etc/network/interfaces
-				sed -i "$(cat -n /etc/network/interfaces | grep 'dns-nameservers ' | sed -n 1p | awk '{print $1}')s/.*/dns-nameservers $INPUT_ADDITIONAL_4/" /etc/network/interfaces
-
-			fi
+			G_CONFIG_INJECT 'iface eth' 'iface eth0 inet static' /etc/network/interfaces
+			sed -i "$(cat -n /etc/network/interfaces | grep 'address ' | sed -n 1p | awk '{print $1}')s/.*/address $INPUT_ADDITIONAL_1/" /etc/network/interfaces
+			sed -i "$(cat -n /etc/network/interfaces | grep 'gateway ' | sed -n 1p | awk '{print $1}')s/.*/gateway $INPUT_ADDITIONAL_2/" /etc/network/interfaces
+			sed -i "$(cat -n /etc/network/interfaces | grep 'netmask ' | sed -n 1p | awk '{print $1}')s/.*/netmask $INPUT_ADDITIONAL_3/" /etc/network/interfaces
+			sed -i "$(cat -n /etc/network/interfaces | grep 'dns-nameservers ' | sed -n 1p | awk '{print $1}')s/.*/dns-nameservers $INPUT_ADDITIONAL_4/" /etc/network/interfaces
 
 		else
 
@@ -272,7 +267,7 @@ _EOF_
 	#/////////////////////////////////////////////////////////////////////////////////////
 	Useradd_Main(){
 
-		if [ -n "$INPUT_MODE_VALUE" ]; then
+		if [[ $INPUT_MODE_VALUE ]]; then
 
 			mkdir -p /home
 			useradd -m -s /bin/bash "$INPUT_MODE_VALUE" -p "$(grep -m1 '^[[:blank:]]*AUTO_SETUP_GLOBAL_PASSWORD=' /DietPi/dietpi.txt | sed 's/^.*=//')"
@@ -332,7 +327,7 @@ _EOF_
 
 	Userdel_Main(){
 
-		if [ -n "$INPUT_MODE_VALUE" ]; then
+		if [[ $INPUT_MODE_VALUE ]]; then
 
 			# - Delete $INPUT_MODE_VALUE
 			userdel -f "$INPUT_MODE_VALUE"
@@ -352,8 +347,8 @@ _EOF_
 	Verify_DietPi_Txt(){
 
 		#Verify entries with git dietpi.txt
-		local gitbranch=$(grep -m1 '^DEV_GITBRANCH=' /DietPi/dietpi.txt | sed 's/.*=//')
-		if [ -z "$gitbranch" ]; then
+		local gitbranch=$(grep -m1 '^[[:blank:]]*DEV_GITBRANCH=' /DietPi/dietpi.txt | sed 's/^.*=//')
+		if [[ -z $gitbranch ]]; then
 
 			gitbranch='master'
 
@@ -361,7 +356,7 @@ _EOF_
 
 		INSTALL_URL="https://raw.githubusercontent.com/Fourdee/DietPi/$gitbranch/dietpi.txt"
 		G_CHECK_URL "$INSTALL_URL"
-		if (( $? == 0 )); then
+		if (( ! $? )); then
 
 			G_DIETPI-NOTIFY 0 "Patching dietpi.txt"
 			wget "$INSTALL_URL" -O /tmp/dietpi.txt_patch
@@ -373,7 +368,7 @@ _EOF_
 
 				entry=$(echo -e "$line" | grep "^[^#;/]" )
 
-				if [ -n "$entry" ]; then
+				if [[ $entry ]]; then
 
 					value=$(echo -e "${entry##*=}") #*=X
 					entry=$(echo -e "${entry%%=*}") #X*
@@ -397,11 +392,61 @@ _EOF_
 			done < /tmp/dietpi.txt_patch
 			rm /tmp/dietpi.txt_patch
 
-			G_DIETPI-NOTIFY 0 "dietpi.txt verification completed"
+			G_DIETPI-NOTIFY 0 'dietpi.txt verification completed'
 
 		else
 
 			G_DIETPI-NOTIFY 1 "Failed to verify dietpi.txt, $INSTALL_URL is offline and/or inaccessible"
+
+		fi
+
+	}
+
+	Password_Main(){
+
+		if [[ -z $INPUT_MODE_VALUE ]] && (( $G_USER_INPUTS )); then
+
+			while true
+			do
+
+				G_WHIP_YESNO 'Change DietPi Global Password?:\n\nDietPi has two accounts by default "root" and "dietpi". Both accounts share and use the default password global password "dietpi".\n\nIt is recommended you change the default global password.\n\nWould you like to change the global password, which will affect "root" and "dietpi" login accounts, and, all future software installed by DietPi that requires a password?'
+				if (( ! $? )); then
+
+					G_WHIP_INPUTBOX "Please enter a new password:\nNB: the following characters are not supported \$'\\\""
+					local password_0="$G_WHIP_RETURNED_VALUE"
+					G_WHIP_INPUTBOX "Please enter the new password again:"
+					local password_1="$G_WHIP_RETURNED_VALUE"
+					if [[ -n $password_0 && $password_0 == $password_1 ]]; then
+
+						INPUT_MODE_VALUE="$password_0"
+						break
+
+					else
+
+						G_WHIP_MSG 'No password entered, or invalid match. Please try again'
+
+					fi
+
+				else
+
+					break
+
+				fi
+
+			done
+
+		fi
+
+		if [[ $INPUT_MODE_VALUE ]]; then
+
+			chpasswd <<< "root:$INPUT_MODE_VALUE"
+			chpasswd <<< "dietpi:$INPUT_MODE_VALUE"
+			G_CONFIG_INJECT 'AUTO_SETUP_GLOBAL_PASSWORD=' "AUTO_SETUP_GLOBAL_PASSWORD=$INPUT_MODE_VALUE" /DietPi/dietpi.txt
+			G_DIETPI-NOTIFY 2 "Global password changed to: $INPUT_MODE_VALUE"
+
+		else
+
+			Unknown_Input_Mode
 
 		fi
 
@@ -416,37 +461,41 @@ _EOF_
 	G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" "$INPUT_MODE_NAME ($INPUT_MODE_VALUE)"
 
 	#-----------------------------------------------------------------------------------
-	if [ "$INPUT_MODE_NAME" = "apt-mirror" ]; then
+	if [[ $INPUT_MODE_NAME == 'apt-mirror' ]]; then
 
 		AptMirror_Main
 
-	elif [ "$INPUT_MODE_NAME" = "useradd" ]; then
+	elif [[ $INPUT_MODE_NAME == 'useradd' ]]; then
 
 		Useradd_Main
 
-	elif [ "$INPUT_MODE_NAME" = "userdel" ]; then
+	elif [[ $INPUT_MODE_NAME == 'userdel' ]]; then
 
 		Userdel_Main
 
-	elif [ "$INPUT_MODE_NAME" = "ntpd-mirror" ]; then
+	elif [[ $INPUT_MODE_NAME == 'ntpd-mirror' ]]; then
 
 		NtpdMirror_Main
 
-	elif [ "$INPUT_MODE_NAME" = "ntpd-mode" ]; then
+	elif [[ $INPUT_MODE_NAME == 'ntpd-mode' ]]; then
 
 		NtpdMode_Main
 
-	elif [ "$INPUT_MODE_NAME" = "allo" ]; then
+	elif [[ $INPUT_MODE_NAME == 'allo' ]]; then
 
 		Allo_Main
 
-	elif [ "$INPUT_MODE_NAME" = "verify_dietpi.txt" ]; then
+	elif [[ $INPUT_MODE_NAME == 'verify_dietpi.txt' ]]; then
 
 		Verify_DietPi_Txt
 
-	elif [ "$INPUT_MODE_NAME" = 'locale' ]; then
+	elif [[ $INPUT_MODE_NAME == 'locale' ]]; then
 
 		Locale_Main
+
+	elif [[ $INPUT_MODE_NAME == 'password' ]]; then
+
+		Password_Main
 
 	else
 

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -410,7 +410,9 @@ _EOF_
 NB: This password will be saved as plain text within /DietPi/dietpi.txt to be useable by DietPi scripts for e.g. web application and database logins. We highly recommand to adjust all passwords for web services and new unix users intependently afterwards.'
 			if (( ! $? )); then
 
-				INPUT_MODE_VALUE=$(G_WHIP_PASSWORD 'Please enter a new global password:\nNB: The following characters are not supported $\'\\"|')
+				G_WHIP_PASSWORD "Please enter a new global password:\nNB: The following characters are not supported \$|\\\"'"
+				INPUT_MODE_VALUE=result
+				unset result
 
 			fi
 
@@ -431,13 +433,14 @@ NB: This password will be saved as plain text within /DietPi/dietpi.txt to be us
 
 		if (( $G_USER_INPUTS )); then
 
-			G_WHIP_YESNO 'Change unix user passwords?:\n\nDietPi has two accounts by default "root" and "dietpi". On first boot, both share the global password "dietpi", respectively the one set in dietpi.txt.\n
+			G_WHIP_YESNO 'Change unix user passwords?\n\nDietPi has two accounts by default "root" and "dietpi". On first boot, both share the global password "dietpi", respectively the one set in dietpi.txt.\n
 It is highly recommended to change this password to one, different than the global DietPi-Software password.\n\nWould you like to change the login passwords for "root" and "dietpi"?'
 			if (( ! $? )); then
 
-				local password=$(G_WHIP_PASSWORD 'Please enter a new unix user password:')
-				chpasswd <<< "root:$password_0"
-				chpasswd <<< "dietpi:$password_0"
+				G_WHIP_PASSWORD 'Please enter a new unix user password:'
+				chpasswd <<< "root:$result"
+				chpasswd <<< "dietpi:$result"
+				unset result
 				G_DIETPI-NOTIFY 2 '"root" and "dietpi" login password successfully changed'
 
 			fi

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -404,25 +404,25 @@ _EOF_
 
 	Passwords_Main(){
 
-		if [[ -z $INPUT_MODE_VALUE ]] && (( $G_USER_INPUTS )); then
+		if [[ -z $INPUT_MODE_VALUE || $INPUT_MODE_VALUE == 'dietpi' ]] && (( $G_USER_INPUTS )); then
 
 			while true
 			do
 
-				G_WHIP_YESNO 'Do you want to adjust the default global password for DietPi-Software installations? This does not effect any unix user login.\n
-NB: This password will be saved as plain text within /DietPi/dietpi.txt to be useable by DietPi-Software for e.g. web application and database logins. We highly recommand to adjust all passwords for services, that are opened to the web.'
+				G_WHIP_YESNO 'Do you want to adjust the default global password for DietPi-Software installations and new unix users? We especially recommend to change the default password "dietpi". This does not effect any existing unix user login.\n
+NB: This password will be saved as plain text within /DietPi/dietpi.txt to be useable by DietPi scripts for e.g. web application and database logins. We highly recommand to adjust all passwords for web services and new unix users intependently afterwards.'
 				if (( ! $? )); then
 
-					local password_0=G_WHIP_PASSWORD "Please enter a new global password:\nNB: the following characters are not supported \$'\\\"\|"
-					local password_1=G_WHIP_PASSWORD "Please enter the new password again:"
-					if [[ -n $password_0 && $password_0 == $password_1 ]]; then
+					local password_0=G_WHIP_PASSWORD 'Please enter a new global password:\nNB: The following characters are not supported $\'\\"|'
+					local password_1=G_WHIP_PASSWORD 'Please enter the new password again:'
+					if [[ $password_0 && $password_0 == $password_1 ]]; then
 
 						INPUT_MODE_VALUE="$password_0"
 						break
 
 					else
 
-						G_WHIP_MSG 'No password entered, or invalid match. Please try again'
+						G_WHIP_MSG 'No password entered, or invalid match. Please try again...'
 
 					fi
 
@@ -438,8 +438,6 @@ NB: This password will be saved as plain text within /DietPi/dietpi.txt to be us
 
 		if [[ $INPUT_MODE_VALUE ]]; then
 
-			chpasswd <<< "root:$INPUT_MODE_VALUE"
-			chpasswd <<< "dietpi:$INPUT_MODE_VALUE"
 			G_CONFIG_INJECT 'AUTO_SETUP_GLOBAL_PASSWORD=' "AUTO_SETUP_GLOBAL_PASSWORD=$INPUT_MODE_VALUE" /DietPi/dietpi.txt &> /dev/null
 			G_DIETPI-NOTIFY 2 'Global password successfully changed'
 
@@ -449,7 +447,38 @@ NB: This password will be saved as plain text within /DietPi/dietpi.txt to be us
 
 		fi
 
-		G_WHIP_YESNO 'Change DietPi Global Password?:\n\nDietPi has two accounts by default "root" and "dietpi". Both accounts share and use the default password global password "dietpi".\n\nIt is recommended you change the default global password.\n\nWould you like to change the global password, which will affect "root" and "dietpi" login accounts, and, all future software installed by DietPi that requires a password?'
+		if (( $G_USER_INPUTS )); then
+
+			while true
+			do
+
+				G_WHIP_YESNO 'Change unix user passwords?:\n\nDietPi has two accounts by default "root" and "dietpi". On first boot, both share the global password "dietpi", respectively the one set in dietpi.txt.\n
+It is highly recommended to change this password to one, different than the global DietPi-Software password.\n\nWould you like to change the login passwords for "root" and "dietpi"?'
+				if (( ! $? )); then
+
+					local password_0=G_WHIP_PASSWORD 'Please enter a new unix user password:'
+					local password_1=G_WHIP_PASSWORD 'Please enter the new password again:'
+					if [[ $password_0 && $password_0 == $password_1 ]]; then
+
+						chpasswd <<< "root:$password_0"
+						chpasswd <<< "dietpi:$password_0"
+						break
+
+					else
+
+						G_WHIP_MSG 'No password entered, or invalid match. Please try again...'
+
+					fi
+
+				else
+
+					break
+
+				fi
+
+			done
+
+		fi
 
 	}
 

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -406,33 +406,13 @@ _EOF_
 
 		if [[ -z $INPUT_MODE_VALUE || $INPUT_MODE_VALUE == 'dietpi' ]] && (( $G_USER_INPUTS )); then
 
-			while true
-			do
-
-				G_WHIP_YESNO 'Do you want to adjust the default global password for DietPi-Software installations and new unix users? We especially recommend to change the default password "dietpi". This does not effect any existing unix user login.\n
+			G_WHIP_YESNO 'Do you want to adjust the default global password for DietPi-Software installations and new unix users? We especially recommend to change the default password "dietpi". This does not effect any existing unix user login.\n
 NB: This password will be saved as plain text within /DietPi/dietpi.txt to be useable by DietPi scripts for e.g. web application and database logins. We highly recommand to adjust all passwords for web services and new unix users intependently afterwards.'
-				if (( ! $? )); then
+			if (( ! $? )); then
 
-					local password_0=G_WHIP_PASSWORD 'Please enter a new global password:\nNB: The following characters are not supported $\'\\"|'
-					local password_1=G_WHIP_PASSWORD 'Please enter the new password again:'
-					if [[ $password_0 && $password_0 == $password_1 ]]; then
+				INPUT_MODE_VALUE=$(G_WHIP_PASSWORD 'Please enter a new global password:\nNB: The following characters are not supported $\'\\"|')
 
-						INPUT_MODE_VALUE="$password_0"
-						break
-
-					else
-
-						G_WHIP_MSG 'No password entered, or invalid match. Please try again...'
-
-					fi
-
-				else
-
-					break
-
-				fi
-
-			done
+			fi
 
 		fi
 
@@ -440,6 +420,8 @@ NB: This password will be saved as plain text within /DietPi/dietpi.txt to be us
 
 			G_CONFIG_INJECT 'AUTO_SETUP_GLOBAL_PASSWORD=' "AUTO_SETUP_GLOBAL_PASSWORD=$INPUT_MODE_VALUE" /DietPi/dietpi.txt &> /dev/null
 			G_DIETPI-NOTIFY 2 'Global password successfully changed'
+			# Mask password for DietPi-Set_Software exit message:
+			unset INPUT_MODE_VALUE
 
 		else
 
@@ -449,34 +431,16 @@ NB: This password will be saved as plain text within /DietPi/dietpi.txt to be us
 
 		if (( $G_USER_INPUTS )); then
 
-			while true
-			do
-
-				G_WHIP_YESNO 'Change unix user passwords?:\n\nDietPi has two accounts by default "root" and "dietpi". On first boot, both share the global password "dietpi", respectively the one set in dietpi.txt.\n
+			G_WHIP_YESNO 'Change unix user passwords?:\n\nDietPi has two accounts by default "root" and "dietpi". On first boot, both share the global password "dietpi", respectively the one set in dietpi.txt.\n
 It is highly recommended to change this password to one, different than the global DietPi-Software password.\n\nWould you like to change the login passwords for "root" and "dietpi"?'
-				if (( ! $? )); then
+			if (( ! $? )); then
 
-					local password_0=G_WHIP_PASSWORD 'Please enter a new unix user password:'
-					local password_1=G_WHIP_PASSWORD 'Please enter the new password again:'
-					if [[ $password_0 && $password_0 == $password_1 ]]; then
+				local password=$(G_WHIP_PASSWORD 'Please enter a new unix user password:')
+				chpasswd <<< "root:$password_0"
+				chpasswd <<< "dietpi:$password_0"
+				G_DIETPI-NOTIFY 2 '"root" and "dietpi" login password successfully changed'
 
-						chpasswd <<< "root:$password_0"
-						chpasswd <<< "dietpi:$password_0"
-						break
-
-					else
-
-						G_WHIP_MSG 'No password entered, or invalid match. Please try again...'
-
-					fi
-
-				else
-
-					break
-
-				fi
-
-			done
+			fi
 
 		fi
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -716,6 +716,9 @@ _EOF_
 			rm /var/lib/dietpi/fs_partition_resize.sh &> /dev/null
 			rm /var/lib/dietpi/dietpi-software/services/kill-ssh-user-sessions-before-network.sh &> /dev/null
 			#-------------------------------------------------------------------------------
+			#Offer to change global and unix user passwords to make users aware of the existance or "dietpi" and how the dietpi.txt password is used.
+			/DietPi/dietpi/func/dietpi-set_software passwords
+			#-------------------------------------------------------------------------------
 
 		fi
 


### PR DESCRIPTION
Ref: https://dietpi.com/phpbb/viewtopic.php?f=9&t=2026#p12842
- The goal is to make users aware of global plain text password and "dietpi" user.
- Further separate global password from unix user passwords for security reasons.
- Global PW (dietpi.txt) is now only used as initial password for new DietPi-Software installs and new unix users via DietPi-Set_Software. Users are asked now to set a different password for unix users, which will not saved anywhere as plain text.
+ DietPi-Globals | Add G_WHIP_PASSWORD, including double input and match check
+ DietPi-Set_Software | Add mode "passwords" with optional argument to set global password. "root" and "dietpi" login passwords can be set on a second interactive-only prompt.
+ DietPi-Software/Config | Now use new Set_Software mode instead of own password function
+ Some code improvements as always.

Testing:
- 🈯️ VM Jessie - update, config, match loop