### PR TITLE
General | Remove fake-hwclock, if real hwclock is available

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ DietPi-Software | Koel: Installation will now skip webserver, as Koel uses PHP-C
 DietPi-Software | Mono: Now installs 'mono-complete' by default, required for Mono based applications (eg: Radarr/Sonarr/Lidarr/Jackett etc)
 DietPi-Software | Lidarr: Now available for installation, automatically download music: https://github.com/Fourdee/DietPi/issues/1874
 General | All DietPi scripts by default now use /tmp RAMFS to create, download and handle temporary files. By this we speed up especially installations and reduce disk I/O: https://github.com/Fourdee/DietPi/issues/1801
+General | "fake-hwclock" is purged now on first run setup and v6.13 patch, if a real hardware clock is available.
 #Image | NanoPC T4: This image now includes a new kernel with support for CIFS, docker and more. Many thanks to
 
 Bug Fixes:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,7 +11,6 @@ DietPi-Software | Mono: Now installs 'mono-complete' by default, required for Mo
 DietPi-Software | Lidarr: Now available for installation, automatically download music: https://github.com/Fourdee/DietPi/issues/1874
 General | All DietPi scripts by default now use /tmp RAMFS to create, download and handle temporary files. By this we speed up especially installations and reduce disk I/O: https://github.com/Fourdee/DietPi/issues/1801
 General | "fake-hwclock" is purged now on first run setup and v6.13 patch, if a real hardware clock is available.
-=======
 Image | NanoPC-T4: Image updated which now includes custom kernel/modules created by @carlosedp. Adds CIFS, docker support and much more. Please note, WiFi scan is intermittent with this kernel, and, may take a few attempts to be successful, however, we believe the additional modules are a higher priority: https://github.com/Fourdee/DietPi/issues/1829
 
 Bug Fixes:

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -103,11 +103,11 @@
 			# - Never save pending state for software (=1). Excluding temp saves.
 			if (( ${aSOFTWARE_INSTALL_STATE[$i]} == 1 && ! $write_software_in_pending_state )); then
 
-				echo -e "aSOFTWARE_INSTALL_STATE[$i]=0" >> $fp_target
+				echo "aSOFTWARE_INSTALL_STATE[$i]=0" >> $fp_target
 
 			else
 
-				echo -e "aSOFTWARE_INSTALL_STATE[$i]=${aSOFTWARE_INSTALL_STATE[$i]}" >> $fp_target
+				echo "aSOFTWARE_INSTALL_STATE[$i]=${aSOFTWARE_INSTALL_STATE[$i]}" >> $fp_target
 
 			fi
 
@@ -14294,6 +14294,9 @@ _EOF_
 
 		# DietPi-Automation
 		if (( $G_DIETPI_INSTALL_STAGE == 0 )); then
+
+			# - Remove fake-hwclock, if real hwclock is available
+			hwclock && G_AGP fake-hwclock
 
 			# - x86_64 microcode installation
 			if (( $G_HW_ARCH == 10 )); then

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -14296,20 +14296,20 @@ _EOF_
 		if (( $G_DIETPI_INSTALL_STAGE == 0 )); then
 
 			# - Remove fake-hwclock, if real hwclock is available
-			hwclock && G_AGP fake-hwclock
+			hwclock &> /dev/null && G_AGP fake-hwclock
 
 			# - x86_64 microcode installation
 			if (( $G_HW_ARCH == 10 )); then
 
-				grep 'vendor_id' /proc/cpuinfo | grep -qi 'intel' && G_AGI intel-microcode
-				grep 'vendor_id' /proc/cpuinfo | grep -qi 'amd' && G_AGI amd64-microcode
+				grep -qi 'vendor_id.*intel' /proc/cpuinfo && G_AGI intel-microcode
+				grep -qi 'vendor_id.*amd' /proc/cpuinfo && G_AGI amd64-microcode
 
 			fi
 
 			# - Apply Timezone
 			if [[ $AUTOINSTALL_TIMEZONE != $(</etc/timezone) ]]; then
 
-				echo -e "\nDietPi: Setting Timezone = $AUTOINSTALL_TIMEZONE"
+				G_DIETPI-NOTIFY 2 "Setting Timezone $AUTOINSTALL_TIMEZONE. Please wait..."
 				rm /etc/timezone
 				rm /etc/localtime
 				ln -fs "/usr/share/zoneinfo/$AUTOINSTALL_TIMEZONE" /etc/localtime
@@ -14321,10 +14321,10 @@ _EOF_
 			if ! locale | grep -qE "(LANG|LC_ALL)=[\'\"]?$AUTOINSTALL_LANGUAGE[\'\"]?" ||
 				! locale -a | grep -q 'en_GB.UTF-8'; then
 
-				G_DIETPI-NOTIFY 2 "Setting Locale $AUTOINSTALL_LANGUAGE. Please wait"
+				G_DIETPI-NOTIFY 2 "Setting Locale $AUTOINSTALL_LANGUAGE. Please wait..."
 
 				#	Sanity, wrong result, revert back to default
-				if [[ ! "$AUTOINSTALL_LANGUAGE" =~ 'UTF-8' ]]; then
+				if [[ ! $AUTOINSTALL_LANGUAGE =~ 'UTF-8' ]]; then
 
 					AUTOINSTALL_LANGUAGE='en_GB.UTF-8'
 
@@ -14338,8 +14338,8 @@ _EOF_
 			# - Apply Keyboard
 			if ! grep -q "XKBLAYOUT=\"$AUTOINSTALL_KEYBOARD\"" /etc/default/keyboard; then
 
-				G_DIETPI-NOTIFY 2 "Setting Keyboard $AUTOINSTALL_KEYBOARD. Please wait...\n"
-				sed -i '/XKBLAYOUT=/c XKBLAYOUT="'"$AUTOINSTALL_KEYBOARD"'"' /etc/default/keyboard
+				G_DIETPI-NOTIFY 2 "Setting Keyboard $AUTOINSTALL_KEYBOARD. Please wait..."
+				G_CONFIG_INJECT 'XKBLAYOUT=' "XKBLAYOUT=\"$AUTOINSTALL_KEYBOARD\"" /etc/default/keyboard
 				#systemctl restart keyboard-setup
 
 			fi

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1015,7 +1015,7 @@ _EOF_
 			chown -R qbittorrent:dietpi /home/qbittorrent &> /dev/null
 			#-------------------------------------------------------------------------------
 			# - Remove fake-hwclock, if real hwclock is available
-			hwclock && G_AGP fake-hwclock
+			hwclock &> /dev/null && G_AGP fake-hwclock
 			#-------------------------------------------------------------------------------
 
 		fi

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1014,6 +1014,9 @@ _EOF_
 			# - qBitTorrent: https://github.com/Fourdee/DietPi/issues/1957
 			chown -R qbittorrent:dietpi /home/qbittorrent &> /dev/null
 			#-------------------------------------------------------------------------------
+			# - Remove fake-hwclock, if real hwclock is available
+			hwclock && G_AGP fake-hwclock
+			#-------------------------------------------------------------------------------
 
 		fi
 


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
- Apply on first run setup
- Apply on v6.13 patch
- Add changelog

_______________

Or the other way round, ship images without "fake-hwclock" and install, if no real hwclock found on first run setup? Could lead to 1970 time stamp until first time sync (?), not sure if this could be a problem.