### PR TITLE
DietPi-Config | Rework of NTP mirror selection / Allow local NTP servers

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ v6.13
 
 Changes / Improvements / Optimizations:
 DietPi-Globals | G_THREAD_WAIT: Now displays errors for each thread, if they occured.
+DietPi-Config | NTP mirror selection has been reworked. It allows now to add local and external non-pool.ntp.org servers and local gateway auto detection: https://github.com/Fourdee/DietPi/issues/1688
 DietPi-Software | A new unified download&install function is implemented, which allows more consistent download and install of software, using /tmp RAMFS as working directory and parallel dependencies installation via G_THREAD.
 DietPi-Software | Koel: Installation will now skip webserver, as Koel uses PHP-CLI instead. To not mess with webserver served pages, Koel install directory is moved to "/mnt/dietpi_userdata/koel", for existing installs as well.
 DietPi-Software | Mono: Now installs 'mono-complete' by default, required for Mono based applications (eg: Radarr/Sonarr/Lidarr/Jackett etc)

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -1265,7 +1265,7 @@
 
 		G_WHIP_MENU_ARRAY=()
 
-		#Get Current Settings
+		#Swap file
 		local swap_size=$(free -m | grep -im1 'Swap:' | awk '{print $2}')
 		local swap_location="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_SWAPFILE_LOCATION=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
 		local swap_size_text="$swap_size MB"
@@ -1274,15 +1274,14 @@
 			swap_size_text='[Off]'
 
 		fi
-
 		G_WHIP_MENU_ARRAY+=('Swapfile' ": $swap_size_text | $swap_location")
 
-		#NTPD
+		#Time sync
 		local ntpd_mode_current=$(grep -m1 '^[[:blank:]]*CONFIG_NTP_MODE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
-		local ntpd_mode_text=""
+		local ntpd_mode_text=''
 		if (( $ntpd_mode_current == 0 )); then
 
-			ntpd_mode_text='[Off]'
+			ntpd_mode_text='Custom'
 
 		elif (( $ntpd_mode_current == 1 )); then
 
@@ -1303,30 +1302,31 @@
 		fi
 		G_WHIP_MENU_ARRAY+=('Time sync mode' ": $ntpd_mode_text")
 
-		serialconsole_state=$(grep -m1 '^CONFIG_SERIAL_CONSOLE_ENABLE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
-		serialconsole_text='[Off]'
-		if (( $serialconsole_state == 1 )); then
-
-			serialconsole_text='[On]'
-
-		fi
-
 		G_WHIP_MENU_ARRAY+=('Update firmware' '')
 
-		local bluetooth_state_text='[On]'
-		local bluetooth_state=1
-		if [[ -f /etc/modprobe.d/disable_bt.conf ]]; then
-
-			bluetooth_state=0
-			bluetooth_state_text='[Off]'
-
-		fi
-
-		# - No bluetooth and serial console for VM
+		#No bluetooth and serial console for VM
 		if (( $G_HW_MODEL != 20 )); then
 
-			G_WHIP_MENU_ARRAY+=('Bluetooth' ": $bluetooth_state_text")
+			#Serial console
+			local serialconsole_state=$(grep -m1 '^[[:blank:]]*CONFIG_SERIAL_CONSOLE_ENABLE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
+			local serialconsole_text='[Off]'
+			if (( $serialconsole_state )); then
+
+				serialconsole_text='[On]'
+
+			fi
 			G_WHIP_MENU_ARRAY+=('Serial console' ": $serialconsole_text")
+
+			#Bluetooth
+			local bluetooth_state_text='[On]'
+			local bluetooth_state=1
+			if [[ -f /etc/modprobe.d/disable_bt.conf ]]; then
+
+				bluetooth_state=0
+				bluetooth_state_text='[Off]'
+
+			fi
+			G_WHIP_MENU_ARRAY+=('Bluetooth' ": $bluetooth_state_text")
 
 		fi
 
@@ -1389,7 +1389,7 @@
 
 				G_WHIP_MENU_ARRAY=(
 
-					'0' 'Disabled'
+					'0' 'Custom'
 					'1' 'Boot Only'
 					'2' 'Boot + Daily (Recommended)'
 					'3' 'Boot + Hourly'
@@ -1398,7 +1398,10 @@
 				)
 
 				G_WHIP_DEFAULT_ITEM="$ntpd_mode_current"
-				G_WHIP_MENU 'Here you can adjust the frequency of NTP time syncs.\n\n - Modes 1-3:\nDietPi will launch systemd-timesyncd as a program, rather than a daemon. Once the time has been updated on your system, NTPD will exit to reduce resource usage.\n\n - Mode 4:\nsystemd-timesyncd will run as a background daemon/service. Differences in time will be gradually adjusted over time, rather than instantly.'
+				G_WHIP_MENU 'Here you can adjust the frequency of network time syncs.\n
+ - Modes 1-3:\nDietPi will launch systemd-timesyncd as a program, rather than a daemon. Once the time has been updated on your system, timesyncd will exit to reduce resource usage.\n
+ - Mode 4:\nsystemd-timesyncd will run as a background daemon/service. Differences in time will be gradually adjusted over time, rather than instantly.\n
+ - Mode 0:\nIf you use a custom time sync method, e.g. the NTP package for high precision demand, select custom mode to avoid systemd-timesyncd interference.'
 				if (( $? == 0 )); then
 
 					/DietPi/dietpi/func/dietpi-set_software ntpd-mode $G_WHIP_RETURNED_VALUE
@@ -1414,7 +1417,7 @@
 				#RPI
 				if (( $G_HW_MODEL < 10 )); then
 
-					G_WHIP_YESNO "Would you like to update the firmware/kernel for $G_HW_MODEL_DESCRIPTION?\n - This will run G_RPI_UPDATE"
+					G_WHIP_YESNO "Would you like to update the firmware/kernel for $G_HW_MODEL_DESCRIPTION?\n - This will run G_RPI_UPDATE, a wrapper for rpi-update"
 					if (( $? == 0 )); then
 
 						G_RPI_UPDATE
@@ -1436,7 +1439,7 @@
 				#G_AGDUG based (not all devices support this)
 				else
 
-					G_WHIP_YESNO "Would you like to update the firmware/kernel for $G_HW_MODEL_DESCRIPTION?\n - This will run G_AGDUG\n - Most (but not all) devices allow APT based firmware updates\n\nNB: If requested to overwrite the current kernel, press TAB and then ENTER (to confirm)."
+					G_WHIP_YESNO "Would you like to update the firmware/kernel for $G_HW_MODEL_DESCRIPTION?\n - This will run G_AGDUG, a wrapper for 'apt-get dist-upgrade'\n - Most (but not all) devices allow APT based firmware updates\n\nNB: If requested to overwrite the current kernel, press TAB and then ENTER (to confirm)."
 					if (( $? == 0 )); then
 
 						G_AGUP
@@ -2979,7 +2982,7 @@
 
 
 	INTERNET_ONLINE=0 # 0=not tested, 1=failed, 2=online
-	INTERNET_URL='http://mirrordirector.raspbian.org'
+	INTERNET_URL='https://dietpi.com'
 
 	Network_CheckInternetConnection(){
 
@@ -2996,6 +2999,7 @@
 			INTERNET_ONLINE=1 #Failed
 
 		fi
+
 	}
 
 	Network_GetData(){
@@ -5103,19 +5107,19 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 
 		fi
 
-		#Apt mirror
-		local apt_mirror_current=$(sed -n 1p /etc/apt/sources.list | awk '{print $2}')
+		#APT mirror
+		local apt_mirror_current=$(grep -m1 '^[[:blank:]]*deb[[:blank:]]' /etc/apt/sources.list | awk '{print $2}')
 		if [[ -z $apt_mirror_current ]]; then
 
 			apt_mirror_current='Unknown, no string from scrape'
 
 		fi
 
-		#NTPD mirror
-		local ntpd_mirror_current=$(grep -m1 '^[[:blank:]]*CONFIG_NTP_MIRROR=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
-		if [[ -z $ntpd_mirror_current ]]; then
+		#NTP mirror
+		local ntp_mirror_current=$(grep -m1 '^[[:blank:]]*CONFIG_NTP_MIRROR=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
+		if [[ -z $ntp_mirror_current ]]; then
 
-			ntpd_mirror_current='Unknown, no string from scrape'
+			ntp_mirror_current='Unknown, no string from scrape'
 
 		fi
 
@@ -5141,12 +5145,12 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 			'Network Drives' 'Mount/control networked storage'
 			'NoIp' "$noip_menutext"
 			'APT Mirror' "Select a different Apt mirror for sources.list"
-			'NTPD Mirror' "Select a different NTPD mirror"
+			'NTP Mirror' "Select a different NTP mirror"
 			'Boot Net Wait' "$boot_wait_for_network_text"
 
 		)
 
-		G_WHIP_MENU "NoIp status  : $noip_status\nApt mirror   : $apt_mirror_current\nNTPD mirror  : $ntpd_mirror_current"
+		G_WHIP_MENU "NoIp status  : $noip_status\nApt mirror   : $apt_mirror_current\nNTP mirror   : $ntp_mirror_current"
 		if (( $? == 0 )); then
 
 			case "$G_WHIP_RETURNED_VALUE" in
@@ -5193,7 +5197,7 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 					#Create Menu List for Whiptail
 					G_WHIP_MENU_ARRAY=(
 
-						'Custom' 'Manually enter Apt mirror'
+						'Custom' 'Manually enter APT mirror'
 
 					)
 
@@ -5210,7 +5214,7 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 					# - Debian
 					else
 
-						G_WHIP_MENU_ARRAY+=('https://deb.debian.org/debian/' 'Global')
+						G_WHIP_MENU_ARRAY+=('https://deb.debian.org/debian/' 'Global mirror director')
 						G_WHIP_MENU_ARRAY+=('http://ftp.debian.org/debian/' 'Global')
 						G_WHIP_MENU_ARRAY+=('http://ftp.uk.debian.org/debian/' 'UK')
 						G_WHIP_MENU_ARRAY+=('http://ftp.us.debian.org/debian/' 'US')
@@ -5220,7 +5224,7 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 					fi
 
 					G_WHIP_DEFAULT_ITEM="$apt_mirror_current"
-					G_WHIP_MENU "Please select a APT mirror, or choose custom for manual entry."
+					G_WHIP_MENU 'Please select an APT mirror, or choose custom for manual entry.'
 					if (( $? == 0 )); then
 
 						case $G_WHIP_RETURNED_VALUE in
@@ -5228,7 +5232,7 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 							'Custom')
 
 								G_WHIP_DEFAULT_ITEM="$apt_mirror_current"
-								G_WHIP_INPUTBOX "Please enter a new APT Mirror\n - eg: http://ftp.debian.org/debian"
+								G_WHIP_INPUTBOX 'Please enter a new APT Mirror\n - eg: http://ftp.debian.org/debian'
 								if (( $? == 0 )); then
 
 									return_value=$G_WHIP_RETURNED_VALUE
@@ -5265,25 +5269,33 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 
 				;;
 
-				'NTPD Mirror')
+				'NTP Mirror')
 
 					#Create Menu List for Whiptail
 					G_WHIP_MENU_ARRAY=(
 
-						'Custom' 'Manually enter NTPD mirror'
-						'debian.pool.ntp.org' 'Debian Global'
-						'pool.ntp.org' 'Global'
+						'Gateway' 'Use local router as NTP server (Recommended)'
+						'Custom' 'Manually enter NTP mirror'
+						'Default' 'Fallback to system defaults'
+						'' '●─ Continental NTP pools '
 						'europe.pool.ntp.org' 'Europe'
 						'north-america.pool.ntp.org' 'North America'
 						'south-america.pool.ntp.org' 'South America'
 						'africa.pool.ntp.org' 'Africa'
 						'asia.pool.ntp.org' 'Asia'
 						'oceania.pool.ntp.org' 'Oceania'
+						'' '●─ Global NTP pools '
+						'debian.pool.ntp.org' 'Debian Global'
+						'pool.ntp.org' 'Global'
 
 					)
 
-					G_WHIP_DEFAULT_ITEM="$ntpd_mirror_current"
-					G_WHIP_MENU "Please select a NTPD mirror, or choose custom for manual entry.\n - Further information: \"http://www.pool.ntp.org/zone/@\""
+					G_WHIP_DEFAULT_ITEM="$ntp_mirror_current"
+					G_WHIP_MENU 'Please select an NTP mirror:\n
+ "Gateway": Try to detect and use local router for time sync. Recommended, allows fastest sync and reduces load to the *.pool.ntp.org servers.\n
+ "Custom": Manually enter local or external NTP server address(es).\n
+ "Default": Leave mirror choice to system. Usually falls back to local gateway (Stretch+ only) or "debian.pool.ntp.org".\n
+ Use "*.pool.ntp.org" mirrors, if your device is mobile or should act as local NTP server. Further information: "http://www.pool.ntp.org/zone/@"'
 					if (( $? == 0 )); then
 
 						return_value="$G_WHIP_RETURNED_VALUE"
@@ -5292,8 +5304,10 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 
 							'Custom')
 
-								G_WHIP_DEFAULT_ITEM="$ntpd_mirror_current"
-								G_WHIP_INPUTBOX 'Please enter a new NTPD Mirror\n - eg: debian.pool.ntp.org'
+								G_WHIP_DEFAULT_ITEM="$ntp_mirror_current"
+								G_WHIP_INPUTBOX 'Please enter one or more (space-separated) NTP mirrors.\n
+NB: If you need to use *.pool.ntp.org servers, enter the base domain only. The subdomains 0-3 will be added automatically.
+- Enter "uk.pool.ntp.org" to use [0-3].uk.pool.ntp.org'
 								if (( $? == 0 )); then
 
 									return_value=$G_WHIP_RETURNED_VALUE
@@ -5304,7 +5318,7 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 
 						esac
 
-						sed -i "/CONFIG_NTP_MIRROR=/c\CONFIG_NTP_MIRROR=$G_WHIP_RETURNED_VALUE" /DietPi/dietpi.txt
+						G_CONFIG_INJECT 'CONFIG_NTP_MIRROR=' "CONFIG_NTP_MIRROR=$G_WHIP_RETURNED_VALUE" /DietPi/dietpi.txt
 						/DietPi/dietpi/func/dietpi-set_software ntpd-mode $(grep -m1 '^[[:blank:]]*CONFIG_NTP_MODE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 						/DietPi/dietpi/func/run_ntpd
 

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -5144,13 +5144,13 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 
 			'Network Drives' 'Mount/control networked storage'
 			'NoIp' "$noip_menutext"
-			'APT Mirror' "Select a different Apt mirror for sources.list"
+			'APT Mirror' "Select a different APT mirror for sources.list"
 			'NTP Mirror' "Select a different NTP mirror"
 			'Boot Net Wait' "$boot_wait_for_network_text"
 
 		)
 
-		G_WHIP_MENU "NoIp status  : $noip_status\nApt mirror   : $apt_mirror_current\nNTP mirror   : $ntp_mirror_current"
+		G_WHIP_MENU "NoIp status  : $noip_status\nAPT mirror   : $apt_mirror_current\nNTP mirror   : $ntp_mirror_current"
 		if (( $? == 0 )); then
 
 			case "$G_WHIP_RETURNED_VALUE" in

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -5292,10 +5292,10 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 
 					G_WHIP_DEFAULT_ITEM="$ntp_mirror_current"
 					G_WHIP_MENU 'Please select an NTP mirror:\n
- "Gateway": Try to detect and use local router for time sync. Recommended, allows fastest sync and reduces load to the *.pool.ntp.org servers.\n
- "Custom": Manually enter local or external NTP server address(es).\n
- "Default": Leave mirror choice to system. Usually falls back to local gateway (Stretch+ only) or "debian.pool.ntp.org".\n
- Use "*.pool.ntp.org" mirrors, if your device is mobile or should act as local NTP server. Further information: "http://www.pool.ntp.org/zone/@"'
+"Gateway": Try to detect and use local router for time sync. Recommended, allows fastest sync and reduces load to the *.pool.ntp.org servers.\n
+"Custom": Manually enter local or external NTP server address(es).\n
+"Default": Leave mirror choice to system. Usually falls back to local gateway (Stretch+ only) or "debian.pool.ntp.org".\n
+Use "*.pool.ntp.org" mirrors, if your device is mobile or should act as local NTP server. Further information: "http://www.pool.ntp.org/zone/@"'
 					if (( $? == 0 )); then
 
 						return_value="$G_WHIP_RETURNED_VALUE"

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -35,10 +35,10 @@ $FP_SCRIPT			passwords				NULL=Prompt user to change DietPi related passwords | 
 	INPUT_ADDITIONAL_4="$6"
 	#Import DietPi-Globals ---------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
-	G_CHECK_ROOT_USER
-	G_CHECK_ROOTFS_RW
 	export G_PROGRAM_NAME='DietPi-Set_software'
 	G_INIT
+	G_CHECK_ROOT_USER
+	G_CHECK_ROOTFS_RW
 	#Import DietPi-Globals ---------------------------------------------------------------
 
 	EXIT_CODE=0
@@ -196,24 +196,63 @@ _EOF_
 			# - Reset global to disabled, prevents run_ntpd in dietpi-software
 			sed -i '/CONFIG_NTP_MODE=/c\CONFIG_NTP_MODE=0' /DietPi/dietpi.txt
 
-			#Kill current
+			# - Kill current
 			killall -w /DietPi/dietpi/func/run_ntpd &> /dev/null
 
-			local ntpd_mirror=$(grep -m1 '^[[:blank:]]*CONFIG_NTP_MIRROR=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
-			# - Set defaults?
-			if [[ $ntpd_mirror == 'default' ]]; then
+			local ntp_mirror=$(grep -m1 '^[[:blank:]]*CONFIG_NTP_MIRROR=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
+			local ntp_mirror_entry='Servers='$ntp_mirror
 
-				ntpd_mirror='debian.pool.ntp.org'
+			# - Default, lets timesyncd use DHCP server (Stretch+ only) or fallback to debian.pool.ntp.org.
+			if [[ $ntp_mirror == [Dd]efault ]]; then
+
+				ntp_mirror_entry='#Servers=0.debian.pool.ntp.org 1.debian.pool.ntp.org 2.debian.pool.ntp.org 3.debian.pool.ntp.org'
+
+			# - Gateway, auto detect local gateway(s) (router) to use as NTP server.
+			elif [[ $ntp_mirror == [Gg]ateway ]]; then
+
+				local gateway="$(ip r | grep '^default' | awk '{print $3}')"
+				if [[ $gateway ]]; then
+
+					G_DIETPI-NOTIFY 0 "Gateway(s) detected:$(printf ' %s' $gateway), adding as NTP server(s)."
+					ntp_mirror_entry='Servers='$(ip r | grep '^default' | awk '{print $3}')
+
+				else
+
+					G_DIETPI-NOTIFY 1 'No local gateway detected. No NTP mirror change will be applied.'
+					EXIT_CODE=1
+					return 1
+
+				fi
+
+			# - Add pool.ntp.org entries with subdomains "[0-3].", other entries without.
+			elif [[ $ntp_mirror =~ 'pool.ntp.org' ]]; then
+
+				ntp_mirror_entry='Servers='
+				local i
+				for i in $ntp_mirror
+				do
+
+					if [[ $i == *'pool.ntp.org' ]]; then
+
+						ntp_mirror_entry+="0.$i 1.$i 2.$i 3.$i "
+
+					else
+
+						ntp_mirror_entry+="$i "
+
+					fi
+
+				done
 
 			fi
 
 			# - Set mirror
 			cat << _EOF_ > /etc/systemd/timesyncd.conf
 [Time]
-Servers=0.$ntpd_mirror 1.$ntpd_mirror 2.$ntpd_mirror 3.$ntpd_mirror
+$ntp_mirror_entry
 _EOF_
 
-			# - Daemon mode, dbus required for timedatectl, that users may require
+			# - Daemon mode, dbus required for timedatectl, that users may expect
 			if (( $INPUT_MODE_VALUE == 4 )); then
 
 				G_AG_CHECK_INSTALL_PREREQ dbus


### PR DESCRIPTION
**Status**: Ready for testing

**Reference**: https://github.com/Fourdee/DietPi/issues/1688

**Commit list/description**:
+ DietPi-Config | NTP: Rework of NTP mirror selection, allow to enter non pool.ntp.org mirrors and auto detection of local gateway (router) as NTP server.
+ DietPi-Config | NTP: Clarification about NTP modes, rename mode 0 to "Custom", as this should be used in combination with ntpd ("ntp" package) to avoid DietPi + timesyncd interference.
+ DietPi-Config | Load bluetooth and serial console related values only for non-VMs
+ DietPi-Config | Minor coding and wording
+ DietPi-Set_Software | NTP mirror rework: Adding only pool.ntp.org entries with "[0-3]." prefix, allow multiple entries (space-separated), handling each correctly, local gateway auto detection, comment entry when [Dd]efault was chosen
+ CHANGELOG | NTP mirror rework