### PR TITLE
DietPi-Globals | G_INIT(): Hide debug output

### DIFF
--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -152,15 +152,15 @@ $(ps f -eo pid,user,tty,cmd | grep -i [d]ietpi)"
 		# Ensure we are in script working dir or users home dir, if available: https://github.com/Fourdee/DietPi/issues/905#issuecomment-298223705
 		if [[ $G_PROGRAM_NAME ]] && mkdir -p /tmp/$G_PROGRAM_NAME && cd /tmp/$G_PROGRAM_NAME; then
 
-			G_DIETPI-NOTIFY 2 "Entered scripts working directory: /tmp/$G_PROGRAM_NAME"
+			[[ G_DEBUG == 1 ]] && G_DIETPI-NOTIFY 2 "Entered scripts working directory: /tmp/$G_PROGRAM_NAME"
 
 		elif [[ -d $HOME ]] && cd $HOME; then
 
-			G_DIETPI-NOTIFY 2 "Entered users home directory: $HOME"
+			[[ G_DEBUG == 1 ]] && G_DIETPI-NOTIFY 2 "Entered users home directory: $HOME"
 
 		else
 
-			G_DIETPI-NOTIFY 2 "Failed to enter scripts working dir or users home dir. Will use current: $PWD"
+			[[ G_DEBUG == 1 ]] && G_DIETPI-NOTIFY 2 "Failed to enter scripts working dir or users home dir. Will use current: $PWD"
 
 		fi
 


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Globals | G_INIT(): Hide debug output

@Fourdee 
What do you think. On demand add some debug output to the code that is just shown with `$G_DEBUG == 1`? Could be beneficial also to allow better debugging on end user systems?

Or simply remove the code, adding `:` as fastest dummy "command".

At least the `cd` in this case should stay within conditional statement, as if it for some reason fails (cd /tmp/DietPi-*), the the script should try to navigate to $HOME instead.