### PR TITLE
DietPi-Set_CPU_fan | Allows to adjust CPU fan speed PWM control

### DIFF
--- a/dietpi/func/dietpi-set_cpu_fan
+++ b/dietpi/func/dietpi-set_cpu_fan
@@ -276,7 +276,7 @@ EG: To have trip points at 35°C, 50°C and 65°C, enter\n     \"35 50 65\""
 
 		G_WHIP_DEFAULT_ITEM="$TRIP_SPEEDS"
 		G_WHIP_INPUTBOX "Please enter $(( $TRIP_POINT_COUNT + 1 )) space-separated fan speeds in % (percent) of the maximum possible speed.
-EG: To disable the fan below $(( ${FP_TRIP_TEMPS} / 1000 ))°C, run it at 45% above, 70% after reaching $(( ${FP_TRIP_TEMPS/0_temp/1_temp} / 1000 ))°C and 95% above $(( ${FP_TRIP_TEMPS/0_temp/2_temp} / 1000 ))°C, enter
+EG: To disable the fan below $(( $(<$FP_TRIP_TEMPS) / 1000 ))°C, run it at 45% above, 70% after reaching $(( $(<${FP_TRIP_TEMPS/0_temp/1_temp}) / 1000 ))°C and 95% above $(( $(<${FP_TRIP_TEMPS/0_temp/2_temp}) / 1000 ))°C, enter
      \"0 45 70 95\""
 		if (( ! $? )); then
 
@@ -352,9 +352,6 @@ EG: To run the fan at 50%, enter\n     \"60\""
 			whip_message+="\nFan speed: ${STATIC_SPEED_CURRENT}%"
 
 		fi
-
-		# Read chosen fan control settings, to generate menu entries, use current settings as default
-		[[ -f $FP_SETTINGS ]] && Read_Settings
 
 		# - Control mode setting
 		TEMP_CONTROLLED=${TEMP_CONTROLLED:-$TEMP_CONTROLLED_CURRENT}
@@ -478,6 +475,9 @@ EG: To run the fan at 50%, enter\n     \"60\""
 
 	elif (( $INPUT == 0 )); then
 
+		# Read settings file, to generate menu entries and use current settings as default.
+		[[ -f $FP_SETTINGS ]] && Read_Settings
+
 		while true
 		do
 
@@ -493,6 +493,6 @@ EG: To run the fan at 50%, enter\n     \"60\""
 	fi
 
 	#-----------------------------------------------------------------------------------
-	G_DIETPI-NOTIFY -1 0 "$G_PROGRAM NAME |" && exit 0
+	G_DIETPI-NOTIFY -1 0 "$G_PROGRAM_NAME |" && exit 0
 	#-----------------------------------------------------------------------------------
 }

--- a/dietpi/func/dietpi-set_cpu_fan
+++ b/dietpi/func/dietpi-set_cpu_fan
@@ -13,8 +13,8 @@
 	# - Runs at boot up /DietPi/dietpi/boot, if settings were applied.
 	# - Toggles CPU fan temp control and:
 	#	- Sets trip point temps, e.g. 35°C, 50°C, 65°C
-	#	- Attaches PWM fan speeds to temp trip points, e.g. 0%, 45%, 70%, 95%
-	#	- Result: Fan off below 35°C, 45% fan speed at 35°C - 50°C, 70% fan speed at 50°C - 65°C, 95% fan speed above 65°C
+	#	- Attaches fan speeds to temp trip points, e.g. 0%, 45%, 70%, 95%
+	#	- Result: Fan off below 35°C, 45% fan speed at 35°C - 50°C, 70% fan speed at 50°C - 65°C and 95% fan speed above 65°C
 	#	or
 	#	- Sets static fan speed
 	#
@@ -33,189 +33,31 @@ dietpi-set_cpu_fan 1	=>	Non-interactively apply settings from $FP_SETTINGS.
 	G_CHECK_ROOT_USER
 	# Import DietPi-Globals ---------------------------------------------------------------
 
-	# Exit path for VM
-	if (( $G_HW_MODEL == 20 )); then
-
-		G_DIETPI-NOTIFY 1 'CPU fan control is not available on VMs. Aborting...'
-		exit 1
-
-	fi
-
-	# Control file paths
+	# File paths
 	FP_SETTINGS='/DietPi/dietpi/.dietpi-set_cpu_fan'
-	FP_FAN_CONTROL_TOGGLE='/sys/devices/platform/pwm-fan/hwmon/hwmon0/automatic'
-	FP_FAN_TRIP_TEMPS='/sys/devices/virtual/thermal/thermal_zone0/trip_point_0_temp'
-	FP_FAN_TRIP_SPEEDS='/sys/devices/platform/pwm-fan/hwmon/hwmon0/fan_speed'
-	FP_FAN_SPEED_STATIC='/sys/devices/platform/pwm-fan/hwmon/hwmon0/pwm1'
+	FP_TEMP_CONTROLLED='/sys/devices/platform/pwm-fan/hwmon/hwmon0/automatic'
+	FP_TRIP_TEMPS='/sys/devices/virtual/thermal/thermal_zone0/trip_point_0_temp'
+	FP_TRIP_SPEEDS='/sys/devices/platform/pwm-fan/hwmon/hwmon0/fan_speed'
+	FP_STATIC_SPEED='/sys/devices/platform/pwm-fan/hwmon/hwmon0/pwm1'
 
-	# Exit without control toggle file
-	if [[ ! -e $FP_FAN_CONTROL_TOGGLE ]]; then
+	# Exit path for unsupported devices
+	if ! [[ -e $FP_TEMP_CONTROLLED && -e $FP_TRIP_TEMPS && -e $FP_TRIP_SPEEDS && -e $FP_STATIC_SPEED ]]; then
 
-		G_DIETPI-NOTIFY 1 'CPU fan control is not available on your system. Aborting...'
+		# - DEBUG
+		echo "$FP_TEMP_CONTROLLED: $(<$FP_TEMP_CONTROLLED)"
+		echo "$FP_TRIP_TEMPS: $(<$FP_TRIP_TEMPS)"
+		echo "$FP_TRIP_SPEEDS: $(<$FP_TRIP_SPEEDS)"
+		echo "$FP_STATIC_SPEED: $(<$FP_STATIC_SPEED)"
+		G_DIETPI-NOTIFY 1 'CPU fan control is not available on your device. Aborting...'
 		exit 1
 
 	fi
 
 	# Grab valid input
 	INPUT=0
-	G_CHECK_VALIDINT $1 && INPUT=$1
+	if G_CHECK_VALIDINT $1; then
 
-	# Read settings file
-	# - $FAN_CONTROL_TOGGLE=0|1; On|Off
-	# - $FAN_TRIP_TEMPS='XX YY ZZ'; XX°C YY°C ZZ°C
-	# - $FAN_TRIP_SPEEDS='AAA BBB CCC DDD'; AAA*100/255 %...
-	# - $FAN_SPEED_STATIC=EEE; EEE*100/255 %
-	read_Settings(){
-
-		. $FP_SETTINGS
-
-	}
-
-	# Write settings file
-	write_Settings(){
-
-		# - Write fan control toggle to settings file
-		echo "FAN_CONTROL_TOGGLE=$FAN_CONTROL_TOGGLE" > $FP_SETTINGS
-
-		if (( $FAN_CONTROL_TOGGLE )); then
-
-			# - Write trip points and attached temperatures to settings file
-			cat << _EOF_ >> $FP_SETTINGS
-FAN_TRIP_TEMPS=$FAN_TRIP_TEMPS
-FAN_TRIP_SPEEDS=$FAN_TRIP_SPEEDS
-_EOF_
-
-		else
-
-			# - Write static fan speed to settings file
-			echo "FAN_SPEED_STATIC=$FAN_SPEED_STATIC" >> $FP_SETTINGS
-
-		fi
-
-	}
-
-	# Read currently applied fan control values
-	read_Current(){
-
-		# - Read current fan control toggle
-		FAN_CONTROL_TOGGLE=$(<$FP_FAN_CONTROL_TOGGLE)
-
-		if (( $FAN_CONTROL_TOGGLE )); then
-
-			# - Read current static fan speed
-			FAN_SPEED_STATIC=$(<$FP_FAN_SPEED_STATIC)
-
-		else
-
-			# - Read current trip point temperatures, assuming values for CPU0 for all CPUs
-			local fp_target=''
-			local i=0
-			for fp_target in /sys/devices/virtual/thermal/thermal_zone0/trip_point_*_temp
-			do
-
-				# Check for file existance. If no file matches string, $ft_target will return the pattern literally.
-				[[ ! -e $fp_target ]] && G_DIETPI-NOTIFY 1 'Trip point temperature files missing. Skipping...' && break
-
-				FAN_TRIP_TEMPS+=" $(</sys/devices/virtual/thermal/thermal_zone0/trip_point_$i_temp)"
-				((i++))
-
-			done
-			# - Remove leading white space
-			FAN_TRIP_TEMPS=${FAN_TRIP_TEMPS% }
-
-			# - Read current trip point fan speeds
-			FAN_TRIP_SPEEDS=$(<$FP_FAN_TRIP_SPEEDS)
-
-		fi
-
-	}
-
-	#/////////////////////////////////////////////////////////////////////////////////////
-	# Main Loop
-	#/////////////////////////////////////////////////////////////////////////////////////
-
-	if (( $INPUT == 1 )); then
-
-		#-----------------------------------------------------------------------------------
-		G_DIETPI-NOTIFY 3 $G_PROGRAM_NAME 'Applying CPU fan settings'
-		#-----------------------------------------------------------------------------------
-
-		# Read settings file, if successfully created
-		if [[ -f $FP_SETTINGS ]]; then
-
-			read_Settings
-
-		else
-
-			G_DIETPI-NOTIFY 1 'No CPU fan control settings file found. Please start "dietpi-set_cpu_fan" first. Aborting...'
-			exit 1
-
-		fi
-
-		# Exit without control files, needed for chosen settings
-		if (( $FAN_CONTROL_TOGGLE )) && [[ ! -e $FP_FAN_TRIP_TEMPS || ! -e $FP_FAN_TRIP_SPEEDS ]]; then
-
-			G_DIETPI-NOTIFY 2 'Temperature based CPU fan control is not available on your system. Aborting...'
-			exit 1
-
-		elif (( ! $FAN_CONTROL_TOGGLE )) && [[ ! -e $FP_FAN_SPEED_STATIC ]]; then
-
-			G_DIETPI-NOTIFY 2 'Changing constant CPU fan speed is not available on your system. Aborting...'
-			exit 1
-
-		fi
-
-		# Apply chosen settings
-		if (( $FAN_CONTROL_TOGGLE )); then
-
-			# - Exit with empty settings strings
-			if [[ -z $FAN_TRIP_TEMPS || -z $FAN_TRIP_SPEEDS ]]; then
-
-				G_DIETPI-NOTIFY 1 'Invalid settings found. Please run "dietpi-set_cpu_fan" to re-apply valid settings. Aborting...'
-				exit 1
-
-			fi
-
-			# - Apply trip point temps
-			local i=0
-			for (( i=0; i<$G_HW_CPU_CORES; i++ ))
-			do
-
-				local fp_target=''
-				local j=0
-				for fp_target in /sys/devices/virtual/thermal/thermal_zone$i/trip_point_*_temp
-				do
-
-					# Check for file existance. If no file matches string, $ft_target will return the pattern literally.
-					[[ ! -e $fp_target ]] && G_DIETPI-NOTIFY 1 "Trip point temperature files missing. Skipping CPU$i" && break
-
-					awk '{print $((j+1))}' <<< $FAN_TRIP_TEMPS > /sys/devices/virtual/thermal/thermal_zone$i/trip_point_$j_temp
-					((j++))
-
-				done
-
-			done
-
-			# - Apply trip point fan speeds
-			echo $FAN_TRIP_SPEEDS > $FP_FAN_TRIP_SPEEDS
-
-		else
-
-			# - Exit with empty settings string
-			if [[ -z $FAN_SPEED_STATIC ]]; then
-
-				G_DIETPI-NOTIFY 1 'Invalid settings found. Please run "dietpi-set_cpu_fan" to re-apply valid settings. Aborting...'
-				exit 1
-
-			fi
-
-			# - Apply static fan speed
-			echo $FAN_SPEED_STATIC > $FP_FAN_SPEED_STATIC
-
-		fi
-
-		# - Apply fan control toggle
-		echo $FAN_CONTROL_TOGGLE > $FP_FAN_CONTROL_TOGGLE
+		INPUT=$1
 
 	else
 
@@ -225,6 +67,324 @@ _EOF_
 	fi
 
 	#-----------------------------------------------------------------------------------
-	exit 0
+	# Functions
+	#-----------------------------------------------------------------------------------
+	# Read currently applied fan control values
+	Read_Control_Files(){
+
+		# - Read current fan control toggle
+		TEMP_CONTROLLED_CURRENT=$(<$FP_TEMP_CONTROLLED)
+
+		if (( $TEMP_CONTROLLED_CURRENT )); then
+
+			# - Read current trip point temperatures, assuming values for CPU0 for all CPUs
+			local fp_target=''
+			local i=0
+			for fp_target in /sys/devices/virtual/thermal/thermal_zone0/trip_point_*_temp
+			do
+
+				#	- Convert "XY000" to XY°C
+				TRIP_TEMPS_CURRENT+=" $(( $(</sys/devices/virtual/thermal/thermal_zone0/trip_point_${i}_temp) / 1000 ))"
+				((i++))
+
+			done
+			#	- Remove leading white space
+			TRIP_TEMPS_CURRENT=${TRIP_TEMPS_CURRENT# }
+
+			# - Read current trip point fan speeds
+			for i in $(<$FP_TRIP_SPEEDS)
+			do
+
+				#	- Convert 0-255 to 0-100%
+				TRIP_SPEEDS_CURRENT+=" $(( $i * 100 / 255 ))"
+
+			done
+			#	- Remove leading white space
+			TRIP_SPEEDS_CURRENT=${TRIP_SPEEDS_CURRENT# }
+
+		else
+
+			# - Read current static fan speed
+			#	- Convert 0-255 to 0-100%
+			STATIC_SPEED_CURRENT=$(( $(<$FP_STATIC_SPEED) * 100 / 255 ))
+
+		fi
+
+	}
+
+	# Read settings from file
+	# - $TEMP_CONTROLLED=0|1; On|Off
+	# - $TRIP_TEMPS='XX YY ZZ'; XX°C YY°C ZZ°C
+	# - $TRIP_SPEEDS='AAA BBB CCC DDD'; AAA*100/255 %...
+	# - $STATIC_SPEED=EEE; EEE*100/255 %
+	Read_Settings(){
+
+		. $FP_SETTINGS
+
+	}
+
+	# Verify valid settings, before applying
+	Verify_Settings(){
+
+		# - $TEMP_CONTROLLED is expected to be either 0 or 1.
+		if ! [[ $TEMP_CONTROLLED == 0 || $TEMP_CONTROLLED == 1 ]]; then
+
+			G_DIETPI-NOTIFY 1 "Invalid setting: \$TEMP_CONTROLLED=$TEMP_CONTROLLED"
+			return 1
+
+		elif (( $TEMP_CONTROLLED )); then
+
+			# - $TRIP_SPEEDS and $TRIP_TEMPS are expected to follow scheme: [0-9]+[[:blank:]][0-9]+...
+			# - $TRIP_TEMPS need to match than $TRIP_POINT_COUNT: Amount of actual CPU0 thermal zone control files
+			# - $TRIP_SPEEDS values need to be exactly one more: Min speed + one each temp trip
+			if ! [[ $TRIP_TEMPS =~ ^[0-9[:blank:]]+$ && $TRIP_SPEEDS =~ ^[0-9[:blank:]]+$ ]] ||
+				! (( $(wc -w <<< "$TRIP_TEMPS") == $TRIP_POINT_COUNT && $(wc -w <<< "$TRIP_SPEEDS") == $TRIP_POINT_COUNT + 1 )); then
+
+				G_DIETPI-NOTIFY 1 "Invalid settings: \$TRIP_TEMPS=$TRIP_TEMPS; \$TRIP_SPEEDS=$TRIP_SPEEDS"
+				return 1
+
+			fi
+
+		elif (( ! $TEMP_CONTROLLED )); then
+
+			# - $STATIC_SPEED is expected to be an integer.
+			if ! G_CHECK_VALIDINT $STATIC_SPEED; then
+
+				G_DIETPI-NOTIFY 1 "Invalid setting: \$STATIC_SPEED=$STATIC_SPEED"
+				return 1
+
+			fi
+
+		fi
+
+		G_DIETPI-NOTIFY 0 'Valid settings verified' # DEBUG
+		return 0
+
+	}
+
+	# Write settings to file
+	Write_Settings(){
+
+		# - Write fan control toggle to settings file
+		echo "TEMP_CONTROLLED=$TEMP_CONTROLLED" > $FP_SETTINGS
+
+		if (( $TEMP_CONTROLLED )); then
+
+			# - Write trip points and attached temperatures to settings file
+			cat << _EOF_ >> $FP_SETTINGS
+TRIP_TEMPS=$TRIP_TEMPS
+TRIP_SPEEDS=$TRIP_SPEEDS
+_EOF_
+
+		else
+
+			# - Write static fan speed to settings file
+			echo "STATIC_SPEED=$STATIC_SPEED" >> $FP_SETTINGS
+
+		fi
+
+	}
+
+	# Apply chosen settings to control files
+	Apply_Settings(){
+
+		#-----------------------------------------------------------------------------------
+		G_DIETPI-NOTIFY 3 $G_PROGRAM_NAME 'Applying CPU fan settings'
+		#-----------------------------------------------------------------------------------
+		# - Apply fan control toggle
+		echo $TEMP_CONTROLLED > $FP_TEMP_CONTROLLED
+
+		if (( $TEMP_CONTROLLED )); then
+
+			local i=0
+
+			# - Apply trip point temps
+			local j=0
+			local temp=0
+			local fp_target=''
+			for (( i=0; i<$G_HW_CPU_CORES; i++ ))
+			do
+
+				j=0
+				for temp in $TRIP_TEMPS
+				do
+
+					fp_target="/sys/devices/virtual/thermal/thermal_zone${i}/trip_point_${j}_temp"
+					#	- DEBUG: Check for file existence, otherwise break for current CPU
+					[[ ! -e $fp_target ]] && G_DIETPI-NOTIFY 1 "Trip point temperature file missing: $fp_target. Skipping..." && break
+
+					#	- Convert XY°C to XY000
+					echo "${temp}000" > $fp_target
+					((j++))
+
+				done
+
+			done
+
+			# - Apply trip point fan speeds
+			local trip_speeds_target=''
+			for i in $TRIP_SPEEDS
+			do
+
+				#	- Convert 0-100% to 0-255
+				trip_speeds_target+=" $(( $i * 255 / 100 ))"
+
+			done
+			#	- Remove leading white space
+			trip_speeds_target=${trip_speeds_target# }
+			echo $trip_speeds_target > $FP_TRIP_SPEEDS
+
+		else
+
+			# - Apply static fan speed
+			#	- Convert 0-100% to 0-255
+			echo $(( $STATIC_SPEED * 255 / 100 )) > $FP_STATIC_SPEED
+
+		fi
+
+	}
+
+	#-----------------------------------------------------------------------------------
+	# Menus
+	#-----------------------------------------------------------------------------------
+	# Main menu
+	Main_Menu(){
+
+		# Currently applied fan controls
+		Read_Control_Files
+
+		if (( $TEMP_CONTROLLED_CURRENT )); then
+
+			# - Current control mode
+			local mode_current_text='Temperature controlled'
+
+			local i=''
+
+			# - Current trip point temps
+			local trip_speeds_current_text=''
+			for i in $TRIP_TEMPS_CURRENT
+			do
+
+				trip_temps_current_text+="	${i}°C"
+
+			done
+			#	- Remove leading white space
+			trip_temps_current_text=${trip_temps_current_text#	}
+
+			# - Current trip point speeds
+			local trip_speeds_current_text=''
+			for i in $TRIP_SPEEDS_CURRENT
+			do
+
+				trip_speeds_current_text+="	${i}%"
+
+			done
+			#	- Remove leading white space
+			trip_speeds_current_text=${trip_speeds_current_text#	}
+
+		else
+
+			# - Current control mode
+			local mode_current_text='Static fan speed'
+
+			# - Static fan speed
+			local static_speed_current_text="${STATIC_SPEED_CURRENT}%"
+
+		fi
+
+		# Chosen fan control settings
+		[[ -f $FP_SETTINGS ]] && Read_Settings
+
+		# - Control mode setting
+		TEMP_CONTROLLED=${TEMP_CONTROLLED:-$TEMP_CONTROLLED_CURRENT}
+		local mode_text='Temperature controlled'
+		(( $TEMP_CONTROLLED )) && mode_current_text='Static fan speed'
+
+		G_WHIP_MENU_ARRAY=(
+
+			'Reset' 'Remove current settings file to reset fan control on reboot'
+			'Mode' "$mode_text"
+
+		)
+
+		if (( $TEMP_CONTROLLED )); then
+
+			local i=''
+
+			# - Trip point temperature settings
+			TRIP_TEMPS=${TRIP_TEMPS:-$TRIP_TEMPS_CURRENT}
+			local trip_speeds_text=''
+			for i in $TRIP_TEMPS
+			do
+
+				trip_temps_text+="	${i}°C"
+
+			done
+			#	- Remove leading white space
+			trip_temps_text=${trip_temps_text#	}
+
+			# - Trip point speed settings
+			TRIP_SPEEDS=${TRIP_SPEEDS:-$TRIP_SPEEDS_CURRENT}
+			local trip_speeds_text=''
+			for i in $TRIP_SPEEDS
+			do
+
+				trip_speeds_text+="	${i}%"
+
+			done
+			#	- Remove leading white space
+			trip_speeds_text=${trip_speeds_text#	}
+
+			G_WHIP_MENU_ARRAY+=(
+
+				'Temperatures' "$trip_temps_text"
+				'Fan speeds' "$trip_speeds_text"
+
+			)
+
+		else
+
+			# - Static fan speed setting
+			STATIC_SPEED=${STATIC_SPEED:-$STATIC_SPEED_CURRENT}
+			local static_speed_current_text="${STATIC_SPEED}%"
+
+		fi
+
+		G_WHIP_MENU_ARRAY+=( 'Apply' 'Apply fan control settings now and on every boot up' )
+
+	}
+
+	#/////////////////////////////////////////////////////////////////////////////////////
+	# Main Loop
+	#/////////////////////////////////////////////////////////////////////////////////////
+
+	TRIP_POINT_COUNT=$(find /sys/devices/virtual/thermal/thermal_zone0 -name 'trip_point_*_temp' | wc -l)
+
+	if (( $INPUT == 1 )); then
+
+		# Exit, if no settings file exists
+		if [[ ! -f $FP_SETTINGS ]]; then
+
+			G_DIETPI-NOTIFY 1 'No CPU settings file found. Please start "dietpi-set_cpu_fan" first. Aborting...'
+			exit 1
+
+		fi
+
+		Read_Settings
+		Verify_Settings && Apply_Settings
+
+	elif (( $INPUT == 0 )); then
+
+		Main_Menu
+
+	else
+
+		G_DIETPI-NOTIFY 1 "Invalid input argument found. Aborting...\n$AVAIABLE_COMMANDS"
+		exit 1
+
+	fi
+
+	#-----------------------------------------------------------------------------------
+	G_DIETPI-NOTIFY -1 0 "$G_PROGRAM NAME |" && exit 0
 	#-----------------------------------------------------------------------------------
 }

--- a/dietpi/func/dietpi-set_cpu_fan
+++ b/dietpi/func/dietpi-set_cpu_fan
@@ -1,0 +1,131 @@
+#!/bin/bash
+{
+	#////////////////////////////////////
+	# DietPi CPU fan PWM script
+	#
+	#////////////////////////////////////
+	# Created by Micha Felle / micha@dietpi.com / dietpi.com
+	#
+	#////////////////////////////////////
+	#
+	# Info:
+	# - Location: /DietPi/dietpi/func/dietpi-set_cpu_fan + /boot/dietpi/func/dietpi-set_cpu_fan
+	# - Runs at boot up /DietPi/dietpi/boot
+	# - Toggles CPU fan temp control and:
+	#	- Sets temp strip points, e.g. 35°C, 50°C, 65°C
+	#	- Attaches PWM fan speeds to temp strip points, e.g. 0%, 45%, 70%, 95%
+	#	or
+	#	- Sets constant fan speed
+	#////////////////////////////////////
+
+	#Import DietPi-Globals ---------------------------------------------------------------
+	. /DietPi/dietpi/func/dietpi-globals
+	export G_PROGRAM_NAME='DietPi-Set_CPU_fan'
+	G_INIT
+	G_CHECK_ROOT_USER
+	#Import DietPi-Globals ---------------------------------------------------------------
+
+	#Exit path for VM
+	if (( $G_HW_MODEL == 20 )); then
+
+		G_DIETPI-NOTIFY 2 'CPU fan control is not available on VMs.'
+		exit
+
+	fi
+
+	#Control file paths
+	FP_SETTINGS='/DietPi/dietpi/.dietpi-set_cpu_fan'
+	FP_FAN_CONTROL_TOGGLE='/sys/devices/platform/pwm-fan/hwmon/hwmon0/automatic'
+	FP_FAN_TRIP_TEMPS='/sys/devices/virtual/thermal/thermal_zone0/trip_point_0_temp'
+	FP_FAN_TRIP_SPEEDS='/sys/devices/platform/pwm-fan/hwmon/hwmon0/fan_speed'
+	FP_FAN_SPEED_FIXED='/sys/devices/platform/pwm-fan/hwmon/hwmon0/pwm1'
+
+	#Exit without settings or control toggle file
+	if [[ ! -f $FP_SETTINGS ]]; then
+
+		G_DIETPI-NOTIFY 2 'No settings file found, keep system defaults'
+		exit
+
+	elif [[ ! -e $FP_FAN_CONTROL_TOGGLE ]]; then
+
+		G_DIETPI-NOTIFY 2 'CPU fan PWM control is not available on your system.'
+		exit
+
+	fi
+
+	#/////////////////////////////////////////////////////////////////////////////////////
+	# Main Loop
+	#/////////////////////////////////////////////////////////////////////////////////////
+	#-----------------------------------------------------------------------------------
+	G_DIETPI-NOTIFY 3 $G_PROGRAM_NAME 'Applying CPU fan PWN settings'
+	#-----------------------------------------------------------------------------------
+	#Read settings file
+	# - $FAN_CONTROL_TOGGLE=0|1; On|Off
+	# - $FAN_TRIP_TEMPS='XX YY ZZ'; XX°C YY°C ZZ°C
+	# - $FAN_TRIP_SPEEDS='AAA BBB CCC DDD'; AAA*100/255 %...
+	# - $FAN_SPEED_FIXED=EEE; EEE*100/255 %
+	. $FP_SETTINGS
+
+	#Exit without control files, needed for chosen settings
+	if (( $FAN_CONTROL_TOGGLE )) && [[ ! -e $FP_FAN_TRIP_TEMPS || ! -e $FP_FAN_TRIP_SPEEDS ]]; then
+
+		G_DIETPI-NOTIFY 2 'Temperature based CPU fan PWM control is not available on your system.'
+		exit
+
+	elif (( ! $FAN_CONTROL_TOGGLE )) && [[ ! -e $FP_FAN_SPEED_FIXED ]]; then
+
+		G_DIETPI-NOTIFY 2 'Changing constant CPU fan speed is not available on your system.'
+		exit
+
+	fi
+
+	#Apply chosen settings
+	if (( $FAN_CONTROL_TOGGLE )); then
+
+		# Exit without control files files or empty settings strings
+		if [[ ! -e $FP_FAN_TRIP_TEMPS || ! -e $FP_FAN_TRIP_SPEEDS ||
+			-z $FAN_TRIP_TEMPS || -z $FAN_TRIP_SPEEDS ]]; then
+
+			G_DIETPI-NOTIFY 2 'Temperature based CPU fan PWM control not chosen or not available on your system.'
+			exit
+
+		fi
+
+		local i=0
+		for (( i=0; i<$G_HW_CPU_CORES; i++ ))
+		do
+
+			local fp_target=''
+			local j=0
+			for fp_target in /sys/devices/virtual/thermal/thermal_zone$i/trip_point_*_temp
+			do
+
+				awk '{print $((j+1))}' <<< $FAN_TRIP_TEMPS > /sys/devices/virtual/thermal/thermal_zone$i/trip_point_$j_temp
+				((j++))
+
+			done
+
+		done
+
+		echo $FAN_TRIP_SPEEDS > $FP_FAN_TRIP_SPEEDS
+
+	else
+
+		# Exit without needed control file or empty settings string
+		if [[ ! -e $FP_FAN_SPEED_FIXED || -z $FAN_SPEED_FIXED ]]; then
+
+			G_DIETPI-NOTIFY 2 'Changing constant CPU fan speed not chosen or not available on your system.'
+			exit
+
+		fi
+
+		echo $FAN_SPEED_FIXED > $FP_FAN_SPEED_FIXED
+
+	fi
+
+	echo $FAN_CONTROL_TOGGLE > $FP_FAN_CONTROL_TOGGLE
+
+	#-----------------------------------------------------------------------------------
+	exit
+	#-----------------------------------------------------------------------------------
+}

--- a/dietpi/func/dietpi-set_cpu_fan
+++ b/dietpi/func/dietpi-set_cpu_fan
@@ -355,12 +355,12 @@ EG: To run the fan at 50%, enter\n     \"60\""
 
 		# - Control mode setting
 		TEMP_CONTROLLED=${TEMP_CONTROLLED:-$TEMP_CONTROLLED_CURRENT}
-		local mode_text='Temperature controlled'
-		(( $TEMP_CONTROLLED )) && mode_text='Static fan speed'
+		local mode_text='Static fan speed'
+		(( $TEMP_CONTROLLED )) && mode_text='Temperature controlled'
 		G_WHIP_MENU_ARRAY=(
 
-			'Reset' 'Remove current settings file to reset fan control on reboot'
-			'Mode' "Toggle fan control mode, Selected: $mode_text"
+			'Reset' 'Remove settings file and reset selections'
+			'Mode' "Selected:  $mode_text"
 
 		)
 
@@ -375,7 +375,7 @@ EG: To run the fan at 50%, enter\n     \"60\""
 				trip_temps_text+=" ${i}°C"
 
 			done
-			G_WHIP_MENU_ARRAY+=( 'Temperatures' "Selected:     $trip_temps_text" )
+			G_WHIP_MENU_ARRAY+=( 'Temp points' "Selected:     $trip_temps_text" )
 
 			# - Trip point speed settings
 			TRIP_SPEEDS="${TRIP_SPEEDS:-$TRIP_SPEEDS_CURRENT}"
@@ -392,11 +392,11 @@ EG: To run the fan at 50%, enter\n     \"60\""
 
 			# - Static fan speed setting
 			STATIC_SPEED=${STATIC_SPEED:-$STATIC_SPEED_CURRENT}
-			G_WHIP_MENU_ARRAY+=( 'Fan speed' "Selected: ${STATIC_SPEED}%" )
+			G_WHIP_MENU_ARRAY+=( 'Fan speed' "Selected:  ${STATIC_SPEED}%" )
 
 		fi
 
-		G_WHIP_MENU_ARRAY+=( 'Apply' 'Apply fan control settings now and on every boot up' )
+		G_WHIP_MENU_ARRAY+=( 'Apply' 'Apply selected settings now and automatically on boot' )
 		G_WHIP_BUTTON_CANCEL_TEXT='Exit'
 		G_WHIP_MENU "$whip_message"
 		if (( ! $? )); then
@@ -418,7 +418,7 @@ EG: To run the fan at 50%, enter\n     \"60\""
 
 				fi
 
-			elif [[ $G_WHIP_RETURNED_VALUE == 'Temperatures' ]]; then
+			elif [[ $G_WHIP_RETURNED_VALUE == 'Temp points' ]]; then
 
 				Temps_Menu
 

--- a/dietpi/func/dietpi-set_cpu_fan
+++ b/dietpi/func/dietpi-set_cpu_fan
@@ -247,60 +247,125 @@ _EOF_
 	#-----------------------------------------------------------------------------------
 	# Menus
 	#-----------------------------------------------------------------------------------
-	# Main menu
+	Reset_Menu(){
+
+		G_WHIP_YESNO 'Reset fan control settings\n\nYour fan control settings file will be removed and current selections purged. This will take effect after next reboot.\n\nDo you want to continue?'
+		if (( ! $? )); then
+
+			l_message="Removing $FP_SETTINGS" G_RUN_CMD rm $FP_SETTINGS
+			l_message='Resetting current selections' G_RUN_CMD unset TEMP_CONTROLLED TRIP_TEMPS TRIP_SPEEDS STATIC_SPEED
+
+		fi
+
+	}
+
+	Temps_Menu(){
+
+		G_WHIP_DEFAULT_ITEM="$TRIP_TEMPS"
+		G_WHIP_INPUTBOX "Please enter $TRIP_POINT_COUNT space-separated temperature points in °C.
+EG: To have trip points at 35°C, 50°C and 65°C, enter\n\t\"35 50 65\""
+		if (( ! $? )); then
+
+			TRIP_TEMPS="$G_WHIP_RETURNED_VALUE"
+
+		fi
+
+	}
+
+	Speeds_Menu(){
+
+		G_WHIP_DEFAULT_ITEM="$TRIP_SPEEDS"
+		G_WHIP_INPUTBOX "Please enter $(( $TRIP_POINT_COUNT + 1 )) space-separated fan speeds in % (percent) of the maximum possible speed.
+EG: To disable the fan below $(( ${FP_TRIP_TEMPS} / 1000 ))°C, run it at 45% above, 70% after reaching $(( ${FP_TRIP_TEMPS/0_temp/1_temp} / 1000 ))°C and 95% above $(( ${FP_TRIP_TEMPS/0_temp/2_temp} / 1000 ))°C, enter
+\t\"0 45 70 95\""
+		if (( ! $? )); then
+
+			TRIP_SPEEDS="$G_WHIP_RETURNED_VALUE"
+
+		fi
+
+	}
+
+	Speed_Menu(){
+
+		G_WHIP_DEFAULT_ITEM="$TRIP_SPEEDS"
+		G_WHIP_INPUTBOX "Please enter the desired static fan speeds in % (percent) of the maximum possible speed.
+EG: To run the fan at 50%, enter\n\t\"60\""
+		if (( ! $? )); then
+
+			STATIC_SPEED="$G_WHIP_RETURNED_VALUE"
+
+		fi
+
+	}
+
+	Reboot_Menu(){
+
+		G_WHIP_BUTTON_CANCEL_TEXT='Later'
+		G_WHIP_YESNO 'Reboot now?\n\nThe system default fan controls are automatically applied after next reboot. Do you want to reboot now?'
+		if (( ! $? )); then
+
+			reboot
+			exit 0
+
+		fi
+
+	}
+
 	Main_Menu(){
 
 		local i=''
 
-		# Currently applied fan controls
+		# Read currently applied fan controls, to generate status message
 		Read_Control_Files
+		local whip_message=''
 
 		if (( $TEMP_CONTROLLED_CURRENT )); then
 
 			# - Current control mode
-			local mode_current_text='Temperature controlled'
+			whip_message+='Mode:	Temperature controlled'
 
 			# - Current trip point temps
-			local trip_temps_current_text=''
+			whip_message+='\nTemperatures:	'
 			for i in $TRIP_TEMPS_CURRENT
 			do
 
-				trip_temps_current_text+="	${i}°C"
+				whip_message+="	${i}°C"
 
 			done
 
 			# - Current trip point speeds
-			local trip_speeds_current_text=''
+			whip_message+='\nFan speeds:'
 			for i in $TRIP_SPEEDS_CURRENT
 			do
 
-				trip_speeds_current_text+="	${i}%"
+				whip_message+="	${i}%"
 
 			done
 			#	- Remove leading tab
-			trip_speeds_current_text=${trip_speeds_current_text#	}
+			#trip_speeds_current_text=${trip_speeds_current_text#	}
 
 		else
 
 			# - Current control mode
-			local mode_current_text='Static fan speed'
+			whip_message+='Mode:	Static fan speed'
 
 			# - Static fan speed
-			local static_speed_current_text="${STATIC_SPEED_CURRENT}%"
+			whip_message+="\nFan speed:	${STATIC_SPEED_CURRENT}%"
 
 		fi
 
-		# Chosen fan control settings
+		# Read chosen fan control settings, to generate menu entries, use current settings as default
 		[[ -f $FP_SETTINGS ]] && Read_Settings
 
 		# - Control mode setting
 		TEMP_CONTROLLED=${TEMP_CONTROLLED:-$TEMP_CONTROLLED_CURRENT}
 		local mode_text='Temperature controlled'
-		(( $TEMP_CONTROLLED )) && mode_current_text='Static fan speed'
+		(( $TEMP_CONTROLLED )) && mode_text='Static fan speed'
 		G_WHIP_MENU_ARRAY=(
 
 			'Reset' 'Remove current settings file to reset fan control on reboot'
-			'Mode' "$mode_text"
+			'Mode' "Toggle fan control mode, Selected: $mode_text"
 
 		)
 
@@ -315,7 +380,7 @@ _EOF_
 				trip_temps_text+="	${i}°C"
 
 			done
-			G_WHIP_MENU_ARRAY+=( 'Temperatures' "$trip_temps_text" )
+			G_WHIP_MENU_ARRAY+=( 'Temperatures' "Selected: $trip_temps_text" )
 
 			# - Trip point speed settings
 			TRIP_SPEEDS=${TRIP_SPEEDS:-$TRIP_SPEEDS_CURRENT}
@@ -328,18 +393,66 @@ _EOF_
 			done
 			#	- Remove leading tab
 			trip_speeds_text=${trip_speeds_text#	}
-			G_WHIP_MENU_ARRAY+=( 'Fan speeds' "$trip_speeds_text" )
+			G_WHIP_MENU_ARRAY+=( 'Fan speeds' "Selected: $trip_speeds_text" )
 
 		else
 
 			# - Static fan speed setting
 			STATIC_SPEED=${STATIC_SPEED:-$STATIC_SPEED_CURRENT}
-			local static_speed_current_text="${STATIC_SPEED}%"
-			G_WHIP_MENU_ARRAY+=( 'Fan speed' "$static_speed_current_text" )
+			G_WHIP_MENU_ARRAY+=( 'Fan speed' "Selected: ${STATIC_SPEED}%" )
 
 		fi
 
 		G_WHIP_MENU_ARRAY+=( 'Apply' 'Apply fan control settings now and on every boot up' )
+		G_WHIP_BUTTON_CANCEL_TEXT='Exit'
+		G_WHIP_MENU "$whip_message"
+		if (( ! $? )); then
+
+			if [[ $G_WHIP_RETURNED_VALUE == 'Reset' ]]; then
+
+				Reset_Menu
+				Reboot_Menu
+
+			elif [[ $G_WHIP_RETURNED_VALUE == 'Mode' ]]; then
+
+				if (( $TEMP_CONTROLLED )); then
+
+					TEMP_CONTROLLED=0
+
+				else
+
+					TEMP_CONTROLLED=1
+
+				fi
+
+			elif [[ $G_WHIP_RETURNED_VALUE == 'Temperatures' ]]; then
+
+				Temps_Menu
+
+			elif [[ $G_WHIP_RETURNED_VALUE == 'Fan speeds' ]]; then
+
+				Speeds_Menu
+
+			elif [[ $G_WHIP_RETURNED_VALUE == 'Fan speed' ]]; then
+
+				Static_Speed_Menu
+
+			elif [[ $G_WHIP_RETURNED_VALUE == 'Apply' ]]; then
+
+				if Verify_Settings; then
+
+					Apply_Settings
+					Write_Settings
+
+				else
+
+					G_WHIP_MSG '[FAILURE] Invalid settings found\n\nYour chosen settings are invalid. Please re-select or reset and follow the instructions within the selection menus.\n\nNothing got applied.'
+
+				fi
+
+			fi
+
+		fi
 
 	}
 
@@ -347,6 +460,7 @@ _EOF_
 	# Main Loop
 	#/////////////////////////////////////////////////////////////////////////////////////
 
+	# Read possibly variable amount of trip points
 	TRIP_POINT_COUNT=$(find /sys/devices/virtual/thermal/thermal_zone0 -name 'trip_point_*_temp' | wc -l)
 
 	if (( $INPUT == 1 )); then
@@ -364,7 +478,12 @@ _EOF_
 
 	elif (( $INPUT == 0 )); then
 
-		Main_Menu
+		while true
+		do
+
+			Main_Menu || break
+
+		done
 
 	else
 

--- a/dietpi/func/dietpi-set_cpu_fan
+++ b/dietpi/func/dietpi-set_cpu_fan
@@ -55,14 +55,18 @@ dietpi-set_cpu_fan 1	=>	Non-interactively apply settings from $FP_SETTINGS.
 
 	# Grab valid input
 	INPUT=0
-	if G_CHECK_VALIDINT $1; then
+	if [[ $@ ]]; then
 
-		INPUT=$1
+		if G_CHECK_VALIDINT "$@"; then
 
-	else
+			INPUT=$@
 
-		G_DIETPI-NOTIFY 1 "Invalid input argument found. Aborting...\n$AVAIABLE_COMMANDS"
-		exit 1
+		else
+
+			G_DIETPI-NOTIFY 1 "Invalid input argument ($@) found. Aborting...\n$AVAIABLE_COMMANDS"
+			exit 1
+
+		fi
 
 	fi
 
@@ -75,40 +79,36 @@ dietpi-set_cpu_fan 1	=>	Non-interactively apply settings from $FP_SETTINGS.
 		# - Read current fan control toggle
 		TEMP_CONTROLLED_CURRENT=$(<$FP_TEMP_CONTROLLED)
 
-		if (( $TEMP_CONTROLLED_CURRENT )); then
+		# - Read current trip point temperatures, assuming values of CPU0 for all CPUs
+		local fp_target=''
+		local i=0
+		TRIP_TEMPS_CURRENT=''
+		for fp_target in /sys/devices/virtual/thermal/thermal_zone0/trip_point_*_temp
+		do
 
-			# - Read current trip point temperatures, assuming values for CPU0 for all CPUs
-			local fp_target=''
-			local i=0
-			for fp_target in /sys/devices/virtual/thermal/thermal_zone0/trip_point_*_temp
-			do
+			#	- Convert "XY000" to XY°C
+			TRIP_TEMPS_CURRENT+=" $(( $(</sys/devices/virtual/thermal/thermal_zone0/trip_point_${i}_temp) / 1000 ))"
+			((i++))
 
-				#	- Convert "XY000" to XY°C
-				TRIP_TEMPS_CURRENT+=" $(( $(</sys/devices/virtual/thermal/thermal_zone0/trip_point_${i}_temp) / 1000 ))"
-				((i++))
+		done
+		#	- Remove leading white space
+		TRIP_TEMPS_CURRENT="${TRIP_TEMPS_CURRENT# }"
 
-			done
-			#	- Remove leading white space
-			TRIP_TEMPS_CURRENT=${TRIP_TEMPS_CURRENT# }
+		# - Read current trip point fan speeds
+		TRIP_SPEEDS_CURRENT=''
+		for i in $(<$FP_TRIP_SPEEDS)
+		do
 
-			# - Read current trip point fan speeds
-			for i in $(<$FP_TRIP_SPEEDS)
-			do
-
-				#	- Convert 0-255 to 0-100%
-				TRIP_SPEEDS_CURRENT+=" $(( $i * 100 / 255 ))"
-
-			done
-			#	- Remove leading white space
-			TRIP_SPEEDS_CURRENT=${TRIP_SPEEDS_CURRENT# }
-
-		else
-
-			# - Read current static fan speed
 			#	- Convert 0-255 to 0-100%
-			STATIC_SPEED_CURRENT=$(( $(<$FP_STATIC_SPEED) * 100 / 255 ))
+			TRIP_SPEEDS_CURRENT+=" $(( $i * 100 / 255 ))"
 
-		fi
+		done
+		#	- Remove leading white space
+		TRIP_SPEEDS_CURRENT="${TRIP_SPEEDS_CURRENT# }"
+
+		# - Read current static fan speed
+		#	- Convert 0-255 to 0-100%
+		STATIC_SPEED_CURRENT=$(( $(<$FP_STATIC_SPEED) * 100 / 255 ))
 
 	}
 
@@ -172,8 +172,8 @@ dietpi-set_cpu_fan 1	=>	Non-interactively apply settings from $FP_SETTINGS.
 
 			# - Write trip points and attached temperatures to settings file
 			cat << _EOF_ >> $FP_SETTINGS
-TRIP_TEMPS=$TRIP_TEMPS
-TRIP_SPEEDS=$TRIP_SPEEDS
+TRIP_TEMPS='$TRIP_TEMPS'
+TRIP_SPEEDS='$TRIP_SPEEDS'
 _EOF_
 
 		else
@@ -231,8 +231,8 @@ _EOF_
 
 			done
 			#	- Remove leading white space
-			trip_speeds_target=${trip_speeds_target# }
-			echo $trip_speeds_target > $FP_TRIP_SPEEDS
+			trip_speeds_target="${trip_speeds_target# }"
+			echo "$trip_speeds_target" > $FP_TRIP_SPEEDS
 
 		else
 
@@ -252,7 +252,7 @@ _EOF_
 		G_WHIP_YESNO 'Reset fan control settings\n\nYour fan control settings file will be removed and current selections purged. This will take effect after next reboot.\n\nDo you want to continue?'
 		if (( ! $? )); then
 
-			l_message="Removing $FP_SETTINGS" G_RUN_CMD rm $FP_SETTINGS
+			[[ -f $FP_SETTINGS ]] && l_message="Removing $FP_SETTINGS" G_RUN_CMD rm $FP_SETTINGS
 			l_message='Resetting current selections' G_RUN_CMD unset TEMP_CONTROLLED TRIP_TEMPS TRIP_SPEEDS STATIC_SPEED
 
 		fi
@@ -263,7 +263,7 @@ _EOF_
 
 		G_WHIP_DEFAULT_ITEM="$TRIP_TEMPS"
 		G_WHIP_INPUTBOX "Please enter $TRIP_POINT_COUNT space-separated temperature points in °C.
-EG: To have trip points at 35°C, 50°C and 65°C, enter\n\t\"35 50 65\""
+EG: To have trip points at 35°C, 50°C and 65°C, enter\n     \"35 50 65\""
 		if (( ! $? )); then
 
 			TRIP_TEMPS="$G_WHIP_RETURNED_VALUE"
@@ -277,7 +277,7 @@ EG: To have trip points at 35°C, 50°C and 65°C, enter\n\t\"35 50 65\""
 		G_WHIP_DEFAULT_ITEM="$TRIP_SPEEDS"
 		G_WHIP_INPUTBOX "Please enter $(( $TRIP_POINT_COUNT + 1 )) space-separated fan speeds in % (percent) of the maximum possible speed.
 EG: To disable the fan below $(( ${FP_TRIP_TEMPS} / 1000 ))°C, run it at 45% above, 70% after reaching $(( ${FP_TRIP_TEMPS/0_temp/1_temp} / 1000 ))°C and 95% above $(( ${FP_TRIP_TEMPS/0_temp/2_temp} / 1000 ))°C, enter
-\t\"0 45 70 95\""
+     \"0 45 70 95\""
 		if (( ! $? )); then
 
 			TRIP_SPEEDS="$G_WHIP_RETURNED_VALUE"
@@ -286,11 +286,11 @@ EG: To disable the fan below $(( ${FP_TRIP_TEMPS} / 1000 ))°C, run it at 45% ab
 
 	}
 
-	Speed_Menu(){
+	Static_Speed_Menu(){
 
-		G_WHIP_DEFAULT_ITEM="$TRIP_SPEEDS"
+		G_WHIP_DEFAULT_ITEM="$STATIC_SPEED"
 		G_WHIP_INPUTBOX "Please enter the desired static fan speeds in % (percent) of the maximum possible speed.
-EG: To run the fan at 50%, enter\n\t\"60\""
+EG: To run the fan at 50%, enter\n     \"60\""
 		if (( ! $? )); then
 
 			STATIC_SPEED="$G_WHIP_RETURNED_VALUE"
@@ -323,14 +323,14 @@ EG: To run the fan at 50%, enter\n\t\"60\""
 		if (( $TEMP_CONTROLLED_CURRENT )); then
 
 			# - Current control mode
-			whip_message+='Mode:	Temperature controlled'
+			whip_message+='Mode:        Temperature controlled'
 
 			# - Current trip point temps
-			whip_message+='\nTemperatures:	'
+			whip_message+='\nTemp points:    '
 			for i in $TRIP_TEMPS_CURRENT
 			do
 
-				whip_message+="	${i}°C"
+				whip_message+=" ${i}°C"
 
 			done
 
@@ -339,19 +339,17 @@ EG: To run the fan at 50%, enter\n\t\"60\""
 			for i in $TRIP_SPEEDS_CURRENT
 			do
 
-				whip_message+="	${i}%"
+				whip_message+="  ${i}%"
 
 			done
-			#	- Remove leading tab
-			#trip_speeds_current_text=${trip_speeds_current_text#	}
 
 		else
 
 			# - Current control mode
-			whip_message+='Mode:	Static fan speed'
+			whip_message+='Mode:      Static fan speed'
 
 			# - Static fan speed
-			whip_message+="\nFan speed:	${STATIC_SPEED_CURRENT}%"
+			whip_message+="\nFan speed: ${STATIC_SPEED_CURRENT}%"
 
 		fi
 
@@ -372,28 +370,26 @@ EG: To run the fan at 50%, enter\n\t\"60\""
 		if (( $TEMP_CONTROLLED )); then
 
 			# - Trip point temperature settings
-			TRIP_TEMPS=${TRIP_TEMPS:-$TRIP_TEMPS_CURRENT}
+			TRIP_TEMPS="${TRIP_TEMPS:-$TRIP_TEMPS_CURRENT}"
 			local trip_temps_text=''
 			for i in $TRIP_TEMPS
 			do
 
-				trip_temps_text+="	${i}°C"
+				trip_temps_text+=" ${i}°C"
 
 			done
-			G_WHIP_MENU_ARRAY+=( 'Temperatures' "Selected: $trip_temps_text" )
+			G_WHIP_MENU_ARRAY+=( 'Temperatures' "Selected:     $trip_temps_text" )
 
 			# - Trip point speed settings
-			TRIP_SPEEDS=${TRIP_SPEEDS:-$TRIP_SPEEDS_CURRENT}
+			TRIP_SPEEDS="${TRIP_SPEEDS:-$TRIP_SPEEDS_CURRENT}"
 			local trip_speeds_text=''
 			for i in $TRIP_SPEEDS
 			do
 
-				trip_speeds_text+="	${i}%"
+				trip_speeds_text+="  ${i}%"
 
 			done
-			#	- Remove leading tab
-			trip_speeds_text=${trip_speeds_text#	}
-			G_WHIP_MENU_ARRAY+=( 'Fan speeds' "Selected: $trip_speeds_text" )
+			G_WHIP_MENU_ARRAY+=( 'Fan speeds' "Selected:$trip_speeds_text" )
 
 		else
 
@@ -452,6 +448,10 @@ EG: To run the fan at 50%, enter\n\t\"60\""
 
 			fi
 
+		else
+
+			exit 0
+
 		fi
 
 	}
@@ -481,7 +481,7 @@ EG: To run the fan at 50%, enter\n\t\"60\""
 		while true
 		do
 
-			Main_Menu || break
+			Main_Menu
 
 		done
 

--- a/dietpi/func/dietpi-set_cpu_fan
+++ b/dietpi/func/dietpi-set_cpu_fan
@@ -250,6 +250,8 @@ _EOF_
 	# Main menu
 	Main_Menu(){
 
+		local i=''
+
 		# Currently applied fan controls
 		Read_Control_Files
 
@@ -258,18 +260,14 @@ _EOF_
 			# - Current control mode
 			local mode_current_text='Temperature controlled'
 
-			local i=''
-
 			# - Current trip point temps
-			local trip_speeds_current_text=''
+			local trip_temps_current_text=''
 			for i in $TRIP_TEMPS_CURRENT
 			do
 
 				trip_temps_current_text+="	${i}°C"
 
 			done
-			#	- Remove leading white space
-			trip_temps_current_text=${trip_temps_current_text#	}
 
 			# - Current trip point speeds
 			local trip_speeds_current_text=''
@@ -279,7 +277,7 @@ _EOF_
 				trip_speeds_current_text+="	${i}%"
 
 			done
-			#	- Remove leading white space
+			#	- Remove leading tab
 			trip_speeds_current_text=${trip_speeds_current_text#	}
 
 		else
@@ -299,7 +297,6 @@ _EOF_
 		TEMP_CONTROLLED=${TEMP_CONTROLLED:-$TEMP_CONTROLLED_CURRENT}
 		local mode_text='Temperature controlled'
 		(( $TEMP_CONTROLLED )) && mode_current_text='Static fan speed'
-
 		G_WHIP_MENU_ARRAY=(
 
 			'Reset' 'Remove current settings file to reset fan control on reboot'
@@ -309,19 +306,16 @@ _EOF_
 
 		if (( $TEMP_CONTROLLED )); then
 
-			local i=''
-
 			# - Trip point temperature settings
 			TRIP_TEMPS=${TRIP_TEMPS:-$TRIP_TEMPS_CURRENT}
-			local trip_speeds_text=''
+			local trip_temps_text=''
 			for i in $TRIP_TEMPS
 			do
 
 				trip_temps_text+="	${i}°C"
 
 			done
-			#	- Remove leading white space
-			trip_temps_text=${trip_temps_text#	}
+			G_WHIP_MENU_ARRAY+=( 'Temperatures' "$trip_temps_text" )
 
 			# - Trip point speed settings
 			TRIP_SPEEDS=${TRIP_SPEEDS:-$TRIP_SPEEDS_CURRENT}
@@ -332,21 +326,16 @@ _EOF_
 				trip_speeds_text+="	${i}%"
 
 			done
-			#	- Remove leading white space
+			#	- Remove leading tab
 			trip_speeds_text=${trip_speeds_text#	}
-
-			G_WHIP_MENU_ARRAY+=(
-
-				'Temperatures' "$trip_temps_text"
-				'Fan speeds' "$trip_speeds_text"
-
-			)
+			G_WHIP_MENU_ARRAY+=( 'Fan speeds' "$trip_speeds_text" )
 
 		else
 
 			# - Static fan speed setting
 			STATIC_SPEED=${STATIC_SPEED:-$STATIC_SPEED_CURRENT}
 			local static_speed_current_text="${STATIC_SPEED}%"
+			G_WHIP_MENU_ARRAY+=( 'Fan speed' "$static_speed_current_text" )
 
 		fi
 

--- a/dietpi/func/dietpi-set_cpu_fan
+++ b/dietpi/func/dietpi-set_cpu_fan
@@ -10,122 +10,221 @@
 	#
 	# Info:
 	# - Location: /DietPi/dietpi/func/dietpi-set_cpu_fan + /boot/dietpi/func/dietpi-set_cpu_fan
-	# - Runs at boot up /DietPi/dietpi/boot
+	# - Runs at boot up /DietPi/dietpi/boot, if settings were applied.
 	# - Toggles CPU fan temp control and:
-	#	- Sets temp strip points, e.g. 35°C, 50°C, 65°C
-	#	- Attaches PWM fan speeds to temp strip points, e.g. 0%, 45%, 70%, 95%
+	#	- Sets trip point temps, e.g. 35°C, 50°C, 65°C
+	#	- Attaches PWM fan speeds to temp trip points, e.g. 0%, 45%, 70%, 95%
+	#	- Result: Fan off below 35°C, 45% fan speed at 35°C - 50°C, 70% fan speed at 50°C - 65°C, 95% fan speed above 65°C
 	#	or
-	#	- Sets constant fan speed
+	#	- Sets static fan speed
+	#
+	# Usage:
+	AVAIABLE_COMMANDS="
+Available commands:
+dietpi-set_cpu_fan	=>	Interactive whiptail menu to choose settings and create $FP_SETTINGS.
+dietpi-set_cpu_fan 1	=>	Non-interactively apply settings from $FP_SETTINGS.
+"
 	#////////////////////////////////////
 
-	#Import DietPi-Globals ---------------------------------------------------------------
+	# Import DietPi-Globals ---------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
 	export G_PROGRAM_NAME='DietPi-Set_CPU_fan'
 	G_INIT
 	G_CHECK_ROOT_USER
-	#Import DietPi-Globals ---------------------------------------------------------------
+	# Import DietPi-Globals ---------------------------------------------------------------
 
-	#Exit path for VM
+	# Exit path for VM
 	if (( $G_HW_MODEL == 20 )); then
 
-		G_DIETPI-NOTIFY 2 'CPU fan control is not available on VMs.'
-		exit
+		G_DIETPI-NOTIFY 1 'CPU fan control is not available on VMs. Aborting...'
+		exit 1
 
 	fi
 
-	#Control file paths
+	# Control file paths
 	FP_SETTINGS='/DietPi/dietpi/.dietpi-set_cpu_fan'
 	FP_FAN_CONTROL_TOGGLE='/sys/devices/platform/pwm-fan/hwmon/hwmon0/automatic'
 	FP_FAN_TRIP_TEMPS='/sys/devices/virtual/thermal/thermal_zone0/trip_point_0_temp'
 	FP_FAN_TRIP_SPEEDS='/sys/devices/platform/pwm-fan/hwmon/hwmon0/fan_speed'
-	FP_FAN_SPEED_FIXED='/sys/devices/platform/pwm-fan/hwmon/hwmon0/pwm1'
+	FP_FAN_SPEED_STATIC='/sys/devices/platform/pwm-fan/hwmon/hwmon0/pwm1'
 
-	#Exit without settings or control toggle file
-	if [[ ! -f $FP_SETTINGS ]]; then
+	# Exit without control toggle file
+	if [[ ! -e $FP_FAN_CONTROL_TOGGLE ]]; then
 
-		G_DIETPI-NOTIFY 2 'No settings file found, keep system defaults'
-		exit
-
-	elif [[ ! -e $FP_FAN_CONTROL_TOGGLE ]]; then
-
-		G_DIETPI-NOTIFY 2 'CPU fan PWM control is not available on your system.'
-		exit
+		G_DIETPI-NOTIFY 1 'CPU fan control is not available on your system. Aborting...'
+		exit 1
 
 	fi
+
+	# Grab valid input
+	INPUT=0
+	G_CHECK_VALIDINT $1 && INPUT=$1
+
+	# Read settings file
+	# - $FAN_CONTROL_TOGGLE=0|1; On|Off
+	# - $FAN_TRIP_TEMPS='XX YY ZZ'; XX°C YY°C ZZ°C
+	# - $FAN_TRIP_SPEEDS='AAA BBB CCC DDD'; AAA*100/255 %...
+	# - $FAN_SPEED_STATIC=EEE; EEE*100/255 %
+	read_Settings(){
+
+		. $FP_SETTINGS
+
+	}
+
+	# Write settings file
+	write_Settings(){
+
+		# - Write fan control toggle to settings file
+		echo "FAN_CONTROL_TOGGLE=$FAN_CONTROL_TOGGLE" > $FP_SETTINGS
+
+		if (( $FAN_CONTROL_TOGGLE )); then
+
+			# - Write trip points and attached temperatures to settings file
+			cat << _EOF_ >> $FP_SETTINGS
+FAN_TRIP_TEMPS=$FAN_TRIP_TEMPS
+FAN_TRIP_SPEEDS=$FAN_TRIP_SPEEDS
+_EOF_
+
+		else
+
+			# - Write static fan speed to settings file
+			echo "FAN_SPEED_STATIC=$FAN_SPEED_STATIC" >> $FP_SETTINGS
+
+		fi
+
+	}
+
+	# Read currently applied fan control values
+	read_Current(){
+
+		# - Read current fan control toggle
+		FAN_CONTROL_TOGGLE=$(<$FP_FAN_CONTROL_TOGGLE)
+
+		if (( $FAN_CONTROL_TOGGLE )); then
+
+			# - Read current static fan speed
+			FAN_SPEED_STATIC=$(<$FP_FAN_SPEED_STATIC)
+
+		else
+
+			# - Read current trip point temperatures, assuming values for CPU0 for all CPUs
+			local fp_target=''
+			local i=0
+			for fp_target in /sys/devices/virtual/thermal/thermal_zone0/trip_point_*_temp
+			do
+
+				# Check for file existance. If no file matches string, $ft_target will return the pattern literally.
+				[[ ! -e $fp_target ]] && G_DIETPI-NOTIFY 1 'Trip point temperature files missing. Skipping...' && break
+
+				FAN_TRIP_TEMPS+=" $(</sys/devices/virtual/thermal/thermal_zone0/trip_point_$i_temp)"
+				((i++))
+
+			done
+			# - Remove leading white space
+			FAN_TRIP_TEMPS=${FAN_TRIP_TEMPS% }
+
+			# - Read current trip point fan speeds
+			FAN_TRIP_SPEEDS=$(<$FP_FAN_TRIP_SPEEDS)
+
+		fi
+
+	}
 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Main Loop
 	#/////////////////////////////////////////////////////////////////////////////////////
-	#-----------------------------------------------------------------------------------
-	G_DIETPI-NOTIFY 3 $G_PROGRAM_NAME 'Applying CPU fan PWN settings'
-	#-----------------------------------------------------------------------------------
-	#Read settings file
-	# - $FAN_CONTROL_TOGGLE=0|1; On|Off
-	# - $FAN_TRIP_TEMPS='XX YY ZZ'; XX°C YY°C ZZ°C
-	# - $FAN_TRIP_SPEEDS='AAA BBB CCC DDD'; AAA*100/255 %...
-	# - $FAN_SPEED_FIXED=EEE; EEE*100/255 %
-	. $FP_SETTINGS
 
-	#Exit without control files, needed for chosen settings
-	if (( $FAN_CONTROL_TOGGLE )) && [[ ! -e $FP_FAN_TRIP_TEMPS || ! -e $FP_FAN_TRIP_SPEEDS ]]; then
+	if (( $INPUT == 1 )); then
 
-		G_DIETPI-NOTIFY 2 'Temperature based CPU fan PWM control is not available on your system.'
-		exit
+		#-----------------------------------------------------------------------------------
+		G_DIETPI-NOTIFY 3 $G_PROGRAM_NAME 'Applying CPU fan settings'
+		#-----------------------------------------------------------------------------------
 
-	elif (( ! $FAN_CONTROL_TOGGLE )) && [[ ! -e $FP_FAN_SPEED_FIXED ]]; then
+		# Read settings file, if successfully created
+		if [[ -f $FP_SETTINGS ]]; then
 
-		G_DIETPI-NOTIFY 2 'Changing constant CPU fan speed is not available on your system.'
-		exit
+			read_Settings
 
-	fi
+		else
 
-	#Apply chosen settings
-	if (( $FAN_CONTROL_TOGGLE )); then
-
-		# Exit without control files files or empty settings strings
-		if [[ ! -e $FP_FAN_TRIP_TEMPS || ! -e $FP_FAN_TRIP_SPEEDS ||
-			-z $FAN_TRIP_TEMPS || -z $FAN_TRIP_SPEEDS ]]; then
-
-			G_DIETPI-NOTIFY 2 'Temperature based CPU fan PWM control not chosen or not available on your system.'
-			exit
+			G_DIETPI-NOTIFY 1 'No CPU fan control settings file found. Please start "dietpi-set_cpu_fan" first. Aborting...'
+			exit 1
 
 		fi
 
-		local i=0
-		for (( i=0; i<$G_HW_CPU_CORES; i++ ))
-		do
+		# Exit without control files, needed for chosen settings
+		if (( $FAN_CONTROL_TOGGLE )) && [[ ! -e $FP_FAN_TRIP_TEMPS || ! -e $FP_FAN_TRIP_SPEEDS ]]; then
 
-			local fp_target=''
-			local j=0
-			for fp_target in /sys/devices/virtual/thermal/thermal_zone$i/trip_point_*_temp
+			G_DIETPI-NOTIFY 2 'Temperature based CPU fan control is not available on your system. Aborting...'
+			exit 1
+
+		elif (( ! $FAN_CONTROL_TOGGLE )) && [[ ! -e $FP_FAN_SPEED_STATIC ]]; then
+
+			G_DIETPI-NOTIFY 2 'Changing constant CPU fan speed is not available on your system. Aborting...'
+			exit 1
+
+		fi
+
+		# Apply chosen settings
+		if (( $FAN_CONTROL_TOGGLE )); then
+
+			# - Exit with empty settings strings
+			if [[ -z $FAN_TRIP_TEMPS || -z $FAN_TRIP_SPEEDS ]]; then
+
+				G_DIETPI-NOTIFY 1 'Invalid settings found. Please run "dietpi-set_cpu_fan" to re-apply valid settings. Aborting...'
+				exit 1
+
+			fi
+
+			# - Apply trip point temps
+			local i=0
+			for (( i=0; i<$G_HW_CPU_CORES; i++ ))
 			do
 
-				awk '{print $((j+1))}' <<< $FAN_TRIP_TEMPS > /sys/devices/virtual/thermal/thermal_zone$i/trip_point_$j_temp
-				((j++))
+				local fp_target=''
+				local j=0
+				for fp_target in /sys/devices/virtual/thermal/thermal_zone$i/trip_point_*_temp
+				do
+
+					# Check for file existance. If no file matches string, $ft_target will return the pattern literally.
+					[[ ! -e $fp_target ]] && G_DIETPI-NOTIFY 1 "Trip point temperature files missing. Skipping CPU$i" && break
+
+					awk '{print $((j+1))}' <<< $FAN_TRIP_TEMPS > /sys/devices/virtual/thermal/thermal_zone$i/trip_point_$j_temp
+					((j++))
+
+				done
 
 			done
 
-		done
+			# - Apply trip point fan speeds
+			echo $FAN_TRIP_SPEEDS > $FP_FAN_TRIP_SPEEDS
 
-		echo $FAN_TRIP_SPEEDS > $FP_FAN_TRIP_SPEEDS
+		else
 
-	else
+			# - Exit with empty settings string
+			if [[ -z $FAN_SPEED_STATIC ]]; then
 
-		# Exit without needed control file or empty settings string
-		if [[ ! -e $FP_FAN_SPEED_FIXED || -z $FAN_SPEED_FIXED ]]; then
+				G_DIETPI-NOTIFY 1 'Invalid settings found. Please run "dietpi-set_cpu_fan" to re-apply valid settings. Aborting...'
+				exit 1
 
-			G_DIETPI-NOTIFY 2 'Changing constant CPU fan speed not chosen or not available on your system.'
-			exit
+			fi
+
+			# - Apply static fan speed
+			echo $FAN_SPEED_STATIC > $FP_FAN_SPEED_STATIC
 
 		fi
 
-		echo $FAN_SPEED_FIXED > $FP_FAN_SPEED_FIXED
+		# - Apply fan control toggle
+		echo $FAN_CONTROL_TOGGLE > $FP_FAN_CONTROL_TOGGLE
+
+	else
+
+		G_DIETPI-NOTIFY 1 "Invalid input argument found. Aborting...\n$AVAIABLE_COMMANDS"
+		exit 1
 
 	fi
 
-	echo $FAN_CONTROL_TOGGLE > $FP_FAN_CONTROL_TOGGLE
-
 	#-----------------------------------------------------------------------------------
-	exit
+	exit 0
 	#-----------------------------------------------------------------------------------
 }


### PR DESCRIPTION
**Status**: WIP
- [x] **Finish menus, currently working on this**
- [x] Add config whip menu to `DietPi-Set_CPU_fan` script, to have it in one place. Non-interactive settings apply: `DietPi-Set_CPU_fan 1`
- [ ] Add entry to DietPi-Config > Performance Options to start script interactively
- [ ] Needs testing across SBCs, should work at least on Odroid XU3/4, if fan is attached
  - USB fans are available for devices without dedicated fan connector. Control interface e.g. via /sys files needs to be checked.
- [ ] Execute within DietPi-Boot, if settings file exists
- [ ] Add changelog entry

**Reference**: https://github.com/Fourdee/DietPi/issues/1818

**Commit list/description**:
+ DietPi-Set_CPU_fan | Allows to adjust CPU fan speed PWM control
+ DietPi-Set_CPU_fan | Prepare to include interactive settings menu + further rework
+ DietPi-Set_CPU_fan | Further work on it, main menu text and entry creation
+ DietPi-Set_CPU_fan | Finish whiptail menus