### PR TITLE
DietPi-Config | Minor, but much code enhancements and consistency

### DIFF
--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -19,10 +19,10 @@
 
 	#Import DietPi-Globals ---------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
-	G_CHECK_ROOT_USER
-	G_CHECK_ROOTFS_RW
 	export G_PROGRAM_NAME='DietPi-Config'
 	G_INIT
+	G_CHECK_ROOT_USER
+	G_CHECK_ROOTFS_RW
 	#Import DietPi-Globals ---------------------------------------------------------------
 
 	#Grab Inputs
@@ -52,7 +52,7 @@
 	#/////////////////////////////////////////////////////////////////////////////////////
 	Load_Installed_Software(){
 
-		if [ -f /DietPi/dietpi/.installed ]; then
+		if [[ -f /DietPi/dietpi/.installed ]]; then
 
 			. /DietPi/dietpi/.installed
 
@@ -117,7 +117,7 @@
 
 				TARGETMENUID=1
 
-			 elif (( $G_WHIP_RETURNED_VALUE == 2 )); then
+			elif (( $G_WHIP_RETURNED_VALUE == 2 )); then
 
 				TARGETMENUID=14
 
@@ -159,7 +159,7 @@
 
 				 TARGETMENUID=16
 
-		   elif (( $G_WHIP_RETURNED_VALUE == 9 )); then
+			elif (( $G_WHIP_RETURNED_VALUE == 9 )); then
 
 				/DietPi/dietpi/dietpi-autostart
 				REBOOT_REQUIRED=1
@@ -168,7 +168,7 @@
 
 				TARGETMENUID=11
 
-		   else
+			else
 
 				Menu_Exit
 
@@ -193,14 +193,14 @@
 			TARGETMENUID=-1
 
 			#Disable Reboot when run from dietpi-software
-			if (( $(ps aux | grep -ci -m1 '/DietPi/dietpi/[d]ietpi-software') )); then
+			if pgrep -ci 'dietpi-software' &> /dev/null; then
 
 				REBOOT_REQUIRED=0
 
 			fi
 
 			# Reboot Required
-			if (( $REBOOT_REQUIRED == 1 )); then
+			if (( $REBOOT_REQUIRED )); then
 
 				G_WHIP_YESNO 'A reboot is required to apply your new settings.\nWould you like to reboot now?'
 				if (( $? == 0 )); then
@@ -226,8 +226,8 @@
 
 		if (( $G_HW_MODEL < 10 )); then
 
-			local framebuffer_x=$(grep -m1 'framebuffer_width=' /DietPi/config.txt | sed 's/.*=//')
-			local framebuffer_y=$(grep -m1 'framebuffer_height=' /DietPi/config.txt | sed 's/.*=//')
+			local framebuffer_x=$(grep -m1 'framebuffer_width=' /DietPi/config.txt | sed 's/^[^=]*=//')
+			local framebuffer_y=$(grep -m1 'framebuffer_height=' /DietPi/config.txt | sed 's/^[^=]*=//')
 
 			#	0/180
 			if (( $input == 0 )); then
@@ -238,8 +238,8 @@
 					framebuffer_x=$framebuffer_y
 					framebuffer_y=$temp
 
-					sed -i "/framebuffer_width=/c\framebuffer_width=$framebuffer_x" /DietPi/config.txt
-					sed -i "/framebuffer_height=/c\framebuffer_height=$framebuffer_y" /DietPi/config.txt
+					G_CONFIG_INJECT 'framebuffer_width=' "framebuffer_width=$framebuffer_x" /DietPi/config.txt
+					G_CONFIG_INJECT 'framebuffer_height' "framebuffer_height=$framebuffer_y" /DietPi/config.txt
 
 				fi
 
@@ -252,8 +252,8 @@
 					framebuffer_x=$framebuffer_y
 					framebuffer_y=$temp
 
-					sed -i "/framebuffer_width=/c\framebuffer_width=$framebuffer_x" /DietPi/config.txt
-					sed -i "/framebuffer_height=/c\framebuffer_height=$framebuffer_y" /DietPi/config.txt
+					G_CONFIG_INJECT 'framebuffer_width=' "framebuffer_width=$framebuffer_x" /DietPi/config.txt
+					G_CONFIG_INJECT 'framebuffer_height' "framebuffer_height=$framebuffer_y" /DietPi/config.txt
 
 				fi
 
@@ -272,58 +272,58 @@
 
 		if (( $G_HW_MODEL == 21 )); then
 
-			G_WHIP_MENU_ARRAY+=("1" "Display Driver")
+			G_WHIP_MENU_ARRAY+=('1' 'Display Driver')
 
 		else
 
-			G_WHIP_MENU_ARRAY+=("1" "Change Resolution")
+			G_WHIP_MENU_ARRAY+=('1' 'Change Resolution')
 
 			# Just offer resolution option for VMs
 			if (( $G_HW_MODEL != 20 )); then
 
-				G_WHIP_MENU_ARRAY+=("2" "GPU/RAM Memory Split")
-				local lcdpanel_text=$(grep -m1 '^CONFIG_LCDPANEL=' /DietPi/dietpi.txt | sed 's/.*=//')
-				G_WHIP_MENU_ARRAY+=("3" "LCD Panel addon: $lcdpanel_text")
+				G_WHIP_MENU_ARRAY+=('2' 'GPU/RAM Memory Split')
+				local lcdpanel_text=$(grep -m1 '^CONFIG_LCDPANEL=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
+				G_WHIP_MENU_ARRAY+=('3' "LCD Panel addon: $lcdpanel_text")
 
 			fi
 
 		fi
 
-		(( $G_HW_MODEL != 20 )) && G_WHIP_MENU_ARRAY+=("14" "LED Control")
+		(( $G_HW_MODEL != 20 )) && G_WHIP_MENU_ARRAY+=('14' 'LED Control')
 
 		#RPi only
 		if (( $G_HW_MODEL < 10 )); then
 
 			# - Get Current Settings
-			local overscan_enabled=$(grep -ci -m1 'disable_overscan=0' /DietPi/config.txt)
+			local overscan_enabled=$(grep -ci -m1 '^[[:blank:]]*disable_overscan=0' /DietPi/config.txt)
 			local overscan_text='[Off]'
 			if (( $overscan_enabled )); then
 				overscan_text='[On]'
 			fi
 
-			local hdmi_boost_disabled=$(cat /DietPi/config.txt | grep -ci -m1 '#config_hdmi_boost=')
+			local hdmi_boost_disabled=$(grep -ci -m1 '#config_hdmi_boost=' /DietPi/config.txt)
 			local hdmi_boost_text='[On]'
 			if (( $hdmi_boost_disabled )); then
 				hdmi_boost_text='[Off]'
 			fi
 
-			local rpi_camera_module_enabled=$(cat /DietPi/config.txt | grep -ci -m1 'start_x=1')
+			local rpi_camera_module_enabled=$(grep -ci -m1 '^[[:blank:]]*start_x=1' /DietPi/config.txt)
 			local rpi_camera_module_text='[Off]'
 			if (( $rpi_camera_module_enabled == 1 )); then
 				rpi_camera_module_text='[On]'
 			fi
 
-			local rpi_camera_led_enabled=$(cat /DietPi/config.txt | grep -ci -m1 'disable_camera_led=0')
+			local rpi_camera_led_enabled=$(grep -ci -m1 '^[[:blank:]]*disable_camera_led=0' /DietPi/config.txt)
 			local rpi_camera_led_text='[Off]'
 			if (( $rpi_camera_led_enabled == 1 )); then
 				rpi_camera_led_text='[On]'
 			fi
 
-			local rotation_hdmi_current=$(cat /DietPi/config.txt | grep -m1 '^display_rotate=' | sed 's/.*=//')
-			local rotation_lcd_current=$(cat /DietPi/config.txt | grep -m1 '^lcd_rotate=' | sed 's/.*=//')
+			local rotation_hdmi_current=$(grep -m1 '^[[:blank:]]*display_rotate=' /DietPi/config.txt | sed 's/^[^=]*=//')
+			local rotation_lcd_current=$(grep -m1 '^[[:blank:]]*lcd_rotate=' /DietPi/config.txt | sed 's/^[^=]*=//')
 
-			local vc1_key_current=$(cat /DietPi/config.txt | grep -m1 '^decode_WVC1=' | sed 's/.*=//')
-			local mpeg2_key_current=$(cat /DietPi/config.txt | grep -m1 '^decode_MPG2=' | sed 's/.*=//')
+			local vc1_key_current=$(grep -m1 '^[[:blank:]]*decode_WVC1=' /DietPi/config.txt | sed 's/^[^=]*=//')
+			local mpeg2_key_current=$(grep -m1 '^[[:blank:]]*decode_MPG2=' /DietPi/config.txt | sed 's/^[^=]*=//')
 
 			#JustBoom IR Remote
 			local justboom_ir_remote_text='[Off]'
@@ -335,9 +335,9 @@
 
 			fi
 
-			G_WHIP_MENU_ARRAY+=("4" "Rotation (HDMI)       : $rotation_hdmi_current")
-			G_WHIP_MENU_ARRAY+=("5" "Rotation (LCD)        : $rotation_lcd_current")
-			G_WHIP_MENU_ARRAY+=("6" "Overscan              : $overscan_text")
+			G_WHIP_MENU_ARRAY+=('4' "Rotation (HDMI)       : $rotation_hdmi_current")
+			G_WHIP_MENU_ARRAY+=('5' "Rotation (LCD)        : $rotation_lcd_current")
+			G_WHIP_MENU_ARRAY+=('6' "Overscan              : $overscan_text")
 			if (( $overscan_enabled )); then
 
 				local overscan_options=(
@@ -347,20 +347,20 @@
 					'overscan_bottom'
 				)
 
-				local overscan_left=$(cat /DietPi/config.txt | grep -m1 'overscan_left=' | sed 's/.*=//')
-				local overscan_right=$(cat /DietPi/config.txt | grep -m1 'overscan_right=' | sed 's/.*=//')
-				local overscan_top=$(cat /DietPi/config.txt | grep -m1 'overscan_top=' | sed 's/.*=//')
-				local overscan_bottom=$(cat /DietPi/config.txt | grep -m1 'overscan_bottom=' | sed 's/.*=//')
-				G_WHIP_MENU_ARRAY+=("15" "Overscan Compensation : L:$overscan_left R:$overscan_right T:$overscan_top B:$overscan_bottom")
+				local overscan_left=$(grep -m1 '^[[:blank:]]*overscan_left=' /DietPi/config.txt | sed 's/^[^=]*=//')
+				local overscan_right=$(grep -m1 '^[[:blank:]]*overscan_right=' /DietPi/config.txt | sed 's/^[^=]*=//')
+				local overscan_top=$(grep -m1 '^[[:blank:]]*overscan_top=' /DietPi/config.txt | sed 's/^[^=]*=//')
+				local overscan_bottom=$(grep -m1 '^[[:blank:]]*overscan_bottom=' /DietPi/config.txt | sed 's/^[^=]*=//')
+				G_WHIP_MENU_ARRAY+=('15' "Overscan Compensation : L:$overscan_left R:$overscan_right T:$overscan_top B:$overscan_bottom")
 
 			fi
 
-			G_WHIP_MENU_ARRAY+=("7" "HDMI Boost            : $hdmi_boost_text")
-			G_WHIP_MENU_ARRAY+=("8" "RPi Camera            : $rpi_camera_module_text")
-			G_WHIP_MENU_ARRAY+=("9" "RPI Camera led        : $rpi_camera_led_text")
-			G_WHIP_MENU_ARRAY+=("11" "JustBoom IR remote    : $justboom_ir_remote_text")
-			G_WHIP_MENU_ARRAY+=("12" "VC1 Key               : $vc1_key_current")
-			G_WHIP_MENU_ARRAY+=("13" "MPEG2 Key             : $mpeg2_key_current")
+			G_WHIP_MENU_ARRAY+=('7'	"HDMI Boost            : $hdmi_boost_text")
+			G_WHIP_MENU_ARRAY+=('8' "RPi Camera            : $rpi_camera_module_text")
+			G_WHIP_MENU_ARRAY+=('9' "RPI Camera led        : $rpi_camera_led_text")
+			G_WHIP_MENU_ARRAY+=('11' "JustBoom IR remote    : $justboom_ir_remote_text")
+			G_WHIP_MENU_ARRAY+=('12' "VC1 Key               : $vc1_key_current")
+			G_WHIP_MENU_ARRAY+=('13' "MPEG2 Key             : $mpeg2_key_current")
 
 		fi
 
@@ -369,20 +369,20 @@
 
 			local odroid_remote_text='[Off]'
 			local odroid_remote_enabled=0
-			if [ -f /etc/systemd/system/odroid-remote.service ]; then
+			if [[ -f /etc/systemd/system/odroid-remote.service ]]; then
 
 				odroid_remote_text='[On]'
 				odroid_remote_enabled=1
 
 			fi
 
-			G_WHIP_MENU_ARRAY+=("10" "Odroid remote  : $odroid_remote_text")
+			G_WHIP_MENU_ARRAY+=('10' "Odroid remote  : $odroid_remote_text")
 
 		fi
 
 		G_WHIP_DEFAULT_ITEM="$WHIP_SELECTION_PREVIOUS"
 
-		G_WHIP_MENU "Please select an option:"
+		G_WHIP_MENU 'Please select an option:'
 		if (( $? == 0 )); then
 
 			WHIP_SELECTION_PREVIOUS=$G_WHIP_RETURNED_VALUE
@@ -510,7 +510,7 @@
 				if (( $G_HW_MODEL < 10 )); then
 
 					#Enabled
-					if [ "$hdmi_boost_disabled" = 0 ]; then
+					if [[ $hdmi_boost_disabled == 0 ]]; then
 
 						G_WHIP_YESNO "Current setting: $hdmi_boost_text \n Would you like to disable HDMI Signal Boost?"
 						if (( $? == 0 )); then
@@ -521,12 +521,12 @@
 						fi
 
 					#Disabled
-					elif [ "$hdmi_boost_disabled" = 1 ]; then
+					elif [[ $hdmi_boost_disabled == 1 ]]; then
 
 						G_WHIP_YESNO "Current setting: $hdmi_boost_text \n Would you like to enable HDMI Signal Boost? \n \n If you have no display output, or, blinking, selecting Enable may resolve it."
 						if (( $? == 0 )); then
 
-							sed -i '/config_hdmi_boost=/c\config_hdmi_boost=4' /DietPi/config.txt
+							G_CONFIG_INJECT 'config_hdmi_boost=' 'config_hdmi_boost=4' /DietPi/config.txt
 							REBOOT_REQUIRED=1
 
 						fi
@@ -576,13 +576,13 @@
 					if (( ! $rpi_camera_led_enabled )); then
 
 						#enable
-						sed -i '/disable_camera_led=/c\disable_camera_led=0' /DietPi/config.txt
+						G_CONFIG_INJECT 'disable_camera_led=' 'disable_camera_led=0' /DietPi/config.txt
 						REBOOT_REQUIRED=1
 
 					else
 
 						#disable
-						sed -i '/disable_camera_led=/c\disable_camera_led=1' /DietPi/config.txt
+						G_CONFIG_INJECT 'disable_camera_led=' 'disable_camera_led=1' /DietPi/config.txt
 						REBOOT_REQUIRED=1
 
 					fi
@@ -624,7 +624,7 @@
 				# - Enable
 				if (( ! $justboom_ir_remote_enabled )); then
 
-					G_WHIP_YESNO "Got a JustBoom IR Remote? Excellent!\n\nDietPi will enable the IR modules, setup Lirc and enable support for MPD controls by default:\n\nDo you wish to continue?"
+					G_WHIP_YESNO 'Got a JustBoom IR Remote? Excellent!\n\nDietPi will enable the IR modules, setup Lirc and enable support for MPD controls by default:\n\nDo you wish to continue?'
 					if (( $? == 0 )); then
 
 						/DietPi/dietpi/func/dietpi-set_hardware remoteir justboom_ir_remote
@@ -648,16 +648,16 @@
 				G_WHIP_INPUTBOX 'Please enter your key for VC1:\n - EG: 0x00000000'
 				if (( $? == 0 )); then
 
-					if (( ! $(grep -ci -m1 'decode_WVC1=' /DietPi/config.txt) )); then
+					if ! grep -qi 'decode_WVC1=' /DietPi/config.txt; then
 
 						echo -e "\ndecode_WVC1=0x00000000" >> /DietPi/config.txt
 
 					fi
 
-					sed -i "/decode_WVC1=/c\decode_WVC1=$G_WHIP_RETURNED_VALUE" /DietPi/config.txt
+					G_CONFIG_INJECT 'decode_WVC1=' "decode_WVC1=$G_WHIP_RETURNED_VALUE" /DietPi/config.txt
 
 					#https://github.com/Fourdee/DietPi/issues/1487
-					local current_gpu_mem=$(grep -m1 '^[[:blank:]]*gpu_mem' /DietPi/config.txt | sed 's/^.*=//g')
+					local current_gpu_mem=$(grep -m1 '^[[:blank:]]*gpu_mem' /DietPi/config.txt | sed 's/^[^=]*=//g')
 					if (( $current_gpu_mem < 128 )); then
 
 						/DietPi/dietpi/func/dietpi-set_hardware gpumemsplit 128
@@ -677,16 +677,16 @@
 				G_WHIP_INPUTBOX 'Please enter your key for MPEG2:\n - EG: 0x00000000'
 				if (( $? == 0 )); then
 
-					if (( ! $(grep -ci -m1 'decode_MPG2=' /DietPi/config.txt) )); then
+					if ! grep -qi 'decode_MPG2=' /DietPi/config.txt; then
 
 						echo -e "\ndecode_MPG2=0x00000000" >> /DietPi/config.txt
 
 					fi
 
-					sed -i "/decode_MPG2=/c\decode_MPG2=$G_WHIP_RETURNED_VALUE" /DietPi/config.txt
+					G_CONFIG_INJECT 'decode_MPG2=' "decode_MPG2=$G_WHIP_RETURNED_VALUE" /DietPi/config.txt
 
 					#https://github.com/Fourdee/DietPi/issues/1487
-					local current_gpu_mem=$(grep -m1 '^[[:blank:]]*gpu_mem' /DietPi/config.txt | sed 's/^.*=//g')
+					local current_gpu_mem=$(grep -m1 '^[[:blank:]]*gpu_mem' /DietPi/config.txt | sed 's/^[^=]*=//g')
 					if (( $current_gpu_mem < 128 )); then
 
 						/DietPi/dietpi/func/dietpi-set_hardware gpumemsplit 128
@@ -717,10 +717,10 @@
 				G_WHIP_MENU "Please select an option:\n\nNB: If you have the RPi touchscreen, please set this to 0 and use LCD rotation option."
 				if (( $? == 0 )); then
 
-					sed -i "/display_rotate=/c\display_rotate=$G_WHIP_RETURNED_VALUE" /DietPi/config.txt
+					G_CONFIG_INJECT 'display_rotate=' "display_rotate=$G_WHIP_RETURNED_VALUE" /DietPi/config.txt
 
 					#	rotation 90/270 | invert x/y on FB (Y > X)
-					if [ "$G_WHIP_RETURNED_VALUE" = "1" ] || [ "$G_WHIP_RETURNED_VALUE" = "3" ]; then
+					if [[ $G_WHIP_RETURNED_VALUE == '1' || $G_WHIP_RETURNED_VALUE == '3' ]]; then
 
 						Display_Rotation_Calc_XY_Invert 1
 
@@ -796,7 +796,7 @@
 		#VM
 		if (( $G_HW_MODEL == 20 )); then
 
-			local current="$(grep '^[[:blank:]]*GRUB_GFXMODE=' /etc/default/grub | sed 's/^.*=//')"
+			local current="$(grep -m1 '^[[:blank:]]*GRUB_GFXMODE=' /etc/default/grub | sed 's/^[^=]*=//')"
 			[[ -z $current ]] && current='System default'
 
 			G_WHIP_MENU_ARRAY=(
@@ -811,7 +811,7 @@
 			)
 
 			G_WHIP_DEFAULT_ITEM="$current"
-			G_WHIP_MENU "Please select a display resolution. Current: $current\n\nNote: This only affects the virtual screen resolution, not the SSH session.\n      You might need to increase the maximum guest screen resolution within your VM software."
+			G_WHIP_MENU 'Please select a display resolution. Current: $current\n\nNote: This only affects the virtual screen resolution, not the SSH session.\n      You might need to increase the maximum guest screen resolution within your VM software.'
 			if (( ! $? )); then
 
 				if [[ $G_WHIP_RETURNED_VALUE == 'System default' ]]; then
@@ -897,9 +897,9 @@
 		#RPI
 		elif (( $G_HW_MODEL < 10 )); then
 
-			local framebuffer_x=$(grep -m1 'framebuffer_width=' /DietPi/config.txt | sed 's/.*=//')
-			local framebuffer_y=$(grep -m1 'framebuffer_height=' /DietPi/config.txt | sed 's/.*=//')
-			local current_value=$(grep -m1 '^dtoverlay=vc4-' /DietPi/config.txt | sed 's/.*=//') #OpenGL check 1st
+			local framebuffer_x=$(grep -m1 'framebuffer_width=' /DietPi/config.txt | sed 's/^[^=]*=//')
+			local framebuffer_y=$(grep -m1 'framebuffer_height=' /DietPi/config.txt | sed 's/^[^=]*=//')
+			local current_value=$(grep -m1 '^dtoverlay=vc4-' /DietPi/config.txt | sed 's/^[^=]*=//') #OpenGL check 1st
 			if [ -z "$current_value" ]; then
 
 				# - FB
@@ -944,10 +944,10 @@
 				TARGETMENUID=2
 
 				# - Always enable HDMI output by default
-				sed -i '/CONFIG_HDMI_OUTPUT=/c\CONFIG_HDMI_OUTPUT=1' /DietPi/dietpi.txt
+				G_CONFIG_INJECT 'CONFIG_HDMI_OUTPUT=' 'CONFIG_HDMI_OUTPUT=1' /DietPi/dietpi.txt
 
 				# - Always set default depth to 16
-				sed -i '/framebuffer_depth=/c\framebuffer_depth=16' /DietPi/config.txt
+				G_CONFIG_INJECT 'framebuffer_depth=' 'framebuffer_depth=16' /DietPi/dietpi.txt
 
 				# - Always disable composite by default
 				sed -i '/sdtv_mode=/c\#sdtv_mode=0' /DietPi/config.txt
@@ -955,16 +955,16 @@
 				# - Always disable OpenGL by default:
 				/DietPi/dietpi/func/dietpi-set_hardware rpi-opengl disable
 
-				if [[ "$G_WHIP_RETURNED_VALUE" = "vc4-"* ]]; then
+				if [[ $G_WHIP_RETURNED_VALUE == 'vc4-'* ]]; then
 
 					/DietPi/dietpi/func/dietpi-set_hardware rpi-opengl $G_WHIP_RETURNED_VALUE
 
-				elif [[ "$G_WHIP_RETURNED_VALUE" = "sdtv_mode"* ]]; then
+				elif [[ $G_WHIP_RETURNED_VALUE == 'sdtv_mode'* ]]; then
 
 					echo $G_WHIP_RETURNED_VALUE
 					sed -i "/sdtv_mode=/c $G_WHIP_RETURNED_VALUE" /DietPi/config.txt
-					sed -i '/framebuffer_width=/c\framebuffer_width=720' /DietPi/config.txt
-					sed -i '/framebuffer_height=/c\framebuffer_height=576' /DietPi/config.txt
+					G_CONFIG_INJECT 'framebuffer_width=' 'framebuffer_width=720' /DietPi/dietpi.txt
+					G_CONFIG_INJECT 'framebuffer_height=' 'framebuffer_height=576' /DietPi/dietpi.txt
 
 				else
 
@@ -1112,15 +1112,15 @@
 
 			#Get Current Values
 			local current_resolution=''
-			if (( $(grep -m1 'setenv videoconfig "' /DietPi/boot.ini | grep -ci -m1 1920x1080) == 1 )); then
+			if grep -m1 'setenv videoconfig "' /DietPi/boot.ini | grep -qi 1920x1080; then
 
 				current_resolution='1080p'
 
-			elif (( $(grep -m1 'setenv videoconfig "' /DietPi/boot.ini | grep -ci -m1 1280x720) == 1 )); then
+			elif grep -m1 'setenv videoconfig "' /DietPi/boot.ini | grep -qi 1280x720; then
 
 				current_resolution='720p'
 
-			elif (( $(grep -m1 'setenv videoconfig "' /DietPi/boot.ini | grep -ci -m1 720x480) == 1 )); then
+			elif grep -m1 'setenv videoconfig "' /DietPi/boot.ini | grep -qi 720x480; then
 
 				current_resolution='480p'
 
@@ -1208,7 +1208,7 @@
 			G_WHIP_MENU "Hardware : $G_HW_MODEL_DESCRIPTION \nCurrent: $current_resolution"
 			if (( $? == 0 )); then
 
-				if [ "$current_resolution" != "$G_WHIP_RETURNED_VALUE" ]; then
+				if [[ $current_resolution != $G_WHIP_RETURNED_VALUE ]]; then
 
 					REBOOT_REQUIRED=1
 
@@ -1219,7 +1219,7 @@
 				sed -i '/setenv vout "vga"/c\# setenv vout "vga"' /DietPi/boot.ini
 
 				#DVI / VU7+
-				if [ "$G_WHIP_RETURNED_VALUE" = "1024x600p 60hz" ]; then
+				if [[ $G_WHIP_RETURNED_VALUE == '1024x600p 60hz' ]]; then
 
 					# + DVI mode
 					sed -i '/setenv vout "dvi"/c\setenv vout "dvi"' /DietPi/boot.ini
@@ -1240,7 +1240,7 @@
 		elif (( $G_HW_MODEL == 40 )); then
 
 			#Get Current Values
-			local current_resolution=$(cat /DietPi/uEnv.txt | grep -m1 'optargs=disp.screen0_output_mode=' | sed 's/.*=//')
+			local current_resolution=$(grep -m1 'optargs=disp.screen0_output_mode=' /DietPi/uEnv.txt | sed 's/.*=//')
 
 			G_WHIP_MENU_ARRAY=(
 
@@ -1261,7 +1261,7 @@
 			G_WHIP_MENU "Hardware : $G_HW_MODEL_DESCRIPTION \nCurrent: $current_resolution"
 			if (( $? == 0 )); then
 
-				if [ "$current_resolution" != "$G_WHIP_RETURNED_VALUE" ]; then
+				if [[ $current_resolution != $G_WHIP_RETURNED_VALUE ]]; then
 
 					sed -i "/^optargs=disp.screen0_output_mode=/c\optargs=disp.screen0_output_mode=$G_WHIP_RETURNED_VALUE" /DietPi/uEnv.txt
 					REBOOT_REQUIRED=1
@@ -1290,7 +1290,7 @@
 
 		#Get Current Settings
 		local swap_size=$(free -m | grep -im1 'Swap:' | awk '{print $2}')
-		local swap_location="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_SWAPFILE_LOCATION=' /DietPi/dietpi.txt | sed 's/.*=//')"
+		local swap_location="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_SWAPFILE_LOCATION=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
 		local swap_size_text="$swap_size MB"
 		if (( $swap_size == 0 )); then
 
@@ -1301,7 +1301,7 @@
 		G_WHIP_MENU_ARRAY+=('Swapfile' ": $swap_size_text | $swap_location")
 
 		#NTPD
-		local ntpd_mode_current=$(grep -m1 '^CONFIG_NTP_MODE=' /DietPi/dietpi.txt | sed 's/.*=//')
+		local ntpd_mode_current=$(grep -m1 '^[[:blank:]]*CONFIG_NTP_MODE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 		local ntpd_mode_text=""
 		if (( $ntpd_mode_current == 0 )); then
 
@@ -1309,24 +1309,24 @@
 
 		elif (( $ntpd_mode_current == 1 )); then
 
-			ntpd_mode_text="Boot Only"
+			ntpd_mode_text='Boot Only'
 
 		elif (( $ntpd_mode_current == 2 )); then
 
-			ntpd_mode_text="Boot + Daily"
+			ntpd_mode_text='Boot + Daily'
 
 		elif (( $ntpd_mode_current == 3 )); then
 
-			ntpd_mode_text="Boot + Hourly"
+			ntpd_mode_text='Boot + Hourly'
 
 		elif (( $ntpd_mode_current == 4 )); then
 
-			ntpd_mode_text="Daemon + Drift"
+			ntpd_mode_text='Daemon + Drift'
 
 		fi
 		G_WHIP_MENU_ARRAY+=("Time sync mode" ": $ntpd_mode_text")
 
-		serialconsole_state=$(cat /DietPi/dietpi.txt | grep -m1 '^CONFIG_SERIAL_CONSOLE_ENABLE=' | sed 's/.*=//')
+		serialconsole_state=$(grep -m1 '^CONFIG_SERIAL_CONSOLE_ENABLE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 		serialconsole_text='[Off]'
 		if (( $serialconsole_state == 1 )); then
 
@@ -1334,27 +1334,22 @@
 
 		fi
 
-		G_WHIP_MENU_ARRAY+=("Update firmware" "")
+		G_WHIP_MENU_ARRAY+=('Update firmware' '')
 
 		local bluetooth_state_text='[On]'
 		local bluetooth_state=1
-		if [ -f /etc/modprobe.d/disable_bt.conf ]; then
+		if [[ -f /etc/modprobe.d/disable_bt.conf ]]; then
 
 			bluetooth_state=0
 			bluetooth_state_text='[Off]'
 
 		fi
-		# - No bluetooth for VM
+
+		# - No bluetooth and serial console for VM
 		if (( $G_HW_MODEL != 20 )); then
 
-			G_WHIP_MENU_ARRAY+=("Bluetooth" ": $bluetooth_state_text")
-
-		fi
-
-		# - No serial console for VM
-		if (( $G_HW_MODEL != 20 )); then
-
-			G_WHIP_MENU_ARRAY+=("Serial console" ": $serialconsole_text")
+			G_WHIP_MENU_ARRAY+=('Bluetooth' ": $bluetooth_state_text")
+			G_WHIP_MENU_ARRAY+=('Serial console' ": $serialconsole_text")
 
 		fi
 
@@ -1369,7 +1364,7 @@
 
 			fi
 
-			local rpi_i2cbaudrate_hz="$(( $(cat /DietPi/config.txt | grep -m1 'i2c_arm_baudrate=' | sed 's/.*=//') / 1000 )) kHz"
+			local rpi_i2cbaudrate_hz="$(( $(grep -m1 'i2c_arm_baudrate=' /DietPi/config.txt | sed 's/.*=//') / 1000 )) kHz"
 			local usb_max_current_enabled=$(grep -ci -m1 'max_usb_current=1' /DietPi/config.txt)
 			local rpi_usbmaxcurrent_text='[Off]'
 			if (( $usb_max_current_enabled )); then
@@ -1388,20 +1383,20 @@
 
 				fi
 
-				G_WHIP_MENU_ARRAY+=("USB boot support" ": $rpi3_usb_boot_bit_enabled_text")
+				G_WHIP_MENU_ARRAY+=('USB boot support' ": $rpi3_usb_boot_bit_enabled_text")
 
 			fi
 
-			G_WHIP_MENU_ARRAY+=("Max USB current" ": $rpi_usbmaxcurrent_text")
-			G_WHIP_MENU_ARRAY+=("I2c state" ": $rpi_i2c_text")
-			G_WHIP_MENU_ARRAY+=("I2c frequency" ": $rpi_i2cbaudrate_hz")
+			G_WHIP_MENU_ARRAY+=('Max USB current' ": $rpi_usbmaxcurrent_text")
+			G_WHIP_MENU_ARRAY+=('I2c state' ": $rpi_i2c_text")
+			G_WHIP_MENU_ARRAY+=('I2c frequency' ": $rpi_i2cbaudrate_hz")
 
 		fi
 
 		G_WHIP_MENU 'Please select an option:'
 		if (( $? == 0 )); then
 
-			if [ "$G_WHIP_RETURNED_VALUE" = 'Swapfile' ]; then
+			if [[ $G_WHIP_RETURNED_VALUE == 'Swapfile' ]]; then
 
 				G_WHIP_YESNO 'Swapfile control has been moved to DietPi-Drive_Manager, would you like to run the application now?\n\nOnce finished, exit to resume DietPi-Config'
 				if (( $? == 0 )); then
@@ -1413,7 +1408,7 @@
 				#Return to This Menu
 				TARGETMENUID=3
 
-			elif [ "$G_WHIP_RETURNED_VALUE" = "Time sync mode" ]; then
+			elif [[ $G_WHIP_RETURNED_VALUE == 'Time sync mode' ]]; then
 
 				G_WHIP_MENU_ARRAY=(
 
@@ -1426,7 +1421,7 @@
 				)
 
 				G_WHIP_DEFAULT_ITEM="$ntpd_mode_current"
-				G_WHIP_MENU "Here you can adjust the frequency of NTP time syncs.\n\n - Modes 1-3:\nDietPi will launch systemd-timesyncd as a program, rather than a daemon. Once the time has been updated on your system, NTPD will exit to reduce resource usage.\n\n - Mode 4:\nsystemd-timesyncd will run as a background daemon/service. Differences in time will be gradually adjusted over time, rather than instantly."
+				G_WHIP_MENU 'Here you can adjust the frequency of NTP time syncs.\n\n - Modes 1-3:\nDietPi will launch systemd-timesyncd as a program, rather than a daemon. Once the time has been updated on your system, NTPD will exit to reduce resource usage.\n\n - Mode 4:\nsystemd-timesyncd will run as a background daemon/service. Differences in time will be gradually adjusted over time, rather than instantly.'
 				if (( $? == 0 )); then
 
 					/DietPi/dietpi/func/dietpi-set_software ntpd-mode $G_WHIP_RETURNED_VALUE
@@ -1437,7 +1432,7 @@
 				#Return to This Menu
 				TARGETMENUID=3
 
-			elif [ "$G_WHIP_RETURNED_VALUE" = "Update firmware" ]; then
+			elif [[ $G_WHIP_RETURNED_VALUE == 'Update firmware' ]]; then
 
 				#RPI
 				if (( $G_HW_MODEL < 10 )); then
@@ -1477,7 +1472,7 @@
 				#Return to This Menu
 				TARGETMENUID=3
 
-			elif [ "$G_WHIP_RETURNED_VALUE" = "Max USB current" ]; then
+			elif [[ $G_WHIP_RETURNED_VALUE == 'Max USB current' ]]; then
 
 				#Enabled
 				if (( $usb_max_current_enabled == 1 )); then
@@ -1506,7 +1501,7 @@
 				#Return to This Menu
 				TARGETMENUID=3
 
-			elif [ "$G_WHIP_RETURNED_VALUE" = "I2c state" ]; then
+			elif [[ $G_WHIP_RETURNED_VALUE == 'I2c state' ]]; then
 
 				if (( ! $rpi_i2c_enabled )); then
 
@@ -1523,7 +1518,7 @@
 				#Return to This Menu
 				TARGETMENUID=3
 
-			elif [ "$G_WHIP_RETURNED_VALUE" = "I2c frequency" ]; then
+			elif [[ $G_WHIP_RETURNED_VALUE == 'I2c frequency' ]]; then
 
 				#remove kHz from current
 				G_WHIP_DEFAULT_ITEM=$(echo -e "$rpi_i2cbaudrate_hz" | tr -d ' kHz')
@@ -1547,7 +1542,7 @@
 				#Return to This Menu
 				TARGETMENUID=3
 
-			elif [ "$G_WHIP_RETURNED_VALUE" = "Serial console" ]; then
+			elif [[ $G_WHIP_RETURNED_VALUE == 'Serial console' ]]; then
 
 				if (( $serialconsole_state == 0 )); then
 
@@ -1564,7 +1559,7 @@
 				#Return to This Menu
 				TARGETMENUID=3
 
-			elif [ "$G_WHIP_RETURNED_VALUE" = "Bluetooth" ]; then
+			elif [[ $G_WHIP_RETURNED_VALUE == 'Bluetooth' ]]; then
 
 				if (( $bluetooth_state )); then
 
@@ -1579,7 +1574,7 @@
 				#Return to This Menu
 				TARGETMENUID=3
 
-			elif [ "$G_WHIP_RETURNED_VALUE" = "USB boot support" ]; then
+			elif [[ $G_WHIP_RETURNED_VALUE == 'USB boot support' ]]; then
 
 				if (( ! $rpi3_usb_boot_bit_enabled )); then
 
@@ -1616,13 +1611,13 @@
 		TARGETMENUID=0
 
 		#All devices
-		local current_cpu_governor=$(grep -m1 '^CONFIG_CPU_GOVERNOR=' /DietPi/dietpi.txt | sed 's/.*=//')
+		local current_cpu_governor=$(grep -m1 '^[[:blank:]]*CONFIG_CPU_GOVERNOR=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 
 		local frequency_min_cpu_governor=1
 		local fp_frequency_min_cpu_governor='/sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq'
 		if [ -f "$fp_frequency_min_cpu_governor" ]; then
 
-			frequency_min_cpu_governor=$(( $(cat "$fp_frequency_min_cpu_governor") / 1000 ))
+			frequency_min_cpu_governor=$(( $(<$fp_frequency_min_cpu_governor) / 1000 ))
 
 		fi
 
@@ -1630,7 +1625,7 @@
 		local fp_frequency_max_cpu_governor='/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq'
 		if [ -f "$fp_frequency_max_cpu_governor" ]; then
 
-			frequency_max_cpu_governor=$(( $(cat "$fp_frequency_max_cpu_governor") / 1000 ))
+			frequency_max_cpu_governor=$(( $(<$fp_frequency_max_cpu_governor) / 1000 ))
 
 		fi
 
@@ -1653,57 +1648,57 @@
 
 		#Overclocking
 		if (( $G_HW_MODEL < 10 )); then
-			G_WHIP_MENU_ARRAY+=("Overclocking" "Set Profile")
+			G_WHIP_MENU_ARRAY+=('Overclocking' 'Set Profile')
 		fi
 
 		#CPU GOV
-		G_WHIP_MENU_ARRAY+=("Change CPU Governor" ": $current_cpu_governor")
+		G_WHIP_MENU_ARRAY+=('Change CPU Governor' ": $current_cpu_governor")
 
 		#Ondemand/Interactive Throttle up menu
-		if [ "$current_cpu_governor" = "ondemand" ] ||
-			[ "$current_cpu_governor" = "conservative" ] ||
-			[ "$current_cpu_governor" = "interactive" ]; then
+		if [[ $current_cpu_governor == 'ondemand' ||
+			$current_cpu_governor == 'conservative' ||
+			$current_cpu_governor == 'interactive' ]]; then
 
-			local current_cpu_throttle_up=$(grep -m1 '^CONFIG_CPU_USAGE_THROTTLE_UP=' /DietPi/dietpi.txt | sed 's/.*=//')
-			G_WHIP_MENU_ARRAY+=("CPU Throttle Up" ": $current_cpu_throttle_up%")
+			local current_cpu_throttle_up=$(grep -m1 '^[[:blank:]]*CONFIG_CPU_USAGE_THROTTLE_UP=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
+			G_WHIP_MENU_ARRAY+=('CPU Throttle Up' ": $current_cpu_throttle_up%")
 
 		fi
 
 
 		#Ondemand extras
-		if [ "$current_cpu_governor" = ondemand ]; then
+		if [[ $current_cpu_governor == 'ondemand' ]]; then
 
-			local current_cpu_sample_rate=$(( $(grep -m1 '^CONFIG_CPU_ONDEMAND_SAMPLE_RATE=' /DietPi/dietpi.txt | sed 's/.*=//') / 1000 )) #convert to ms
-			G_WHIP_MENU_ARRAY+=("Ondemand Sample Rate" ": $current_cpu_sample_rate ms")
+			local current_cpu_sample_rate=$(( $(grep -m1 '^[[:blank:]]*CONFIG_CPU_ONDEMAND_SAMPLE_RATE=' /DietPi/dietpi.txt | sed 's/[^=]*=//') / 1000 )) #convert to ms
+			G_WHIP_MENU_ARRAY+=('Ondemand Sample Rate' ": $current_cpu_sample_rate ms")
 
-			local current_cpu_down_factor=$(grep -m1 '^CONFIG_CPU_ONDEMAND_SAMPLE_DOWNFACTOR=' /DietPi/dietpi.txt | sed 's/.*=//')
+			local current_cpu_down_factor=$(grep -m1 '^[[:blank:]]*CONFIG_CPU_ONDEMAND_SAMPLE_DOWNFACTOR=' /DietPi/dietpi.txt | sed 's/[^=]*=//')
 			local current_cpu_down_factor_ms=$(( $current_cpu_down_factor * $current_cpu_sample_rate ))
-			G_WHIP_MENU_ARRAY+=("Ondemand Down Factor" ": $current_cpu_down_factor ($current_cpu_down_factor_ms ms)")
+			G_WHIP_MENU_ARRAY+=('Ondemand Down Factor' ": $current_cpu_down_factor ($current_cpu_down_factor_ms ms)")
 
 		fi
 
 
 		# User Scaling Max Freq limit.
-		local user_frequency_max_current=$(grep -m1 '^CONFIG_CPU_MAX_FREQ=' /DietPi/dietpi.txt | sed 's/.*=//')
+		local user_frequency_max_current=$(grep -m1 '^[[:blank:]]*CONFIG_CPU_MAX_FREQ=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 		local user_frequency_max_text="$user_frequency_max_current MHz"
-		if (( ! $user_frequency_max_current	)); then
+		if (( ! $user_frequency_max_current )); then
 
 			user_frequency_max_text='[Off]'
 
 		fi
 
-		G_WHIP_MENU_ARRAY+=("CPU Max Freq Limit" ": $user_frequency_max_text")
+		G_WHIP_MENU_ARRAY+=('CPU Max Freq Limit' ": $user_frequency_max_text")
 
 		# User Scaling Min Freq limit.
-		local user_frequency_min_current=$(grep -m1 '^CONFIG_CPU_MIN_FREQ=' /DietPi/dietpi.txt | sed 's/.*=//')
+		local user_frequency_min_current=$(grep -m1 '^[[:blank:]]*CONFIG_CPU_MIN_FREQ=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 		local user_frequency_min_text="$user_frequency_min_current MHz"
-		if (( ! $user_frequency_min_current	)); then
+		if (( ! $user_frequency_min_current )); then
 
 			user_frequency_min_text='[Off]'
 
 		fi
 
-		G_WHIP_MENU_ARRAY+=("CPU Min Freq Limit" ": $user_frequency_min_text")
+		G_WHIP_MENU_ARRAY+=('CPU Min Freq Limit' ": $user_frequency_min_text")
 
 		#RPi extras
 		if (( $G_HW_MODEL < 10 )); then
@@ -1724,7 +1719,7 @@
 			#fi
 			#G_WHIP_MENU_ARRAY+=('ARM Initial Turbo' ": $text_current_initial_turbo")
 
-			local current_arm_temp_limit=$(grep -m1 'temp_limit' /DietPi/config.txt | sed 's/^.*=//')
+			local current_arm_temp_limit=$(grep -m1 'temp_limit' /DietPi/config.txt | sed 's/^[^=]*=//')
 			G_WHIP_MENU_ARRAY+=('ARM Temp Limit   ' ": $current_arm_temp_limit 'c")
 
 			#Min freqs
@@ -1789,7 +1784,7 @@
 					for ((i=0; i<${#input_fp[@]}; i++))
 					do
 
-						if [ -f "${input_fp[$i]}" ]; then
+						if [[ -f ${input_fp[$i]} ]]; then
 
 							index=$i
 							break
@@ -1805,7 +1800,7 @@
 
 					else
 
-						MIN_VALUE=$(( $(cat "${input_fp[$index]}") / 1000 ))
+						MIN_VALUE=$(( $(<${input_fp[$index]}) / 1000 ))
 
 					fi
 
@@ -1836,48 +1831,49 @@
 
 				;;
 
-				"Lower Idle Frequencies"*)
+				##Disabled due to https://github.com/Fourdee/DietPi/issues/73
+				#"Lower Idle Frequencies"*)
 
-					G_WHIP_MENU_ARRAY=(
+				#	G_WHIP_MENU_ARRAY=(
 
-						'Enable' 'Lowers the idle frequencies for CPU, CORE, RAM.'
-						'Disable' 'Returns the idle frequencies to defaults.'
+				#		'Enable' 'Lowers the idle frequencies for CPU, CORE, RAM.'
+				#		'Disable' 'Returns the idle frequencies to defaults.'
 
-					)
+				#	)
 
-					G_WHIP_MENU "Toggle the use of lower idle frequencies for CPU, CORE and RAM.\n\nAs the lower frequencies are active only when the device is idle, enabling this feature allows for potential power saving without impacting performance.\n\nCurrent Setting: $rpi_freq_min_text\n\nEnable: (Allows for potential power saving)\nSets arm_freq_min=100, core_freq_min=75 and sdram_freq_min=200.\n\nDisable: (Default)\nSets arm_freq_min=700, core_freq_min=250 and sdram_freq_min=400."
-					if (( $? == 0 )); then
+				#	G_WHIP_MENU "Toggle the use of lower idle frequencies for CPU, CORE and RAM.\n\nAs the lower frequencies are active only when the device is idle, enabling this feature allows for potential power saving without impacting performance.\n\nCurrent Setting: $rpi_freq_min_text\n\nEnable: (Allows for potential power saving)\nSets arm_freq_min=100, core_freq_min=75 and sdram_freq_min=200.\n\nDisable: (Default)\nSets arm_freq_min=700, core_freq_min=250 and sdram_freq_min=400."
+				#	if (( $? == 0 )); then
 
-						if [ "$G_WHIP_RETURNED_VALUE" = "Enable" ]; then
+				#		if [[ $G_WHIP_RETURNED_VALUE == 'Enable' ]]; then
 
-							sed -i "/arm_freq_min=/c\arm_freq_min=100" /DietPi/config.txt
-							sed -i "/core_freq_min=/c\core_freq_min=75" /DietPi/config.txt
-							sed -i "/sdram_freq_min=/c\sdram_freq_min=200" /DietPi/config.txt
+				#			G_CONFIG_INJECT 'arm_freq_min=' 'arm_freq_min=100' /DietPi/config.txt
+				#			G_CONFIG_INJECT 'core_freq_min=' 'core_freq_min=75' /DietPi/config.txt
+				#			G_CONFIG_INJECT 'sdram_freq_min=' 'sdram_freq_min=200' /DietPi/config.txt
 
-						else
+				#		else
 
-							sed -i "/arm_freq_min=/c\#arm_freq_min=700" /DietPi/config.txt
-							sed -i "/core_freq_min=/c\#core_freq_min=250" /DietPi/config.txt
-							sed -i "/sdram_freq_min=/c\#sdram_freq_min=400" /DietPi/config.txt
+				#			sed -i "/arm_freq_min=/c\#arm_freq_min=700" /DietPi/config.txt
+				#			sed -i "/core_freq_min=/c\#core_freq_min=250" /DietPi/config.txt
+				#			sed -i "/sdram_freq_min=/c\#sdram_freq_min=400" /DietPi/config.txt
 
-						fi
+				#		fi
 
-						REBOOT_REQUIRED=1
+				#		REBOOT_REQUIRED=1
 
-					fi
+				#	fi
 
 					#Return to This Menu
-					TARGETMENUID=4
+				#	TARGETMENUID=4
 
-				;;
+				#;;
 
 				"CPU Max Freq Limit"*)
 
 					/DietPi/dietpi/dietpi-cpuinfo 2
 
-					if [ ! -f /tmp/dietpi-available_cpu_freqs ]; then
+					if [[ ! -f /tmp/dietpi-available_cpu_freqs ]]; then
 
-						G_WHIP_MSG "Your processor / kernel, does not support this feature.\n\n(Info): Scaling_available_frequencies does not exist."
+						G_WHIP_MSG 'Your processor / kernel, does not support this feature.\n\n(Info): Scaling_available_frequencies does not exist.'
 
 					else
 
@@ -1890,7 +1886,7 @@
 						for ((i=0; i<${#available_frequency_array[@]}; i++))
 						do
 
-							G_WHIP_MENU_ARRAY+=("$(( ${available_frequency_array[$i]} / 1000 ))" "MHz")
+							G_WHIP_MENU_ARRAY+=("$(( ${available_frequency_array[$i]} / 1000 ))" 'MHz')
 							if (( ${available_frequency_array[$i]} > $max_clock )); then
 
 								max_clock=$(( ${available_frequency_array[$i]} / 1000 ))
@@ -1900,22 +1896,25 @@
 						done
 
 						#Add disable option
-						G_WHIP_MENU_ARRAY+=("Disabled" "Returns clocks to default")
+						G_WHIP_MENU_ARRAY+=('Disabled' 'Returns clocks to default')
 
 						G_WHIP_DEFAULT_ITEM="$user_frequency_max_current"
 						G_WHIP_MENU "Limit the maximum frequency that your processor can reach.\nThis can be useful for lowering temperature and saving power.\n\nCurrent setting: $user_frequency_max_text"
 						if (( $? == 0 )); then
 
 							#	Set max > return to default
-							if [ "$G_WHIP_RETURNED_VALUE" = "Disabled" ]; then
+							if [[ $G_WHIP_RETURNED_VALUE == 'Disabled' ]]; then
 
-								sed -i "/CONFIG_CPU_MAX_FREQ=/c\CONFIG_CPU_MAX_FREQ=$max_clock" /DietPi/dietpi.txt
+								G_CONFIG_INJECT 'CONFIG_CPU_MAX_FREQ=' "CONFIG_CPU_MAX_FREQ=$max_clock" /DietPi/dietpi.txt
+								/DietPi/dietpi/func/dietpi-set_cpu
+								G_CONFIG_INJECT 'CONFIG_CPU_MAX_FREQ=' 'CONFIG_CPU_MAX_FREQ=Disabled' /DietPi/dietpi.txt
+
+							else
+
+								G_CONFIG_INJECT 'CONFIG_CPU_MAX_FREQ=' "CONFIG_CPU_MAX_FREQ=$G_WHIP_RETURNED_VALUE" /DietPi/dietpi.txt
 								/DietPi/dietpi/func/dietpi-set_cpu
 
 							fi
-
-							sed -i "/CONFIG_CPU_MAX_FREQ=/c\CONFIG_CPU_MAX_FREQ=$G_WHIP_RETURNED_VALUE" /DietPi/dietpi.txt
-							/DietPi/dietpi/func/dietpi-set_cpu
 
 						fi
 
@@ -1933,7 +1932,7 @@
 
 					/DietPi/dietpi/dietpi-cpuinfo 2
 
-					if [ ! -f /tmp/dietpi-available_cpu_freqs ]; then
+					if [[ ! -f /tmp/dietpi-available_cpu_freqs ]]; then
 
 						G_WHIP_MSG "Your processor / kernel, does not support this feature.\n\n(Info): Scaling_available_frequencies does not exist."
 
@@ -1963,14 +1962,16 @@
 						if (( $? == 0 )); then
 
 							#	Set min > return to default
-							if [ "$G_WHIP_RETURNED_VALUE" = "Disabled" ]; then
+							if [[ $G_WHIP_RETURNED_VALUE == 'Disabled' ]]; then
 
-								sed -i "/CONFIG_CPU_MIN_FREQ=/c\CONFIG_CPU_MIN_FREQ=$min_clock" /DietPi/dietpi.txt
-								/DietPi/dietpi/func/dietpi-set_cpu
+								G_CONFIG_INJECT 'CONFIG_CPU_MIN_FREQ=' "CONFIG_CPU_MIN_FREQ=$min_clock" /DietPi/dietpi.txt
+
+							else
+
+								G_CONFIG_INJECT 'CONFIG_CPU_MIN_FREQ=' "CONFIG_CPU_MIN_FREQ=$G_WHIP_RETURNED_VALUE" /DietPi/dietpi.txt
 
 							fi
 
-							sed -i "/CONFIG_CPU_MIN_FREQ=/c\CONFIG_CPU_MIN_FREQ=$G_WHIP_RETURNED_VALUE" /DietPi/dietpi.txt
 							/DietPi/dietpi/func/dietpi-set_cpu
 
 						fi
@@ -1993,48 +1994,48 @@
 				"Change CPU Governor"*)
 
 					# - Scaling govs not available
-					if [ ! -f "$FP_CPU_SCALING_GOV" ]; then
+					if [[ ! -f $FP_CPU_SCALING_GOV ]]; then
 
-						G_WHIP_MSG "Your processor, or kernel, does not support this feature.\n\n(Info): scaling_available_governors does not exist."
+						G_WHIP_MSG 'Your processor, or kernel, does not support this feature.\n\n(Info): scaling_available_governors does not exist.'
 
 					# - Obtain available Govs. Setup their menu and description.
 					else
 
-						local Description="Change CPU Governor:"
+						local Description='Change CPU Governor:'
 						G_WHIP_MENU_ARRAY=()
 
-						if (( $(grep -ci -m1 'ondemand' "$FP_CPU_SCALING_GOV") == 1 )); then
+						if grep -qi 'ondemand' $FP_CPU_SCALING_GOV; then
 
-							G_WHIP_MENU_ARRAY+=("ondemand" "Scales CPU frequency between $frequency_min_cpu_governor MHz and $frequency_max_cpu_governor MHz.")
-							Description+="\nOndemand     | Dynamic CPU frequency based on usage (recommended)."
-
-						fi
-
-						if (( $(grep -ci -m1 'interactive' "$FP_CPU_SCALING_GOV") == 1 )); then
-
-							G_WHIP_MENU_ARRAY+=("interactive" "Scales CPU frequency between $frequency_min_cpu_governor MHz and $frequency_max_cpu_governor MHz.")
-							Description+="\nInteractive  | Dynamic CPU frequency based on usage."
+							G_WHIP_MENU_ARRAY+=('ondemand' "Scales CPU frequency between $frequency_min_cpu_governor MHz and $frequency_max_cpu_governor MHz.")
+							Description+='\nOndemand     | Dynamic CPU frequency based on usage (recommended).'
 
 						fi
 
-						if (( $(grep -ci -m1 'conservative' "$FP_CPU_SCALING_GOV") == 1 )); then
+						if grep -qi 'interactive' $FP_CPU_SCALING_GOV; then
 
-							G_WHIP_MENU_ARRAY+=("conservative" "Scales CPU frequency between $frequency_min_cpu_governor MHz and $frequency_max_cpu_governor MHz.")
-							Description+="\nConservative | Same as ondemand. Bias towards powersaving, slower scaling. "
-
-						fi
-
-						if (( $(grep -ci -m1 'powersave' "$FP_CPU_SCALING_GOV") == 1 )); then
-
-							G_WHIP_MENU_ARRAY+=("powersave" "Limits CPU frequency to $frequency_min_cpu_governor MHz.")
-							Description+="\nPowersave    | Static. Reduces energy consumption, heat, performance."
+							G_WHIP_MENU_ARRAY+=('interactive' "Scales CPU frequency between $frequency_min_cpu_governor MHz and $frequency_max_cpu_governor MHz.")
+							Description+='\nInteractive  | Dynamic CPU frequency based on usage.'
 
 						fi
 
-						if (( $(grep -ci -m1 'performance' "$FP_CPU_SCALING_GOV") == 1 )); then
+						if grep -qi 'conservative' $FP_CPU_SCALING_GOV; then
 
-							G_WHIP_MENU_ARRAY+=("performance" "Forces CPU frequency to $frequency_max_cpu_governor MHz.")
-							Description+="\nPerformance  | Static. Increases energy consumption, heat, performance."
+							G_WHIP_MENU_ARRAY+=('conservative' "Scales CPU frequency between $frequency_min_cpu_governor MHz and $frequency_max_cpu_governor MHz.")
+							Description+='\nConservative | Same as ondemand. Bias towards powersaving, slower scaling.'
+
+						fi
+
+						if grep -qi 'powersave' $FP_CPU_SCALING_GOV; then
+
+							G_WHIP_MENU_ARRAY+=('powersave' "Limits CPU frequency to $frequency_min_cpu_governor MHz.")
+							Description+='\nPowersave    | Static. Reduces energy consumption, heat, performance.'
+
+						fi
+
+						if grep -qi 'performance' $FP_CPU_SCALING_GOV; then
+
+							G_WHIP_MENU_ARRAY+=('performance' "Forces CPU frequency to $frequency_max_cpu_governor MHz.")
+							Description+='\nPerformance  | Static. Increases energy consumption, heat, performance.'
 
 						fi
 
@@ -2042,7 +2043,7 @@
 						G_WHIP_MENU "$Description"
 						if (( $? == 0 )); then
 
-							sed -i "/CONFIG_CPU_GOVERNOR=/c\CONFIG_CPU_GOVERNOR=$G_WHIP_RETURNED_VALUE" /DietPi/dietpi.txt
+							G_CONFIG_INJECT 'CONFIG_CPU_GOVERNOR=' "CONFIG_CPU_GOVERNOR=$G_WHIP_RETURNED_VALUE" /DietPi/dietpi.txt
 							/DietPi/dietpi/func/dietpi-set_cpu
 
 						fi
@@ -2065,7 +2066,7 @@
 						if G_CHECK_VALIDINT $G_WHIP_RETURNED_VALUE &&
 							(( $G_WHIP_RETURNED_VALUE <= $MAX_VALUE && $G_WHIP_RETURNED_VALUE >= $MIN_VALUE )); then
 
-							sed -i "/CONFIG_CPU_USAGE_THROTTLE_UP=/c\CONFIG_CPU_USAGE_THROTTLE_UP=$G_WHIP_RETURNED_VALUE" /DietPi/dietpi.txt
+							G_CONFIG_INJECT 'CONFIG_CPU_USAGE_THROTTLE_UP=' "CONFIG_CPU_USAGE_THROTTLE_UP=$G_WHIP_RETURNED_VALUE" /DietPi/dietpi.txt
 							#Apply changes
 							/DietPi/dietpi/func/dietpi-set_cpu
 
@@ -2082,31 +2083,32 @@
 
 				;;
 
-				"ARM Initial Turbo"*)
+				# initial_turbo disabled due to: https://github.com/Fourdee/DietPi/issues/1836
+				#"ARM Initial Turbo"*)
 
-					MIN_VALUE=0
-					MAX_VALUE=60
-					G_WHIP_DEFAULT_ITEM=$current_initial_turbo
-					G_WHIP_INPUTBOX "Activates turbo mode during boot ($frequency_max_cpu_governor MHz), for the duration of value in seconds. \n - Recommended value is 20 \n - Valid range $MIN_VALUE (disabled) - $MAX_VALUE"
-					if (( $? == 0 )); then
+				#	MIN_VALUE=0
+				#	MAX_VALUE=60
+				#	G_WHIP_DEFAULT_ITEM=$current_initial_turbo
+				#	G_WHIP_INPUTBOX "Activates turbo mode during boot ($frequency_max_cpu_governor MHz), for the duration of value in seconds. \n - Recommended value is 20 \n - Valid range $MIN_VALUE (disabled) - $MAX_VALUE"
+				#	if (( $? == 0 )); then
 
-						if G_CHECK_VALIDINT $G_WHIP_RETURNED_VALUE &&
-							(( $G_WHIP_RETURNED_VALUE <= $MAX_VALUE && $G_WHIP_RETURNED_VALUE >= $MIN_VALUE )); then
+				#		if G_CHECK_VALIDINT $G_WHIP_RETURNED_VALUE &&
+				#			(( $G_WHIP_RETURNED_VALUE <= $MAX_VALUE && $G_WHIP_RETURNED_VALUE >= $MIN_VALUE )); then
 
-							sed -i "/initial_turbo=/c\initial_turbo=$G_WHIP_RETURNED_VALUE" /DietPi/config.txt
-							REBOOT_REQUIRED=1
+				#			G_CONFIG_INJECT 'initial_turbo=' "initial_turbo=$G_WHIP_RETURNED_VALUE" /DietPi/dietpi.txt
+				#			REBOOT_REQUIRED=1
 
-						else
+				#		else
 
-							Info_Input_Not_Valid_Integer
+				#			Info_Input_Not_Valid_Integer
 
-						fi
+				#		fi
 
-					fi
+				#	fi
 
 					#Return to this menu
-					TARGETMENUID=4
-				;;
+				#	TARGETMENUID=4
+				#;;
 
 				"ARM Temp Limit"*)
 
@@ -2125,7 +2127,7 @@
 
 							fi
 
-							sed -i "/temp_limit=/c\temp_limit=$G_WHIP_RETURNED_VALUE" /DietPi/config.txt
+							G_CONFIG_INJECT 'temp_limit=' "temp_limit=$G_WHIP_RETURNED_VALUE" /DietPi/config.txt
 							REBOOT_REQUIRED=1
 
 						else
@@ -2149,10 +2151,10 @@
 	Change_Hostname(){
 
 		#Get existing Hostname
-		local hostname_existing=$(cat /etc/hostname)
+		local hostname_existing=$(</etc/hostname)
 		G_WHIP_DEFAULT_ITEM="$hostname_existing"
 		G_WHIP_INPUTBOX 'Please enter a new hostname'
-		if (( $? == 0 )) && [ "$hostname_existing" != "$G_WHIP_RETURNED_VALUE" ]; then
+		if (( $? == 0 )) && [[ $hostname_existing != $G_WHIP_RETURNED_VALUE ]]; then
 
 			/DietPi/dietpi/func/change_hostname "$G_WHIP_RETURNED_VALUE"
 			REBOOT_REQUIRED=1
@@ -2185,7 +2187,7 @@
 
 		)
 
-		G_WHIP_MENU "Lock down your DietPi Install"
+		G_WHIP_MENU 'Lock down your DietPi Install'
 		if (( ! $? )); then
 
 			if (( $G_WHIP_RETURNED_VALUE == 1 )); then
@@ -2216,19 +2218,19 @@
 
 		if (( $G_HW_MODEL == 0 )); then
 
-			gpu_mem_current=$(grep -m1 'gpu_mem_256=' /DietPi/config.txt  | sed 's/.*=//')
+			gpu_mem_current=$(grep -m1 'gpu_mem_256=' /DietPi/config.txt  | sed 's/^.*=//')
 			ram_mem_current=$((256-gpu_mem_current))
 			ram_mem_total=256
 
 		elif (( $G_HW_MODEL == 1 )); then
 
-			gpu_mem_current=$(grep -m1 'gpu_mem_512=' /DietPi/config.txt  | sed 's/.*=//')
+			gpu_mem_current=$(grep -m1 'gpu_mem_512=' /DietPi/config.txt  | sed 's/^.*=//')
 			ram_mem_current=$((512-gpu_mem_current))
 			ram_mem_total=512
 
 		elif (( $G_HW_MODEL == 2 || $G_HW_MODEL == 3 )); then
 
-			gpu_mem_current=$(grep -m1 'gpu_mem_1024=' /DietPi/config.txt  | sed 's/.*=//')
+			gpu_mem_current=$(grep -m1 'gpu_mem_1024=' /DietPi/config.txt  | sed 's/^.*=//')
 			ram_mem_current=$((1024-gpu_mem_current))
 			ram_mem_total=1024
 
@@ -2269,7 +2271,7 @@
 
 			if (( $G_HW_MODEL == 0 )); then
 
-				echo -e "As above, array is defaulted to RPi1 - 256mb" &> /dev/null
+				echo 'As above, array is defaulted to RPi1 - 256mb' &> /dev/null
 
 			elif (( $G_HW_MODEL == 1 )); then
 
@@ -2300,7 +2302,7 @@
 				for ((i=0; i<${#option_name[@]}; i++))
 				do
 
-					if [ "$G_WHIP_RETURNED_VALUE" = "${option_name[$i]}" ]; then
+					if [[ $G_WHIP_RETURNED_VALUE == ${option_name[$i]} ]]; then
 
 						local temp_index=$i
 						break
@@ -2484,8 +2486,8 @@
 					done < /tmp/available_locale
 					rm /tmp/available_locale
 
-					G_WHIP_DEFAULT_ITEM="$(grep -m1 '^AUTO_SETUP_LOCALE=' /DietPi/dietpi.txt | sed 's/.*=//')"
-					G_WHIP_MENU "Please select a system locale. DietPi will automatically apply this as the default locale:"
+					G_WHIP_DEFAULT_ITEM="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_LOCALE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
+					G_WHIP_MENU 'Please select a system locale. DietPi will automatically apply this as the default locale:'
 					if (( $? == 0 )); then
 
 						/DietPi/dietpi/func/dietpi-set_software locale "$G_WHIP_RETURNED_VALUE"
@@ -2511,7 +2513,7 @@
 
 					REBOOT_REQUIRED=1
 
-					G_WHIP_MSG "NB: A keyboard must be physically plugged into the system, before its configuration can be changed.\n\nIf a keyboard is plugged in, please ignore this message. If not, plug one in ;)"
+					G_WHIP_MSG 'NB: A keyboard must be physically plugged into the system, before its configuration can be changed.\n\nIf a keyboard is plugged in, please ignore this message. If not, plug one in ;)'
 					dpkg-reconfigure keyboard-configuration
 					invoke-rc.d keyboard-setup start
 
@@ -2543,8 +2545,8 @@
 
 		if [[ -f /sys/class/net/$input/statistics/rx_bytes && -f /sys/class/net/$input/statistics/tx_bytes ]]; then
 
-			NET_RX_BYTE=$(cat /sys/class/net/$input/statistics/rx_bytes)
-			NET_TX_BYTE=$(cat /sys/class/net/$input/statistics/tx_bytes)
+			NET_RX_BYTE=$(</sys/class/net/$input/statistics/rx_bytes)
+			NET_TX_BYTE=$(</sys/class/net/$input/statistics/tx_bytes)
 			NET_RX_MB='Unknown'
 			if G_CHECK_VALIDINT $NET_RX_BYTE && (( $NET_RX_BYTE > 0 )); then
 
@@ -2652,7 +2654,7 @@
 		#dhclient -r
 
 		#Drop Connections
-		G_DIETPI-NOTIFY 2 "Dropping connections, please wait..."
+		G_DIETPI-NOTIFY 2 'Dropping connections, please wait...'
 		ifdown eth$ETH_INDEX &> /dev/null
 		ifdown wlan$WIFI_INDEX &> /dev/null
 
@@ -2775,13 +2777,13 @@
 		if (( $WIFI_HOTSPOT == 0 )); then
 
 			# - Update globals
-			sed -i "/^AUTO_SETUP_NET_WIFI_SSID=/c\AUTO_SETUP_NET_WIFI_SSID=$WIFI_SSID" /DietPi/dietpi.txt
-			sed -i "/^AUTO_SETUP_NET_WIFI_KEY=/c\AUTO_SETUP_NET_WIFI_KEY=$WIFI_KEY" /DietPi/dietpi.txt
+			G_CONFIG_INJECT 'AUTO_SETUP_NET_WIFI_SSID=' "AUTO_SETUP_NET_WIFI_SSID=$WIFI_SSID" /DietPi/dietpi.txt
+			G_CONFIG_INJECT 'AUTO_SETUP_NET_WIFI_KEY=' "AUTO_SETUP_NET_WIFI_KEY=$WIFI_KEY" /DietPi/dietpi.txt
 
 			#	Open host
-			if [ -z "$WIFI_KEY" ]; then
+			if [[ -z $WIFI_KEY ]]; then
 
-				sed -i '/AUTO_SETUP_NET_WIFI_KEYMGR=/c\AUTO_SETUP_NET_WIFI_KEYMGR=NONE' /DietPi/dietpi.txt
+				G_CONFIG_INJECT 'AUTO_SETUP_NET_WIFI_KEYMGR=' 'AUTO_SETUP_NET_WIFI_KEYMGR=NONE' /DietPi/dietpi.txt
 
 
 			#	Key host
@@ -2789,7 +2791,7 @@
 			#	WEP tests failed, dropping support as its outdated and not secure. WPA-PSK is recommended for router.
 			else
 
-				sed -i '/AUTO_SETUP_NET_WIFI_KEYMGR=/c\AUTO_SETUP_NET_WIFI_KEYMGR=WPA-PSK' /DietPi/dietpi.txt
+				G_CONFIG_INJECT 'AUTO_SETUP_NET_WIFI_KEYMGR=' 'AUTO_SETUP_NET_WIFI_KEYMGR=WPA-PSK' /DietPi/dietpi.txt
 
 			fi
 
@@ -3041,7 +3043,7 @@
 
 			# - Check if country code was successfully applied
 			WIFI_COUNTRYCODE=$(iw reg get | grep -m1 'country' | awk '{print $2}' | tr -d ':')
-			if [ "$WIFI_COUNTRYCODE" != "$wifi_country_code_target" ]; then
+			if [[ $WIFI_COUNTRYCODE != $wifi_country_code_target ]]; then
 
 				G_WHIP_MSG "Country code ($wifi_country_code_target) could not been applied. Please check the country code and try again.\n\nIf problems persist, this may be a limitation with the driver/chipset."
 
@@ -3058,8 +3060,8 @@
 
 		#Get all ssids
 		printf '\ec' # clear current terminal screen
-		echo -e "Scanning SSIDS, please wait...."
-		echo -e "-------------------------------"
+		echo 'Scanning SSIDS, please wait....'
+		echo '-------------------------------'
 		iwlist wlan$WIFI_INDEX scan | grep ESSID: | sed 's/[ \t]*ESSID:"\(.*\)"/\1/' > /tmp/dietpi-config_temp
 
 		#read file to array
@@ -3097,7 +3099,7 @@
 
 			#Apply Changes
 			printf '\ec' # clear current terminal screen
-			echo -e "Connecting to $WIFI_SSID , please wait"
+			echo "Connecting to $WIFI_SSID , please wait"
 			Network_ApplyChanges
 
 		fi
@@ -3106,12 +3108,12 @@
 
 	Ethernet_Reconnect(){
 
-		G_WHIP_YESNO "Do you wish to apply settings and reconnect network now? \n\n(NOTICE) All Ethernet connections will be dropped!"
+		G_WHIP_YESNO 'Do you wish to apply settings and reconnect network now? \n\n(NOTICE) All Ethernet connections will be dropped!'
 		if (( $? == 0 )); then
 
 			#Apply Changes
 			printf '\ec' # clear current terminal screen
-			echo -e "Reconnecting Ethernet , please wait"
+			echo -e 'Reconnecting Ethernet , please wait'
 			Network_ApplyChanges
 
 		fi
@@ -3154,7 +3156,7 @@
 		ETH_DNS_STATIC=$(cat -n /tmp/net_interfaces | grep 'dns-nameservers ' | sed -n 1p | awk '{print $3,$4}')
 
 		ETH_INDEX=$(sed -n 1p /DietPi/dietpi/.network)
-		ETH_DISABLED=$(cat /tmp/net_interfaces | grep -ci -m1 "#allow-hotplug eth$ETH_INDEX")
+		ETH_DISABLED=$(grep -ci -m1 "#allow-hotplug eth$ETH_INDEX" /tmp/net_interfaces)
 		ETH_HARDWARE=0
 		ETH_CONNECTED=0
 		ETH_IP='0.0.0.0'
@@ -3170,7 +3172,7 @@
 		WIFI_DNS_STATIC=$(cat -n /tmp/net_interfaces | grep 'dns-nameservers ' | sed -n 2p | awk '{print $3,$4}')
 
 		WIFI_INDEX=$(sed -n 2p /DietPi/dietpi/.network)
-		WIFI_DISABLED=$(cat /tmp/net_interfaces | grep -ci -m1 "#allow-hotplug wlan$WIFI_INDEX")
+		WIFI_DISABLED=$(grep -ci -m1 "#allow-hotplug wlan$WIFI_INDEX" /tmp/net_interfaces)
 		WIFI_HARDWARE=0
 		WIFI_CONNECTED=0
 		WIFI_IP='0.0.0.0'
@@ -3186,7 +3188,7 @@
 		WIFI_SIGNALSTRENGTH=0
 		# - Hotspot enabled?
 		WIFI_HOTSPOT=0
-		if [ -f /usr/sbin/hostapd ]; then
+		if [[ -f /usr/sbin/hostapd ]]; then
 
 			WIFI_HOTSPOT=1
 
@@ -3198,7 +3200,7 @@
 		# Redirect stderr and stdout does nowt 2> /dev/null and &> /dev/null no effect.
 		#if (( $(lsmod | grep -ci -m1 'cfg80211' ) )); then
 		WIFI_COUNTRYCODE='GB'
-		if [ -n "$(which iw)" ]; then
+		if [[ $(which iw) ]]; then
 
 			WIFI_COUNTRYCODE=$(iw reg get | grep -m1 'country' | awk '{print $2}' | tr -d ':')
 
@@ -3273,8 +3275,8 @@
 			WIFI_CONNECTED=$(ip r | grep -ci -m1 "wlan$WIFI_INDEX")
 
 			#Wifi Extras
-			WIFI_SSID="$(grep -m1 '^AUTO_SETUP_NET_WIFI_SSID=' /DietPi/dietpi.txt | sed 's/.*=//')"
-			WIFI_KEY="$(grep -m1 '^AUTO_SETUP_NET_WIFI_KEY=' /DietPi/dietpi.txt | sed 's/.*=//')"
+			WIFI_SSID="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_NET_WIFI_SSID=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
+			WIFI_KEY="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_NET_WIFI_KEY=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
 
 			#Enabled and Connected
 			if (( $WIFI_DISABLED == 0 && $WIFI_CONNECTED == 1 )); then
@@ -3461,7 +3463,7 @@
 					#Disable
 					if (( $ipv6_enabled )); then
 
-						G_WHIP_YESNO "IPv6 is currently enabled. Would you like to disable it?\n\n - A system restart is required for settings to take effect.\n - Disabling IPv6 may break certain programs that rely on it."
+						G_WHIP_YESNO 'IPv6 is currently enabled. Would you like to disable it?\n\n - A system restart is required for settings to take effect.\n - Disabling IPv6 may break certain programs that rely on it.'
 						if (( $? == 0 )); then
 
 							# - On amd64 images, IPv6 is no kernel module, but can be disabled via grub: https://github.com/Fourdee/DietPi/issues/1343#issuecomment-359652751
@@ -3537,7 +3539,7 @@
 					#Disabled
 					elif (( $ETH_DISABLED )); then
 
-						G_WHIP_YESNO "Ethernet must be enabled before settings can be changed.\n\nWould you like to enable Ethernet now?\n - (NOTICE) Connections may drop!"
+						G_WHIP_YESNO 'Ethernet must be enabled before settings can be changed.\n\nWould you like to enable Ethernet now?\n - (NOTICE) Connections may drop!'
 						if (( $? == 0 )); then
 
 							ETH_DISABLED=0
@@ -3564,7 +3566,7 @@
 					#Disabled | Offer chance to enable (also enables wifi modules)
 					if (( $WIFI_DISABLED )); then
 
-						G_WHIP_YESNO "WiFi must be enabled before settings can be changed.\n\nWould you like to enable WiFi now? \n - (NOTICE) Connections may drop!"
+						G_WHIP_YESNO 'WiFi must be enabled before settings can be changed.\n\nWould you like to enable WiFi now? \n - (NOTICE) Connections may drop!'
 						if (( $? == 0 )); then
 
 							WIFI_DISABLED=0
@@ -3578,7 +3580,7 @@
 					# - No hardware found
 					elif (( ! $WIFI_HARDWARE )); then
 
-						G_WHIP_YESNO "No supported Wifi Hardware was found.\n\nWould you like to disable WiFi? \n - (NOTICE) Connections may drop!"
+						G_WHIP_YESNO 'No supported Wifi Hardware was found.\n\nWould you like to disable WiFi? \n - (NOTICE) Connections may drop!'
 						if (( $? == 0 )); then
 
 							WIFI_DISABLED=1
@@ -3600,7 +3602,7 @@
 				'Test')
 
 					G_WHIP_DEFAULT_ITEM="$INTERNET_URL"
-					G_WHIP_INPUTBOX "Press enter a URL address to test (eg: http://google.com)"
+					G_WHIP_INPUTBOX 'Press enter a URL address to test (eg: http://google.com)'
 					if (( $? == 0 )); then
 
 						INTERNET_URL=$G_WHIP_RETURNED_VALUE
@@ -3665,10 +3667,10 @@
 		if (( $ETH_MODE_TARGET == 0 )); then
 
 			G_WHIP_MENU_ARRAY+=('Copy' 'Copy Current address to Static')
-			G_WHIP_MENU_ARRAY+=("Static Ip" "$ETH_IP_STATIC")
-			G_WHIP_MENU_ARRAY+=("Static Mask" "$ETH_MASK_STATIC")
-			G_WHIP_MENU_ARRAY+=("Static Gateway" "$ETH_GATEWAY_STATIC")
-			G_WHIP_MENU_ARRAY+=("Static DNS" "$ETH_DNS_STATIC")
+			G_WHIP_MENU_ARRAY+=('Static Ip' "$ETH_IP_STATIC")
+			G_WHIP_MENU_ARRAY+=('Static Mask' "$ETH_MASK_STATIC")
+			G_WHIP_MENU_ARRAY+=('Static Gateway' "$ETH_GATEWAY_STATIC")
+			G_WHIP_MENU_ARRAY+=('Static DNS' "$ETH_DNS_STATIC")
 
 		fi
 		G_WHIP_MENU_ARRAY+=('Disable' 'Disable Ethernet adapter')
@@ -3700,7 +3702,7 @@
 
 				'Disable')
 
-					G_WHIP_YESNO "Would you like to disable the Ethernet adapter?\n - (NOTICE) All Ethernet connections will be dropped."
+					G_WHIP_YESNO 'Would you like to disable the Ethernet adapter?\n - (NOTICE) All Ethernet connections will be dropped.'
 					if (( $? == 0 )); then
 
 						ETH_DISABLED=1
@@ -3856,9 +3858,9 @@ _EOF_
 			# - Load current details into global vars, once.
 			if [[ -z $HOTSPOT_SSID ]]; then
 
-				HOTSPOT_SSID=$(grep -m1 '^ssid=' /etc/hostapd/hostapd.conf | sed 's/.*=//')
-				HOTSPOT_CHANNEL=$(grep -m1 '^channel=' /etc/hostapd/hostapd.conf | sed 's/.*=//')
-				HOTSPOT_KEY=$(grep -m1 '^wpa_passphrase=' /etc/hostapd/hostapd.conf | sed 's/.*=//')
+				HOTSPOT_SSID=$(grep -m1 '^[[:blank:]]*ssid=' /etc/hostapd/hostapd.conf | sed 's/^[^=]*=//')
+				HOTSPOT_CHANNEL=$(grep -m1 '^[[:blank:]]*channel=' /etc/hostapd/hostapd.conf | sed 's/^[^=]*=//')
+				HOTSPOT_KEY=$(grep -m1 '^[[:blank:]]*wpa_passphrase=' /etc/hostapd/hostapd.conf | sed 's/^[^=]*=//')
 
 			fi
 
@@ -3899,11 +3901,11 @@ _EOF_
 
 			fi
 
-			G_WHIP_MENU_ARRAY+=("Scan" "Scan and Connect")
-			G_WHIP_MENU_ARRAY+=("Manual" "Manually Set Wireless Details")
+			G_WHIP_MENU_ARRAY+=('Scan' 'Scan and Connect')
+			G_WHIP_MENU_ARRAY+=('Manual' 'Manually Set Wireless Details')
 
 			if (( $WIFI_CONNECTED ||
-				$(systemctl is-active dietpi-wifi-monitor.service | grep -ci -m1 '^active') )); then
+				systemctl is-active dietpi-wifi-monitor.service | grep -qi '^active'; then
 
 				local wifi_auto_reconnect_text='[Off]'
 				WIFI_AUTO_RECONNECT_ACTIVE=0
@@ -3914,11 +3916,11 @@ _EOF_
 
 				fi
 
-				G_WHIP_MENU_ARRAY+=("Auto Reconnect" ": $wifi_auto_reconnect_text")
+				G_WHIP_MENU_ARRAY+=('Auto Reconnect' ": $wifi_auto_reconnect_text")
 
 			fi
 
-			G_WHIP_MENU_ARRAY+=("Change Mode" ": $mode_target")
+			G_WHIP_MENU_ARRAY+=('Change Mode' ": $mode_target")
 
 			# - show static options
 			if (( $WIFI_MODE_TARGET == 0 )); then
@@ -4020,7 +4022,7 @@ _EOF_
 					done
 
 					G_WHIP_DEFAULT_ITEM=$HOTSPOT_CHANNEL
-					G_WHIP_MENU "Please select a WiFi channel for the hotspot."
+					G_WHIP_MENU 'Please select a WiFi channel for the hotspot.'
 					if (( $? == 0 )); then
 
 						HOTSPOT_CHANNEL=$G_WHIP_RETURNED_VALUE
@@ -4042,7 +4044,7 @@ _EOF_
 
 				'Disable')
 
-					G_WHIP_YESNO "Would you like to disable the WiFi adapter?\n - (NOTICE) All WiFi connections will be dropped."
+					G_WHIP_YESNO 'Would you like to disable the WiFi adapter?\n - (NOTICE) All WiFi connections will be dropped.'
 					if (( $? == 0 )); then
 
 						WIFI_DISABLED=1
@@ -4196,7 +4198,7 @@ _EOF_
 
 		)
 
-		G_WHIP_MENU "Please select an option:"
+		G_WHIP_MENU 'Please select an option:'
 		if (( $? == 0 )); then
 
 			case "$G_WHIP_RETURNED_VALUE" in
@@ -4437,7 +4439,7 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 				'Custom')
 
 					/DietPi/dietpi/dietpi-drive_manager 1
-					FP_FSBENCH_CUSTOM_MOUNT="$(cat /tmp/dietpi-drive_manager_selmnt)"
+					FP_FSBENCH_CUSTOM_MOUNT="$(</tmp/dietpi-drive_manager_selmnt)"
 
 					if [[ -n $FP_FSBENCH_CUSTOM_MOUNT ]]; then
 
@@ -4453,13 +4455,13 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 				'RAM')
 
 					#Check for /tmp as tmpfs, before running: https://github.com/Fourdee/DietPi/issues/1130#issuecomment-350348081
-					if (( $(df | grep '[[:space:]]/tmp' | grep -ci -m1 '^tmpfs[[:space:]]') )); then
+					if df | grep -qi '^tmpfs[[:space:]].*[[:space:]]/tmp'; then
 
 						Run_FilesystemBenchmark 2
 
 					else
 
-						G_WHIP_MSG "Unable to run RAM benchmark, as /tmp is not mounted as tmpfs.\n\nThis mount is disabled automatically on <=512MB devices to prevent out of memory errors, please see here for more info:\n\n - https://github.com/Fourdee/DietPi/issues/1027"
+						G_WHIP_MSG 'Unable to run RAM benchmark, as /tmp is not mounted as tmpfs.\n\nThis mount is disabled automatically on <=512MB devices to prevent out of memory errors, please see here for more info:\n\n - https://github.com/Fourdee/DietPi/issues/1027'
 
 					fi
 
@@ -4540,7 +4542,7 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 
 		#Overclocking Pi1
 		# - Zero
-		echo -e "$G_HW_MODEL"
+		echo "$G_HW_MODEL"
 		if cat /DietPi/dietpi/.hw_model | tr '[:upper:]' '[:lower:]' | grep -qi 'rpi zero'; then
 
 			G_WHIP_MENU_ARRAY=(
@@ -4822,7 +4824,7 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 
 		TARGETMENUID=0
 
-		local soundcard_current=$(grep -m1 '^[[:blank:]]*CONFIG_SOUNDCARD=' /DietPi/dietpi.txt | sed 's/^.*=//')
+		local soundcard_current=$(grep -m1 '^[[:blank:]]*CONFIG_SOUNDCARD=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 
 		G_WHIP_MENU_ARRAY=()
 
@@ -4853,7 +4855,7 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 
 		fi
 
-		G_WHIP_MENU "Please select an option:"
+		G_WHIP_MENU 'Please select an option:'
 		if (( $? == 0 )); then
 
 			if [[ $G_WHIP_RETURNED_VALUE == 'PSU noise reduction' ]]; then
@@ -4916,10 +4918,10 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 
 								if [[ -f /proc/asound/card$i/pcm${j}p/info ]]; then
 
-									local card_index=$(cat /proc/asound/card$i/pcm${j}p/info | grep -m1 '^card:' | awk '{print $2}')
-									local device_index=$(cat /proc/asound/card$i/pcm${j}p/info | grep -m1 '^device:' | awk '{print $2}')
-									local card_name=$(cat /proc/asound/card$i/id)
-									card_name+=$(cat /proc/asound/card$i/pcm${j}p/info | grep -m1 '^name:' | sed 's/name://g')
+									local card_index=$(grep -m1 '^card:' /proc/asound/card$i/pcm${j}p/info | awk '{print $2}')
+									local device_index=$(grep -m1 '^device:' /proc/asound/card$i/pcm${j}p/info | awk '{print $2}')
+									local card_name=$(</proc/asound/card$i/id)
+									card_name+=$(grep -m1 '^name:' /proc/asound/card$i/pcm${j}p/info | sed 's/name://g')
 
 									G_WHIP_MENU_ARRAY+=( "hw:$card_index,$device_index" "$card_name" )
 
@@ -5030,7 +5032,7 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 				#Return to This Menu
 				TARGETMENUID=14
 
-			elif [ "$G_WHIP_RETURNED_VALUE" = "DietPi-JustBoom" ]; then
+			elif [[ $G_WHIP_RETURNED_VALUE == 'DietPi-JustBoom' ]]; then
 
 				/DietPi/dietpi/misc/dietpi-justboom
 
@@ -5066,14 +5068,14 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 
 		G_WHIP_MENU_ARRAY=(
 
-			"Mode" "$stress_test_mode_text"
-			"Duration" "$(( $STRESS_TEST_DURATION / 60 )) Minutes"
-			"Start" "Launch the stress test"
+			'Mode' "$stress_test_mode_text"
+			'Duration' "$(( $STRESS_TEST_DURATION / 60 )) Minutes"
+			'Start' 'Launch the stress test'
 
 		)
 
 
-		G_WHIP_MENU "Please select an option:"
+		G_WHIP_MENU 'Please select an option:'
 		if (( $? == 0 )); then
 
 			if [[ $G_WHIP_RETURNED_VALUE == 'Duration' ]]; then
@@ -5089,7 +5091,7 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 				)
 
 				G_WHIP_DEFAULT_ITEM="$STRESS_TEST_DURATION"
-				G_WHIP_MENU "Please select a duration for the test"
+				G_WHIP_MENU 'Please select a duration for the test'
 				if (( $? == 0 )); then
 
 					STRESS_TEST_DURATION=$G_WHIP_RETURNED_VALUE
@@ -5133,7 +5135,7 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 				local cores=$(nproc --all) # double up cpu threads, maximize overheads.
 				local memory_per_thread=$(( $(free -m | awk '/^Mem:/{print $2}') / ( $cores * 2 ) ))
 				local fp_log="$HOME/dietpi-config_stress.log"
-				rm "$fp_log" &> /dev/null
+				rm $fp_log &> /dev/null
 
 				if (( $STRESS_TEST_MODE == 0 )); then
 
@@ -5255,7 +5257,7 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 		fi
 
 		#NTPD mirror
-		local ntpd_mirror_current=$(grep -m1 '^CONFIG_NTP_MIRROR=' /DietPi/dietpi.txt | sed 's/.*=//')
+		local ntpd_mirror_current=$(grep -m1 '^[[:blank:]]*CONFIG_NTP_MIRROR=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 		if [[ -z $ntpd_mirror_current ]]; then
 
 			ntpd_mirror_current='Unknown, no string from scrape'
@@ -5263,7 +5265,7 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 		fi
 
 		#Network boot wait
-		local boot_wait_for_network=$(grep -m1 '^[[:blank:]]*CONFIG_BOOT_WAIT_FOR_NETWORK=' /DietPi/dietpi.txt | sed 's/^.*=//')
+		local boot_wait_for_network=$(grep -m1 '^[[:blank:]]*CONFIG_BOOT_WAIT_FOR_NETWORK=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 		local boot_wait_for_network_text=': '
 		if (( $boot_wait_for_network == 0 )); then
 
@@ -5436,7 +5438,7 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 							'Custom')
 
 								G_WHIP_DEFAULT_ITEM="$ntpd_mirror_current"
-								G_WHIP_INPUTBOX "Please enter a new NTPD Mirror\n - eg: debian.pool.ntp.org"
+								G_WHIP_INPUTBOX 'Please enter a new NTPD Mirror\n - eg: debian.pool.ntp.org'
 								if (( $? == 0 )); then
 
 									return_value=$G_WHIP_RETURNED_VALUE
@@ -5448,7 +5450,7 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 						esac
 
 						sed -i "/CONFIG_NTP_MIRROR=/c\CONFIG_NTP_MIRROR=$G_WHIP_RETURNED_VALUE" /DietPi/dietpi.txt
-						/DietPi/dietpi/func/dietpi-set_software ntpd-mode $(grep -m1 '^CONFIG_NTP_MODE=' /DietPi/dietpi.txt | sed 's/.*=//')
+						/DietPi/dietpi/func/dietpi-set_software ntpd-mode $(grep -m1 '^[[:blank:]]*CONFIG_NTP_MODE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 						/DietPi/dietpi/func/run_ntpd
 
 						#Return to this Menu
@@ -5464,7 +5466,7 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 					if (( ! $noip_installed )); then
 
 						local noip_url_address=''
-						G_WHIP_YESNO "NoIp Client is not installed, would you like to install it now?\n\n- NoIp will allow you to use a fixed web address, regardless of your internet IP\neg: MySuperDooperWebsite.noip2.biz would point to this device!"
+						G_WHIP_YESNO 'NoIp Client is not installed, would you like to install it now?\n\n- NoIp will allow you to use a fixed web address, regardless of your internet IP\neg: MySuperDooperWebsite.noip2.biz would point to this device!'
 						if (( $? == 0 )); then
 
 							#Install
@@ -5477,7 +5479,7 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 						printf '\ec' # clear current terminal screen
 						service noip2 stop
 						noip2 -C
-						read -p "Press any key to continue....."
+						read -p 'Press any key to continue.....'
 						service noip2 start
 
 					fi
@@ -5514,11 +5516,11 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 	#So we can call this in other menus (eg: submenu of this)
 	Load_Proxy_Vars(){
 
-		PROXY_ENABLED=$(cat /DietPi/dietpi.txt | grep -m1 '^[[:blank:]]*CONFIG_PROXY_ENABLED=' | sed 's/^.*=//')
-		PROXY_ADDRESS=$(cat /DietPi/dietpi.txt | grep -m1 '^[[:blank:]]*CONFIG_PROXY_ADDRESS=' | sed 's/^.*=//')
-		PROXY_PORT=$(cat /DietPi/dietpi.txt | grep -m1 '^[[:blank:]]*CONFIG_PROXY_PORT=' | sed 's/^.*=//')
-		PROXY_USERNAME=$(cat /DietPi/dietpi.txt | grep -m1 '^[[:blank:]]*CONFIG_PROXY_USERNAME=' | sed 's/^.*=//')
-		PROXY_PASSWORD=$(cat /DietPi/dietpi.txt | grep -m1 '^[[:blank:]]*CONFIG_PROXY_PASSWORD=' | sed 's/^.*=//')
+		PROXY_ENABLED=$(grep -m1 '^[[:blank:]]*CONFIG_PROXY_ENABLED=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
+		PROXY_ADDRESS=$(grep -m1 '^[[:blank:]]*CONFIG_PROXY_ADDRESS=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
+		PROXY_PORT=$(grep -m1 '^[[:blank:]]*CONFIG_PROXY_PORT=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
+		PROXY_USERNAME=$(grep -m1 '^[[:blank:]]*CONFIG_PROXY_USERNAME=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
+		PROXY_PASSWORD=$(grep -m1 '^[[:blank:]]*CONFIG_PROXY_PASSWORD=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 
 	}
 
@@ -5596,7 +5598,7 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 				'Port')
 
 					G_WHIP_DEFAULT_ITEM="$PROXY_PORT"
-					G_WHIP_INPUTBOX "Please enter the proxy port number\n - eg: 1234"
+					G_WHIP_INPUTBOX 'Please enter the proxy port number\n - eg: 1234'
 					if (( $? == 0 )); then
 
 						PROXY_PORT=$G_WHIP_RETURNED_VALUE

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -1965,14 +1965,15 @@
 							if [[ $G_WHIP_RETURNED_VALUE == 'Disabled' ]]; then
 
 								G_CONFIG_INJECT 'CONFIG_CPU_MIN_FREQ=' "CONFIG_CPU_MIN_FREQ=$min_clock" /DietPi/dietpi.txt
+								/DietPi/dietpi/func/dietpi-set_cpu
+								G_CONFIG_INJECT 'CONFIG_CPU_MIN_FREQ=' 'CONFIG_CPU_MIN_FREQ=Disabled' /DietPi/dietpi.txt
 
 							else
 
 								G_CONFIG_INJECT 'CONFIG_CPU_MIN_FREQ=' "CONFIG_CPU_MIN_FREQ=$G_WHIP_RETURNED_VALUE" /DietPi/dietpi.txt
+								/DietPi/dietpi/func/dietpi-set_cpu
 
 							fi
-
-							/DietPi/dietpi/func/dietpi-set_cpu
 
 						fi
 


### PR DESCRIPTION
Wanted to start with local NTP mirror implementation, but ended up doing the usual code improvements throughout the while script 😆. There is still a bid left, as I became a lazy after 50% 😉.

Btw.: As for the other scripts, I moved `G_CHECK_ROOT_USER` and `G_CHECK_ROOTFS_RW` to after `G_INIT`, so `G_DIETPI-NOTIFY` adds the script name to them. For rootfs check this doesn't work, since notification is called within drive manager. I thought anyway the whole check fits better into `dietpi-globals`, which would also prevent loading of the whole drive manager script each time?
Dunno if position of the checks is really better then, it's basically visual, that we can see which script asks for the checks, versus the tiny speed up on failure, to skip `G_INIT`, including working dir creation+removal.

**Status**: Ready for review and testing

**Commit list/description**:
+ DietPi-Config | Minor, but much code enhancements and consistency
