### PR TITLE
DietPi-FS_partition_resize | Fix resizing for SCSI/SATA drives and further /dev scheme support

### DIFF
--- a/rootfs/var/lib/dietpi/services/fs_partition_resize.sh
+++ b/rootfs/var/lib/dietpi/services/fs_partition_resize.sh
@@ -4,27 +4,23 @@ systemctl disable dietpi-fs_partition_resize
 
 sync
 
-TARGET_PARTITION=0
+# Naming scheme: https://askubuntu.com/questions/56929/what-is-the-linux-drive-naming-scheme
+# - SCSI/SATA:	/dev/sd[a-z][0-9]
+# - IDE:	/dev/hd[a-z][0-9]
+# - eMMC:	/dev/mmcblk[0-9]p[0-9]
+# - NVMe:	/dev/nvme[0-9]n[0-9]
 TARGET_DEV=$(findmnt / -o source -n)
+TARGET_PARTITION=${TARGET_DEV##*[a-z]} # Last [0-9]
+TARGET_DRIVE=${TARGET_DEV%[0-9]} # EG: /dev/mmcblk[0-9]p
+[[ $TARGET_DEV =~ mmcblk ]] || [[ $TARGET_DEV =~ nvme ]] && TARGET_DRIVE=${TARGET_DRIVE%[a-z]} # EG: /dev/mmcblk[0-9]
 
-# - MMCBLK[0-9]p[0-9] scrape
-if [[ $TARGET_DEV =~ mmcblk ]]; then
+# Only redo partitions, if drive actually contains a partition table.
+if [[ $TARGET_PARTITION ]]; then
 
-	TARGET_PARTITION=${TARGET_DEV##*p}
-	TARGET_DEV=${TARGET_DEV%p[0-9]}
+	#Rock64 GPT resize | modified version of ayufan-rock64 resize script. I take no credit for this.
+	if [[ -f /etc/.dietpi_hw_model_identifier ]] && (( $(</etc/.dietpi_hw_model_identifier) == 43 )); then
 
-# - Everything else scrape (eg: /dev/sdX[0-9])
-else
-
-	TARGET_PARTITION=${TARGET_DEV##*/sd}
-	TARGET_DEV=${TARGET_DEV%[0-9]}
-
-fi
-
-#Rock64 GPT resize | modified version of ayufan-rock64 resize script. I take no credit for this.
-if [[ -f /etc/.dietpi_hw_model_identifier ]] && (( $(</etc/.dietpi_hw_model_identifier) == 43 )); then
-
-	gdisk $TARGET_DEV << _EOF_
+		gdisk $TARGET_DRIVE << _EOF_
 x
 e
 m
@@ -42,25 +38,30 @@ w
 Y
 _EOF_
 
-#Everything else
-else
+	#Everything else
+	else
 
-	cat << _EOF_ | fdisk $TARGET_DEV
+		cat << _EOF_ | fdisk $TARGET_DRIVE
 p
 d
 $TARGET_PARTITION
 n
 p
 $TARGET_PARTITION
-$(parted $TARGET_DEV -ms unit s p | grep ':ext4::;' | sed 's/:/ /g' | sed 's/s//g' | awk '{ print $2 }')
+$(parted $TARGET_DRIVE -ms unit s p | grep ':ext4::;' | sed 's/:/ /g' | sed 's/s//g' | awk '{ print $2 }')
 
 p
 w
 
 _EOF_
 
+	fi
+
 fi
 
-partprobe $TARGET_DEV
+partprobe $TARGET_DRIVE
 
-resize2fs ${TARGET_DEV}p$TARGET_PARTITION
+resize2fs $TARGET_DEV
+
+exit 0
+


### PR DESCRIPTION
/dev/sd[a-z][0-9] drives were not correctly resized. Now other possible drive types will be handled as well.
And now, if the file system is directly written to /dev/sd[a-z] instead of /dev/sd[a-z][0-9] (no partition table created and single partition only), the repartitioning will be skipped.
- I don't know if without partition table, resizing is even needed. But it should not hurt though.

**Status**: Ready

**Commit list/description**:
+ DietPi-FS_partition_resize | Fix resizing for SCSI/SATA drives
+ DietPi-FS_partition_resize | Allow resizing for old IDE named and NVMe drives
+ DietPi-FS_partition_resize | Only repartition the drive, if the file system was actually written within a partition table