### PR TITLE
DietPi-Software | Node.js uninstall cleanup; useradd nologin fix; consistency

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Changes / Improvements / Optimizations:
  - DietPi-Automation | Added settings to dietpi.txt to toggle IPv6 and IPv4 preference on first boot.
  - DietPi-Update | You now have the option to view the changelog, prior to updating: https://github.com/Fourdee/DietPi/issues/2081
  - DietPi-Software | Card/CalDAV request redirection was added to new Baikal, ownCloud and Nextcloud installs. Now only the servers domain/IP need to be entered on Card/CalDAV clients, without any further path to the DAV endpoints: https://github.com/Fourdee/DietPi/issues/2057
+ - DietPi-Software | Plex Media Server and Transmission services run now as group "dietpi", to allow cross access with download managers and media software: https://github.com/Fourdee/DietPi/issues/2067#issuecomment-427579779
  - DietPi-Drive_Manager | Formatting: Now has the option to format the whole drive, or patition only, for drives with existing partitions.
  - DietPi-Drive_Manager | Mounting NTFS drives now enabled native linux permissions support (eg: you can use this as your userdata location). Many thanks to @Random90 for making this possible! https://github.com/Fourdee/DietPi/issues/2096#issuecomment-425553333
  - DietPi-Drive_Manager | Improved detection and formatting for NVMe based drives: https://github.com/Fourdee/DietPi/issues/2102

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5381,7 +5381,7 @@ _EOF_
 			#x86_64
 			if (( $G_HW_ARCH == 10 )); then
 
-				Download_Install 'https://downloads.plex.tv/plex-media-server/1.13.0.5023-31d3c0c65/plexmediaserver_1.13.0.5023-31d3c0c65_amd64.deb'
+				Download_Install 'https://downloads.plex.tv/plex-media-server/1.13.8.5395-10d48da0d/plexmediaserver_1.13.8.5395-10d48da0d_amd64.deb'
 
 			#ARM
 			else
@@ -5389,8 +5389,11 @@ _EOF_
 				INSTALL_URL_ADDRESS='http://dev2day.de/pms/'
 				G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
-				echo -e "deb [arch=armhf] $INSTALL_URL_ADDRESS $G_DISTRO_NAME main" > /etc/apt/sources.list.d/plex.list
+				echo "deb [arch=armhf] $INSTALL_URL_ADDRESS $G_DISTRO_NAME main" > /etc/apt/sources.list.d/plex.list
 				wget -O - "$INSTALL_URL_ADDRESS"dev2day-pms.gpg.key | apt-key add -
+
+				# Buster: Revert repo to Stretch, as Buster is not yet available
+				sed -i 's/buster/stretch/g' /etc/apt/sources.list.d/plex.list
 
 				#ARMv8: Install 32bit binaries
 				if (( $G_HW_ARCH == 3 )); then
@@ -8237,26 +8240,14 @@ _EOF_
 
 			Banner_Configuration
 
-			#Jessie, Transmission uses my systemd service: https://github.com/Fourdee/DietPi/issues/350#issuecomment-220828884
+			# Remove obsolete init.d service
 			rm /etc/init.d/transmission-daemon &> /dev/null
-			rm /lib/systemd/system/transmission-daemon.service &> /dev/null
-			cat << _EOF_ > /etc/systemd/system/transmission-daemon.service
-[Unit]
-Description=Barebones transmission-daemon service
-DefaultDependencies=no
 
-[Service]
-Type=forking
-RemainAfterExit=yes
-ExecStart=/usr/bin/transmission-daemon --config-dir /var/lib/transmission-daemon/info
-StandardOutput=tty
+			# Run service as "dietpi" group: https://github.com/Fourdee/DietPi/issues/350#issuecomment-423763518
+			echo -e '[Service]\nGroup=dietpi' >> /etc/systemd/system/transmission-daemon.service.d/dietpi-group.conf
 
-[Install]
-WantedBy=multi-user.target
-_EOF_
-
-			#Apply optimized settings
-			sed -i '/}/d' /etc/transmission-daemon/settings.json
+			# Apply optimized settings
+			sed -i '/^}/d' /etc/transmission-daemon/settings.json
 
 			G_CONFIG_INJECT '"cache-size-mb"' '"cache-size-mb": '$(Optimize_BitTorrent 0)',' /etc/transmission-daemon/settings.json
 			G_CONFIG_INJECT '"download-queue-size"' '"download-queue-size": '$(Optimize_BitTorrent 1)',' /etc/transmission-daemon/settings.json
@@ -8279,7 +8270,10 @@ _EOF_
 			G_CONFIG_INJECT '"rpc-whitelist-enabled"' '"rpc-whitelist-enabled": false,' /etc/transmission-daemon/settings.json
 			G_CONFIG_INJECT '"message-level"' '"message-level": 0,' /etc/transmission-daemon/settings.json
 
-			echo -e "}" >> /etc/transmission-daemon/settings.json
+			# To allow access for download managers and media software, files need to be created with 77X permissions.
+			G_CONFIG_INJECT '\"umask\":' '    \"umask\": 7,' /etc/transmission-daemon/settings.json
+
+			echo '}' >> /etc/transmission-daemon/settings.json
 
 		fi
 
@@ -10310,22 +10304,24 @@ location = /.well-known/caldav {
 		if (( ${aSOFTWARE_INSTALL_STATE[$INSTALLING_INDEX]} == 1 )); then
 
 			Banner_Configuration
-
 			Download_Test_Media
 
-			#For all ARM devices:
-			# - en_US.UTF8 must be installed and the default locale on system. This is for SBC installs using dev2day repo: https://github.com/Fourdee/DietPi/issues/116#issuecomment-222195911
-			if (( $G_USER_INPUTS &&
-				$G_HW_ARCH < 10 && ! $(locale | grep -ci -m1 'en_US.UTF-8') )); then
+			# For all ARM devices:
+			# - en_US.UTF-8 must be installed and the default locale on system. This is for SBC installs using dev2day repo: https://github.com/Fourdee/DietPi/issues/116#issuecomment-222195911
+			if (( $G_USER_INPUTS && $G_HW_ARCH < 10 ))
+				&& ! locale | grep -q 'en_US.UTF-8'; then
 
 				sed -i '/en_US.UTF-8 UTF-8/c\en_US.UTF-8 UTF-8' /etc/locale.gen
 				locale-gen
 
-				G_WHIP_MSG 'Plex Media Server requires en_US.UTF8 locale to be installed and set to default, else, Plex will not start.\n\nDietPi-Config will now be launched, on the next screen:\n - Select "locale" option\n\nOn the screen after:\n - Select en_US.UTF8 and press enter.\n\nOnce completed, exit dietpi-config to resume setup'
+				G_WHIP_MSG 'Plex Media Server requires en_US.UTF-8 locale to be installed and set to default, else, Plex will not start.\n\nDietPi-Config will now be launched, on the next screen:\n - Select "locale" option\n\nOn the screen after:\n - Select en_US.UTF-8 and press enter.\n\nOnce completed, exit dietpi-config to resume setup'
 
 				/DietPi/dietpi/dietpi-config 7 1
 
 			fi
+
+			# Run service as "dietpi" group: https://github.com/Fourdee/DietPi/issues/350#issuecomment-423763518
+			echo -e '[Service]\nGroup=dietpi' >> /etc/systemd/system/plexmediaserver.service.d/dietpi-group.conf
 
 		fi
 
@@ -12345,7 +12341,8 @@ _EOF_
 
 			Banner_Uninstalling
 			G_AGP transmission-daemon
-			rm /etc/init.d/transmission-daemon /etc/systemd/system/transmission-daemon.service &> /dev/null
+			rm /etc/systemd/system/transmission-daemon.service &> /dev/null # pre v6.17
+			rm /etc/systemd/system/transmission-daemon.service.d/dietpi-group.conf &> /dev/null # post v6.17
 
 		fi
 
@@ -13551,6 +13548,7 @@ _EOF_
 			G_AGP $(dpkg --get-selections plexmediaserver* | awk '{print $1}')
 			rm -R /var/lib/plexmediaserver
 			rm /etc/apt/sources.list.d/plex.list 2> /dev/null && G_AGUP
+			rm /etc/systemd/system/plexmediaserver.service.d/dietpi-group.conf &> /dev/null # post v6.17
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8244,6 +8244,7 @@ _EOF_
 			rm /etc/init.d/transmission-daemon &> /dev/null
 
 			# Run service as "dietpi" group: https://github.com/Fourdee/DietPi/issues/350#issuecomment-423763518
+			mkdir -p /etc/systemd/system/transmission-daemon.service.d
 			echo -e '[Service]\nGroup=dietpi' >> /etc/systemd/system/transmission-daemon.service.d/dietpi-group.conf
 
 			# Apply optimized settings
@@ -10321,6 +10322,7 @@ location = /.well-known/caldav {
 			fi
 
 			# Run service as "dietpi" group: https://github.com/Fourdee/DietPi/issues/350#issuecomment-423763518
+			mkdir -p /etc/systemd/system/plexmediaserver.service.d
 			echo -e '[Service]\nGroup=dietpi' >> /etc/systemd/system/plexmediaserver.service.d/dietpi-group.conf
 
 		fi
@@ -12341,8 +12343,8 @@ _EOF_
 
 			Banner_Uninstalling
 			G_AGP transmission-daemon
-			rm /etc/systemd/system/transmission-daemon.service &> /dev/null # pre v6.17
-			rm /etc/systemd/system/transmission-daemon.service.d/dietpi-group.conf &> /dev/null # post v6.17
+			[[ -f /etc/systemd/system/transmission-daemon.service ]] && rm /etc/systemd/system/transmission-daemon.service # pre v6.17
+			[[ -d /etc/systemd/system/transmission-daemon.service.d ]] && rm /etc/systemd/system/transmission-daemon.service.d # post v6.17
 
 		fi
 
@@ -13548,7 +13550,7 @@ _EOF_
 			G_AGP $(dpkg --get-selections plexmediaserver* | awk '{print $1}')
 			rm -R /var/lib/plexmediaserver
 			rm /etc/apt/sources.list.d/plex.list 2> /dev/null && G_AGUP
-			rm /etc/systemd/system/plexmediaserver.service.d/dietpi-group.conf &> /dev/null # post v6.17
+			[[ -d /etc/systemd/system/plexmediaserver.service.d ]] && rm -R /etc/systemd/system/plexmediaserver.service.d # post v6.17
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7003,18 +7003,20 @@ _EOF_
 			#RPi's + ARMv6 only available in raspbian repo: https://github.com/Fourdee/DietPi/issues/1023
 			if (( $G_HW_MODEL < 10 || $G_HW_ARCH == 1 )); then
 
-				echo -e "deb http://download.mono-project.com/repo/debian raspbian$G_DISTRO_NAME main" > /etc/apt/sources.list.d/mono-xamarin.list
+				echo "deb https://download.mono-project.com/repo/debian raspbian$G_DISTRO_NAME main" > /etc/apt/sources.list.d/mono-xamarin.list
 
 			else
 
-				echo -e "deb http://download.mono-project.com/repo/debian $G_DISTRO_NAME main" > /etc/apt/sources.list.d/mono-xamarin.list
+				echo "deb https://download.mono-project.com/repo/debian $G_DISTRO_NAME main" > /etc/apt/sources.list.d/mono-xamarin.list
 
 			fi
+			# - Buster: Revert to Stretch, since Buster is not yet available
+			sed -i 's/buster/stretch/g' /etc/apt/sources.list.d/mono-xamarin.list
 
 			G_AGUP
 
 			G_AGI mono-runtime mono-complete
-			rm /tmp/mono* #https://github.com/Fourdee/DietPi/issues/1877#issuecomment-403856446
+			rm /tmp/mono* &> /dev/null #https://github.com/Fourdee/DietPi/issues/1877#issuecomment-403856446
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4550,7 +4550,7 @@ _EOF_
 			G_AGI $package_list
 
 			# - Serialport fails to build unless below flags are provided
-			npm install -g node-red --unsafe-perm
+			npm i -g --unsafe-perm node-red
 
 		fi
 
@@ -4580,8 +4580,8 @@ _EOF_
 
 			# - Install Blynk JS Libary
 			G_AGI python
-			npm install -g onoff --unsafe-perm
-			npm install -g blynk-library --unsafe-perm
+			npm i -g --unsafe-perm onoff
+			npm i -g --unsafe-perm blynk-library
 
 		fi
 
@@ -5459,10 +5459,10 @@ _EOF_
 			chmod +x service.js mineos_console.js generate-sslcert.sh webui.js
 
 			#Install Node 8, as MineOS is currently not compatible with Node 10
-			npm install n -g --unsafe-perm
+			npm i -g --unsafe-perm n
 			n 8
 
-			npm install --unsafe-perm
+			npm i --unsafe-perm
 
 			cd /tmp/$G_PROGRAM_NAME
 
@@ -5928,7 +5928,7 @@ _EOF_
 			mv koel-* $G_FP_DIETPI_USERDATA/koel
 
 			# Install pre-req yarn and "n" to downgrade to Node 8, as Node 10 is not (yet) compatible with Koel build.
-			npm i yarn n -g --unsafe-perm
+			npm i -g --unsafe-perm yarn n
 			n 8
 
 			# Download and install Composer:
@@ -6923,15 +6923,12 @@ _EOF_
 
 			Banner_Installing
 
-			#check, is online
 			INSTALL_URL_ADDRESS='http://raw.githubusercontent.com/taaem/nodejs-linux-installer/master/node-install.sh'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
-			# - Preqs
 			wget "$INSTALL_URL_ADDRESS" -O node_install.sh
 			chmod +x node_install.sh
 			./node_install.sh
-
 			rm node_install.sh
 
 		fi
@@ -8300,7 +8297,7 @@ _EOF_
 			Banner_Configuration
 
 			# Create MPD user
-			useradd -r -M mpd -G dietpi,audio -s /usr/bin/nologin
+			useradd -rM mpd -G dietpi,audio -s /usr/sbin/nologin
 
 			# - Add files/folders
 			mkdir -p /var/run/mpd
@@ -8425,7 +8422,7 @@ _EOF_
 
 			Banner_Configuration
 
-			useradd -r -M ympd -G dietpi -s /usr/bin/nologin
+			useradd -rM ympd -G dietpi -s /usr/sbin/nologin
 
 			#YMPD service
 			cat << _EOF_ > /etc/systemd/system/ympd.service
@@ -8450,7 +8447,7 @@ _EOF_
 
 			Banner_Configuration
 
-			useradd -r -M mympd -G dietpi -s /usr/bin/nologin
+			useradd -rM mympd -G dietpi -s /usr/sbin/nologin
 
 			cat << _EOF_ > /lib/systemd/system/mympd.service
 [Unit]
@@ -8494,7 +8491,7 @@ _EOF_
 
 			Banner_Configuration
 
-			useradd -r -M roon -G dietpi,audio -s /usr/bin/nologin
+			useradd -rM roon -G dietpi,audio -s /usr/sbin/nologin
 
 			mkdir -p $G_FP_DIETPI_USERDATA/roon
 
@@ -8592,7 +8589,7 @@ _EOF_
 
 			Banner_Configuration
 
-			useradd -r -M mopidy -G dietpi,audio -s /usr/bin/nologin
+			useradd -rM mopidy -G dietpi,audio -s /usr/sbin/nologin
 			sed -i "/User=/c\User=mopidy" /lib/systemd/system/mopidy.service
 
 			# - conf
@@ -8681,8 +8678,8 @@ _EOF_
 
 			Banner_Configuration
 
-			userdel -f minidlna &> /dev/null
-			useradd -r -M minidlna -G dietpi -s /usr/bin/nologin
+			userdel -rf minidlna &> /dev/null
+			useradd -rM minidlna -G dietpi -s /usr/sbin/nologin
 
 			rm /etc/init.d/minidlna &> /dev/null
 			rm /etc/systemd/system/minidlna.service &> /dev/null
@@ -8939,7 +8936,7 @@ _EOF_
 
 			Banner_Configuration
 
-			useradd -r -M deluge -G dietpi -s /usr/bin/nologin
+			useradd -rM deluge -G dietpi -s /usr/sbin/nologin
 
 			mkdir -p $G_FP_DIETPI_USERDATA/deluge/.config/deluge
 
@@ -9071,7 +9068,7 @@ _EOF_
 
 			Banner_Configuration
 
-			useradd -r -M airsonic -G dietpi,audio -s /usr/bin/nologin
+			useradd -rM airsonic -G dietpi,audio -s /usr/sbin/nologin
 
 			#Optimize memory limit
 			local airsonic_memory_max=$(( $RAM_TOTAL / 5 ))
@@ -9656,7 +9653,7 @@ _EOF_
 
 			Banner_Configuration
 
-			useradd -r -M ubooquity -G dietpi -s /usr/bin/nologin
+			useradd -rM ubooquity -G dietpi -s /usr/sbin/nologin
 
 			mkdir -p $G_FP_DIETPI_USERDATA/ebooks $G_FP_DIETPI_USERDATA/comics
 
@@ -10044,8 +10041,7 @@ alsa =
 _EOF_
 
 			#Create shairport user
-			groupadd -r shairport-sync &> /dev/null
-			useradd -r -M -g shairport-sync -s /usr/bin/nologin -G audio shairport-sync &> /dev/null
+			useradd -rM shairport-sync -G audio -s /usr/sbin/nologin
 
 			chmod +x /usr/local/bin/shairport-sync
 
@@ -10210,8 +10206,7 @@ _EOF_
 			systemctl daemon-reload
 
 			# - Create netdata user/group
-			getent group netdata > /dev/null || groupadd -r netdata
-			getent passwd netdata > /dev/null || useradd -r -g netdata -c netdata -s /sbin/nologin -d / netdata
+			getent passwd netdata > /dev/null || useradd -r netdata -c netdata -s /usr/sbin/nologin -d /
 
 			for x in /var/cache/netdata /usr/share/netdata/web /etc/netdata /var/log/netdata /var/lib/netdata; do
 
@@ -10338,7 +10333,7 @@ location = /.well-known/caldav {
 
 			Banner_Configuration
 
-			useradd -r -M cuberite -G dietpi -s /usr/bin/nologin
+			useradd -rM cuberite -G dietpi -s /usr/sbin/nologin
 
 			cat << _EOF_ > /etc/systemd/system/cuberite.service
 [Unit]
@@ -10459,7 +10454,7 @@ _EOF_
 
 			Banner_Configuration
 
-			useradd -rm qbittorrent -p "$GLOBAL_PW" -G dietpi -s /usr/bin/nologin
+			useradd -rm qbittorrent -p "$GLOBAL_PW" -G dietpi -s /usr/sbin/nologin
 
 			# - conf.
 			mkdir -p /home/qbittorrent/.config/qBittorrent
@@ -10969,7 +10964,7 @@ _EOF_
 
 			Banner_Configuration
 
-			useradd -r -M sickrage -G dietpi -s /usr/bin/nologin
+			useradd -rM sickrage -G dietpi -s /usr/sbin/nologin
 
 			cat << _EOF_ > /etc/systemd/system/sickrage.service
 [Unit]
@@ -11034,7 +11029,7 @@ _EOF_
 
 			Banner_Configuration
 
-			useradd -rm tonido -G dietpi -s /usr/bin/nologin
+			useradd -rm tonido -G dietpi -s /usr/sbin/nologin
 
 			#service
 			cat << _EOF_ > /etc/systemd/system/tonido.service
@@ -11427,7 +11422,7 @@ _EOF_
 
 			Banner_Configuration
 
-			useradd -r -M koel -G dietpi -s /usr/bin/nologin
+			useradd -rM koel -G dietpi -s /usr/sbin/nologin
 
 			Download_Test_Media
 
@@ -11474,7 +11469,7 @@ _EOF_
 
 			Banner_Configuration
 
-			useradd -r -M sonarr -G dietpi -s /usr/bin/nologin
+			useradd -rM sonarr -G dietpi -s /usr/sbin/nologin
 
 			mkdir -p $G_FP_DIETPI_USERDATA/sonarr
 
@@ -11501,7 +11496,7 @@ _EOF_
 
 			Banner_Configuration
 
-			useradd -r -M radarr -G dietpi -s /usr/bin/nologin
+			useradd -rM radarr -G dietpi -s /usr/sbin/nologin
 
 			mkdir -p $G_FP_DIETPI_USERDATA/radarr
 
@@ -11528,7 +11523,7 @@ _EOF_
 
 			Banner_Configuration
 
-			useradd -r -M lidarr -G dietpi -s /usr/bin/nologin
+			useradd -rM lidarr -G dietpi -s /usr/sbin/nologin
 
 			mkdir -p $G_FP_DIETPI_USERDATA/lidarr
 
@@ -11557,7 +11552,7 @@ _EOF_
 
 			mkdir -p $G_FP_DIETPI_USERDATA/plexpy
 
-			useradd -r -M plexpy -G dietpi -s /usr/bin/nologin
+			useradd -rM plexpy -G dietpi -s /usr/sbin/nologin
 
 			cat << _EOF_ > /etc/systemd/system/plexpy.service
 [Unit]
@@ -11612,7 +11607,7 @@ _EOF_
 
 			Banner_Configuration
 
-			useradd -r -M nzbget -G dietpi -s /usr/bin/nologin
+			useradd -rM nzbget -G dietpi -s /usr/sbin/nologin
 
 			sed -i "/MainDir=/c\MainDir=$G_FP_DIETPI_USERDATA/downloads" $G_FP_DIETPI_USERDATA/nzbget/nzbget.conf
 			sed -i "/DestDir=/c\DestDir=$G_FP_DIETPI_USERDATA/downloads/complete" $G_FP_DIETPI_USERDATA/nzbget/nzbget.conf
@@ -11982,7 +11977,7 @@ _EOF_
 
 			Banner_Configuration
 
-			useradd -r -m gmrender -G dietpi,audio -s /usr/bin/nologin
+			useradd -rm gmrender -G dietpi,audio -s /usr/sbin/nologin
 
 			cat << _EOF_ > /etc/systemd/system/gmrender.service
 [Unit]
@@ -12284,7 +12279,7 @@ _EOF_
 
 	Uninstall_Software(){
 
-		#NB: systemctl daemon-reload is executed after this func in Uninstall_Software_Finalize()
+		#NB: systemctl daemon-reload is executed at the end of this function
 		#----------------------------------------------------------------------
 		#DIETPI SOFTWARE
 		local UNINSTALLING_INDEX=23
@@ -12538,7 +12533,7 @@ _EOF_
 		if (( aSOFTWARE_INSTALL_STATE[$UNINSTALLING_INDEX] == -1 )); then
 
 			Banner_Uninstalling
-			userdel -f ympd
+			userdel -rf ympd
 			rm /usr/bin/ympd
 			rm /etc/systemd/system/ympd.service
 
@@ -12547,7 +12542,7 @@ _EOF_
 		UNINSTALLING_INDEX=148
 		if (( aSOFTWARE_INSTALL_STATE[$UNINSTALLING_INDEX] == -1 )); then
 
-			userdel -f mympd
+			userdel -rf mympd
 			rm -R /etc/mympd
 			rm -R /usr/share/mympd
 			rm $(which mympd)
@@ -12562,7 +12557,7 @@ _EOF_
 			#apt-mark auto libavformat57 libupnp6 libao-common libao4 libasound2 libasound2-data libasyncns0 libaudiofile1 libavahi-client3 libavahi-common-data libavahi-common3 libavcodec56 libavformat56 libavresample2 libavutil54 libbinio1ldbl libcaca0 libcdio-cdda1 libcdio-paranoia1 libcdio13 libcups2 libcurl3-gnutls libdirectfb-1.2-9 libdnet libfaad2 libflac8 libfluidsynth1 libgme0 libgomp1 libgsm1 libice6 libid3tag0 libiso9660-8 libjack-jackd2-0 libjson-c2 libldb1 libmad0 libmikmod3 libmms0 libmodplug1 libmp3lame0 libmpcdec6 libmpg123-0 libnfs4 libntdb1 libogg0 libopenal-data libopenal1 libopenjpeg5 libopus0 liborc-0.4-0 libpulse0 libresid-builder0c2a libroar2 libsamplerate0 libschroedinger-1.0-0 libsdl1.2debian libshout3 libsidplay2 libsidutils0 libslp1 libsm6 libsmbclient libsndfile1 libsoxr0 libspeex1 libspeexdsp1 libsqlite3-0 libtalloc2 libtdb1 libtevent0 libtheora0 libupnp6 libva1 libvorbis0a libvorbisenc2 libvorbisfile3 libvpx1 libwavpack1 libwbclient0 libwildmidi-config libwildmidi1 libx11-6 libx11-data libx11-xcb1 libx264-142 libxau6 libxcb1 libxdmcp6 libxext6 libxi6 libxtst6 libxvidcore4 libyajl2 libzzip-0-13 mime-support python python-talloc python2.7 samba-libs x11-common file &> /dev/null
 			apt-mark unhold mpd 1> /dev/null
 			G_AGP mpd libmpdclient2
-			userdel -f mpd
+			userdel -rf mpd
 			rm /lib/systemd/system/mpd.service
 			rm -R $G_FP_DIETPI_USERDATA/.mpd_cache
 
@@ -12572,11 +12567,13 @@ _EOF_
 		if (( aSOFTWARE_INSTALL_STATE[$UNINSTALLING_INDEX] == -1 )); then
 
 			Banner_Uninstalling
+			npm r -g node-red
 			rm /etc/systemd/system/node-red.service
 			rm $HOME/.node-red
 			rm -R $G_FP_DIETPI_USERDATA/node-red
-
-			userdel -f nodered
+			[[ -f /usr/local/bin/node-red ]] && rm /usr/local/bin/node-red
+			[[ -f /usr/local/bin/node-red-pi ]] && rm /usr/local/bin/node-red-pi
+			userdel -rf nodered
 
 		fi
 
@@ -12684,7 +12681,7 @@ _EOF_
 			rm /etc/systemd/system/tonido.service
 			rm -R $G_FP_DIETPI_USERDATA/tonido
 
-			userdel -f tonido
+			userdel -rf tonido
 			rm -R /home/tonido
 
 		fi
@@ -12766,7 +12763,7 @@ _EOF_
 			rm -R /etc/couchpotato
 			rm -R $G_FP_DIETPI_USERDATA/couchpotato
 			rm /etc/init.d/couchpotato
-			#userdel -f couchpotato
+			#userdel -rf couchpotato
 
 		fi
 
@@ -12775,7 +12772,7 @@ _EOF_
 
 			Banner_Uninstalling
 
-			userdel -f koel
+			userdel -rf koel
 
 			systemctl start mysql
 			mysqladmin drop koel -f
@@ -12800,7 +12797,7 @@ _EOF_
 
 			rm -R $G_FP_DIETPI_USERDATA/sonarr
 
-			userdel -f sonarr
+			userdel -rf sonarr
 
 			rm /etc/apt/sources.list.d/sonarr.list 2>/dev/null
 			G_AGUP
@@ -12817,7 +12814,7 @@ _EOF_
 
 			rm -R $G_FP_DIETPI_USERDATA/radarr
 
-			userdel -f radarr
+			userdel -rf radarr
 
 		fi
 
@@ -12831,7 +12828,7 @@ _EOF_
 
 			rm -R $G_FP_DIETPI_USERDATA/lidarr
 
-			userdel -f lidarr
+			userdel -rf lidarr
 
 		fi
 
@@ -12843,7 +12840,7 @@ _EOF_
 			rm -R $G_FP_DIETPI_USERDATA/plexpy
 			rm /etc/systemd/system/plexpy.service
 
-			userdel -f plexpy
+			userdel -rf plexpy
 
 		fi
 
@@ -12851,7 +12848,7 @@ _EOF_
 		if (( aSOFTWARE_INSTALL_STATE[$UNINSTALLING_INDEX] == -1 )); then
 
 			Banner_Uninstalling
-			userdel -f jackett
+			userdel -rf jackett
 			rm -R /opt/jackett
 			rm /etc/systemd/system/jackett.service
 
@@ -12864,7 +12861,7 @@ _EOF_
 			rm -R $G_FP_DIETPI_USERDATA/nzbget
 			rm /etc/systemd/system/nzbget.service
 
-			userdel -f nzbget
+			userdel -rf nzbget
 
 		fi
 
@@ -12921,7 +12918,7 @@ _EOF_
 			Banner_Uninstalling
 			rm /etc/systemd/system/roonbridge.service
 			rm -R /etc/roonbridge
-			userdel -f roon
+			userdel -rf roon
 
 		fi
 
@@ -12962,7 +12959,7 @@ _EOF_
 			rm /etc/apt/sources.list.d/mopidy.list
 			rm -R $G_FP_DIETPI_USERDATA/mopidy
 
-			userdel -f mopidy
+			userdel -rf mopidy
 
 			pip uninstall -y Mopidy-MusicBox-Webclient Mopidy-Local-Images
 
@@ -12987,7 +12984,7 @@ _EOF_
 			rm -R $G_FP_DIETPI_USERDATA/.MiniDLNA_Cache
 
 			rm /etc/systemd/system/minidlna.service
-			userdel -f minidlna
+			userdel -rf minidlna
 
 		fi
 
@@ -13025,7 +13022,7 @@ _EOF_
 			rm /etc/systemd/system/deluge-web.service
 			rm -R $G_FP_DIETPI_USERDATA/deluge
 
-			userdel -f deluge
+			userdel -rf deluge
 
 		fi
 
@@ -13115,7 +13112,7 @@ _EOF_
 			rm -R $G_FP_DIETPI_USERDATA/airsonic
 			rm /etc/systemd/system/airsonic.service
 
-			userdel -f airsonic
+			userdel -rf airsonic
 
 		fi
 
@@ -13291,7 +13288,7 @@ _EOF_
 			Banner_Uninstalling
 			rm /etc/apt/sources.list.d/swupdate.openvpn.net.list
 			pivpn -u
-			userdel -f pivpn
+			userdel -rf pivpn
 
 		fi
 
@@ -13415,7 +13412,7 @@ _EOF_
 			# https://github.com/Fourdee/DietPi/blob/testing/dietpi/dietpi-software#L5968
 			#G_AGP shairport-sync
 			rm /lib/systemd/system/shairport-sync.service /usr/local/bin/shairport-sync /usr/local/etc/shairport-sync.conf* /usr/local/share/man/man7/shairport-sync.7.gz &> /dev/null
-			userdel -f shairport-sync
+			userdel -rf shairport-sync
 
 		fi
 
@@ -13492,7 +13489,7 @@ _EOF_
 			#all
 			rm /etc/systemd/system/netdata.service
 
-			userdel -f netdata
+			userdel -rf netdata
 			groupdel netdata
 
 			#1.2.0+
@@ -13563,7 +13560,7 @@ _EOF_
 			rm -R $G_FP_DIETPI_USERDATA/cubrite
 			rm /etc/systemd/system/cuberite.service
 
-			userdel -f cuberite
+			userdel -rf cuberite
 
 		fi
 
@@ -13579,7 +13576,7 @@ _EOF_
 
 			rm /usr/local/bin/mineos
 
-			userdel -f mineos
+			userdel -rf mineos
 
 		fi
 
@@ -13588,7 +13585,7 @@ _EOF_
 
 			Banner_Uninstalling
 
-			userdel -f gogs
+			userdel -rf gogs
 
 			rm -R /etc/gogs
 			rm /etc/systemd/system/gogs.service
@@ -13606,7 +13603,7 @@ _EOF_
 			Banner_Uninstalling
 			G_AGP qbittorrent-nox
 
-			userdel -f qbittorrent
+			userdel -rf qbittorrent
 
 			rm /etc/systemd/system/qbittorrent.service
 			rm -R /home/qbittorrent
@@ -13637,7 +13634,7 @@ _EOF_
 			rm -R  /etc/sickrage &> /dev/null # v6.11<
 			rm -R $G_FP_DIETPI_USERDATA/sickrage
 
-			userdel -f sickrage
+			userdel -rf sickrage
 
 		fi
 
@@ -13716,7 +13713,7 @@ _EOF_
 			rm -R /srv/homeassistant
 
 			# Remove the user and all files. This removed pyenv for this user as well.
-			userdel -r -f homeassistant
+			userdel -rf homeassistant
 			groupdel homeassistant
 
 			# Remove the service.
@@ -13798,7 +13795,7 @@ _EOF_
 			rm /etc/default/minio
 
 			# Remove userdel
-			userdel -r -f minio-user
+			userdel -rf minio-user
 
 			# Remove certbot renewal hook:
 			rm /etc/systemd/system/certbot.service.d/dietpi-minio.conf &> /dev/null
@@ -13821,7 +13818,7 @@ _EOF_
 			rm /etc/rc5.d/S99bdd
 			rm /etc/init.d/bdd
 
-			userdel -r bd
+			userdel -rf bd
 
 		fi
 
@@ -13864,7 +13861,7 @@ _EOF_
 			G_AGP gmrender
 			rm /etc/systemd/system/gmrender.service
 
-			userdel -f gmrender
+			userdel -rf gmrender
 
 		fi
 
@@ -13874,7 +13871,7 @@ _EOF_
 
 			Banner_Uninstalling
 			rm -R /var/www/allo
-			userdel -f allo
+			userdel -rf allo
 			rm /etc/sudoers.d/allo
 			systemctl start mysql
 			mysqladmin drop allo_db -f
@@ -13940,7 +13937,7 @@ _EOF_
 			rm /etc/systemd/system/ubooquity.service
 			rm -R $G_FP_DIETPI_USERDATA/ubooquity
 
-			userdel -f ubooquity
+			userdel -rf ubooquity
 
 		fi
 
@@ -14245,7 +14242,7 @@ _EOF_
 		if (( aSOFTWARE_INSTALL_STATE[$UNINSTALLING_INDEX] == -1 )); then
 
 			Banner_Uninstalling
-			npm r n yarn npm -g
+			npm r -g n yarn npm
 			G_AGP nodejs
 
 			# - old install via repo
@@ -14256,9 +14253,20 @@ _EOF_
 
 			fi
 
-			rm /usr/local/bin/node
+			[[ -f /usr/local/bin/node ]] && rm /usr/local/bin/node
 			[[ -d /usr/local/n ]] && rm -R /usr/local/n
 			[[ -d /usr/local/yarn ]] && rm -R /usr/local/yarn
+			[[ -d /usr/local/include/node ]] && rm -R /usr/local/include/node
+			[[ -d /usr/local/lib/node_modules ]] && rm -R /usr/local/lib/node_modules
+			[[ -d /usr/local/share/doc/node ]] && rm -R /usr/local/share/doc/node
+			[[ -f /usr/local/man/man1/node.1 ]] && rm /usr/local/man/man1/node.1
+			[[ -f /usr/local/share/man/man1/node.1 ]] && rm /usr/local/share/man/man1/node.1
+			[[ -f /usr/local/README.md ]] && /usr/local/README.md
+			[[ -f /usr/local/CHANGELOG.md ]] && /usr/local/CHANGELOG.md
+			[[ -f /usr/local/LICENSE ]] && /usr/local/LICENSE
+			[[ -f /usr/local/share/systemtap/tapset/node.stp ]] && rm /usr/local/share/systemtap/tapset/node.stp
+			[[ -d $HOME/.npm ]] && rm -R $HOME/.npm
+			[[ -f $HOME/.config/configstore/update-notifier-npm.json ]] && rm $HOME/.config/configstore/update-notifier-npm.json
 
 		fi
 
@@ -14268,49 +14276,19 @@ _EOF_
 			Banner_Uninstalling
 			G_AGP vifm
 
-		#else
-
-		#	G_DIETPI-NOTIFY 2 "Software index $index is unknown, or, has no removal code."
-		#	valid_input=0
-
 		fi
 
-		#----------------------------------------------------------------------
-		#log to .uninstalled file
-		#if [ ! -f /DietPi/dietpi/.uninstalled ]; then
-
-		#	echo -e "DietPi Uninstall Software Log\n----------------------\n" > /DietPi/dietpi/.uninstalled
-
-		#fi
-
-		#echo -e "$index | $(date)" >> /DietPi/dietpi/.uninstalled
-
-		#Update array installed state
-		#aSOFTWARE_INSTALL_STATE[$index]=0
+		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Finalize uninstall'
 
 		#Uninstall finished, set all uninstalled software to state 0 (not installed)
 		for ((i=0; i<$TOTAL_SOFTWARE_INDICES; i++))
 		do
 
-			if (( ${aSOFTWARE_INSTALL_STATE[$i]} == -1 )); then
-
-				aSOFTWARE_INSTALL_STATE[$i]=0
-
-			fi
+			(( ${aSOFTWARE_INSTALL_STATE[$i]} == -1 )) && aSOFTWARE_INSTALL_STATE[$i]=0
 
 		done
 
-		#----------------------------------------------------------------------
-		#Reset error handler (eg: for usermsg clear)
-		G_ERROR_HANDLER_RESET
-		#----------------------------------------------------------------------
-
-	}
-
-	Uninstall_Software_Finalize(){
-
-		#Purge
-		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Removing packages that are no longer required'
+		#apt-get autoremove
 		G_AGA
 
 		#Check if we need to clear DietPi choices
@@ -14344,6 +14322,11 @@ _EOF_
 		rm $fp_temp
 
 		systemctl daemon-reload
+
+		#----------------------------------------------------------------------
+		#Reset error handler (eg: for usermsg clear)
+		G_ERROR_HANDLER_RESET
+		#----------------------------------------------------------------------
 
 	}
 
@@ -14731,7 +14714,6 @@ _EOF_
 				elif [[ $1 == 'uninstall' ]]; then
 
 					Uninstall_Software
-					Uninstall_Software_Finalize
 
 					#Save
 					Write_InstallFileList
@@ -14867,7 +14849,7 @@ _EOF_
 
 			done
 
-			echo -e "Total Software indices : $TOTAL_SOFTWARE_INDICES"
+			echo "Total Software indices : $TOTAL_SOFTWARE_INDICES"
 
 		else
 
@@ -16023,9 +16005,6 @@ _EOF_
 
 						done
 						Uninstall_Software
-
-						#Finish up and clear non-required packages
-						Uninstall_Software_Finalize
 
 						#Save
 						Write_InstallFileList

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1309,7 +1309,26 @@ You should not face any difference by following this advice, no IPv6 addresses w
 			#-------------------------------------------------------------------------------
 			#Reinstalls:
 			#	myMPD: https://twitter.com/ta11/status/1045978421967421440
-			(( $G_DIETPI_INSTALL_STAGE == 1 )) && /DietPi/dietpi/dietpi-software reinstall 148
+			if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
+
+				/DietPi/dietpi/dietpi-software reinstall 148
+			#-------------------------------------------------------------------------------
+				#Run Transmission and Plex Media Server as "dietpi" group: https://github.com/Fourdee/DietPi/issues/2067#issuecomment-427579779
+				if grep -q '^aSOFTWARE_INSTALL_STATE\[44\]=2' /DietPi/dietpi/.installed; then
+
+					mkdir -p /etc/systemd/system/transmission-daemon.service.d
+					echo -e '[Service]\nGroup=dietpi' >> /etc/systemd/system/transmission-daemon.service.d/dietpi-group.conf
+					G_CONFIG_INJECT '\"umask\":' '    \"umask\": 7,' /etc/transmission-daemon/settings.json
+
+				fi
+				if grep -q '^aSOFTWARE_INSTALL_STATE\[42\]=2' /DietPi/dietpi/.installed; then
+
+					mkdir -p /etc/systemd/system/plexmediaserver.service.d
+					echo -e '[Service]\nGroup=dietpi' >> /etc/systemd/system/plexmediaserver.service.d/dietpi-group.conf
+
+				fi
+
+			fi
 			#-------------------------------------------------------------------------------
 			#Now part of rootfs: https://github.com/Fourdee/DietPi/issues/2103
 			chmod +x /var/lib/dietpi/services/dietpi-wifi-monitor.sh
@@ -1342,7 +1361,7 @@ sleep 20
 # - Set USB ETH if found
 if ip a | grep -qi 'eth1'; then
 
-	echo -e "blacklist ethernet" > /etc/modprobe.d/disable_sparkysbc_ethernet.conf
+	echo 'blacklist ethernet' > /etc/modprobe.d/disable_sparkysbc_ethernet.conf
 	rm /etc/udev/rules.d/70-persistent-net.rules &> /dev/null
 	rm /etc/udev/rules.d/70-persistant-net.rules &> /dev/null
 	reboot


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Software | Merge Uninstall_Software_Finalize() into Uninstall_Software()
+ DietPi-Software | npm call consistency
+ DietPi-Software | useradd consistancy: group is added automatically; /usr/sbin/nologin is only available nologin bin
+ DietPi-Software | Remove users home directory as well, when removing users
+ DietPi-Software | Node.js: On uninstall, remove the unbelievable amount of left files across system

Hijack:
+ DietPi-Software | Plax/Transmission: Allow access for download managers and media software, by running the services as "dietpi" group
  - And updated x86 Plex download to current version 1.13.8
+ DietPi-Patch | Run Transmission and Plex Media Server as "dietpi" group
+ Changelog entry
+ DietPi-Software | Whoopsie, add directories first, before placing files inside and remove them on uninstall