### PR TITLE
DietPi-Software | Xserver uninstall fix + minor improvements

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,7 @@ DietPi-Config | ASUS TB: Resolved loss of WiFi device after a reboot: https://gi
 DietPi-Drive_Manager | Resolved an issue where the program could remove a non-empty directory in rare situations.
 DietPi-Software | Resolved a potential Mono instability issue with Radarr, Sonarr and Jackett, due to using '--optimize=all --server'. This has now been removed for new installations. Many thanks to @hellfirehd for debugging/testing and @Taloth for dev insights: https://github.com/Fourdee/DietPi/issues/1896
 DietPi-Software | Mono: Temp mono files are now cleared from memory once installed, preventing out of memory errors for additional software installs afterwards: https://github.com/Fourdee/DietPi/issues/1877#issuecomment-403856446
+DietPi-Software | Xserver: Resolved rarely occuring uninstall issus by not purging dependencies, but leaving them for autoremove: https://github.com/Fourdee/DietPi/issues/1921
 DietPi-Update | Resolved an issue where incorrect version would be displayed, once update was completed. This is due to '| tee' on a function, making var changes local: https://github.com/Fourdee/DietPi/issues/1877#issuecomment-403866204
 
 -----------------------------------------------------------------------------------------------------------

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3326,7 +3326,7 @@ _EOF_
 			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/conf/desktop'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
-			G_AGI lxde upower policykit-1 iceweasel
+			G_AGI lxde upower policykit-1 firefox-esr
 			#upower policykit-1. Needed for LXDE logout menu item to show shutdown/restart ...
 
 			#RPi, revert to Debian pcmanfm install package: https://github.com/Fourdee/DietPi/issues/1558#issuecomment-390328173
@@ -3350,10 +3350,9 @@ _EOF_
 
 			# - For desktop entries/icons hosted on dietpi.com
 			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/conf/desktop'
-
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
-			G_AGI mate-desktop-environment-extras upower policykit-1 iceweasel
+			G_AGI mate-desktop-environment-extras upower policykit-1 firefox-esr
 
 		fi
 
@@ -3365,10 +3364,9 @@ _EOF_
 
 			# - For desktop entries/icons hosted on dietpi.com
 			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/conf/desktop'
-
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
-			G_AGI x-window-system-core wmaker gnustep gnustep-devel gnustep-games libc-dbg upower policykit-1 iceweasel
+			G_AGI x-window-system-core wmaker gnustep gnustep-devel gnustep-games libc-dbg upower policykit-1 firefox-esr
 
 		fi
 
@@ -3380,10 +3378,9 @@ _EOF_
 
 			# - For desktop entries/icons hosted on dietpi.com
 			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/conf/desktop'
-
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
-			G_AGI xfce4 xfce4-terminal gnome-icon-theme tango-icon-theme iceweasel
+			G_AGI xfce4 xfce4-terminal gnome-icon-theme tango-icon-theme firefox-esr
 
 		fi
 
@@ -3392,7 +3389,6 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$INSTALLING_INDEX]} == 1 )); then
 
 			Banner_Installing
-
 			G_AGI xrdp
 
 		fi
@@ -6861,7 +6857,7 @@ _EOF_
 			Banner_Installing
 
 			#Xserver Prereqs (ALL)
-			G_AGI xcompmgr xterm xinit xauth xserver-xorg dbus-x11 xfonts-base x11-xserver-utils x11-common x11-utils libgl1-mesa-dri libgles2-mesa mesa-utils mesa-utils-extra
+			G_AGI xserver-xorg xinit xcompmgr xterm dbus-x11 xfonts-base x11-xserver-utils x11-utils libgl1-mesa-dri mesa-utils mesa-utils-extra
 
 			#Improve performance on all desktops and devices (eg: removes window lag in desktops) by limiting compositions
 			mkdir -p /etc/xdg/autostart
@@ -6893,7 +6889,7 @@ _EOF_
 			#RPI
 			if (( $G_HW_MODEL < 10 )); then
 
-				sleep 1
+				:
 
 			#Odroid N1
 			elif (( $G_HW_MODEL == 14 )); then
@@ -12606,7 +12602,7 @@ _EOF_
 		if (( aSOFTWARE_INSTALL_STATE[$UNINSTALLING_INDEX] == -1 )); then
 
 			Banner_Uninstalling
-			G_AGP lxde $(dpkg --get-selections lxde-* | awk '{print $1}') upower policykit-1 iceweasel
+			G_AGP lxde $(dpkg --get-selections lxde-* | awk '{print $1}') upower policykit-1 firefox-esr
 
 		fi
 
@@ -12614,7 +12610,7 @@ _EOF_
 		if (( aSOFTWARE_INSTALL_STATE[$UNINSTALLING_INDEX] == -1 )); then
 
 			Banner_Uninstalling
-			G_AGP mate-desktop-environment-extras upower policykit-1 iceweasel
+			G_AGP mate-desktop-environment-extras upower policykit-1 firefox-esr
 
 		fi
 
@@ -12622,7 +12618,7 @@ _EOF_
 		if (( aSOFTWARE_INSTALL_STATE[$UNINSTALLING_INDEX] == -1 )); then
 
 			Banner_Uninstalling
-			G_AGP x-window-system-core wmaker gnustep gnustep-devel gnustep-games upower policykit-1 iceweasel
+			G_AGP x-window-system-core wmaker gnustep gnustep-devel gnustep-games upower policykit-1 firefox-esr
 
 		fi
 
@@ -12630,7 +12626,7 @@ _EOF_
 		if (( aSOFTWARE_INSTALL_STATE[$UNINSTALLING_INDEX] == -1 )); then
 
 			Banner_Uninstalling
-			G_AGP xfce4 gnome-icon-theme tango-icon-theme iceweasel
+			G_AGP xfce4 gnome-icon-theme tango-icon-theme firefox-esr
 
 		fi
 
@@ -12807,7 +12803,7 @@ _EOF_
 			Banner_Uninstalling
 			systemctl start mysql
 			mysqladmin drop phpbb3 -f
-			mysql -e "drop user phpbb3@localhost"
+			mysql -e "drop user 'phpbb3'@'localhost'"
 			rm -R /var/www/phpBB3
 
 		fi
@@ -14355,7 +14351,7 @@ _EOF_
 
 			Banner_Uninstalling
 			#apt-mark auto xserver-xorg-video-armsoc libdrm-rockchip1 libmali-rk-utgard-450-r7p0 aml-libs-odroid mali450-odroid xf86-video-mali-odroid libump* xf86-video-fbturbo* firmware-samsung xf86-video-armsoc-odroid malit628-odroid &> /dev/null
-			G_AGP xcompmgr xterm xinit xauth xserver-xorg dbus-x11 xfonts-base x11-xserver-utils x11-common x11-utils lxlock
+			G_AGP xserver-xorg xinit xcompmgr xterm dbus-x11 xfonts-base x11-xserver-utils x11-utils
 			rm /etc/xdg/autostart/xcompmgr.desktop /etc/X11/xorg.conf /etc/X11/xorg.conf.d/99-dietpi-dpms_off.conf &> /dev/null
 
 		fi
@@ -14566,27 +14562,23 @@ _EOF_
 		# Set current path to home folder
 		cd "$HOME"
 
-		# Update APT
+		# Update & Upgrade APT
 		Banner_Apt_Update
 
-		# Always update APT, before running installs.
+		# - Always update APT, before running installs.
 		G_AGUP
 
-		# Simulated APT installation to check for failures related to apt-cache.
-		G_DIETPI-NOTIFY 2 "Running apt simulation to check for errors, please wait..."
-
+		# - Simulated APT installation to check for failures related to apt-cache.
+		G_DIETPI-NOTIFY 2 'Running apt simulation to check for errors, please wait...'
 		local package_to_test='bash-doc'
-
 		G_AGI $package_to_test -s
 
-		# Upgrade APT
-		#Banner_Setup
-		Banner_Apt_Update
+		# - Upgrade APT
 		G_AGUG
 
 		# Generate dir for dietpi-software installed "non-service" based control scripts
-		G_RUN_CMD mkdir -p /var/lib/dietpi/dietpi-software/services
-		G_RUN_CMD chmod -R +x /var/lib/dietpi/dietpi-software/services
+		mkdir -p /var/lib/dietpi/dietpi-software/services
+		chmod -R +x /var/lib/dietpi/dietpi-software/services
 
 		# Disable software installation, if user input is required for automated installs
 		Install_Disable_Requires_UserInput

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -960,6 +960,9 @@ _EOF_
 			#Reinstall net-tools as dependency, if HomeAssistant is installed. Thanks to @lupa18 for reporting this: https://github.com/Fourdee/DietPi/issues/1911
 			grep -q '^aSOFTWARE_INSTALL_STATE\[157\]=2' /DietPi/dietpi/.installed && G_AGI net-tools
 			#-------------------------------------------------------------------------------
+			#Removal of CurlFTPFS from dietpi-software
+			sed -i '/^aSOFTWARE_INSTALL_STATE\[2\]=/c\aSOFTWARE_INSTALL_STATE\[2\]=0' /DietPi/dietpi/.installed &> /dev/null
+			#-------------------------------------------------------------------------------
 
 
 		fi

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -863,7 +863,7 @@ _EOF_
 			#Moved to userdata folder, pre-reinstall to keep existing settings
 			if [[ -d '/etc/sickrage' ]]; then
 
-				mv /etc/sickrage/* $G_FP_DIETPI_USERDATA/sickrage/
+				G_RUN_CMD mv /etc/sickrage/* $G_FP_DIETPI_USERDATA/sickrage/
 				rm -R /etc/sickrage
 
 				G_WHIP_MSG "INFO:\n\nSickrage has been moved to the DietPi userdata directory:\n\n - /etc/sickrage > $G_FP_DIETPI_USERDATA/sickrage"
@@ -872,14 +872,14 @@ _EOF_
 
 			if [[ -d '/root/.config/NzbDrone' ]]; then
 
-				mv /root/.config/NzbDrone $G_FP_DIETPI_USERDATA/sonarr
+				G_RUN_CMD mv /root/.config/NzbDrone $G_FP_DIETPI_USERDATA/sonarr
 				G_WHIP_MSG "INFO:\n\nSonarr userdata has been moved to the DietPi userdata directory:\n\n - /root/.config/NzbDrone > $G_FP_DIETPI_USERDATA/sonarr"
 
 			fi
 
 			if [[ -d '/root/.config/Radarr' ]]; then
 
-				mv /root/.config/Radarr $G_FP_DIETPI_USERDATA/radarr
+				G_RUN_CMD mv /root/.config/Radarr $G_FP_DIETPI_USERDATA/radarr
 				G_WHIP_MSG "INFO:\n\nRadarr userdata has been moved to the DietPi userdata directory:\n\n - /root/.config/Radarr > $G_FP_DIETPI_USERDATA/radarr"
 
 			fi
@@ -887,7 +887,7 @@ _EOF_
 			if [[ -d $HOME/.config/deluge ]]; then
 
 				mkdir -p $G_FP_DIETPI_USERDATA/deluge/.config/deluge
-				mv $HOME/.config/deluge/* $G_FP_DIETPI_USERDATA/deluge/.config/deluge/
+				G_RUN_CMD mv $HOME/.config/deluge/* $G_FP_DIETPI_USERDATA/deluge/.config/deluge/
 				rm -R $HOME/.config/deluge
 				G_WHIP_MSG "INFO:\n\nDeluge userdata has been moved to the DietPi userdata directory:\n\n - /root/.config/deluge > $G_FP_DIETPI_USERDATA/deluge"
 
@@ -942,7 +942,11 @@ _EOF_
 
 			fi
 			#-------------------------------------------------------------------------------
-
+			#Fix Xserver uninstall issus by not purging dependencies, but leaving them for autoremove: https://github.com/Fourdee/DietPi/pull/1930/files
+			local dpkg_list="$(dpkg --get-selections)"
+			grep -q '^xinit[[:space:]]' <<< "$dpkg_list" && apt-mark auto xauth x11-common
+			grep -q '^mesa-utils-extra[[:space:]]' <<< "$dpkg_list" && apt-mark auto libgles2-mesa
+			#-------------------------------------------------------------------------------
 
 		fi
 


### PR DESCRIPTION
**Status**: Ready for review and testing
- [x] Patch fix on v6.12 update
- [x] Add changelog entry

**Reference**: https://github.com/Fourdee/DietPi/issues/1921

**Commit list/description**:
+ DietPi-Software | Desktops: "iceweasel" is transitional package for "firefox-esr" on all repos. Switch to latter to avoid confusion, doubled menu/desktop entries etc: https://packages.debian.org/stretch/iceweasel
+ DietPi-Software | Xserver: Clean up manual installed packages based on dependencies, to avoid uninstall errors: https://github.com/Fourdee/DietPi/issues/1921
+ DietPi-Software | Reduce e.g. doubled install output a bid
+ DietPi-Patchfile | Fix Xserver uninstall issus by not purging dependencies, but leaving them for autoremove: #1921 
+ DietPi-Patchfile | Added G_RUN_CMD to software userdata `mv`, to prevent removing them in case of failure
+ CHANGELOG | Xserver: Resolved rarely occuring uninstall issus by not purging dependencies, but leaving them for autoremove
+ DietPi-Patchfile | Reset CurlFTPFS install state, which was removed with v6.10