### PR TITLE
DietPi-Software | Uninstall, minor general code and visual improvements

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12767,7 +12767,7 @@ _EOF_
 		if (( aSOFTWARE_INSTALL_STATE[$UNINSTALLING_INDEX] == -1 )); then
 
 			Banner_Uninstalling
-			G_AGP lxde lxde-* upower policykit-1 iceweasel
+			G_AGP lxde $(dpkg --get-selections lxde-* | awk '{print $1}') upower policykit-1 iceweasel
 
 		fi
 
@@ -12825,6 +12825,7 @@ _EOF_
 			Banner_Uninstalling
 			G_AGP transmission-daemon
 			rm /etc/init.d/transmission-daemon /etc/systemd/system/transmission-daemon.service &> /dev/null
+
 		fi
 
 		UNINSTALLING_INDEX=47
@@ -12835,23 +12836,27 @@ _EOF_
 			# Remove background cron job
 			crontab -u www-data -l | grep -v '/var/www/owncloud/cron.php'  | crontab -u www-data -
 			# Disable and remove webserver configs
-			a2dissite owncloud 2>/dev/null
-			rm /etc/apache2/sites-available/owncloud.conf 2>/dev/null
-			rm /etc/nginx/sites-dietpi/owncloud.config 2>/dev/null
-			# Find datadir for backups
-			G_DIETPI-NOTIFY 2 "DietPi will perform an automated backup of your ownCloud database and installation directory, which will be stored inside your ownCloud data directory.\nThe data directory won't be removed. So you can at any time recover your whole ownCloud instance.\nRemove the data directory manually, if you don't need it anymore."
-			local datadir=$(grep -m1 "'datadirectory'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/[',]//g")
-			[[ -n $datadir ]] || datadir="$G_FP_DIETPI_USERDATA/owncloud_data"
-			# Drop MariaDB user and database
+			a2dissite owncloud 2> /dev/null
+			rm /etc/apache2/sites-available/owncloud.conf 2> /dev/null
+			rm /etc/nginx/sites-dietpi/owncloud.config 2> /dev/null
+			G_WHIP_MSG "DietPi will perform an automated backup of your ownCloud database and installation directory, which will be stored inside your ownCloud data directory.\n\nThe data directory won't be removed. So you can recover your whole ownCloud instance any time later.\n\nRemove the data directory manually, if you don't need it anymore."
+			# Drop MariaDB users and database
+			local dbuser=$(grep -m1 "^[[:blank:]]*'dbuser'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed 's/,//')
+			local dbhost=$(grep -m1 "^[[:blank:]]*'dbhost'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed 's/,//')
+			# - Find datadir for backups
+			local datadir=$(grep -m1 "^[[:blank:]]*'datadirectory'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/[',]//g")
+			[[ $datadir ]] || datadir=$G_FP_DIETPI_USERDATA/owncloud_data
 			systemctl start mysql
-			mysql -e "drop user $(grep -m1 "'dbuser'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")@$(grep -m1 "'dbhost'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")"
-			mysql -e "drop user $(grep -m1 "'dbuser'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/,//")" 2> /dev/null
-			[[ -d $G_FP_DIETPI_USERDATA/mysql/owncloud ]] && mysqldump owncloud > "$datadir"/dietpi-owncloud-database-backup.sql
+			mysql -e "drop user $dbuser@$dbhost"
+			mysql -e "drop user $dbuser" 2> /dev/null
+			# - Perform database backup if existent, otherwise skip to not overwrite existing one
+			[[ -d $G_FP_DIETPI_USERDATA/mysql/owncloud ]] && mysqldump owncloud > $datadir/dietpi-owncloud-database-backup.sql
 			mysqladmin drop owncloud -f
 			# Backup ownCloud installation folder
-			cp -a /var/www/owncloud/. "$datadir"/dietpi-owncloud-installation-backup
+			cp -a /var/www/owncloud/. $datadir/dietpi-owncloud-installation-backup
 			# Remove ownCloud installation folder
 			rm -R /var/www/owncloud
+
 		fi
 
 		UNINSTALLING_INDEX=114
@@ -12861,25 +12866,29 @@ _EOF_
 			#Nextcloud
 			crontab -u www-data -l | grep -v '/var/www/nextcloud/cron.php'  | crontab -u www-data -
 			# Disable and remove webserver configs
-			a2dissite nextcloud 2>/dev/null
-			rm /etc/apache2/sites-available/nextcloud.conf 2>/dev/null
-			rm /etc/nginx/sites-dietpi/nextcloud.config 2>/dev/null
-			lighttpd-disable-mod dietpi-nextcloud 2>/dev/null
-			rm /etc/lighttpd/conf-available/99-dietpi-nextcloud.conf 2>/dev/null
-			# Find datadir for backups
-			G_DIETPI-NOTIFY 2 "DietPi will perform an automated backup of your Nextcloud database and installation directory, which will be stored inside your Nextcloud data directory.\nThe data directory won't be removed. So you can at any time recover your whole Nextcloud instance.\nRemove the data directory manually, if you don't need it anymore."
-			local datadir=$(grep -m1 "'datadirectory'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/[',]//g")
-			[[ -n $datadir ]] || datadir="$G_FP_DIETPI_USERDATA/nextcloud_data"
-			# Drop MariaDB user and database
+			a2dissite nextcloud 2> /dev/null
+			rm /etc/apache2/sites-available/nextcloud.conf 2> /dev/null
+			rm /etc/nginx/sites-dietpi/nextcloud.config 2> /dev/null
+			lighttpd-disable-mod dietpi-nextcloud 2> /dev/null
+			rm /etc/lighttpd/conf-available/99-dietpi-nextcloud.conf 2> /dev/null
+			G_WHIP_MSG "DietPi will perform an automated backup of your Nextcloud database and installation directory, which will be stored inside your Nextcloud data directory.\n\nThe data directory won't be removed. So you can recover your whole Nextcloud instance any time later.\n\nRemove the data directory manually, if you don't need it anymore."
+			# Drop MariaDB users and database
+			local dbuser=$(grep -m1 "^[[:blank:]]*'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed 's/,//')
+			local dbhost=$(grep -m1 "^[[:blank:]]*'dbhost'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed 's/,//')
+			# - Find datadir for backups
+			local datadir=$(grep -m1 "^[[:blank:]]*'datadirectory'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/[',]//g")
+			[[ $datadir ]] || datadir=$G_FP_DIETPI_USERDATA/nextcloud_data
 			systemctl start mysql
-			mysql -e "drop user $(grep -m1 "'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")@$(grep -m1 "'dbhost'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")"
-			mysql -e "drop user $(grep -m1 "'dbuser'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/,//")" 2> /dev/null
-			[[ -d $G_FP_DIETPI_USERDATA/mysql/nextcloud ]] && mysqldump nextcloud > "$datadir"/dietpi-nextcloud-database-backup.sql
+			mysql -e "drop user $dbuser@$dbhost"
+			mysql -e "drop user $dbuser" 2> /dev/null
+			# - Perform database backup if existent, otherwise skip to not overwrite existing one
+			[[ -d $G_FP_DIETPI_USERDATA/mysql/nextcloud ]] && mysqldump nextcloud > $datadir/dietpi-nextcloud-database-backup.sql
 			mysqladmin drop nextcloud -f
 			# Backup Nextcloud installation folder
-			cp -a /var/www/nextcloud/. "$datadir"/dietpi-nextcloud-installation-backup
+			cp -a /var/www/nextcloud/. $datadir/dietpi-nextcloud-installation-backup
 			# Remove Nextcloud installation folder
 			rm -R /var/www/nextcloud
+
 		fi
 
 		UNINSTALLING_INDEX=83
@@ -12887,13 +12896,15 @@ _EOF_
 
 			Banner_Uninstalling
 			G_AGP apache2
+
 		fi
 
 		UNINSTALLING_INDEX=85
 		if (( aSOFTWARE_INSTALL_STATE[$UNINSTALLING_INDEX] == -1 )); then
 
 			Banner_Uninstalling
-			G_AGP nginx nginx-light
+			G_AGP nginx $(dpkg --get-selections nginx-* | awk '{print $1}')
+
 		fi
 
 		UNINSTALLING_INDEX=84
@@ -12929,9 +12940,9 @@ _EOF_
 		if (( aSOFTWARE_INSTALL_STATE[$UNINSTALLING_INDEX] == -1 )); then
 
 			Banner_Uninstalling
-			rm "$FP_PHP_BASE_DIR"/fpm/pool.d/www.conf 2> /dev/null
-			rm "$FP_PHP_BASE_DIR"/mods-available/dietpi.ini 2> /dev/null
-			G_AGP "$PHP_APT_PACKAGE_NAME"-* libapache2-mod-"$PHP_APT_PACKAGE_NAME"
+			rm $FP_PHP_BASE_DIR/fpm/pool.d/www.conf 2> /dev/null
+			rm $FP_PHP_BASE_DIR/mods-available/dietpi.ini 2> /dev/null
+			G_AGP $(dpkg --get-selections "$PHP_APT_PACKAGE_NAME"-* | awk '{print $1}') libapache2-mod-"$PHP_APT_PACKAGE_NAME"
 			rm /var/www/phpinfo.php
 			rm /var/www/apc.php
 			rm /var/www/opcache.php
@@ -13054,7 +13065,7 @@ _EOF_
 			rm -R /var/www/ompd
 			systemctl start mysql
 			mysqladmin drop ompd -f
-			mysql -e "drop user ompd@localhost"
+			mysql -e "drop user 'ompd'@'localhost'"
 
 		fi
 
@@ -13197,7 +13208,7 @@ _EOF_
 			Banner_Uninstalling
 			systemctl start mysql
 			mysqladmin drop koel -f
-			mysql -e "drop user koel@localhost"
+			mysql -e "drop user 'koel'@'localhost'"
 			rm -R /var/www/koel
 			rm /etc/systemd/system/koel.service
 
@@ -13547,8 +13558,8 @@ _EOF_
 
 			rm -r /etc/haproxy
 
-			#Shared dev libraries. Leave these installed
-			#G_AGP libpcre3-dev libssl-dev
+			# Shared dev libraries. Leave these installed
+			#apt-mark auto libpcre3-dev libssl-dev &> /dev/null
 
 		fi
 
@@ -13570,7 +13581,7 @@ _EOF_
 			Banner_Uninstalling
 			systemctl start mysql
 			mysqladmin drop wordpress -f
-			mysql -e "drop user wordpress@localhost"
+			mysql -e "drop user 'wordpress'@'localhost'"
 
 			rm -R /var/www/wordpress
 
@@ -13582,11 +13593,7 @@ _EOF_
 			(( aSOFTWARE_INSTALL_STATE[120] == -1 )); then
 
 			Banner_Uninstalling
-			G_AGP tightvncserver
-			G_AGP vnc4server
-			G_AGP x11vnc
-			G_AGP realvnc-vnc-server
-			G_AGP tigervnc-*
+			G_AGP tightvncserver $(dpkg --get-selections tigervnc-* | awk '{print $1}') vnc4server x11vnc realvnc-vnc-server
 
 			rm /etc/systemd/system/vncserver.service
 			rm /etc/init.d/vncserver
@@ -13633,7 +13640,7 @@ _EOF_
 			#drop database
 			systemctl start mysql
 			mysqladmin drop ampache -f
-			mysql -e "drop user ampache@localhost"
+			mysql -e "drop user 'ampache'@'localhost'"
 
 		fi
 
@@ -13763,8 +13770,8 @@ _EOF_
 
 			Banner_Uninstalling
 			#apt-mark auto libssl1.0.0 openssl libsoxr0 libavahi-client3 libtool libconfig9 libpopt0 libdaemon0 &> /dev/null
-			#No package is installed anymore, files are directly extracted into places, need to remove them manually?
-			#https://github.com/Fourdee/DietPi/blob/testing/dietpi/dietpi-software#L5968
+			# No package is installed anymore, files are directly extracted into places, need to remove them manually?
+			# https://github.com/Fourdee/DietPi/blob/testing/dietpi/dietpi-software#L5968
 			#G_RUN_CMD dpkg -P shairport-sync
 			rm /lib/systemd/system/shairport-sync.service /usr/local/bin/shairport-sync /usr/local/etc/shairport-sync.conf* /usr/local/share/man/man7/shairport-sync.7.gz &> /dev/null
 			userdel -f shairport-sync
@@ -13836,7 +13843,7 @@ _EOF_
 			#drop database
 			systemctl start mysql
 			mysqladmin drop baikal -f
-			mysql -e "drop user baikal@localhost"
+			mysql -e "drop user 'baikal'@'localhost'"
 
 		fi
 
@@ -13898,7 +13905,7 @@ _EOF_
 		if (( aSOFTWARE_INSTALL_STATE[$UNINSTALLING_INDEX] == -1 )); then
 
 			Banner_Uninstalling
-			(( $G_HW_ARCH == 10 )) && G_RUN_CMD dpkg -P plexmediaserver plexmediaserver-installer || G_AGP plexmediaserver*
+			(( $G_HW_ARCH == 10 )) && G_RUN_CMD dpkg -P plexmediaserver plexmediaserver-installer || G_AGP $(dpkg --get-selections plexmediaserver* | awk '{print $1}')
 			rm -R /var/lib/plexmediaserver
 			rm /etc/apt/sources.list.d/plex.list 2> /dev/null && G_AGUP
 
@@ -13917,7 +13924,7 @@ _EOF_
 		if (( aSOFTWARE_INSTALL_STATE[$UNINSTALLING_INDEX] == -1 )); then
 
 			Banner_Uninstalling
-			rm -R "$USERDATA_DIRECTORY"/mineos
+			rm -R $G_FP_DIETPI_USERDATA/mineos
 			rm -R /var/games/minecraft
 
 			rm /etc/supervisor/conf.d/mineos.conf
@@ -13941,7 +13948,7 @@ _EOF_
 
 			systemctl start mysql
 			mysqladmin drop gogs -f
-			mysql -e "drop user gogs@localhost"
+			mysql -e "drop user 'gogs'@'localhost'"
 
 		fi
 
@@ -14039,7 +14046,7 @@ _EOF_
 			rm /var/lib/dietpi/dietpi-software/installed/chromium-autostart.sh
 			rm "$HOME"/.chromium-browser.init
 
-			(( $G_DISTRO >=4 )) && G_AGP chromium* || G_RUN_CMD dpkg -P chromium chromedriver
+			(( $G_DISTRO >=4 )) && G_AGP $(dpkg --get-selections chromium* | awk '{print $1}') || G_RUN_CMD dpkg -P chromium chromedriver
 
 		fi
 
@@ -14073,7 +14080,7 @@ _EOF_
 			# drop/delete database
 			systemctl start mysql
 			mysqladmin drop gitea -f
-			mysql -e "drop user gitea@localhost"
+			mysql -e "drop user 'gitea'@'localhost'"
 
 		fi
 
@@ -14100,7 +14107,6 @@ _EOF_
 		if (( aSOFTWARE_INSTALL_STATE[$UNINSTALLING_INDEX] == -1 )); then
 
 			Banner_Uninstalling
-			echo 'pending'
 
 		fi
 
@@ -14216,7 +14222,7 @@ _EOF_
 			rm /etc/sudoers.d/allo
 			systemctl start mysql
 			mysqladmin drop allo_db -f
-			mysql -e "drop user allo_db@localhost"
+			mysql -e "drop user 'allo_db'@'localhost'"
 
 		fi
 
@@ -14226,7 +14232,7 @@ _EOF_
 			Banner_Uninstalling
 			G_WHIP_MSG "Creating MariaDB database backup before uninstallation:\n\nIn case of accident, we create a database backup for you. You can remove it manually, if you are sure, that you don't need it any more.\n\n$G_FP_DIETPI_USERDATA/mariadb-database-backup.sql"
 			G_RUN_CMD systemctl start mysql
-			mysqldump --all-databases > "$G_FP_DIETPI_USERDATA/mariadb-database-backup.sql"
+			mysqldump --all-databases > $G_FP_DIETPI_USERDATA/mariadb-database-backup.sql
 			G_AGP mariadb-server
 
 			# - config folder
@@ -14244,8 +14250,7 @@ _EOF_
 			Banner_Uninstalling
 
 			G_AGP influxdb
-			rm /etc/apt/sources.list.d/influxdb.list
-			G_AGUP
+			rm /etc/apt/sources.list.d/influxdb.list && G_AGUP
 
 			rm -R /var/lib/influxdb
 			rm -R $G_FP_DIETPI_USERDATA/influxdb
@@ -14260,8 +14265,7 @@ _EOF_
 			Banner_Uninstalling
 
 			G_AGP grafana
-			rm /etc/apt/sources.list.d/grafana*.list &> /dev/null
-			G_AGUP
+			rm /etc/apt/sources.list.d/grafana*.list &> /dev/null && G_AGUP
 
 			rm -R /var/lib/grafana
 			rm -R $G_FP_DIETPI_USERDATA/grafana
@@ -14382,8 +14386,8 @@ _EOF_
 		if (( aSOFTWARE_INSTALL_STATE[$UNINSTALLING_INDEX] == -1 )); then
 
 			Banner_Uninstalling
-			#This also removes OpenSSH server. So lets check OpenSSH server isn't installed before hand.
-			if (( ! $(dpkg -l | grep -ci -m1 'openssh-server') )); then
+			# This also removes OpenSSH server. So lets check OpenSSH server isn't installed before hand.
+			if dpkg --get-selections | grep -qi 'openssh-server'; then
 
 				G_AGP openssh-client
 
@@ -14400,7 +14404,7 @@ _EOF_
 			#Disable in fstab
 			sed -i '/\/mnt\/samba/c\#\/mnt\/samba . Please use dietpi-config and the Networking Options: NAS menu to setup this mount' /etc/fstab
 			#Add info file for installation method.
-			echo -e "Samba client can be installed and setup by DietPi-Config.\nSimply run: dietpi-config and select the Networking Options: NAS/Misc menu" > /mnt/samba/readme.txt
+			echo -e 'Samba client can be installed and setup by DietPi-Config.\nSimply run: dietpi-config and select the Networking Options: NAS/Misc menu' > /mnt/samba/readme.txt
 
 		fi
 
@@ -14438,7 +14442,7 @@ _EOF_
 			sed -i '/\/mnt\/nfs_client/c\#\/mnt\/nfs_client . Please use dietpi-config and the Networking Options: NAS menu to setup this mount' /etc/fstab
 
 			#Add info file for installation method.
-			echo -e "NFS client can be installed and setup by DietPi-Config.\nSimply run: dietpi-config and select the Networking Options: NAS/Misc menu" > /mnt/nfs_client/readme.txt
+			echo -e 'NFS client can be installed and setup by DietPi-Config.\nSimply run: dietpi-config and select the Networking Options: NAS/Misc menu' > /mnt/nfs_client/readme.txt
 
 		fi
 
@@ -14492,7 +14496,7 @@ _EOF_
 
 			Banner_Uninstalling
 
-			apt-mark auto default-jre* default-jdk* ca-certificates-java openjdk-8-jre* openjdk-8-jdk*
+			apt-mark auto $(dpkg --get-selections default-jre* default-jdk* openjdk-8-jre* openjdk-8-jdk* | awk '{print $1}') ca-certificates-java
 			rm /etc/apt/preferences.d/99-dietpi-openjdk-8-jdk &> /dev/null
 
 		fi
@@ -14501,7 +14505,7 @@ _EOF_
 		if (( aSOFTWARE_INSTALL_STATE[$UNINSTALLING_INDEX] == -1 )); then
 
 			Banner_Uninstalling
-			G_AGP dropbear* #stretch | dropbear-initramfs dropbear-run
+			G_AGP $(dpkg --get-selections dropbear* | awk '{print $1}') #stretch | dropbear-initramfs dropbear-run
 
 		fi
 
@@ -14509,7 +14513,7 @@ _EOF_
 		if (( aSOFTWARE_INSTALL_STATE[$UNINSTALLING_INDEX] == -1 )); then
 
 			Banner_Uninstalling
-			G_AGP openssh-*
+			G_AGP $(dpkg --get-selections openssh-* | awk '{print $1}')
 
 			# This also clears Openssh-client
 			aSOFTWARE_INSTALL_STATE[0]=0
@@ -14584,7 +14588,7 @@ _EOF_
 		#Update array installed state
 		#aSOFTWARE_INSTALL_STATE[$index]=0
 
-		#Uninstall finished, set all installed software to state 0 (not installed)
+		#Uninstall finished, set all uninstalled software to state 0 (not installed)
 		for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
 		do
 
@@ -14606,23 +14610,22 @@ _EOF_
 	Uninstall_Software_Finalize(){
 
 		#Purge
-		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" "Removing packages that are no longer required"
-
+		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Removing packages that are no longer required'
 		G_AGA
 
 		#Check if we need to clear DietPi choices
 		local fp_temp='/tmp/.dietpi-uninstall_dpkg'
-		dpkg --get-selections | awk '{print $1}' > "$fp_temp"
-		if ! grep -q '^openssh-server' "$fp_temp" &&
-			! grep -q '^dropbear' "$fp_temp"; then
+		dpkg --get-selections | awk '{print $1}' > $fp_temp
+		if ! grep -q '^openssh-server' $fp_temp &&
+			! grep -q '^dropbear' $fp_temp; then
 
 			INDEX_SSHSERVER_CURRENT=0
 			INDEX_SSHSERVER_TARGET=0
 
 		fi
 
-		if ! grep -q '^samba$' "$fp_temp" &&
-			! grep -q '^proftpd-basic' "$fp_temp"; then
+		if ! grep -q '^samba$' $fp_temp &&
+			! grep -q '^proftpd-basic' $fp_temp; then
 
 			INDEX_FILESERVER_CURRENT=0
 			INDEX_FILESERVER_TARGET=0
@@ -14630,15 +14633,15 @@ _EOF_
 		fi
 
 		if grep -q '#/var/log' /etc/fstab &&
-			! grep -q '^rsyslog' "$fp_temp" &&
-			! grep -q '^logrotate' "$fp_temp"; then
+			! grep -q '^rsyslog' $fp_temp &&
+			! grep -q '^logrotate' $fp_temp; then
 
 			INDEX_LOGGING_CURRENT=0
 			INDEX_LOGGING_TARGET=0
 
 		fi
 
-		rm "$fp_temp"
+		rm $fp_temp
 
 		systemctl daemon-reload
 
@@ -14668,71 +14671,71 @@ _EOF_
 		#Generate userdata folders:
 		Create_UserContent_Folders
 		#------------------------------------------------------------
-		#Set current path to home folder
+		# Set current path to home folder
 		cd "$HOME"
 
-		#Update APT
+		# Update APT
 		Banner_Apt_Update
 
-		#Always update APT, before running installs.
+		# Always update APT, before running installs.
 		G_AGUP
 
-		#Simulated APT installation to check for failures related to apt-cache.
+		# Simulated APT installation to check for failures related to apt-cache.
 		G_DIETPI-NOTIFY 2 "Running apt simulation to check for errors, please wait..."
 
 		local package_to_test='bash-doc'
 
 		G_AGI $package_to_test -s
 
-		#Upgrade APT
-		Banner_Setup
+		# Upgrade APT
+		#Banner_Setup
 		Banner_Apt_Update
 		G_AGUG
 
-		#Generate dir for dietpi-software installed "non-service" based control scripts
+		# Generate dir for dietpi-software installed "non-service" based control scripts
 		G_RUN_CMD mkdir -p /var/lib/dietpi/dietpi-software/services
 		G_RUN_CMD chmod -R +x /var/lib/dietpi/dietpi-software/services
 
-		#Disable software installation, if user input is required for automated installs
+		# Disable software installation, if user input is required for automated installs
 		Install_Disable_Requires_UserInput
 
-		#Apply DietPi choice systems
+		# Apply DietPi choice systems
 		Apply_FileServer_Choices
 		Apply_SSHServer_Choices
 		Apply_Logging_Choices
 
-		#Apply DietPi preference systems
+		# Apply DietPi preference systems
 		Apply_Webserver_Preference
 
-		#Update required software that needs to be installed
+		# Update required software that needs to be installed
 		Install_Flag_Prereq_Software
 
-		#Install Linux Software
+		# Install Linux Software
 		/DietPi/dietpi/dietpi-services stop
 		Install_Linux_Software
 
-		#Install DietPi Optimized Software
+		# Install DietPi Optimized Software
 		/DietPi/dietpi/dietpi-services stop
 		Install_Dietpi_Software
 
-		#Apply Uninstall script created by DietPi choice system
+		# Apply Uninstall script created by DietPi choice system
 		Uninstall_Software
 
-		#Apply DietPi configurations and optimizations
+		# Apply DietPi configurations and optimizations
 		/DietPi/dietpi/dietpi-services stop
 		Banner_Configs
 		Install_Apply_Configs
 
 		Install_Apply_Permissions &> /dev/null
 
-		#Apply autostart index
+		# Apply autostart index
 		local autostart_current="$(cat /DietPi/dietpi/.dietpi-autostart_index)"
 		/DietPi/dietpi/dietpi-autostart "$autostart_current"
 
-		#Disable services so DietPi-services can take control (DietPi will start all services from dietpi-postboot.service)
+		# Disable services so DietPi-services can take control (DietPi will start all services from dietpi-postboot.service)
 		/DietPi/dietpi/dietpi-services dietpi_controlled
 
-		#Install finished, set all installed software to state 2 (installed)
+		# Install finished, set all installed software to state 2 (installed)
 		for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
 		do
 
@@ -14745,13 +14748,13 @@ _EOF_
 
 		done
 
-		#Apply GPU Memory Splits: NB, this only checks for installed state '=2'
+		# Apply GPU Memory Splits: NB, this only checks for installed state '=2'
 		Install_Apply_GPU_Settings
 
-		#Write to .install File
+		# Write to .install File
 		Write_InstallFileList
 
-		#DietPi-Automation
+		# DietPi-Automation
 		if (( $G_DIETPI_INSTALL_STAGE == 0 )); then
 
 			# - x86_64 microcode installation
@@ -14762,8 +14765,8 @@ _EOF_
 
 			fi
 
-			#Apply Timezone
-			if [ "$AUTOINSTALL_TIMEZONE" != "$(cat /etc/timezone)" ]; then
+			# - Apply Timezone
+			if [[ $AUTOINSTALL_TIMEZONE != $(</etc/timezone) ]]; then
 
 				echo -e "\nDietPi: Setting Timezone = $AUTOINSTALL_TIMEZONE"
 				rm /etc/timezone
@@ -14773,7 +14776,7 @@ _EOF_
 
 			fi
 
-			#Apply Language (Locale)
+			# - Apply Language (Locale)
 			if ! locale | grep -qE "(LANG|LC_ALL)=[\'\"]?$AUTOINSTALL_LANGUAGE[\'\"]?" ||
 				! locale -a | grep -q 'en_GB.UTF-8'; then
 
@@ -14791,7 +14794,7 @@ _EOF_
 
 			fi
 
-			#Apply Keyboard
+			# - Apply Keyboard
 			if ! grep -q "XKBLAYOUT=\"$AUTOINSTALL_KEYBOARD\"" /etc/default/keyboard; then
 
 				G_DIETPI-NOTIFY 2 "Setting Keyboard $AUTOINSTALL_KEYBOARD. Please wait...\n"
@@ -14800,15 +14803,15 @@ _EOF_
 
 			fi
 
-			#Custom 1st run Script (Local file)
+			# - Custom 1st run Script (Local file)
 			local run_custom_script=0
-			if [ -f /boot/Automation_Custom_Script.sh ]; then
+			if [[ -f /boot/Automation_Custom_Script.sh ]]; then
 
 				cp /boot/Automation_Custom_Script.sh /root/AUTO_CustomScript.sh
 				run_custom_script=1
 
-			#Custom 1st run Script (Online file)
-			elif [ "$AUTOINSTALL_CUSTOMSCRIPTURL" != "0" ]; then
+			# - Custom 1st run Script (Online file)
+			elif [[ $AUTOINSTALL_CUSTOMSCRIPTURL != '0' ]]; then
 
 				INSTALL_URL_ADDRESS="$AUTOINSTALL_CUSTOMSCRIPTURL"
 				G_CHECK_URL "$INSTALL_URL_ADDRESS"
@@ -14839,12 +14842,12 @@ _EOF_
 
 			fi
 
-			#Apply AutoStart
+			# Apply AutoStart
 			/DietPi/dietpi/dietpi-autostart "$AUTOINSTALL_AUTOSTARTTARGET"
 
 		fi
 
-		#Set Install Stage to Finished
+		# Set Install Stage to Finished
 		echo 1 > /DietPi/dietpi/.install_stage
 
 	}
@@ -14950,7 +14953,7 @@ _EOF_
 		/DietPi/dietpi/dietpi-update 1
 
 		#Check update stage file again (dietpi-update will set to 0 if an update was applied and requires a reboot)
-		if (( $(cat /DietPi/dietpi/.update_stage) == 0 )); then
+		if (( $(</DietPi/dietpi/.update_stage) == 0 )); then
 
 			#Update .update_stage file to completed
 			echo 1 > /DietPi/dietpi/.update_stage
@@ -15442,7 +15445,7 @@ _EOF_
 				#Please let DietPi install them for you...
 				if (( ${aSOFTWARE_INSTALL_STATE[$i]} == 1 )); then
 
-					G_WHIP_MSG "DietPi will automatically install a webserver stack (based on your Webserver Preference) when any software that requires a webserver is selected for installation (eg: ownCloud, PiHole etc).\n\nIt is highly recommended that you allow DietPi to do this for you, ensuring compatibility and stability across DietPi installed programs.\n\nPlease only select a webserver stack if you specifically require it, and, no other webserver stack is installed.\n\nTLDR: You do NOT need to select a webserver stack for installation with DietPi. Its all automatic."
+					G_WHIP_MSG 'DietPi will automatically install a webserver stack (based on your Webserver Preference) when any software that requires a webserver is selected for installation (eg: ownCloud, PiHole etc).\n\nIt is highly recommended that you allow DietPi to do this for you, ensuring compatibility and stability across DietPi installed programs.\n\nPlease only select a webserver stack if you specifically require it, and, no other webserver stack is installed.\n\nTLDR: You do NOT need to select a webserver stack for installation with DietPi. Its all automatic.'
 					break
 
 				fi
@@ -15455,7 +15458,7 @@ _EOF_
 				$INDEX_WEBSERVER_TARGET == -2 &&
 				${aSOFTWARE_INSTALL_STATE[82]} < 2 )); then
 
-				G_WHIP_MSG "Due to a apt-get installation issue with PhpMyAdmin, you must have a fully installed Lighttpd + MaridaDB webserver stack, before PhpMyAdmin can be selected for install.\n\nYour selection for PhpMyAdmin has been removed."
+				G_WHIP_MSG 'Due to a apt-get installation issue with PhpMyAdmin, you must have a fully installed Lighttpd + MaridaDB webserver stack, before PhpMyAdmin can be selected for install.\n\nYour selection for PhpMyAdmin has been removed.'
 				aSOFTWARE_INSTALL_STATE[90]=0
 
 			fi
@@ -15463,7 +15466,7 @@ _EOF_
 			#RPiCamInterface - warn user of locking out camera: https://github.com/Fourdee/DietPi/issues/249
 			if (( ${aSOFTWARE_INSTALL_STATE[59]} == 1 )); then
 
-				G_WHIP_MSG "RPi Cam Control Interface will automatically start and activate the camera during boot. This will prevent other programs (eg: raspistill) from using the camera.\n\nYou can free up the camera by selecting \"Stop Camera\" from the web interface:\n - http://myip/rpicam"
+				G_WHIP_MSG 'RPi Cam Control Interface will automatically start and activate the camera during boot. This will prevent other programs (eg: raspistill) from using the camera.\n\nYou can free up the camera by selecting "Stop Camera" from the web interface:\n - http://myip/rpicam'
 
 			fi
 
@@ -15527,41 +15530,41 @@ _EOF_
 					local ethernet_active_state=$(ip r | grep -ci -m1 "eth$(sed -n 1p /DietPi/dietpi/.network)")
 					if (( $ethernet_active_state == 1 )); then
 
-						output_string+="\n\n - Ethernet online: PASSED"
+						output_string+='\n\n - Ethernet online: PASSED'
 
 					else
 
 						criteria_passed=0
-						output_string+="\n\n - Ethernet online: FAILED.\nUse dietpi-config to connect and configure ethernet."
+						output_string+='\n\n - Ethernet online: FAILED.\nUse dietpi-config to connect and configure ethernet.'
 
 					fi
 
 					if [ -d /sys/class/net/wlan$(sed -n 2p /DietPi/dietpi/.network) ]; then
 
-						output_string+="\n\n - Wifi adapter detected: PASSED"
+						output_string+='\n\n - Wifi adapter detected: PASSED'
 
 					else
 
 						criteria_passed=0
-						output_string+="\n\n - Wifi adapter detected: FAILED.\nPlease connect a WiFi adapter and try again."
+						output_string+='\n\n - Wifi adapter detected: FAILED.\nPlease connect a WiFi adapter and try again.'
 
 					fi
 
 					#Passed
 					if (( $criteria_passed == 1 )); then
 
-						output_string+="\n\nPASSED: Criteria met. Good to go."
+						output_string+='\n\nPASSED: Criteria met. Good to go.'
 						G_WHIP_MSG "$output_string"
 						check_criteria=0
 
 					#Failed, retry?
 					else
 
-						output_string+="\n\nFAILED: Criteria not met. Would you like to check again?"
+						output_string+='\n\nFAILED: Criteria not met. Would you like to check again?'
 						G_WHIP_YESNO "$output_string"
 						if (( $? == 0 )); then
 
-							echo "retry" &> /dev/null
+							echo 'retry' &> /dev/null
 
 						else
 
@@ -15838,20 +15841,20 @@ _EOF_
 					if (( $? == 0 )); then
 
 						# - Assign target index
-						if [ "$G_WHIP_RETURNED_VALUE" = "None" ]; then
+						if [[ $G_WHIP_RETURNED_VALUE == 'None' ]]; then
 
 							INDEX_FILESERVER_TARGET=0
-							toberemoved_text="ProFTP and Samba Server"
+							toberemoved_text='ProFTP and Samba Server'
 
-						elif [ "$G_WHIP_RETURNED_VALUE" = "ProFTP" ]; then
+						elif [[ $G_WHIP_RETURNED_VALUE == 'ProFTP' ]]; then
 
 							INDEX_FILESERVER_TARGET=-1
-							toberemoved_text="Samba Server"
+							toberemoved_text='Samba Server'
 
-						elif [ "$G_WHIP_RETURNED_VALUE" = "Samba" ]; then
+						elif [[ $G_WHIP_RETURNED_VALUE == 'Samba' ]]; then
 
 							INDEX_FILESERVER_TARGET=-2
-							toberemoved_text="ProFTP"
+							toberemoved_text='ProFTP'
 
 						# - Reset to current
 						else
@@ -15891,22 +15894,22 @@ _EOF_
 					if (( $? == 0 )); then
 
 						# - Assign target index
-						if [ "$G_WHIP_RETURNED_VALUE" = "None" ]; then
+						if [[ $G_WHIP_RETURNED_VALUE == 'None' ]]; then
 
 							INDEX_LOGGING_TARGET=0
 							toberemoved_text='DietPi-Ramlog, Logrotate, Rsyslog'
 
-						elif [ "$G_WHIP_RETURNED_VALUE" = "DietPi-Ramlog #1" ]; then
+						elif [[ $G_WHIP_RETURNED_VALUE == 'DietPi-Ramlog #1' ]]; then
 
 							INDEX_LOGGING_TARGET=-1
 							toberemoved_text='Logrotate, Rsyslog'
 
-						elif [ "$G_WHIP_RETURNED_VALUE" = "DietPi-Ramlog #2" ]; then
+						elif [[ $G_WHIP_RETURNED_VALUE == 'DietPi-Ramlog #2' ]]; then
 
 							INDEX_LOGGING_TARGET=-2
 							toberemoved_text='Logrotate, Rsyslog'
 
-						elif [ "$G_WHIP_RETURNED_VALUE" = "Full" ]; then
+						elif [[ $G_WHIP_RETURNED_VALUE == 'Full' ]]; then
 
 							INDEX_LOGGING_TARGET=-3
 							toberemoved_text='DietPi-Ramlog'
@@ -15950,19 +15953,19 @@ _EOF_
 					if (( $? == 0 )); then
 
 						# - DriveMan
-						if [ "$G_WHIP_RETURNED_VALUE" = 'Drive' ]; then
+						if [[ $G_WHIP_RETURNED_VALUE == 'Drive' ]]; then
 
 							/DietPi/dietpi/dietpi-drive_manager
 
 						# - List
-						elif [ "$G_WHIP_RETURNED_VALUE" = 'List' ]; then
+						elif [[ $G_WHIP_RETURNED_VALUE == 'List' ]]; then
 
 							/DietPi/dietpi/dietpi-drive_manager 1
 
-							local return_value="$(cat /tmp/dietpi-drive_manager_selmnt)"
-							if [ -n "$return_value" ]; then
+							local return_value="$(</tmp/dietpi-drive_manager_selmnt)"
+							if [[ $return_value ]]; then
 
-								if [ "$return_value" = "/" ]; then
+								if [[ $return_value == '/' ]]; then
 
 									return_value='/mnt'
 
@@ -15974,9 +15977,9 @@ _EOF_
 							fi
 
 						# - Manual filepath entry
-						elif [ "$G_WHIP_RETURNED_VALUE" = 'Custom' ]; then
+						elif [[ $G_WHIP_RETURNED_VALUE == 'Custom' ]]; then
 
-							G_WHIP_INPUTBOX "Please input a location. Your user data will be stored inside this location.\n - eg: /mnt/MyDrive/MyData"
+							G_WHIP_INPUTBOX 'Please input a location. Your user data will be stored inside this location.\n - eg: /mnt/MyDrive/MyData'
 							if (( $? == 0 )); then
 
 								move_data_target="$G_WHIP_RETURNED_VALUE"
@@ -15986,7 +15989,7 @@ _EOF_
 						fi
 
 						# - Move data if the new entry has changed
-						if [ "$user_data_location_current" != "$move_data_target" ]; then
+						if [[ $user_data_location_current != $move_data_target ]]; then
 
 							# - Ask before we begin
 							G_WHIP_YESNO "DietPi will now attempt to transfer your existing user data to the new location:\n\n- From: $user_data_location_current\n- To: $move_data_target\n\nWould you like to begin?"
@@ -16030,15 +16033,15 @@ _EOF_
 					if (( $? == 0 )); then
 
 						#Assign target index
-						if [ "$G_WHIP_RETURNED_VALUE" = 'Apache2' ]; then
+						if [[ $G_WHIP_RETURNED_VALUE == 'Apache2' ]]; then
 
 							INDEX_WEBSERVER_TARGET=0
 
-						elif [ "$G_WHIP_RETURNED_VALUE" = 'Nginx' ]; then
+						elif [[ $G_WHIP_RETURNED_VALUE == 'Nginx' ]]; then
 
 							INDEX_WEBSERVER_TARGET=-1
 
-						elif [ "$G_WHIP_RETURNED_VALUE" = 'Lighttpd' ]; then
+						elif [[ $G_WHIP_RETURNED_VALUE == 'Lighttpd' ]]; then
 
 							INDEX_WEBSERVER_TARGET=-2
 
@@ -16056,7 +16059,7 @@ _EOF_
 							local incompatible_webserver_preference=0
 							local info_currently_installed_webserver='None'
 
-							if (( $(dpkg -l | awk '{print $2}' | grep -ci -m1 'apache2'))); then
+							if dpkg --get-selections | grep -qi '^apache2'; then
 
 								INDEX_WEBSERVER_CURRENT=0
 								info_currently_installed_webserver='Apache2'
@@ -16066,7 +16069,7 @@ _EOF_
 
 								fi
 
-							elif (( $(dpkg -l | awk '{print $2}' | grep -ci -m1 'nginx') )); then
+							elif dpkg --get-selections | grep -qi '^nginx'; then
 
 								INDEX_WEBSERVER_CURRENT=-1
 								info_currently_installed_webserver='Nginx'
@@ -16076,7 +16079,7 @@ _EOF_
 
 								fi
 
-							elif (( $(dpkg -l | awk '{print $2}' | grep -ci -m1 'lighttpd') )); then
+							elif dpkg --get-selections | grep -qi '^lighttpd'; then
 
 								INDEX_WEBSERVER_CURRENT=-2
 								info_currently_installed_webserver='Lighttpd'
@@ -16144,7 +16147,7 @@ _EOF_
 
 						if (( ${aSOFTWARE_INSTALL_STATE[$i]} > 0 )); then
 
-							if [ -n "${aSOFTWARE_ONLINEDOC_URL[$i]}" ]; then
+							if [[ ${aSOFTWARE_ONLINEDOC_URL[$i]} ]]; then
 
 								string+="\n${aSOFTWARE_WHIP_NAME[$i]}: ${aSOFTWARE_WHIP_NAME[$i]}"
 								string+="\n$FP_ONLINEDOC_URL${aSOFTWARE_ONLINEDOC_URL[$i]}\n"
@@ -16409,12 +16412,12 @@ _EOF_
 	# Banner Print
 	#/////////////////////////////////////////////////////////////////////////////////////
 
-	Banner_Setup(){
+	#Banner_Setup(){
 
-		/DietPi/dietpi/dietpi-banner 0
-		echo -e "\n Welcome to DietPi-Software \n"
+	#	/DietPi/dietpi/dietpi-banner 0
+	#	echo -e '\n Welcome to DietPi-Software \n'
 
-	}
+	#}
 
 	Banner_Installing(){
 
@@ -16450,7 +16453,7 @@ _EOF_
 		else
 
 			G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" "Installation completed"
-			G_DIETPI-NOTIFY 0 "The system will now reboot. \n This completes the DietPi-Software installation.\n"
+			G_DIETPI-NOTIFY 0 'The system will now reboot. \n This completes the DietPi-Software installation.\n'
 			sleep 3
 
 		fi
@@ -16469,7 +16472,7 @@ _EOF_
 		if (( $G_DIETPI_INSTALL_STAGE == 0 )); then
 
 			/DietPi/dietpi/dietpi-banner 0
-			G_DIETPI-NOTIFY 1 "\n Installation Aborted by User \n Installation must be completed prior to using DietPi \n Please run dietpi-software to restart the installation \n"
+			G_DIETPI-NOTIFY 1 '\n Installation Aborted by User \n Installation must be completed prior to using DietPi \n Please run dietpi-software to restart the installation \n'
 
 		#Standard abort
 		else
@@ -16525,41 +16528,38 @@ _EOF_
 
 				/DietPi/dietpi/func/dietpi-set_software passwords
 				# - Update
-				GLOBAL_PW="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_GLOBAL_PASSWORD=' /DietPi/dietpi.txt | sed 's/^.*=//')"
+				GLOBAL_PW="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_GLOBAL_PASSWORD=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
 
 			fi
 
 		fi
 
-		Banner_Setup
+		#Banner_Setup
 
-		#Prevent continue if no Network or NTPD is not completed: https://github.com/Fourdee/DietPi/issues/786
+		# Prevent continue if no Network or NTPD is not completed: https://github.com/Fourdee/DietPi/issues/786
 		Check_Internet_and_NTPD
 
-		# - Survey
-		if (( $G_DIETPI_INSTALL_STAGE == 0 )); then
-
-			# - DietPi-Survey opt in/out
-			/DietPi/dietpi/dietpi-survey
-
-		fi
-
 		# - 1st run DietPi updates
-		if (( $(cat /DietPi/dietpi/.update_stage) == -1 )); then
+		if (( $(</DietPi/dietpi/.update_stage) == -1 )); then
 
 			FirstRun_DietPi_Update
 
 		fi
 
-		#- Apply 1st run automation
+		# - Apply 1st run automation
 		if (( $G_DIETPI_INSTALL_STAGE == 0 )); then
 
-			#Activate automation settings from dietpi.txt, if set.
+			# - Activate automation settings from dietpi.txt, if set.
 			FirstRun_Automation_Set
+
+			# - DietPi-Survey opt in/out:
+			#	- As this is called as well after dietpi-update, don't force menu.
+			#	- Menu will promt automatically, if no survey settings file exist, even with $1=1.
+			/DietPi/dietpi/dietpi-survey 1
 
 		fi
 
-		#Start DietPi Menu
+		# Start DietPi Menu
 		while (( $TARGETMENUID > -1 )); do
 
 			printf '\ec' # clear current terminal screen
@@ -16587,10 +16587,10 @@ _EOF_
 	fi
 
 	#--------------------------------------------------------------------------------------
-	#Start DietPi-Software installs
+	# Start DietPi-Software installs
 	if (( $GOSTARTINSTALL )); then
 
-		#Insufficient free space
+		# Insufficient free space
 		G_CHECK_FREESPACE / 500
 		if (( ! $? )); then
 
@@ -16598,13 +16598,13 @@ _EOF_
 
 		fi
 
-		#Start installations for software
+		# Start installations for software
 		Run_Installations
 
-		#Upload DietPi-Survey Data
+		# Upload DietPi-Survey Data
 		/DietPi/dietpi/dietpi-survey 1
 
-		#Reboot
+		# Reboot
 		Banner_Reboot
 
 		if (( $DISABLE_REBOOT )); then


### PR DESCRIPTION
**Status**: Ready for review/testing

**Commit list/description**:
+ DietPi-Software | Changed `G_AGP`/`apt-get mark` wildcard usage to `$(dpkg --get-selections package* | awk '{print $1}')`, to prevent noisy output about non-installed packages
+ DietPi-Software | Removed `Banner_Setup`, as there is always a whiptail menu or `G_DIETPI-NOTIFY 3` showing script info before
+ DietPi-Software | Always call `dietpi-survey` with $1=1, to prevent doubled whiptail menu, as this will show up automatically if no survey settings file was found (first `G_USER_INPUT=1` run)
+ DietPi-Software | Minor code improvements
