### PR TITLE
General | Remove faulty ramlog storage update from cron job

### DIFF
--- a/dietpi/dietpi-logclear
+++ b/dietpi/dietpi-logclear
@@ -231,6 +231,19 @@
 		#delete[] array
 		unset ARRAY_LOG_FILEPATH
 
+		#Update dietpi-ramlog file structure, if enabled:
+ 		LOGGING_MODE=0
+ 		if [[ -r '/DietPi/dietpi/.installed' ]]; then
+ 
+ 			LOGGING_MODE=$(grep -m1 '^[[:blank:]]*INDEX_LOGGING_CURRENT=' /DietPi/dietpi/.installed | sed 's/^.*=//')
+ 
+ 		fi
+		if (( $LOGGING_MODE == -1 || $LOGGING_MODE == -2 )); then
+
+			/DietPi/dietpi/dietpi-ramlog 1 &> /dev/null # Prevent confusing startup/shutdown output
+
+		fi
+
 	}
 
 	#////////////////////////////////////////////////////////////////

--- a/dietpi/dietpi-logclear
+++ b/dietpi/dietpi-logclear
@@ -231,19 +231,6 @@
 		#delete[] array
 		unset ARRAY_LOG_FILEPATH
 
-		#Update dietpi-ramlog file structure, if enabled:
- 		LOGGING_MODE=0
- 		if [[ -r '/DietPi/dietpi/.installed' ]]; then
- 
- 			LOGGING_MODE=$(grep -m1 '^[[:blank:]]*INDEX_LOGGING_CURRENT=' /DietPi/dietpi/.installed | sed 's/^.*=//')
- 
- 		fi
-		if (( $LOGGING_MODE == -1 || $LOGGING_MODE == -2 )); then
-
-			/DietPi/dietpi/dietpi-ramlog 1 &> /dev/null # Prevent confusing startup/shutdown output
-
-		fi
-
 	}
 
 	#////////////////////////////////////////////////////////////////

--- a/rootfs/etc/cron.hourly/dietpi
+++ b/rootfs/etc/cron.hourly/dietpi
@@ -32,15 +32,11 @@
 	if (( $LOGGING_MODE == -1 )); then
 
 		/DietPi/dietpi/dietpi-logclear 1 &> /dev/null
-		rm -R /var/lib/dietpi/dietpi-ramlog/storage
-		cp -R -p --attributes-only /var/log/. /var/lib/dietpi/dietpi-ramlog/storage/
 
 	# - Update current log files data to /$HOME/logfile_storage/*. Then clear.
 	elif (( $LOGGING_MODE == -2 )); then
 
 		/DietPi/dietpi/dietpi-logclear 0 &> /dev/null
-		rm -R /var/lib/dietpi/dietpi-ramlog/storage
-		cp -R -p --attributes-only /var/log/. /var/lib/dietpi/dietpi-ramlog/storage/
 
 	fi
 	#----------------------------------------------------------------


### PR DESCRIPTION
**Status**: Ready
- Whoopsie, excuse wrong version string

**Reference**: https://github.com/Fourdee/DietPi/issues/1947

**Commit list/description**:
+ General | Logging: Move dietpi-ramlog storage handling to "dietpi-logclear"