### PR TITLE
DietPi-Ramlog | Toggle service on (un)install

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7297,9 +7297,10 @@ _EOF_
 
 			Banner_Installing
 
+			l_message='Copy /var/log skeletons to temporary storage' G_RUN_CMD /DietPi/dietpi/dietpi-ramlog 1
 			#Install (add tmpfs mount to fstab)
-			local tmpfs_max_size=$(grep -m1 '^AUTO_SETUP_RAMLOG_MAXSIZE=' /DietPi/dietpi.txt | sed 's/^.*=//')
-			sed -i "/\/var\/log/c\tmpfs                   \/var\/log                tmpfs   defaults,size=${tmpfs_max_size}m,noatime,nodev,nosuid,mode=1777  0 0" /etc/fstab
+			local tmpfs_max_size=$(grep -m1 '^[[:blank:]]*AUTO_SETUP_RAMLOG_MAXSIZE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
+			sed -i "/\/var\/log/c\tmpfs \/var\/log tmpfs defaults,size=${tmpfs_max_size}m,noatime,nodev,nosuid,mode=1777 0 0" /etc/fstab
 			systemctl enable dietpi-ramlog
 
 		fi
@@ -14435,8 +14436,14 @@ _EOF_
 		if (( aSOFTWARE_INSTALL_STATE[$UNINSTALLING_INDEX] == -1 )); then
 
 			Banner_Uninstalling
-			sed -i '/\/var\/log/c\#\/var\/log DietPi Ramlog Disabled' /etc/fstab
-			systemctl disable dietpi-ramlog
+			G_RUN_CMD systemctl stop dietpi-ramlog
+			# Failsafe, if service was already stopped:
+			l_message='Copy /var/log skeletons to temporary storage' G_RUN_CMD /DietPi/dietpi/dietpi-ramlog 1
+			l_message='Unmounting tmpfs from /var/log' G_RUN_CMD umount /var/log
+			l_message='Copy temporary log skeletons back to /var/log' G_RUN_CMD /DietPi/dietpi/dietpi-ramlog 0
+			G_RUN_CMD systemctl disable dietpi-ramlog
+			sed -i '/\/var\/log/c\#\/var\/log DietPi-RAMlog disabled' /etc/fstab
+			rm -R /var/lib/dietpi/dietpi-ramlog &> /dev/null
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7300,6 +7300,7 @@ _EOF_
 			#Install (add tmpfs mount to fstab)
 			local tmpfs_max_size=$(grep -m1 '^AUTO_SETUP_RAMLOG_MAXSIZE=' /DietPi/dietpi.txt | sed 's/^.*=//')
 			sed -i "/\/var\/log/c\tmpfs                   \/var\/log                tmpfs   defaults,size=${tmpfs_max_size}m,noatime,nodev,nosuid,mode=1777  0 0" /etc/fstab
+			systemctl enable dietpi-ramlog
 
 		fi
 
@@ -14435,6 +14436,7 @@ _EOF_
 
 			Banner_Uninstalling
 			sed -i '/\/var\/log/c\#\/var\/log DietPi Ramlog Disabled' /etc/fstab
+			systemctl disable dietpi-ramlog
 
 		fi
 


### PR DESCRIPTION
**Status**: Ready for testing
- Or is there any reason why the service stays active, saving and recovering the /var/log file/folder structure on reboot?