### PR TITLE
DietPi-Survey | Tuning

### DIFF
--- a/dietpi/dietpi-survey
+++ b/dietpi/dietpi-survey
@@ -34,8 +34,8 @@
 	INPUT=0
 	G_CHECK_VALIDINT $1 && INPUT=$1
 
-	OPTED_IN=2 #2=yes | 1=no | 0=no and cleared data
-	SURVEY_SENTCOUNT=1
+	OPTED_IN=2 #2=yes | 1=no | 0=no and clear data
+	SURVEY_SENTCOUNT=0
 	SURVEY_VERSION=5
 
 	DIETPI_VERSION="$(paste -sd '.' /DietPi/dietpi/.version)"
@@ -74,20 +74,22 @@ _EOF_
 		if (( $? )); then
 
 			G_DIETPI-NOTIFY 1 'Failed to connect to SFTP server. Please try again later or report this to DietPi forum or GitHub repo in the first place.'
-			#return 1
+			# Return error code to skip writing to settings file, if error occured.
+			return 1
 
 		else
 
 			if (( $OPTED_IN == 2 )); then
 
-				#Update .dietpi-survey file
-				((SURVEY_SENTCOUNT++))
-
 				G_DIETPI-NOTIFY 0 'Successfully sent survey data'
+				#Increase sent count
+				((SURVEY_SENTCOUNT++))
 
 			elif (( $OPTED_IN == 0 )); then
 
 				G_DIETPI-NOTIFY 0 'Successfully purged survey data'
+				#Data only need to be purged once
+				OPTED_IN=1
 
 			fi
 
@@ -107,10 +109,10 @@ _EOF_
 
 		Read_Settings
 
-	#Create new file + generate UUID
+	#Force interactive user choice, if no settings file found = no choice made yet
 	else
 
-		Write_Settings
+		INPUT=0
 
 	fi
 
@@ -140,7 +142,7 @@ _EOF_
 	if (( $INPUT == 1 )); then
 
 		#Opted in - Setup and send
-		(( $OPTED_IN == 2 )) && Send_File
+		(( $OPTED_IN == 2 )) && Send_File && Write_Settings
 
 	else
 
@@ -177,11 +179,12 @@ Would you like to opt in for DietPi-Survey?"
 
 			fi
 
+			Write_Settings
+
 		fi
 
 	fi
 
-	Write_Settings
 	cd "$HOME"
 	rm -R "$FP_TMP"
 

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -43,7 +43,7 @@
 	FP_LOG='/var/tmp/dietpi/logs/dietpi-update.log'
 	DIETPIUPDATE_COREVERSION_CURRENT=6 # Version of dietpi-update / set server_version-6 line one to value++ and obsolete previous dietpi-update scripts
 
-	FILEPATH_TEMP="/tmp/dietpi-update"
+	FILEPATH_TEMP='/tmp/dietpi-update'
 
 	SERVER_ONLINE=0
 	UPDATE_AVAILABLE=0
@@ -104,7 +104,7 @@
 
 			G_DIETPI-NOTIFY 2 "Checking Mirror : ${URL_MIRROR_SERVERVERSION[$i]}"
 			curl -k -L "${URL_MIRROR_SERVERVERSION[$i]}" > "$FILEPATH_TEMP"/server_version
-			if (( $? == 0 )); then
+			if (( ! $? )); then
 
 				#Get server Version info
 				COREVERSION_SERVER=$(sed -n 1p "$FILEPATH_TEMP"/server_version)
@@ -115,7 +115,6 @@
 
 					SERVER_ONLINE=1
 					G_DIETPI-NOTIFY 0 "Using update server: ${URL_MIRROR_SERVERVERSION[$i]}"
-
 					break
 
 				else
@@ -203,7 +202,7 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 
 		#git clone Zip method (no need to install GIT)
 		curl -k -L "${URL_MIRROR_ZIP[$URL_MIRROR_INDEX]}" > "$FILEPATH_TEMP"/update.zip
-		if (( $? == 0 )); then
+		if (( ! $? )); then
 
 			l_message='Unpack update archieve' G_RUN_CMD unzip "$FILEPATH_TEMP"/update.zip -d "$FILEPATH_TEMP"/
 
@@ -312,9 +311,9 @@ _EOF_
 
 			#Insufficient free space
 			/DietPi/dietpi/dietpi-drive_manager 2
-			if (( $? != 0 )); then
+			if (( $? )); then
 
-				> /dev/null #exit normally for delete []
+				: #exit normally for delete []
 
 			#Noninteractive update
 			elif (( $INPUT == 1 )); then
@@ -357,6 +356,9 @@ _EOF_
 
 			#Remove update_available file
 			rm /DietPi/dietpi/.update_available &> /dev/null
+
+			#Update DietPi-Survey
+			/DietPi/dietpi/dietpi-survey 1
 
 			#Sync to disk now: http://dietpi.com/phpbb/viewtopic.php?f=9&t=2591
 			sync


### PR DESCRIPTION
+ DietPi-Update | Run DietPi-Survey at the end of successful DietPi-Update
+ DietPi-Survey | Force interactive user choice, if survey settings file does not exist.
+ DietPi-Survey | Only write settings file, if user successfully selected choice or successfully uploaded survey file.