### PR TITLE
DietPi-Cron | Disable cron.minutely by default

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ DietPi-Software | A new unified download&install function is implemented, which 
 DietPi-Software | Koel: Installation will now skip webserver, as Koel uses PHP-CLI instead. To not mess with webserver served pages, Koel install directory is moved to "/mnt/dietpi_userdata/koel", for existing installs as well.
 DietPi-Software | Mono: Now installs 'mono-complete' by default, required for Mono based applications (eg: Radarr/Sonarr/Lidarr/Jackett etc)
 DietPi-Software | Lidarr: Now available for installation, automatically download music: https://github.com/Fourdee/DietPi/issues/1874
+DietPi-Cron | /etc/cron.minutely/ is now disabled by default, to reduce cron executions and logs. This is also patched with v6.13, if no script is placed within the folder. Use "dietpi-cron" to enable and configure this feature.
 General | All DietPi scripts by default now use /tmp RAMFS to create, download and handle temporary files. By this we speed up especially installations and reduce disk I/O: https://github.com/Fourdee/DietPi/issues/1801
 Image | NanoPC-T4: Image updated which now includes custom kernel/modules created by @carlosedp. Adds CIFS, docker support and much more. Please note, WiFi scan is intermittent with this kernel, and, may take a few attempts to be successful, however, we believe the additional modules are a higher priority: https://github.com/Fourdee/DietPi/issues/1829
 

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -1048,15 +1048,13 @@ _EOF_
 
 		G_DIETPI-NOTIFY 2 "Configuring Cron"
 
-		mkdir -p /etc/cron.minutely #: https://github.com/Fourdee/DietPi/pull/1578
-
 		cat << _EOF_ > /etc/crontab
 #Please use dietpi-cron to change cron start times
 SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
 # m h dom mon dow user  command
-*/30 * * * *   root    cd / && run-parts --report /etc/cron.minutely
+#*/0 * * * *   root    cd / && run-parts --report /etc/cron.minutely
 17 *    * * *   root    cd / && run-parts --report /etc/cron.hourly
 25 1    * * *   root    test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.daily )
 47 1    * * 7   root    test -x /usr/sbin/anacron || ( cd / && run-parts --report /etc/cron.weekly )

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1014,6 +1014,9 @@ _EOF_
 			# - qBitTorrent: https://github.com/Fourdee/DietPi/issues/1957
 			chown -R qbittorrent:dietpi /home/qbittorrent &> /dev/null
 			#-------------------------------------------------------------------------------
+			# - Disable cron.minutely, if unused to reduce cron executions and logs
+			(( $(find /etc/cron.minutely/ | wc -l) > 2 )) || sed -i '\|cron\.minutely|s|^\*/[0-9]*[[:blank:]]|#*/0 |' /etc/crontab
+			#-------------------------------------------------------------------------------
 
 		fi
 

--- a/rootfs/etc/cron.minutely/readme.txt
+++ b/rootfs/etc/cron.minutely/readme.txt
@@ -1,0 +1,2 @@
+# /etc/cron.minutely/ is implemented by DietPi and allows to run scripts every chosen amount of minutes.
+# Run "dietpi-cron" to enable and configure this feature.


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
- Place readme.txt into /etc/cron.minutely/. Due to file ending, this is not executed by cron/run-parts.
- Disable it by default to reduce unneeded cron executions and logs.
- Disable it with patch_file, if no file was placed inside by user.