### PR TITLE
DietPi-Software | Add folding@home to software list

### DIFF
--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -26,8 +26,8 @@
 	INPUT_S2="$2"
 	#Import DietPi-Globals ---------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
-	G_CHECK_ROOT_USER
 	export G_PROGRAM_NAME='DietPi-Services'
+	G_CHECK_ROOT_USER
 	G_INIT
 	#Import DietPi-Globals ---------------------------------------------------------------
 
@@ -174,6 +174,7 @@
 		#'openmediavault-engined'
 		'docker'
 		'cron'
+		'FAHClient'
 		#Frontends / Misc ------------------------------------------------------
 
 	)
@@ -190,7 +191,7 @@
 		aSERVICE_NAME+=('ssh') 						#: OpenSSH-server
 
 		# - Misc
-		#aSERVICE_NAME+=('systemd-timesyncd') 		#: Timesync. DietPi disables this by default after success, may confuse user/prompt questions.
+		#aSERVICE_NAME+=('systemd-timesyncd') 		#: Timesync. DietPi stops this by default after success, may confuse user/prompt questions.
 		aSERVICE_NAME+=('dnsmasq') 					#: https://github.com/Fourdee/DietPi/issues/1501
 		aSERVICE_NAME+=('pihole-FTL')					#: https://github.com/Fourdee/DietPi/issues/1696
 		aSERVICE_NAME+=('openvpn') 					#: https://github.com/Fourdee/DietPi/issues/1501

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7935,6 +7935,8 @@ _EOF_
 
 			Banner_Configuration
 
+			l_message='Wait 5 seconds for FAHClient to create configuration file' G_RUN_CMD sleep 5
+
 			# Allow web access for localhost and local network: IP 192.168.0.100 => allow 192.168.0.0/24
 			local ip_address="$(sed -n 4p /DietPi/dietpi/.network)"
 			if [[ $ip_address ]]; then

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3889,8 +3889,42 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$INSTALLING_INDEX]} == 1 )); then
 
 			Banner_Installing
+
+			G_DIETPI-NOTIFY 2 'Preparing data folder'
+			if [[ -d $G_FP_DIETPI_USERDATA/fahclient ]]; then
+
+				G_DIETPI-NOTIFY 2 "$G_FP_DIETPI_USERDATA/fahclient exists, will migrate contained data"
+
+			else
+				# Otherwise use possibly existent /var/lib/fahclient
+				# - Remove possible dead symlinks/files:
+				rm $G_FP_DIETPI_USERDATA/fahclient &> /dev/null
+				mkdir -p $G_FP_DIETPI_USERDATA/fahclient
+				if [[ -d /var/lib/fahclient ]]; then
+
+					G_DIETPI-NOTIFY 2 '/var/lib/fahclient exists, will migrate contained data'
+					G_RUN_CMD cp -a /var/lib/fahclient/. $G_FP_DIETPI_USERDATA/fahclient
+
+				fi
+
+			fi
+
+			G_DIETPI-NOTIFY 2 'Removing /var/lib/fahclient, if existent'
+			[[ -L /var/lib/fahclient && ! $(readlink /var/lib/fahclient) =~ $G_FP_DIETPI_USERDATA/fahclient ]] &&
+				rm -R "$(readlink /var/lib/fahclient)" &> /dev/null
+			rm -R /var/lib/fahclient &> /dev/null
+
+			l_message="Creating symlink: /var/lib/fahclient -> $G_FP_DIETPI_USERDATA/fahclient" G_RUN_CMD ln -sf $G_FP_DIETPI_USERDATA/fahclient /var/lib/fahclient
+			chown fahclient:fahclient -h /var/lib/fahclient &> /dev/null
+			chown fahclient:fahclient -RL /var/lib/fahclient &> /dev/null
+
+			G_DIETPI-NOTIFY 2 'Pre-configuring FAHClient deb package'
 			debconf-set-selections <<< 'fahclient fahclient/autostart boolean true'
-			debconf-set-selections <<< 'fahclient fahclient/team string 234437'
+			debconf-set-selections <<< 'fahclient fahclient/power select light'
+			debconf-set-selections <<< 'fahclient fahclient/team string 234437' # Team "DietPi"
+			debconf-set-selections <<< 'fahclient fahclient/user string DietPi-Anonymous' # Default, until user chooses an own username
+			debconf-set-selections <<< 'fahclient fahclient/passkey string'
+
 			Download_Install 'https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v7.5/latest.deb'
 
 		fi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1515,6 +1515,24 @@ _EOF_
 			 aSOFTWARE_ONLINEDOC_URL[$index_current]='f=8&t=5&p=6202#p6202'
 
 		#------------------
+		index_current=2
+
+		aSOFTWARE_WHIP_NAME[$index_current]='Folding@Home'
+		aSOFTWARE_WHIP_DESC[$index_current]='distributed disease research project'
+		aSOFTWARE_CATEGORY_INDEX[$index_current]=6
+		aSOFTWARE_TYPE[$index_current]=0
+		aSOFTWARE_ONLINEDOC_URL[$index_current]=''
+		# - Enter user name, passkey, light/medium/full power
+		aSOFTWARE_REQUIRES_USERINPUT[$i]=1
+		# - x86_64 only
+		for ((i=0; i<$MAX_G_HW_ARCH; i++))
+		do
+
+			aSOFTWARE_AVAIL_G_HW_ARCH[$i,$j]=0
+
+		done
+
+		#------------------
 
 		#Camera
 		#--------------------------------------------------------------------------------
@@ -3863,6 +3881,17 @@ _EOF_
 
 			Banner_Installing
 			Download_Install 'http://yacy.net/release/yacy_v1.92_20161226_9000.tar.gz' /etc
+
+		fi
+
+		#Folding@Home
+		INSTALLING_INDEX=2
+		if (( ${aSOFTWARE_INSTALL_STATE[$INSTALLING_INDEX]} == 1 )); then
+
+			Banner_Installing
+			debconf-set-selections <<< 'fahclient fahclient/autostart boolean true'
+			debconf-set-selections <<< 'fahclient fahclient/team string 234437'
+			Download_Install 'https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v7.5/latest.deb'
 
 		fi
 
@@ -7860,6 +7889,31 @@ _EOF_
 
 			#	Create admin login account:
 			/etc/yacy/bin/passwd.sh "$GLOBAL_PW"
+
+		fi
+
+		#Folding@Home
+		INSTALLING_INDEX=2
+		if (( ${aSOFTWARE_INSTALL_STATE[$INSTALLING_INDEX]} == 1 )); then
+
+			Banner_Configuration
+
+			# Allow web access for localhost and local network: IP 192.168.0.100 => allow 192.168.0.0/24
+			local ip_address="$(sed -n 4p /DietPi/dietpi/.network)"
+			if [[ $ip_address ]]; then
+
+				ip_address=${ip_address%.[0-9]*}
+				ip_address+='.0/24'
+				G_CONFIG_INJECT '<allow' "<allow v='127.0.0.1 $ip_address'/>" /etc/fahclient/config.xml '<config>'
+				G_CONFIG_INJECT '<web-allow' "<web-allow v='127.0.0.1 $ip_address'/>" /etc/fahclient/config.xml '<config>'
+
+			# If local IP coundn't be detected, allow access to all IPs: 0/0
+			else
+
+				G_CONFIG_INJECT '<allow' '<allow v=\'0/0\'/>' /etc/fahclient/config.xml '<config>'
+				G_CONFIG_INJECT '<web-allow' '<web-allow v=\'0/0\'/>' /etc/fahclient/config.xml '<config>'
+
+			fi
 
 		fi
 
@@ -12536,6 +12590,14 @@ _EOF_
 			Banner_Uninstalling
 			rm /etc/systemd/system/yacy.service
 			rm -R /etc/yacy
+
+		fi
+
+		UNINSTALLING_INDEX=2
+		if (( aSOFTWARE_INSTALL_STATE[$UNINSTALLING_INDEX] == -1 )); then
+
+			Banner_Uninstalling
+			dpkg -P fahclient
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7431,6 +7431,9 @@ _EOF_
 		# - qBitTorrent
 		chown -R qbittorrent:dietpi /home/qbittorrent
 
+		# - FAHClient (Folding@Home)
+		chown -R fahclient:dietpi $G_FP_DIETPI_USERDATA/fahclient
+
 	}
 
 	#/////////////////////////////////////////////////////////////////////////////////////
@@ -7944,8 +7947,8 @@ _EOF_
 			# If local IP coundn't be detected, allow access to all IPs: 0/0
 			else
 
-				G_CONFIG_INJECT '<allow' '<allow v=\'0/0\'/>' /etc/fahclient/config.xml '<config>'
-				G_CONFIG_INJECT '<web-allow' '<web-allow v=\'0/0\'/>' /etc/fahclient/config.xml '<config>'
+				G_CONFIG_INJECT '<allow' "<allow v='0/0'/>" /etc/fahclient/config.xml '<config>'
+				G_CONFIG_INJECT '<web-allow' "<web-allow v='0/0'/>" /etc/fahclient/config.xml '<config>'
 
 			fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1521,7 +1521,7 @@ _EOF_
 		aSOFTWARE_WHIP_DESC[$index_current]='distributed disease research project'
 		aSOFTWARE_CATEGORY_INDEX[$index_current]=6
 		aSOFTWARE_TYPE[$index_current]=0
-		aSOFTWARE_ONLINEDOC_URL[$index_current]=''
+		aSOFTWARE_ONLINEDOC_URL[$index_current]='f=8&t=5&p=13704#p13704'
 		# - Enter user name, passkey, light/medium/full power
 		aSOFTWARE_REQUIRES_USERINPUT[$i]=1
 		# - x86_64 only


### PR DESCRIPTION
**Status**: WIP
- [x] Software category?
- [x] DietPi-Services handling?
- [x] Allow fully automated install by providing user name, passkey and power choice via dietpi.txt?
- [x] Move data dir to dietpi_userdata?
- [x] Changelog entry

**Reference**: https://github.com/Fourdee/DietPi/issues/1985

**Commit list/description**:
+ DietPi-Software | Add folding@home to software list
  - Preconfigured autostart + DietPi team
  - User name, passkey, power choice need to be entered 