### PR TITLE
DietPi-Globals | Speed up G_DIETPI-NOTIFY, let PS1 promt kill processing animation as last resort

### DIFF
--- a/dietpi/dietpi-process_tool
+++ b/dietpi/dietpi-process_tool
@@ -52,9 +52,8 @@
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Apply'
 
-		local status_text=''
-		local status_text_ok="$(G_DIETPI-NOTIFY 0)"
-		local status_text_failed="$(G_DIETPI-NOTIFY 1)"
+		# G_DIETPI-NOTIFY 0/OK or 1/FAILURE
+		local status=0
 
 		#Update process list again (incase of PID changes via forking processes, during init of this script)
 		ps ax > $FP_PS_LIST
@@ -84,11 +83,11 @@
 					renice -n ${aNICE[$i]} ${aPID[$i]} &> /dev/null
 					if (( ! $? )); then
 
-						status_text=$status_text_ok
+						status=0
 
 					else
 
-						status_text=$status_text_failed
+						status=1
 						EXIT_CODE=1
 						print_info=1
 
@@ -96,8 +95,7 @@
 
 					if (( $print_info )); then
 
-						status_text+="${aNAME[$i]} (${aPID[$i]}) : \e[90mNice      ${aNICE[$i]}\e[0m"
-						echo -e "$status_text"
+						G_DIETPI-NOTIFY $status "${aNAME[$i]} (${aPID[$i]}) : \e[90mNice      ${aNICE[$i]}\e[0m"
 
 					fi
 
@@ -105,11 +103,11 @@
 					taskset -pc ${aAFFINITY[$i]} ${aPID[$i]} &> /dev/null
 					if (( ! $? )); then
 
-						status_text=$status_text_ok
+						status=0
 
 					else
 
-						status_text=$status_text_failed
+						status=1
 						EXIT_CODE=2
 						print_info=1
 
@@ -117,8 +115,7 @@
 
 					if (( $print_info )); then
 
-						status_text+="${aNAME[$i]} (${aPID[$i]}) : \e[90mAffinity  ${aAFFINITY[$i]}\e[0m"
-						echo -e "$status_text"
+						G_DIETPI-NOTIFY $status "${aNAME[$i]} (${aPID[$i]}) : \e[90mAffinity  ${aAFFINITY[$i]}\e[0m"
 
 					fi
 
@@ -166,11 +163,11 @@
 					chrt $chrt_mode -p ${aSCHEDULE_PRIORITY[$i]} ${aPID[$i]} &> /dev/null
 					if (( ! $? )); then
 
-						status_text=$status_text_ok
+						status=0
 
 					else
 
-						status_text=$status_text_failed
+						status=1
 						EXIT_CODE=3
 						print_info=1
 
@@ -178,8 +175,7 @@
 
 					if (( $print_info )); then
 
-						status_text+="${aNAME[$i]} (${aPID[$i]}) : \e[90mScheduler ${aSCHEDULE_POLICY[$i]} ${aSCHEDULE_PRIORITY[$i]}\e[0m"
-						echo -e "$status_text"
+						G_DIETPI-NOTIFY $status "${aNAME[$i]} (${aPID[$i]}) : \e[90mScheduler ${aSCHEDULE_POLICY[$i]} ${aSCHEDULE_PRIORITY[$i]}\e[0m"
 
 					fi
 

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -46,7 +46,7 @@
 
 	#User input? (eg: interactive shell available via STDIN check)
 	# - Affects:
-	#	G_ERROR_HANDLER whiptail display
+	#	G_ERROR_HANDLER / G_WHIP whiptail display
 	#	NB: You can export G_USER_INPUTS=0 to force non-interactive (eg: .bashrc) Must run 'unset G_USER_INPUTS' after to return to auto detection.
 	if [[ -z $G_USER_INPUTS ]]; then
 
@@ -72,7 +72,7 @@
 	G_DIETPI_INSTALL_STAGE=-2
 	if [[ -f /DietPi/dietpi/.install_stage ]]; then
 
-		G_DIETPI_INSTALL_STAGE=$(cat /DietPi/dietpi/.install_stage)
+		G_DIETPI_INSTALL_STAGE=$(</DietPi/dietpi/.install_stage)
 
 	fi
 
@@ -80,15 +80,6 @@
 	G_FP_DIETPI_USERDATA='/mnt/dietpi_userdata'
 
 	#Device details
-	G_HW_MODEL=${G_HW_MODEL:-0}
-	G_HW_MODEL_DESCRIPTION=${G_HW_MODEL_DESCRIPTION:-NULL}
-	G_HW_ARCH=${G_HW_ARCH:-0}
-	G_HW_CPUID=${G_HW_CPUID:-0}
-	G_HW_CPU_CORES=$(nproc --all)
-
-	G_DISTRO=${G_DISTRO:-0}
-	G_DISTRO_NAME=${G_DISTRO_NAME:-NULL}
-
 	# - Update
 	#	NB: dietpi-boot service launches dietpi-obtain_hw_model to create the following file
 	if [[ -f /DietPi/dietpi/.hw_model ]]; then
@@ -111,6 +102,16 @@
 		fi
 
 	fi
+
+	# - Create variables, if empty
+	G_HW_MODEL=${G_HW_MODEL:-0}
+	G_HW_MODEL_DESCRIPTION=${G_HW_MODEL_DESCRIPTION:-NULL}
+	G_HW_ARCH=${G_HW_ARCH:-0}
+	G_HW_CPUID=${G_HW_CPUID:-0}
+	G_HW_CPU_CORES=$(nproc --all)
+
+	G_DISTRO=${G_DISTRO:-0}
+	G_DISTRO_NAME=${G_DISTRO_NAME:-NULL}
 
 	#INIT functions for originating script
 	#	eg: stuff we cant init in main globals/funcs due to .bashrc load into current session.
@@ -146,128 +147,55 @@
 	G_DIETPI-NOTIFY(){
 
 		local ainput_string=("$@")
-
-		#header_line='\e[38;5;154m─────────────────────────────────────────────────────\e[0m'
-		local header_line='\e[90m─────────────────────────────────────────────────────\e[0m'
-
-		local status_text_ok='\e[32m  OK  \e[0m'
-		local status_text_error='\e[31mFAILED\e[0m'
-		local status_text_info='\e[0m INFO \e[0m'
-		local status_subfunction='\e[33m SUBF \e[0m'
-		if [[ $HIERARCHY ]]; then
-
-			# - >=10 should never occur, however, if it is, lets make it line up regardless
-			if (( $HIERARCHY < 10 )); then
-
-				status_subfunction="\e[33m SUB$HIERARCHY \e[0m"
-
-			else
-
-				status_subfunction="\e[33m SUB$HIERARCHY\e[0m"
-
-			fi
-
-		fi
-
-		local bracket_string_l='\e[90m[\e[0m'
-		local bracket_string_r='\e[90m]\e[0m'
+		local output_string=''
+		local bracket_l='\e[90m['
+		local bracket_r='\e[90m]\e[0m'
 
 		#Funcs
-
-		Print_Process_Animation(){
-
-			local bright_dot='\e[1;93m.\e[0m'
-			local dimmed_dot='\e[2;33m.\e[0m'
-			# Alternative: \u23F9
-			local aprocess_string=(
-				"$bright_dot     "
-				"$dimmed_dot$bright_dot    "
-				" $dimmed_dot$bright_dot   "
-				"  $dimmed_dot$bright_dot  "
-				"   $dimmed_dot$bright_dot "
-				"    $dimmed_dot$bright_dot"
-				"    $bright_dot$dimmed_dot"
-				"   $bright_dot$dimmed_dot "
-				"  $bright_dot$dimmed_dot  "
-				" $bright_dot$dimmed_dot   "
-				"$bright_dot$dimmed_dot    "
-			)
-
-			local i=0
-			for (( i=0; i<=${#aprocess_string[@]}; i++ )); do
-
-				(( i == 11 )) && i=1
-				[[ -w /tmp/dietpi-process.pid ]] && echo -ne "\r$bracket_string_l${aprocess_string[i]}$bracket_string_r " || break
-				sleep 0.15
-
-			done
-
-		}
-
 		Clean_Process_Animation(){
 
 			if [[ -w /tmp/dietpi-process.pid ]]; then
 
-				kill "$(</tmp/dietpi-process.pid)" &> /dev/null
+				kill $(</tmp/dietpi-process.pid) &> /dev/null
 				rm /tmp/dietpi-process.pid &> /dev/null
 				# In case, the output took more than one line, clean from cursor (animation position) until end of terminal.
 				tput ed
 
 			fi
-			echo -ne '\r\e[K'
+			output_string+='\r\e[K'
 
 		}
 
-		Print_Process(){
-
-			echo -ne '\r\e[9C'
-
-		}
-
-		Print_Ok(){
+		Status_Ok(){
 
 			Clean_Process_Animation
-			echo -ne "$bracket_string_l$status_text_ok$bracket_string_r "
+			output_string+="$bracket_l\e[32m  OK  $bracket_r "
 
 		}
 
-		Print_Failed(){
+		Status_Failed(){
 
 			Clean_Process_Animation
-			echo -ne "$bracket_string_l$status_text_error$bracket_string_r "
+			output_string+="$bracket_l\e[31mFAILED$bracket_r "
 
 		}
 
-		Print_Info(){
-
-			Clean_Process_Animation
-			echo -ne "$bracket_string_l$status_text_info$bracket_string_r "
-
-		}
-
-		Print_Subfunction(){
-
-			Clean_Process_Animation
-			echo -ne "$bracket_string_l$status_subfunction$bracket_string_r "
-
-		}
-
-		# - Print all input string on same line
+		# Print all input string on same line
 		# - $1 = start printing from word number $1
-		Print_Input_String(){
+		Print_Output_String(){
 
 			if (( $1 == 1 )) && [[ $G_PROGRAM_NAME ]]; then
 
-				echo -ne "\e[90m$G_PROGRAM_NAME | \e[0m"
+				output_string+="\e[90m$G_PROGRAM_NAME | \e[0m"
 
 			fi
-
 			local i=0
 			for (( i=$1; i<${#ainput_string[@]}; i++ )); do
 
-				echo -ne "${ainput_string[$i]}"
+				output_string+="${ainput_string[$i]}"
 
 			done
+			echo -ne "$output_string\e[0m"
 
 		}
 
@@ -281,17 +209,15 @@
 
 			if (( ! $2 )); then
 
-				ainput_string+=(' Completed')
-				Print_Ok
-				Print_Input_String 2
-				echo ''
+				Status_Ok
+				ainput_string+=(' Completed\n')
+				Print_Output_String 2
 
 			else
 
-				ainput_string+=(' An issue has occured')
-				Print_Failed
-				Print_Input_String 2
-				echo ''
+				Status_Failed
+				ainput_string+=(' An issue has occured\n')
+				Print_Output_String 2
 
 			fi
 
@@ -300,74 +226,113 @@
 		#$@ = txt desc
 		elif (( $1 == -2 )); then
 
-			Print_Process
-			Print_Input_String 1
+			Print_Process_Animation(){
+
+				local bright_dot='\e[1;93m.\e[0m'
+				local dimmed_dot='\e[2;33m.\e[0m'
+				# Alternative: \u23F9
+				local aprocess_string=(
+					"$bright_dot     "
+					"$dimmed_dot$bright_dot    "
+					" $dimmed_dot$bright_dot   "
+					"  $dimmed_dot$bright_dot  "
+					"   $dimmed_dot$bright_dot "
+					"    $dimmed_dot$bright_dot"
+					"    $bright_dot$dimmed_dot"
+					"   $bright_dot$dimmed_dot "
+					"  $bright_dot$dimmed_dot  "
+					" $bright_dot$dimmed_dot   "
+					"$bright_dot$dimmed_dot    "
+				)
+
+				local i=0
+				for (( i=0; i<=${#aprocess_string[@]}; i++ )); do
+
+					(( i == 11 )) && i=1
+					[[ -w /tmp/dietpi-process.pid ]] && echo -ne "\r$bracket_l${aprocess_string[i]}$bracket_r " || return
+					sleep 0.15
+
+				done
+
+			}
+
+			output_string+="\r$bracket_l\e[33m......$bracket_r "
+			Print_Output_String 1
+
 			# Calculate the amount of output lines and in case move cursor up for correct animation and to allow cleaning the whole output.
-			local string="$*"
-			local lines=0
-			(( lines=(${#string}+6)/$(tput cols) ))
-			while (( lines > 0 )); do
-
-				tput cuu1
-				(( lines-- ))
-
-			done
+			local input_string="$*"
+			local output_lines=$(( ( ${#input_string} + 6 ) / $(tput cols) ))
+			(( $output_lines )) && tput cuu $output_lines
 			[[ ! -e /tmp/dietpi-process.pid ]] && > /tmp/dietpi-process.pid && ( Print_Process_Animation & echo $! > /tmp/dietpi-process.pid )
+
+			unset Print_Process_Animation
 
 		#Status Ok
 		#$@ = txt desc
 		elif (( $1 == 0 )); then
 
-			Print_Ok
-			Print_Input_String 1
-			echo ''
+			Status_Ok
+			ainput_string+=('\n')
+			Print_Output_String 1
 
 		#Status failed
 		#$@ = txt desc
 		elif (( $1 == 1 )); then
 
-			Print_Failed
-			Print_Input_String 1
-			echo ''
+			Status_Failed
+			ainput_string+=('\n')
+			Print_Output_String 1
 
 		#Status Info
 		#$@ = txt desc
 		elif (( $1 == 2 )); then
 
-			Print_Info
-			echo -ne '\e[90m'
-			Print_Input_String 1
-			echo -e '\e[0m'
+			Clean_Process_Animation
+			output_string+="$bracket_l\e[0m INFO $bracket_r "
+			# Keep info messages in gray, even if "G_PROGRAM_NAME | \e[0m" is added:
+			ainput_string[1]="\e[90m${ainput_string[1]}"
+			ainput_string+=('\e[0m\n')
+			Print_Output_String 1
 
 		#DietPi banner style
 		#$2 = txt program name
 		#$3 = txt mode
 		elif (( $1 == 3 )); then
 
+			Clean_Process_Animation
 			if [[ $HIERARCHY ]] && (( $HIERARCHY > 0 )); then
 
-					Print_Subfunction
-					echo -e "$2 > $(Print_Input_String 2)"
+				# >=10 should never occur, however, if it is, lets make it line up regardless
+				if (( $HIERARCHY < 10 )); then
+
+					local status_subfunction="\e[33m SUB$HIERARCHY \e[0m"
+
+				else
+
+					local status_subfunction="\e[33m SUB$HIERARCHY\e[0m"
+
+				fi
+				output_string+="$bracket_l$status_subfunction$bracket_r $2 > "
+				ainput_string+=('\n')
+				Print_Output_String 2
 
 			else
 
-					echo -e "\n \e[38;5;154m$2\e[0m"
-					echo -e "$header_line"
-					echo -e " \e[90mMode: \e[0m$(Print_Input_String 2)\n"
+				output_string+="\n \e[38;5;154m$2"
+				output_string+='\n\e[90m─────────────────────────────────────────────────────'
+				output_string+='\n Mode: \e[0m'
+				ainput_string+=('\n\n')
+				Print_Output_String 2
 
 			fi
 
 		fi
 		#-----------------------------------------------------------------------------------
-		# Unset also internal functions, otherwise they are accessible from terminal.
-		unset Print_Process_Animation
+		# Unset also internal functions, otherwise they are accessible from terminal:
 		unset Clean_Process_Animation
-		unset Print_Process
-		unset Print_Ok
-		unset Print_Failed
-		unset Print_Info
-		unset Print_Input_String
-		unset Print_Subfunction
+		unset Status_Ok
+		unset Status_Failed
+		unset Print_Output_String
 		#-----------------------------------------------------------------------------------
 
 	}
@@ -1793,7 +1758,7 @@ $print_logfile_info
 
 				# - Boards that provide 2 digit output
 				#	Pine
-				# 	NanoPi M2
+				#	NanoPi M2
 				#	NanoPi M3
 				#	H3 3.x
 				#	H2+ 3.x
@@ -1845,7 +1810,7 @@ $print_logfile_info
 
 	#Check available free space on path, against input value (MB)
 	# - Returns 1=Ok, 0=insufficient space available
-	# 	If $2 is not used, returns available space in MB
+	#	If $2 is not used, returns available space in MB
 	# - $1 = path
 	# - $2 = Optional, free space (MB)
 	#	EG: if (( $(G_CHECK_FREESPACE /path 100) )); then
@@ -2033,7 +1998,7 @@ $print_logfile_info
 
 		syntax_error(){
 
- 			[[ $after ]] && after='\nafter line\n	'.$after.' ($4)'
+			[[ $after ]] && after='\nafter line\n	'.$after.' ($4)'
 			G_WHIP_MSG "[FAILED] Syntax error\n
 Couldn't add setting (\$2)\n	$setting\ninto file (\$3)\n	$file$after\n\nNB:
 - Please escape any of the following characters with leading backslash (\):\n	\".+*?\\|^\$()[]{}
@@ -2060,7 +2025,7 @@ Please verify the existance of the file, retry with proper permissions or apply 
 
 				sed -Ei "0,\|^[[:blank:]]*$pattern.*$|s||$setting|" $file
 				(( $? )) && syntax_error && return 1
- 				G_DIETPI-NOTIFY 0 "Setting in \e[33m$file\e[0m adjusted: \e[33m$(sed -E "c\\$setting" <<< '' | sed 's|\\|\\\\|g')\e[0m"
+				G_DIETPI-NOTIFY 0 "Setting in \e[33m$file\e[0m adjusted: \e[33m$(sed -E "c\\$setting" <<< '' | sed 's|\\|\\\\|g')\e[0m"
 
 			fi
 

--- a/rootfs/etc/bashrc.d/dietpi-ps1_kill_animation.sh
+++ b/rootfs/etc/bashrc.d/dietpi-ps1_kill_animation.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# "G_DIETPI-NOFITY -2 message" starts a process animation.
+# If scripts fail to kill the animation, e.g. cancelled by user, terminal PS1 promt has to do it as last resort:
+PS1="\\[\$([[ -w /tmp/dietpi-process.pid ]] && rm /tmp/dietpi-process.pid && tput cub 9 && tput ed)\\]$PS1"


### PR DESCRIPTION
**Status**: Ready for review/testing
- [x] DietPi-Process_Tool message fix
- [x] Make PS1 kill process animation as last resort

**Commit list/description**:
+ DietPi-Globals | G_DIETPI-NOTIFY: Speed up notifications by defining variables and functions just where they are used and execute "echo" just a single time each notification.
   - Also `[ INFO ]` messages will stay in grey, even that `G_PROGRAM_NAME | \e[0m` is added to string.
   - It looses a bid consistency style, but since we use it much within the other scripts, I moved priority towards speed.
+ DietPi-Globals | Minor: Try to scrape "/DietPi/dietpi/.hw_model" first, fill with 0/NULL afterwards, if empty. Otherwise 0/NULL could be overwritten with empty string.
+ DietPi-Process_Tool | Simplify/Fix status messages by using G_DIETPI-NOTIFY as expected
+ G_DIETPI-NOFITY -2: Make terminal PS1 promt kill processing animation as last resort

**Speed comparison**
- Not as much as I thought it would be, but a clear difference. <s>I think for longer messages the difference will increase, as the number of echo calls was one each word.</s> **€: Nope, everything within quotations is handled as single argument and single array index within `ainput_string`, thus the amount of words had no impact on amount of `echo`s. But that the amount of echo calls has significant influence can be seen on `G_DIETPI-NOTIFY 3` speed. So generally it makes sense to use echo just one time and collect/build the output variable.**
<details>
<summary>New G_DIETPI-NOTIFY speed</summary>

```
root@VM-Stretch:~# time for ((i=0;i<1000;i++)); do G_DIETPI-NOTIFY 0 OK &> /dev/null; done

real    0m1.936s
user    0m1.888s
sys     0m0.044s
root@VM-Stretch:~# time for ((i=0;i<1000;i++)); do G_DIETPI-NOTIFY 0 OK &> /dev/null; done

real    0m1.975s
user    0m1.944s
sys     0m0.028s
root@VM-Stretch:~# time for ((i=0;i<1000;i++)); do G_DIETPI-NOTIFY 1 OK &> /dev/null; done

real    0m1.966s
user    0m1.904s
sys     0m0.056s
root@VM-Stretch:~# time for ((i=0;i<1000;i++)); do G_DIETPI-NOTIFY 1 OK &> /dev/null; done

real    0m1.947s
user    0m1.880s
sys     0m0.064s
root@VM-Stretch:~# time for ((i=0;i<1000;i++)); do G_DIETPI-NOTIFY 2 OK &> /dev/null; done

real    0m2.008s
user    0m1.960s
sys     0m0.044s
root@VM-Stretch:~# time for ((i=0;i<1000;i++)); do G_DIETPI-NOTIFY 2 OK &> /dev/null; done

real    0m2.008s
user    0m1.948s
sys     0m0.052s
root@VM-Stretch:~# time for ((i=0;i<1000;i++)); do G_DIETPI-NOTIFY 3 OK &> /dev/null; done

real    0m2.122s
user    0m2.052s
sys     0m0.064s
root@VM-Stretch:~# time for ((i=0;i<1000;i++)); do G_DIETPI-NOTIFY 3 OK &> /dev/null; done

real    0m2.110s
user    0m2.036s
sys     0m0.072s
root@VM-Stretch:~# time for ((i=0;i<1000;i++)); do G_DIETPI-NOTIFY -1 0 OK &> /dev/null; done

real    0m1.954s
user    0m1.892s
sys     0m0.060s
root@VM-Stretch:~# time for ((i=0;i<1000;i++)); do G_DIETPI-NOTIFY -1 0 OK &> /dev/null; done

real    0m1.941s
user    0m1.900s
sys     0m0.040s
root@VM-Stretch:~# time for ((i=0;i<1000;i++)); do G_DIETPI-NOTIFY -2 OK &> /dev/null; done

real    0m8.015s
user    0m4.000s
sys     0m3.396s
root@VM-Stretch:~# time for ((i=0;i<1000;i++)); do G_DIETPI-NOTIFY -2 OK &> /dev/null; done

real    0m8.192s
user    0m3.804s
sys     0m3.660s
```
</details>

<details>
<summary>Old G_DIETPI-NOTIFY speed</summary>

```
root@VM-Stretch:~# time for ((i=0;i<1000;i++)); do G_DIETPI-NOTIFY 0 OK &> /dev/null; done

real    0m2.631s
user    0m2.524s
sys     0m0.096s
root@VM-Stretch:~# time for ((i=0;i<1000;i++)); do G_DIETPI-NOTIFY 0 OK &> /dev/null; done

real    0m2.668s
user    0m2.604s
sys     0m0.056s
root@VM-Stretch:~# time for ((i=0;i<1000;i++)); do G_DIETPI-NOTIFY 1 OK &> /dev/null; done

real    0m2.649s
user    0m2.580s
sys     0m0.064s
root@VM-Stretch:~# time for ((i=0;i<1000;i++)); do G_DIETPI-NOTIFY 1 OK &> /dev/null; done

real    0m2.673s
user    0m2.616s
sys     0m0.048s
root@VM-Stretch:~# time for ((i=0;i<1000;i++)); do G_DIETPI-NOTIFY 2 OK &> /dev/null; done

real    0m2.767s
user    0m2.668s
sys     0m0.092s
root@VM-Stretch:~# time for ((i=0;i<1000;i++)); do G_DIETPI-NOTIFY 2 OK &> /dev/null; done

real    0m2.743s
user    0m2.672s
sys     0m0.060s
root@VM-Stretch:~# time for ((i=0;i<1000;i++)); do G_DIETPI-NOTIFY 3 OK &> /dev/null; done

real    0m6.691s
user    0m2.652s
sys     0m1.020s
root@VM-Stretch:~# time for ((i=0;i<1000;i++)); do G_DIETPI-NOTIFY 3 OK &> /dev/null; done

real    0m6.668s
user    0m2.604s
sys     0m1.032s
root@VM-Stretch:~# time for ((i=0;i<1000;i++)); do G_DIETPI-NOTIFY -1 0 OK &> /dev/null; done

real    0m2.793s
user    0m2.712s
sys     0m0.068s
root@VM-Stretch:~# time for ((i=0;i<1000;i++)); do G_DIETPI-NOTIFY -1 0 OK &> /dev/null; done

real    0m2.778s
user    0m2.720s
sys     0m0.048s
root@VM-Stretch:~# time for ((i=0;i<1000;i++)); do G_DIETPI-NOTIFY -2 OK &> /dev/null; done

real    0m8.657s
user    0m4.672s
sys     0m3.284s
root@VM-Stretch:~# time for ((i=0;i<1000;i++)); do G_DIETPI-NOTIFY -2 OK &> /dev/null; done

real    0m8.652s
user    0m4.684s
sys     0m3.248s
```
</details>