### PR TITLE
DietPi-RAMlog | Improvements

### DIFF
--- a/dietpi/dietpi-logclear
+++ b/dietpi/dietpi-logclear
@@ -18,9 +18,9 @@
 
 	#Import DietPi-Globals ---------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
-	G_CHECK_ROOT_USER
 	export G_PROGRAM_NAME='DietPi-Logclear'
 	G_INIT
+	G_CHECK_ROOT_USER
 	#Import DietPi-Globals ---------------------------------------------------------------
 
 	INPUT=-1
@@ -35,7 +35,7 @@
 	FILEPATH_BACKUPFOLDER="$HOME/logfile_storage"
 
 	FILE_NAME=''
-	#0=text log, 1=compressed
+	#0=text log, 1=compressed, 2=Pi-hole
 	FILE_TYPE=0
 	FILESIZE_BYTES=0
 	PROCESS_FILE=0
@@ -258,9 +258,6 @@
 	elif (( $INPUT >= 0 )); then
 
 		Process_Logfiles
-
-		#Reset permissions for log files/dir
-		chmod -R 775 /var/log
 
 		#Delete logfile backups
 		if (( $INPUT == 2 )); then

--- a/dietpi/dietpi-logclear
+++ b/dietpi/dietpi-logclear
@@ -63,10 +63,10 @@
 
 		#-----------------------------------------------------------------------------------
 		#Find existing logs and generate a filepath list.
-		find "$FILEPATH_LOGFOLDER" -type f > "$TEMP_FILE"
+		find $FILEPATH_LOGFOLDER -type f > $TEMP_FILE
 
 		#Read logfile filepath list into array.
-		readarray -t ARRAY_LOG_FILEPATH < "$TEMP_FILE"
+		readarray -t ARRAY_LOG_FILEPATH < $TEMP_FILE
 
 		#-----------------------------------------------------------------------------------
 		#Process Logfiles
@@ -185,7 +185,7 @@
 				elif (( $INPUT == 0 )); then
 
 					#Generate filepaths
-					if [ ! -f "$FILEPATH_BACKUPFOLDER/$FILE_NAME" ]; then
+					if [[ ! -f $FILEPATH_BACKUPFOLDER/$FILE_NAME ]]; then
 
 						#This is a little "hack" to automatically generate the required subdirectories.
 						# EG: /this/is/my/logfile.txt | will create the folders /this/is/my
@@ -195,7 +195,7 @@
 					fi
 
 					#Write current logfile contents to existing.
-					cat "${ARRAY_LOG_FILEPATH[$i]}" >> "$FILEPATH_BACKUPFOLDER"/"$FILE_NAME"
+					cat "${ARRAY_LOG_FILEPATH[$i]}" >> "$FILEPATH_BACKUPFOLDER/$FILE_NAME"
 					((INFO_BACKUPS_MADE++))
 
 					#Clear logfile contents
@@ -226,7 +226,7 @@
 		done
 
 		#Remove temp files
-		rm "$TEMP_FILE" &> /dev/null
+		rm $TEMP_FILE &> /dev/null
 
 		#delete[] array
 		unset ARRAY_LOG_FILEPATH
@@ -262,7 +262,7 @@
 		#Delete logfile backups
 		if (( $INPUT == 2 )); then
 
-			rm -R "$FILEPATH_BACKUPFOLDER" &> /dev/null
+			rm -R $FILEPATH_BACKUPFOLDER &> /dev/null
 
 		fi
 

--- a/dietpi/dietpi-ramlog
+++ b/dietpi/dietpi-ramlog
@@ -25,6 +25,8 @@
 	export LC_ALL=en_GB.UTF-8
 	#Ensure we are in users home dir: https://github.com/Fourdee/DietPi/issues/905#issuecomment-298223705
 	cd $HOME
+	#Grab valid input
+	[[ $1 =~ ^-?[0-9]+$ ]] && INPUT=$1
 	#-------------------------------------------------------------------------------------
 
 	#Import DietPi-Globals ---------------------------------------------------------------
@@ -38,7 +40,7 @@
 	#Main Loop
 	#/////////////////////////////////////////////////////////////////////////////////////
 	#Startup Phase (restore /var/log directory structure and files)
-	if [[ $INPUT == 0 ]]; then
+	if (( $INPUT == 0 )); then
 
 		echo 'DietPi-Ramlog: Startup - Restoring log folder structure to ramdisk...'
 
@@ -58,7 +60,7 @@
 		fi
 
 	#Shutdown Phase (saves /var/log directory structure and filenames)
-	elif [[ $INPUT == 1 ]]; then
+	elif (( $INPUT == 1 )); then
 
 		echo 'DietPi-Ramlog: Shutdown - Saving log folder structure to disk...'
 

--- a/dietpi/dietpi-ramlog
+++ b/dietpi/dietpi-ramlog
@@ -19,96 +19,72 @@
 	# - /DietPi/dietpi/dietpi-ramlog 1				= Shutdown Phase (saves /var/log)
 	#////////////////////////////////////
 
-	#-----------------------------------------------------------------------------------
+	#-------------------------------------------------------------------------------------
 	#Set locale for all scripts, prevents incorrect scraping
 	export LANG=en_GB.UTF-8
 	export LC_ALL=en_GB.UTF-8
 	#Ensure we are in users home dir: https://github.com/Fourdee/DietPi/issues/905#issuecomment-298223705
 	cd $HOME
-	#-----------------------------------------------------------------------------------
-
-	INPUT=0
-	if [[ $1 =~ ^-?[0-9]+$ ]]; then
-
-		INPUT=$1
-
-	fi
+	#-------------------------------------------------------------------------------------
 
 	#Import DietPi-Globals ---------------------------------------------------------------
 	#. /DietPi/dietpi/func/dietpi-globals # Not compatible until dietpi-boot.service
 	#Import DietPi-Globals ---------------------------------------------------------------
 
 	FILEPATH_DIETPI_RAMLOG_SAVE='/var/lib/dietpi/dietpi-ramlog/storage'
-
-	#/////////////////////////////////////////////////////////////////////////////////////
-	#Funcs
-	#/////////////////////////////////////////////////////////////////////////////////////
-	Apply_Unique_Logfile_Permissions(){
-
-		# - Pihole
-		chown www-data:www-data /var/log/pihole.log
-
-		# - Mongodb
-		chown -R mongodb:mongodb /var/log/mongodb
-
-		# - EmonCMS
-		chmod 666 /var/log/emoncms.log
-
-		# - Tor notices
-		chown -R debian-tor:nogroup /var/log/tor/notices.log
-
-	}
+	EXIT_CODE=0
 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	#Main Loop
 	#/////////////////////////////////////////////////////////////////////////////////////
 	#Startup Phase (restore /var/log directory structure and files)
-	if (( $INPUT == 0 )); then
+	if [[ $INPUT == 0 ]]; then
 
-		echo 'DietPi-Ramlog: Starting'
+		echo 'DietPi-Ramlog: Startup - Restoring log folder structure to ramdisk...'
 
-		#Create core directories, regardless of Logging mode.
-		# - This prevents core system programs failing to write to their logfile (eg: logsave process will not terminate if the /fsck directory does not exist).
-		mkdir -p /var/log/apt &> /dev/null
-		mkdir -p /var/log/apache2 &> /dev/null
-		mkdir -p /var/log/fsck &> /dev/null
-		mkdir -p /var/log/news &> /dev/null
-		mkdir -p /var/log/samba &> /dev/null
-		mkdir -p /var/log/ntpstats &> /dev/null
+		#Set bit permission
+		chmod 775 /var/log
 
 		#Apply previous attributes and ownerships. Generates empty file if it doesnt exist.
-		if [[ -d $FILEPATH_DIETPI_RAMLOG_SAVE ]]; then
+		[[ -d $FILEPATH_DIETPI_RAMLOG_SAVE ]] && cp -R -p --attributes-only $FILEPATH_DIETPI_RAMLOG_SAVE/. /var/log/
+		EXIT_CODE=$?; if (( $EXIT_CODE )); then
 
-			cp -R -p --attributes-only $FILEPATH_DIETPI_RAMLOG_SAVE/* /var/log/
+			echo "DietPi-Ramlog: Startup failed with exit code $EXIT_CODE"
+
+		else
+
+			echo 'DietPi-Ramlog: Startup completed'
 
 		fi
 
-		#Set bit permission
-		chmod -R 775 /var/log
-
-		#Apply any unique permission for software based log files.
-		Apply_Unique_Logfile_Permissions &> /dev/null
-
-		echo 'DietPi-Ramlog: Completed'
-
 	#Shutdown Phase (saves /var/log directory structure and filenames)
-	elif (( $INPUT == 1 )); then
+	elif [[ $INPUT == 1 ]]; then
 
-		echo 'DietPi-Ramlog: Stopping'
+		echo 'DietPi-Ramlog: Shutdown - Saving log folder structure to disk...'
 
 		#Clear previous storage data
-		rm -R $FILEPATH_DIETPI_RAMLOG_SAVE
-
-		#Generate Storage Directory
-		mkdir -p $FILEPATH_DIETPI_RAMLOG_SAVE
+		[[ -d $FILEPATH_DIETPI_RAMLOG_SAVE ]] && rm -R $FILEPATH_DIETPI_RAMLOG_SAVE
 
 		#Copy logfile attributes and ownership to storage (not file contents)
-		cp -R -p --attributes-only /var/log/* $FILEPATH_DIETPI_RAMLOG_SAVE/
+		cp -R -p --attributes-only /var/log/. $FILEPATH_DIETPI_RAMLOG_SAVE/
+		EXIT_CODE=$?; if (( $EXIT_CODE )); then
 
-		echo 'DietPi-Ramlog: Completed'
+			echo "DietPi-Ramlog: Shutdown failed with exit code $EXIT_CODE"
+
+		else
+
+			echo 'DietPi-Ramlog: Shutdown completed'
+
+		fi
+
+	#Unknown argument
+	else
+
+		EXIT_CODE=1
+		echo 'DietPi-Ramlog: Aborted - Unknown input mode'
 
 	fi
 	#-----------------------------------------------------------------------------------
-	exit
+	exit $EXIT_CODE
 	#-----------------------------------------------------------------------------------
 }

--- a/dietpi/dietpi-ramlog
+++ b/dietpi/dietpi-ramlog
@@ -23,8 +23,6 @@
 	#Set locale for all scripts, prevents incorrect scraping
 	export LANG=en_GB.UTF-8
 	export LC_ALL=en_GB.UTF-8
-	#Ensure we are in users home dir: https://github.com/Fourdee/DietPi/issues/905#issuecomment-298223705
-	cd $HOME
 	#Grab valid input
 	[[ $1 =~ ^-?[0-9]+$ ]] && INPUT=$1
 	#-------------------------------------------------------------------------------------

--- a/rootfs/etc/cron.hourly/dietpi
+++ b/rootfs/etc/cron.hourly/dietpi
@@ -32,11 +32,15 @@
 	if (( $LOGGING_MODE == -1 )); then
 
 		/DietPi/dietpi/dietpi-logclear 1 &> /dev/null
+		rm -R /var/lib/dietpi/dietpi-ramlog/storage
+		cp -R -p --attributes-only /var/log/. /var/lib/dietpi/dietpi-ramlog/storage/
 
 	# - Update current log files data to /"$HOME"/logfile_storage/*. Then clear.
 	elif (( $LOGGING_MODE == -2 )); then
 
 		/DietPi/dietpi/dietpi-logclear 0 &> /dev/null
+		rm -R /var/lib/dietpi/dietpi-ramlog/storage
+		cp -R -p --attributes-only /var/log/. /var/lib/dietpi/dietpi-ramlog/storage/
 
 	fi
 	#----------------------------------------------------------------


### PR DESCRIPTION
I observed unused log folders and permission errors (too less strict), thus reworked ramlog handling a bid, as there is no need to change anything about log file permissions.

Important: https://github.com/Fourdee/DietPi/blob/testing/dietpi/dietpi-logclear#L46
- Exclude file is currently not used. We should add essential logs there as well by default: btmp, wtmp, dpkg.log
- Otherwise `dietpi-logclear 2` is currently dangerous to use? Maybe use it just to clear backup and leave /var/log file removal to end user, as complete clearing can lead to several software fail and system throwing error messages at least.

**Status**: ready for testing and review
- [x] Optional: Add saving ramlog to disk to hourly cron job, to minimize risk of lost log files and folders in case of failed shutdown

**Commit list/description**:
+ DietPi-RAMlog | Removed special folder creation and permissions, as "cp -R -p --attributes-only" handles all of this, creates empty folders as well
+ DietPi-RAMlog | Switch to "cp folder/." (with dot), which copies hidden files (<dot>filename) as well and creates target folder, if needed
+ DietPi-RAMlog | Remove default script argument/input to avoid accidents, giving meaningful error output in case
+ DietPi-RAMlog | Add error handling and exit code
+ DietPi-Logclear | Do not reset file permissions, as they are not changed by script and 755 leads to error messages on some system logs, e.g. btmp and auth.log
+ DietPi-Ramlog | Copy log folder structure to disk after dietpi-logclear, to prevent lost log files on unordinary shutdown
+ DietPi-Logclear | Minor: File path variables don't need to be double quoted
+ DietPi-RAMlog | Do no navigate to $HOME, as this variable is not assigned on early boot and late shutdown phases