### PR TITLE
DietPi-Software | phpMyAdmin: New workaround for Lighttpd + phpMyAdmin APT issue

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3750,6 +3750,10 @@ _EOF_
 			elif (( ${aSOFTWARE_INSTALL_STATE[84]} == 1 )); then
 
 				debconf-set-selections <<< 'phpmyadmin phpmyadmin/reconfigure-webserver multiselect lighttpd'
+				# Workaround an APT error, when installing lighttpd and phpmyadmin in the same session: https://github.com/Fourdee/DietPi/issues/316
+				G_USER_INPUTS=0 G_RUN_CMD_INFO_ONLY=1 G_AGI phpmyadmin
+				G_WHIP_MSG 'Working around Lighttpd + phpMyAdmin APT errors:\n\nYou may have seen an error during the phpMyAdmin APT installation. This occurs, when Lighttpd webserver was installed within the same session.\n
+We work around this error by running APT a second time. Please don\'t worry and ignore any error or failure message within this install steps. After DietPi-Software finished, Lighttpd should start up and phpMyAdmin web UI should be available as expected.'
 
 			else
 
@@ -3910,7 +3914,7 @@ _EOF_
 			debconf-set-selections <<< 'fahclient fahclient/power select light'
 			debconf-set-selections <<< 'fahclient fahclient/team string 234437' # Team "DietPi"
 			debconf-set-selections <<< 'fahclient fahclient/user string DietPi' # Default, until user chooses an own username
-			debconf-set-selections <<< 'fahclient fahclient/passkey string'
+			debconf-set-selections <<< 'fahclient fahclient/passkey string 06c869246e88c00cb05cc4d1758a97f9'
 
 			Download_Install 'https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v7.5/latest.deb'
 
@@ -7703,7 +7707,7 @@ _EOF_
 			# Thus default "phpmyadmin" user need to be used, who on Jessie does not have all privileges:
 			# https://dietpi.com/phpbb/viewtopic.php?f=8&t=5&p=54#p54
 			systemctl start mysql
-			mysql -e "grant all privileges on *.* to phpmyadmin@localhost with grant option"
+			mysql -e 'grant all privileges on *.* to phpmyadmin@localhost with grant option'
 
 		fi
 
@@ -15030,23 +15034,12 @@ _EOF_
 				#Please let DietPi install them for you...
 				if (( ${aSOFTWARE_INSTALL_STATE[$i]} == 1 )); then
 
-					G_WHIP_MSG 'DietPi will automatically install a webserver stack (based on your Webserver Preference) when any software that requires a webserver is selected for installation (eg: ownCloud, PiHole etc).\n\nIt is highly recommended that you allow DietPi to do this for you, ensuring compatibility and stability across DietPi installed programs.\n\nPlease only select a webserver stack if you specifically require it, and, no other webserver stack is installed.\n\nTLDR: You do NOT need to select a webserver stack for installation with DietPi. Its all automatic.'
+					G_WHIP_MSG 'DietPi will automatically install a webserver stack (based on your Webserver Preference) when any software that requires a webserver is selected for installation (eg: ownCloud, Pi-hole etc).\n\nIt is highly recommended that you allow DietPi to do this for you, ensuring compatibility and stability across DietPi installed programs.\n\nPlease only select a webserver stack if you specifically require it, and, no other webserver stack is installed.\n\nTLDR: You do NOT need to select a webserver stack for installation with DietPi. Its all automatic.'
 					break
 
 				fi
 
 			done
-
-			#phpmyadmin + Lighttpd | broken apt-get installation. User must have a fully installed LLAP stack before phpmyadmin can be selected:
-			#https://github.com/Fourdee/DietPi/issues/316#issuecomment-219474664
-			if (( ${aSOFTWARE_INSTALL_STATE[90]} == 1 &&
-				$INDEX_WEBSERVER_TARGET == -2 &&
-				${aSOFTWARE_INSTALL_STATE[82]} < 2 )); then
-
-				G_WHIP_MSG 'Due to a apt-get installation issue with PhpMyAdmin, you must have a fully installed Lighttpd + MaridaDB webserver stack, before PhpMyAdmin can be selected for install.\n\nYour selection for PhpMyAdmin has been removed.'
-				aSOFTWARE_INSTALL_STATE[90]=0
-
-			fi
 
 			#RPiCamInterface - warn user of locking out camera: https://github.com/Fourdee/DietPi/issues/249
 			if (( ${aSOFTWARE_INSTALL_STATE[59]} == 1 )); then


### PR DESCRIPTION
**Status**: Ready
🈯️ VM Jessie
🈯️ VM Stretch
🈯️ VM Buster
- APT throws the error and also the second run shows "failed" of package internal install steps, but APT then exits without error. After DietPi-Software finished everything is running fine, phpMyAdmin accessible, login and web UI working.
- Must have something to do with Lighttpd and/or MariaDB being installed, but not yet configured as we intend and/or phpMyAdmin installer expects. However as afterwards everything is working, informing user to ignore errors should be a sufficient solution.
- Works for interactive and non-interactive installs then and no reboot + phpMyAdmin reselect needed.

**Reference**: https://github.com/Fourdee/DietPi/issues/316#issuecomment-411488409

**Commit list/description**:
+ DietPi-Software | phpMyAdmin: Better workaround Lighttpd stack + phpMyAdmin APT issue, now applying for non-interactive install as well and allowing install of both packages without reboot and reselect.
+ DietPi-Software | Folding@Home: Add correct default passkey as well to APT pre-configuration, to match service argument, for consistency.