### PR TITLE
DietPi-Update | Check GitHub repo first

### DIFF
--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -302,7 +302,7 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 				/DietPi/dietpi/patch_file $G_DIETPI_VERSION_SUB
 
 				#Update Local Version ID
-				((G_DIETPI_VERSION_SUB++))
+				export G_DIETPI_VERSION_SUB=$((G_DIETPI_VERSION_SUB+1))
 				echo -e "$G_DIETPI_VERSION_CORE\n$G_DIETPI_VERSION_SUB" > /DietPi/dietpi/.version
 
 				G_DIETPI-NOTIFY 0 "Patch v$G_DIETPI_VERSION_CORE.$G_DIETPI_VERSION_SUB completed\n"
@@ -344,7 +344,7 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 		else
 
 			G_DIETPI-NOTIFY 0 'Repatch was requested: Update will reapply the current subversion patch'
-			((G_DIETPI_VERSION_SUB--))
+			export G_DIETPI_VERSION_SUB=$((G_DIETPI_VERSION_SUB-1))
 
 		fi
 

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -23,9 +23,9 @@
 	#Import DietPi-Globals ---------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
 	export G_PROGRAM_NAME='DietPi-Update'
-	G_INIT
 	G_CHECK_ROOT_USER
 	G_CHECK_ROOTFS_RW
+	G_INIT
 	#Import DietPi-Globals ---------------------------------------------------------------
 
 	INPUT=0
@@ -35,18 +35,10 @@
 	#GIT Branch | master / testing
 	#/////////////////////////////////////////////////////////////////////////////////////
 	GITBRANCH="$(grep -m1 '^[[:blank:]]*DEV_GITBRANCH=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
-	if [[ ! $GITBRANCH ]]; then
-
-		GITBRANCH='master'
-
-	fi
+	[[ ! $GITBRANCH ]] && GITBRANCH='master'
 
 	GITFORKOWNER="$(grep -m1 '^[[:blank:]]*DEV_GITOWNER=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
-	if [[ ! $GITFORKOWNER ]]; then
-
-		GITFORKOWNER='Fourdee'
-
-	fi
+	[[ ! $GITFORKOWNER ]] && GITFORKOWNER='Fourdee'
 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	#UPDATE Vars
@@ -68,22 +60,22 @@
 	URL_MIRROR_INDEX=0
 	URL_MIRROR_SERVERVERSION=(
 
-		"https://dietpi.com/downloads/dietpi-update_mirror/$GITBRANCH/server_version-6"
 		"https://raw.githubusercontent.com/$GITFORKOWNER/DietPi/$GITBRANCH/dietpi/server_version-6"
+		"https://dietpi.com/downloads/dietpi-update_mirror/$GITBRANCH/server_version-6"
 
 	)
 
 	URL_MIRROR_ZIP=(
 
-		"https://dietpi.com/downloads/dietpi-update_mirror/$GITBRANCH/DietPi-$GITBRANCH.zip"
 		"https://github.com/$GITFORKOWNER/DietPi/archive/$GITBRANCH.zip"
+		"https://dietpi.com/downloads/dietpi-update_mirror/$GITBRANCH/DietPi-$GITBRANCH.zip"
 
 	)
 
 	URL_MIRROR_CHANGELOG=(
 
-		"https://dietpi.com/downloads/dietpi-update_mirror/$GITBRANCH/CHANGELOG.txt"
 		"https://raw.githubusercontent.com/$GITFORKOWNER/DietPi/$GITBRANCH/CHANGELOG.txt"
+		"https://dietpi.com/downloads/dietpi-update_mirror/$GITBRANCH/CHANGELOG.txt"
 
 	)
 
@@ -206,7 +198,7 @@
 	#/////////////////////////////////////////////////////////////////////////////////////
 	Menu_Update(){
 
-		while true
+		while :
 		do
 
 			G_WHIP_BUTTON_CANCEL_TEXT='Exit'
@@ -310,11 +302,8 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 				/DietPi/dietpi/patch_file $G_DIETPI_VERSION_SUB
 
 				#Update Local Version ID
-				export G_DIETPI_VERSION_SUB=$((G_DIETPI_VERSION_SUB+1))
-				cat << _EOF_ > /DietPi/dietpi/.version
-$G_DIETPI_VERSION_CORE
-$G_DIETPI_VERSION_SUB
-_EOF_
+				((G_DIETPI_VERSION_SUB++))
+				echo -e "$G_DIETPI_VERSION_CORE\n$G_DIETPI_VERSION_SUB" > /DietPi/dietpi/.version
 
 				G_DIETPI-NOTIFY 0 "Patch v$G_DIETPI_VERSION_CORE.$G_DIETPI_VERSION_SUB completed\n"
 
@@ -355,7 +344,7 @@ _EOF_
 		else
 
 			G_DIETPI-NOTIFY 0 'Repatch was requested: Update will reapply the current subversion patch'
-			export G_DIETPI_VERSION_SUB=$((G_DIETPI_VERSION_SUB-1))
+			((G_DIETPI_VERSION_SUB--))
 
 		fi
 
@@ -364,16 +353,9 @@ _EOF_
 	fi
 	Check_Update_Available
 	#----------------------------------------------------------------
-	#Check for updates only. Send result to global file for use by dietpi-banner.
-	if (( $INPUT == 2 )); then
+	# $INPUT == 2: Check for updates only. Send result to global file for use by dietpi-banner.
+	if (( $INPUT != 2 )); then
 
-		: #exit normally for delete []
-
-	#----------------------------------------------------------------
-	#Run menus / prompts / updates
-	else
-
-		#----------------------------------------------------------------
 		#Server offline
 		if (( ! $SERVER_ONLINE )); then
 
@@ -394,12 +376,10 @@ _EOF_
 			G_CHECK_USERDATA
 
 			#Insufficient free space
-			if ! G_CHECK_FREESPACE / 500; then
-
-				: #exit normally for delete []
+			G_CHECK_FREESPACE / 500 || exit 1
 
 			#Noninteractive update
-			elif (( $INPUT == 1 )); then
+			if (( $INPUT == 1 )); then
 
 				RUN_UPDATE=1
 				G_DIETPI-NOTIFY 0 'Update is being applied, please wait...'


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Update | Check GitHub repo first
  - Reduce dietpi.com load. Just found the max Apache spaws up, most of them update checks. Apache (mod_php) is not the best for many small requests, as every access spawns a new process. For this nginx/lighttpd (php-fpm) would do better job.
  - When users adjust `GIT_OWNER` in dietpi.txt, this is just ignored on dietpi.com repo, thus is ignored until now in most cases.
+ DietPi-Update | Minor codeing
  - No active array unset done (also not needed) and no tmp file removal needed due to G_EXIT().