### PR TITLE
DietPi-Survey | Collected data adjustments, source-able survey file and further simplification

### DIFF
--- a/dietpi/dietpi-survey
+++ b/dietpi/dietpi-survey
@@ -36,7 +36,7 @@
 
 	OPTED_IN=1 #1=yes | 0=no and purge data
 	SURVEY_SENTCOUNT=0
-	SURVEY_VERSION=5
+	SURVEY_VERSION=6
 
 	DIETPI_VERSION="$(paste -sd '.' /DietPi/dietpi/.version)"
 	UNIQUE_ID=$(sed -n 5p /DietPi/dietpi/.hw_model)
@@ -60,6 +60,8 @@ _EOF_
 	Read_Settings(){
 
 		OPTED_IN=$(sed -n 1p $FP_SETTINGS)
+		# Force interactive mode, if invalid opt value is found:
+		(( OPTED_IN < 0 || OPTED_IN > 1 )) && INPUT=0
 		SURVEY_SENTCOUNT=$(sed -n 2p $FP_SETTINGS)
 
 	}
@@ -121,27 +123,35 @@ _EOF_
 
 	fi
 
-	#Generate text file for upload
-	cat << _EOF_ > "$UPLOAD_FILENAME"
--------------------------
-DietPi-Survey v$SURVEY_VERSION
--------------------------
-Upload Count   : $((SURVEY_SENTCOUNT+1))
-DietPi Version : $DIETPI_VERSION
-Hardware Index : $G_HW_MODEL
-Hardware Name  : $G_HW_MODEL_DESCRIPTION
-CPU Arch Index : $G_HW_ARCH
-CPU Count      : $G_HW_CPU_CORES
-Distro Index   : $G_DISTRO
-Distro Name    : $G_DISTRO_NAME
-Autoboot Index : $(</DietPi/dietpi/.dietpi-autostart_index)
-
--------------------------
-DietPi-Software Installed
--------------------------
-$(grep '=2' /DietPi/dietpi/.installed)
-
+	#Generate file for upload
+	cat << _EOF_ > $UPLOAD_FILENAME
+#!/bin/bash
+# -------------------------
+((aSURVEY_VERSION[$SURVEY_VERSION]++))
+# -------------------------
+((aSURVEY_SENTCOUNT[$((SURVEY_SENTCOUNT+1))]++))
+((aDIETPI_VERSION[$DIETPI_VERSION]++))
+((aDEVICE_NAME[$G_HW_MODEL_DESCRIPTION]++))
+((aCPU_ARCH[${aCPU_NAME[$G_HW_ARCH]}]++))
+((aCPU_COUNT[$G_HW_CPU_CORES]++))
+((aDISTRO_VERSION[$G_DISTRO_NAME]++))
+((aAUTOSTART_OPTION[$(</DietPi/dietpi/.dietpi-autostart_index)]++))
+((aAUTO_SETUP_AUTOMATED[$(grep -m1 -ci '^[[:blank:]]*AUTO_SETUP_AUTOMATED=1' /DietPi/dietpi.txt)]++))
+((aNETWORK_INTERFACE[$(sed -n 3p /DietPi/dietpi/.network)]++))
+# -------------------------
+# DietPi-Software Installed
+# -------------------------
 _EOF_
+
+	# - Add installed software in source-able array format, use DietPi version specific index => name translation:
+	while read software
+	do
+
+		software=${software##*[}
+		software=${software%%]*}
+		echo "((aSOFTWARE[\${aSOFTWARE_NAME$(paste -sd '_' /DietPi/dietpi/.version)[$software]}]++))" >> $UPLOAD_FILENAME
+
+	done <<< "$(grep '=2' /DietPi/dietpi/.installed)"
 
 	#-----------------------------------------------------------------------------------
 	#Input mode: Send survey if opted in or empty file if opted out
@@ -168,7 +178,7 @@ The current survey statistics can be reviewed at: https://dietpi.com/survey
 Your personal upload file would look like this:
 $(<$UPLOAD_FILENAME)
 
-Would you join DietPi-Survey?"
+Would you like to join DietPi-Survey?"
 		if (( ! $? )); then
 
 			OPTED_IN=$G_WHIP_RETURNED_VALUE

--- a/dietpi/dietpi-survey
+++ b/dietpi/dietpi-survey
@@ -132,10 +132,10 @@ _EOF_
 ((aSURVEY_SENTCOUNT[$((SURVEY_SENTCOUNT+1))]++))
 ((aDIETPI_VERSION[$DIETPI_VERSION]++))
 ((aDEVICE_NAME[$G_HW_MODEL_DESCRIPTION]++))
-((aCPU_ARCH[${aCPU_NAME[$G_HW_ARCH]}]++))
+((aCPU_ARCH[\${aCPU_NAME[$G_HW_ARCH]}]++))
 ((aCPU_COUNT[$G_HW_CPU_CORES]++))
 ((aDISTRO_VERSION[$G_DISTRO_NAME]++))
-((aAUTOSTART_OPTION[$(</DietPi/dietpi/.dietpi-autostart_index)]++))
+((aAUTOSTART_OPTION[\${aAUTOSTART_NAME[$(</DietPi/dietpi/.dietpi-autostart_index)]}]++))
 ((aAUTO_SETUP_AUTOMATED[$(grep -m1 -ci '^[[:blank:]]*AUTO_SETUP_AUTOMATED=1' /DietPi/dietpi.txt)]++))
 ((aNETWORK_INTERFACE[$(sed -n 3p /DietPi/dietpi/.network)]++))
 # -------------------------

--- a/dietpi/dietpi-survey
+++ b/dietpi/dietpi-survey
@@ -16,9 +16,8 @@
 	# - Runs on dietpi-update and when user installs software using dietpi-software
 	#
 	# Usage:
-	# - /DietPi/dietpi/dietpi-survey	Interactively let user opt-in, opt-out or remove already uploaded data
-	# - /DietPi/dietpi/dietpi-survey 1	Non-interactively send survey data, IF user opted in (!)
-	# - /DietPi/dietpi/dietpi-survey 2	Non-interactively purge any existing survey data, then set to Opted out
+	# - /DietPi/dietpi/dietpi-survey	Interactively let user opt in or opt out and purge existing survey data
+	# - /DietPi/dietpi/dietpi-survey 1	Non-interactively send survey data or empty file, based on previous user choice
 	#
 	# File sent format:
 	# $(sed -n 5p /DietPi/dietpi/.hw_model).txt
@@ -35,7 +34,7 @@
 	INPUT=0
 	G_CHECK_VALIDINT $1 && INPUT=$1
 
-	OPTED_IN=2 #2=yes | 0=no and clear data
+	OPTED_IN=1 #1=yes | 0=no and purge data
 	SURVEY_SENTCOUNT=0
 	SURVEY_VERSION=5
 
@@ -70,36 +69,35 @@ _EOF_
 		#Check if we have a working internet connection beforehand
 		G_CHECK_URL "$SFTP_ADDR"
 
-		if (( $OPTED_IN == 0 )); then
+		if (( ! $OPTED_IN )); then
 
 			# Send empty file to overwrite existing data, rm is not possible due to missing file list permissions
 			> "$UPLOAD_FILENAME"
 
 		fi
 
-		#upload to server
+		#Upload to server
 		curl --connect-timeout 4 --retry 1 --retry-delay 4 -sT "$UPLOAD_FILENAME" sftp://"$SFTP_USER":"$SFTP_PASS"@"$SFTP_ADDR"/survey/
 		if (( $? )); then
 
-			G_DIETPI-NOTIFY 1 'Failed to connect to SFTP server. Please try again later or report this to DietPi forum or GitHub repo in the first place.'
-			# Return error code to skip writing to settings file, if error occured.
-			return 1
+			# Silently fail, in case of non-interactive mode
+			(( ! $INPUT )) && G_DIETPI-NOTIFY 1 'Failed to connect to SFTP server. Please try again later or report this to DietPi forum or GitHub repo in the first place.'
 
-		else
+		# Successful upload + opted in
+		elif (( $OPTED_IN )); then
 
-			if (( $OPTED_IN == 2 )); then
+			G_DIETPI-NOTIFY 0 'Successfully sent survey data'
+			# Increase sent count
+			((SURVEY_SENTCOUNT++))
 
-				G_DIETPI-NOTIFY 0 'Successfully sent survey data'
-				#Increase sent count
-				((SURVEY_SENTCOUNT++))
+		# Successful upload + opted out + interactive
+		elif (( ! $INPUT )); then
 
-			elif (( $OPTED_IN == 0 )); then
-
-				G_DIETPI-NOTIFY 0 'Successfully purged survey data'
-
-			fi
+			G_DIETPI-NOTIFY 0 'Successfully purged survey data'
 
 		fi
+
+		Write_Settings
 
 	}
 
@@ -107,8 +105,8 @@ _EOF_
 	# Main Loop
 	#/////////////////////////////////////////////////////////////////////////////////////
 	#Enter ramfs
-	mkdir -p "$FP_TMP"
-	cd "$FP_TMP"
+	mkdir -p $FP_TMP
+	cd $FP_TMP
 
 	#Read data from .dietpi-survey file
 	if [[ -f $FP_SETTINGS ]]; then
@@ -116,7 +114,7 @@ _EOF_
 		Read_Settings
 
 	#Force interactive user choice, if no settings file found = no choice made yet
-	#Force opted in, for automated installations by default.
+	#Force opted in, for automated installations by default
 	elif (( $G_USER_INPUTS )); then
 
 		INPUT=0
@@ -128,7 +126,7 @@ _EOF_
 -------------------------
 DietPi-Survey v$SURVEY_VERSION
 -------------------------
-Upload Count   : $SURVEY_SENTCOUNT
+Upload Count   : $((SURVEY_SENTCOUNT+1))
 DietPi Version : $DIETPI_VERSION
 Hardware Index : $G_HW_MODEL
 Hardware Name  : $G_HW_MODEL_DESCRIPTION
@@ -146,55 +144,42 @@ $(grep '=2' /DietPi/dietpi/.installed)
 _EOF_
 
 	#-----------------------------------------------------------------------------------
-	#Input mode: Force opted out, clear existing uploaded data
-	if (( $INPUT == 2 )); then
+	#Input mode: Send survey if opted in or empty file if opted out
+	if (( $INPUT == 1 )); then
 
-		OPTED_IN=0
 		Send_File
-		Write_Settings
-
-	#Input mode: Send survey if opted in
-	elif (( $INPUT == 1 )); then
-
-		if (( $OPTED_IN == 2 )); then
-
-			Send_File
-			Write_Settings
-
-		fi
 
 	else
 
 		G_WHIP_DEFAULT_ITEM=$OPTED_IN
 		G_WHIP_MENU_ARRAY=(
 
-			'2' 'Opt IN to DietPi-Survey.'
-			'0' 'Opt OUT and purge any existing survey data.'
+			'1' 'Opt IN to DietPi-Survey.'
+			'0' 'Opt OUT and purge my existing survey data.'
 
 		)
 
-		G_WHIP_MENU "DietPi-Survey would like to collect anonymous statistics about your device, version and installed software. \
+		G_WHIP_MENU "DietPi-Survey would like to collect anonymous statistics about your hardware, DietPi software and settings. \
 This allows us to focus development based on popularity. NO private data will be collected and NO ONE can identify you based on the data. \
 The data is sent via secured connection to our SFTP server and is stored there unreadable to the public upload user. \
-If you agree, your uploaded data will be automatically updated on every DietPi-Update and whenever you install software via DietPi-Software. \
-We regularly publish results of the collected data at: https://dietpi.com/survey
-Your personal upload file would currently look like this:
+If you agree, your uploaded data will be automatically updated on every DietPi-Update and DietPi-Software usage. \
+The current survey statistics can be reviewed at: https://dietpi.com/survey
+
+Your personal upload file would look like this:
 $(<$UPLOAD_FILENAME)
 
-Would you like to opt in for DietPi-Survey?"
+Would you join DietPi-Survey?"
 		if (( ! $? )); then
 
 			OPTED_IN=$G_WHIP_RETURNED_VALUE
 			Send_File
 
-			Write_Settings
-
 		fi
 
 	fi
 
-	cd "$HOME"
-	rm -R "$FP_TMP"
+	cd $HOME
+	rm -R $FP_TMP
 
 	#-----------------------------------------------------------------------------------
 	exit 0

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -709,34 +709,12 @@ _EOF_
 			>> /root/.ssh/known_hosts
 			G_CONFIG_INJECT 'dietpi.com ' 'dietpi.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDE6aw3r6aOEqendNu376iiCHr9tGBIWPgfrLkzjXjEsHGyVSUFNnZt6pftrDeK7UX\+qX4FxOwQlugG4fymOHbimRCFiv6cf7VpYg1Ednquq9TLb7/cIIbX8a6AuRmX4fjdGuqwmBq3OG7ZksFcYEFKt5U4mAJIaL8hXiM2iXjgY02LqiQY/QWATsHI4ie9ZOnwrQE\+Rr6mASN1BVFuIgyHIbwX54jsFSnZ/7CdBMkuAd9B8JkxppWVYpYIFHE9oWNfjh/epdK8yv9Oo6r0w5Rb\+4qaAc5g\+RAaknHeV6Gp75d2lxBdCm5XknKKbGma2\+/DfoE8WZTSgzXrYcRlStYN' /root/.ssh/known_hosts
 			#-------------------------------------------------------------------------------
-			#Run DietPi-Survey interactively to allow user opt in or out:
-			#	Reset save file due to OPTED_IN index change (2=yes), and, new SFTP system, start fresh
-			rm /DietPi/dietpi/.dietpi-survey &> /dev/null
-			# - Interactive
-			if (( $G_USER_INPUTS )); then
-
-				/DietPi/dietpi/dietpi-survey
-
-			# - Automated install, OPT user in by default + send new survey.
-			else
-
-				/DietPi/dietpi/dietpi-survey 1
-
-			fi
+			#Reset DietPi-Survey settings file due to rework (execution moved to patch v6.10): https://github.com/Fourdee/DietPi/pull/1822
+			[[ -f /DietPi/dietpi/.dietpi-survey ]] && rm /DietPi/dietpi/.dietpi-survey
 			#-------------------------------------------------------------------------------
 
 		elif (( $SUBVERSION_CURRENT == 9 )); then
 
-			#-------------------------------------------------------------------------------
-			#Removal of option 1 for DietPi-Survey: https://github.com/Fourdee/DietPi/issues/1827#issuecomment-395970075
-			#	Set to opted out and cleared existing data
-			local fp_temp='/DietPi/dietpi/.dietpi-survey'
-			if [[ -f $fp_temp ]] &&
-				(( $(sed -n 1p $fp_temp) == 1 )); then
-
-				/DietPi/dietpi/dietpi-survey 2
-
-			fi
 			#-------------------------------------------------------------------------------
 			#Switch to IP commands, removal of net-tools: https://github.com/Fourdee/DietPi/pull/1839
 			apt-mark auto net-tools
@@ -834,6 +812,33 @@ _EOF_
 				G_RUN_CMD wget https://raw.githubusercontent.com/sparky-sbc/sparky-test/master/dsd-marantz/snd-usbmidi-lib.ko -O /lib/modules/3.10.38/kernel/sound/usb/snd-usbmidi-lib.ko
 
 			fi
+			#-------------------------------------------------------------------------------
+			#DietPi-Survey rework phase 2: https://github.com/Fourdee/DietPi/issues/1827#issuecomment-395970075, https://github.com/Fourdee/DietPi/pull/1884
+			local fp_temp='/DietPi/dietpi/.dietpi-survey'
+			if [[ -f $fp_temp ]]; then
+
+				local opted_in=$(sed -n 1p $fp_temp)
+ 				local survey_sentcount=$(sed -n 2p $fp_temp)
+				# OLD: 2=yes, 1=no, 0=no+purge
+				# NEW: 1=yes, 0=no+purge
+				if (( $opted_in < 2 )); then
+
+					opted_in=0
+
+				else
+
+					opted_in=1
+
+				fi
+
+			fi
+			# - Increase DietPi version to v6.10 manually to have correct survey data:
+			cat << _EOF_ > /DietPi/dietpi/.version
+6
+10
+_EOF_
+			# - Non-interactive execution, interactive mode is force internally, if no settings file is found:
+			/DietPi/dietpi/dietpi-survey 1
 			#-------------------------------------------------------------------------------
 
 		fi

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -831,6 +831,11 @@ _EOF_
 
 				fi
 
+				cat << _EOF_ > $fp_temp
+$opted_in
+$survey_sentcount
+_EOF_
+
 			fi
 			# - Increase DietPi version to v6.10 manually to have correct survey data:
 			cat << _EOF_ > /DietPi/dietpi/.version


### PR DESCRIPTION
**Status**: Ready for testing and review
- [x] Patch_file fix: dietpi-survey command argument + settings file + fix DietPi-Version (increase to target version before uploading)
- [x] Adjust collected data, survey version and count? Automation!
- [x] Make survey files source-able by survey-report script: `array[$UNIQUE_ID]=$value` or `((array[$value]++))` ?

**Reference**: https://github.com/Fourdee/DietPi/issues/1827

**Commit list/description**:
+ DietPi-Survey | Further simplification: Just two modes ($1=1 non-interactive, else interactive), opt choices = 0/1 instead of 0/2
+ DietPi-Survey | Silently fail in non-interactive mode
+ DietPi-Survey | Only show successful purge message in interactive mode
+ DietPi-Patch_file | Fix dietpi-survey command argument, settings file and DietPi-Version (increase to target version before uploading)
+ DietPi-Survey | Force interactive mode, if invalid opt-in/out setting is found
+ DietPi-Survey | Switch survey file to source-able format to speed up automated survey report web page generation
+ DietPi-Survey | Minor wording fix
+ DietPi-Survey | Added active network interface and DietPi-Automation info to survey file
+ DietPi-Survey | Patch: Whoopsie, values need to be written back to settings file