### PR TITLE
DietPi-Software | Add Node.js version 8 as compatibility version

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -478,6 +478,7 @@ _EOF_
 			aSOFTWARE_REQUIRES_FFMPEG[$i]=0
 			aSOFTWARE_REQUIRES_JAVA_JRE_JDK[$i]=0
 			aSOFTWARE_REQUIRES_NODEJS[$i]=0
+			aSOFTWARE_REQUIRES_NODEJS8[$i]=0
 
 			# - aSOFTWARE_AVAIL_G_HW_MODEL Init available for (set to yes by default)
 			for ((j=0; j<=$MAX_G_HW_MODEL; j++))

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -328,6 +328,7 @@ _EOF_
 	aSOFTWARE_REQUIRES_FFMPEG=0
 	aSOFTWARE_REQUIRES_JAVA_JRE_JDK=0
 	aSOFTWARE_REQUIRES_NODEJS=0
+	aSOFTWARE_REQUIRES_NODEJS8=0
 
 	# - Available for
 	MAX_G_HW_MODEL=71		#This needs to match highest G_HW_MODEL value in dietpi-obtain_hw_model
@@ -952,7 +953,7 @@ _EOF_
 			 aSOFTWARE_ONLINEDOC_URL[$index_current]='f=8&t=5&p=7305#p7305'
 		aSOFTWARE_REQUIRES_WEBSERVER[$index_current]=1
  			aSOFTWARE_REQUIRES_MYSQL[$index_current]=1
-		   aSOFTWARE_REQUIRES_NODEJS[$index_current]=1
+		   aSOFTWARE_REQUIRES_NODEJS8[$index_current]=1
    aSOFTWARE_REQUIRES_BUILDESSENTIAL[$index_current]=1
 		   aSOFTWARE_REQUIRES_FFMPEG[$index_current]=1
 		# Currently user prompt asks for admin user credentials:
@@ -1389,7 +1390,7 @@ _EOF_
    aSOFTWARE_REQUIRES_BUILDESSENTIAL[$index_current]=1
 			  aSOFTWARE_REQUIRES_GIT[$index_current]=1
 	   aSOFTWARE_REQUIRES_JAVA_JRE_JDK[$index_current]=1
-		   aSOFTWARE_REQUIRES_NODEJS[$index_current]=1
+		   aSOFTWARE_REQUIRES_NODEJS8[$index_current]=1
 			 aSOFTWARE_ONLINEDOC_URL[$index_current]='f=8&t=5&start=60#p2069'
 
 		#------------------
@@ -2276,6 +2277,13 @@ _EOF_
 			aSOFTWARE_CATEGORY_INDEX[$index_current]=4
 					  aSOFTWARE_TYPE[$index_current]=1
 		#------------------
+		index_current=2
+
+				 aSOFTWARE_WHIP_NAME[$index_current]='Node.js 8'
+				 aSOFTWARE_WHIP_DESC[$index_current]='legacy compatibility Node.js version'
+			aSOFTWARE_CATEGORY_INDEX[$index_current]=4
+					  aSOFTWARE_TYPE[$index_current]=1
+		#------------------
 		index_current=130
 
 				 aSOFTWARE_WHIP_NAME[$index_current]='Python Pip'
@@ -3054,6 +3062,24 @@ _EOF_
 				aSOFTWARE_INSTALL_STATE[9]=1
 
 				G_DIETPI-NOTIFY 2 'NodeJS will be installed'
+
+				break
+
+			fi
+
+		done
+
+		#NODEJS8
+		for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
+		do
+
+			if (( ${aSOFTWARE_REQUIRES_NODEJS8[$i]} &&
+				${aSOFTWARE_INSTALL_STATE[$i]} == 1 )); then
+
+				# - Flag for install
+				aSOFTWARE_INSTALL_STATE[2]=1
+
+				G_DIETPI-NOTIFY 2 'NodeJS 8 will be installed'
 
 				break
 
@@ -6295,9 +6321,8 @@ _EOF_
 			rm $INSTALLING_INDEX.zip
 			mv koel-* /var/www/koel
 
-			# Install pre-req yarn and "n" to downgrade to Node 8, as Node 10 is not (yet) compatible with Koel build.
-			npm i yarn n -g --unsafe-perm
-			n 8
+			# Install pre-req yarn
+			npm i yarn -g --unsafe-perm
 
 			# Download and install Composer:
 			php -r "readfile('https://getcomposer.org/installer');" > composer-setup.php
@@ -7350,6 +7375,23 @@ _EOF_
 			./node_install.sh
 
 			rm node_install.sh
+
+		fi
+
+		INSTALLING_INDEX=2
+		if (( ${aSOFTWARE_INSTALL_STATE[$INSTALLING_INDEX]} == 1 )); then
+
+			Banner_Installing
+
+			# Check, is online
+			INSTALL_URL_ADDRESS='https://deb.nodesource.com/setup_8.x'
+			G_CHECK_URL "$INSTALL_URL_ADDRESS"
+
+			# Preqs + APT repo
+			curl -sL https://deb.nodesource.com/setup_8.x | bash -
+
+			# Install
+			G_AGI nodejs
 
 		fi
 
@@ -10753,9 +10795,6 @@ _EOF_
 			ln -sf $G_FP_DIETPI_USERDATA/mineos/serverdata /var/games/minecraft
 
 			chown -R mineos:mineos /var/games/minecraft
-
-			# - correct the node filepath for supervisor mineos
-			sed -i '/^command=/c\command=/usr/local/bin/node webui.js' /etc/supervisor/conf.d/mineos.conf
 
 			# - Set directory to G_FP_DIETPI_USERDATA
 			sed -i "/^directory=/c\directory=$G_FP_DIETPI_USERDATA/mineos/minecraft" /etc/supervisor/conf.d/mineos.conf
@@ -14441,7 +14480,7 @@ _EOF_
 
 		fi
 
-		UNINSTALLING_INDEX=9
+		UNINSTALLING_INDEX=9 # Node.js
 		if (( aSOFTWARE_INSTALL_STATE[$UNINSTALLING_INDEX] == -1 )); then
 
 			Banner_Uninstalling
@@ -14456,6 +14495,16 @@ _EOF_
 			fi
 
 			rm /usr/local/bin/node
+
+		fi
+
+		UNINSTALLING_INDEX=2 # Node.js 8
+		if (( aSOFTWARE_INSTALL_STATE[$UNINSTALLING_INDEX] == -1 )); then
+
+			Banner_Uninstalling
+			G_AGP nodejs
+			#apt-mark auto lsb-release
+			rm /etc/apt/sources.list.d/nodesource.list
 
 		fi
 


### PR DESCRIPTION
**Status**: Ready for review and testing
- [x] VM Jessie, Koel + MineOS
  - [x] Test Node10 installations with Node8 installed: 🈯️ netdata, 🈴 Node-red, 🈴 Blynk, 🈯️ RoonExtentionManager
  - 🈴 Blynk first (🈯️), MineOS afterwards (🈴), `gyp ERR! node -v v10.6.0` v10 used, as /usr/local/bin/node (v10) is used before /usr/bin/node (v8). Messy issue with parallel node versions...
- [ ] VM Stretch, Koel + MineOS
- [ ] VM Buster, Koel + MineOS

**Reference**: https://github.com/Fourdee/DietPi/issues/1880

**Commit list/description**:
+ DietPi-Software | Add Node.js version 8 as compatibility version for software titles that do not support Node 10 yet