### PR TITLE
General | Mask systemd-logind by default, allow to unmask via dietpi.txt and libpam-systemd install

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ DietPi-Software | Koel: Installation will now skip webserver, as Koel uses PHP-C
 DietPi-Software | Mono: Now installs 'mono-complete' by default, required for Mono based applications (eg: Radarr/Sonarr/Lidarr/Jackett etc)
 DietPi-Software | Lidarr: Now available for installation, automatically download music: https://github.com/Fourdee/DietPi/issues/1874
 General | All DietPi scripts by default now use /tmp RAMFS to create, download and handle temporary files. By this we speed up especially installations and reduce disk I/O: https://github.com/Fourdee/DietPi/issues/1801
+General | By default systemd-logind is now masked on DietPi images. This can be changed by setting AUTO_UNMASK_SYSTEMD=1 within dietpi.txt. As well it will be unmasked automatically, if libpam-systemd was installed during dietpi-software installation: https://github.com/Fourdee/DietPi/issues/1767
 #Image | NanoPC T4: This image now includes a new kernel with support for CIFS, docker and more. Many thanks to
 
 Bug Fixes:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,7 +12,7 @@ DietPi-Software | Mono: Now installs 'mono-complete' by default, required for Mo
 DietPi-Software | Lidarr: Now available for installation, automatically download music: https://github.com/Fourdee/DietPi/issues/1874
 DietPi-Cron | /etc/cron.minutely/ is now disabled by default, to reduce cron executions and logs. This is also patched with v6.13, if no script is placed within the folder. Use "dietpi-cron" to enable and configure this feature.
 General | All DietPi scripts by default now use /tmp RAMFS to create, download and handle temporary files. By this we speed up especially installations and reduce disk I/O: https://github.com/Fourdee/DietPi/issues/1801
-General | By default systemd-logind is now masked on DietPi images. This can be changed by setting AUTO_UNMASK_SYSTEMD=1 within dietpi.txt. As well it will be unmasked automatically, if libpam-systemd was installed during dietpi-software installation: https://github.com/Fourdee/DietPi/issues/1767
+General | By default systemd-logind is now masked on DietPi images. This can be changed by setting AUTO_UNMASK_LOGIND=1 within dietpi.txt. As well it will be unmasked automatically, if libpam-systemd was installed during dietpi-software installation: https://github.com/Fourdee/DietPi/issues/1767
 General | "fake-hwclock" is purged now on first run setup and v6.13 patch, if a real hardware clock is available.
 Image | NanoPC-T4: Image updated which now includes custom kernel/modules created by @carlosedp. Adds CIFS, docker support and much more. Please note, WiFi scan is intermittent with this kernel, and, may take a few attempts to be successful, however, we believe the additional modules are a higher priority: https://github.com/Fourdee/DietPi/issues/1829
 

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -1179,8 +1179,8 @@ _EOF_
 		systemctl mask getty-static
 		# - logind features disabled by default. Usually not needed and all features besides auto getty creation are not available without libpam-systemd package.
 		#	- It will be unmasked/enabled, automatically if libpam-systemd got installed during dietpi-software install, usually with desktops.
-		systemctl stop systemd-logind
-		systemctl disable systemd-logind
+		systemctl stop systemd-logind &> /dev/null
+		systemctl disable systemd-logind &> /dev/null
 		systemctl mask systemd-logind
 
 		G_DIETPI-NOTIFY 2 'Configuring regional settings (TZdata):'

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -1177,6 +1177,7 @@ _EOF_
 		G_DIETPI-NOTIFY 2 'Reducing getty count and resource usage:'
 
 		systemctl mask getty-static
+		systemctl mask systemd-logind
 
 		G_DIETPI-NOTIFY 2 'Configuring regional settings (TZdata):'
 

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -1177,6 +1177,10 @@ _EOF_
 		G_DIETPI-NOTIFY 2 'Reducing getty count and resource usage:'
 
 		systemctl mask getty-static
+		# - logind features disabled by default. Usually not needed and all features besides auto getty creation are not available without libpam-systemd package.
+		#	- It will be unmasked/enabled, automatically if libpam-systemd got installed during dietpi-software install, usually with desktops.
+		systemctl stop systemd-logind
+		systemctl disable systemd-logind
 		systemctl mask systemd-logind
 
 		G_DIETPI-NOTIFY 2 'Configuring regional settings (TZdata):'

--- a/dietpi.txt
+++ b/dietpi.txt
@@ -59,6 +59,9 @@ AUTO_SETUP_SWAPFILE_SIZE=1
 #		Optional swapfile location
 AUTO_SETUP_SWAPFILE_LOCATION=/var/swap
 
+# Unmask (enable) systemd-logind service, which is masked by default on DietPi 
+AUTO_UNMASK_LOGIND=0
+
 ##### Software Automation Options #####
 
 #	Fully automate installation

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -16134,8 +16134,8 @@ _EOF_
 
 		# Unmask systemd-logind is set in dietpi.txt or libpam-systemd was installed
 		if [[ $(readlink /etc/systemd/system/systemd-logind.service) == '/dev/null' ]] &&
-			[[ $(grep -m1 '^[[:blank:]]*AUTO_UNMASK_SYSTEMD=1' /DietPi/dietpi.txt) ||
-			$(grep -m1 '^libpam-systemd[[:space:]]' <<< "$(dpkg --get-selections)") ]]; then
+			{ grep -q '^[[:blank:]]*AUTO_UNMASK_SYSTEMD=1' /DietPi/dietpi.txt ||
+			dpkg-query -s 'libpam-systemd' &> /dev/null; }; then
 
 			G_RUN_CMD systemctl unmask systemd-logind
 			systemctl enable systemd-logind &> /dev/null

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -16135,8 +16135,8 @@ _EOF_
 			$(grep -m1 '^libpam-systemd[[:space:]]' <<< "$(dpkg --get-selections)") ]]; then
 
 			G_RUN_CMD systemctl unmask systemd-logind
-			systemctl enable systemd-logind
-			systemctl start systemd-logind
+			systemctl enable systemd-logind &> /dev/null
+			systemctl start systemd-logind &> /dev/null
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -16135,6 +16135,8 @@ _EOF_
 			$(grep -m1 '^libpam-systemd[[:space:]]' <<< "$(dpkg --get-selections)") ]]; then
 
 			G_RUN_CMD systemctl unmask systemd-logind
+			systemctl enable systemd-logind
+			systemctl start systemd-logind
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -16132,9 +16132,9 @@ _EOF_
 		# Start installations for software
 		Run_Installations
 
-		# Unmask systemd-logind is set in dietpi.txt or libpam-systemd was installed
+		# Unmask systemd-logind if set in dietpi.txt or libpam-systemd was installed
 		if [[ $(readlink /etc/systemd/system/systemd-logind.service) == '/dev/null' ]] &&
-			{ grep -q '^[[:blank:]]*AUTO_UNMASK_SYSTEMD=1' /DietPi/dietpi.txt ||
+			{ grep -q '^[[:blank:]]*AUTO_UNMASK_LOGIND=1' /DietPi/dietpi.txt ||
 			dpkg-query -s 'libpam-systemd' &> /dev/null; }; then
 
 			G_RUN_CMD systemctl unmask systemd-logind

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -16129,6 +16129,15 @@ _EOF_
 		# Start installations for software
 		Run_Installations
 
+		# Unmask systemd-logind is set in dietpi.txt or libpam-systemd was installed
+		if [[ $(readlink /etc/systemd/system/systemd-logind.service) == '/dev/null' ]] &&
+			[[ $(grep -m1 '^[[:blank:]]*AUTO_UNMASK_SYSTEMD=1' /DietPi/dietpi.txt) ||
+			$(grep -m1 '^libpam-systemd[[:space:]]' <<< "$(dpkg --get-selections)") ]]; then
+
+			G_RUN_CMD systemctl unmask systemd-logind
+
+		fi
+
 		# Upload DietPi-Survey Data, if opted in, prompt user choice, if no settings file exists
 		/DietPi/dietpi/dietpi-survey 1
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1017,8 +1017,8 @@ _EOF_
 			#Mask systemd-logind as new default, if libpam-systemd is not installed: https://github.com/Fourdee/DietPi/issues/1767
 			if grep -q '^libpam-systemd[[:space:]]' <<< "$(dpkg --get-selections)"; then
 
-				systemctl stop systemd-logind
-				systemctl disable systemd-logind
+				systemctl stop systemd-logind &> /dev/null
+				systemctl disable systemd-logind &> /dev/null
 				systemctl mask systemd-logind
 
 			fi

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1015,7 +1015,7 @@ _EOF_
 			chown -R qbittorrent:dietpi /home/qbittorrent &> /dev/null
 			#-------------------------------------------------------------------------------
 			#Mask systemd-logind as new default, if libpam-systemd is not installed: https://github.com/Fourdee/DietPi/issues/1767
-			if grep -q '^libpam-systemd[[:space:]]' <<< "$(dpkg --get-selections)"; then
+			if dpkg-query -s 'libpam-systemd' &> /dev/null; then
 
 				systemctl stop systemd-logind &> /dev/null
 				systemctl disable systemd-logind &> /dev/null

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1014,6 +1014,9 @@ _EOF_
 			# - qBitTorrent: https://github.com/Fourdee/DietPi/issues/1957
 			chown -R qbittorrent:dietpi /home/qbittorrent &> /dev/null
 			#-------------------------------------------------------------------------------
+			#Mask systemd-logind as new default, if libpam-systemd is not installed: https://github.com/Fourdee/DietPi/issues/1767
+			grep -q '^libpam-systemd[[:space:]]' <<< "$(dpkg --get-selections)" || systemctl mask systemd-logind
+			#-------------------------------------------------------------------------------
 
 		fi
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1015,7 +1015,13 @@ _EOF_
 			chown -R qbittorrent:dietpi /home/qbittorrent &> /dev/null
 			#-------------------------------------------------------------------------------
 			#Mask systemd-logind as new default, if libpam-systemd is not installed: https://github.com/Fourdee/DietPi/issues/1767
-			grep -q '^libpam-systemd[[:space:]]' <<< "$(dpkg --get-selections)" || systemctl mask systemd-logind
+			if grep -q '^libpam-systemd[[:space:]]' <<< "$(dpkg --get-selections)"; then
+
+				systemctl stop systemd-logind
+				systemctl disable systemd-logind
+				systemctl mask systemd-logind
+
+			fi
 			#-------------------------------------------------------------------------------
 
 		fi


### PR DESCRIPTION
**Status**: Ready

**Reference**: https://github.com/Fourdee/DietPi/issues/1767

**Commit list/description**:
+ DietPi.txt | Setting to unmask systemd-logind, which is now masked by default, as long as libpam-systemd is not installed
+ DietPi-Software | Unmask systemd-logind after software installs, if it was masked and either dietpi.txt setting was found or libpam-systemd was installed
+ DietPi-PREP | Mask systemd-logind by default for new images
+ DietPi-Patchfile | Mask systemd-logind as new default, if libpam-systemd is not installed
+ CHANGELOG | Masked systemd-logind