### PR TITLE
DietPi-Globals | G_INIT(): Check for concurrent DietPi script executions

### DIFF
--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -134,7 +134,7 @@ $(ps f -eo pid,user,tty,cmd | grep -i [d]ietpi)"
 			if (( $? )); then
 
 				G_DIETPI-NOTIFY "Canceled $script_name due to concurrent execution."
-				[[ $DEBUG == 1 ]] && ps f -eo pid,user,tty,cmd | grep -i [d]ietpi)
+				[[ $DEBUG == 1 ]] && ps f -eo pid,user,tty,cmd | grep -i [d]ietpi
 				exit 1
 
 			fi

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -74,6 +74,7 @@
 	fi
 
 	#Default DietPi userdata location. This must NEVER change.
+	# - In case of moved userdata location, a symlink stays here to keep this path valid.
 	G_FP_DIETPI_USERDATA='/mnt/dietpi_userdata'
 
 	#Device details
@@ -116,7 +117,31 @@
 	#	eg: stuff we cant init in main globals/funcs due to .bashrc load into current session.
 	G_INIT(){
 
-		# Set locale for scripts, prevents incorrect scraping
+		# Check for concurrent execution
+		local script_name="$0"
+		while (( $(pgrep -cif "$script_name") > 1 ))
+		do
+
+			G_WHIP_BUTTON_OK_TEXT='Retry'
+			G_WHIP_YESNO "WARNING: Concurrent execution of $script_name detected.\n
+Please check if one of the following applies:
+ - The script already runs on another terminal/SSH session.
+ - Currently a cron or systemd background job executes the script.
+ - You started this script from within another DietPi program, causing a loop.\n
+Please assure that the concurrent execution has finished, before trying again, otherwise cancel this instance.\n
+The following info might help:
+$(ps f -eo pid,user,tty,cmd | grep -i [d]ietpi)"
+			if (( $? )); then
+
+				G_DIETPI-NOTIFY "Canceled $script_name due to concurrent execution."
+				[[ $DEBUG == 1 ]] && ps f -eo pid,user,tty,cmd | grep -i [d]ietpi)
+				exit 1
+
+			fi
+
+		done		
+
+		# Set locale for scripts to prevent incorrect scraping due to translated command outputs
 		export LANG=en_GB.UTF-8
 		export LC_ALL=en_GB.UTF-8
 
@@ -124,21 +149,25 @@
 		[[ $HIERARCHY ]] && export HIERARCHY=$((HIERARCHY+1)) || export HIERARCHY=0
 
 		# Ensure we are in script working dir or users home dir, if available: https://github.com/Fourdee/DietPi/issues/905#issuecomment-298223705
-		# - If any $FP_WORK_DIR step fails, go to $HOME if it is assigned
+		# - If any $FP_WORK_DIR step fails, go to $HOME, if assigned
 		if [[ $FP_WORK_DIR ]] && mkdir -p $FP_WORK_DIR && cd $FP_WORK_DIR; then
 
-			: # G_DIETPI-NOTIFY 2 "Entered working directory: $FP_WORK_DIR"
+			[[ $DEBUG == 1 ]] && G_DIETPI-NOTIFY 2 "Entered assigned working directory: $FP_WORK_DIR"
 
-		elif [[ $HOME ]]; then
+		elif [[ $HOME ]] && cd $HOME; then
 
-			cd $HOME
+			[[ $DEBUG == 1 ]] && G_DIETPI-NOTIFY 2 "Entered users home directory: $HOME"
+
+		else
+
+			[[ $DEBUG == 1 ]] && G_DIETPI-NOTIFY 2 "No \$FP_WORK_DIR nor \$HOME assigned, or failed to "cd" inside. Will use current: $PWD"
 
 		fi
 
-		# Declare and trap G_EXIT() as exit function, that runs on EXIT signal, which includes INT (error) and TERM (kill).
+		# Declare and trap G_EXIT() as exit function, that runs on EXIT signal, which includes INT (error) and TERM (kill)
 		G_EXIT(){
 
-			# - Purging working directory
+			# - Purge working directory, if existent
 			[[ $FP_WORK_DIR && -d $FP_WORK_DIR ]] && rm -R $FP_WORK_DIR
 
 			# - Execute custom exit function, if existent
@@ -148,7 +177,7 @@
 		trap 'G_EXIT' EXIT
 
 		# Auto print init header for all scripts
-		# G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Init'
+		#G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Init'
 
 	}
 

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -133,7 +133,7 @@ The following info might help:
 $(ps f -eo pid,user,tty,cmd | grep -i [d]ietpi)"
 			if (( $? )); then
 
-				G_DIETPI-NOTIFY "Canceled $script_name due to concurrent execution."
+				G_DIETPI-NOTIFY 1 "Canceled $script_name due to concurrent execution."
 				[[ $DEBUG == 1 ]] && ps f -eo pid,user,tty,cmd | grep -i [d]ietpi
 				exit 1
 


### PR DESCRIPTION
**Status**: Ready
- [ ] Extensive testing/usage of all DietPi programs/scripts to detect loops.
- [ ] In case solve loops and/or check whether a simple cancel causes problems (on automated executions).

**Reference**: https://github.com/Fourdee/DietPi/issues/1997#issuecomment-411314188

**Commit list/description**:
+ DietPi-Globals | G_INIT(): Check for concurrent DietPi script executions, prompt user information and choice in case.
+ DietPi-Globals | Minor wording and debug output
_______________
Detected loops:
- `DietPi-Software` > `DietPi-Config` > `DietPi-Drive_Manager` > `DietPi-Set_Userdata` > `DietPi-Software` (to set permissions)
  - Solving by: Allow moving userdata only, if target fs supports permissions. Then rely on `cp -a` to transfer file permissions and skip `DietPi-Software` for reapplying then.
- Even simpler  `DietPi-Software` > `DietPi-Set_Userdata` > `DietPi-Software` (to set permissions)
![upload](https://user-images.githubusercontent.com/28480705/43852740-5156b03e-9b3e-11e8-834e-6b4cffe4fafc.png)
  - Same solution as above