### PR TITLE
DietPi-Globals | Working directory rework

### DIFF
--- a/dietpi/dietpi-bugreport
+++ b/dietpi/dietpi-bugreport
@@ -20,17 +20,17 @@
 
 	#Import DietPi-Globals ---------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
+	export G_PROGRAM_NAME='DietPi-Bugreport'
+	FP_WORK_DIR='/tmp/dietpi-bugreport'
+	G_INIT
 	G_CHECK_ROOT_USER
 	G_CHECK_ROOTFS_RW
-	G_INIT
-	export G_PROGRAM_NAME='DietPi-Bugreport'
 	#Import DietPi-Globals ---------------------------------------------------------------
 
 	INPUT=0
 	G_CHECK_VALIDINT $1 && INPUT=$1
 
 	UNIQUE_ID=$(sed -n 5p /DietPi/dietpi/.hw_model)
-	FP_TMP='/tmp/dietpi-bugreport'
 	UPLOAD_FILENAME="$UNIQUE_ID.7z"
 
 	# - byte
@@ -249,11 +249,6 @@ $(printf "\t- %s\n" "${aFILE_LIST[@]}")"
 
 	if (( $INPUT == 1 || $INPUT == -1 )); then
 
-		# Clean, recreate and enter tmp ramfs
-		[[ -d $FP_TMP ]] && rm -R "$FP_TMP"
-		mkdir -p "$FP_TMP"
-		cd "$FP_TMP"
-
 		if (( $INPUT == 1 )); then
 
 			# Generate 7z bug report file
@@ -268,10 +263,6 @@ $(printf "\t- %s\n" "${aFILE_LIST[@]}")"
 
 		# Upload bug report file
 		Upload_Bug_Report
-
-		# Clean tmp ramfs
-		cd $HOME
-		rm -R "$FP_TMP"
 
 	fi
 

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -20,10 +20,18 @@
 
 	#Import DietPi-Globals ---------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
-	G_CHECK_ROOT_USER
 	export G_PROGRAM_NAME='DietPi-Drive_Manager'
+	FP_WORK_DIR='/tmp/dietpi-drive_manager'
 	G_INIT
+	G_CHECK_ROOT_USER
 	#Import DietPi-Globals ---------------------------------------------------------------
+
+	#Custom exit trap extension, being called on every kind of script exit, err, int
+	G_EXIT_CUSTOM(){
+
+		Destroy
+
+	}
 
 	#Grab Input (valid interger)
 	INPUT=0
@@ -37,10 +45,10 @@
 	SERVICE_CONTROL=1
 
 	#Return values
-	FP_DRIVE_MANAGER_SELECTION='/tmp/dietpi-drive_manager_selmnt'
+	FP_DRIVE_MANAGER_SELECTION='dietpi-drive_manager_selmnt'
 
 	#FP
-	FP_TEMP_FSTAB='/tmp/.fstab'
+	FP_TEMP_FSTAB='.fstab'
 
 
 	#Drive data
@@ -181,7 +189,7 @@ _EOF_
 		local cmd_scrape_string=''
 		local index=0
 		G_DIETPI-NOTIFY 0 'Detecting currently mounted drives, please wait...'
-		df -Ph | tail -n +2 | sed '/tmpfs/d' | sed '/^udev/d' > /tmp/.dietpi-drive_manager_df_tmp
+		df -Ph | tail -n +2 | sed '/tmpfs/d' | sed '/^udev/d' > .dietpi-drive_manager_df_tmp
 		while read line
 		do
 
@@ -308,12 +316,12 @@ _EOF_
 
 			fi
 
-		done < /tmp/.dietpi-drive_manager_df_tmp
-		rm /tmp/.dietpi-drive_manager_df_tmp
+		done < .dietpi-drive_manager_df_tmp
+		rm .dietpi-drive_manager_df_tmp
 
 		#Check blkid for unmounted drives, if drive is not mounted, add entry as disabled mount
 		G_DIETPI-NOTIFY 0 'Detecting unmounted drives, please wait...'
-		blkid -o device > /tmp/.dietpi-drive_manager_blkid_tmp
+		blkid -o device > .dietpi-drive_manager_blkid_tmp
 		while read line
 		do
 
@@ -366,11 +374,11 @@ _EOF_
 
 			done
 
-		done < /tmp/.dietpi-drive_manager_blkid_tmp
-		rm /tmp/.dietpi-drive_manager_blkid_tmp
+		done < .dietpi-drive_manager_blkid_tmp
+		rm .dietpi-drive_manager_blkid_tmp
 
 		#Find drives that have no partitions
-		lsblk -r -o NAME | tail +2 > /tmp/.dietpi-drive_manager_lsblk_tmp
+		lsblk -r -o NAME | tail +2 > .dietpi-drive_manager_lsblk_tmp
 		while read line
 		do
 
@@ -401,8 +409,8 @@ _EOF_
 
 			fi
 
-		done < /tmp/.dietpi-drive_manager_lsblk_tmp
-		rm /tmp/.dietpi-drive_manager_lsblk_tmp
+		done < .dietpi-drive_manager_lsblk_tmp
+		rm .dietpi-drive_manager_lsblk_tmp
 
 		#Set required global flags, for all drives found
 		for ((i=0; i<${#aDRIVE_MOUNT_SOURCE[@]}; i++))
@@ -1174,7 +1182,7 @@ aDRIVE_ISPARTITIONTABLE ${aDRIVE_ISPARTITIONTABLE[$i]}
 						if [[ ${aDRIVE_FSTYPE[$INDEX_DRIVE_BEING_EDITED]} == 'ext4' ]]; then
 
 							local reserved_blocks_percent_current=0
-							local fp_temp='/tmp/.dietpi-drive_manager_dumpe2fs'
+							local fp_temp='.dietpi-drive_manager_dumpe2fs'
 							dumpe2fs -h "${aDRIVE_MOUNT_SOURCE[$INDEX_DRIVE_BEING_EDITED]}" > "$fp_temp"
 							local block_count="$(grep -m1 '^Block count:' $fp_temp | awk '{print $3}')"
 							local reserved_block_count="$(grep -m1 '^Reserved block count:' $fp_temp | awk '{print $4}')"
@@ -1519,9 +1527,9 @@ aDRIVE_ISPARTITIONTABLE ${aDRIVE_ISPARTITIONTABLE[$i]}
 				if [[ $fsck_dry ]]; then
 
 					G_WHIP_MSG "The following drive will now be checked for errors:\n${aDRIVE_MOUNT_SOURCE[$INDEX_DRIVE_BEING_EDITED]}\n\nNo repair will be completed during this process. An option to repair the drive, will be provided after the check."
-					$fsck_dry ${aDRIVE_MOUNT_SOURCE[$INDEX_DRIVE_BEING_EDITED]} &> /tmp/.dietpi-drive_manager_check.log
-					G_WHIP_VIEWLOG /tmp/.dietpi-drive_manager_check.log
-					rm /tmp/.dietpi-drive_manager_check.log &> /dev/null
+					$fsck_dry ${aDRIVE_MOUNT_SOURCE[$INDEX_DRIVE_BEING_EDITED]} &> .dietpi-drive_manager_check.log
+					G_WHIP_VIEWLOG .dietpi-drive_manager_check.log
+					rm .dietpi-drive_manager_check.log &> /dev/null
 
 				fi
 
@@ -1532,9 +1540,9 @@ NB:
 - These services are usually very expensive, but might be able to recover more data than (after) this automated repair steps!"
 				if (( ! $? )); then
 
-					$fsck_fix ${aDRIVE_MOUNT_SOURCE[$INDEX_DRIVE_BEING_EDITED]} &> /tmp/.dietpi-drive_manager_repair.log
-					G_WHIP_VIEWLOG /tmp/.dietpi-drive_manager_repair.log
-					rm /tmp/.dietpi-drive_manager_repair.log &> /dev/null
+					$fsck_fix ${aDRIVE_MOUNT_SOURCE[$INDEX_DRIVE_BEING_EDITED]} &> .dietpi-drive_manager_repair.log
+					G_WHIP_VIEWLOG .dietpi-drive_manager_repair.log
+					rm .dietpi-drive_manager_repair.log &> /dev/null
 
 				fi
 
@@ -1915,15 +1923,15 @@ _EOF_
 		#Generate menu
 		G_WHIP_MENU_ARRAY=()
 
-		df -Ph | tail -n +2 | sed '/tmpfs/d' | sed '/^udev/d' > /tmp/dietpi-drive_manager_selmnt
+		df -Ph | tail -n +2 | sed '/tmpfs/d' | sed '/^udev/d' > dietpi-drive_manager_selmnt
 
 		while read line
 		do
 
 			G_WHIP_MENU_ARRAY+=("$(echo -e $line | awk '{print $6}')" ": $(echo -e $line | awk '{print $1}') | size: $(echo -e $line | awk '{print $2}') | available: $(echo -e $line | awk '{print $4}')")
 
-		done < /tmp/dietpi-drive_manager_selmnt
-		rm /tmp/dietpi-drive_manager_selmnt
+		done < dietpi-drive_manager_selmnt
+		rm dietpi-drive_manager_selmnt
 
 		G_WHIP_DEFAULT_ITEM="$MENU_LASTITEM"
 		G_WHIP_MENU 'Please select a mount location to use:'
@@ -2018,10 +2026,6 @@ _EOF_
 		done
 
 	fi
-	#-----------------------------------------------------------------------------------
-	#Destroy
-	Destroy
-
 	#-----------------------------------------------------------------------------------
 	# Start Services
 	if (( $SERVICE_CONTROL )); then

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -30,9 +30,40 @@
 	G_INIT
 	G_CHECK_ROOT_USER
 	G_CHECK_ROOTFS_RW
-	[[ -f $FP_WORK_DIR ]] && rm -R $FP_WORK_DIR
-	mkdir -p $FP_WORK_DIR
 	#Import DietPi-Globals ---------------------------------------------------------------
+
+	# Custom exit trap
+	G_EXIT_CUSTOM(){
+
+		unset aSOFTWARE_CATEGORIES_DIETPI
+		unset aSOFTWARE_CATEGORIES_LINUX
+
+		unset aSOFTWARE_CATEGORY_INDEX
+		unset aSOFTWARE_TYPE
+		unset aSOFTWARE_WHIP_NAME
+		unset aSOFTWARE_WHIP_DESC
+		unset aSOFTWARE_ONLINEDOC_URL
+		unset aSOFTWARE_INSTALL_STATE
+
+		unset aSOFTWARE_REQUIRES_USERINPUT
+
+		unset aSOFTWARE_REQUIRES_ALSA
+		unset aSOFTWARE_REQUIRES_XSERVERXORG
+		unset aSOFTWARE_REQUIRES_MYSQL
+		unset aSOFTWARE_REQUIRES_SQLITE
+		unset aSOFTWARE_REQUIRES_WEBSERVER
+		unset aSOFTWARE_REQUIRES_DESKTOP
+		unset aSOFTWARE_REQUIRES_GIT
+		unset aSOFTWARE_REQUIRES_BUILDESSENTIAL
+		unset aSOFTWARE_REQUIRES_RSYSLOG
+		unset aSOFTWARE_REQUIRES_FFMPEG
+		unset aSOFTWARE_REQUIRES_JAVA_JRE_JDK
+		unset aSOFTWARE_REQUIRES_NODEJS
+
+		unset aSOFTWARE_AVAIL_G_HW_MODEL
+		unset aSOFTWARE_AVAIL_G_HW_ARCH
+
+	}
 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	#Filepath
@@ -2512,38 +2543,6 @@ _EOF_
 		aSOFTWARE_INSTALL_STATE[103]=2
 		aSOFTWARE_INSTALL_STATE[104]=2
 		#--------------------------------------------------------------------------------
-
-	}
-
-	Software_Arrays_Destroy(){
-
-		unset aSOFTWARE_CATEGORIES_DIETPI
-		unset aSOFTWARE_CATEGORIES_LINUX
-
-		unset aSOFTWARE_CATEGORY_INDEX
-		unset aSOFTWARE_TYPE
-		unset aSOFTWARE_WHIP_NAME
-		unset aSOFTWARE_WHIP_DESC
-		unset aSOFTWARE_ONLINEDOC_URL
-		unset aSOFTWARE_INSTALL_STATE
-
-		unset aSOFTWARE_REQUIRES_USERINPUT
-
-		unset aSOFTWARE_REQUIRES_ALSA
-		unset aSOFTWARE_REQUIRES_XSERVERXORG
-		unset aSOFTWARE_REQUIRES_MYSQL
-		unset aSOFTWARE_REQUIRES_SQLITE
-		unset aSOFTWARE_REQUIRES_WEBSERVER
-		unset aSOFTWARE_REQUIRES_DESKTOP
-		unset aSOFTWARE_REQUIRES_GIT
-		unset aSOFTWARE_REQUIRES_BUILDESSENTIAL
-		unset aSOFTWARE_REQUIRES_RSYSLOG
-		unset aSOFTWARE_REQUIRES_FFMPEG
-		unset aSOFTWARE_REQUIRES_JAVA_JRE_JDK
-		unset aSOFTWARE_REQUIRES_NODEJS
-
-		unset aSOFTWARE_AVAIL_G_HW_MODEL
-		unset aSOFTWARE_AVAIL_G_HW_ARCH
 
 	}
 
@@ -11900,7 +11899,7 @@ _EOF_
 #We need to wait until USB eth is established on USB bus. This takes much longer than onboard init and network.target network-pre.target
 sleep 20
 # - Set USB ETH if found
-if (( \$(ip a | grep -ci -m1 'eth1') )); then
+if ip a | grep -qi 'eth1'; then
 
 	echo -e "blacklist ethernet" > /etc/modprobe.d/disable_sparkysbc_ethernet.conf
 	rm /etc/udev/rules.d/70-persistent-net.rules &> /dev/null
@@ -11908,7 +11907,7 @@ if (( \$(ip a | grep -ci -m1 'eth1') )); then
 	reboot
 
 # - Enable onboard ETH if no adapter found
-elif (( ! \$(ip a | grep -ci -m1 'eth0') )); then
+elif ip a | grep -qi 'eth0'; then
 
 	rm /etc/modprobe.d/disable_sparkysbc_ethernet.conf &> /dev/null
 	rm /etc/udev/rules.d/70-persistent-net.rules &> /dev/null
@@ -14430,11 +14429,11 @@ _EOF_
 		AUTOINSTALL_LOGGINGINDEX="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_LOGGING_INDEX=' /DietPi/dietpi.txt | sed 's/^.*=//')"
 		AUTOINSTALL_WEBSERVERINDEX="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_WEB_SERVER_INDEX=' /DietPi/dietpi.txt | sed 's/^.*=//')"
 
-		AUTOINSTALL_TIMEZONE="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_TIMEZONE=' /DietPi/dietpi.txt | sed 's/^.*=//' )"
-		AUTOINSTALL_LANGUAGE="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_LOCALE=' /DietPi/dietpi.txt | sed 's/^.*=//' )"
-		AUTOINSTALL_KEYBOARD="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_KEYBOARD_LAYOUT=' /DietPi/dietpi.txt | sed 's/^.*=//' )"
+		AUTOINSTALL_TIMEZONE="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_TIMEZONE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//' )"
+		AUTOINSTALL_LANGUAGE="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_LOCALE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//' )"
+		AUTOINSTALL_KEYBOARD="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_KEYBOARD_LAYOUT=' /DietPi/dietpi.txt | sed 's/^[^=]*=//' )"
 
-		AUTOINSTALL_CUSTOMSCRIPTURL="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_CUSTOM_SCRIPT_EXEC=' /DietPi/dietpi.txt | sed 's/^.*=//')"
+		AUTOINSTALL_CUSTOMSCRIPTURL="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_CUSTOM_SCRIPT_EXEC=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
 
 	}
 
@@ -14443,7 +14442,7 @@ _EOF_
 		#Automated install
 		if (( $AUTOINSTALL_ENABLED >= 1 )); then
 
-			G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" "Running automated installation"
+			G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Running automated installation'
 
 			#Skip dietpi-software menu
 			TARGETMENUID=-1
@@ -14452,10 +14451,9 @@ _EOF_
 			GOSTARTINSTALL=1
 
 			#Find all software entires of AUTO_SETUP_INSTALL_SOFTWARE_ID= in dietpi.txt. Then set to state 1 for installation.
-			while read -r line
+			local index=0
+			while read -r index
 			do
-
-				local index=$( echo -e "$line" | grep '^[[:blank:]]*AUTO_SETUP_INSTALL_SOFTWARE_ID=' | sed 's/[^0-9]*//g' )
 
 				# - Flag for installation
 				if G_CHECK_VALIDINT $index; then
@@ -14466,7 +14464,7 @@ _EOF_
 
 				fi
 
-			done < /DietPi/dietpi.txt
+			done <<< "$(grep '^[[:blank:]]*AUTO_SETUP_INSTALL_SOFTWARE_ID=' /DietPi/dietpi.txt | sed 's/[^0-9]*//g')"
 
 		fi
 
@@ -14515,7 +14513,7 @@ _EOF_
 
 			#Reboot required NOW
 			reboot
-			Exit_Destroy
+			exit
 
 		fi
 
@@ -14781,14 +14779,6 @@ _EOF_
 		fi
 
 		unset ainput
-
-	}
-
-	Exit_Destroy(){
-
-		Software_Arrays_Destroy
-		rm -R $FP_WORK_DIR
-		exit
 
 	}
 
@@ -15755,7 +15745,7 @@ _EOF_
 
 				Banner_Aborted
 				#Exit script NOW
-				Exit_Destroy
+				exit
 
 			else
 
@@ -15772,7 +15762,7 @@ _EOF_
 
 				Banner_Aborted
 				#Exit script NOW
-				Exit_Destroy
+				exit
 
 			else
 
@@ -15976,13 +15966,6 @@ _EOF_
 	# Banner Print
 	#/////////////////////////////////////////////////////////////////////////////////////
 
-	#Banner_Setup(){
-
-	#	/DietPi/dietpi/dietpi-banner 0
-	#	echo -e '\n Welcome to DietPi-Software \n'
-
-	#}
-
 	Banner_Installing(){
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" "Installing ${aSOFTWARE_WHIP_NAME[$INSTALLING_INDEX]}: ${aSOFTWARE_WHIP_DESC[$INSTALLING_INDEX]}"
@@ -16010,17 +15993,9 @@ _EOF_
 
 	Banner_Reboot(){
 
-		if (( $DISABLE_REBOOT )); then
+		G_DIETPI-NOTIFY 0 'The system will now reboot. \n This completes the DietPi-Software installation.\n'
+		sleep 3
 
-			G_DIETPI-NOTIFY 0 'DietPi-Software installation completed.'
-
-		else
-
-			G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" "Installation completed"
-			G_DIETPI-NOTIFY 0 'The system will now reboot. \n This completes the DietPi-Software installation.\n'
-			sleep 3
-
-		fi
 	}
 
 	Banner_Configs(){
@@ -16098,8 +16073,6 @@ _EOF_
 
 		fi
 
-		#Banner_Setup
-
 		# Prevent continue if no Network or NTPD is not completed: https://github.com/Fourdee/DietPi/issues/786
 		Check_Internet_and_NTPD
 
@@ -16115,11 +16088,6 @@ _EOF_
 
 			# - Activate automation settings from dietpi.txt, if set.
 			FirstRun_Automation_Set
-
-			# - DietPi-Survey opt in/out:
-			#	- As this is called as well after dietpi-update, don't force menu.
-			#	- Menu will promt automatically, if no survey settings file exist, even with $1=1.
-			/DietPi/dietpi/dietpi-survey 1
 
 		fi
 
@@ -16158,7 +16126,7 @@ _EOF_
 		G_CHECK_FREESPACE / 500
 		if (( ! $? )); then
 
-			Exit_Destroy
+			exit
 
 		fi
 
@@ -16168,11 +16136,10 @@ _EOF_
 		# Start installations for software
 		Run_Installations
 
-		# Upload DietPi-Survey Data
+		# Upload DietPi-Survey Data, if opted in, prompt user choice, if no settings file exists
 		/DietPi/dietpi/dietpi-survey 1
 
-		# Reboot
-		Banner_Reboot
+		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" "Installation completed"
 
 		if (( $DISABLE_REBOOT )); then
 
@@ -16181,14 +16148,13 @@ _EOF_
 
 		else
 
+			# - Reboot
 			sync
+			Banner_Reboot
 			reboot
 
 		fi
 
 	fi
 
-	#-----------------------------------------------------------------------------------
-	Exit_Destroy
-	#-----------------------------------------------------------------------------------
 }

--- a/dietpi/dietpi-survey
+++ b/dietpi/dietpi-survey
@@ -25,9 +25,10 @@
 
 	#Import DietPi-Globals ---------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
-	G_CHECK_ROOT_USER
-	G_INIT
 	export G_PROGRAM_NAME='DietPi-Survey'
+	FP_WORK_DIR='/tmp/dietpi-survey'
+	G_INIT
+	G_CHECK_ROOT_USER
 	#Import DietPi-Globals ---------------------------------------------------------------
 
 	#Grab Input (valid interger)
@@ -41,7 +42,6 @@
 
 	DIETPI_VERSION="$(paste -sd '.' /DietPi/dietpi/.version)"
 	UNIQUE_ID=$(sed -n 5p /DietPi/dietpi/.hw_model)
-	FP_TMP='/tmp/dietpi-survey'
 	UPLOAD_FILENAME="$UNIQUE_ID.txt"
 
 	SFTP_ADDR='dietpi.com'
@@ -153,9 +153,6 @@ _EOF_
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Main Loop
 	#/////////////////////////////////////////////////////////////////////////////////////
-	#Enter ramfs
-	mkdir -p $FP_TMP
-	cd $FP_TMP
 
 	#Read data from .dietpi-survey file
 	if [[ -f $FP_SETTINGS ]]; then
@@ -205,9 +202,6 @@ Would you like to join DietPi-Survey?"
 		fi
 
 	fi
-
-	cd $HOME
-	rm -R $FP_TMP
 
 	#-----------------------------------------------------------------------------------
 	exit 0

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -22,10 +22,11 @@
 
 	#Import DietPi-Globals ---------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
+	export G_PROGRAM_NAME='DietPi-Update'
+	FP_WORK_DIR='/tmp/dietpi-update'
+	G_INIT
 	G_CHECK_ROOT_USER
 	G_CHECK_ROOTFS_RW
-	export G_PROGRAM_NAME='DietPi-Update'
-	G_INIT
 	#Import DietPi-Globals ---------------------------------------------------------------
 
 	INPUT=0
@@ -40,7 +41,6 @@
 	#/////////////////////////////////////////////////////////////////////////////////////
 	#UPDATE Vars
 	#/////////////////////////////////////////////////////////////////////////////////////
-	FP_TEMP='/tmp/dietpi-update'
 	FP_LOG='/var/tmp/dietpi/logs/dietpi-update.log'
 	DIETPIUPDATE_COREVERSION_CURRENT=6 # Version of dietpi-update / set server_version-6 line one to value++ and obsolete previous dietpi-update scripts
 
@@ -102,12 +102,12 @@
 			URL_MIRROR_INDEX=$i
 
 			G_DIETPI-NOTIFY 2 "Checking Mirror : ${URL_MIRROR_SERVERVERSION[$i]}"
-			curl -k -L "${URL_MIRROR_SERVERVERSION[$i]}" > $FP_TEMP/server_version
+			curl -k -L "${URL_MIRROR_SERVERVERSION[$i]}" > server_version
 			if (( ! $? )); then
 
 				#Get server Version info
-				COREVERSION_SERVER=$(sed -n 1p $FP_TEMP/server_version)
-				SUBVERSION_SERVER=$(sed -n 2p $FP_TEMP/server_version)
+				COREVERSION_SERVER=$(sed -n 1p server_version)
+				SUBVERSION_SERVER=$(sed -n 2p server_version)
 
 				#Check if server_version is a valid interger.
 				if G_CHECK_VALIDINT $SUBVERSION_SERVER; then
@@ -205,21 +205,22 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 	Run_Update(){
 
 		#git clone Zip method (no need to install GIT)
-		curl -k -L "${URL_MIRROR_ZIP[$URL_MIRROR_INDEX]}" > $FP_TEMP/update.zip
+		curl -k -L "${URL_MIRROR_ZIP[$URL_MIRROR_INDEX]}" > update.zip
 		if (( ! $? )); then
 
-			l_message='Unpack update archieve' G_RUN_CMD unzip $FP_TEMP/update.zip -d $FP_TEMP/
+			l_message='Unpack update archieve' G_RUN_CMD unzip update.zip
+			rm update.zip &> /dev/null
 
 			#Remove setting files from git that are not to be updated on client
-			rm $FP_TEMP/DietPi-"$GITBRANCH"/dietpi/.* &> /dev/null
+			rm DietPi-"$GITBRANCH"/dietpi/.* &> /dev/null
 
 			#Remove folders of "non-critical scripts" before updating them. (eg: so we dont need to patch for /conf/* file removals)
 			# rm -R /DietPi/dietpi/conf #:https://github.com/Fourdee/DietPi/issues/905#issuecomment-298241622
 			# rm -R /DietPi/dietpi/func
 			# rm -R /DietPi/dietpi/misc
 
-			l_message='Copy DietPi core files to ramdisk' G_RUN_CMD cp -Rf $FP_TEMP/DietPi-"$GITBRANCH"/dietpi /DietPi/
-			l_message='Copy rootfs files in place' G_RUN_CMD cp -Rf $FP_TEMP/DietPi-"$GITBRANCH"/rootfs/. /
+			l_message='Copy DietPi core files to ramdisk' G_RUN_CMD cp -Rf DietPi-"$GITBRANCH"/dietpi /DietPi/
+			l_message='Copy rootfs files in place' G_RUN_CMD cp -Rf DietPi-"$GITBRANCH"/rootfs/. /
 
 			l_message='Set execute permissions for DietPi scripts' G_RUN_CMD chmod -R +x /DietPi /etc/cron.*/dietpi /var/lib/dietpi/services
 			systemctl daemon-reload
@@ -256,9 +257,6 @@ _EOF_
 			rm /DietPi/dietpi/patch_file &> /dev/null
 			rm /DietPi/dietpi/server_version &> /dev/null
 
-			#Remove temp
-			rm -R $FP_TEMP &> /dev/null
-
 		#Unable to download file.
 		else
 
@@ -275,10 +273,6 @@ _EOF_
 	#----------------------------------------------------------------
 	#Inform user
 	G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Checking for DietPi updates'
-	#----------------------------------------------------------------
-	#Create temp directory used in dietpi-update
-	rm -R $FP_TEMP &> /dev/null
-	mkdir -p $FP_TEMP &> /dev/null
 	#----------------------------------------------------------------
 	#Get versions
 	Get_Client_Version
@@ -400,9 +394,6 @@ _EOF_
 		fi
 
 	fi
-	#----------------------------------------------------------------
-	#Clear temp files and folders
-	rm -R $FP_TEMP &> /dev/null
 	#----------------------------------------------------------------
 	exit 0
 	#----------------------------------------------------------------

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -124,15 +124,8 @@
 		[[ $HIERARCHY ]] && export HIERARCHY=$((HIERARCHY+1)) || export HIERARCHY=0
 
 		# - Ensure we are in script working dir or users home dir, if available: https://github.com/Fourdee/DietPi/issues/905#issuecomment-298223705
-		if [[ $FP_WORK_DIR ]]; then
-
-			mkdir -p $FP_WORK_DIR && cd $FP_WORK_DIR || cd $HOME
-
-		elif 
-
-			cd $HOME
-
-		fi
+		#	- If any $FP_WORK_DIR step fails, go to $HOME if it is assigned
+		[[ $FP_WORK_DIR ]] && mkdir -p $FP_WORK_DIR && cd $FP_WORK_DIR || [[ $HOME ]] && cd $HOME
 
 		# - Auto print init header for all scripts
 		# G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Init'

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -152,7 +152,7 @@
 		local ainput_string=("$@")
 		local output_string=''
 		local bracket_l='\e[90m[\e[0m'
-		local bracket_r='\e[90m]\e[0m'
+		local bracket_r='\e[0m\e[90m]\e[0m'
 
 		#Funcs
 		Clean_Process_Animation(){

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -175,7 +175,7 @@
 		#Funcs
 		Clean_Process_Animation(){
 
-			if (( $G_USER_INPUTS )) && [[ -w /tmp/dietpi-process.pid ]]; then
+			if [[ -t 0 ]] && [[ -w /tmp/dietpi-process.pid ]]; then
 
 				kill $(</tmp/dietpi-process.pid) &> /dev/null
 				rm /tmp/dietpi-process.pid &> /dev/null
@@ -250,7 +250,7 @@
 			output_string+="\r$bracket_l\e[33m .... $bracket_r "
 			Print_Output_String 1
 
-			if (( $G_USER_INPUTS )); then
+			if [[ -t 0 ]]; then
 
 				Print_Process_Animation(){
 
@@ -287,7 +287,7 @@
 				local output_lines=0
 				(( output_lines=(${#input_string}+6)/$(tput cols) ))
 				(( $output_lines )) && tput cuu $output_lines
-				[[ ! -e /tmp/dietpi-process.pid ]] && > /tmp/dietpi-process.pid && ( Print_Process_Animation & echo $! > /tmp/dietpi-process.pid )
+				( set -o noclobber; > /tmp/dietpi-process.pid ) && ( Print_Process_Animation & echo $! > /tmp/dietpi-process.pid )
 
 				unset Print_Process_Animation
 

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -289,11 +289,17 @@
 				local output_lines=0
 				(( output_lines=(${#input_string}+6)/$(tput cols) ))
 				(( $output_lines )) && tput cuu $output_lines
-				# If redirect to PID file fails (due to noclobber on existent file), start processing animation.
+				# If redirect to PID file fails (due to noclobber, on existent file), start processing animation.
 				# - This method prevents a tiny condition race from checking file existance to creating it, when doing: [[ ! -e file ]] && > file
-				if set -o noclobber && > /tmp/dietpi-process.pid &> /dev/null && set +o noclobber; then
+				set -o noclobber
+				if { > /tmp/dietpi-process.pid; } &> /dev/null; then
 
-					Print_Process_Animation & echo $! > /tmp/dietpi-process.pid
+					set +o noclobber
+					{ Print_Process_Animation & echo $! > /tmp/dietpi-process.pid; disown; } 2> /dev/null
+
+				else
+
+					set +o noclobber
 
 				fi
 				unset Print_Process_Animation

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -142,7 +142,7 @@
 			# - Execute custom exit commands, if existent
 			declare -F G_EXIT_CUSTOM &> /dev/null && G_EXIT_CUSTOM
 
-		fi
+		}
 		trap 'G_EXIT' EXIT
 
 		# Auto print init header for all scripts

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -127,28 +127,21 @@
 		# - If any $FP_WORK_DIR step fails, go to $HOME if it is assigned
 		if [[ $FP_WORK_DIR ]] && mkdir -p $FP_WORK_DIR && cd $FP_WORK_DIR; then
 
-			G_DIETPI-NOTIFY 2 "Entered working directory: $FP_WORK_DIR" # DEBUG
+			: # G_DIETPI-NOTIFY 2 "Entered working directory: $FP_WORK_DIR"
 
-		else
+		elif [[ $HOME ]]; then
 
-			[[ $HOME ]] && cd $HOME
+			cd $HOME
 
 		fi
 
-		# Declare and trap G_EXIT() as exit script, that runs on INT, ERR and usual EXIT signal.
+		# Declare and trap G_EXIT() as exit function, that runs on EXIT signal, which includes INT (error) and TERM (kill).
 		G_EXIT(){
 
 			# - Purging working directory
-			if [[ $FP_WORK_DIR && -d $FP_WORK_DIR ]]; then
+			[[ $FP_WORK_DIR && -d $FP_WORK_DIR ]] && rm -R $FP_WORK_DIR
 
-				# - Failsafe: Navigate incrementally to parent directory, if parent shell pwd is within $FP_WORK_DIR
-				while [[ $(pwd) =~ $FP_WORK_DIR ]]; do cd ..; done
-				> $G_PROGRAM_NAME # DEBUG
-				rm -R $FP_WORK_DIR
-
-			fi
-
-			# - Execute custom exit commands, if existent
+			# - Execute custom exit function, if existent
 			declare -F G_EXIT_CUSTOM &> /dev/null && G_EXIT_CUSTOM
 
 		}

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -125,7 +125,15 @@
 
 		# Ensure we are in script working dir or users home dir, if available: https://github.com/Fourdee/DietPi/issues/905#issuecomment-298223705
 		# - If any $FP_WORK_DIR step fails, go to $HOME if it is assigned
-		[[ $FP_WORK_DIR ]] && mkdir -p $FP_WORK_DIR && cd $FP_WORK_DIR || [[ $HOME ]] && cd $HOME
+		if [[ $FP_WORK_DIR ]] && mkdir -p $FP_WORK_DIR && cd $FP_WORK_DIR; then
+
+			G_DIETPI-NOTIFY 2 "Entered working directory: $FP_WORK_DIR" # DEBUG
+
+		else
+
+			[[ $HOME ]] && cd $HOME
+
+		fi
 
 		# Declare and trap G_EXIT() as exit script, that runs on INT, ERR and usual EXIT signal.
 		G_EXIT(){
@@ -135,6 +143,7 @@
 
 				# - Failsafe: Navigate incrementally to parent directory, if parent shell pwd is within $FP_WORK_DIR
 				while [[ $(pwd) =~ $FP_WORK_DIR ]]; do cd ..; done
+				> $G_PROGRAM_NAME # DEBUG
 				rm -R $FP_WORK_DIR
 
 			fi

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -289,8 +289,13 @@
 				local output_lines=0
 				(( output_lines=(${#input_string}+6)/$(tput cols) ))
 				(( $output_lines )) && tput cuu $output_lines
-				( set -o noclobber; > /tmp/dietpi-process.pid ) && ( Print_Process_Animation & echo $! > /tmp/dietpi-process.pid )
+				# If redirect to PID file fails (due to noclobber on existent file), start processing animation.
+				# - This method prevents a tiny condition race from checking file existance to creating it, when doing: [[ ! -e file ]] && > file
+				if set -o noclobber && > /tmp/dietpi-process.pid &> /dev/null && set +o noclobber; then
 
+					Print_Process_Animation & echo $! > /tmp/dietpi-process.pid
+
+				fi
 				unset Print_Process_Animation
 
 			fi

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -422,9 +422,6 @@
 			/DietPi/dietpi/dietpi-drive_manager 3
 			local exit_code=$?
 
-			#Prevent HIERARCHY increase (as this pre-check runs before we define it in originating script)
-			export HIERARCHY=$((HIERARCHY-1))
-
 			if (( $exit_code != 0 )); then
 
 				G_DIETPI-NOTIFY 1 'RootFS is currently Read Only, unable to continue.\n'

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -23,9 +23,6 @@
 	#////////////////////////////////////
 
 	#-----------------------------------------------------------------------------------
-	#Ensure we are in users home dir: https://github.com/Fourdee/DietPi/issues/905#issuecomment-298223705
-	cd $HOME
-	#-----------------------------------------------------------------------------------
 	#Exit script for unsupported terminal and set dumb: https://github.com/Fourdee/DietPi/issues/1703#issue-314330405
 	if [[ -z $TERM || $TERM == 'unknown' ]]; then
 
@@ -80,9 +77,20 @@
 	G_FP_DIETPI_USERDATA='/mnt/dietpi_userdata'
 
 	#Device details
+	# - Declare
+	G_HW_MODEL=0
+	G_HW_MODEL_DESCRIPTION='NULL'
+	G_HW_ARCH=0
+	G_HW_ARCH_DESCRIPTION='NULL'
+	G_HW_CPUID=0
+	G_HW_CPU_CORES=$(nproc --all)
+
+	G_DISTRO=0
+	G_DISTRO_NAME='NULL'
+
 	# - Update
 	#	NB: dietpi-boot service launches dietpi-obtain_hw_model to create the following file
-	if [[ -f /DietPi/dietpi/.hw_model ]]; then
+	if [[ -r /DietPi/dietpi/.hw_model ]]; then
 
 		G_HW_MODEL=$(sed -n 1p /DietPi/dietpi/.hw_model)
 		G_HW_MODEL_DESCRIPTION=$(sed -n 2p /DietPi/dietpi/.hw_model)
@@ -104,17 +112,6 @@
 
 	fi
 
-	# - Create variables, if empty
-	G_HW_MODEL=${G_HW_MODEL:-0}
-	G_HW_MODEL_DESCRIPTION=${G_HW_MODEL_DESCRIPTION:-NULL}
-	G_HW_ARCH=${G_HW_ARCH:-0}
-	G_HW_ARCH_DESCRIPTION=${G_HW_ARCH_DESCRIPTION:-NULL}
-	G_HW_CPUID=${G_HW_CPUID:-0}
-	G_HW_CPU_CORES=$(nproc --all)
-
-	G_DISTRO=${G_DISTRO:-0}
-	G_DISTRO_NAME=${G_DISTRO_NAME:-NULL}
-
 	#INIT functions for originating script
 	#	eg: stuff we cant init in main globals/funcs due to .bashrc load into current session.
 	G_INIT(){
@@ -125,6 +122,17 @@
 
 		# - HIERARCHY system for G_DIETPI-NOTIFY 3
 		[[ $HIERARCHY ]] && export HIERARCHY=$((HIERARCHY+1)) || export HIERARCHY=0
+
+		# - Ensure we are in script working dir or users home dir, if available: https://github.com/Fourdee/DietPi/issues/905#issuecomment-298223705
+		if [[ $FP_WORK_DIR ]]; then
+
+			mkdir -p $FP_WORK_DIR && cd $FP_WORK_DIR || cd $HOME
+
+		elif 
+
+			cd $HOME
+
+		fi
 
 		# - Auto print init header for all scripts
 		# G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Init'
@@ -228,7 +236,7 @@
 		#$@ = txt desc
 		elif (( $1 == -2 )); then
 
-			output_string+="\r$bracket_l\e[33m......$bracket_r "
+			output_string+="\r$bracket_l\e[33m .... $bracket_r "
 			Print_Output_String 1
 
 			if (( $G_USER_INPUTS )); then
@@ -296,7 +304,7 @@
 
 			Clean_Process_Animation
 			output_string+="$bracket_l INFO $bracket_r "
-			# Keep info messages in gray, even if "G_PROGRAM_NAME | \e[0m" is added:
+			# Keep info messages in gray, even if "$G_PROGRAM_NAME | \e[0m" is added:
 			ainput_string[1]="\e[90m${ainput_string[1]}"
 			ainput_string+=('\n')
 			Print_Output_String 1
@@ -325,7 +333,7 @@
 
 			else
 
-				output_string+="\n \e[38;5;154m$2"
+				output_string+="\n \e[38;5;154m$2\e[0m"
 				output_string+='\n\e[90m─────────────────────────────────────────────────────'
 				output_string+='\n Mode: \e[0m'
 				ainput_string+=('\n\n')
@@ -505,7 +513,7 @@
 
 		#Update backtitle
 		WHIP_BACKTITLE="$G_PROGRAM_NAME | $G_HW_MODEL_DESCRIPTION"
-		if [[ -f '/DietPi/dietpi/.network' ]]; then
+		if [[ -r '/DietPi/dietpi/.network' ]]; then
 
 			WHIP_BACKTITLE+=" | IP: $(sed -n 4p /DietPi/dietpi/.network)"
 

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -116,18 +116,36 @@
 	#	eg: stuff we cant init in main globals/funcs due to .bashrc load into current session.
 	G_INIT(){
 
-		# - Set locale for scripts, prevents incorrect scraping
+		# Set locale for scripts, prevents incorrect scraping
 		export LANG=en_GB.UTF-8
 		export LC_ALL=en_GB.UTF-8
 
-		# - HIERARCHY system for G_DIETPI-NOTIFY 3
+		# HIERARCHY system for G_DIETPI-NOTIFY 3
 		[[ $HIERARCHY ]] && export HIERARCHY=$((HIERARCHY+1)) || export HIERARCHY=0
 
-		# - Ensure we are in script working dir or users home dir, if available: https://github.com/Fourdee/DietPi/issues/905#issuecomment-298223705
-		#	- If any $FP_WORK_DIR step fails, go to $HOME if it is assigned
+		# Ensure we are in script working dir or users home dir, if available: https://github.com/Fourdee/DietPi/issues/905#issuecomment-298223705
+		# - If any $FP_WORK_DIR step fails, go to $HOME if it is assigned
 		[[ $FP_WORK_DIR ]] && mkdir -p $FP_WORK_DIR && cd $FP_WORK_DIR || [[ $HOME ]] && cd $HOME
 
-		# - Auto print init header for all scripts
+		# Declare and trap G_EXIT() as exit script, that runs on INT, ERR and usual EXIT signal.
+		G_EXIT(){
+
+			# - Purging working directory
+			if [[ $FP_WORK_DIR && -d $FP_WORK_DIR ]]; then
+
+				# - Failsafe: Navigate incrementally to parent directory, if parent shell pwd is within $FP_WORK_DIR
+				while [[ $(pwd) =~ $FP_WORK_DIR ]]; do cd ..; done
+				rm -R $FP_WORK_DIR
+
+			fi
+
+			# - Execute custom exit commands, if existent
+			declare -F G_EXIT_CUSTOM &> /dev/null && G_EXIT_CUSTOM
+
+		fi
+		trap 'G_EXIT' EXIT
+
+		# Auto print init header for all scripts
 		# G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Init'
 
 	}


### PR DESCRIPTION
**Status**: Ready
- [x] Adjust scripts to assign `$FP_WORK_DIR` as their temporary working directory, before calling `G_INIT()`, to automatically create and navigate into it.
- [x] Optional: `G_EXIT()` or `G_CLEAN()` to remove `$FP_WORK_DIR`?

**Commit list/description**:
+ DietPi-Globals | Move automated dir navigation to `G_INIT()` to prevent messing with current terminal session
+ DietPi-Globals | Only navigate to $HOME dir, if it is assigned
  - **Currently, many error messages about unassigned `$HOME` show up during boot.**
+ DietPi-Globals | Allow automated creation and navigation into `$FP_WORK_DIR`, if assigned within script, e.g. /tmp/dietpi-*
+ DietPi-Globals | Minor coding
  - Make use of more selective file checking, file types, read/write-ability etc: https://www.gnu.org/software/bash/manual/html_node/Bash-Conditional-Expressions.html
+ DietPi-Globals | Syntax fix; Always attempt to go to `$HOME`, if assigned and any step with `$FP_WORK_DIR` failed.
+ DietPi-Globals | G_DIETPI-NOTIFY: Reset color in front of right bracket, in case "\e[90m" is not supported by terminal
+ DietPi-Globals | Automatically add a trap exit function, to purge existing working dir. Allow custom additional exit commands via declaring G_EXIT_CUSTOM() within the actual script.
+ DietPi-Software | Leave $FP_WORK_DIR handling to G_INIT() and G_EXIT() trap
+ DietPi-Software | Turn Software_Arrays_Destroy() into G_EXIT_CUSTOM() trap addition, to be executed on every kind of script exit
+ DietPi-Software | Reboot banner reorder, avoid doubled $DISABLE_REBOOT check, sync to fs before printing banner + sleep 3, to allow using the time for file sync
+ DietPi-Software | Remove DietPi-Survey call within first run setup, as this is already called after first run update and install.
+ DietPi-Software | Optimize marking software titles on automated first run install, to call grep + sed just once and directly pass indices to loop.
+ DietPi-Survey | Rely on G_INIT() > G_EXIT() to create and purge tmp $FP_WORK_DIR
+ DietPi-Globals | G_DIETPI-NOTIFY: Remove race condition between checking and creating /tmp/dietpi-process.pid: https://www.davidpashley.com/articles/writing-robust-shell-scripts/
+ DietPi-Globals | G_DIETPI-NOTIFY: Allow processing animation, if G_USER_INPUTS=0 was set manually, only verify input terminal
+ DietPi-Update | Rely on G_INIT() and G_EXIT() to handle working directory
+ DietPi-Bugreport | Rely on G_INIT() and G_EXIT() to handle working directory
+ DietPi-Drive_Manager | Use G_INIT() and G_EXIT() to enter and exit+purge /tmp working directory, to create tmp files inside
+ DietPi-Globals | G_DIETPI-NOTIFY: Avoid creating subshells, as this takes relatively much time: https://github.com/Fourdee/DietPi/issues/1510#issuecomment-407512160
+ DietPi-Globals | G_CHECK_ROOTFS_RW(): Do not decrease $HIERARCHY by 1, as this will let scripts start with $HIERARCHY == -1, leading to wrong output. export $HIERARCHY within dietpi-drive_manager does not have any influence on $HIERARCHY declaration or value within parent script/shell.
_______________________
Use this within all scripts, that produce temporary files? We could further increase automation/consistency via `FP_WORK_DIR="/tmp/$G_PROGRAM_NAME"`, but this would include capital letters.

Further idea: Use "trap" to clean temp working dir as well on error or `<ctrl>+<c>` cancel: http://redsymbol.net/articles/bash-exit-traps/
🈯️ `trap 'G_EXIT' EXIT`
___________________
Testing:
🈯️ Software installation via cmd
🈯️ Software installation via menu
🈯️ Bugreport
🈯️ dietpi-update
🈯️ dietpi-drive_manager
🈯️ dietpi-survey