### PR TITLE
General | Fix "wireless-tools" pre-up script bug

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ DietPi-Software | Pi-hole: You can now install Pi-hole again on Debian Jessie sy
 
 Bug Fixes:
 General | Resolved an issue where 1st run setup password prompt, would run twice. Once on 1st run and once after updates are completed.
+General | Resolved an external issue where in very rare cases WiFi interfaces were not initiated successfully: https://github.com/Fourdee/DietPi/issues/2074
 DietPi-Config | Resolved an issue with selected WiFi SSID not being correctly applied: https://github.com/Fourdee/DietPi/issues/2070#issuecomment-421060961
 
 -----------------------------------------------------------------------------------------------------------

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -1139,6 +1139,9 @@ _EOF_
 
 		fi
 
+		#	Fix rare WiFi interface start issue: https://github.com/Fourdee/DietPi/issues/2074
+		sed -i '\|^[[:blank:]]ifconfig "$IFACE" up$|c\\t/sbin/ip link set dev "$IFACE" up' /etc/network/if-pre-up.d/wireless-tools &> /dev/null
+
 		G_DIETPI-NOTIFY 2 'Tweaking DHCP timeout:'
 
 		# - Reduce DHCP request retry count and timeouts: https://github.com/Fourdee/DietPi/issues/711
@@ -1165,7 +1168,7 @@ _EOF_
 		mkdir -p /root/.config/htop
 		cp /DietPi/dietpi/conf/htoprc /root/.config/htop/htoprc
 
-		G_DIETPI-NOTIFY 2 'Configuring fakehwclock:'
+		G_DIETPI-NOTIFY 2 'Configuring fake-hwclock:'
 
 		# - allow times in the past
 		G_CONFIG_INJECT 'FORCE=' 'FORCE=force' /etc/default/fake-hwclock

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1274,6 +1274,9 @@ _EOF_
 
 			fi
 			#-------------------------------------------------------------------------------
+			#Fix rare WiFi interface start issue: https://github.com/Fourdee/DietPi/issues/2074
+			sed -i '\|^[[:blank:]]ifconfig "$IFACE" up$|c\\t/sbin/ip link set dev "$IFACE" up' /etc/network/if-pre-up.d/wireless-tools &> /dev/null
+			#-------------------------------------------------------------------------------
 
 		fi
 


### PR DESCRIPTION
**Status**: Ready
- [x] PREP
- [x] Patch
- [x] Changelog

**Reference**: https://github.com/Fourdee/DietPi/issues/2074

**Commit list/description**:
+ DietPi-PREP | Fix "wireless-tools" pre-up script bug, which produced error messages and not fully configured WiFi interfaces in very rare cases
