### PR TITLE
DietPi-Drive_Manager | Several

### DIFF
--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -557,7 +557,7 @@ aDRIVE_ISPARTITIONTABLE ${aDRIVE_ISPARTITIONTABLE[$i]}
 
 		#$1 = dev source
 		local drive=${1#/dev/}
-		if [[ $drive == '[sh]d'* ]]; then
+		if [[ $drive == [sh]d* ]]; then
 
 			echo ${drive%[0-9]}
 

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -49,9 +49,9 @@
 	FP_TEMP_FSTAB='.fstab'
 
 	#Drive data
-	FP_ROOTFS_SOURCE=0
-	FP_USERDATA_CURRENT=0
-	FP_SWAPFILE_CURRENT=0
+	FP_ROOTFS_SOURCE=''
+	FP_USERDATA_CURRENT=''
+	FP_SWAPFILE_CURRENT=''
 
 	INDEX_DRIVE_BEING_EDITED=0
 	DRIVE_TARGET_BEING_EDITED=''
@@ -127,10 +127,10 @@
 		FP_ROOTFS_SOURCE=$(findmnt / -o source -n)
 
 		#Recreate FStab
-		cp /etc/fstab $FP_TEMP_FSTAB
+		cp -a /etc/fstab $FP_TEMP_FSTAB
 
 		# - Grab current tmpfs entries
-		local tmpfs_mounts=$(grep '^tmpfs[[:space:]]' $FP_TEMP_FSTAB)
+		local tmpfs_mounts=$(grep '^tmpfs[[:blank:]]' $FP_TEMP_FSTAB)
 
 		# - Grab current bind
 		local bind_mounts=$(grep '[[:blank:],]bind[[:blank:],]' $FP_TEMP_FSTAB)
@@ -139,8 +139,8 @@
 		local swap_mount=$(grep -m1 '[[:blank:]]swap[[:blank:]]' $FP_TEMP_FSTAB)
 
 		# - Grab current network mounts + creds
-		local net_mounts_samba=$(grep '[[:space:]]cifs[[:space:]]' $FP_TEMP_FSTAB)
-		local net_mounts_nfs=$(grep '[[:space:]]nfs.*[[:space:]]' $FP_TEMP_FSTAB)
+		local net_mounts_samba=$(grep '[[:blank:]]cifs[[:blank:]]' $FP_TEMP_FSTAB)
+		local net_mounts_nfs=$(grep '[[:blank:]]nfs.*[[:blank:]]' $FP_TEMP_FSTAB)
 		local net_mounts_ftp=$(grep '^curlftpfs' $FP_TEMP_FSTAB)
 
 		#	Force regen (PREP)
@@ -161,8 +161,7 @@ tmpfs /DietPi tmpfs defaults,size=10m,noatime,nodev,nosuid,mode=1777 0 0
 
 		fi
 
-		cat << _EOF_ > $FP_TEMP_FSTAB
-#-----------------------------------------------------------
+		echo "#-----------------------------------------------------------
 #NETWORK
 #-----------------------------------------------------------
 #Please use DietPi-Drive_Manager to setup network mounts
@@ -184,8 +183,7 @@ $swap_mount
 
 #-----------------------------------------------------------
 #PHYSICAL DRIVES
-#-----------------------------------------------------------
-_EOF_
+#-----------------------------------------------------------" > $FP_TEMP_FSTAB
 
 		#Detect mounted drives and add them to fstab
 		G_DIETPI-NOTIFY 2 'Detecting drives, please wait...'
@@ -200,7 +198,7 @@ _EOF_
 
 			if [[ ! $line ]]; then
 
-				break
+				continue
 
 			fi
 
@@ -222,7 +220,7 @@ _EOF_
 
 			if [[ ! $line ]]; then
 
-				break
+				continue
 
 			elif [[ $(awk '{print $1}' <<< $line) =~ '/' ]]; then
 
@@ -275,7 +273,7 @@ _EOF_
 				# root@DietPi:~# cat /proc/mounts | grep ' / '
 				# rootfs / rootfs rw 0 0
 				# /dev/mmcblk0p2 / ext4 ro,noatime,discard,data=ordered 0 0
-				if grep -q "[[:space:]]${aDRIVE_MOUNT_TARGET[$INDEX_INIT_CURRENT_DEVICE]}[[:space:]].*[[:space:]]ro," /proc/mounts; then
+				if grep -q "[[:blank:]]${aDRIVE_MOUNT_TARGET[$INDEX_INIT_CURRENT_DEVICE]}[[:blank:]].*[[:blank:]]ro," /proc/mounts; then
 
 					aDRIVE_ISREADONLY_CURRENTLY[$INDEX_INIT_CURRENT_DEVICE]=1
 
@@ -295,9 +293,8 @@ _EOF_
 							/DietPi/dietpi/dietpi-services start
 
 							G_DIETPI-NOTIFY 0 'RootFS currently set to R/O.'
-							G_DIETPI-NOTIFY 2 "Please run 'dietpi-drive_manager' again, if you want to re-enable RootFS R/W."
+							G_DIETPI-NOTIFY 2 'Please run "dietpi-drive_manager" again, if you want to re-enable RootFS R/W.'
 
-							Destroy
 							exit
 
 						fi
@@ -336,16 +333,14 @@ _EOF_
 
 					fi
 
-					cat << _EOF_ >> $FP_TEMP_FSTAB
-$dev_entry ${aDRIVE_MOUNT_TARGET[$INDEX_INIT_CURRENT_DEVICE]} auto defaults,noatime$string_options 0 $fsck_flag
-_EOF_
+					echo "$dev_entry ${aDRIVE_MOUNT_TARGET[$INDEX_INIT_CURRENT_DEVICE]} auto defaults,noatime$string_options 0 $fsck_flag" >> $FP_TEMP_FSTAB
 
 				fi
 
 			fi
 
 		done < .dietpi-drive_manager_df_tmp
-		rm .dietpi-drive_manager_df_tmp &> /dev/null
+		rm .dietpi-drive_manager_df_tmp
 
 		#Check blkid for unmounted drives, if drive is not mounted, add entry as disabled mount
 		G_DIETPI-NOTIFY 0 'Detecting unmounted drives, please wait...'
@@ -355,7 +350,7 @@ _EOF_
 
 			if [[ ! $line ]]; then
 
-				break
+				continue
 
 			fi
 
@@ -394,16 +389,14 @@ _EOF_
 
 					fi
 
-					cat << _EOF_ >> $FP_TEMP_FSTAB
-#UUID=${aDRIVE_UUID[$INDEX_INIT_CURRENT_DEVICE]} ${aDRIVE_MOUNT_TARGET[$INDEX_INIT_CURRENT_DEVICE]} auto defaults,x-systemd.automount,noatime,rw,nofail 0 0
-_EOF_
+					echo "#UUID=${aDRIVE_UUID[$INDEX_INIT_CURRENT_DEVICE]} ${aDRIVE_MOUNT_TARGET[$INDEX_INIT_CURRENT_DEVICE]} auto defaults,x-systemd.automount,noatime,rw,nofail 0 0" >> $FP_TEMP_FSTAB
 
 				fi
 
 			done
 
 		done < .dietpi-drive_manager_blkid_tmp
-		rm .dietpi-drive_manager_blkid_tmp &> /dev/null
+		rm .dietpi-drive_manager_blkid_tmp
 
 		#Find drives that have no partitions
 		lsblk -nro NAME > .dietpi-drive_manager_lsblk_tmp
@@ -412,7 +405,7 @@ _EOF_
 
 			if [[ ! $line ]]; then
 
-				break
+				continue
 
 			fi
 
@@ -444,7 +437,7 @@ _EOF_
 			fi
 
 		done < .dietpi-drive_manager_lsblk_tmp
-		rm .dietpi-drive_manager_lsblk_tmp &> /dev/null
+		rm .dietpi-drive_manager_lsblk_tmp
 
 		#Set required global flags, for all drives found
 		for ((i=0; i<${#aDRIVE_MOUNT_SOURCE[@]}; i++))
@@ -470,8 +463,6 @@ _EOF_
 
 		done
 
-
-		#DEBUG
 		if (( $DEBUG )); then
 
 			G_DIETPI-NOTIFY 0 'DEBUG INFO:'
@@ -499,7 +490,6 @@ aDRIVE_ISPARTITIONTABLE ${aDRIVE_ISPARTITIONTABLE[$i]}
 
 			done
 
-			Destroy
 			exit
 
 		fi
@@ -530,7 +520,7 @@ aDRIVE_ISPARTITIONTABLE ${aDRIVE_ISPARTITIONTABLE[$i]}
 
 		fi
 
-		cp $FP_TEMP_FSTAB /etc/fstab
+		cp -a $FP_TEMP_FSTAB /etc/fstab
 		systemctl daemon-reload
 
 		rm $FP_TEMP_FSTAB
@@ -566,14 +556,15 @@ aDRIVE_ISPARTITIONTABLE ${aDRIVE_ISPARTITIONTABLE[$i]}
 	Return_Drive_Without_Partitions(){
 
 		#$1 = dev source
-		if [[ $1 == '/dev/sd'* || $1 == '/dev/hd'* ]]; then
+		local drive=${1#/dev/}
+		if [[ $drive == '[sh]d'* ]]; then
 
-			echo $1 | sed 's/[0-9]$//' | sed 's/\/dev\///'
+			echo ${drive%[0-9]}
 
 		#mmc/NVMe
 		else
 
-			echo $1 | sed 's/[pn][0-9]$//' | sed 's/\/dev\///'
+			echo ${drive%[pn][0-9]}
 
 		fi
 
@@ -593,7 +584,7 @@ aDRIVE_ISPARTITIONTABLE ${aDRIVE_ISPARTITIONTABLE[$i]}
 			if [[ $G_WHIP_RETURNED_VALUE == '/mnt/'* ]]; then
 
 				# - replace spaces with underscores
-				target=$(sed 's/[[:space:]]/_/g' <<< "$G_WHIP_RETURNED_VALUE")
+				target="${G_WHIP_RETURNED_VALUE//[[:space:]]/_}"
 
 			else
 
@@ -840,7 +831,7 @@ aDRIVE_ISPARTITIONTABLE ${aDRIVE_ISPARTITIONTABLE[$i]}
 		G_AG_CHECK_INSTALL_PREREQ rsync
 
 		#Remove previous fstab entry and mount location
-		cp /etc/fstab /etc/fstab.bak #incase of Rsync fail
+		cp -a /etc/fstab /etc/fstab.bak #incase of Rsync fail
 
 		#	Remove automatic entry for new uuid
 		sed -i "\@[[:space:]]${aDRIVE_MOUNT_TARGET[$INDEX_DRIVE_BEING_EDITED]}[[:space:]]@d" /etc/fstab
@@ -862,9 +853,8 @@ aDRIVE_ISPARTITIONTABLE ${aDRIVE_ISPARTITIONTABLE[$i]}
 
 			G_DIETPI-NOTIFY 1 'Rsync has failed, RootFS transfer has been aborted.'
 			#	revert FSTAB changes
-			cp /etc/fstab.bak /etc/fstab
+			cp -a /etc/fstab.bak /etc/fstab
 
-			Destroy
 			exit
 
 		fi
@@ -902,9 +892,9 @@ aDRIVE_ISPARTITIONTABLE ${aDRIVE_ISPARTITIONTABLE[$i]}
 		fi
 
 		systemctl daemon-reload
+		sync
 
 		G_WHIP_MSG 'RootFS transfer completed. Press enter to reboot system.'
-
 		reboot
 
 	}
@@ -1110,14 +1100,11 @@ aDRIVE_ISPARTITIONTABLE ${aDRIVE_ISPARTITIONTABLE[$i]}
 							G_ERROR_HANDLER_NO_FAIL=1 G_RUN_CMD hdparm -B $apm /dev/${aDRIVE_SOURCE_DEVICE[$i]}
 							G_ERROR_HANDLER_NO_FAIL=1 G_RUN_CMD hdparm -S $G_WHIP_RETURNED_VALUE /dev/${aDRIVE_SOURCE_DEVICE[$i]}
 
-							cat << _EOF_ >> /etc/hdparm.conf
-/dev/${aDRIVE_SOURCE_DEVICE[$i]}
+							echo "/dev/${aDRIVE_SOURCE_DEVICE[$i]}
 {
    apm = $apm
    spindown_time = $G_WHIP_RETURNED_VALUE
-}
-
-_EOF_
+}" >> /etc/hdparm.conf
 
 						fi
 
@@ -1252,8 +1239,8 @@ _EOF_
 
 							# - Swapfile
 							#	NB: / rootfs will always be detected in this check, however, no rootFS options for umount and format...
-							local swapfile_location="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_SWAPFILE_LOCATION=' /DietPi/dietpi.txt | sed 's/.*=//')"
-							local swapfile_size=$(grep -m1 '^[[:blank:]]*AUTO_SETUP_SWAPFILE_SIZE=' /DietPi/dietpi.txt | sed 's/.*=//')
+							local swapfile_location="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_SWAPFILE_LOCATION=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
+							local swapfile_size=$(grep -m1 '^[[:blank:]]*AUTO_SETUP_SWAPFILE_SIZE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 							if [[ $swapfile_location == ${aDRIVE_MOUNT_TARGET[$INDEX_DRIVE_BEING_EDITED]}* && ${aDRIVE_MOUNT_TARGET[$INDEX_DRIVE_BEING_EDITED]} != '/' ]] ||
 								[[ $swapfile_location == '/var/swap' && ${aDRIVE_MOUNT_TARGET[$INDEX_DRIVE_BEING_EDITED]} == '/' ]]; then
 
@@ -1849,7 +1836,7 @@ NB:
 
 			fi
 			#	NB: Convert spaces into '\040': https://github.com/Fourdee/DietPi/issues/1201#issuecomment-339720271
-			samba_clientshare=$(sed 's/ /\\\\040/g' <<< "$G_WHIP_RETURNED_VALUE")
+			samba_clientshare="${G_WHIP_RETURNED_VALUE//[[:space:]]/\\\\040}"
 
 			G_WHIP_DEFAULT_ITEM="$samba_clientuser"
 			G_WHIP_INPUTBOX 'Please enter the fileservers username\n - eg: JoeBloggs'
@@ -1872,7 +1859,7 @@ NB:
 				break
 
 			fi
-			samba_fp_mount_target="/mnt/$(sed 's/\///g' <<< $G_WHIP_RETURNED_VALUE | sed 's/[[:space:]]/_/g')"
+			samba_fp_mount_target="/mnt/${G_WHIP_RETURNED_VALUE//[[:space:]]/_}"
 
 			# - Unmount if connected
 			umount /mnt/$samba_fp_mount_target &> /dev/null
@@ -1901,9 +1888,7 @@ NB:
 
 					# - Apply to fstab
 					sed -i "\#[[:space:]]$samba_fp_mount_target[[:space:]]#d" /etc/fstab
-					cat << _EOF_ >> /etc/fstab
-//$samba_clientname/$samba_clientshare $samba_fp_mount_target cifs username=$samba_clientuser,password=$samba_clientpassword,iocharset=utf8,vers=${acifs_versions[$i]},_netdev,nofail 0 0
-_EOF_
+					echo "//$samba_clientname/$samba_clientshare $samba_fp_mount_target cifs username=$samba_clientuser,password=$samba_clientpassword,iocharset=utf8,vers=${acifs_versions[$i]},_netdev,nofail 0 0" >> /etc/fstab
 
 					DRIVE_TARGET_BEING_EDITED="$samba_fp_mount_target"
 					TARGETMENUID=1
@@ -1986,9 +1971,7 @@ _EOF_
 
 				#Apply to fstab
 				sed -i "\#[[:space:]]$nfs_fp_mount_target[[:space:]]#d" /etc/fstab
-				cat << _EOF_ >> /etc/fstab
-$nfs_server_ip:/ $nfs_fp_mount_target nfs auto,_netdev,nofail 0 0
-_EOF_
+				echo "$nfs_server_ip:/ $nfs_fp_mount_target nfs auto,_netdev,nofail 0 0" >> /etc/fstab
 
 				DRIVE_TARGET_BEING_EDITED="$nfs_fp_mount_target"
 				TARGETMENUID=1
@@ -2017,9 +2000,7 @@ _EOF_
 
 					#Apply to fstab
 					sed -i "\#[[:space:]]$nfs_fp_mount_target[[:space:]]#d" /etc/fstab
-					cat << _EOF_ >> /etc/fstab
-$nfs_server_ip:$nfs_fp_server_share $nfs_fp_mount_target nfs auto,_netdev,nofail 0 0
-_EOF_
+					echo "$nfs_server_ip:$nfs_fp_server_share $nfs_fp_mount_target nfs auto,_netdev,nofail 0 0" >> /etc/fstab
 
 					DRIVE_TARGET_BEING_EDITED="$nfs_fp_mount_target"
 					TARGETMENUID=1
@@ -2094,7 +2075,7 @@ $(<$fp_tmp)"
 		while read line
 		do
 
-			G_WHIP_MENU_ARRAY+=("$(echo -e $line | awk '{print $6}')" ": $(echo -e $line | awk '{print $1}') | size: $(echo -e $line | awk '{print $2}') | available: $(echo -e $line | awk '{print $4}')")
+			G_WHIP_MENU_ARRAY+=("$(awk '{print $6}' <<< $line)" ": $(awk '{print $1}' <<< $line) | size: $(awk '{print $2}' <<< $line) | available: $(awk '{print $4}' <<< $line)")
 
 		done < dietpi-drive_manager_selmnt
 		rm dietpi-drive_manager_selmnt
@@ -2106,7 +2087,7 @@ $(<$fp_tmp)"
 			local drive_manager_selection="$G_WHIP_RETURNED_VALUE"
 
 			G_DIETPI-NOTIFY 0 "Drive mount selected: $drive_manager_selection"
-			echo -e "$drive_manager_selection" > "$FP_DRIVE_MANAGER_SELECTION"
+			echo "$drive_manager_selection" > "$FP_DRIVE_MANAGER_SELECTION"
 
 		fi
 


### PR DESCRIPTION
**Status**: ready
<s>🈴 Drives and partitions both are listed as headers (doubled)</s> **€: Fixed with https://github.com/Fourdee/DietPi/pull/2062/commits/daa6ab62b33e066356a219e3a7e434541a76476c**

**References**:
- https://dietpi.com/phpbb/viewtopic.php?f=11&t=4649
- https://github.com/Fourdee/DietPi/issues/1510#issuecomment-419722975

**Commit list/description**:
+ DietPi-Drive_Manager | Allow sub directories for samba mounts: https://dietpi.com/phpbb/viewtopic.php?f=11&t=4649
+ DietPi-Drive_Manager | When scraping device detection commands, use "continue" instead of "break" to just skip empty lines instead of breaking the whole loop
  - @Fourdee 
Currently, if I am not totally mistaken, an empty line would break the whole output command/file loop. This should never be an issue, since these commands do not have empty lines. But if we already check (failsafe), then continue should do the job, skipping current line and go on with the next.
+ DietPi-Drive_Manager | Keep file permissions when copying fstab
+ DietPi-Drive_Manager | "Destroy()" call is no needed directly before "exit", since it is now called on all kinds of exits via exit trap.
+ DietPi-Drive_Manager | Replace "cat" with "echo" for writing content to file: https://github.com/Fourdee/DietPi/issues/1510#issuecomment-419722975
  - This is something we can roll out to all scripts by times, since the performance difference is huge.
+ DietPi-Drive_Manager | Further minor code and stability improvements
+ DietPi-Drive_Manager | Syntax fix: In "[[ $string == '<pattern>' ]]", inside single (and double) quotes, braces are taken literally. 