### PR TITLE
Generel | Remove "net-tools" commands in favour of "ip" and "/proc/" + "/sys/" scraping

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ v6.10
 (xx/06/18)
 
 Changes / Improvements / Optimizations:
+General | "net-tools" commands (ifconfig, netstat, route, ...) were replaced by modern "ip" commands (ip a, ip r, ...) within DietPi scripts and the package therefore removed from DietPi core packages: https://github.com/Fourdee/DietPi/issues/1666
 DietPi-Survey | Simplified available options. You can now either Opt In, or Opt Out and automatically have any existing data cleared. Interactive installations will be prompted to Opt In or Out during 1st run. Automated installations are Opted In by default, you can change this at once setup is completed. More information on DietPi-Survey and how to change the options: https://dietpi.com/phpbb/viewtopic.php?f=8&t=20 https://github.com/Fourdee/DietPi/issues/1827#issuecomment-396005575
 
 Bug Fixes:

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -658,7 +658,6 @@ _EOF_
 		'isc-dhcp-client'	# DHCP client
 		'locales'		# Support locales, necessary for DietPi scripts, as we use enGB.UTF8 as default language
 		'nano'			# Simple text editor
-		'net-tools'		# Classic network commands: ifconfig, route, netstat
 		'ntfs-3g'		# DietPi-Drive_Manager NTPS (Windows) file system support
 		'p7zip-full'		# .7z wrapper
 		'parted'		# DietPi-Boot + DietPi-Drive_Manager

--- a/dietpi/boot
+++ b/dietpi/boot
@@ -252,25 +252,23 @@
 		while true
 		do
 
-			if (( $loop_count >= $max_loops )); then
+			if [[ $(ip r) =~ ' via ' ]]; then
 
-				G_DIETPI-NOTIFY 1 "$(date) | Valid connection wait timed out."
+				G_DIETPI-NOTIFY 0 "$(date) | Valid connection found."
+				# - Update network details (for IP in dietpi-banner etc..)
+				/DietPi/dietpi/func/obtain_network_details
+				# - Mount all drives again (eg: network shares)
+				mount -a
 				break
 
-			elif (( ! $(route | awk '{print $4}' | grep -ci -m1 'UG') )); then
+			elif (( $loop_count < $max_loops )); then
 
 				G_DIETPI-NOTIFY 2 "$(date) | Waiting for valid connection, before continuing boot | Mode=$boot_wait_for_network"
 				sleep 1
 
 			else
 
-				# - Update network details (for IP in dietpi-banner etc..)
-				G_DIETPI-NOTIFY 0 "$(date) | Valid connection found."
-				/DietPi/dietpi/func/obtain_network_details
-
-				#	Mount all drives again (eg: network shares)
-				mount -a
-
+				G_DIETPI-NOTIFY 1 "$(date) | Valid connection wait timed out."
 				break
 
 			fi

--- a/dietpi/dietpi-bugreport
+++ b/dietpi/dietpi-bugreport
@@ -46,8 +46,9 @@
 
 		'ls -lha /var/log'
 		'dpkg -l'
-		'ifconfig -a'
 		'ip a'
+		'ip r'
+		'ip l'
 		'lsusb'
 		'cat /proc/cpuinfo'
 		'ps aux'

--- a/dietpi/dietpi-cloudshell
+++ b/dietpi/dietpi-cloudshell
@@ -653,7 +653,7 @@
 
 		fi
 
-		#Ifconfig to /tmp
+		#ip a to /tmp
 		ip a s "$NETWORK_DETAILS_ADAPTER" > $FP_TEMP
 
 		#IP / MAC addresses

--- a/dietpi/dietpi-cloudshell
+++ b/dietpi/dietpi-cloudshell
@@ -634,7 +634,7 @@
 	NETWORK_DETAILS_MODE=0 #1=dhcp, 0=static
 	Obtain_NETWORK_DETAILS(){
 
-		FP_TEMP="/tmp/.ifconfig"
+		FP_TEMP="/tmp/.ip_address"
 
 		#Hostname
 		NETWORK_DETAILS_HOSTNAME=$(hostname)

--- a/dietpi/dietpi-cloudshell
+++ b/dietpi/dietpi-cloudshell
@@ -26,11 +26,7 @@
 
 	#Grab Input (valid interger)
 	INPUT=0
-	if G_CHECK_VALIDINT $1; then
-
-		INPUT=$1
-
-	fi
+	G_CHECK_VALIDINT $1 && INPUT=$1
 
 	#Version
 	DIETPI_CLOUDSHELL_VERSION=9
@@ -80,15 +76,15 @@
 
 		#BC - Add leading zero to start of .* string.
 		# +0
-		if [ "${return_value:0:1}" = "." ]; then
+		if [[ ${return_value:0:1} == '.' ]]; then
 
 			return_value="0$return_value"
 
 
 		# -0
-		elif [ "${return_value:0:2}" = "-." ]; then
+		elif [[ ${return_value:0:2} == '-.' ]]; then
 
-			return_value=$(echo -e "$return_value" | sed 's/^-./-0./')
+			return_value=$(sed 's/^-./-0./' <<< "$return_value")
 
 		fi
 
@@ -381,7 +377,7 @@
 	Obtain_CPU(){
 
 		CPU_TOTALPROCESSES=$(( $(ps --ppid 2 -p 2 --deselect | wc -l) - 2 )) # - ps process and descriptions.
-		CPU_GOV=$(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor)
+		CPU_GOV=$(</sys/devices/system/cpu/cpu0/cpufreq/scaling_governor)
 		CPU_TEMP=$(G_OBTAIN_CPU_TEMP)
 
 		if G_CHECK_VALIDINT $CPU_TEMP; then
@@ -412,13 +408,13 @@
 
 		fi
 
-		CPU_FREQ_1=$(( $(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq) / 1000 ))
+		CPU_FREQ_1=$(( $(</sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq) / 1000 ))
 		CPU_FREQ_2="N/A"
 
 		#Unique additional freq readout for Odroid XU4 (octo, 2nd quad set)
 		if (( $G_HW_MODEL == 11 )); then
 
-			CPU_FREQ_2=$(( $(cat /sys/devices/system/cpu/cpu4/cpufreq/scaling_cur_freq) / 1000 ))
+			CPU_FREQ_2=$(( $(</sys/devices/system/cpu/cpu4/cpufreq/scaling_cur_freq) / 1000 ))
 
 		fi
 
@@ -514,7 +510,7 @@
 		# - Wait X seconds before terminating the df thread
 		local max_seconds=4
 		local current_seconds=0
-		while (( $(ps aux | awk '{print $2}' | grep -ci -m1 "$pid$") )) # ! -f may exist, but no data at time of scrape, causing 'mount not found'. so lets wait for process to exit.
+		while ps aux | awk '{print $2}' | grep -q "$pid\$" # ! -f may exist, but no data at time of scrape, causing 'mount not found'. so lets wait for process to exit.
 		do
 
 			if (( $current_seconds >= $max_seconds )); then
@@ -556,12 +552,12 @@
 			for ((i=$index_start; i<=$index_end; i++))
 			do
 
-				if (( $(grep -ci -m1 "${STORAGE_PATH[$i]}$" $FP_TEMP) )); then
+				if grep -q "${STORAGE_PATH[$i]}\$" $FP_TEMP; then
 
-					STORAGE_TOTAL[$i]=$(grep -m1 "${STORAGE_PATH[$i]}$" $FP_TEMP | awk '{print $2}'); STORAGE_TOTAL[$i]+='B'
-					STORAGE_USED[$i]=$(grep -m1 "${STORAGE_PATH[$i]}$" $FP_TEMP | awk '{print $3}'); STORAGE_USED[$i]+='B'
-					STORAGE_FREE[$i]=$(grep -m1 "${STORAGE_PATH[$i]}$" $FP_TEMP | awk '{print $4}'); STORAGE_FREE[$i]+='B'
-					STORAGE_PERCENT[$i]=$(grep -m1 "${STORAGE_PATH[$i]}$" $FP_TEMP | awk '{print $5}' | sed 's/%//g')
+					STORAGE_TOTAL[$i]=$(grep -m1 "${STORAGE_PATH[$i]}\$" $FP_TEMP | awk '{print $2}'); STORAGE_TOTAL[$i]+='B'
+					STORAGE_USED[$i]=$(grep -m1 "${STORAGE_PATH[$i]}\$" $FP_TEMP | awk '{print $3}'); STORAGE_USED[$i]+='B'
+					STORAGE_FREE[$i]=$(grep -m1 "${STORAGE_PATH[$i]}\$" $FP_TEMP | awk '{print $4}'); STORAGE_FREE[$i]+='B'
+					STORAGE_PERCENT[$i]=$(grep -m1 "${STORAGE_PATH[$i]}\$" $FP_TEMP | awk '{print $5}' | sed 's/%//g')
 
 					Percent_To_Graph ${STORAGE_PERCENT[$i]}
 					STORAGE_PERCENT[$i]=$C_PERCENT_GRAPH
@@ -608,13 +604,13 @@
 
 		#DietPi-Update available?
 		DIETPI_UPDATE_AVAILABLE="N/A"
-		if [ -f /DietPi/dietpi/.update_available ]; then
+		if [[ -f /DietPi/dietpi/.update_available ]]; then
 
 			#Set current version to red
 			DIETPI_VERSION_CURRENT="${aCOLOUR[1]}$(sed -n 1p /DietPi/dietpi/.version).$(sed -n 2p /DietPi/dietpi/.version)$C_RESET"
 
 			local update_version=$(cat /DietPi/dietpi/.update_available)
-			if [ "$update_version" = '-1' ]; then
+			if [[ $update_version == '-1' ]]; then
 
 				DIETPI_UPDATE_AVAILABLE="${aCOLOUR[2]}New Image$C_RESET"
 
@@ -647,7 +643,7 @@
 		NETWORK_DETAILS_ADAPTER=$(sed -n 3p /DietPi/dietpi/.network)
 
 		#Mode (dhcp/static)
-		if (( $(grep -ci -m1 "iface $NETWORK_DETAILS_ADAPTER inet dhcp" /etc/network/interfaces) )); then
+		if grep -q "iface $NETWORK_DETAILS_ADAPTER inet dhcp" /etc/network/interfaces; then
 
 			NETWORK_DETAILS_MODE="Dhcp"
 
@@ -658,15 +654,15 @@
 		fi
 
 		#Ifconfig to /tmp
-		ifconfig $NETWORK_DETAILS_ADAPTER > $FP_TEMP
+		ip a s "$NETWORK_DETAILS_ADAPTER" > $FP_TEMP
 
 		#IP / MAC addresses
-		NETWORK_DETAILS_IP_INT=$(grep -m1 'inet ' "$FP_TEMP" | cut -d: -f2 | awk '{ print $1}')
-		NETWORK_DETAILS_MAC_ADDRESS=$(cat /sys/class/net/$NETWORK_DETAILS_ADAPTER/address)
+		NETWORK_DETAILS_IP_INT=$(grep -m1 '^[[:blank:]]*inet ' "$FP_TEMP" | awk '{ print $2 }' | sed 's|/.*$||')
+		NETWORK_DETAILS_MAC_ADDRESS=$(</sys/class/net/$NETWORK_DETAILS_ADAPTER/address)
 
 		#Speed/Strength
 		#Wifi
-		if (( $(echo $NETWORK_DETAILS_ADAPTER | grep -ci -m1 'wlan') == 1 )); then
+		if [[ $NETWORK_DETAILS_ADAPTER =~ 'wlan' ]]; then
 
 			NETWORK_DETAILS_SIGNAL_STRENGTH="$(iwconfig $NETWORK_DETAILS_ADAPTER | grep -m1 'Signal level=' | awk '{ print $4 }' | sed 's/level=//g' | cut -f1 -d "/")%"
 			NETWORK_DETAILS_DUPLEXSPEED="$(iwconfig $NETWORK_DETAILS_ADAPTER | grep -m1 'Bit Rate:' | awk '{ print $2 }' | sed 's/Rate://g')Mbit"
@@ -674,7 +670,7 @@
 		#Lan
 		else
 
-			NETWORK_DETAILS_DUPLEXSPEED="$(cat /sys/class/net/$NETWORK_DETAILS_ADAPTER/speed) Mbit"
+			NETWORK_DETAILS_DUPLEXSPEED="$(</sys/class/net/$NETWORK_DETAILS_ADAPTER/speed) Mbit"
 			#NETWORK_DETAILS_DUPLEXSPEED=$(mii-tool | awk '{print $3}')
 			NETWORK_DETAILS_SIGNAL_STRENGTH="N/A"
 
@@ -702,12 +698,10 @@
 		#Check for valid integer scrapes from netstat, before running calculations: http://dietpi.com/phpbb/viewtopic.php?f=11&t=441&p=1927#p1927 | https://github.com/Fourdee/DietPi/issues/355
 		local run_update=1
 
-		local mtu_size=$(netstat -N -i | grep "$NETWORK_DETAILS_ADAPTER" | awk '{print $2}')
-		local network_usage_current_recieved=$(netstat -N -i | grep "$NETWORK_DETAILS_ADAPTER" | awk '{print $4}')
-		local network_usage_current_sent=$(netstat -N -i | grep "$NETWORK_DETAILS_ADAPTER" | awk '{print $8}')
+		local network_usage_current_recieved=$(</sys/class/net/$NETWORK_DETAILS_ADAPTER/statistics/rx_bytes)
+		local network_usage_current_sent=$(</sys/class/net/$NETWORK_DETAILS_ADAPTER/statistics/tx_bytes)
 
-		if ! G_CHECK_VALIDINT $mtu_size ||
-			! G_CHECK_VALIDINT $network_usage_current_recieved ||
+		if ! G_CHECK_VALIDINT $network_usage_current_recieved ||
 			! G_CHECK_VALIDINT $network_usage_current_sent; then
 
 			run_update=0
@@ -721,8 +715,8 @@
 			local total_previous_recieved=$NETWORK_USAGE_TOTAL_CURRENT_RECIEVED
 
 			#Update current totals
-			NETWORK_USAGE_TOTAL_CURRENT_RECIEVED=$(( $network_usage_current_recieved * $mtu_size ))
-			NETWORK_USAGE_TOTAL_CURRENT_SENT=$(( $network_usage_current_sent * $mtu_size ))
+			NETWORK_USAGE_TOTAL_CURRENT_RECIEVED=$network_usage_current_recieved
+			NETWORK_USAGE_TOTAL_CURRENT_SENT=$network_usage_current_sent
 
 			#Current usage
 			# - Work out seconds since last update
@@ -746,12 +740,6 @@
 
 			# - Update timestamp
 			NETWORK_USAGE_SECONDS_SINCE_LAST_UPDATE=$(date +%s)
-
-			# - Ifconfig to /tmp
-			#ifconfig $NETWORK_DETAILS_ADAPTER > $FP_TEMP
-			#/sys/class/net/ values are being reset by system/kernel when they reach X size. Some sort of "cap".
-			#NETWORK_USAGE_TOTAL_CURRENT_SENT=$(( $(cat /sys/class/net/$NETWORK_DETAILS_ADAPTER/statistics/tx_bytes) / 1024 / 1024 ))
-			#NETWORK_USAGE_TOTAL_CURRENT_RECIEVED=$(( $(cat /sys/class/net/$NETWORK_DETAILS_ADAPTER/statistics/rx_bytes) / 1024 / 1024 ))
 
 			#Usage today
 			# - Has the day changed? Also runs on init.
@@ -837,7 +825,7 @@
 		#Lets pull the total number of blocked domains only once during 1st run, its quite cpu intensive.
 		if (( $PIHOLE_TOTAL_DOMAINS == 0 )); then
 
-			if [ -f /etc/pihole/gravity.list ]; then
+			if [[ -f /etc/pihole/gravity.list ]]; then
 
 				PIHOLE_TOTAL_DOMAINS=$(wc -l /etc/pihole/gravity.list | awk '{print $1}')
 
@@ -1220,11 +1208,11 @@
 	# Settings File
 	#/////////////////////////////////////////////////////////////////////////////////////
 	#Define Location
-	FILEPATH_SETTINGS="/DietPi/dietpi/.dietpi-cloudshell"
+	FILEPATH_SETTINGS='/DietPi/dietpi/.dietpi-cloudshell'
 
 	Read_Settings_File(){
 
-		if [ -f "$FILEPATH_SETTINGS" ]; then
+		if [[ -f $FILEPATH_SETTINGS ]]; then
 
 			. "$FILEPATH_SETTINGS"
 
@@ -1291,7 +1279,7 @@ _EOF_
 		#--------------------------------------------------------------------------------
 		#Check and disable scenes if software is not installed:
 		# 6 Pi-hole
-		if [ ! -f /etc/pihole/gravity.list ]; then
+		if [[ ! -f /etc/pihole/gravity.list ]]; then
 
 			aEnabledScenes[8]=0
 
@@ -1351,7 +1339,7 @@ _EOF_
 
 		#Are we starting on the current screen? (eg: from tty1)
 		local output_current_screen=0
-		if [ "$(tty)" = "/dev/tty1" ]; then
+		if [[ $(tty) == '/dev/tty1' ]]; then
 
 			output_current_screen=1
 
@@ -1470,19 +1458,19 @@ _EOF_
 
 			case "$G_WHIP_RETURNED_VALUE" in
 
-				"Storage")
+				'Storage')
 
 					TARGETMENUID=5
 
 				;;
 
-				"Auto screen off")
+				'Auto screen off')
 
 					TARGETMENUID=4
 
 				;;
 
-				"Net Usage Current")
+				'Net Usage Current')
 
 					((NETWORK_USAGE_CURRENT_OUTPUT_TYPE++))
 					if (( $NETWORK_USAGE_CURRENT_OUTPUT_TYPE > 1 )); then
@@ -1504,7 +1492,7 @@ _EOF_
 
 				;;
 
-				"Output Display")
+				'Output Display')
 
 					((OUTPUT_DISPLAY_INDEX++))
 					if (( $OUTPUT_DISPLAY_INDEX > 1 )); then
@@ -1515,7 +1503,7 @@ _EOF_
 
 				;;
 
-				"Start / Restart")
+				'Start / Restart')
 
 					Write_Settings_File
 					Stop
@@ -1523,7 +1511,7 @@ _EOF_
 
 				;;
 
-				"Stop")
+				'Stop')
 
 					Stop
 
@@ -1535,7 +1523,7 @@ _EOF_
 
 				;;
 
-				"Update Rate")
+				'Update Rate')
 
 					TARGETMENUID=2
 
@@ -1706,7 +1694,7 @@ _EOF_
 		G_WHIP_MENU 'Automatically power down the screen and disable DietPi-Cloudshell processing during a specific time.\n\nNB: This feature will only work if DietPi-Cloudshell was launched with the DietPi-Autostart option, or, launched from the main screen (tty1).'
 		if (( $? == 0 )); then
 
-			if [ "$G_WHIP_RETURNED_VALUE" = "Toggle" ];then
+			if [[ $G_WHIP_RETURNED_VALUE == 'Toggle' ]];then
 
 				((BLANK_SCREEN_AT_SPECIFIC_TIME_ENABLED++))
 				if (( $BLANK_SCREEN_AT_SPECIFIC_TIME_ENABLED > 1 )); then
@@ -1715,7 +1703,7 @@ _EOF_
 
 				fi
 
-			elif [ "$G_WHIP_RETURNED_VALUE" = "Start time" ];then
+			elif [[ $G_WHIP_RETURNED_VALUE == 'Start time' ]];then
 
 				G_WHIP_MENU_ARRAY=()
 				for ((i=0; i<24; i++))
@@ -1733,7 +1721,7 @@ _EOF_
 
 				fi
 
-			elif [ "$G_WHIP_RETURNED_VALUE" = "End time" ];then
+			elif [[ $G_WHIP_RETURNED_VALUE == 'End time' ]];then
 
 				G_WHIP_MENU_ARRAY=()
 				for ((i=0; i<24; i++))
@@ -1780,8 +1768,8 @@ _EOF_
 			local index=$G_WHIP_RETURNED_VALUE
 
 			/DietPi/dietpi/dietpi-drive_manager 1
-			local return_string="$(cat /tmp/dietpi-drive_manager_selmnt)"
-			if [ -n "$return_string" ]; then
+			local return_string="$(</tmp/dietpi-drive_manager_selmnt)"
+			if [[ $return_string ]]; then
 
 				STORAGE_PATH[$index]="$return_string"
 

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -3146,8 +3146,37 @@
 
 		#??????????????????????????????????????????????????????
 
+		# Convert CIDR integer to net mask, e.g. "192.168.0.100/24" (take "24") to "255.255.255.0"
+		cidr2mask() {
+
+			local i mask=''
+			local full_octets=$(( $1 / 8 ))
+			local partial_octet=$(( $1%8 ))
+
+			for ((i=0; i<4; i++)); do
+
+				if [[ $i -lt $full_octets ]]; then
+
+					mask+=255
+
+				elif [[ $i -eq $full_octets ]]; then
+
+					mask+=$(( 256 - 2 ** ( 8 - $partial_octet ) ))
+
+				else
+
+					mask+=0
+
+				fi
+				test $i -lt 3 && mask+=.
+
+			done
+			echo "$mask"
+
+		}
+
 		#eth
-		if [ -d /sys/class/net/eth$ETH_INDEX ]; then
+		if [[ -d /sys/class/net/eth$ETH_INDEX ]]; then
 
 			#Hardware
 			ETH_HARDWARE=1
@@ -3162,16 +3191,16 @@
 			#Enabled and Connected
 			if (( $ETH_DISABLED == 0 && $ETH_CONNECTED == 1 )); then
 
-				ETH_IP=$(ifconfig eth$ETH_INDEX | grep -m1 'inet' | awk '{ print $2 }' | sed 's/addr://g')
+				ETH_IP=$(ip a s $ETH_INDEX | grep -m1 '^[[:blank:]]*inet ' | awk '{ print $2 }' | sed 's|/.*$||')
 				ETH_GATEWAY=$(ip r | grep -m1 'default' | awk '{ print $3 }')
-				ETH_MASK=$(ifconfig eth$ETH_INDEX | grep -m1 'inet' | awk '{ print $4 }' | sed 's/Mask://g')
+				ETH_MASK=$(cidr2mask $(ip a s $ETH_INDEX | grep -m1 '^[[:blank:]]*inet ' | awk '{ print $2 }' | sed 's|^.*/||'))
 				ETH_DNS=$(grep -m1 'nameserver' /etc/resolv.conf | awk '{print $2}')
 
 			fi
 
 		fi
 
-		if [ -d /sys/class/net/wlan$WIFI_INDEX ]; then
+		if [[ -d /sys/class/net/wlan$WIFI_INDEX ]]; then
 
 			#Hardware
 			WIFI_HARDWARE=1
@@ -3190,9 +3219,9 @@
 			#Enabled and Connected
 			if (( $WIFI_DISABLED == 0 && $WIFI_CONNECTED == 1 )); then
 
-				WIFI_IP=$(ifconfig wlan$WIFI_INDEX | grep -m1 'inet' | awk '{ print $2 }' | sed 's/addr://g')
+				WIFI_IP=$(ip a s $WIFI_INDEX | grep -m1 '^[[:blank:]]*inet ' | awk '{ print $2 }' | sed 's|/.*$||')
 				WIFI_GATEWAY=$(ip r | grep -m1 'default' | awk '{ print $3 }')
-				WIFI_MASK=$(ifconfig wlan$WIFI_INDEX | grep -m1 'inet' | awk '{ print $4 }' | sed 's/Mask://g')
+				WIFI_MASK=$(cidr2mask $(ip a s $WIFI_INDEX | grep -m1 '^[[:blank:]]*inet ' | awk '{ print $2 }' | sed 's|^.*/||'))
 				WIFI_DNS=$(grep -m1 'nameserver' /etc/resolv.conf | awk '{print $2}')
 
 				#Get extra wifi stats
@@ -3298,7 +3327,7 @@
 		#IPv6 status
 		local ipv6_enabled=1
 		local ipv6_status_text='[On]'
-		if [ ! -d /proc/sys/net/ipv6 ]; then
+		if [[ ! -d /proc/sys/net/ipv6 ]]; then
 
 			ipv6_enabled=0
 			ipv6_status_text='[Off]'
@@ -3325,7 +3354,7 @@
 		#	RPi 3/ZeroW
 		if (( $HW_ONBOARD_WIFI )); then
 
-			if [ -f /etc/modprobe.d/disable_wifi_rpi3_onboard.conf ]; then
+			if [[ -f /etc/modprobe.d/disable_wifi_rpi3_onboard.conf ]]; then
 
 				onboard_wifi_enabled=0
 				G_WHIP_MENU_ARRAY+=('Onboard WiFi' '[Off] | select to toggle')
@@ -3347,7 +3376,7 @@
 
 			case "$G_WHIP_RETURNED_VALUE" in
 
-				"Onboard WiFi")
+				'Onboard WiFi')
 
 					if (( $onboard_wifi_enabled )); then
 
@@ -3395,11 +3424,7 @@
 							# - APT force IPv4
 							echo 'Acquire::ForceIPv4 "true";' > /etc/apt/apt.conf.d/99-dietpi-force-ipv4
 							# - Wget prefer IPv4
-							grep -q '^[[:blank:]]*prefer-family =' /etc/wgetrc &&
-							sed -i '/^[[:blank:]]*prefer-family =/c\prefer-family = IPv4' /etc/wgetrc ||
-							grep -q '^[[:blank:]#;]*prefer-family =' /etc/wgetrc &&
-							sed -i '/^[[:blank:]#;]*prefer-family =/c\prefer-family = IPv4' /etc/wgetrc ||
-							echo 'prefer-family = IPv4' >> /etc/wgetrc
+							G_CONFIG_INJECT 'prefer-family =' 'prefer-family = IPv4' /etc/wgetrc
 							REBOOT_REQUIRED=1
 
 						fi
@@ -3424,11 +3449,7 @@
 							# - APT allow IPv6 but do not force it: https://github.com/Fourdee/DietPi/issues/472#issuecomment-356444922
 							rm /etc/apt/apt.conf.d/99-dietpi-force-ipv4 &> /dev/null
 							# - Wget prefer IPv6
-							grep -q '^[[:blank:]]*prefer-family =' /etc/wgetrc &&
-							sed -i '/^[[:blank:]]*prefer-family =/c\prefer-family = IPv6' /etc/wgetrc ||
-							grep -q '^[[:blank:]#;]*prefer-family =' /etc/wgetrc &&
-							sed -i '/^[[:blank:]#;]*prefer-family =/c\prefer-family = IPv6' /etc/wgetrc ||
-							echo 'prefer-family = IPv6' >> /etc/wgetrc
+							G_CONFIG_INJECT 'prefer-family =' 'prefer-family = IPv6' /etc/wgetrc
 							REBOOT_REQUIRED=1
 
 						fi
@@ -3576,7 +3597,7 @@
 
 		G_WHIP_MENU_ARRAY=()
 
-		G_WHIP_MENU_ARRAY+=("Change Mode" "$mode_target")
+		G_WHIP_MENU_ARRAY+=('Change Mode' "$mode_target")
 		# - show static options
 		if (( $ETH_MODE_TARGET == 0 )); then
 
@@ -3633,7 +3654,6 @@
 				'Apply')
 
 					Ethernet_Reconnect
-
 					#Return to this menu
 					TARGETMENUID=9
 
@@ -3691,7 +3711,7 @@
 
 	WiFi_Monitor_Disable(){
 
-		if [ -f /etc/systemd/system/dietpi-wifi-monitor.service ]; then
+		if [[ -f /etc/systemd/system/dietpi-wifi-monitor.service ]]; then
 
 			systemctl stop dietpi-wifi-monitor.service
 			rm /etc/systemd/system/dietpi-wifi-monitor.service
@@ -3820,7 +3840,7 @@ _EOF_
 
 				local wifi_auto_reconnect_text='[Off]'
 				WIFI_AUTO_RECONNECT_ACTIVE=0
-				if (( $(systemctl is-active dietpi-wifi-monitor.service | grep -ci -m1 '^active') )); then
+				if systemctl is-active dietpi-wifi-monitor.service | grep -qi '^active'; then
 
 					WIFI_AUTO_RECONNECT_ACTIVE=1
 					wifi_auto_reconnect_text='[On]'
@@ -3837,10 +3857,10 @@ _EOF_
 			if (( $WIFI_MODE_TARGET == 0 )); then
 
 				G_WHIP_MENU_ARRAY+=('Copy' 'Copy Current address to Static')
-				G_WHIP_MENU_ARRAY+=("Static Ip" ": $WIFI_IP_STATIC")
-				G_WHIP_MENU_ARRAY+=("Static Mask" ": $WIFI_MASK_STATIC")
-				G_WHIP_MENU_ARRAY+=("Static Gateway" ": $WIFI_GATEWAY_STATIC")
-				G_WHIP_MENU_ARRAY+=("Static DNS" ": $WIFI_DNS_STATIC")
+				G_WHIP_MENU_ARRAY+=('Static Ip' ": $WIFI_IP_STATIC")
+				G_WHIP_MENU_ARRAY+=('Static Mask' ": $WIFI_MASK_STATIC")
+				G_WHIP_MENU_ARRAY+=('Static Gateway' ": $WIFI_GATEWAY_STATIC")
+				G_WHIP_MENU_ARRAY+=('Static DNS' ": $WIFI_DNS_STATIC")
 
 			fi
 
@@ -3992,7 +4012,7 @@ _EOF_
 
 				;;
 
-				"Change Mode")
+				'Change Mode')
 
 					((WIFI_MODE_TARGET++))
 					if (( $WIFI_MODE_TARGET >= 2 )); then
@@ -4556,7 +4576,7 @@ Custom     : Write = $CUSTOM_WRITE | Read = $CUSTOM_READ"
 		#Overclocking Pi1
 		# - Zero
 		echo -e "$G_HW_MODEL"
-		if (( $(cat /DietPi/dietpi/.hw_model | tr '[:upper:]' '[:lower:]' | grep -ci -m1 'rpi zero') )); then
+		if cat /DietPi/dietpi/.hw_model | tr '[:upper:]' '[:lower:]' | grep -qi 'rpi zero'; then
 
 			G_WHIP_MENU_ARRAY=(
 
@@ -4738,7 +4758,7 @@ Custom     : Write = $CUSTOM_WRITE | Read = $CUSTOM_READ"
 		#Overclocking Pi3
 		elif (( $G_HW_MODEL == 3 )); then
 
-			if (( $(grep -ci -m1 'RPi 3 Model B+' /DietPi/dietpi/.hw_model) )); then
+			if grep -qi 'RPi 3 Model B+' /DietPi/dietpi/.hw_model; then
 
 				G_WHIP_MENU_ARRAY=(
 
@@ -4837,13 +4857,13 @@ Custom     : Write = $CUSTOM_WRITE | Read = $CUSTOM_READ"
 
 		TARGETMENUID=0
 
-		local soundcard_current=$(grep -m1 '^CONFIG_SOUNDCARD=' /DietPi/dietpi.txt | sed 's/.*=//')
+		local soundcard_current=$(grep -m1 '^[[:blank:]]*CONFIG_SOUNDCARD=' /DietPi/dietpi.txt | sed 's/^.*=//')
 
 		G_WHIP_MENU_ARRAY=()
 
-		G_WHIP_MENU_ARRAY+=("Soundcard" ": $soundcard_current")
+		G_WHIP_MENU_ARRAY+=('Soundcard' ": $soundcard_current")
 
-		if (( $(dpkg --get-selections | grep -ci -m1 '^alsa-utils') )); then
+		if dpkg --get-selections | grep -qi '^alsa-utils'; then
 
 			G_WHIP_MENU_ARRAY+=('DietPi-JustBoom' ': Launches EQ and MPD audio options menu')
 
@@ -4855,7 +4875,7 @@ Custom     : Write = $CUSTOM_WRITE | Read = $CUSTOM_READ"
 			local current_cpu_governor=$(grep -m1 '^CONFIG_CPU_GOVERNOR=' /DietPi/dietpi.txt | sed 's/.*=//')
 			local hdmi_output=$(grep -m1 'CONFIG_HDMI_OUTPUT=' /DietPi/dietpi.txt | sed 's/.*=//')
 			local psu_noise_reduction_enabled=0
-			if [ "$current_cpu_governor" = "powersave" ] && (( ! $hdmi_output )); then
+			if [[ $current_cpu_governor == 'powersave' ]] && (( ! $hdmi_output )); then
 
 				G_WHIP_MENU_ARRAY+=('PSU noise reduction' ': Enabled | Select now to disable')
 				psu_noise_reduction_enabled=1
@@ -4871,7 +4891,7 @@ Custom     : Write = $CUSTOM_WRITE | Read = $CUSTOM_READ"
 		G_WHIP_MENU "Please select an option:"
 		if (( $? == 0 )); then
 
-			if [ "$G_WHIP_RETURNED_VALUE" = "PSU noise reduction" ]; then
+			if [[ $G_WHIP_RETURNED_VALUE == 'PSU noise reduction' ]]; then
 
 				if (( ! $psu_noise_reduction_enabled )); then
 
@@ -4894,7 +4914,7 @@ Custom     : Write = $CUSTOM_WRITE | Read = $CUSTOM_READ"
 				#Return to This Menu
 				TARGETMENUID=14
 
-			elif [ "$G_WHIP_RETURNED_VALUE" = "Soundcard" ]; then
+			elif [[ $G_WHIP_RETURNED_VALUE == 'Soundcard' ]]; then
 
 				G_WHIP_MENU_ARRAY=()
 
@@ -4915,7 +4935,7 @@ Custom     : Write = $CUSTOM_WRITE | Read = $CUSTOM_READ"
 					G_WHIP_MENU_ARRAY+=('default' 'HW:0,0')
 
 					#	Install prereqs to allow for detection
-					if (( ! $(dpkg --get-selections | grep -ci -m1 '^alsa-utils') )); then
+					if dpkg --get-selections | grep -qi '^alsa-utils'; then
 
 						/DietPi/dietpi/func/dietpi-set_hardware soundcard default
 
@@ -4924,12 +4944,12 @@ Custom     : Write = $CUSTOM_WRITE | Read = $CUSTOM_READ"
 					for ((i=0; i<10; i++))
 					do
 
-						if [ -f /proc/asound/card$i/id ]; then
+						if [[ -f /proc/asound/card$i/id ]]; then
 
 							for ((j=0; j<10; j++))
 							do
 
-								if [ -f /proc/asound/card$i/pcm${j}p/info ]; then
+								if [[ -f /proc/asound/card$i/pcm${j}p/info ]]; then
 
 									local card_index=$(cat /proc/asound/card$i/pcm${j}p/info | grep -m1 '^card:' | awk '{print $2}')
 									local device_index=$(cat /proc/asound/card$i/pcm${j}p/info | grep -m1 '^device:' | awk '{print $2}')
@@ -5090,7 +5110,7 @@ Custom     : Write = $CUSTOM_WRITE | Read = $CUSTOM_READ"
 		G_WHIP_MENU "Please select an option:"
 		if (( $? == 0 )); then
 
-			if [ "$G_WHIP_RETURNED_VALUE" = "Duration" ]; then
+			if [[ $G_WHIP_RETURNED_VALUE == 'Duration' ]]; then
 
 				G_WHIP_MENU_ARRAY=(
 
@@ -5111,7 +5131,7 @@ Custom     : Write = $CUSTOM_WRITE | Read = $CUSTOM_READ"
 
 				fi
 
-			elif [ "$G_WHIP_RETURNED_VALUE" = "Mode" ]; then
+			elif [[ $G_WHIP_RETURNED_VALUE == 'Mode' ]]; then
 
 				G_WHIP_MENU_ARRAY=(
 
@@ -5130,7 +5150,7 @@ Custom     : Write = $CUSTOM_WRITE | Read = $CUSTOM_READ"
 
 				fi
 
-			elif [ "$G_WHIP_RETURNED_VALUE" = "Start" ]; then
+			elif [[ $G_WHIP_RETURNED_VALUE == 'Start' ]]; then
 
 				G_AG_CHECK_INSTALL_PREREQ stress
 				if (( $? != 0 )); then
@@ -5178,7 +5198,7 @@ Custom     : Write = $CUSTOM_WRITE | Read = $CUSTOM_READ"
 
 				# - Loop until stress completed
 				local remaning_time=0
-				while (( $(ps aux | grep -ci -m1 '[s]tress') == 1 ))
+				while ps aux | grep -qi '[s]tress'
 				do
 
 					cpu_temp=$(G_OBTAIN_CPU_TEMP)
@@ -5254,7 +5274,7 @@ Custom     : Write = $CUSTOM_WRITE | Read = $CUSTOM_READ"
 			sambaclient_menutext='Input/Modify Details'
 
 			#Check if mount exists and is valid
-			if (( $(df -h | grep -ci -m1 '/mnt/samba') == 1 )); then
+			if df -h | grep -qi '/mnt/samba'; then
 
 				#Get stats
 				sambaclient_mounted_size=$(df -h | grep -m1 '/mnt/samba' | awk '{print $(NF-4)}')
@@ -5277,7 +5297,7 @@ Custom     : Write = $CUSTOM_WRITE | Read = $CUSTOM_READ"
 			curlftpfs_menutext='Input/Modify Details'
 
 			#Check if mount exists and is valid
-			if (( $(df -h | grep -ci -m1 '/mnt/ftp_client') == 1 )); then
+			if df -h | grep -qi '/mnt/ftp_client'; then
 
 				#Get stats
 				curlftpfs_status='/mnt/ftp_client | Connected'
@@ -5297,7 +5317,7 @@ Custom     : Write = $CUSTOM_WRITE | Read = $CUSTOM_READ"
 			noip_menutext='Enter/Setup NoIp Details'
 
 			#Check if noip is running (indicates login details are valid)
-			if (( $(ps aux | grep -ci -m1 '/usr/local/bin/[n]oip2') == 1 )); then
+			if ps aux | grep -qi '/usr/local/bin/[n]oip2'; then
 
 				noip_status='Online / Active'
 				noip_menutext='Change NoIp Details'
@@ -5320,7 +5340,7 @@ Custom     : Write = $CUSTOM_WRITE | Read = $CUSTOM_READ"
 			nfsclient_menutext='Input/Modify Details'
 
 			#Check if mount exists and is valid
-			if (( $(df -h | grep -ci -m1 '/mnt/nfs_client') == 1 )); then
+			if df -h | grep -qi '/mnt/nfs_client'; then
 
 				#Get stats
 				nfsclient_mounted_size=$(df -h | grep -m1 '/mnt/nfs_client' | awk '{ print $2 }')
@@ -5334,7 +5354,7 @@ Custom     : Write = $CUSTOM_WRITE | Read = $CUSTOM_READ"
 
 		#Apt mirror
 		local apt_mirror_current=$(sed -n 1p /etc/apt/sources.list | awk '{print $2}')
-		if [ ! -n "$apt_mirror_current" ]; then
+		if [[ -z $apt_mirror_current ]]; then
 
 			apt_mirror_current='Unknown, no string from scrape'
 
@@ -5342,14 +5362,14 @@ Custom     : Write = $CUSTOM_WRITE | Read = $CUSTOM_READ"
 
 		#NTPD mirror
 		local ntpd_mirror_current=$(grep -m1 '^CONFIG_NTP_MIRROR=' /DietPi/dietpi.txt | sed 's/.*=//')
-		if [ ! -n "$ntpd_mirror_current" ]; then
+		if [[ -z $ntpd_mirror_current ]]; then
 
 			ntpd_mirror_current='Unknown, no string from scrape'
 
 		fi
 
 		#Network boot wait
-		local boot_wait_for_network=$(grep -m1 '^CONFIG_BOOT_WAIT_FOR_NETWORK=' /DietPi/dietpi.txt | sed 's/.*=//')
+		local boot_wait_for_network=$(grep -m1 '^[[:blank:]]*CONFIG_BOOT_WAIT_FOR_NETWORK=' /DietPi/dietpi.txt | sed 's/^.*=//')
 		local boot_wait_for_network_text=': '
 		if (( $boot_wait_for_network == 0 )); then
 
@@ -5367,13 +5387,13 @@ Custom     : Write = $CUSTOM_WRITE | Read = $CUSTOM_READ"
 
 		G_WHIP_MENU_ARRAY=(
 
-			"Samba Client" "$sambaclient_menutext"
-			"FTP Client" "$curlftpfs_menutext"
-			"NFS Client" "$nfsclient_menutext"
-			"NoIp" "$noip_menutext"
-			"APT Mirror" "Select a different Apt mirror for sources.list"
-			"NTPD Mirror" "Select a different NTPD mirror"
-			"Boot Net Wait" "$boot_wait_for_network_text"
+			'Samba Client' "$sambaclient_menutext"
+			'FTP Client' "$curlftpfs_menutext"
+			'NFS Client' "$nfsclient_menutext"
+			'NoIp' "$noip_menutext"
+			'APT Mirror' "Select a different Apt mirror for sources.list"
+			'NTPD Mirror' "Select a different NTPD mirror"
+			'Boot Net Wait' "$boot_wait_for_network_text"
 
 		)
 
@@ -5465,11 +5485,11 @@ Custom     : Write = $CUSTOM_WRITE | Read = $CUSTOM_READ"
 						/DietPi/dietpi/func/dietpi-set_software apt-mirror $G_WHIP_RETURNED_VALUE
 
 						# - test it
-						G_DIETPI-NOTIFY 2 "Updating APT, please wait..."
+						G_DIETPI-NOTIFY 2 'Updating APT, please wait...'
 
 						G_AGUP
 						local exit_code=$?
-						if (( $exit_code != 0 )); then
+						if (( $exit_code )); then
 
 							G_WHIP_MSG "Failed to update APT, exit code: $exit_code.\n\nIf problems persist, please try another APT mirror."
 
@@ -5659,11 +5679,11 @@ Custom     : Write = $CUSTOM_WRITE | Read = $CUSTOM_READ"
 	#So we can call this in other menus (eg: submenu of this)
 	Load_Proxy_Vars(){
 
-		PROXY_ENABLED=$(cat /DietPi/dietpi.txt | grep -m1 '^CONFIG_PROXY_ENABLED=' | sed 's/.*=//')
-		PROXY_ADDRESS=$(cat /DietPi/dietpi.txt | grep -m1 '^CONFIG_PROXY_ADDRESS=' | sed 's/.*=//')
-		PROXY_PORT=$(cat /DietPi/dietpi.txt | grep -m1 '^CONFIG_PROXY_PORT=' | sed 's/.*=//')
-		PROXY_USERNAME=$(cat /DietPi/dietpi.txt | grep -m1 '^CONFIG_PROXY_USERNAME=' | sed 's/.*=//')
-		PROXY_PASSWORD=$(cat /DietPi/dietpi.txt | grep -m1 '^CONFIG_PROXY_PASSWORD=' | sed 's/.*=//')
+		PROXY_ENABLED=$(cat /DietPi/dietpi.txt | grep -m1 '^[[:blank:]]*CONFIG_PROXY_ENABLED=' | sed 's/^.*=//')
+		PROXY_ADDRESS=$(cat /DietPi/dietpi.txt | grep -m1 '^[[:blank:]]*CONFIG_PROXY_ADDRESS=' | sed 's/^.*=//')
+		PROXY_PORT=$(cat /DietPi/dietpi.txt | grep -m1 '^[[:blank:]]*CONFIG_PROXY_PORT=' | sed 's/^.*=//')
+		PROXY_USERNAME=$(cat /DietPi/dietpi.txt | grep -m1 '^[[:blank:]]*CONFIG_PROXY_USERNAME=' | sed 's/^.*=//')
+		PROXY_PASSWORD=$(cat /DietPi/dietpi.txt | grep -m1 '^[[:blank:]]*CONFIG_PROXY_PASSWORD=' | sed 's/^.*=//')
 
 	}
 
@@ -5695,12 +5715,12 @@ Custom     : Write = $CUSTOM_WRITE | Read = $CUSTOM_READ"
 
 		G_WHIP_MENU_ARRAY=(
 
-			"Toggle" "Use Proxy?: $proxy_state_text_new"
-			"Address" "Enter Proxy server IP/URL"
-			"Port" "Enter Proxy server port"
-			"Username" "Enter Proxy server username"
-			"Password" "Enter Proxy server password"
-			"Apply" "Save Changes"
+			'Toggle' "Use Proxy?: $proxy_state_text_new"
+			'Address' 'Enter Proxy server IP/URL'
+			'Port' 'Enter Proxy server port'
+			'Username' 'Enter Proxy server username'
+			'Password' 'Enter Proxy server password'
+			'Apply' 'Save Changes'
 
 		)
 
@@ -5800,7 +5820,7 @@ Custom     : Write = $CUSTOM_WRITE | Read = $CUSTOM_READ"
 					# - Add export settings
 					if (( $PROXY_ENABLED == 1 )); then
 
-						if [ -n "$PROXY_USERNAME" ] && [ -n "$PROXY_PASSWORD" ]; then
+						if [[ $PROXY_USERNAME ]] && [[ $PROXY_PASSWORD ]]; then
 							cat << _EOF_ >> /etc/bash.bashrc
 export {http,https,ftp}_proxy="http://$PROXY_USERNAME:$PROXY_PASSWORD@$PROXY_ADDRESS:$PROXY_PORT"
 _EOF_
@@ -5932,7 +5952,7 @@ _EOF_
 
 	else
 
-		echo -e " >> Filesystem prep has not yet completed: \n Please wait for the system to reboot "
+		echo -e ' >> Filesystem prep has not yet completed: \n Please wait for the system to reboot '
 
 	fi
 


### PR DESCRIPTION
Ref: https://github.com/Fourdee/DietPi/issues/1666
+ DietPi-Cloudshell | Replace "net-tools" commands with "ip" and "/proc/sys/net" or "/sys/class/net/" where applicable.
+ DietPi-Cloudshell | General code rework
NB: #/sys/class/net/ values are being reset by system/kernel when they reach X size. Some sort of "cap".
	- Retest? Even on long time running dietpi.com server, values match with output of currently used "netstat -i"
	- Alternative "cat /proc/sys/net"?
	- Otherwise workaround/fail_safe by sum new value to old value, if (( $NETWORK_USAGE_TOTAL_CURRENT_RECIEVED < $total_previous_recieved ))?
_______________________
+ DietPi-Boot | Switch from "net-tools" commands (route) to "ip" commands (ip r)
+ DietPi-Bugreport | Replace "net-tools" commands (ifconfig) with "ip" commands (ip a + ip r + ip l to not miss something)
+ DietPi-Config | Replace "ifconfig" with "ip a", add CIDR to mask function to generate e.g. 255.255.255.0 out of 192.168.0.100/**24**
+ DietPi-Config | General code improvements
+ DietPi-PREP | Remove "net-tools" from DietPi core packages
+ Changelog entry