### PR TITLE
#Fixed ExecStart for Radarr, Sonarr and Jackett.

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11745,7 +11745,7 @@ After=network.target
 [Service]
 User=root
 Type=simple
-ExecStart=/usr/bin/mono --debug /opt/NzbDrone/NzbDrone.exe -nobrowser
+ExecStart=/usr/bin/mono --optimize=all --server /opt/NzbDrone/NzbDrone.exe -nobrowser
 
 [Install]
 WantedBy=multi-user.target
@@ -11767,7 +11767,7 @@ After=network.target
 [Service]
 User=root
 Type=simple
-ExecStart=/usr/bin/mono --debug /opt/Radarr/Radarr.exe -nobrowser
+ExecStart=/usr/bin/mono --optimize=all --server /opt/Radarr/Radarr.exe -nobrowser
 
 [Install]
 WantedBy=multi-user.target
@@ -11816,7 +11816,7 @@ User=root
 Restart=always
 RestartSec=5
 Type=simple
-ExecStart=/usr/bin/mono --debug /opt/jackett/JackettConsole.exe
+ExecStart=/usr/bin/mono --optimize=all --server /opt/jackett/JackettConsole.exe
 TimeoutStopSec=20
 
 [Install]


### PR DESCRIPTION
Running mono with debug option affects the application performance.

**Status**: <!-- WIP / Testing / Ready / ... -->
Ready. Tested.

**Reference**: no

**Commit list/description**:
#Fixed ExecStart for Radarr, Sonarr and Jackett.
Running mono with debug option affects the application performance.