### PR TITLE
General | RPi: Revert "gpu_mem" to "gpu_mem_XXX" as it is more failure safe

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,7 +6,7 @@ Changes / Improvements / Optimizations:
 General | ASUS TB: GLES GPU and VPU support now enabled, once Xserver is installed.
 General | 'firmware-iwlwifi': Is now a pre-req to WiFi enable. Adds support for Intel based WiFi chips by default: https://github.com/Fourdee/DietPi/issues/1855
 General | "net-tools" commands (ifconfig, netstat, route, ...) were replaced by modern "ip" commands (ip a, ip r, ...) within DietPi scripts and the package therefore removed from DietPi core packages: https://github.com/Fourdee/DietPi/issues/1666
-General | Removed unused "/DietPi/config.txt" form non-RPi devices: https://github.com/Fourdee/DietPi/pull/1863
+General | Removed unused "/DietPi/config.txt" from non-RPi devices: https://github.com/Fourdee/DietPi/pull/1863
 General | CurlFTPFS: Removed from DietPi scripts and is no longer supported. Due to lack of security, and, single digit install count (survey).
 General | Timesync: DietPi will now only check for a sucessful sync once per system boot, and, again hourly/daily if set. This is to prevent excess delay of systemd-timesyncd service, once the time has already been synced.
 General | Sparky SBC: Designs patch added for DSD on MPD-5 dac , new Ids added Mytek Manhatten , LH labs 1V5 2V0 ,HD-AVP/AVA IDA-8: https://github.com/sparky-sbc/sparky-test/tree/master/dsd-marantz

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,7 +6,7 @@ Changes / Improvements / Optimizations:
 General | ASUS TB: GLES GPU and VPU support now enabled, once Xserver is installed.
 General | 'firmware-iwlwifi': Is now a pre-req to WiFi enable. Adds support for Intel based WiFi chips by default: https://github.com/Fourdee/DietPi/issues/1855
 General | "net-tools" commands (ifconfig, netstat, route, ...) were replaced by modern "ip" commands (ip a, ip r, ...) within DietPi scripts and the package therefore removed from DietPi core packages: https://github.com/Fourdee/DietPi/issues/1666
-General | Removed unused "/DietPi/config.txt" form non-RPi devices and switched from "gpu_mem_256/512/1024" settings to single "gpu_mem" setting: https://github.com/Fourdee/DietPi/pull/1863
+General | Removed unused "/DietPi/config.txt" form non-RPi devices: https://github.com/Fourdee/DietPi/pull/1863
 General | CurlFTPFS: Removed from DietPi scripts and is no longer supported. Due to lack of security, and, single digit install count (survey).
 General | Timesync: DietPi will now only check for a sucessful sync once per system boot, and, again hourly/daily if set. This is to prevent excess delay of systemd-timesyncd service, once the time has already been synced.
 General | Sparky SBC: Designs patch added for DSD on MPD-5 dac , new Ids added Mytek Manhatten , LH labs 1V5 2V0 ,HD-AVP/AVA IDA-8: https://github.com/sparky-sbc/sparky-test/tree/master/dsd-marantz

--- a/config.txt
+++ b/config.txt
@@ -46,7 +46,9 @@ start_x=0
 disable_camera_led=0
 
 #-------GPU memory Splits-------
-gpu_mem=16
+gpu_mem_256=16
+gpu_mem_512=16
+gpu_mem_1024=16
 
 #-------Max USB Current -------
 max_usb_current=1

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -164,7 +164,9 @@ systemctl enable dietpi-rm_program_usb_boot_mode
 		# - int, assume RPi
 		if G_CHECK_VALIDINT $INPUT_DEVICE_VALUE; then
 
-			G_CONFIG_INJECT 'gpu_mem=' "gpu_mem=$INPUT_DEVICE_VALUE" $FP_RPI_CONFIG
+			G_CONFIG_INJECT 'gpu_mem_256=' "gpu_mem_256=$INPUT_DEVICE_VALUE" $FP_RPI_CONFIG
+			G_CONFIG_INJECT 'gpu_mem_512=' "gpu_mem_512=$INPUT_DEVICE_VALUE" $FP_RPI_CONFIG
+			G_CONFIG_INJECT 'gpu_mem_1024=' "gpu_mem_1024=$INPUT_DEVICE_VALUE" $FP_RPI_CONFIG
 
 		else
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -776,27 +776,8 @@ _EOF_
 
 			fi
 			#-------------------------------------------------------------------------------
-			#Remove config.txt for non-RPi devices and switch from "gpu_mem_256/512/1024" to "gpu_mem" setting: https://github.com/Fourdee/DietPi/pull/1863
-			if (( $G_HW_MODEL < 10 )); then
-
-				local gpu_mem=$(grep -m1 '^[[:blank:]]*gpu_mem' /DietPi/config.txt | sed 's/^[^=]*=//' | sed 's/[[:blank:]]*#.*$//')
-				sed -i '/^[[:blank:]#]*gpu_mem/d' /DietPi/config.txt
-				sed -i '/GPU memory Splits/d' /DietPi/config.txt
-				if [[ $gpu_mem ]]; then
-
-					echo -e '\n#-------GPU memory Splits-------\ngpu_mem=$gpu_mem' >> /DietPi/config.txt
-
-				else
-
-					echo -e '\n#-------GPU memory Splits-------\n#gpu_mem=16' >> /DietPi/config.txt
-
-				fi
-
-			else
-
-				[[ -f /DietPi/config.txt ]] && rm /DietPi/config.txt
-
-			fi
+			#Remove config.txt for non-RPi devices: https://github.com/Fourdee/DietPi/pull/1863
+			(( $G_HW_MODEL >= 10 )) && [[ -f /DietPi/config.txt ]] && rm /DietPi/config.txt
 			#-------------------------------------------------------------------------------
 			#Removal of NTP from dietpi-software
 			sed -i '/^aSOFTWARE_INSTALL_STATE\[106\]=/c\aSOFTWARE_INSTALL_STATE\[106\]=0' /DietPi/dietpi/.installed &> /dev/null

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -777,7 +777,12 @@ _EOF_
 			fi
 			#-------------------------------------------------------------------------------
 			#Remove config.txt for non-RPi devices: https://github.com/Fourdee/DietPi/pull/1863
-			(( $G_HW_MODEL >= 10 )) && [[ -f /DietPi/config.txt ]] && rm /DietPi/config.txt
+			if (( $G_HW_MODEL >= 10 )); then
+
+				[[ -f /DietPi/config.txt ]] && rm /DietPi/config.txt
+				[[ -f /boot/config.txt ]] && rm /boot/config.txt
+
+			fi
 			#-------------------------------------------------------------------------------
 			#Removal of NTP from dietpi-software
 			sed -i '/^aSOFTWARE_INSTALL_STATE\[106\]=/c\aSOFTWARE_INSTALL_STATE\[106\]=0' /DietPi/dietpi/.installed &> /dev/null


### PR DESCRIPTION
**Status**: Ready for review and testing
- [x] config.txt
- [x] dietpi-set_hardware
- [x] patch_file
- [x] CHANGELOG.md

**Reference**: https://github.com/Fourdee/DietPi/issues/1816#issuecomment-401642190

**Commit list/description**:
+ General | RPi: Revert "gpu_mem" to "gpu_mem_XXX" as it is more failure safe
