### PR TITLE
General | Improve/Fix IPv6 handling

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,14 +6,14 @@ Changes / Improvements / Optimizations:
  - General | Improved detection of permissions support during user data transfers: https://github.com/Fourdee/DietPi/issues/2096
  - General | IPv6: Due to the requirements of various software titles available in dietpi-software (eg: nginx, redis-server), and that IPv6 is slowly becoming more common place, IPv6 is now disabled via sysctl on interface level, while it stays enabled on kernel level: https://github.com/Fourdee/DietPi/issues/2027
  - DietPi-Config | Added an option to toggle preferring IPv4 connections with APT and wget, if IPv6 is enabled. This enhances compatibility and performance in some cases.
- - DietPi-Automation | Added settings to dietpi.txt to toggle IPv6 and IPv4 preferance on first boot.
+ - DietPi-Automation | Added settings to dietpi.txt to toggle IPv6 and IPv4 preference on first boot.
  - DietPi-Update | You now have the option to view the changelog, prior to updating: https://github.com/Fourdee/DietPi/issues/2081
  - DietPi-Software | Card/CalDAV request redirection was added to new Baikal, ownCloud and Nextcloud installs. Now only the servers domain/IP need to be entered on Card/CalDAV clients, without any further path to the DAV endpoints: https://github.com/Fourdee/DietPi/issues/2057
  - DietPi-Drive_Manager | Formatting: Now has the option to format the whole drive, or patition only, for drives with existing partitions.
  - DietPi-Drive_Manager | Mounting NTFS drives now enabled native linux permissions support (eg: you can use this as your userdata location). Many thanks to @Random90 for making this possible! https://github.com/Fourdee/DietPi/issues/2096#issuecomment-425553333
 
 Bug Fixes:
- - DietPi-Config | If '/var/lib/dietpi/dietpi-wifi.db' has not been created yet, it will be generated automatically to allow for WiFi array init: https://github.com/Fourdee/DietPi/issues/2087#issuecomment-423836528
+ - DietPi-Config | dietpi-wifi.db code has been optimized, and, also resolves an issue where '/var/lib/dietpi/dietpi-wifi.db' was not generated automatically: https://github.com/Fourdee/DietPi/issues/2087#issuecomment-423836528
  - DietPi-Survey | Resolved an issue where dietpi-survey under mode 1 would not generate the survey file.
  - DietPi-Software | MPD: Now runs under the group 'dietpi' and user 'root', allowing access to music directories when contained on samba networked drives: https://github.com/Fourdee/DietPi/issues/2092
  - DietPi-Software | Fixed an issue where software uninstalls could have failed due to dependant packages. Thanks to @dynobot for reporting this issue: https://github.com/Fourdee/DietPi/issues/2091

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,7 +4,9 @@ v6.17
 
 Changes / Improvements / Optimizations:
  - General | Improved detection of permissions support during user data transfers: https://github.com/Fourdee/DietPi/issues/2096
- - General | IPv6: Due to the requirements of various software titles available in dietpi-software (eg: nginx, redis-server), and that IPv6 is slowly becoming more common place, IPv6 is now enabled by default, and, can no longer be disabled in DietPi scripts: https://github.com/Fourdee/DietPi/issues/2027
+ - General | IPv6: Due to the requirements of various software titles available in dietpi-software (eg: nginx, redis-server), and that IPv6 is slowly becoming more common place, IPv6 is now disabled via sysctl on interface level, while it stays enabled on kernel level: https://github.com/Fourdee/DietPi/issues/2027
+ - DietPi-Config | Added an option to toggle preferring IPv4 connections with APT and wget, if IPv6 is enabled. This enhances compatibility and performance in some cases.
+ - DietPi-Automation | Added settings to dietpi.txt to toggle IPv6 and IPv4 preferance on first boot.
  - DietPi-Update | You now have the option to view the changelog, prior to updating: https://github.com/Fourdee/DietPi/issues/2081
  - DietPi-Software | Card/CalDAV request redirection was added to new Baikal, ownCloud and Nextcloud installs. Now only the servers domain/IP need to be entered on Card/CalDAV clients, without any further path to the DAV endpoints: https://github.com/Fourdee/DietPi/issues/2057
  - DietPi-Drive_Manager | Formatting: Now has the option to format the whole drive, or patition only, for drives with existing partitions.

--- a/dietpi.txt
+++ b/dietpi.txt
@@ -182,7 +182,13 @@ CONFIG_SOUNDCARD=none
 #	NB: Do not modify, you must use dietpi-config to configure/set options
 CONFIG_LCDPANEL=none
 
-#Apt mirrors which are applied to /etc/apt/sources.list | Values here will also be applied during 1st run setup
+#IPv6
+CONFIG_ENABLE_IPV6=1
+
+#Prefer IPv4 with APT and wget, NB: This has no effect if IPv6 is disabled anyway!
+CONFIG_PREFER_IPV4=1
+
+#APT mirrors which are applied to /etc/apt/sources.list | Values here will also be applied during 1st run setup
 #	Raspbian = https://www.raspbian.org/RaspbianMirrors
 #	Debian = https://www.debian.org/mirror/official#list
 CONFIG_APT_RASPBIAN_MIRROR=http://raspbian.raspberrypi.org/raspbian

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -2865,7 +2865,7 @@ _EOF_
 		WIFI_DNS='0.0.0.0'
 		WIFI_MODE=1
 		WIFI_MODE_TARGET=$WIFI_MODE
-		WIFI_SSID_CURRENT="$(iwgetid -r)"
+		which iwgetid &> /dev/null && WIFI_SSID_CURRENT="$(iwgetid -r)"
 		[[ ! $WIFI_SSID_CURRENT ]] && WIFI_SSID_CURRENT='Disconnected / No SSID'
 		WIFI_CRED_INDEX=0 # Which index of SSID/KEY etc we are editing
 

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -20,9 +20,9 @@
 	#Import DietPi-Globals ---------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
 	export G_PROGRAM_NAME='DietPi-Config'
-	G_INIT
 	G_CHECK_ROOT_USER
 	G_CHECK_ROOTFS_RW
+	G_INIT
 	#Import DietPi-Globals ---------------------------------------------------------------
 
 	#Grab Inputs
@@ -48,11 +48,7 @@
 	#/////////////////////////////////////////////////////////////////////////////////////
 	Load_Installed_Software(){
 
-		if [[ -f /DietPi/dietpi/.installed ]]; then
-
-			. /DietPi/dietpi/.installed
-
-		fi
+		[[ -f /DietPi/dietpi/.installed ]] && . /DietPi/dietpi/.installed
 
 	}
 
@@ -182,22 +178,14 @@
 
 			TARGETMENUID=-1
 
-			#Disable Reboot when run from dietpi-software
-			if pgrep -ci 'dietpi-software' &> /dev/null; then
+			#Disable reboot when run from dietpi-software
+			pgrep 'dietpi-software' &> /dev/null && REBOOT_REQUIRED=0
 
-				REBOOT_REQUIRED=0
-
-			fi
-
-			# Reboot Required
+			# Reboot required
 			if (( $REBOOT_REQUIRED )); then
 
 				G_WHIP_YESNO 'A reboot is required to apply your new settings.\nWould you like to reboot now?'
-				if (( $? == 0 )); then
-
-					reboot
-
-				fi
+				(( $? == 0 )) && reboot
 
 			fi
 
@@ -1201,12 +1189,8 @@
 		elif (( $G_HW_MODEL == 40 )); then
 
 			#Get Current Values
-			local current_resolution=$(grep -m1 '^hdmi_mode=' /DietPi/uEnv.txt | sed 's/.*=//')
-			if [[ ! $current_resolution ]]; then
-
-				current_resolution='Not set'
-
-			fi
+			local current_resolution=$(grep -m1 '^[[:blank:]]*hdmi_mode=' /DietPi/uEnv.txt | sed 's/^[^=]*=//')
+			[[ ! $current_resolution ]] && current_resolution='Not set'
 
 			G_WHIP_MENU_ARRAY=(
 
@@ -1258,11 +1242,7 @@
 		local swap_size=$(free -m | grep -im1 'Swap:' | awk '{print $2}')
 		local swap_location="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_SWAPFILE_LOCATION=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
 		local swap_size_text="$swap_size MB"
-		if (( $swap_size == 0 )); then
-
-			swap_size_text='[Off]'
-
-		fi
+		(( ! $swap_size )) && swap_size_text='[Off]'
 		G_WHIP_MENU_ARRAY+=('Swapfile' ": $swap_size_text | $swap_location")
 
 		#Time sync
@@ -1333,7 +1313,7 @@
 		#RPi Specific
 		if (( $G_HW_MODEL < 10 )); then
 
-			local rpi_i2c_enabled=$(grep -ci -m1 'dtparam=i2c_arm=on' /DietPi/config.txt)
+			local rpi_i2c_enabled=$(grep -ci -m1 '^[[:blank:]]*dtparam=i2c_arm=on' /DietPi/config.txt)
 			local rpi_i2c_text='[Off]'
 			if (( $rpi_i2c_enabled )); then
 
@@ -1341,7 +1321,7 @@
 
 			fi
 
-			local rpi_i2cbaudrate_hz="$(( $(grep -m1 'i2c_arm_baudrate=' /DietPi/config.txt | sed 's/.*=//') / 1000 )) kHz"
+			local rpi_i2cbaudrate_hz="$(( $(grep -m1 '^[[:blank:]]*i2c_arm_baudrate=' /DietPi/config.txt | sed 's/^[^=]*=//') / 1000 )) kHz"
 			local usb_max_current_enabled=$(grep -ci -m1 'max_usb_current=1' /DietPi/config.txt)
 			local rpi_usbmaxcurrent_text='[Off]'
 			if (( $usb_max_current_enabled )); then
@@ -1489,17 +1469,16 @@
 
 			elif [[ $G_WHIP_RETURNED_VALUE == 'I2c state' ]]; then
 
-				if (( ! $rpi_i2c_enabled )); then
+				if (( $rpi_i2c_enabled )); then
 
-					/DietPi/dietpi/func/dietpi-set_hardware i2c enable
-					REBOOT_REQUIRED=1
+					/DietPi/dietpi/func/dietpi-set_hardware i2c disable
 
 				else
 
-					/DietPi/dietpi/func/dietpi-set_hardware i2c disable
-					REBOOT_REQUIRED=1
+					/DietPi/dietpi/func/dietpi-set_hardware i2c enable
 
 				fi
+				REBOOT_REQUIRED=1
 
 			elif [[ $G_WHIP_RETURNED_VALUE == 'I2c frequency' ]]; then
 
@@ -1523,14 +1502,13 @@
 				if (( $serialconsole_state == 0 )); then
 
 					/DietPi/dietpi/func/dietpi-set_hardware serialconsole enable
-					REBOOT_REQUIRED=1
 
 				else
 
 					/DietPi/dietpi/func/dietpi-set_hardware serialconsole disable
-					REBOOT_REQUIRED=1
 
 				fi
+				REBOOT_REQUIRED=1
 
 			elif [[ $G_WHIP_RETURNED_VALUE == 'Bluetooth' ]]; then
 
@@ -2888,11 +2866,7 @@ _EOF_
 		WIFI_MODE=1
 		WIFI_MODE_TARGET=$WIFI_MODE
 		WIFI_SSID_CURRENT="$(iwgetid -r)"
-		if [[ ! $WIFI_SSID_CURRENT ]]; then
-
-			WIFI_SSID_CURRENT='Disconnected / No SSID'
-
-		fi
+		[[ ! $WIFI_SSID_CURRENT ]] && WIFI_SSID_CURRENT='Disconnected / No SSID'
 		WIFI_CRED_INDEX=0 # Which index of SSID/KEY etc we are editing
 
 		#Get extra wifi stats
@@ -2900,19 +2874,11 @@ _EOF_
 		WIFI_SIGNALSTRENGTH=0
 		# - Hotspot enabled?
 		WIFI_HOTSPOT=0
-		if [[ -f /usr/sbin/hostapd ]]; then
-
-			WIFI_HOTSPOT=1
-
-		fi
+		[[ -f /usr/sbin/hostapd ]] && WIFI_HOTSPOT=1
 
 		WIFI_COUNTRYCODE='GB'
 		# - Prevent "nl80211 not found" message, when running this command with cfg80211 module disabled.
-		if [[ $(which iw) ]]; then
-
-			WIFI_COUNTRYCODE=$(iw reg get | grep -m1 'country' | awk '{print $2}' | tr -d ':')
-
-		fi
+		which iw &> /dev/null && WIFI_COUNTRYCODE=$(iw reg get | grep -m1 'country' | awk '{print $2}' | tr -d ':')
 
 		# Convert CIDR integer to net mask, e.g. "192.168.0.100/24" (take "24") to "255.255.255.0"
 		cidr2mask() {
@@ -2923,11 +2889,11 @@ _EOF_
 
 			for ((i=0; i<4; i++)); do
 
-				if [[ $i -lt $full_octets ]]; then
+				if (( $i < $full_octets )); then
 
 					mask+=255
 
-				elif [[ $i -eq $full_octets ]]; then
+				elif (( $i == $full_octets )); then
 
 					mask+=$(( 256 - 2 ** ( 8 - $partial_octet ) ))
 
@@ -2936,7 +2902,7 @@ _EOF_
 					mask+=0
 
 				fi
-				test $i -lt 3 && mask+=.
+				[[ $i < 3 ]] && mask+=.
 
 			done
 			echo "$mask"
@@ -2949,7 +2915,7 @@ _EOF_
 			#Hardware
 			ETH_HARDWARE=1
 
-			#Static or Dhcp?
+			#Static or DHCP?
 			ETH_MODE=$(grep -ci -m1 "iface eth$ETH_DEV_INDEX inet dhcp" /tmp/net_interfaces)
 			ETH_MODE_TARGET=$ETH_MODE
 
@@ -2973,7 +2939,7 @@ _EOF_
 			#Hardware
 			WIFI_HARDWARE=1
 
-			#Static or Dhcp?
+			#Static or DHCP?
 			WIFI_MODE=$(grep -ci -m1 "iface wlan$WIFI_DEV_INDEX inet dhcp" /tmp/net_interfaces)
 			WIFI_MODE_TARGET=$WIFI_MODE
 
@@ -3024,52 +2990,27 @@ _EOF_
 
 		#Obtain enabled/disabled status
 		local eth_disabled_text='[On]'
-		if (( $ETH_DISABLED == 1 )); then
-
-			eth_disabled_text='[Off]'
-
-		fi
+		(( $ETH_DISABLED )) && eth_disabled_text='[Off]'
 
 		local wlan_disabled_text='[On]'
-		if (( $WIFI_DISABLED == 1 )); then
-
-			wlan_disabled_text='[Off]'
-
-		fi
+		(( $WIFI_DISABLED )) && wlan_disabled_text='[Off]'
 
 		#Obtain Hardware Status
 		local eth_hardware_text='Available'
-		if (( ! $ETH_HARDWARE )); then
-
-			eth_hardware_text='Not Found'
-
-		fi
+		(( ! $ETH_HARDWARE )) && eth_hardware_text='Not Found'
 
 		local wlan_hardware_text='Available'
-		if (( ! $WIFI_HARDWARE )); then
-
-			wlan_hardware_text='Not Found'
-
-		fi
+		(( ! $WIFI_HARDWARE )) && wlan_hardware_text='Not Found'
 
 		#Obtain Connected/Carrier Status
 		local eth_connected_text='Disconnected'
-		if (( $ETH_CONNECTED == 1 )); then
-
-			eth_connected_text='Connected'
-
-		fi
+		(( $ETH_CONNECTED )) && eth_connected_text='Connected'
 
 		local wlan_connected_text='Disconnected'
-		if (( $WIFI_CONNECTED == 1 )); then
+		if (( $WIFI_CONNECTED )); then
 
 			wlan_connected_text='Connected'
-
-			if (( $WIFI_HOTSPOT == 1 )); then
-
-				wlan_connected_text="Wifi Hotspot Mode"
-
-			fi
+			(( $WIFI_HOTSPOT )) && wlan_connected_text="WiFi Hotspot Mode"
 
 		fi
 
@@ -3085,25 +3026,12 @@ _EOF_
 
 		fi
 
-		#IPv6 status
-		local ipv6_enabled=1
-		local ipv6_status_text='[On]'
-		if [[ ! -d /proc/sys/net/ipv6 ]]; then
-
-			ipv6_enabled=0
-			ipv6_status_text='[Off]'
-
-		fi
-
 		#Proxy settings (global vars, force an int to obtain current values stored in dietpi.txt)
 		Load_Proxy_Vars
 
 		local proxy_state_text='[Off]'
-		if (( $PROXY_ENABLED )); then
+		(( $PROXY_ENABLED )) && proxy_state_text="[On] | $PROXY_ADDRESS:$PROXY_PORT"
 
-			proxy_state_text="[On] | $PROXY_ADDRESS:$PROXY_PORT"
-
-		fi
 		# - Reset init flag. Ensures Menu_Proxy() reloads current settings.
 		PROXY_ENABLED=-1
 
@@ -3118,21 +3046,52 @@ _EOF_
 			if [[ -f /etc/modprobe.d/disable_wifi_rpi3_onboard.conf ]]; then
 
 				onboard_wifi_enabled=0
-				G_WHIP_MENU_ARRAY+=('Onboard WiFi' '[Off] | select to toggle')
+				G_WHIP_MENU_ARRAY+=('Onboard WiFi' '[Off] | Select to toggle')
 
 			else
 
-				G_WHIP_MENU_ARRAY+=('Onboard WiFi' '[On] | select to toggle')
+				G_WHIP_MENU_ARRAY+=('Onboard WiFi' '[On] | Select to toggle')
 
 			fi
 
 		fi
 
-		G_WHIP_MENU_ARRAY+=('IPv6' "$ipv6_status_text | Toggle IPv6 Support")
-		G_WHIP_MENU_ARRAY+=('Test' 'Run the Internet Connection Test')
+		#IPv6
+		local ipv6_status_text='[WARNING] Not supported or disabled on kernel level!'
+		if [[ -d /proc/sys/net/ipv6 ]]; then
+
+			local ipv6_enabled=0
+			ipv6_status_text='[Off]'
+			if [[ $(ip -6 a) ]]; then
+
+				ipv6_enabled=1
+				ipv6_status_text='[On]'
+
+			fi
+			G_WHIP_MENU_ARRAY+=('IPv6' "$ipv6_status_text | Select to toggle")
+			# Only offer to prefer IPv4, if IPv6 is enabled
+			if (( $ipv6_enabled )); then
+
+				local ipv4_preferred=0
+				local ipv4_status_text='[Off]'
+				local ipv4_status_long='\nIPv4         : Not preferred over IPv6 with APT and wget'
+				if [[ -f /etc/apt/apt.conf.d/99-dietpi-force-ipv4 ]]; then
+
+					ipv4_preferred=1
+					ipv4_status_text='[On]'
+					ipv4_status_long='\nIPv4         : Preferred over IPv6 with APT and wget'
+
+				fi
+				G_WHIP_MENU_ARRAY+=('Prefer IPv4' "$ipv4_status_text | Select to toggle")
+
+			fi
+
+		fi
+
+		G_WHIP_MENU_ARRAY+=('Test' 'Run the internet connection test')
 		G_WHIP_MENU_ARRAY+=('Proxy' 'Configure proxy settings')
 
-		G_WHIP_MENU "Ethernet     : $eth_hardware_text | $eth_disabled_text | $eth_connected_text \nWifi         : $wlan_hardware_text | $wlan_disabled_text | $wlan_connected_text\nIPv6         : $ipv6_status_text\nInternet     : $Internet_connected_text\nProxy        : $proxy_state_text"
+		G_WHIP_MENU "Ethernet     : $eth_hardware_text | $eth_disabled_text | $eth_connected_text \nWifi         : $wlan_hardware_text | $wlan_disabled_text | $wlan_connected_text\nIPv6         : $ipv6_status_text$ipv4_status_long\nInternet     : $Internet_connected_text\nProxy        : $proxy_state_text"
 		if (( $? == 0 )); then
 
 			#Return to this Menu
@@ -3163,61 +3122,28 @@ _EOF_
 					#Disable
 					if (( $ipv6_enabled )); then
 
-						G_WHIP_YESNO 'IPv6 is currently enabled. Would you like to disable it?\n\n - A system restart is required for settings to take effect.\n - Disabling IPv6 may break certain programs that rely on it.'
-						if (( $? == 0 )); then
-
-							# - On amd64 images, IPv6 is no kernel module, but can be disabled via grub: https://github.com/Fourdee/DietPi/issues/1343#issuecomment-359652751
-							if (( $G_HW_ARCH == 10 )); then
-
-								if ! grep -qi '^[[:blank:]]*GRUB_CMDLINE_LINUX_DEFAULT=".*ipv6.disable=1' /etc/default/grub; then
-
-									sed -i '/^[[:blank:]]*GRUB_CMDLINE_LINUX_DEFAULT="/s/="/="ipv6.disable=1 /' /etc/default/grub
-									update-grub
-
-								fi
-
-							# - On all other images, IPv6 is a kernel module, which can be blacklisted.
-							else
-
-								# Since RPi kernel 4.14.y, IPv6 is no kernel module as well, but keep blacklist as fail-safe:
-								(( $G_HW_MODEL < 10 )) && sed -Ei '/root=/s/( ipv6.disable=.|$)/ ipv6.disable=1/' /boot/cmdline.txt
-								echo 'blacklist ipv6' > /etc/modprobe.d/99-dietpi-blacklist-ipv6.conf
-
-							fi
-
-							# - APT force IPv4
-							echo 'Acquire::ForceIPv4 "true";' > /etc/apt/apt.conf.d/99-dietpi-force-ipv4
-							# - Wget prefer IPv4
-							G_CONFIG_INJECT 'prefer-family =' 'prefer-family = IPv4' /etc/wgetrc
-							REBOOT_REQUIRED=1
-
-						fi
+						/DietPi/dietpi/func/dietpi-set_hardware enableipv6 0
 
 					#Enable
 					else
 
-						G_WHIP_YESNO "IPv6 is currently disabled. Would you like to enable it?\n\n - NB: A system restart is required for settings to take effect."
-						if (( $? == 0 )); then
+						/DietPi/dietpi/func/dietpi-set_hardware enableipv6 1
 
-							if (( $G_HW_ARCH == 10 )); then
+					fi
 
-								sed -i '/^[[:blank:]]*GRUB_CMDLINE_LINUX_DEFAULT="/s/ipv6.disable=. //' /etc/default/grub
-								update-grub
+				;;
 
-							else
+				'Prefer IPv4')
 
-								(( $G_HW_MODEL < 10 )) && sed -i '/root=/s/ ipv6.disable=.//' /boot/cmdline.txt
-								rm /etc/modprobe.d/99-dietpi-blacklist-ipv6.conf &> /dev/null
+					#Don't prefer
+					if (( $ipv4_preferred )); then
 
-							fi
+						/DietPi/dietpi/func/dietpi-set_hardware preferipv4 0
 
-							# - APT allow IPv6 but do not force it: https://github.com/Fourdee/DietPi/issues/472#issuecomment-356444922
-							rm /etc/apt/apt.conf.d/99-dietpi-force-ipv4 &> /dev/null
-							# - Wget prefer IPv6
-							G_CONFIG_INJECT 'prefer-family =' 'prefer-family = IPv6' /etc/wgetrc
-							REBOOT_REQUIRED=1
+					#Prefer
+					else
 
-						fi
+						/DietPi/dietpi/func/dietpi-set_hardware preferipv4 1
 
 					fi
 
@@ -4801,8 +4727,8 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 
 			'Network Drives' 'Mount/control networked storage'
 			'NoIp' "$noip_menutext"
-			'APT Mirror' "Select a different APT mirror for sources.list"
-			'NTP Mirror' "Select a different NTP mirror"
+			'APT Mirror' 'Select a different APT mirror for sources.list'
+			'NTP Mirror' 'Select a different NTP mirror'
 			'Boot Net Wait' "$boot_wait_for_network_text"
 
 		)
@@ -4818,11 +4744,7 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 				'Network Drives')
 
 					G_WHIP_YESNO 'The ability to mount and control networked drives has moved to:\n - DietPi-Drive_manager\n\nWould you like to launch the program now?'
-					if (( $? == 0 )); then
-
-						/DietPi/dietpi/dietpi-drive_manager
-
-					fi
+					(( $? == 0 )) && /DietPi/dietpi/dietpi-drive_manager
 
 				;;
 
@@ -4838,11 +4760,7 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 
 					G_WHIP_DEFAULT_ITEM=$boot_wait_for_network
 					G_WHIP_MENU 'The following options will allow you to delay boot, until a valid network connection is available:'
-					if (( $? == 0 )); then
-
-						sed -i "/^CONFIG_BOOT_WAIT_FOR_NETWORK=/c CONFIG_BOOT_WAIT_FOR_NETWORK=$G_WHIP_RETURNED_VALUE" /DietPi/dietpi.txt
-
-					fi
+					(( $? == 0 )) && G_CONFIG_INJECT 'CONFIG_BOOT_WAIT_FOR_NETWORK=' "CONFIG_BOOT_WAIT_FOR_NETWORK=$G_WHIP_RETURNED_VALUE" /DietPi/dietpi.txt
 
 				;;
 
@@ -4899,16 +4817,7 @@ Custom         : Write = $FSBENCH_CUSTOM_WRITE | Read = $FSBENCH_CUSTOM_READ"
 
 						/DietPi/dietpi/func/dietpi-set_software apt-mirror $G_WHIP_RETURNED_VALUE
 
-						# - test it
-						G_DIETPI-NOTIFY 2 'Updating APT, please wait...'
-
-						G_AGUP
-						local exit_code=$?
-						if (( $exit_code )); then
-
-							G_WHIP_MSG "Failed to update APT, exit code: $exit_code.\n\nIf problems persist, please try another APT mirror."
-
-						fi
+						G_AGUP || G_WHIP_MSG "Failed to update APT, exit code: $exit_code.\n\nIf problems persist, please try another APT mirror."
 
 					fi
 
@@ -4973,14 +4882,14 @@ NB: If you need to use *.pool.ntp.org servers, enter the base domain only. The s
 						if (( $apply )); then
 
 							G_CONFIG_INJECT 'CONFIG_NTP_MIRROR=' "CONFIG_NTP_MIRROR=$new_setting_ntp_mirror" /DietPi/dietpi.txt
-							/DietPi/dietpi/func/dietpi-set_software ntpd-mode $(grep -m1 '^[[:blank:]]*CONFIG_NTP_MODE=' /DietPi/dietpi.txt | sed 's/^.*=//')
+							/DietPi/dietpi/func/dietpi-set_software ntpd-mode $(grep -m1 '^[[:blank:]]*CONFIG_NTP_MODE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 							MAX_LOOPS_CHECK=10 /DietPi/dietpi/func/run_ntpd 1
 							if (( $? )); then
 
-								G_WHIP_MSG "NTP sync failed:\n - $G_WHIP_RETURNED_VALUE\n\nSetting reverted to previous."
+								G_WHIP_MSG "Time sync failed:\n - $G_WHIP_RETURNED_VALUE\n\nSetting reverted to previous."
 
 								G_CONFIG_INJECT 'CONFIG_NTP_MIRROR=' "CONFIG_NTP_MIRROR=$previous_setting_ntp_mirror" /DietPi/dietpi.txt
-								/DietPi/dietpi/func/dietpi-set_software ntpd-mode $(grep -m1 '^[[:blank:]]*CONFIG_NTP_MODE=' /DietPi/dietpi.txt | sed 's/^.*=//')
+								/DietPi/dietpi/func/dietpi-set_software ntpd-mode $(grep -m1 '^[[:blank:]]*CONFIG_NTP_MODE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 
 							fi
 
@@ -5062,20 +4971,12 @@ NB: If you need to use *.pool.ntp.org servers, enter the base domain only. The s
 			Load_Proxy_Vars
 
 			proxy_state_text='[Off]'
-			if (( $PROXY_ENABLED )); then
-
-				proxy_state_text='[On]'
-
-			fi
+			(( $PROXY_ENABLED )) && proxy_state_text='[On]'
 
 		fi
 
 		proxy_state_text_new='No'
-		if (( $PROXY_ENABLED )); then
-
-			proxy_state_text_new='Yes'
-
-		fi
+		(( $PROXY_ENABLED )) && proxy_state_text_new='Yes'
 
 		G_WHIP_MENU_ARRAY=(
 
@@ -5099,11 +5000,7 @@ NB: If you need to use *.pool.ntp.org servers, enter the base domain only. The s
 				'Toggle')
 
 					((PROXY_ENABLED++))
-					if (( $PROXY_ENABLED >= 2 )); then
-
-						PROXY_ENABLED=0
-
-					fi
+					(( $PROXY_ENABLED > 1 )) && PROXY_ENABLED=0
 
 				;;
 
@@ -5111,11 +5008,7 @@ NB: If you need to use *.pool.ntp.org servers, enter the base domain only. The s
 
 					G_WHIP_DEFAULT_ITEM="$PROXY_ADDRESS"
 					G_WHIP_INPUTBOX 'Please enter the proxy URL or IP address\n - eg: MyProxy.com'
-					if (( $? == 0 )); then
-
-						PROXY_ADDRESS="$G_WHIP_RETURNED_VALUE"
-
-					fi
+					(( $? == 0 )) && PROXY_ADDRESS="$G_WHIP_RETURNED_VALUE"
 
 				;;
 
@@ -5123,11 +5016,7 @@ NB: If you need to use *.pool.ntp.org servers, enter the base domain only. The s
 
 					G_WHIP_DEFAULT_ITEM="$PROXY_PORT"
 					G_WHIP_INPUTBOX 'Please enter the proxy port number\n - eg: 1234'
-					if (( $? == 0 )); then
-
-						PROXY_PORT=$G_WHIP_RETURNED_VALUE
-
-					fi
+					(( $? == 0 )) && PROXY_PORT=$G_WHIP_RETURNED_VALUE
 
 				;;
 
@@ -5135,11 +5024,7 @@ NB: If you need to use *.pool.ntp.org servers, enter the base domain only. The s
 
 					G_WHIP_DEFAULT_ITEM="$PROXY_USERNAME"
 					G_WHIP_INPUTBOX 'Please enter the proxy username\n - eg: JoeBloggs\n - Leave blank if not required'
-					if (( $? == 0 )); then
-
-						PROXY_USERNAME="$G_WHIP_RETURNED_VALUE"
-
-					fi
+					(( $? == 0 )) && PROXY_USERNAME="$G_WHIP_RETURNED_VALUE"
 
 				;;
 
@@ -5147,33 +5032,29 @@ NB: If you need to use *.pool.ntp.org servers, enter the base domain only. The s
 
 					G_WHIP_DEFAULT_ITEM="$PROXY_PASSWORD"
 					G_WHIP_INPUTBOX 'Please enter the proxy password\n - eg: LetMeIn\n - Leave blank if not required'
-					if (( $? == 0 )); then
-
-						PROXY_PASSWORD="$G_WHIP_RETURNED_VALUE"
-
-					fi
+					(( $? == 0 )) && PROXY_PASSWORD="$G_WHIP_RETURNED_VALUE"
 
 				;;
 
 				'Apply')
 
 					# - Save settings to dietpi.txt
-					sed -i "/^CONFIG_PROXY_ENABLED=/c\CONFIG_PROXY_ENABLED=$PROXY_ENABLED" /DietPi/dietpi.txt
-					sed -i "/^CONFIG_PROXY_ADDRESS=/c\CONFIG_PROXY_ADDRESS=$PROXY_ADDRESS" /DietPi/dietpi.txt
-					sed -i "/^CONFIG_PROXY_PORT=/c\CONFIG_PROXY_PORT=$PROXY_PORT" /DietPi/dietpi.txt
-					sed -i "/^CONFIG_PROXY_USERNAME=/c\CONFIG_PROXY_USERNAME=$PROXY_USERNAME" /DietPi/dietpi.txt
-					sed -i "/^CONFIG_PROXY_PASSWORD=/c\CONFIG_PROXY_PASSWORD=$PROXY_PASSWORD" /DietPi/dietpi.txt
+					G_CONFIG_INJECT 'CONFIG_PROXY_ENABLED=' "CONFIG_PROXY_ENABLED=$PROXY_ENABLED" /DietPi/dietpi.txt
+					G_CONFIG_INJECT 'CONFIG_PROXY_ADDRESS=' "CONFIG_PROXY_ADDRESS=$PROXY_ADDRESS" /DietPi/dietpi.txt
+					G_CONFIG_INJECT 'CONFIG_PROXY_PORT=' "CONFIG_PROXY_PORT=$PROXY_PORT" /DietPi/dietpi.txt
+					G_CONFIG_INJECT 'CONFIG_PROXY_USERNAME=' "CONFIG_PROXY_USERNAME=$PROXY_USERNAME" /DietPi/dietpi.txt
+					G_CONFIG_INJECT 'CONFIG_PROXY_PASSWORD=' "CONFIG_PROXY_PASSWORD=$PROXY_PASSWORD" /DietPi/dietpi.txt
 
 					# - Delete active export vars
 					#unset {http,https,ftp}_proxy #Does not apply to system when running from a bash script.
 
 					# - Delete any existing export settings from /etc/bash.bashrc
-					sed -i '/{http,https,ftp}_proxy=/d' /etc/bash.bashrc
+					sed -i '/^[[:blank:]]*{http,https,ftp}_proxy=/d' /etc/bash.bashrc
 
 					# - Add export settings
 					if (( $PROXY_ENABLED )); then
 
-						if [[ $PROXY_USERNAME ]] && [[ $PROXY_PASSWORD ]]; then
+						if [[ $PROXY_USERNAME && $PROXY_PASSWORD ]]; then
 							cat << _EOF_ >> /etc/bash.bashrc
 export {http,https,ftp}_proxy="http://$PROXY_USERNAME:$PROXY_PASSWORD@$PROXY_ADDRESS:$PROXY_PORT"
 _EOF_
@@ -5190,11 +5071,7 @@ _EOF_
 					REBOOT_REQUIRED=1
 
 					G_WHIP_YESNO 'The updated proxy settings have been saved.\n\nNB: You must reboot your system, before the new proxy settings will take effect.\n\nReboot system now?'
-					if (( $? == 0 )); then
-
-						reboot
-
-					fi
+					(( $? == 0 )) && reboot
 
 					# - Reset init flag to force a reload of setings next time this menu is run.
 					PROXY_ENABLED=-1
@@ -5218,7 +5095,7 @@ _EOF_
 	if (( $G_DIETPI_INSTALL_STAGE >= 0 )); then
 
 		#Start DietPi-Config
-		while (( $TARGETMENUID > -1 )); do
+		while (( $TARGETMENUID >= 0 )); do
 
 			printf '\ec' # clear current terminal screen
 			G_WHIP_BUTTON_CANCEL_TEXT="$TEXT_MENU_BACK"
@@ -5296,13 +5173,20 @@ _EOF_
 
 				Menu_NetworkAdapters_Proxy
 
+			else
+
+				G_WHIP_MSG "[FAILED] Unknown menu ID $TARGETMENUID, reverting to DietPi-Config main menu\n
+This error should never show up. Please try to reproduce it. If it reappears, you found a coding bug.
+Please report it to: https://github.com/Fourdee/DietPi/issues"
+				TARGETMENUID=0
+
 			fi
 
 		done
 
 	else
 
-		echo -e ' >> Filesystem prep has not yet completed: \n Please wait for the system to reboot '
+		echo -e ' >> Filesystem prep has not yet completed:\n Please wait for the system to reboot'
 
 	fi
 

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -22,6 +22,8 @@ $FP_SCRIPT 		rpi-opengl		vc4-kms-v3d/vc4-fkms-v3d/disable
 $FP_SCRIPT 		i2c			enable/disable/khz
 $FP_SCRIPT 		wificountrycode		GB/US/DE
 $FP_SCRIPT 		wifimodules		enable/disable/onboard_enable/onboard_disable
+$FP_SCRIPT		enableipv6		enable/disable
+$FP_SCRIPT 		preferipv4		enable/disable
 $FP_SCRIPT 		bluetooth 		enable/disable
 $FP_SCRIPT 		serialconsole		enable/disable
 $FP_SCRIPT 		soundcard 		target_card (non-matching name for reset to default) add '-eq' to target_card string, enable alsa eq on card. HW:x,x (specify target card and device index eg: HW:9,1)
@@ -45,9 +47,9 @@ $FP_SCRIPT 		lcdpanel 		target_panel (none to remove all)
 
 	#Import DietPi-Globals ---------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
+	export G_PROGRAM_NAME='DietPi-Set_Hardware'
 	G_CHECK_ROOT_USER
 	G_CHECK_ROOTFS_RW
-	export G_PROGRAM_NAME='DietPi-Set_Hardware'
 	G_INIT
 	#Import DietPi-Globals ---------------------------------------------------------------
 
@@ -1055,6 +1057,93 @@ _EOF_
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Network
 	#/////////////////////////////////////////////////////////////////////////////////////
+
+	Enable_IPv6(){
+
+		if [[ ! -d /proc/sys/net/ipv6 ]]; then
+
+			G_DIETPI-NOTIFY 1 'IPv6 is not supported or disabled on kernel level. Aborting...'
+			EXIT_CODE=1
+			return
+
+		elif [[ $INPUT_DEVICE_VALUE == 'enable' ]]; then
+
+			[[ -f /etc/sysctl.d/dietpi-disable_ipv6.conf ]] && rm /etc/sysctl.d/dietpi-disable_ipv6.conf
+			# - Apply to current session:
+			#	- "all" => all existing interfaces
+			#	- "default" => all future interfaces
+			echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6
+			echo 0 > /proc/sys/net/ipv6/conf/default/disable_ipv6
+			# - dietpi.txt entry
+			G_CONFIG_INJECT 'CONFIG_ENABLE_IPV6=' 'CONFIG_ENABLE_IPV6=1' $FP_RPI_CONFIG
+
+
+		elif [[ $INPUT_DEVICE_VALUE == 'disable' ]]; then
+
+			echo -e 'net.ipv6.conf.all.disable_ipv6=1\nnet.ipv6.conf.default.disable_ipv6=1' > /etc/sysctl.d/dietpi-disable_ipv6.conf
+			sysctl -qp /etc/sysctl.d/dietpi-disable_ipv6.conf
+			# - dietpi.txt entry
+			G_CONFIG_INJECT 'CONFIG_ENABLE_IPV6=' 'CONFIG_ENABLE_IPV6=0' $FP_RPI_CONFIG
+			# - Stop preferring IPv4, if IPv6 is disabled, to reduce obsolete/confusing entries
+			INPUT_DEVICE_VALUE='disable' Prefer_IPv4
+
+		else
+
+			Unknown_Input_Mode
+			return
+
+		fi
+
+		# Failsafe: Comment "disable_ipv6" entries in all other sysctl config files
+		local i=''
+		for i in /etc/sysctl.conf /etc/sysctl.d/*
+		do
+
+			[[ ! -f $i || $i == *'dietpi-disable_ipv6.conf' ]] && continue
+			sed -i 's/^[[:blank:]]*net.ipv6.conf.[^[:blank:]].disable_ipv6[[:blank:]]*=/#&/' $i
+
+		done
+
+	}
+
+	Prefer_IPv4(){
+
+		if [[ $INPUT_DEVICE_VALUE == 'enable' ]]; then
+
+			# - APT force IPv4
+			echo 'Acquire::ForceIPv4 "true";' > /etc/apt/apt.conf.d/99-dietpi-force-ipv4
+			# - Wget prefer IPv4
+			G_CONFIG_INJECT 'prefer-family[[:blank:]]*=' 'prefer-family = IPv4' /etc/wgetrc
+			# - dietpi.txt entry
+			G_CONFIG_INJECT 'CONFIG_PREFER_IPV4=' 'CONFIG_PREFER_IPV4=1' $FP_RPI_CONFIG
+
+		elif [[ $INPUT_DEVICE_VALUE == 'disable' ]]; then
+
+			# - APT allow IPv6
+			[[ -f /etc/apt/apt.conf.d/99-dietpi-force-ipv4 ]] && rm /etc/apt/apt.conf.d/99-dietpi-force-ipv4
+			# - Wget back to default
+			sed -i 's/^[[:blank:]]*prefer-family[[:blank:]]*=/#&/' /etc/wgetrc
+			# - dietpi.txt entry
+			G_CONFIG_INJECT 'CONFIG_PREFER_IPV4=' 'CONFIG_PREFER_IPV4=0' $FP_RPI_CONFIG
+
+		else
+
+			Unknown_Input_Mode
+			return
+
+		fi
+
+		# Failsafe: Comment "ForceIPv[46]" entries in all other APT config files
+		local i=''
+		for i in /etc/apt/apt.conf.d/*
+		do
+
+			[[ ! -f $i || $i == *'99-dietpi-force-ipv4' ]] && continue
+			sed -i 's/^[[:blank:]]*Acquire::ForceIPv[46][[:blank:]]*=/#&/' $i
+
+		done
+
+	}
 
 	Wifi_Modules_Main(){
 
@@ -2099,6 +2188,14 @@ _EOF_
 	elif [[ $INPUT_DEVICE_NAME == 'wifimodules' ]]; then
 
 		Wifi_Modules_Main
+
+	elif [[ $INPUT_DEVICE_NAME == 'enableipv6' ]]; then
+
+		Enable_IPv6
+
+	elif [[ $INPUT_DEVICE_NAME == 'preferipv4' ]]; then
+
+		Prefer_IPv4
 
 	elif [[ $INPUT_DEVICE_NAME == 'wificountrycode' ]]; then
 

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -1075,7 +1075,7 @@ _EOF_
 			echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6
 			echo 0 > /proc/sys/net/ipv6/conf/default/disable_ipv6
 			# - dietpi.txt entry
-			G_CONFIG_INJECT 'CONFIG_ENABLE_IPV6=' 'CONFIG_ENABLE_IPV6=1' $FP_RPI_CONFIG
+			G_CONFIG_INJECT 'CONFIG_ENABLE_IPV6=' 'CONFIG_ENABLE_IPV6=1' /DietPi/dietpi.txt
 
 
 		elif [[ $INPUT_DEVICE_VALUE == 'disable' ]]; then
@@ -1083,7 +1083,7 @@ _EOF_
 			echo -e 'net.ipv6.conf.all.disable_ipv6=1\nnet.ipv6.conf.default.disable_ipv6=1' > /etc/sysctl.d/dietpi-disable_ipv6.conf
 			sysctl -qp /etc/sysctl.d/dietpi-disable_ipv6.conf
 			# - dietpi.txt entry
-			G_CONFIG_INJECT 'CONFIG_ENABLE_IPV6=' 'CONFIG_ENABLE_IPV6=0' $FP_RPI_CONFIG
+			G_CONFIG_INJECT 'CONFIG_ENABLE_IPV6=' 'CONFIG_ENABLE_IPV6=0' /DietPi/dietpi.txt
 			# - Stop preferring IPv4, if IPv6 is disabled, to reduce obsolete/confusing entries
 			INPUT_DEVICE_VALUE='disable' Prefer_IPv4
 
@@ -1115,7 +1115,7 @@ _EOF_
 			# - Wget prefer IPv4
 			G_CONFIG_INJECT 'prefer-family[[:blank:]]*=' 'prefer-family = IPv4' /etc/wgetrc
 			# - dietpi.txt entry
-			G_CONFIG_INJECT 'CONFIG_PREFER_IPV4=' 'CONFIG_PREFER_IPV4=1' $FP_RPI_CONFIG
+			G_CONFIG_INJECT 'CONFIG_PREFER_IPV4=' 'CONFIG_PREFER_IPV4=1' /DietPi/dietpi.txt
 
 		elif [[ $INPUT_DEVICE_VALUE == 'disable' ]]; then
 
@@ -1124,7 +1124,7 @@ _EOF_
 			# - Wget back to default
 			sed -i 's/^[[:blank:]]*prefer-family[[:blank:]]*=/#&/' /etc/wgetrc
 			# - dietpi.txt entry
-			G_CONFIG_INJECT 'CONFIG_PREFER_IPV4=' 'CONFIG_PREFER_IPV4=0' $FP_RPI_CONFIG
+			G_CONFIG_INJECT 'CONFIG_PREFER_IPV4=' 'CONFIG_PREFER_IPV4=0' /DietPi/dietpi.txt
 
 		else
 

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -1074,14 +1074,21 @@ _EOF_
 			#	- "default" => all future interfaces
 			echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6
 			echo 0 > /proc/sys/net/ipv6/conf/default/disable_ipv6
+			# - Add IPv6 specific host entries
+			G_CONFIG_INJECT '::1[[:blank:]]' '::1 localhost ip6-localhost ip6-loopback' /etc/hosts
+			G_CONFIG_INJECT 'ff02::1[[:blank:]]' 'ff02::1 ip6-allnodes' /etc/hosts
+			G_CONFIG_INJECT 'ff02::2[[:blank:]]' 'ff02::2 ip6-allrouters' /etc/hosts
 			# - dietpi.txt entry
 			G_CONFIG_INJECT 'CONFIG_ENABLE_IPV6=' 'CONFIG_ENABLE_IPV6=1' /DietPi/dietpi.txt
-
 
 		elif [[ $INPUT_DEVICE_VALUE == 'disable' ]]; then
 
 			echo -e 'net.ipv6.conf.all.disable_ipv6=1\nnet.ipv6.conf.default.disable_ipv6=1' > /etc/sysctl.d/dietpi-disable_ipv6.conf
 			sysctl -qp /etc/sysctl.d/dietpi-disable_ipv6.conf
+			# - Comment IPv6 specific host entries
+			sed -i 's/^::1[[:blank:]]/#::1 ' /etc/hosts
+			sed -i 's/^ff02::1[[:blank:]]/#ff02::1 ' /etc/hosts
+			sed -i 's/^ff02::2[[:blank:]]/#ff02::2 ' /etc/hosts
 			# - dietpi.txt entry
 			G_CONFIG_INJECT 'CONFIG_ENABLE_IPV6=' 'CONFIG_ENABLE_IPV6=0' /DietPi/dietpi.txt
 			# - Stop preferring IPv4, if IPv6 is disabled, to reduce obsolete/confusing entries

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1271,6 +1271,8 @@ You should not face any difference by following this advice, no IPv6 addresses w
 				fi
 
 			fi
+			# - Remove old dietpi.txt entry (this includes the comment):
+			sed -i '/CONFIG_PREFER_IPVERSION/d' /DietPi/dietpi.txt
 			#-------------------------------------------------------------------------------
 			#Reinstalls:
 			#	myMPD: https://twitter.com/ta11/status/1045978421967421440

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -158,11 +158,7 @@
 			#	Kodi: https://github.com/Fourdee/DietPi/issues/1428
 			#	Fail2Ban: https://github.com/Fourdee/DietPi/issues/1431
 			#	Tonido: https://github.com/Fourdee/DietPi/issues/1432
-			if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
-
-				/DietPi/dietpi/dietpi-software reinstall 31 73 134
-
-			fi
+			(( $G_DIETPI_INSTALL_STAGE == 1 )) && /DietPi/dietpi/dietpi-software reinstall 31 73 134
 			#-------------------------------------------------------------------------------
 
 		elif (( $G_DIETPI_VERSION_SUB == 1 )); then
@@ -231,11 +227,7 @@
 			#Reinstalls:
 			#	NetData 1.9
 			#	Allo GUI update
-			if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
-
-				/DietPi/dietpi/dietpi-software reinstall 65 160
-
-			fi
+			(( $G_DIETPI_INSTALL_STAGE == 1 )) && /DietPi/dietpi/dietpi-software reinstall 65 160
 			#-------------------------------------------------------------------------------
 
 		elif (( $G_DIETPI_VERSION_SUB == 2 )); then
@@ -408,11 +400,7 @@ _EOF_
 			#-------------------------------------------------------------------------------
 			#Reinstalls
 			#	UrBackupServer
-			if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
-
-				/DietPi/dietpi/dietpi-software reinstall 111
-
-			fi
+			(( $G_DIETPI_INSTALL_STAGE == 1 )) && /DietPi/dietpi/dietpi-software reinstall 111
 			#-------------------------------------------------------------------------------
 			#Cron minutely support: https://github.com/Fourdee/DietPi/pull/1578
 			mkdir -p /etc/cron.minutely
@@ -537,8 +525,8 @@ _EOF_
 			#Deluge systemD service update: https://github.com/Fourdee/DietPi/issues/1658
 			# + Service fix for in v6.6 https://github.com/Fourdee/DietPi/issues/1689#issuecomment-379024795
 			rm /DietPi/dietpi/conf/deluge.service &> /dev/null
-			if [[ -f /var/lib/dietpi/dietpi-software/services/deluge.service ]] ||
-				[[ -f /etc/systemd/system/deluged.service ]]; then
+			if [[ -f /var/lib/dietpi/dietpi-software/services/deluge.service ||
+				-f /etc/systemd/system/deluged.service ]]; then
 
 				#New services
 				cat << _EOF_ > /etc/systemd/system/deluged.service
@@ -582,22 +570,14 @@ _EOF_
 			#-------------------------------------------------------------------------------
 			#Uninstalls:
 			#	Removal of fbset on new installs: https://github.com/Fourdee/DietPi/issues/1716
-			if (( $G_DIETPI_INSTALL_STAGE <= 0 )); then
-
-				apt-mark auto fbset
-
-			fi
+			(( $G_DIETPI_INSTALL_STAGE <= 0 )) && apt-mark auto fbset
 			#-------------------------------------------------------------------------------
 			#Reinstalls:
 			#	XRDP: https://github.com/Fourdee/DietPi/issues/1727#issuecomment-383858979
 			#	AmiBerry 2.19: https://github.com/Fourdee/DietPi/issues/1707
 			#	Allo GUI v7
 			#	Pi-SPC
-			if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
-
-				/DietPi/dietpi/dietpi-software reinstall 29 108 160 166
-
-			fi
+			(( $G_DIETPI_INSTALL_STAGE == 1 )) && /DietPi/dietpi/dietpi-software reinstall 29 108 160 166
 			#-------------------------------------------------------------------------------
 			#Pi-hole: Enable FTLDNS support by removing pihole-FTL from DietPi control: https://github.com/Fourdee/DietPi/pull/1714
 			systemctl enable pihole-FTL 2> /dev/null
@@ -629,7 +609,6 @@ _EOF_
 			if [[ -f /DietPi/config.txt ]]; then
 
 				local serial_state=$(grep -m1 '^[[:blank:]]*CONFIG_SERIAL_CONSOLE_ENABLE=' /DietPi/dietpi.txt | sed 's/^.*=//')
-
 				G_CONFIG_INJECT 'enable_uart=' "enable_uart=$serial_state" /DietPi/config.txt
 
 			fi
@@ -694,11 +673,7 @@ _EOF_
 			#	CloudPrint
 			#	TightVNC/VNC4/RealVNC: https://github.com/Fourdee/DietPi/pull/1798#issuecomment-392594878
 			#	Xserver: https://github.com/Fourdee/DietPi/issues/1823
-			if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
-
-				/DietPi/dietpi/dietpi-software reinstall 23 33 34 119 137 27 28 120 6
-
-			fi
+			(( $G_DIETPI_INSTALL_STAGE == 1 )) && /DietPi/dietpi/dietpi-software reinstall 23 33 34 119 137 27 28 120 6
 			#-------------------------------------------------------------------------------
 			#Sickrage service update: https://github.com/Fourdee/DietPi/issues/1762
 			if [[ -f /etc/systemd/system/sickrage.service ]]; then
@@ -744,11 +719,7 @@ _EOF_
 			#-------------------------------------------------------------------------------
 			#Offer to change global and unix user passwords to make users aware of the existance or "dietpi" and how the dietpi.txt password is used.
 			#	If already installed only, else, dietpi-software will handle this on first run, after the update
-			if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
-
-				/DietPi/dietpi/func/dietpi-set_software passwords
-
-			fi
+			(( $G_DIETPI_INSTALL_STAGE == 1 )) && /DietPi/dietpi/func/dietpi-set_software passwords
 			#-------------------------------------------------------------------------------
 			#Add dietpi.com SSH pub host key for survey and bug report uploads:
 			mkdir -p /root/.ssh
@@ -779,11 +750,7 @@ _EOF_
 			#Reinstalls
 			#	GMrender: https://dietpi.com/phpbb/viewtopic.php?f=11&t=3900&p=12985#p12985
 			# 	Xserver (ASUSTB GPU)
-			if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
-
-				/DietPi/dietpi/dietpi-software reinstall 163 6
-
-			fi
+			(( $G_DIETPI_INSTALL_STAGE == 1 )) && /DietPi/dietpi/dietpi-software reinstall 163 6
 			#-------------------------------------------------------------------------------
 			#DietPi-Backup rewrite, no longer supports older backups: https://github.com/Fourdee/DietPi/issues/1851
 			if [[ -f '/DietPi/dietpi/.dietpi-backup_settings' ]]; then
@@ -887,11 +854,7 @@ _EOF_
 			#-------------------------------------------------------------------------------
 			#Reinstalls
 			#	Allo GUI
-			if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
-
-				/DietPi/dietpi/dietpi-software reinstall 160
-
-			fi
+			(( $G_DIETPI_INSTALL_STAGE == 1 )) && /DietPi/dietpi/dietpi-software reinstall 160
 			#-------------------------------------------------------------------------------
 
 		elif (( $G_DIETPI_VERSION_SUB == 11 )); then
@@ -902,11 +865,7 @@ _EOF_
 			sed -i '/^aSOFTWARE_INSTALL_STATE\[148\]=/c\aSOFTWARE_INSTALL_STATE\[148\]=0' /DietPi/dietpi/.installed &> /dev/null
 			#-------------------------------------------------------------------------------
 			#ASUS TB WiFi: https://github.com/Fourdee/DietPi/issues/1760
-			if (( $G_HW_MODEL == 52 )); then
-
-				G_CONFIG_INJECT '^8723bs' '8723bs' /etc/modules
-
-			fi
+			(( $G_HW_MODEL == 52 )) && G_CONFIG_INJECT '^8723bs' '8723bs' /etc/modules
 			#-------------------------------------------------------------------------------
 			#Software reinstalls:
 			#	https://github.com/Fourdee/DietPi/issues/1877#issuecomment-403421942
@@ -997,11 +956,7 @@ _EOF_
 			fi
 			#-------------------------------------------------------------------------------
 			# - ARM64 packages no longer available: https://github.com/Fourdee/DietPi/issues/1915
-			if (( $G_DISTRO < 4 && $G_HW_ARCH == 3 )); then
-
-				sed -i '/debian-security/d' /etc/apt/sources.list
-
-			fi
+			(( $G_DISTRO < 4 && $G_HW_ARCH == 3 )) && sed -i '/debian-security/d' /etc/apt/sources.list
 			#-------------------------------------------------------------------------------
 			#Fix Xserver uninstall issus by not purging dependencies, but leaving them for autoremove: https://github.com/Fourdee/DietPi/pull/1930/files
 			local dpkg_list="$(dpkg --get-selections)"
@@ -1067,11 +1022,7 @@ _EOF_
 			grep -q 'hfs' <<< $fs_list || apt-mark auto hfsplus
 			#-------------------------------------------------------------------------------
 			#Pine 64, WiFi module: https://github.com/Fourdee/DietPi/issues/1995#issuecomment-410931618
-			if (( $G_HW_MODEL == 40 )); then
-
-				G_CONFIG_INJECT '8723bs' '8723bs' /etc/modules
-
-			fi
+			(( $G_HW_MODEL == 40 )) && G_CONFIG_INJECT '8723bs' '8723bs' /etc/modules
 			#-------------------------------------------------------------------------------
 			#Autoremove all marked packages during all patches with a single final call
 			G_AGA
@@ -1082,21 +1033,13 @@ _EOF_
 			if [[ -f $fp_old ]]; then
 
 				# - generate the new file, if not done already
-				if [[ ! -f $fp_new ]]; then
-
-					/DietPi/dietpi/dietpi-services stop cron
-
-				fi
+				[[ ! -f $fp_new ]] && /DietPi/dietpi/dietpi-services stop cron
 
 				# - Transfer existing entries over
 				while read line
 				do
 
-					if [[ $line != '#'* ]]; then
-
-						echo -e "+ $line" >> $fp_new
-
-					fi
+					[[ $line != '#'* ]] && echo -e "+ $line" >> $fp_new
 
 				done < $fp_old
 
@@ -1134,11 +1077,7 @@ _EOF_
 
 				local pw_dietpi_software="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_GLOBAL_PASSWORD=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
 				# - Failsafe, should never occur.
-				if [[ -z $pw_dietpi_software ]]; then
-
-					pw_dietpi_software='dietpi'
-
-				fi
+				[[ -z $pw_dietpi_software ]] && pw_dietpi_software='dietpi'
 
 				G_CONFIG_INJECT 'AUTO_SETUP_GLOBAL_PASSWORD=' 'AUTO_SETUP_GLOBAL_PASSWORD=Password has been encrypted and secured on rootFS' /DietPi/dietpi.txt
 
@@ -1175,11 +1114,7 @@ _EOF_
 			#-------------------------------------------------------------------------------
 			#Reinstalls:
 			#	NAA: https://dietpi.com/phpbb/viewtopic.php?f=11&t=4420&p=13914#p13914
-			if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
-
-				/DietPi/dietpi/dietpi-software reinstall 124
-
-			fi
+			(( $G_DIETPI_INSTALL_STAGE == 1 )) && /DietPi/dietpi/dietpi-software reinstall 124
 			#-------------------------------------------------------------------------------
 
 		elif (( $G_DIETPI_VERSION_SUB == 14 )); then
@@ -1197,7 +1132,7 @@ _EOF_
 			for file in /etc/network/if-up.d/*
 			do
 
-				if [[ $file != 'dietpi-disable_offload' ]]; then
+				if [[ -f $file && $file != *'dietpi-disable_offload' ]]; then
 
 					if (( $(grep -ci -m1 '\$ETHTOOL -K "\$IFACE" rx off tx off' $file) )); then
 
@@ -1223,11 +1158,7 @@ _EOF_
 			#Reinstalls:
 			#	MPD: https://github.com/Fourdee/DietPi/issues/2032#issuecomment-415559451
 			# 	PlexPy: https://github.com/Fourdee/DietPi/issues/2047
-			if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
-
-				/DietPi/dietpi/dietpi-software reinstall 128 146
-
-			fi
+			(( $G_DIETPI_INSTALL_STAGE == 1 )) && /DietPi/dietpi/dietpi-software reinstall 128 146
 			#-------------------------------------------------------------------------------
 			#Update DietPi-Sync save file to new format
 			if [[ -f /DietPi/dietpi/.dietpi-sync_settings ]] && ! grep -q '^FP_SOURCE=' /DietPi/dietpi/.dietpi-sync_settings; then
@@ -1282,11 +1213,7 @@ _EOF_
 
 			#-------------------------------------------------------------------------------
 			#Rock64, remove HW accell config, as its not currently functional: https://github.com/Fourdee/DietPi/issues/2086
-			if (( $G_HW_MODEL == 43 )); then
-
-				rm /etc/X11/xorg.conf.d/20-armsoc.conf &> /dev/null
-
-			fi
+			(( $G_HW_MODEL == 43 )) && rm /etc/X11/xorg.conf.d/20-armsoc.conf &> /dev/null
 			#-------------------------------------------------------------------------------
 			#MPD run as dietpi group:
 			if [[ -f /etc/mpd.conf ]]; then
@@ -1296,37 +1223,65 @@ _EOF_
 
 			fi
 			#-------------------------------------------------------------------------------
-			#IPv6 now enabled by default, and, all previous disable options removed: https://github.com/Fourdee/DietPi/issues/2027
-			# - APT allow IPv6
-			rm /etc/apt/apt.conf.d/99-dietpi-force-ipv4 &> /dev/null
+			#Update IPv6 handling: https://github.com/Fourdee/DietPi/issues/2027
+			# - Advice user to re-enable IPv6 on kernel level
+			if [[ ! -d /proc/sys/net/ipv6 ]]; then
 
-			# - Wget back to default
-			sed -i '/^prefer-family/d' /etc/wgetrc
+				G_WHIP_MENU_ARRAY=(
 
-			# - Re-enable IPv6
-			(( $G_HW_MODEL < 10 )) && sed -i '/root=/s/ ipv6.disable=.//' /boot/cmdline.txt
-			rm /etc/modprobe.d/99-dietpi-blacklist-ipv6.conf &> /dev/null
+					0 'Re-enable IPv6 on kernel level, disable via sysctl instead (Recommended)'
+					1 'Keep IPv6 disabled on kernel level, I know what I am doing!'
 
-			if (( $G_HW_ARCH == 10 )); then
+				)
+				G_WHIP_DEFAULT_ITEM=0
+				G_WHIP_MENU '[WARNING] IPv6 is disabled on kernel level\n
+You disabled IPv6 via kernel module blacklist or boot cmd line. We also offered to do this via DietPi-Config.\n
+Since more and more software requires and expects IPv6 kernel settings to be available, this might lead to APT install errors and worse.\n
+For this we strongly advice to re-enable IPv6 on kernel level. However, instead IPv6 will be disabled for the interfaces on sysctl level.
+You should not face any difference by following this advice, no IPv6 addresses will be assigned to your network devices.'
+				if ! (( $? || $G_WHIP_RETURNED_VALUE )); then
 
-				sed -i '/^[[:blank:]]*GRUB_CMDLINE_LINUX_DEFAULT="/s/ipv6.disable=. //' /etc/default/grub
-				update-grub
+					# - Remove kernel module blacklisting
+					rm /etc/modprobe.d/99-dietpi-blacklist-ipv6.conf &> /dev/null
+					# - Failsafe: Comment "blacklist ipv6" entries in all other sysctl config files
+					local i=''
+					for i in /etc/modprobe.d/*
+					do
+
+						[[ ! -f $i ]] && continue
+						sed -i 's/^[[:blank:]]*blacklist ipv6/#&/' $i
+
+					done
+
+					# - Remove boot cmd line entry
+					if (( $G_HW_MODEL < 10 )); then
+
+						sed -i '/root=/s/ ipv6.disable=.//' /boot/cmdline.txt
+
+					elif (( $G_HW_ARCH == 10 )); then
+
+						sed -i '/^[[:blank:]]*GRUB_CMDLINE_LINUX_DEFAULT="/s/ipv6.disable=. //' /etc/default/grub
+						update-grub
+
+					fi
+
+					# - Disable IPv6 via sysctl
+					/DietPi/dietpi/func/dietpi-set_hardware enableipv6 0 &> /dev/null
+
+				fi
 
 			fi
 			#-------------------------------------------------------------------------------
 			#Reinstalls:
 			#	myMPD: https://twitter.com/ta11/status/1045978421967421440
-			if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
-
-				/DietPi/dietpi/dietpi-software reinstall 148
-
-			fi
+			(( $G_DIETPI_INSTALL_STAGE == 1 )) && /DietPi/dietpi/dietpi-software reinstall 148
 			#-------------------------------------------------------------------------------
 
 		fi
 
 		#-------------------------------------------------------------------------------
 		#NB: all if statements must contain at least one command. Prevents bash having a hissy fit :)
+		#	The fastest dummy command is ":", which really does nothing ;).
 		#-------------------------------------------------------------------------------
 
 	}

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1239,7 +1239,7 @@ You disabled IPv6 via kernel module blacklist or boot cmd line. We also offered 
 Since more and more software requires and expects IPv6 kernel settings to be available, this might lead to APT install errors and worse.\n
 For this we strongly advice to re-enable IPv6 on kernel level. However, instead IPv6 will be disabled for the interfaces on sysctl level.
 You should not face any difference by following this advice, no IPv6 addresses will be assigned to your network devices.'
-				if ! (( $? || $G_WHIP_RETURNED_VALUE )); then
+				if (( ! $? )) && (( ! $G_WHIP_RETURNED_VALUE )); then
 
 					# - Remove kernel module blacklisting
 					rm /etc/modprobe.d/99-dietpi-blacklist-ipv6.conf &> /dev/null

--- a/dietpi/preboot
+++ b/dietpi/preboot
@@ -169,13 +169,9 @@
 
 		fi
 
-		# - Set apt mirror
+		# - Set APT mirror
 		local target_repo='CONFIG_APT_DEBIAN_MIRROR'
-		if (( $G_HW_MODEL < 10 )); then
-
-			target_repo='CONFIG_APT_RASPBIAN_MIRROR'
-
-		fi
+		(( $G_HW_MODEL < 10 )) && target_repo='CONFIG_APT_RASPBIAN_MIRROR'
 
 		/DietPi/dietpi/func/dietpi-set_software apt-mirror "$(grep -m1 "^[[:blank:]]*$target_repo=" /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
 
@@ -260,15 +256,16 @@
 		systemctl stop networking
 		killall -w dhclient &> /dev/null
 
+		# - IPv6
+		local enable_ipv6=$(grep -ci -m1 '^[[:blank:]]*CONFIG_ENABLE_IPV6=1' /DietPi/dietpi.txt)
+		/DietPi/dietpi/func/dietpi-set_hardware enableipv6 $enable_ipv6
+		(( $enable_ipv6 )) && /DietPi/dietpi/func/dietpi-set_hardware preferipv4 $(grep -ci -m1 '^[[:blank:]]*CONFIG_PREFER_IPV4=1' /DietPi/dietpi.txt)
+
 		# - reload networking
 		systemctl daemon-reload
 
 		# - Jessie service fails to start: https://github.com/Fourdee/DietPi/issues/2075#issuecomment-424747579
-		if (( $G_DISTRO == 3 )); then
-
-			systemctl start networking
-
-		fi
+		(( $G_DISTRO == 3 )) && systemctl start networking
 
 		# - Bring up networking (this is required, not sure what systemd isn't doing here, as this service runs before networking?!!?)
 		if (( $wifi_enabled )); then
@@ -283,87 +280,60 @@
 
 	}
 
-	Run_Init(){
-
-		#----------------------------------------------------------------
-		#Apply DietPi CPU Governor and settings
-		/DietPi/dietpi/func/dietpi-set_cpu &
-		#----------------------------------------------------------------
-		#Apply LED triggers if set
-		/DietPi/dietpi/func/dietpi-led_control 1 &
-		#----------------------------------------------------------------
-		#RPi Specials
-		#	set volume to -0.1db | We have to do it here because sound card modules (dietpi-set_hardware) are not enabled on the fly, requires a reboot.
-		#	Disable RPi hdmi output if set in dietpi.txt
-		if (( $G_HW_MODEL < 10 )); then
-
-			which amixer &> /dev/null && amixer set PCM -- -010 &
-			if grep -qi '^[[:blank:]]*CONFIG_HDMI_OUTPUT=0' /DietPi/dietpi.txt; then
-
-				/opt/vc/bin/tvservice -o &> /dev/null &
-
-			fi
-
-		fi
-		#----------------------------------------------------------------
-
-	}
-
-	Main(){
-
-		#Pre-Installed image, 1st run
-		if (( $G_DIETPI_INSTALL_STAGE == 2 )); then
-
-			:
-
-		fi
-
-		#Normal Boot
-		if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
-
-			:
-
-		#First run prep
-		elif (( $G_DIETPI_INSTALL_STAGE == -1 )); then
-
-			# - Set RPi v1 safe overclocking profile (900mhz)
-			RPi_Set_Clock_Speeds
-
-			# - End user automated script
-			if [[ -f /boot/Automation_Custom_PreScript.sh ]]; then
-
-				G_DIETPI-NOTIFY 2 'Running custom script, please wait...'
-
-				local fp_dietpiautomation_custom_prescript_log='/var/tmp/dietpi/logs/dietpi-automation_custom_prescript.log'
-				chmod +x /boot/Automation_Custom_PreScript.sh
-				/boot/Automation_Custom_PreScript.sh | tee $fp_dietpiautomation_custom_prescript_log
-				if (( $? == 0 )); then
-
-					G_DIETPI-NOTIFY 0 'Custom script'
-
-				else
-
-					G_DIETPI-NOTIFY 1 "Custom script: Please see the log file for more information $fp_dietpiautomation_custom_prescript_log"
-
-				fi
-
-			fi
-
-			# - Activate DietPi Boot Loader User Settings and bring up network (dietpi.txt)
-			Apply_DietPi_FirstRun_Settings
-
-		fi
-
-	}
-
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Main Loop
 	#/////////////////////////////////////////////////////////////////////////////////////
 	#-----------------------------------------------------------------------------------
-	# Init
-	Run_Init
+	#Apply DietPi CPU Governor and settings
+	/DietPi/dietpi/func/dietpi-set_cpu &
+
+	#Apply LED triggers if set
+	/DietPi/dietpi/func/dietpi-led_control 1 &
+
+	#RPi Specials
+	#	set volume to -0.1db | We have to do it here because sound card modules (dietpi-set_hardware) are not enabled on the fly, requires a reboot.
+	#	Disable RPi hdmi output if set in dietpi.txt
+	if (( $G_HW_MODEL < 10 )); then
+
+		which amixer &> /dev/null && amixer set PCM -- -010 &
+		if grep -qi '^[[:blank:]]*CONFIG_HDMI_OUTPUT=0' /DietPi/dietpi.txt; then
+
+			/opt/vc/bin/tvservice -o &> /dev/null &
+
+		fi
+
+	fi
 	#-----------------------------------------------------------------------------------
-	Main
+	#First run prep
+	if (( $G_DIETPI_INSTALL_STAGE == -1 )); then
+
+		# - Set RPi v1 safe overclocking profile (900mhz)
+		RPi_Set_Clock_Speeds
+
+		# - End user automated script
+		if [[ -f /boot/Automation_Custom_PreScript.sh ]]; then
+
+			G_DIETPI-NOTIFY 2 'Running custom script, please wait...'
+
+			local fp_dietpiautomation_custom_prescript_log='/var/tmp/dietpi/logs/dietpi-automation_custom_prescript.log'
+			chmod +x /boot/Automation_Custom_PreScript.sh
+			/boot/Automation_Custom_PreScript.sh | tee $fp_dietpiautomation_custom_prescript_log
+			if (( $? == 0 )); then
+
+				G_DIETPI-NOTIFY 0 'Custom script'
+
+			else
+
+				G_DIETPI-NOTIFY 1 "Custom script: Please see the log file for more information $fp_dietpiautomation_custom_prescript_log"
+
+			fi
+
+		fi
+
+		# - Activate DietPi Boot Loader User Settings and bring up network (dietpi.txt)
+		Apply_DietPi_FirstRun_Settings
+
+	fi
 	#-----------------------------------------------------------------------------------
 	exit
 	#-----------------------------------------------------------------------------------


### PR DESCRIPTION
**Status**: Ready
🈯️ Jessie VM, dietpi-update and dietpi-config all toggles
- [x] dietpi.txt entries
- [x] First run setup
- [x] Fix on patch
- [x] Changelog

**Reference**:
<s>- IPv6 support for Lighttpd + SSL: https://github.com/Fourdee/DietPi/issues/1840</s> **€: Separate PR**
- IPv6 disable method: https://github.com/Fourdee/DietPi/issues/2027

**Commit list/description**:
+ DietPi-Config | Move IPv6 handling to DietPi-Set_Hardware
+ DietPi-Config | Allow toggle IPv6 only, if not disabled on kernel level
+ DietPi-Config | Add toggle preferring IPv4, if IPv6 is enabled
+ DietPi-Config | Minor code and wording improvements
+ DietPi-Set_Hardware | Add improved/fixed IPv6 handling
+ DietPi-Set_Hardware | Add IPv4 preference toggle
+ dietpi.txt | (Re)add IPv4 preference and IPv6 toggle
+ DietPi-PreBoot | Add IPv6 + IPv4 first run setup
+ DietPi-PreBoot | Minor code improvements and rearrangement/simplification
+ DietPi-Patch | Allow user to decide, whether to keep IPv6 disabled on kernel level, or disable via sysctl instead
+ DietPi-Patch | Revert IPv4 preference removal
+ DietPi-Patch | Minor coding => line count reduction
+ Changelog entries
+ DietPi-Patch | Remove obsolete dietpi.txt entry on patch: "CONFIG_PREFER_IPVERSION"
+ DietPi-Patch | Syntax fix when G_WHIP_MENU is cancelled
+ DietPi-Set_Hardware | Whoopsie, want to write to dietpi.txt, not RPi's config.txt
+ DietPi-Config | Fix "iwgetid: command not found"
+ DietPi-Set_Hardware | Handle IPv6 specific /etc/hosts entries, when toggling IPv6
  - E.g. `/var/lib/dpkg/info/netbase.postinst` lists them as most common expected IPv6 entries
  - Ah great, DietPi-PREP already adds the same 👍.