### PR TITLE
DietPi-Obtain_network_details | Prefer and use only active network devices to estimate IP

### DIFF
--- a/dietpi/dietpi-cloudshell
+++ b/dietpi/dietpi-cloudshell
@@ -137,7 +137,7 @@
 		# - Kbit
 		if (( $1 < 1000000 )); then
 
-				return_value="$(echo "scale=$decimal_count; $1 * 8 / 1000" | bc -l) Kbit"
+			return_value="$(echo "scale=$decimal_count; $1 * 8 / 1000" | bc -l) Kbit"
 
 		# - MBit
 		elif (( $1 < 1000000000 )); then
@@ -176,11 +176,11 @@
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Colours
 	#/////////////////////////////////////////////////////////////////////////////////////
-	C_RESET="\e[0m"
-	C_REVERSE="\e[7m"
+	C_RESET='\e[0m'
+	C_REVERSE='\e[7m'
 
 	#C_BOLD makes normal text "brighter"
-	C_BOLD="\e[1m"
+	C_BOLD='\e[1m'
 
 	#Colour array
 	#0 WHITE
@@ -193,14 +193,14 @@
 	#7 TEST
 	aCOLOUR=(
 
-		"\e[39m"
-		"\e[31m"
-		"\e[32m"
-		"\e[33m"
-		"\e[34m"
-		"\e[35m"
-		"\e[36m"
-		"\e[93m"
+		'\e[39m'
+		'\e[31m'
+		'\e[32m'
+		'\e[33m'
+		'\e[34m'
+		'\e[35m'
+		'\e[36m'
+		'\e[93m'
 
 	)
 
@@ -334,7 +334,7 @@
 	UPTIME=0
 	Obtain_UPTIME(){
 
-		local fSeconds=$(cat /proc/uptime | awk '{print $1}')
+		local fSeconds=$(awk '{print $1}' <<< $(</proc/uptime))
 
 		local seconds=${fSeconds%.*}
 		local minutes=0
@@ -409,7 +409,7 @@
 		fi
 
 		CPU_FREQ_1=$(( $(</sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq) / 1000 ))
-		CPU_FREQ_2="N/A"
+		CPU_FREQ_2='N/A'
 
 		#Unique additional freq readout for Odroid XU4 (octo, 2nd quad set)
 		if (( $G_HW_MODEL == 11 )); then
@@ -419,10 +419,10 @@
 		fi
 
 		CPU_USAGE=0
-		FP_TEMP="/tmp/.cpu_usage"
+		FP_TEMP='/tmp/.cpu_usage'
 
 		# PS (inaccurate)
-		ps -axo %cpu | sed '1d' | sed 's/ //' > "$FP_TEMP"
+		ps -axo %cpu | sed '1d' | sed 's/ //' > $FP_TEMP
 		while read -r line
 		do
 
@@ -498,8 +498,8 @@
 		local index_start=$1
 		local index_end=$2
 
-		FP_TEMP="/tmp/.df"
-		rm "$FP_TEMP"
+		FP_TEMP='/tmp/.df'
+		rm $FP_TEMP
 
 		#df will endless hang when NFS server is down: https://github.com/Fourdee/DietPi/issues/395
 		# - So lets run it as another thread so we can kill it if it hangs.
@@ -577,8 +577,8 @@
 					echo -e "$(date) | Mount not found:\n" >> /var/log/dietpi-cloudshell.log
 					echo -e " - Index = $i" >> /var/log/dietpi-cloudshell.log
 					echo -e " - Path  = ${STORAGE_PATH[$i]}\n" >> /var/log/dietpi-cloudshell.log
-					cat "$FP_TEMP" >> /var/log/dietpi-cloudshell.log
-					echo -e "\n" >> /var/log/dietpi-cloudshell.log
+					cat $FP_TEMP >> /var/log/dietpi-cloudshell.log
+					echo -e '\n' >> /var/log/dietpi-cloudshell.log
 
 				fi
 
@@ -609,7 +609,7 @@
 			#Set current version to red
 			DIETPI_VERSION_CURRENT="${aCOLOUR[1]}$(sed -n 1p /DietPi/dietpi/.version).$(sed -n 2p /DietPi/dietpi/.version)$C_RESET"
 
-			local update_version=$(cat /DietPi/dietpi/.update_available)
+			local update_version=$(</DietPi/dietpi/.update_available)
 			if [[ $update_version == '-1' ]]; then
 
 				DIETPI_UPDATE_AVAILABLE="${aCOLOUR[2]}New Image$C_RESET"
@@ -634,7 +634,7 @@
 	NETWORK_DETAILS_MODE=0 #1=dhcp, 0=static
 	Obtain_NETWORK_DETAILS(){
 
-		FP_TEMP="/tmp/.ip_address"
+		FP_TEMP='/tmp/.ip_address'
 
 		#Hostname
 		NETWORK_DETAILS_HOSTNAME=$(hostname)
@@ -645,19 +645,16 @@
 		#Mode (dhcp/static)
 		if grep -q "iface $NETWORK_DETAILS_ADAPTER inet dhcp" /etc/network/interfaces; then
 
-			NETWORK_DETAILS_MODE="Dhcp"
+			NETWORK_DETAILS_MODE='Dhcp'
 
 		else
 
-			NETWORK_DETAILS_MODE="Static"
+			NETWORK_DETAILS_MODE='Static'
 
 		fi
 
-		#ip a to /tmp
-		ip a s "$NETWORK_DETAILS_ADAPTER" > $FP_TEMP
-
 		#IP / MAC addresses
-		NETWORK_DETAILS_IP_INT=$(grep -m1 '^[[:blank:]]*inet ' "$FP_TEMP" | awk '{ print $2 }' | sed 's|/.*$||')
+		NETWORK_DETAILS_IP_INT=$(sed -n 4p /DietPi/dietpi/.network)
 		NETWORK_DETAILS_MAC_ADDRESS=$(</sys/class/net/$NETWORK_DETAILS_ADAPTER/address)
 
 		#Speed/Strength
@@ -672,7 +669,7 @@
 
 			NETWORK_DETAILS_DUPLEXSPEED="$(</sys/class/net/$NETWORK_DETAILS_ADAPTER/speed) Mbit"
 			#NETWORK_DETAILS_DUPLEXSPEED=$(mii-tool | awk '{print $3}')
-			NETWORK_DETAILS_SIGNAL_STRENGTH="N/A"
+			NETWORK_DETAILS_SIGNAL_STRENGTH='N/A'
 
 		fi
 
@@ -745,7 +742,7 @@
 			# - Has the day changed? Also runs on init.
 			#	String if statement, to prevent "leading zero integer error" from $(date): https://github.com/Fourdee/DietPi/issues/272
 			local dayofmonth=$(date +"%d")
-			if [ "$NETWORK_USAGE_DAY_OF_MONTH" != "$dayofmonth" ]; then
+			if [[ $NETWORK_USAGE_DAY_OF_MONTH != $dayofmonth ]]; then
 
 				#Update previous day values to current
 				NETWORK_USAGE_DAY_PREVIOUS_SENT=$NETWORK_USAGE_TOTAL_CURRENT_SENT
@@ -775,7 +772,7 @@
 	Obtain_MEMORY(){
 
 		#Write to temp
-		FP_TEMP="/tmp/.mem"
+		FP_TEMP='/tmp/.mem'
 		free -m > $FP_TEMP
 
 		#RAM MB
@@ -820,7 +817,7 @@
 	PIHOLE_LAST_DOMAIN_BLOCKED=0
 	Obtain_PIHOLE(){
 
-		local pihole_log_file="/var/log/pihole.log"
+		local pihole_log_file='/var/log/pihole.log'
 
 		#Lets pull the total number of blocked domains only once during 1st run, its quite cpu intensive.
 		if (( $PIHOLE_TOTAL_DOMAINS == 0 )); then
@@ -839,7 +836,7 @@
 
 		local today=$(date +'%b %e')
 
-		PIHOLE_QUERY_COUNT=$(grep "$today" "$pihole_log_file" | awk '/query/ {print $7}' | wc -l)
+		PIHOLE_QUERY_COUNT=$(grep "$today" $pihole_log_file | awk '/query/ {print $7}' | wc -l)
 		#Prevent / 0 on percentage
 		if (( $PIHOLE_QUERY_COUNT <= 0 )); then
 
@@ -847,7 +844,7 @@
 
 		fi
 
-		PIHOLE_TOTAL_ADS=$(grep "$today" "$pihole_log_file" | awk '/\/etc\/pihole\/gravity.list/ {print $7}' | wc -l)
+		PIHOLE_TOTAL_ADS=$(grep "$today" $pihole_log_file | awk '/\/etc\/pihole\/gravity.list/ {print $7}' | wc -l)
 		PIHOLE_PERCENT_ADS=$(echo | awk "{print $PIHOLE_TOTAL_ADS / $PIHOLE_QUERY_COUNT * 100}")
 
 		#convert to interger and graph it
@@ -949,13 +946,10 @@
 
 			clear
 			echo -e "$C_RESET"
-			echo -e ""
-			echo -e ""
-			echo -e ""
+			echo -e '\n\n'
 			echo -e "$C_RESET${aCOLOUR[$USER_COLOUR_INDEX]}${aAnimation[$i]}"
 			echo -e "$C_RESET          v$DIETPI_CLOUDSHELL_VERSION"
-			echo -e ""
-			echo -e "       Loading..."
+			echo -e '\n       Loading...'
 			echo -e "$C_RESET${aCOLOUR[$USER_COLOUR_INDEX]}$C_REVERSE${aBar[$i]}"
 
 			sleep 0.2
@@ -1214,7 +1208,7 @@
 
 		if [[ -f $FILEPATH_SETTINGS ]]; then
 
-			. "$FILEPATH_SETTINGS"
+			. $FILEPATH_SETTINGS
 
 		fi
 
@@ -1222,7 +1216,7 @@
 
 	Write_Settings_File(){
 
-		cat << _EOF_ > "$FILEPATH_SETTINGS"
+		cat << _EOF_ > $FILEPATH_SETTINGS
 REFRESH_RATE=$REFRESH_RATE
 USER_COLOUR_INDEX=$USER_COLOUR_INDEX
 TEMPERATURE_OUTPUT_TYPE=$TEMPERATURE_OUTPUT_TYPE
@@ -1325,7 +1319,7 @@ _EOF_
 		systemctl stop dietpi-cloudshell
 
 		#Kill all , excluding Menu.
-		ps ax | grep '[d]ietpi-cloudshell [1-9]' | awk '{print $1}' > "$FP_TEMP"
+		ps ax | grep '[d]ietpi-cloudshell [1-9]' | awk '{print $1}' > $FP_TEMP
 		while read -r line
 		do
 
@@ -1378,7 +1372,7 @@ _EOF_
 	# Menu System
 	#/////////////////////////////////////////////////////////////////////////////////////
 	TARGETMENUID=0
-	LASTSELECTED_ITEM=""
+	LASTSELECTED_ITEM=''
 
 	Menu_Exit(){
 
@@ -1436,16 +1430,16 @@ _EOF_
 
 		G_WHIP_MENU_ARRAY=(
 
-			"Colour" "Setting: Change the colour scheme."
-			"Update Rate" "Setting: Control the time between screen updates."
-			"Scenes" "Setting: Toggle which scenes are shown."
-			"Storage" "Setting: Set mount locations used for storage stats"
-			"Temperature" "Setting: Output = $temp_output_text"
-			"Net Usage Current" "Setting: Output = $bitbyte_output_text"
-			"Output Display" "Setting: $target_output_text."
-			"Auto screen off" "Setting: $autoscreenoff | Start $BLANK_SCREEN_TIME_HOUR_START h | End $BLANK_SCREEN_TIME_HOUR_END h"
-			"Start / Restart" "Apply settings. Launch on $target_output_text."
-			"Stop" "Stops $G_PROGRAM_NAME."
+			'Colour' 'Setting: Change the colour scheme.'
+			'Update Rate' 'Setting: Control the time between screen updates.'
+			'Scenes' 'Setting: Toggle which scenes are shown.'
+			'Storage' 'Setting: Set mount locations used for storage stats'
+			'Temperature' "Setting: Output = $temp_output_text"
+			'Net Usage Current' "Setting: Output = $bitbyte_output_text"
+			'Output Display' "Setting: $target_output_text."
+			'Auto screen off' "Setting: $autoscreenoff | Start $BLANK_SCREEN_TIME_HOUR_START h | End $BLANK_SCREEN_TIME_HOUR_END h"
+			'Start / Restart' "Apply settings. Launch on $target_output_text."
+			'Stop' "Stops $G_PROGRAM_NAME."
 
 		)
 
@@ -1635,15 +1629,15 @@ _EOF_
 		#Define options
 		local index=0
 		G_WHIP_CHECKLIST_ARRAY=()
-		index=0;G_WHIP_CHECKLIST_ARRAY+=("$index" "CPU: Temperatures, Usage, frequency and more." "${aWhip_OnOff_Status[$index]}")
-		index=1;G_WHIP_CHECKLIST_ARRAY+=("$index" "Storage: Usage information for Flash and USB drives" "${aWhip_OnOff_Status[$index]}")
-		index=2;G_WHIP_CHECKLIST_ARRAY+=("$index" " - Additional Storage (USB_2/3)" "${aWhip_OnOff_Status[$index]}")
-		index=3;G_WHIP_CHECKLIST_ARRAY+=("$index" " - Additional Storage (USB_4/5)" "${aWhip_OnOff_Status[$index]}")
-		index=4;G_WHIP_CHECKLIST_ARRAY+=("$index" "DietPi: Information, stats and updates for DietPi." "${aWhip_OnOff_Status[$index]}")
-		index=5;G_WHIP_CHECKLIST_ARRAY+=("$index" "Network Details: Ip address, Speeds, Signal and more." "${aWhip_OnOff_Status[$index]}")
-		index=6;G_WHIP_CHECKLIST_ARRAY+=("$index" "Network Usage: Bandwidth usage (sent / recieved)." "${aWhip_OnOff_Status[$index]}")
-		index=7;G_WHIP_CHECKLIST_ARRAY+=("$index" "Memory: Stats for RAM and Swapfile usage." "${aWhip_OnOff_Status[$index]}")
-		index=8;G_WHIP_CHECKLIST_ARRAY+=("$index" "Pi-hole: Stats for Pi-hole. Total Ads blocked etc." "${aWhip_OnOff_Status[$index]}")
+		index=0;G_WHIP_CHECKLIST_ARRAY+=("$index" 'CPU: Temperatures, Usage, frequency and more.' "${aWhip_OnOff_Status[$index]}")
+		index=1;G_WHIP_CHECKLIST_ARRAY+=("$index" 'Storage: Usage information for Flash and USB drives' "${aWhip_OnOff_Status[$index]}")
+		index=2;G_WHIP_CHECKLIST_ARRAY+=("$index" ' - Additional Storage (USB_2/3)' "${aWhip_OnOff_Status[$index]}")
+		index=3;G_WHIP_CHECKLIST_ARRAY+=("$index" ' - Additional Storage (USB_4/5)' "${aWhip_OnOff_Status[$index]}")
+		index=4;G_WHIP_CHECKLIST_ARRAY+=("$index" 'DietPi: Information, stats and updates for DietPi.' "${aWhip_OnOff_Status[$index]}")
+		index=5;G_WHIP_CHECKLIST_ARRAY+=("$index" 'Network Details: Ip address, Speeds, Signal and more.' "${aWhip_OnOff_Status[$index]}")
+		index=6;G_WHIP_CHECKLIST_ARRAY+=("$index" 'Network Usage: Bandwidth usage (sent / recieved).' "${aWhip_OnOff_Status[$index]}")
+		index=7;G_WHIP_CHECKLIST_ARRAY+=("$index" 'Memory: Stats for RAM and Swapfile usage.' "${aWhip_OnOff_Status[$index]}")
+		index=8;G_WHIP_CHECKLIST_ARRAY+=("$index" 'Pi-hole: Stats for Pi-hole. Total Ads blocked etc.' "${aWhip_OnOff_Status[$index]}")
 
 		G_WHIP_CHECKLIST 'Please use the spacebar to toggle which scenes are active.'
 		if (( $? == 0 )); then
@@ -1685,9 +1679,9 @@ _EOF_
 
 		G_WHIP_MENU_ARRAY=(
 
-			"Toggle" "$blank_screen_at_specific_time_enabled_text"
-			"Start time" "Set which hour to power off screen ($BLANK_SCREEN_TIME_HOUR_START)."
-			"End time" "Set which hour to power on screen ($BLANK_SCREEN_TIME_HOUR_END)."
+			'Toggle' "$blank_screen_at_specific_time_enabled_text"
+			'Start time' "Set which hour to power off screen ($BLANK_SCREEN_TIME_HOUR_START)."
+			'End time' "Set which hour to power on screen ($BLANK_SCREEN_TIME_HOUR_END)."
 
 		)
 
@@ -1727,7 +1721,7 @@ _EOF_
 				for ((i=0; i<24; i++))
 				do
 
-					G_WHIP_MENU_ARRAY+=("$i" "Hour")
+					G_WHIP_MENU_ARRAY+=("$i" 'Hour')
 
 				done
 
@@ -1909,7 +1903,7 @@ _EOF_
 
 	#-----------------------------------------------------------------------------------
 	#Clean up temp files
-	rm "$FP_TEMP" &> /dev/null
+	rm $FP_TEMP &> /dev/null
 	#-----------------------------------------------------------------------------------
 	#Delete[] Global arrays
 	unset aCOLOUR

--- a/dietpi/func/obtain_network_details
+++ b/dietpi/func/obtain_network_details
@@ -19,9 +19,9 @@
 	# $FP_NETFILE line2
 	# - wlan index
 	# $FP_NETFILE line3
-	# - Active adapter name (eg: eth9)
+	# - Active adapter name (eg: eth0)
 	# $FP_NETFILE line4
-	# - IP Address
+	# - IP address
 	#////////////////////////////////////
 
 	#Import DietPi-Globals ---------------------------------------------------------------
@@ -34,14 +34,12 @@
 	# Global
 	#/////////////////////////////////////////////////////////////////////////////////////
 
-	MAX_DEVICE=10
-	FP_TEMP='/tmp/find_network_index'
+	FP_TEMP='/tmp/dietpi-ip_list'
 	FP_NETFILE='/DietPi/dietpi/.network'
 
-	ACTIVE_DEVICE='NULL'
-	DEVICE_FOUND=0
 	ETH_INDEX=0
 	WLAN_INDEX=0
+	ACTIVE_DEVICE='NULL'
 	IP_ADDRESS='Use dietpi-config to setup a connection'
 
 	#/////////////////////////////////////////////////////////////////////////////////////
@@ -49,70 +47,64 @@
 	#/////////////////////////////////////////////////////////////////////////////////////
 
 	#grab content of ip l
-	ip l > "$FP_TEMP"
+	ip -o l > $FP_TEMP
 
-	#find eth[0-9]
-	for ((i=0; i<$MAX_DEVICE; i++))
-	do
+	# Find active eth device
+	if tmp=$(grep -m1 ' eth[0-9]: .* state UP ' $FP_TEMP); then
 
-		if grep -qi "eth$i" "$FP_TEMP"; then
+		tmp=${tmp#* eth}
+		ETH_INDEX=${tmp%%: *}
 
-			ETH_INDEX=$i
-			DEVICE_FOUND=1
-			break
+		ACTIVE_DEVICE="eth$ETH_INDEX"
+		IP_ADDRESS=$(ip -o a s $ACTIVE_DEVICE)
+		IP_ADDRESS=${IP_ADDRESS#*inet* }
+		IP_ADDRESS=${IP_ADDRESS%%/*}
 
-		fi
+	# Else find available eth device
+	elif tmp=$(grep -m1 ' eth[0-9]: ' $FP_TEMP); then
 
-	done
+		tmp=${tmp#* eth}
+		ETH_INDEX=${tmp%%: *}
 
-	#find wlan[0-9]
-	for ((i=0; i<$MAX_DEVICE; i++))
-	do
+	fi
 
-		if grep -qi "wlan$i" "$FP_TEMP"; then
+	# Find active wlan device
+	if tmp=$(grep -m1 ' wlan[0-9]: .* state UP ' $FP_TEMP); then
 
-			WLAN_INDEX=$i
-			DEVICE_FOUND=1
-			break
+		tmp=${tmp#* eth}
+		WLAN_INDEX=${tmp%%: *}
 
-		fi
-
-	done
-
-	#Obtain device/ip info
-	if (( $DEVICE_FOUND )); then
-
-		#Find active network device
-		# - eth takes priority, if both eth wlan are active.
-		ip r > "$FP_TEMP"
-		if grep -qi "eth$ETH_INDEX" "$FP_TEMP"; then
-
-			ACTIVE_DEVICE="eth$ETH_INDEX"
-
-		elif grep -qi "wlan$WLAN_INDEX" "$FP_TEMP"; then
+		# Eth has priority
+		if [[ $ACTIVE_DEVICE == NULL ]]; then
 
 			ACTIVE_DEVICE="wlan$WLAN_INDEX"
+			IP_ADDRESS=$(ip -o a s $ACTIVE_DEVICE)
+			IP_ADDRESS=${IP_ADDRESS#*inet* }
+			IP_ADDRESS=${IP_ADDRESS%%/*}
 
 		fi
 
-		#IP address
-		IP_ADDRESS="$(ip a show $ACTIVE_DEVICE | grep -m1 'inet' | awk '{ print $2 }' | sed -E 's/(:|\/).*$//')"
+	# Else find available wlan device
+	elif tmp=$(grep -m1 ' eth[0-9]: ' $FP_TEMP); then
+
+		tmp=${tmp#* eth}
+		WLAN_INDEX=${tmp%%: *}
 
 	fi
 
 	#-----------------------------------------------------------------------------------
 	#Output to file
-	cat << _EOF_ > "$FP_NETFILE"
+	cat << _EOF_ > $FP_NETFILE
 $ETH_INDEX
 $WLAN_INDEX
 $ACTIVE_DEVICE
 $IP_ADDRESS
 _EOF_
 	# Assure that non-root user can call this script:
-	chmod 666 "$FP_NETFILE" &> /dev/null
+	chmod 666 $FP_NETFILE &> /dev/null
 
 	#Clean up tmp files used
-	rm "$FP_TEMP"
+	rm $FP_TEMP
 	#-----------------------------------------------------------------------------------
 	exit
 	#-----------------------------------------------------------------------------------


### PR DESCRIPTION
+ DietPi-Obtain_network_details | Prefer and use only active network devices to estimate IP: https://github.com/Fourdee/DietPi/issues/1842
+ DietPi-Obtain_network_details | General code rework and speed up:
   - Ref: https://github.com/Fourdee/DietPi/issues/1510#issuecomment-397808477

**Old:**
```
root@VM-Stretch:~# time for ((i=0;i<100;i++)); do /DietPi/dietpi/func/obtain_network_details; done

real    0m21.557s
user    0m8.756s
sys     0m4.468s
root@VM-Stretch:~# time for ((i=0;i<100;i++)); do /DietPi/dietpi/func/obtain_network_details; done

real    0m20.991s
user    0m8.360s
sys     0m4.300s
```
**New:**
```
root@VM-Stretch:~# time for ((i=0;i<100;i++)); do /DietPi/dietpi/func/obtain_network_details; done

real    0m14.596s
user    0m7.180s
sys     0m2.456s
root@VM-Stretch:~# time for ((i=0;i<100;i++)); do /DietPi/dietpi/func/obtain_network_details; done

real    0m14.489s
user    0m7.204s
sys     0m2.444s

```

Hijacked to improve the following:
+ DietPi-Cloudshell | Fall back to "/DietPi/dietpi/.network" to obtain IP
+ DietPi-Cloudshell | Minor code improvements