### PR TITLE
DietPi-Boot | "tee" output to log file instead of redirect to preserve/show logs in terminal as well

### DIFF
--- a/rootfs/etc/systemd/system/dietpi-boot.service
+++ b/rootfs/etc/systemd/system/dietpi-boot.service
@@ -7,7 +7,7 @@ After=network-online.target network.target networking.service dietpi-ramdisk.ser
 Type=oneshot
 RemainAfterExit=yes
 StandardOutput=tty
-ExecStart=/bin/bash -c '/DietPi/dietpi/boot &> /var/tmp/dietpi/logs/dietpi-boot.log'
+ExecStart=/bin/bash -c '/DietPi/dietpi/boot | tee /var/tmp/dietpi/logs/dietpi-boot.log'
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
**Status**: Ready for review

**Commit list/description**:
+ DietPi-Boot | "tee" output to log file instead of redirect to preserve/show logs in terminal as well

@Fourdee 
What you think, as we also use `tee` for our other services? Currently it is a bid inconsistent.