### PR TITLE
DietPi-Drive_Manager | Fixes

### DIFF
--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -176,7 +176,7 @@ _EOF_
 		local cmd_scrape_string=''
 		local index=0
 		G_DIETPI-NOTIFY 0 'Detecting currently mounted drives, please wait...'
-		df -Ph | tail -n +2 | sed '/^tmpfs/d' | sed '/^udev/d' > /tmp/.dietpi-drive_manager_df_tmp
+		df -Ph | tail -n +2 | sed '/tmpfs/d' | sed '/^udev/d' > /tmp/.dietpi-drive_manager_df_tmp
 		while read line
 		do
 

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -191,7 +191,7 @@ _EOF_
 			Init_New_Device
 
 			aDRIVE_ISMOUNTED[$INDEX_INIT_CURRENT_DEVICE]=1
-      aDRIVE_ISPARTITIONTABLE[$INDEX_INIT_CURRENT_DEVICE]=1
+			aDRIVE_ISPARTITIONTABLE[$INDEX_INIT_CURRENT_DEVICE]=1
 			aDRIVE_MOUNT_SOURCE[$INDEX_INIT_CURRENT_DEVICE]=$(awk '{print $1}' <<< $line)
 			aDRIVE_MOUNT_TARGET[$INDEX_INIT_CURRENT_DEVICE]=$(awk '{print $6}' <<< $line)
 			#	Workaround for /dev/root under RPi, force physical location

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -31,8 +31,6 @@
 
 	EXIT_CODE=0
 
-	PROGRAM_NAME='DietPi-Drive Manager'
-
 	#Service control for script
 	SERVICE_CONTROL=1
 
@@ -86,6 +84,8 @@
 		INDEX_INIT_CURRENT_DEVICE=-1
 
 		#Delete []
+		unset aDRIVE_UUID
+		unset aDRIVE_PART_UUID
 		unset aDRIVE_MOUNT_SOURCE
 		unset aDRIVE_MOUNT_TARGET
 		unset aDRIVE_SOURCE_DEVICE
@@ -94,11 +94,9 @@
 		unset aDRIVE_SIZE_USED
 		unset aDRIVE_SIZE_PERCENTUSED
 		unset aDRIVE_SIZE_FREE
-		unset aDRIVE_PART_UUID
-		unset aDRIVE_UUID
 
-		unset aDRIVE_ISMOUNTED
 		unset aDRIVE_ISFILESYSTEM
+		unset aDRIVE_ISMOUNTED
 		unset aDRIVE_ISREADONLY_CURRENTLY
 		unset aDRIVE_ISNETWORKED
 
@@ -114,7 +112,7 @@
 		FP_USERDATA_CURRENT="$(readlink -f $G_FP_DIETPI_USERDATA)"
 
 		# - Swapfile location
-		FP_SWAPFILE_CURRENT="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_SWAPFILE_LOCATION=' /DietPi/dietpi.txt | sed 's/.*=//')"
+		FP_SWAPFILE_CURRENT="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_SWAPFILE_LOCATION=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
 
 		# - ROOTFS location
 		FP_ROOTFS_SOURCE=$(findmnt / -o source -n)
@@ -178,7 +176,7 @@ _EOF_
 		local cmd_scrape_string=''
 		local index=0
 		G_DIETPI-NOTIFY 0 'Detecting currently mounted drives, please wait...'
-		df -Ph | tail -n +2 | sed '/tmpfs/d' | sed '/^udev/d' > /tmp/.dietpi-drive_manager_df_tmp
+		df -Ph | tail -n +2 | sed '/^tmpfs/d' | sed '/^udev/d' > /tmp/.dietpi-drive_manager_df_tmp
 		while read line
 		do
 
@@ -191,9 +189,9 @@ _EOF_
 			Init_New_Device
 
 			aDRIVE_ISMOUNTED[$INDEX_INIT_CURRENT_DEVICE]=1
-			aDRIVE_MOUNT_SOURCE[$INDEX_INIT_CURRENT_DEVICE]=$(echo $line | awk '{print $1}')
-			aDRIVE_MOUNT_TARGET[$INDEX_INIT_CURRENT_DEVICE]=$(echo $line | awk '{print $6}')
-			#	Workaround for /dev/root under RPi, force psyhical location
+			aDRIVE_MOUNT_SOURCE[$INDEX_INIT_CURRENT_DEVICE]=$(awk '{print $1}' <<< $line)
+			aDRIVE_MOUNT_TARGET[$INDEX_INIT_CURRENT_DEVICE]=$(awk '{print $6}' <<< $line)
+			#	Workaround for /dev/root under RPi, force physical location
 			if [[ ${aDRIVE_MOUNT_TARGET[$INDEX_INIT_CURRENT_DEVICE]} == '/' ]]; then
 
 				aDRIVE_MOUNT_SOURCE[$INDEX_INIT_CURRENT_DEVICE]=$FP_ROOTFS_SOURCE
@@ -208,7 +206,7 @@ _EOF_
 				aDRIVE_ISFILESYSTEM[$INDEX_INIT_CURRENT_DEVICE]=1
 				aDRIVE_FSTYPE[$INDEX_INIT_CURRENT_DEVICE]='Net'
 
-			# - Psyhical
+			# - Physical
 			else
 
 				cmd_scrape_string=$(blkid ${aDRIVE_MOUNT_SOURCE[$INDEX_INIT_CURRENT_DEVICE]} -s TYPE -o value)
@@ -223,10 +221,10 @@ _EOF_
 
 			G_DIETPI-NOTIFY 2 " - Detected: ${aDRIVE_MOUNT_SOURCE[$INDEX_INIT_CURRENT_DEVICE]} > ${aDRIVE_MOUNT_TARGET[$INDEX_INIT_CURRENT_DEVICE]}"
 
-			aDRIVE_SIZE_TOTAL[$INDEX_INIT_CURRENT_DEVICE]=$(echo $line | awk '{print $2}')
-			aDRIVE_SIZE_USED[$INDEX_INIT_CURRENT_DEVICE]=$(echo $line | awk '{print $3}')
-			aDRIVE_SIZE_PERCENTUSED[$INDEX_INIT_CURRENT_DEVICE]=$(echo $line | awk '{print $5}')
-			aDRIVE_SIZE_FREE[$INDEX_INIT_CURRENT_DEVICE]=$(echo $line | awk '{print $4}')
+			aDRIVE_SIZE_TOTAL[$INDEX_INIT_CURRENT_DEVICE]=$(awk '{print $2}' <<< $line)
+			aDRIVE_SIZE_USED[$INDEX_INIT_CURRENT_DEVICE]=$(awk '{print $3}' <<< $line)
+			aDRIVE_SIZE_FREE[$INDEX_INIT_CURRENT_DEVICE]=$(awk '{print $4}' <<< $line)
+			aDRIVE_SIZE_PERCENTUSED[$INDEX_INIT_CURRENT_DEVICE]=$(awk '{print $5}' <<< $line)
 
 			aDRIVE_UUID[$INDEX_INIT_CURRENT_DEVICE]=$(blkid ${aDRIVE_MOUNT_SOURCE[$INDEX_INIT_CURRENT_DEVICE]} -s UUID -o value)
 			aDRIVE_PART_UUID[$INDEX_INIT_CURRENT_DEVICE]=$(blkid ${aDRIVE_MOUNT_SOURCE[$INDEX_INIT_CURRENT_DEVICE]} -s PARTUUID -o value)
@@ -244,13 +242,13 @@ _EOF_
 				# - RootFS RW check
 				if [[ ${aDRIVE_MOUNT_TARGET[$INDEX_INIT_CURRENT_DEVICE]} == '/' ]]; then
 
-					G_DIETPI-NOTIFY 2 "RootFS is currently set to R/O. $PROGRAM_NAME requires R/W access."
+					G_DIETPI-NOTIFY 2 "RootFS is currently set to R/O. $G_PROGRAM_NAME requires R/W access."
 
-					G_WHIP_YESNO "RootFS is currently set to 'Read Only'. DietPi-Drive_Manager requires 'Read Write' access to function.\n\nWould you like to renable 'Read Write' access on RootFS?"
+					G_WHIP_YESNO "RootFS is currently set to 'Read Only'. $G_PROGRAM_NAME requires 'Read Write' access to function.\n\nWould you like to renable 'Read Write' access on RootFS?"
 					if (( $? == 0 )); then
 
 						G_RUN_CMD mount -v -o rw,remount ${aDRIVE_MOUNT_TARGET[$INDEX_INIT_CURRENT_DEVICE]}
-						G_DIETPI-NOTIFY 0 "RootFS R/W now enabled."
+						G_DIETPI-NOTIFY 0 'RootFS R/W now enabled.'
 
 					else
 
@@ -269,18 +267,21 @@ _EOF_
 			fi
 
 			# - Add entry to fstab
-			if [[ -n ${aDRIVE_UUID[$INDEX_INIT_CURRENT_DEVICE]} ]]; then
+			if [[ ${aDRIVE_UUID[$INDEX_INIT_CURRENT_DEVICE]} ]]; then
 
-				local string_options='rw'
+				local string_options=',rw'
 				if (( ${aDRIVE_ISREADONLY_CURRENTLY[$INDEX_INIT_CURRENT_DEVICE]} )); then
 
-					string_options='ro'
+					string_options=',ro'
 
 				fi
 
+				# fsck flag for root device, to allow check on reboot
+				local fsck_flag=1
 				if [[ ${aDRIVE_MOUNT_TARGET[$INDEX_INIT_CURRENT_DEVICE]} != '/' ]]; then
 
 					string_options+=',nofail'
+					fsck_flag=0
 
 				fi
 
@@ -293,8 +294,10 @@ _EOF_
 
 				fi
 
+				if [[ ${aDRIVE_MOUNT_TARGET[$INDEX_INIT_CURRENT_DEVICE]} == '/' ]]; then
+
 				cat << _EOF_ >> $FP_TEMP_FSTAB
-$dev_entry ${aDRIVE_MOUNT_TARGET[$INDEX_INIT_CURRENT_DEVICE]} auto $string_options,noatime 0 0
+$dev_entry ${aDRIVE_MOUNT_TARGET[$INDEX_INIT_CURRENT_DEVICE]} auto defaults,x-systemd.automount,noatime$string_options 0 $fsck_flag
 _EOF_
 
 			fi
@@ -326,7 +329,7 @@ _EOF_
 				# - New unmounted drive found on system, add entry to fstab
 				#	Must have a valid UUID! (this excludes /dev/mmcblk0)
 				if (( $i == ( ${#aDRIVE_MOUNT_SOURCE[@]} - 1 ) )) &&
-					[[ -n $(blkid $line -s UUID -o value) ]]; then
+					[[ $(blkid $line -s UUID -o value) ]]; then
 
 					G_DIETPI-NOTIFY 2 " - Detected unmounted drive: $line, updating fstab"
 
@@ -349,7 +352,7 @@ _EOF_
 					fi
 
 					cat << _EOF_ >> $FP_TEMP_FSTAB
-#UUID=${aDRIVE_UUID[$INDEX_INIT_CURRENT_DEVICE]} ${aDRIVE_MOUNT_TARGET[$INDEX_INIT_CURRENT_DEVICE]} auto noatime,nofail 0 0
+#UUID=${aDRIVE_UUID[$INDEX_INIT_CURRENT_DEVICE]} ${aDRIVE_MOUNT_TARGET[$INDEX_INIT_CURRENT_DEVICE]} auto defaults,x-systemd.automount,noatime,rw,nofail 0 0
 _EOF_
 
 				fi
@@ -386,7 +389,7 @@ _EOF_
 				Init_New_Device
 
 				aDRIVE_MOUNT_SOURCE[$INDEX_INIT_CURRENT_DEVICE]="/dev/$line"
-				aDRIVE_MOUNT_TARGET[$INDEX_INIT_CURRENT_DEVICE]=${aDRIVE_MOUNT_SOURCE[$INDEX_INIT_CURRENT_DEVICE]}
+				aDRIVE_MOUNT_TARGET[$INDEX_INIT_CURRENT_DEVICE]=''
 				aDRIVE_SOURCE_DEVICE[$INDEX_INIT_CURRENT_DEVICE]=$line
 
 			fi
@@ -403,7 +406,7 @@ _EOF_
 		fi
 
 		#Find the drive we are to edit, then set its index (this is due to array list total being not constant)
-		if [[ -n $DRIVE_TARGET_BEING_EDITED ]]; then
+		if [[ $DRIVE_TARGET_BEING_EDITED ]]; then
 
 			for ((i=0; i<${#aDRIVE_MOUNT_SOURCE[@]}; i++))
 			do
@@ -481,8 +484,8 @@ _EOF_
 
 		if [[ ${aDRIVE_MOUNT_TARGET[$INDEX_DRIVE_BEING_EDITED]} == '/' ]]; then
 
-			systemctl unmask dietpi-fs_partition_resize.service
-			G_RUN_CMD systemctl enable dietpi-fs_partition_resize.service
+			systemctl unmask dietpi-fs_partition_resize
+			G_RUN_CMD systemctl enable dietpi-fs_partition_resize
 
 			G_WHIP_YESNO 'RootFS resize will occur on next reboot.\n\nWould you like to reboot the system now?'
 			if (( $? == 0 )); then
@@ -596,7 +599,7 @@ _EOF_
 
 		local format_new_uuid=$(blkid $FORMAT_PREVIOUS_MOUNT_SOURCE -s UUID -o value)
 
-		rm -R $FORMAT_PREVIOUS_MOUNT_TARGET
+		[[ -e $FORMAT_PREVIOUS_MOUNT_TARGET ]] && rm -R $FORMAT_PREVIOUS_MOUNT_TARGET
 
 		# - Automatically mount it
 		DRIVE_TARGET_BEING_EDITED="/mnt/$format_new_uuid"
@@ -688,7 +691,7 @@ _EOF_
 		if mount | grep -m1 '[[:blank:]]/[[:blank:]]' | grep -q '(ro,'; then
 
 			G_DIETPI-NOTIFY 1 'RootFS is currently set to R/O.'
-			G_DIETPI-NOTIFY 2 "DietPi requires RootFS R/W access. Please run 'dietpi-drive_manager' to re-enable.\n"
+			G_DIETPI-NOTIFY 2 'DietPi requires RootFS R/W access. Please run "dietpi-drive_manager" to re-enable.\n'
 			EXIT_CODE=1
 
 		else
@@ -1425,7 +1428,9 @@ NB:
 
 				FORMAT_GPT=1
 
-				G_WHIP_YESNO "Would you like to use GPT or MBR parition table?\n - GPT is required for 2TB+ drives\n - MBR does NOT support 2TB+ drives\n\nIf unsure, select GPT (default)"
+				G_WHIP_BUTTON_OK_TEXT='MBR'
+				G_WHIP_BUTTON_CANCEL_TEXT='GPT'
+				G_WHIP_YESNO 'Would you like to use GPT or MBR parition table?\n - GPT is required for 2TB+ drives\n - MBR does NOT support 2TB+ drives\n\nIf unsure, select GPT (default)'
 				if (( ! $? )); then
 
 					FORMAT_GPT=0
@@ -1448,7 +1453,7 @@ NB:
 				)
 
 				G_WHIP_DEFAULT_ITEM="$FORMAT_FILESYSTEM_TYPE"
-				G_WHIP_MENU "Please select a filesystem type for this format:\n\nEXT4:\nHighly recommended if you plan to use this drive solely on this system (dedicated drive).\n\nNTFS:\nRecommended if you plan to use this drive on a Windows system. High CPU usage during transfers.\n\nFull list of different filesystem types:\nhttp://dietpi.com/phpbb/viewtopic.php?f=8&t=673&p=2898#p2898"
+				G_WHIP_MENU 'Please select a filesystem type for this format:\n\nEXT4:\nHighly recommended if you plan to use this drive solely on this system (dedicated drive).\n\nNTFS:\nRecommended if you plan to use this drive on a Windows system. High CPU usage during transfers.\n\nFull list of different filesystem types:\nhttp://dietpi.com/phpbb/viewtopic.php?f=8&t=673&p=2898#p2898'
 				if (( ! $? )); then
 
 					# Install FS pre-reqs
@@ -1532,7 +1537,7 @@ NB:
 
 			G_WHIP_DEFAULT_ITEM="$samba_clientname"
 			G_WHIP_INPUTBOX 'Please enter the fileservers IP address\n - eg: 192.168.0.2'
-			if (( $? != 0 )); then
+			if (( $? )); then
 
 				break
 
@@ -1541,7 +1546,7 @@ NB:
 
 			G_WHIP_DEFAULT_ITEM="$samba_clientshare"
 			G_WHIP_INPUTBOX 'Please enter the fileservers shared folder name\n - eg: MySharedFolder'
-			if (( $? != 0 )); then
+			if (( $? )); then
 
 				break
 
@@ -1550,7 +1555,7 @@ NB:
 
 			G_WHIP_DEFAULT_ITEM="$samba_clientuser"
 			G_WHIP_INPUTBOX 'Please enter the fileservers username\n - eg: JoeBloggs'
-			if (( $? != 0 )); then
+			if (( $? )); then
 
 				break
 
@@ -1564,7 +1569,7 @@ NB:
 
 			G_WHIP_DEFAULT_ITEM="$samba_fp_mount_target"
 			G_WHIP_INPUTBOX 'Please enter a unique folder name for the mount location (eg: samba). This will be placed in /mnt/'
-			if (( $? != 0 )); then
+			if (( $? )); then
 
 				break
 
@@ -1617,7 +1622,7 @@ _EOF_
 
 			G_WHIP_DEFAULT_ITEM="$nfs_clientname"
 			G_WHIP_INPUTBOX 'Please enter the fileservers IP address\n - eg: 192.168.0.2'
-			if (( $? != 0 )); then
+			if (( $? )); then
 
 				break
 
@@ -1626,7 +1631,7 @@ _EOF_
 
 			G_WHIP_DEFAULT_ITEM="$nfs_fp_mount_target"
 			G_WHIP_INPUTBOX 'Please enter a unique folder name for the mount location (eg: samba). This will be placed in /mnt/'
-			if (( $? != 0 )); then
+			if (( $? )); then
 
 				break
 


### PR DESCRIPTION
**Status**: WIP
- [x] Add /tmp mount size, that we forced elsewhere
Current: `tmpfs /tmp tmpfs defaults,size=1023M,noatime,nodev,nosuid,mode=1777 0 0`
- [ ] Make use of `FORMAT_RECREATE_PARTITION_TABLE` to allow formatting partition only. Currently everything is handled as drive.
- [ ] Decide whether to create partition tables on drives or write fs directly to drive (mount source will be /dev/sda instead of /dev/sda1). Currently on drives without partition table, partition table is written first, but as mount source is still `/dev/sda` it gets overwritten by `mkfs /dev/sda`. All partition table/parted steps could be skipped instead, if we found no reason where it is needed on single partition drives.
- [ ] Consider using `lsblk -npao KNAME,TYPE,RO,SIZE,UUID,FSTYPE,MOUNTPOINT` to detect all drives within single loop. Current solution works, but as to it's complexity it should be slower and makes debugging more difficult.
- [ ] Check if it's possible to mount root on RPi via UUID as well and skip PARTUUID handling:
```
2018-07-02 16:32:06 root@micha:/var/log# blkid /dev/mmcblk0p2 -s UUID -o value
90a83158-560d-48ee-9de9-40c51d93c287
2018-07-02 16:33:07 root@micha:/var/log# blkid /dev/mmcblk0p1 -s UUID -o value
A365-6756
```
- [x] Support ROM devices: https://github.com/Fourdee/DietPi/commit/8f6a654709485db6bcb0b075649310de760a9e06

**Reference**: https://github.com/Fourdee/DietPi/issues/1858

**Commit list/description**:
+ DietPi-Drive_Manager | Re-add partition type buttons text
+ DietPi-Drive_Manager | Re-add "defaults" and "x-systemd.automount" to fstab entries
+ DietPi-Drive_Manager | Add fsck flag =1 to RootFS, to allow scan on reboot
+ DietPi-Drive_Manager | Fix: Drives without partition got mount_target=mount_source and mount_target for removed after format, which lead to error on mounting the drive until reboot.
+ DietPi-Drive_Manager | Minor code and wording
