### PR TITLE
DietPi-Software | PHP, Koel, several

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -53,7 +53,7 @@
 
 		local write_software_in_pending_state=0
 
-		local fp_target="$FP_INSTALLED_FILE"
+		local fp_target=$FP_INSTALLED_FILE
 
 		if [[ $1 == 'temp' ]]; then
 
@@ -62,7 +62,7 @@
 
 		fi
 
-		rm "$fp_target" &> /dev/null
+		rm $fp_target &> /dev/null
 
 		#Save installed states
 		for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
@@ -71,18 +71,18 @@
 			# - Never save pending state for software (=1). Excluding temp saves.
 			if (( ${aSOFTWARE_INSTALL_STATE[$i]} == 1 && ! $write_software_in_pending_state )); then
 
-				echo -e "aSOFTWARE_INSTALL_STATE[$i]=0" >> "$fp_target"
+				echo -e "aSOFTWARE_INSTALL_STATE[$i]=0" >> $fp_target
 
 			else
 
-				echo -e "aSOFTWARE_INSTALL_STATE[$i]=${aSOFTWARE_INSTALL_STATE[$i]}" >> "$fp_target"
+				echo -e "aSOFTWARE_INSTALL_STATE[$i]=${aSOFTWARE_INSTALL_STATE[$i]}" >> $fp_target
 
 			fi
 
 		done
 
 		#Misc
-		cat << _EOF_ >> "$fp_target"
+		cat << _EOF_ >> $fp_target
 
 #DietPi Choice System: SSH Server
 INDEX_SSHSERVER_CURRENT=$INDEX_SSHSERVER_CURRENT
@@ -105,11 +105,11 @@ _EOF_
 
 	Read_InstallFileList(){
 
-		local fp_target="$FP_INSTALLED_FILE"
+		local fp_target=$FP_INSTALLED_FILE
 
 		if [[ $1 == 'temp' ]]; then
 
-			fp_target="$FP_INSTALLED_FILE_TEMP"
+			fp_target=$FP_INSTALLED_FILE_TEMP
 
 		fi
 
@@ -302,38 +302,12 @@ _EOF_
 
 	# - Software
 	#NB: All software has a unique index that must not be changed (eg: DESKTOP_LXDE = 23)
-	TOTAL_SOFTWARE_INDEXS=0
 	TOTAL_SOFTWARE_INDEXS_HARDLIMIT=170	#Increase as needed. Must be higher than TOTAL_SOFTWARE_INDEXS once calculated in Software_Arrays_Init
+	TOTAL_SOFTWARE_INDEXS=$TOTAL_SOFTWARE_INDEXS_HARDLIMIT # Currently all indexes 0 - 169 are initiated, thus $TOTAL_SOFTWARE_INDEXS == $TOTAL_SOFTWARE_INDEXS_HARDLIMIT anyway.
 
 	INSTALLING_INDEX=0					#Which software index is currently being installed?
 
-	aSOFTWARE_CATEGORY_INDEX=0			#Category index
-	aSOFTWARE_TYPE=0					#0=DietPi 1=Linux | -1=Hidden from install menu, visible in uninstall menu | -2 Hidden from all menus
-
-	aSOFTWARE_INSTALL_STATE=0			#0=not / 1=tobe, or not tobe that is the... / 2=installed
-
-	aSOFTWARE_WHIP_NAME=0				#Item name eg: Kodi
-	aSOFTWARE_WHIP_DESC=0				#Blah blah
-
 	FP_ONLINEDOC_URL='https://dietpi.com/phpbb/viewtopic.php?'
-	aSOFTWARE_ONLINEDOC_URL=0
-
-	# - Disable software installation, if user input is required for automated installs
-	aSOFTWARE_REQUIRES_USERINPUT=0
-
-	# - Optional pre req software that needs to be installed
-	aSOFTWARE_REQUIRES_ALSA=0
-	aSOFTWARE_REQUIRES_XSERVERXORG=0
-	aSOFTWARE_REQUIRES_MYSQL=0
-	aSOFTWARE_REQUIRES_SQLITE=0
-	aSOFTWARE_REQUIRES_WEBSERVER=0
-	aSOFTWARE_REQUIRES_DESKTOP=0
-	aSOFTWARE_REQUIRES_GIT=0
-	aSOFTWARE_REQUIRES_BUILDESSENTIAL=0
-	aSOFTWARE_REQUIRES_RSYSLOG=0
-	aSOFTWARE_REQUIRES_FFMPEG=0
-	aSOFTWARE_REQUIRES_JAVA_JRE_JDK=0
-	aSOFTWARE_REQUIRES_NODEJS=0
 
 	# - Available for
 	MAX_G_HW_MODEL=71		#This needs to match highest G_HW_MODEL value in dietpi-obtain_hw_model
@@ -466,8 +440,9 @@ _EOF_
 			aSOFTWARE_WHIP_NAME[$i]='NULL'
 			aSOFTWARE_WHIP_DESC[$i]=''
 			aSOFTWARE_ONLINEDOC_URL[$i]=''
-			aSOFTWARE_CATEGORY_INDEX[$i]=0
-			aSOFTWARE_TYPE[$i]=-1
+			aSOFTWARE_CATEGORY_INDEX[$i]=-1
+			aSOFTWARE_TYPE[$i]=-2 # 0=DietPi 1=Linux | -1=Hidden from install menu, visible in uninstall menu | -2 Hidden from all menus
+			aSOFTWARE_INSTALL_STATE[$i]=0
 
 			# - Init Software requires/pre-reqs
 			aSOFTWARE_REQUIRES_USERINPUT[$i]=0
@@ -476,6 +451,7 @@ _EOF_
 			aSOFTWARE_REQUIRES_MYSQL[$i]=0
 			aSOFTWARE_REQUIRES_SQLITE[$i]=0
 			aSOFTWARE_REQUIRES_WEBSERVER[$i]=0
+			aSOFTWARE_REQUIRES_PHP[$i]=0
 			aSOFTWARE_REQUIRES_DESKTOP[$i]=0
 			aSOFTWARE_REQUIRES_GIT[$i]=0
 			aSOFTWARE_REQUIRES_BUILDESSENTIAL[$i]=0
@@ -956,7 +932,7 @@ _EOF_
 			aSOFTWARE_CATEGORY_INDEX[$index_current]=2
 					  aSOFTWARE_TYPE[$index_current]=0
 			 aSOFTWARE_ONLINEDOC_URL[$index_current]='f=8&t=5&p=7305#p7305'
-		aSOFTWARE_REQUIRES_WEBSERVER[$index_current]=1
+		aSOFTWARE_REQUIRES_PHP[$index_current]=1
  			aSOFTWARE_REQUIRES_MYSQL[$index_current]=1
 		   aSOFTWARE_REQUIRES_NODEJS[$index_current]=1
    aSOFTWARE_REQUIRES_BUILDESSENTIAL[$index_current]=1
@@ -2497,20 +2473,9 @@ _EOF_
 		#------------------
 
 		#--------------------------------------------------------------------------------
-		#Total software installations
-		TOTAL_SOFTWARE_INDEXS=${#aSOFTWARE_TYPE[@]}
-		#--------------------------------------------------------------------------------
-		#Init Installed state - 0=not 1=to be 2=installed
-		for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
-		do
-
-			aSOFTWARE_INSTALL_STATE[$i]=0
-
-		done
-
 		#Installed software on DietPi image by default.
-		aSOFTWARE_INSTALL_STATE[103]=2
-		aSOFTWARE_INSTALL_STATE[104]=2
+		aSOFTWARE_INSTALL_STATE[103]=2 # DietPi-RAMlog
+		aSOFTWARE_INSTALL_STATE[104]=2 # Dropbear
 		#--------------------------------------------------------------------------------
 
 	}
@@ -2736,6 +2701,8 @@ _EOF_
 		fi
 
 		#Software that requires Redis
+		#	ownCloud
+		#	Nextcloud
 		index=91
 		if (( ${aSOFTWARE_INSTALL_STATE[47]} == 1 ||
 			${aSOFTWARE_INSTALL_STATE[114]} == 1 )); then
@@ -2830,6 +2797,24 @@ _EOF_
 					G_DIETPI-NOTIFY 2 'PHP will be installed'
 
 				fi
+
+				break
+
+			fi
+
+		done
+
+		#WEBSERVER_PHP
+		for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
+		do
+
+			if (( ${aSOFTWARE_REQUIRES_PHP[$i]} &&
+				${aSOFTWARE_INSTALL_STATE[$i]} == 1 )); then
+
+				#WEBSERVER_PHP
+				aSOFTWARE_INSTALL_STATE[89]=1
+
+				G_DIETPI-NOTIFY 2 'PHP will be installed'
 
 				break
 
@@ -3646,56 +3631,53 @@ _EOF_
 
 			Banner_Installing
 
-			#Install base PHP packages/modules.
+			# Install base PHP packages/modules
+			# - Apache
 			if (( ${aSOFTWARE_INSTALL_STATE[83]} >= 1 )); then
 
 				local package_list="libapache2-mod-$PHP_APT_PACKAGE_NAME"
 
-			else
+			# - Lighttpd or Nginx
+			elif (( ${aSOFTWARE_INSTALL_STATE[84]} >= 1 || ${aSOFTWARE_INSTALL_STATE[85]} >= 1 )); then
 
 				local package_list="$PHP_APT_PACKAGE_NAME-fpm"
 
+			# - No webserver, /usr/bin/php cmd usage
+			else
+
+				local package_list="$PHP_APT_PACKAGE_NAME-cli"
+
 			fi
 
-			#php-common modules, used by most web software
-			package_list+=" $PHP_APT_PACKAGE_NAME-curl $PHP_APT_PACKAGE_NAME-gd $PHP_APT_PACKAGE_NAME-apcu $PHP_APT_PACKAGE_NAME-sqlite* $PHP_APT_PACKAGE_NAME-cli"
+			# php-common modules, used by most web software
+			package_list+=" $PHP_APT_PACKAGE_NAME-curl $PHP_APT_PACKAGE_NAME-gd $PHP_APT_PACKAGE_NAME-apcu"
 
 			# + stretch extras
-			if (( $G_DISTRO >= 4 )); then
-
-				package_list+=" $PHP_APT_PACKAGE_NAME-mbstring $PHP_APT_PACKAGE_NAME-zip $PHP_APT_PACKAGE_NAME-xml"
-
-			fi
+			(( $G_DISTRO >= 4 )) && package_list+=" $PHP_APT_PACKAGE_NAME-mbstring $PHP_APT_PACKAGE_NAME-zip $PHP_APT_PACKAGE_NAME-xml"
 
 			# PHP7.2/Buster dropped support for mcrypt: https://liorkaplan.wordpress.com/2017/09/10/php-7-2-is-coming-mcrypt-extension-isnt/
-			if (( $G_DISTRO < 5 )); then
+			(( $G_DISTRO < 5 )) && package_list+=" $PHP_APT_PACKAGE_NAME-mcrypt"
 
-				package_list+=" $PHP_APT_PACKAGE_NAME-mcrypt"
-
-			fi
-
+			# MySQL/MariaDB php module
 			if (( ${aSOFTWARE_INSTALL_STATE[88]} >= 1 )); then
 
 				if (( $G_DISTRO < 4 )); then
-					#For <= Jessie, php5-mysqlnd provides the newer mysql client libraries compared to php5-mysql.
+					# For <= Jessie, php5-mysqlnd provides the newer mysql client libraries compared to php5-mysql.
 					package_list+=' php5-mysqlnd'
 
 				else
-					#For >= Stretch, php(7.X)-mysqlnd does not exist, thus php-mysql need to be installed: https://packages.debian.org/de/stretch/php-mysql
+					# For >= Stretch, php(7.X)-mysqlnd does not exist, thus php-mysql need to be installed: https://packages.debian.org/de/stretch/php-mysql
 					package_list+=" $PHP_APT_PACKAGE_NAME-mysql"
 
 				fi
 
 			fi
 
-			package_list+=" $PHP_APT_PACKAGE_NAME-sqlite*" #wildcard for version (eg:3)
+			# SQLite php module
+			(( ${aSOFTWARE_INSTALL_STATE[87]} >= 1 )) && package_list+=" $PHP_APT_PACKAGE_NAME-sqlite*" # Wildcard for version (eg:3)
 
-			#Redis php module
-			if (( ${aSOFTWARE_INSTALL_STATE[91]} >= 1 )); then
-
-				package_list+=" $PHP_APT_PACKAGE_NAME-redis"
-
-			fi
+			# Redis php module
+			(( ${aSOFTWARE_INSTALL_STATE[91]} >= 1 )) && package_list+=" $PHP_APT_PACKAGE_NAME-redis"
 
 			G_AGI $package_list
 
@@ -3870,7 +3852,7 @@ _EOF_
 			Banner_Installing
 
 			G_DIETPI-NOTIFY 2 'Installing needed PHP modules' # https://doc.owncloud.org/server/latest/admin_manual/installation/source_installation.html#php-extensions
-			G_AGI "$PHP_APT_PACKAGE_NAME"-intl "$PHP_APT_PACKAGE_NAME"-redis
+			G_AGI "$PHP_APT_PACKAGE_NAME"-intl
 
 			if [[ -f /var/www/owncloud/occ ]]; then
 
@@ -3906,7 +3888,7 @@ _EOF_
 			Banner_Installing
 
 			G_DIETPI-NOTIFY 2 'Installing needed PHP modules' # https://docs.nextcloud.com/server/13/admin_manual/installation/source_installation.html#prerequisites-label
-			G_AGI "$PHP_APT_PACKAGE_NAME"-intl "$PHP_APT_PACKAGE_NAME"-redis
+			G_AGI "$PHP_APT_PACKAGE_NAME"-intl
 
 			if [[ -f /var/www/nextcloud/occ ]]; then
 
@@ -5922,7 +5904,10 @@ _EOF_
 
 			Banner_Installing
 
-			DEPS_LIST='python'
+			# Needed PHP modules, (re)install to be failsafe: https://koel.phanan.net/docs/#/?id=server, https://laravel.com/docs/5.6/installation#server-requirements
+			DEPS_LIST="python $PHP_APT_PACKAGE_NAME-json"
+			(( $G_DISTRO > 3 )) && DEPS_LIST+=" $PHP_APT_PACKAGE_NAME-mbstring $PHP_APT_PACKAGE_NAME-xml"
+
 			Download_Install 'https://github.com/phanan/koel/archive/v3.7.2.zip'
 			mv koel-* /var/www/koel
 
@@ -12221,7 +12206,7 @@ _EOF_
 		FP_DIETPI_DEDICATED_USBDRIVE="$(df -P | grep -m1 '^/dev/sda1' | awk '{print $6}')"
 
 		#Only enable if mounted
-		if [ -n "$FP_DIETPI_DEDICATED_USBDRIVE" ] &&
+		if [[ $FP_DIETPI_DEDICATED_USBDRIVE ]] &&
 			(( $(df -P | grep -ci -m1 "$FP_DIETPI_DEDICATED_USBDRIVE") )); then
 
 			USBDRIVE=1
@@ -14277,7 +14262,7 @@ _EOF_
 		Install_Apply_Permissions &> /dev/null
 
 		# Apply autostart index
-		local autostart_current="$(cat /DietPi/dietpi/.dietpi-autostart_index)"
+		local autostart_current="$(</DietPi/dietpi/.dietpi-autostart_index)"
 		/DietPi/dietpi/dietpi-autostart "$autostart_current"
 
 		# Disable services so DietPi-services can take control (DietPi will start all services from dietpi-postboot.service)

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -30,7 +30,7 @@
 	G_INIT
 	G_CHECK_ROOT_USER
 	G_CHECK_ROOTFS_RW
-	[[ -f $FP_WORK_DIR ]] && rm -R $FP_WORK_DIR
+	[[ -e $FP_WORK_DIR ]] && rm -R $FP_WORK_DIR
 	mkdir -p $FP_WORK_DIR
 	#Import DietPi-Globals ---------------------------------------------------------------
 
@@ -57,7 +57,7 @@
 
 		if [[ $1 == 'temp' ]]; then
 
-			fp_target="$FP_INSTALLED_FILE_TEMP"
+			fp_target=$FP_INSTALLED_FILE_TEMP
 			write_software_in_pending_state=1
 
 		fi
@@ -65,7 +65,7 @@
 		rm $fp_target &> /dev/null
 
 		#Save installed states
-		for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
+		for ((i=0; i<$TOTAL_SOFTWARE_INDICES; i++))
 		do
 
 			# - Never save pending state for software (=1). Excluding temp saves.
@@ -302,10 +302,8 @@ _EOF_
 
 	# - Software
 	#NB: All software has a unique index that must not be changed (eg: DESKTOP_LXDE = 23)
-	TOTAL_SOFTWARE_INDEXS_HARDLIMIT=170	#Increase as needed. Must be higher than TOTAL_SOFTWARE_INDEXS once calculated in Software_Arrays_Init
-	TOTAL_SOFTWARE_INDEXS=$TOTAL_SOFTWARE_INDEXS_HARDLIMIT # Currently all indexes 0 - 169 are initiated, thus $TOTAL_SOFTWARE_INDEXS == $TOTAL_SOFTWARE_INDEXS_HARDLIMIT anyway.
-
-	INSTALLING_INDEX=0					#Which software index is currently being installed?
+	TOTAL_SOFTWARE_INDICES=170	#Increase as needed, must be at least highest used software index +1
+	INSTALLING_INDEX=0		#Which software index is currently being installed?
 
 	FP_ONLINEDOC_URL='https://dietpi.com/phpbb/viewtopic.php?'
 
@@ -433,7 +431,7 @@ _EOF_
 		#--------------------------------------------------------------------------------
 		#Init aSOFTWARE arrays
 		#--------------------------------------------------------------------------------
-		for ((i=0; i<$TOTAL_SOFTWARE_INDEXS_HARDLIMIT; i++))
+		for ((i=0; i<$TOTAL_SOFTWARE_INDICES; i++))
 		do
 
 			# - Init main entries to NULL + hidden from GUI
@@ -2517,7 +2515,7 @@ _EOF_
 
 		if (( ! $G_USER_INPUTS )); then
 
-			for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
+			for ((i=0; i<$TOTAL_SOFTWARE_INDICES; i++))
 			do
 
 				if (( ${aSOFTWARE_INSTALL_STATE[$i]} == 1 &&
@@ -2759,7 +2757,7 @@ _EOF_
 		fi
 
 		#WEBSERVER - Auto install via choice system
-		for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
+		for ((i=0; i<$TOTAL_SOFTWARE_INDICES; i++))
 		do
 
 			if (( ${aSOFTWARE_REQUIRES_WEBSERVER[$i]} &&
@@ -2805,7 +2803,7 @@ _EOF_
 		done
 
 		#WEBSERVER_PHP
-		for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
+		for ((i=0; i<$TOTAL_SOFTWARE_INDICES; i++))
 		do
 
 			if (( ${aSOFTWARE_REQUIRES_PHP[$i]} &&
@@ -2823,7 +2821,7 @@ _EOF_
 		done
 
 		#WEBSERVER_MARIADB
-		for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
+		for ((i=0; i<$TOTAL_SOFTWARE_INDICES; i++))
 		do
 
 			if (( ${aSOFTWARE_REQUIRES_MYSQL[$i]} &&
@@ -2841,7 +2839,7 @@ _EOF_
 		done
 
 		#WEBSERVER_SQLITE
-		for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
+		for ((i=0; i<$TOTAL_SOFTWARE_INDICES; i++))
 		do
 
 			if (( ${aSOFTWARE_REQUIRES_SQLITE[$i]} &&
@@ -2921,7 +2919,7 @@ _EOF_
 		fi
 
 		#DESKTOP
-		for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
+		for ((i=0; i<$TOTAL_SOFTWARE_INDICES; i++))
 		do
 
 			if (( ${aSOFTWARE_REQUIRES_DESKTOP[$i]} &&
@@ -2945,7 +2943,7 @@ _EOF_
 		done
 
 		#GIT
-		for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
+		for ((i=0; i<$TOTAL_SOFTWARE_INDICES; i++))
 		do
 
 			if (( ${aSOFTWARE_REQUIRES_GIT[$i]} &&
@@ -2963,7 +2961,7 @@ _EOF_
 		done
 
 		#BUILDESSENTIAL
-		for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
+		for ((i=0; i<$TOTAL_SOFTWARE_INDICES; i++))
 		do
 
 			if (( ${aSOFTWARE_REQUIRES_BUILDESSENTIAL[$i]} &&
@@ -2981,7 +2979,7 @@ _EOF_
 		done
 
 		#RSYSLOG
-		for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
+		for ((i=0; i<$TOTAL_SOFTWARE_INDICES; i++))
 		do
 
 			if (( ${aSOFTWARE_REQUIRES_RSYSLOG[$i]} &&
@@ -2999,7 +2997,7 @@ _EOF_
 		done
 
 		#FFMPEG
-		for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
+		for ((i=0; i<$TOTAL_SOFTWARE_INDICES; i++))
 		do
 
 			if (( ${aSOFTWARE_REQUIRES_FFMPEG[$i]} &&
@@ -3017,7 +3015,7 @@ _EOF_
 		done
 
 		#ORACLEJAVA
-		for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
+		for ((i=0; i<$TOTAL_SOFTWARE_INDICES; i++))
 		do
 
 			if (( ${aSOFTWARE_REQUIRES_JAVA_JRE_JDK[$i]} &&
@@ -3035,7 +3033,7 @@ _EOF_
 		done
 
 		#NODEJS
-		for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
+		for ((i=0; i<$TOTAL_SOFTWARE_INDICES; i++))
 		do
 
 			if (( ${aSOFTWARE_REQUIRES_NODEJS[$i]} &&
@@ -3053,7 +3051,7 @@ _EOF_
 		done
 
 		#ALSA
-		for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
+		for ((i=0; i<$TOTAL_SOFTWARE_INDICES; i++))
 		do
 
 			if (( ${aSOFTWARE_REQUIRES_ALSA[$i]} &&
@@ -3071,7 +3069,7 @@ _EOF_
 		done
 
 		#XSERVERXORG
-		for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
+		for ((i=0; i<$TOTAL_SOFTWARE_INDICES; i++))
 		do
 
 			if (( ${aSOFTWARE_REQUIRES_XSERVERXORG[$i]} &&
@@ -3266,7 +3264,7 @@ _EOF_
 		#no_check_url = Optional disable URL check
 		local url="$1"
 		local target="$2" # Extract target
-		local type="$(echo -e $url | sed 's/.*\.//')" # grab ext from URL | compatbile with >> deb|zip|tar|7z
+		local type="${url##*.}" # grab ext from URL | compatbile with >> deb|zip|tar(.gz|.bz2)|7z
 		if [[ $type == 'gz' || $type == 'bz2' ]]; then
 
 			type='tar'
@@ -3315,7 +3313,7 @@ _EOF_
 
 		else
 
-			G_DIETPI-NOTIFY 1 'Download_Install: Invalid argument $1, needs to be one of: deb|zip|tar|7z'
+			G_DIETPI-NOTIFY 1 'Download_Install: Invalid file type, needs to be one of: deb|zip|tar(.gz|.bz2)|7z'
 
 		fi
 
@@ -3338,6 +3336,12 @@ _EOF_
 	# - INSTALL_URL_ADDRESS:
 	#   This can be used to check conectivity to items you need to download later.
 	#   A good example would also be a git repo.
+	#
+	# - Use Download_Install() (see code above) to check URL, download and install/extract
+	#   deb|zip|tar(.gz|.bz2)|7z sources automatically and consistent, e.g.
+	#   	Download_Install 'https://www.phpbb.com/files/release/phpBB-3.2.2.zip' /var/www
+	#   will check the URL, download phpBB archive, extract it to /var/www(/phpBB3)
+	#   and remove the archieve afterwards.
 	#
 	# Example:
 	#	#------------------ Bittorrent: HTPC Manager ------------------
@@ -14126,7 +14130,7 @@ _EOF_
 		#aSOFTWARE_INSTALL_STATE[$index]=0
 
 		#Uninstall finished, set all uninstalled software to state 0 (not installed)
-		for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
+		for ((i=0; i<$TOTAL_SOFTWARE_INDICES; i++))
 		do
 
 			if (( ${aSOFTWARE_INSTALL_STATE[$i]} == -1 )); then
@@ -14269,7 +14273,7 @@ _EOF_
 		/DietPi/dietpi/dietpi-services dietpi_controlled
 
 		# Install finished, set all installed software to state 2 (installed)
-		for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
+		for ((i=0; i<$TOTAL_SOFTWARE_INDICES; i++))
 		do
 
 			if (( ${aSOFTWARE_INSTALL_STATE[$i]} == 1 )); then
@@ -14544,7 +14548,7 @@ _EOF_
 				do
 
 					# - check for valid int, and is lower than array limit
-					if G_CHECK_VALIDINT $i && (( $i < $TOTAL_SOFTWARE_INDEXS_HARDLIMIT )); then
+					if G_CHECK_VALIDINT $i && (( $i < $TOTAL_SOFTWARE_INDICES )); then
 
 						if [[ $1 == 'uninstall' ]]; then
 
@@ -14641,7 +14645,7 @@ _EOF_
 		#List unique software names and ID's
 		elif [[ $1 == 'list' ]]; then
 
-			for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
+			for ((i=0; i<$TOTAL_SOFTWARE_INDICES; i++))
 			do
 
 				local string=''
@@ -14656,7 +14660,7 @@ _EOF_
 
 				fi
 
-				string+="=${aSOFTWARE_INSTALL_STATE[$i]} | ${aSOFTWARE_WHIP_NAME[$i]}: \e[90m${aSOFTWARE_WHIP_DESC[$i]}\e[0m |"
+				string+="=${aSOFTWARE_INSTALL_STATE[$i]} | ${aSOFTWARE_WHIP_NAME[$i]}: \e[0m\e[90m${aSOFTWARE_WHIP_DESC[$i]}\e[0m |"
 
 				if (( ${aSOFTWARE_REQUIRES_ALSA[$i]} == 1 )); then
 
@@ -14718,9 +14722,15 @@ _EOF_
 
 				fi
 
+				if (( ${aSOFTWARE_REQUIRES_PHP[$i]} == 1 )); then
+
+					string+=' +PHP'
+
+				fi
+
 				if (( ${aSOFTWARE_REQUIRES_MYSQL[$i]} == 1 )); then
 
-					string+=' +MYSQL'
+					string+=' +MARIADB'
 
 				fi
 
@@ -14745,7 +14755,7 @@ _EOF_
 				fi
 
 				# - Online docs
-				if [[ -n ${aSOFTWARE_ONLINEDOC_URL[$i]} ]]; then
+				if [[ ${aSOFTWARE_ONLINEDOC_URL[$i]} ]]; then
 
 					string+=" | \e[90m$FP_ONLINEDOC_URL${aSOFTWARE_ONLINEDOC_URL[$i]}\e[0m"
 
@@ -14756,8 +14766,7 @@ _EOF_
 
 			done
 
-			echo -e "Total Software index HARD limit : $TOTAL_SOFTWARE_INDEXS_HARDLIMIT"
-			echo -e "Total Software index Current    : $TOTAL_SOFTWARE_INDEXS"
+			echo -e "Total Software indices : $TOTAL_SOFTWARE_INDICES"
 
 		else
 
@@ -14800,7 +14809,7 @@ _EOF_
 				G_WHIP_CHECKLIST_ARRAY=()
 				local item_found=0
 				search_string="$G_WHIP_RETURNED_VALUE"
-				for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
+				for ((i=0; i<$TOTAL_SOFTWARE_INDICES; i++))
 				do
 
 					if (( ${aSOFTWARE_AVAIL_G_HW_MODEL[$i,$G_HW_MODEL]} && ${aSOFTWARE_AVAIL_G_HW_ARCH[$i,$G_HW_ARCH]} )) &&
@@ -14867,7 +14876,7 @@ _EOF_
 				local category_enabled=0
 
 				#Now run through all available software
-				for ((j=0; j<$TOTAL_SOFTWARE_INDEXS; j++))
+				for ((j=0; j<$TOTAL_SOFTWARE_INDICES; j++))
 				do
 
 					#Check if this software matches the current category and sofware type for this menu.
@@ -15691,7 +15700,7 @@ _EOF_
 					string+='───────────────────────────────────────────────────────────────\n'
 
 					# - Installed software
-					for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
+					for ((i=0; i<$TOTAL_SOFTWARE_INDICES; i++))
 					do
 
 						if (( ${aSOFTWARE_INSTALL_STATE[$i]} > 0 )); then
@@ -15774,7 +15783,7 @@ _EOF_
 
 		#Obtain list of pending software installation:
 		local string_output=''
-		for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
+		for ((i=0; i<$TOTAL_SOFTWARE_INDICES; i++))
 		do
 
 			if (( ${aSOFTWARE_INSTALL_STATE[$i]} == 1 )); then
@@ -15880,7 +15889,7 @@ _EOF_
 		local software_installed_count=0
 
 		#Obtain list of installed software
-		for ((i=0; i<$TOTAL_SOFTWARE_INDEXS; i++))
+		for ((i=0; i<$TOTAL_SOFTWARE_INDICES; i++))
 		do
 
 			if (( ${aSOFTWARE_INSTALL_STATE[$i]} == 2 &&


### PR DESCRIPTION
**Status**: WIP
- [x] Further use aSOFTWARE_REQUIRES_PHP , where applicable
- [x] Optional: Merge `TOTAL_SOFTWARE_INDEXS` and `TOTAL_SOFTWARE_INDEXS_HARDLIMIT` or reimplement `TOTAL_SOFTWARE_INDEXS` to only count actually available software titles.

**Commit list/description**:
+ DietPi-Software | Add aSOFTWARE_REQUIRES_PHP for software that needs PHP binary, but no webserver; Add to Koel
+ DietPi-Software | PHP: Install php(5)-cli (PHP binary), if no webserver is installed
+ DietPi-Software | PHP: Revert SQLite module to be only installed, of SQLite is installed
+ DietPi-Software | Koel: (Re)install required PHP modules, to be failsafe
+ DietPi-Software | Minor code improvements and simplifications; Currently: TOTAL_SOFTWARE_INDEXS == TOTAL_SOFTWARE_INDEXS_HARDLIMIT, due to all possible indexes are initialized
+ DietPi-Software | Remove obsolete $TOTAL_SOFTWARE_INDEXS_HARDLIMIT, using $TOTAL_SOFTWARE_INDICES to loop through in every case.
+ DietPi-Software | List: Add "+PHP" string, in case of aSOFTWARE_REQUIRES_PHP
+ DietPi-Software | Download_Install: Minor coding, use direct bash var manipulation instead of "sed"
+ DietPi-Software | Download_Install: Add description to the HowTo comments