### PR TITLE
DietPi-Software | Renaming MariaDB webserver stacks to have well-known "LAMP" stack again.

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1902,7 +1902,7 @@ _EOF_
 		#------------------
 		index_current=76
 
-				 aSOFTWARE_WHIP_NAME[$index_current]='LAAP'
+				 aSOFTWARE_WHIP_NAME[$index_current]='LAMP'
 				 aSOFTWARE_WHIP_DESC[$index_current]='apache2  | mariadb | php'
 			aSOFTWARE_CATEGORY_INDEX[$index_current]=13
 					  aSOFTWARE_TYPE[$index_current]=0
@@ -1920,7 +1920,7 @@ _EOF_
 		#------------------
 		index_current=79
 
-				 aSOFTWARE_WHIP_NAME[$index_current]='LEAP'
+				 aSOFTWARE_WHIP_NAME[$index_current]='LEMP'
 				 aSOFTWARE_WHIP_DESC[$index_current]='nginx    | mariadb | php'
 			aSOFTWARE_CATEGORY_INDEX[$index_current]=13
 					  aSOFTWARE_TYPE[$index_current]=0
@@ -1938,7 +1938,7 @@ _EOF_
 		#------------------
 		index_current=82
 
-				 aSOFTWARE_WHIP_NAME[$index_current]='LLAP'
+				 aSOFTWARE_WHIP_NAME[$index_current]='LLMP'
 				 aSOFTWARE_WHIP_DESC[$index_current]='lighttpd | mariadb | php'
 			aSOFTWARE_CATEGORY_INDEX[$index_current]=13
 					  aSOFTWARE_TYPE[$index_current]=0
@@ -2731,7 +2731,7 @@ _EOF_
 		#Pre-req software, for items that do DO have their own array aSOFTWARE_REQUIRES_SOFTWARENAME
 		#	WEBSERVER - Manual stack install
 		#	 - Define extra DietPi install flags for WEBSERVER_STACKS
-		#LLAP
+		#LLMP
 		if (( ${aSOFTWARE_INSTALL_STATE[82]} == 1 )); then
 			aSOFTWARE_INSTALL_STATE[84]=1
 			aSOFTWARE_INSTALL_STATE[88]=1
@@ -2745,7 +2745,7 @@ _EOF_
 			aSOFTWARE_INSTALL_STATE[89]=1
 		fi
 
-		#LEAP
+		#LEMP
 		if (( ${aSOFTWARE_INSTALL_STATE[79]} == 1 )); then
 			aSOFTWARE_INSTALL_STATE[85]=1
 			aSOFTWARE_INSTALL_STATE[88]=1
@@ -2759,7 +2759,7 @@ _EOF_
 			aSOFTWARE_INSTALL_STATE[89]=1
 		fi
 
-		#LAAP
+		#LAMP
 		if (( ${aSOFTWARE_INSTALL_STATE[76]} == 1 )); then
 			aSOFTWARE_INSTALL_STATE[83]=1
 			aSOFTWARE_INSTALL_STATE[88]=1
@@ -2888,7 +2888,7 @@ _EOF_
 			#MariaDB
 			if (( ${aSOFTWARE_INSTALL_STATE[88]} >= 1 )); then
 
-				#WEBSERVER_LAAP
+				#WEBSERVER_LAMP
 				aSOFTWARE_INSTALL_STATE[76]=1
 
 			fi
@@ -2908,7 +2908,7 @@ _EOF_
 			#MariaDB
 			if (( ${aSOFTWARE_INSTALL_STATE[88]} >= 1 )); then
 
-				#WEBSERVER_LEAP
+				#WEBSERVER_LEMP
 				aSOFTWARE_INSTALL_STATE[79]=1
 
 			fi
@@ -2927,7 +2927,7 @@ _EOF_
 			#MariaDB
 			if (( ${aSOFTWARE_INSTALL_STATE[88]} >= 1 )); then
 
-				#WEBSERVER_LLAP
+				#WEBSERVER_LLMP
 				aSOFTWARE_INSTALL_STATE[82]=1
 
 			fi


### PR DESCRIPTION
@Fourdee 
Just remember some users wondering where LAMP was going. As MariaDB is nowadays on Debian the direct replacement, I think it's okay, rename the stacks accordingly. What you think?