### PR TITLE
RPi | Disable "initial_turbo" setting within config.txt

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@ DietPi-Survey | Simplified available options. You can now either Opt In, or Opt 
 PREP | 'os-prober' installed by default for x86_64 devices. Ensures dual boot OSs are detected by grub. Also added a 3 second timeout to grub boot prompt, allowing OS selection: https://github.com/Fourdee/DietPi/issues/1855
 
 Bug Fixes:
+Raspberry Pi | Disabled "initial_turbo" setting in config.txt, as it prevents CPU governor from throttling down: https://github.com/Fourdee/DietPi/issues/1836
 DietPi-Software | GMrender: Resolved an issue where two systems on the same network would nullify the other. Hostname is now used for the server name, UUID used is applied via DietPi generated UUID during 1st run: https://dietpi.com/phpbb/viewtopic.php?f=11&t=3900&p=12985#p12985
 DietPi-Software | Apache2: Fixed a syntax error that leads to Apache logging to "/error.log" instead of "/var/log/apache2/error.log"
 

--- a/config.txt
+++ b/config.txt
@@ -14,7 +14,7 @@ disable_overscan=1
 #overscan_top=16
 #overscan_bottom=16
 
-# uncomment to force a console size. By default it will be display's size minus
+# uncomment to force a console size. By default it will be display's size minus overscan
 framebuffer_width=1280
 framebuffer_height=720
 #framebuffer_depth=16
@@ -63,7 +63,6 @@ disable_splash=1
 avoid_pwm_pll=1
 
 #-------SoundCard-------
-#dtoverlay=none
 dtparam=audio=off
 
 #-------i2c-------------
@@ -75,12 +74,13 @@ i2c_arm_baudrate=100000
 dtparam=spi=off
 
 #-------Serial/UART-----
-#NB: enabled for 1st run only, if you want to keep this setting, please set CONFIG_SERIAL_CONSOLE_ENABLE=1 in dietpi.txt
+# NB: enabled for 1st run only, if you want to keep this setting, please set CONFIG_SERIAL_CONSOLE_ENABLE=1 in dietpi.txt
 enable_uart=1
 
 #-------Overclock-------
 temp_limit=65
-initial_turbo=20
+# Initial turbo currently leads to CPU not being throttled down by CPU governor: https://github.com/Fourdee/DietPi/issues/1836
+#initial_turbo=20
 force_turbo=0
 
 #over_voltage=0
@@ -92,4 +92,4 @@ force_turbo=0
 #core_freq_min=250
 #sdram_freq_min=400
 
-#Note To Self, NEVER enable L2 cache, breaks most X based applications that were not compiled with L2 cache enabled.
+# Note To Self, NEVER enable L2 cache, breaks most X based applications that were not compiled with L2 cache enabled.

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -783,6 +783,14 @@ _EOF_
 
 			fi
 			#-------------------------------------------------------------------------------
+			#Disable "initial_turbo" option for RPi within config.txt, as it currently prevents CPU throttle down: https://github.com/Fourdee/DietPi/issues/1836
+			if [[ -f /DietPi/config.txt ]]; then
+
+				sed -i '/[[:blank:]#]*initial_turbo/d' /DietPi/config.txt
+				echo -e "\n# Initial turbo currently leads to CPU not being throttled down by CPU governor: https://github.com/Fourdee/DietPi/issues/1836\n#initial_turbo=20" >> /DietPi/config.txt
+
+			fi
+			#-------------------------------------------------------------------------------
 
 		fi
 


### PR DESCRIPTION
**Status**: Ready for testing
- [x] Adjust config.txt
- [x] Adding to patch_file
- [x] Adding to changelog

**Reference**: https://github.com/Fourdee/DietPi/issues/1836

**Commit list/description**:
+ RPi | Disable "initial_turbo" setting within config.txt, as it leads to CPU governor not being able to throttle down CPU
+ DietPi-Patchfile | Comment "initial_turbo" option from config.txt on DietPi patch
+ CHANGELOG | RPi: Disabled "initial_turbo" setting in config.txt, as it prevents CPU governor from throttling down