### PR TITLE
DietPi-Software | Enable RPi unrar support for Jessie and Buster

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5554,11 +5554,11 @@ _EOF_
 			mv ruTorrent-*/* /var/www/rutorrent/
 			rm -R ruTorrent-*
 
-			#Raspbian unrar free only available in repos
+			#Raspbian "unrar-free" only available in repos
 			if (( $G_HW_MODEL < 10 )); then
 
-				#G_AGI unrar-free #https://github.com/Fourdee/DietPi/issues/176#issuecomment-240101365
-				Download_Install 'https://dietpi.com/downloads/binaries/all/unrar_5.3.2-1+deb9u1_armhf.deb'
+				#G_AGI unrar-free #Does not support all rar formats, better use "unrar-nonfree" from Debian repo
+				Download_Install "https://dietpi.com/downloads/binaries/rpi/unrar-armhf-$G_DISTRO_NAME.deb"
 
 			else
 
@@ -5635,11 +5635,11 @@ _EOF_
 			cp -R SickRage-*/* $G_FP_DIETPI_USERDATA/sickrage/
 			rm -R SickRage-*
 
-			#Raspbian unrar free
+			#Raspbian "unrar-free" only available in repos
 			if (( $G_HW_MODEL < 10 )); then
 
-				#G_AGI unrar-free #https://github.com/Fourdee/DietPi/issues/176#issuecomment-240101365
-				Download_Install 'https://dietpi.com/downloads/binaries/all/unrar_5.3.2-1+deb9u1_armhf.deb'
+				#G_AGI unrar-free #Does not support all rar formats, better use "unrar-nonfree" from Debian repo
+				Download_Install "https://dietpi.com/downloads/binaries/rpi/unrar-armhf-$G_DISTRO_NAME.deb"
 
 			else
 
@@ -5895,11 +5895,11 @@ _EOF_
 			mv /etc/sabnzbd/sabnzbd-"$version"/* /etc/sabnzbd/
 			rm -R /etc/sabnzbd/sabnzbd-"$version"
 
-			#Raspbian unrar free
+			#Raspbian "unrar-free" only available in repos
 			if (( $G_HW_MODEL < 10 )); then
 
-				#G_AGI unrar-free #https://github.com/Fourdee/DietPi/issues/176#issuecomment-240101365
-				Download_Install 'https://dietpi.com/downloads/binaries/all/unrar_5.3.2-1+deb9u1_armhf.deb'
+				#G_AGI unrar-free #Does not support all rar formats, better use "unrar-nonfree" from Debian repo
+				Download_Install "https://dietpi.com/downloads/binaries/rpi/unrar-armhf-$G_DISTRO_NAME.deb"
 
 			else
 


### PR DESCRIPTION
Minor, just wanted to add most current version from Buster repo. Found Jessie actually should not work, as it requires an unavailable library version. We usually don't offer RPi Jessie images anymore, but it doesn't hurt otherwise.
- Remove version string from URL/filename, so we can silently update to newer version, if available. We should go with this for all binaries we offer via dietpi.com.

Alternative would be to use offered ARM binary from rarlab: https://www.rarlab.com/rar/unrar-5.5.0-arm.gz
But not sure if it works flawlessly on all distro version. Debian repo should be failure safe.

**Status**: Ready
- [x] Archives added to server, Stretch version via symlink
  - Source: https://packages.debian.org/stretch/unrar, Buster and Jessie respectively

**Commit list/description**:
+ DietPi-Software | Enable RPi unrar support for Jessie and Buster