### PR TITLE
DietPi-Set_userdata | Remove possible DietPi script loops + other improvements

### DIFF
--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -1369,7 +1369,7 @@ aDRIVE_ISPARTITIONTABLE ${aDRIVE_ISPARTITIONTABLE[$i]}
 					G_WHIP_YESNO "Your user data will be moved:\n - From: $FP_USERDATA_CURRENT\n - To: $fp_target_userdata_dir\n\nDo you wish to continue?"
 					if (( ! $? )); then
 
-						/DietPi/dietpi/func/dietpi-set_userdata "$FP_USERDATA_CURRENT" "$fp_target_userdata_dir"
+						SKIP_SERVICES=1 /DietPi/dietpi/func/dietpi-set_userdata "$FP_USERDATA_CURRENT" "$fp_target_userdata_dir"
 						sleep 1
 
 					fi

--- a/dietpi/func/dietpi-set_userdata
+++ b/dietpi/func/dietpi-set_userdata
@@ -18,74 +18,49 @@
 
 	#Import DietPi-Globals ---------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
-	G_CHECK_ROOT_USER
 	export G_PROGRAM_NAME='DietPi-Set_userdata'
+	G_CHECK_ROOT_USER
 	G_INIT
 	#Import DietPi-Globals ---------------------------------------------------------------
 
 	EXIT_CODE=0
 
-	SOURCE_DIRECTORY="$1"
-	TARGET_DIRECTORY="$2"
+	# Grab input
+	# - Remove trailing slashes
+	SOURCE_DIRECTORY="${1%/}"
+	TARGET_DIRECTORY="${2%/}"
 
-	LOGFILE_OUTPUT_TEXT=''
 	FP_LOGFILE='/var/log/dietpi-move_userdata.log'
-
-	SWAPFILE_SIZE=$(/DietPi/dietpi/func/dietpi-set_dphys-swapfile | awk '{print $1}')
-
-	FREESPACE_AVAILABLE_TARGET=0
+	LOGFILE_OUTPUT_TEXT=''
 	FREESPACE_REQUIRED_SOURCE=0
 
 	Run_Move_Data(){
 
-		# - stop all running services.
-		/DietPi/dietpi/dietpi-services stop
-
-		# - Remove directory if its currently a symlink.
-		if [[ -L $TARGET_DIRECTORY ]]; then
-
-			rm -R "$TARGET_DIRECTORY"
-
-		fi
-
-		mkdir -p "$TARGET_DIRECTORY"
+		# - Stop all running services
+		[[ $SKIP_SERVICES == 1 ]] || /DietPi/dietpi/dietpi-services stop
 
 		# - Copy source to target, if it contains any files/folders
 		if [[ -z $(find $SOURCE_DIRECTORY -maxdepth 0 -empty) ]]; then
 
 			G_DIETPI-NOTIFY 0 "Moving your existing data from $SOURCE_DIRECTORY to $TARGET_DIRECTORY"
-			G_DIETPI-NOTIFY 2 "Please wait...\n"
-
-			sleep 1
-
-			# - Check if user permissions are supported on target filesystem
-			local fp_test_target="$TARGET_DIRECTORY/.permissions_test"
-
-			rm "$fp_test_target" &> /dev/null
-
-			echo 0 > "$fp_test_target"
-			chown www-data:www-data "$fp_test_target" &> /dev/null
-
-			local cp_options='-vR'
-
-			if (( $(ls -lha "$fp_test_target" | grep -ci -m1 "www-data") )); then
-
-				cp_options+='p'
-				G_DIETPI-NOTIFY 2 "Target filesystem supports user permissions:"
-				G_DIETPI-NOTIFY 2 " - Attempting to preserve permissions during transfer."
-				sleep 1
-
-			fi
-
-			rm "$fp_test_target" &> /dev/null
+			G_DIETPI-NOTIFY 2 'Please wait...\n'
 
 			# - Begin transfer
-			cp "$cp_options" "$SOURCE_DIRECTORY"/* "$TARGET_DIRECTORY"/
+			cp -a "$SOURCE_DIRECTORY"/. "$TARGET_DIRECTORY"/
+			if (( ! $? )); then
 
-			# - Remove all files in source
-			if (( $? == 0 )); then
+				# - Remove source
+				rm -R "$SOURCE_DIRECTORY"
 
-				rm -R "$SOURCE_DIRECTORY"/*
+				# - Create symlink to G_FP_DIETPI_USERDATA if required
+				if [[ $TARGET_DIRECTORY != $G_FP_DIETPI_USERDATA ]]; then
+
+					rm -R $G_FP_DIETPI_USERDATA &> /dev/null
+					ln -sf "$TARGET_DIRECTORY" $G_FP_DIETPI_USERDATA
+
+				fi
+
+				LOGFILE_OUTPUT_TEXT="SUCCESS: Successfully moved your data from $SOURCE_DIRECTORY to $TARGET_DIRECTORY"
 
 			else
 
@@ -97,57 +72,26 @@
 
 		fi
 
-		# - Remove source base folder if its a symlink
-		if [[ -L $SOURCE_DIRECTORY ]]; then
-
-			rm -R "$SOURCE_DIRECTORY"
-
-		fi
-
-		# - Create symlink to G_FP_DIETPI_USERDATA if required
-		if [[ $TARGET_DIRECTORY != $G_FP_DIETPI_USERDATA ]]; then
-
-			rm -R "$G_FP_DIETPI_USERDATA" &> /dev/null
-			ln -sf "$TARGET_DIRECTORY" "$G_FP_DIETPI_USERDATA"
-
-		fi
-
-		# - Set permissions for userdata dirs:
-		/DietPi/dietpi/dietpi-software setpermissions
-
 		# - Start services back up again
-		/DietPi/dietpi/dietpi-services start
+		[[ $SKIP_SERVICES == 1 ]] || /DietPi/dietpi/dietpi-services start
 
 	}
 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Main Loop
 	#/////////////////////////////////////////////////////////////////////////////////////
-	#init
-
-	# - If there is no directory or symlink for $G_FP_DIETPI_USERDATA, always create a directory.
-	if [[ ! -d $G_FP_DIETPI_USERDATA ]] && [[ ! -L $G_FP_DIETPI_USERDATA ]]; then
-
-		#Run full core_env set
-		/DietPi/dietpi/func/dietpi-set_core_environment
-
-	fi
-
-	#-------------------------------------------------------------------------------------
-	#Run
-	target_to_lowercase=$(echo -e "$TARGET_DIRECTORY" | tr '[:upper:]' '[:lower:]')
 
 	G_DIETPI-NOTIFY 3 'DietPi Updating user data location'
 	G_DIETPI-NOTIFY 2 " - From : $SOURCE_DIRECTORY"
 	G_DIETPI-NOTIFY 2 " - To   : $TARGET_DIRECTORY"
-	G_DIETPI-NOTIFY 2 "Please wait..."
+	G_DIETPI-NOTIFY 2 'Please wait...'
 
-	while true
+	while :
 	do
 
 		# Sanity checks
 		# - Check for both inputs
-		if [[ -z $SOURCE_DIRECTORY ]] || [[ -z $TARGET_DIRECTORY ]]; then
+		if [[ -z $SOURCE_DIRECTORY || -z $TARGET_DIRECTORY ]]; then
 
 			LOGFILE_OUTPUT_TEXT="ERROR: Please provide a source ($SOURCE_DIRECTORY) and target ($TARGET_DIRECTORY) directory for input."
 			EXIT_CODE=1
@@ -156,27 +100,26 @@
 		# - Check if symlink is already pointing to target directory.
 		elif [[ $(readlink -f $G_FP_DIETPI_USERDATA) == $TARGET_DIRECTORY ]]; then
 
-			LOGFILE_OUTPUT_TEXT="$G_FP_DIETPI_USERDATA is already symlinked to target directory."
+			LOGFILE_OUTPUT_TEXT="INFO: $G_FP_DIETPI_USERDATA is already symlinked to target directory."
 			EXIT_CODE=0 #return ok
 			break
 
 		# - Check if source directory exists
-		elif [ ! -d "$SOURCE_DIRECTORY" ]; then
+		elif [[ ! -d $SOURCE_DIRECTORY ]]; then
 
 			LOGFILE_OUTPUT_TEXT="ERROR: source directory $SOURCE_DIRECTORY does not exist."
 			EXIT_CODE=1
 			break
 
 		# - Check for disallowed directory match
-		elif (( $(echo -e "$SOURCE_DIRECTORY" | grep -ci -m1 "$TARGET_DIRECTORY") ||
-			$(echo -e "$TARGET_DIRECTORY" | grep -ci -m1 "$SOURCE_DIRECTORY") )); then
+		elif [[ $SOURCE_DIRECTORY =~ $TARGET_DIRECTORY || $TARGET_DIRECTORY =~ $SOURCE_DIRECTORY ]]; then
 
 			LOGFILE_OUTPUT_TEXT="ERROR: $SOURCE_DIRECTORY and $TARGET_DIRECTORY cannot be within each other. Disallowed directory match."
 			EXIT_CODE=1
 			break
 
 		# - Only allow full filepaths
-		elif [[ ${SOURCE_DIRECTORY:0:1} != '/' ]] || [[ ${TARGET_DIRECTORY:0:1} != '/' ]]; then
+		elif [[ ${SOURCE_DIRECTORY:0:1} != '/' || ${TARGET_DIRECTORY:0:1} != '/' ]]; then
 
 			LOGFILE_OUTPUT_TEXT="ERROR: Both source ($SOURCE_DIRECTORY) and target directories ($TARGET_DIRECTORY) must contain the full filepath (eg: /mnt/drive1)"
 			EXIT_CODE=1
@@ -186,7 +129,7 @@
 		# - Disallow FS with no permissions support.
 		elif ! G_CHECK_FS_PERMISSION_SUPPORT $TARGET_DIRECTORY; then
 
-			LOGFILE_OUTPUT_TEXT="$TARGET_DIRECTORY does not support filesystem permissions. Transfer aborted."
+			LOGFILE_OUTPUT_TEXT="ERROR: $TARGET_DIRECTORY does not support filesystem permissions. Transfer aborted."
 			EXIT_CODE=1
 			break
 
@@ -194,18 +137,14 @@
 
 		mkdir -p "$TARGET_DIRECTORY" &> /dev/null
 
-		#Ensure enough freespace in target
-		FREESPACE_AVAILABLE_TARGET=$(( $(df -Pk "$TARGET_DIRECTORY" | awk '{print $4}' | sed -n 2p) * 1024 )) #bytes
+		# - Ensure enough freespace in target
+		#	"-BM" => result in MiB actual disc usage, respecting disk block size, e.g. "144M"
+		# 	"-b"  => result in bytes apparent size, ignoring disk block size, e.g. "142662603"
+		#	Trailing slash required with "du" to correctly check symlink target in case
+		FREESPACE_REQUIRED_SOURCE=$(du -sBM "$SOURCE_DIRECTORY/" | awk '{print $1}')
+		if (( ! $(G_CHECK_FREESPACE "$TARGET_DIRECTORY" ${FREESPACE_REQUIRED_SOURCE/M/}) )); then
 
-		G_DIETPI-NOTIFY 2 "Calculating space required for moving data, please wait..."
-		FREESPACE_REQUIRED_SOURCE=$(du -cbs "$SOURCE_DIRECTORY" | awk '{print $1}' | sed -n 1p) #bytes
-
-		echo -e " - Available $FREESPACE_AVAILABLE_TARGET bytes"
-		echo -e " - Required  $FREESPACE_REQUIRED_SOURCE bytes"
-
-		if (( $FREESPACE_AVAILABLE_TARGET < $FREESPACE_REQUIRED_SOURCE )); then
-
-			LOGFILE_OUTPUT_TEXT="ERROR: Not enough free space in target directory $TARGET_DIRECTORY.\n - Available $FREESPACE_AVAILABLE_TARGET\n - Required $FREESPACE_REQUIRED_SOURCE"
+			LOGFILE_OUTPUT_TEXT="ERROR: Not enough free space in target directory $TARGET_DIRECTORY.\n - Required $FREESPACE_REQUIRED_SOURCE"
 			EXIT_CODE=1
 			break
 
@@ -217,9 +156,9 @@
 	done
 
 	#-----------------------------------------------------------------------------------
-	#Print any errors and send to logfile
-	rm "$FP_LOGFILE" &> /dev/null
-	if [[ -n $LOGFILE_OUTPUT_TEXT ]]; then
+	#Print results and send to logfile
+	rm $FP_LOGFILE &> /dev/null
+	if [[ $LOGFILE_OUTPUT_TEXT ]]; then
 
 		# - Info
 		if (( $EXIT_CODE == 0 )); then
@@ -233,21 +172,13 @@
 
 		fi
 
-		echo ''
-
 		# + send to logfile
-		echo -e "$LOGFILE_OUTPUT_TEXT" > "$FP_LOGFILE"
-
-	else
-
-		G_DIETPI-NOTIFY 2 'User data location setup completed.'
-
-		echo ''
+		echo -e "$LOGFILE_OUTPUT_TEXT" > $FP_LOGFILE
 
 	fi
 
 	#-----------------------------------------------------------------------------------
-	G_DIETPI-NOTIFY -1 ${EXIT_CODE:=0}
+	G_DIETPI-NOTIFY -1 $EXIT_CODE
 	#-----------------------------------------------------------------------------------
 	exit $EXIT_CODE
 	#-----------------------------------------------------------------------------------

--- a/dietpi/func/dietpi-set_userdata
+++ b/dietpi/func/dietpi-set_userdata
@@ -134,6 +134,8 @@
 
 		fi
 
+		# - Remove $G_FP_DIETPI_USERDATA symlink, if chosen as target
+		[[ $TARGET_DIRECTORY == $G_FP_DIETPI_USERDATA ]] && rm $G_FP_DIETPI_USERDATA &> /dev/null
 		mkdir -p "$TARGET_DIRECTORY" &> /dev/null
 
 		# - Ensure enough freespace in target

--- a/dietpi/func/dietpi-set_userdata
+++ b/dietpi/func/dietpi-set_userdata
@@ -66,7 +66,6 @@
 
 				LOGFILE_OUTPUT_TEXT="ERROR: Failed to copy $SOURCE_DIRECTORY/* to $TARGET_DIRECTORY."
 				EXIT_CODE=1
-				break
 
 			fi
 

--- a/dietpi/func/dietpi-set_userdata
+++ b/dietpi/func/dietpi-set_userdata
@@ -85,76 +85,70 @@
 	G_DIETPI-NOTIFY 2 " - To   : $TARGET_DIRECTORY"
 	G_DIETPI-NOTIFY 2 'Please wait...'
 
-	while :
-	do
+	# Sanity checks
+	# - Check for both inputs
+	if [[ -z $SOURCE_DIRECTORY || -z $TARGET_DIRECTORY ]]; then
 
-		# Sanity checks
-		# - Check for both inputs
-		if [[ -z $SOURCE_DIRECTORY || -z $TARGET_DIRECTORY ]]; then
+		LOGFILE_OUTPUT_TEXT="ERROR: Please provide a source ($SOURCE_DIRECTORY) and target ($TARGET_DIRECTORY) directory for input."
+		EXIT_CODE=1
 
-			LOGFILE_OUTPUT_TEXT="ERROR: Please provide a source ($SOURCE_DIRECTORY) and target ($TARGET_DIRECTORY) directory for input."
-			EXIT_CODE=1
-			break
+	# - Check if symlink is already pointing to target directory.
+	elif [[ $(readlink -f $G_FP_DIETPI_USERDATA) == $TARGET_DIRECTORY ]]; then
 
-		# - Check if symlink is already pointing to target directory.
-		elif [[ $(readlink -f $G_FP_DIETPI_USERDATA) == $TARGET_DIRECTORY ]]; then
+		LOGFILE_OUTPUT_TEXT="INFO: $G_FP_DIETPI_USERDATA is already symlinked to target directory."
 
-			LOGFILE_OUTPUT_TEXT="INFO: $G_FP_DIETPI_USERDATA is already symlinked to target directory."
-			EXIT_CODE=0 #return ok
-			break
+	# - Check if source directory exists
+	elif [[ ! -d $SOURCE_DIRECTORY ]]; then
 
-		# - Check if source directory exists
-		elif [[ ! -d $SOURCE_DIRECTORY ]]; then
+		LOGFILE_OUTPUT_TEXT="ERROR: source directory $SOURCE_DIRECTORY does not exist."
+		EXIT_CODE=1
 
-			LOGFILE_OUTPUT_TEXT="ERROR: source directory $SOURCE_DIRECTORY does not exist."
-			EXIT_CODE=1
-			break
+	# - Check for disallowed directory match
+	elif [[ $SOURCE_DIRECTORY =~ $TARGET_DIRECTORY || $TARGET_DIRECTORY =~ $SOURCE_DIRECTORY ]]; then
 
-		# - Check for disallowed directory match
-		elif [[ $SOURCE_DIRECTORY =~ $TARGET_DIRECTORY || $TARGET_DIRECTORY =~ $SOURCE_DIRECTORY ]]; then
+		LOGFILE_OUTPUT_TEXT="ERROR: $SOURCE_DIRECTORY and $TARGET_DIRECTORY cannot be within each other. Disallowed directory match."
+		EXIT_CODE=1
 
-			LOGFILE_OUTPUT_TEXT="ERROR: $SOURCE_DIRECTORY and $TARGET_DIRECTORY cannot be within each other. Disallowed directory match."
-			EXIT_CODE=1
-			break
+	# - Only allow full filepaths
+	elif [[ ${SOURCE_DIRECTORY:0:1} != '/' || ${TARGET_DIRECTORY:0:1} != '/' ]]; then
 
-		# - Only allow full filepaths
-		elif [[ ${SOURCE_DIRECTORY:0:1} != '/' || ${TARGET_DIRECTORY:0:1} != '/' ]]; then
+		LOGFILE_OUTPUT_TEXT="ERROR: Both source ($SOURCE_DIRECTORY) and target directories ($TARGET_DIRECTORY) must contain the full filepath (eg: /mnt/drive1)"
+		EXIT_CODE=1
 
-			LOGFILE_OUTPUT_TEXT="ERROR: Both source ($SOURCE_DIRECTORY) and target directories ($TARGET_DIRECTORY) must contain the full filepath (eg: /mnt/drive1)"
-			EXIT_CODE=1
-			break
-
-		# - Ensure we can create and write to target directory
-		# - Disallow FS with no permissions support.
-		elif ! G_CHECK_FS_PERMISSION_SUPPORT $TARGET_DIRECTORY; then
-
-			LOGFILE_OUTPUT_TEXT="ERROR: $TARGET_DIRECTORY does not support filesystem permissions. Transfer aborted."
-			EXIT_CODE=1
-			break
-
-		fi
+	else
 
 		# - Remove $G_FP_DIETPI_USERDATA symlink, if chosen as target
 		[[ $TARGET_DIRECTORY == $G_FP_DIETPI_USERDATA ]] && rm $G_FP_DIETPI_USERDATA &> /dev/null
 		mkdir -p "$TARGET_DIRECTORY" &> /dev/null
 
-		# - Ensure enough freespace in target
-		#	"-BM" => result in MiB actual disc usage, respecting disk block size, e.g. "144M"
-		# 	"-b"  => result in bytes apparent size, ignoring disk block size, e.g. "142662603"
-		#	Trailing slash required with "du" to correctly check symlink target in case
-		FREESPACE_REQUIRED_SOURCE=$(du -sBM "$SOURCE_DIRECTORY/" | awk '{print $1}')
-		if (( ! $(G_CHECK_FREESPACE "$TARGET_DIRECTORY" ${FREESPACE_REQUIRED_SOURCE/M/}) )); then
+		# - Ensure we can create, write and set permissions to target directory
+		if ! G_CHECK_FS_PERMISSION_SUPPORT $TARGET_DIRECTORY; then
 
-			LOGFILE_OUTPUT_TEXT="ERROR: Not enough free space in target directory $TARGET_DIRECTORY.\n - Required $FREESPACE_REQUIRED_SOURCE"
+			LOGFILE_OUTPUT_TEXT="ERROR: $TARGET_DIRECTORY does not support filesystem permissions. Transfer aborted."
 			EXIT_CODE=1
-			break
+
+		else
+
+			# - Ensure enough freespace in target
+			#	"-BM" => result in MiB actual disc usage, respecting disk block size, e.g. "144M"
+			# 	"-b"  => result in bytes apparent size, ignoring disk block size, e.g. "142662603"
+			#	Trailing slash required with "du" to correctly check symlink target in case
+			FREESPACE_REQUIRED_SOURCE=$(du -sBM "$SOURCE_DIRECTORY/" | awk '{print $1}')
+			if (( ! $(G_CHECK_FREESPACE "$TARGET_DIRECTORY" ${FREESPACE_REQUIRED_SOURCE/M/}) )); then
+
+				LOGFILE_OUTPUT_TEXT="ERROR: Not enough free space in target directory $TARGET_DIRECTORY.\n - Required $FREESPACE_REQUIRED_SOURCE"
+				EXIT_CODE=1
+
+			else
+
+				#Run, attempt to move data.
+				Run_Move_Data
+
+			fi
 
 		fi
 
-		#Run, attempt to move data.
-		Run_Move_Data
-
-	done
+	fi
 
 	#-----------------------------------------------------------------------------------
 	#Print results and send to logfile


### PR DESCRIPTION
**Status**: Ready

**Reference**: https://github.com/Fourdee/DietPi/issues/1997

**Commit list/description**:
+ DietPi-Set_userdata | Allow symlinks as target directory, assure correct checks and handling (trailing slash)
+ DietPi-Set_userdata | Cleanup unavailable script calls and unused variables
+ DietPi-Set_userdata | Removed doubled target dir permission support check, remove obsolete "dietpi-software setpermissions" call
+ DietPi-Set_userdata | Use G_CHECK_FREESPACE()
+ DietPi-Set_userdata | Allow to skip service handling, e.g. when calling from within DietPi-Drive_Manager
+ DietPi-Drive_Manager | Use ability to skip service control within "dietpi-set_software"
+ DietPi-Set_userdata | Minor coding and output
+ DietPi-Set_userdata | Remove $G_FP_DIETPI_USERDATA symlink, if chosen as target
+ DietPi-Set_userdata | Remove checks loop to avoid confusing log file output and terminal output about already existing symlink

We could use G_SKIP_SERVICES and export it to child services to always leave start/stop to parent?