### PR TITLE
DietPi-Update | Pre-patch, code and wording

### DIFF
--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -241,8 +241,10 @@ Please select 'Update' option to apply the update."
 
 					G_WHIP_YESNO "
 ------------------------Notice------------------------
-A benefit of DietPi is, that we use standard Linux (Debian) configurations and commands. The downside is, that we can't possibly accommodate or predict every modifcation to Linux configurations files by the end user, during the update.
-Although we test the updates thoroughly, if you made custom changes to Linux configuration files, outside of the DietPi programs, an update may trigger a potential issue.
+- A benefit of DietPi is: We use standard Linux (Debian) configurations and commands.
+- A potential downside is: We can't possibly accommodate or predict all modification to Linux configurations files by the end user, outside of DietPi programs, during updates.
+
+Although we test the updates thoroughly, if you have made any custom changes to Linux configuration files outside of the DietPi programs, an update may trigger a potential issue.
 ------------------------------------------------------
 
 Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SERVER.$RCVERSION_SERVER?"

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -72,6 +72,13 @@
 
 	)
 
+	URL_MIRROR_PREPATCH=(
+
+		"https://raw.githubusercontent.com/$GITFORKOWNER/DietPi/$G_GITBRANCH/dietpi/pre-patch_file"
+		"https://dietpi.com/downloads/dietpi-update_mirror/$G_GITBRANCH/pre-patch_file"
+
+	)
+
 	URL_MIRROR_ZIP=(
 
 		"https://github.com/$GITFORKOWNER/DietPi/archive/$G_GITBRANCH.zip"
@@ -270,6 +277,14 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 
 	Run_Update(){
 
+		#Applying pre-patch
+		G_RUN_CMD wget "${URL_MIRROR_PREPATCH[$URL_MIRROR_INDEX]}" -O pre-patch_file
+		if ! ./pre-patch_file $G_DIETPI_VERSION_SUB; then
+
+			G_DIETPI-NOTIFY 1 "An error occured during pre-patching. Please check terminal messages for errors, or $FP_LOG, and retry dietpi-update."
+
+		fi
+
 		#Update APT packages
 		G_AGUP
 		G_AGUG
@@ -281,8 +296,9 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 			rm update.zip
 
 			#Remove setting files/info from Git that are not to be updated on client
-			rm DietPi-"$G_GITBRANCH"/dietpi/.*
+			rm -R DietPi-"$G_GITBRANCH"/dietpi/.??*
 			rm DietPi-"$G_GITBRANCH"/dietpi/server_version*
+			rm DietPi-"$G_GITBRANCH"/dietpi/pre-patch_file
 
 			#Remove folders of "non-critical scripts" before updating them. (eg: so we dont need to patch for /conf/* file removals)
 			# rm -R /DietPi/dietpi/conf #:https://github.com/Fourdee/DietPi/issues/905#issuecomment-298241622
@@ -292,7 +308,7 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 			l_message='Copy DietPi core files to RAMdisk' G_RUN_CMD cp -Rf DietPi-"$G_GITBRANCH"/dietpi /DietPi/
 			l_message='Copy rootfs files in place' G_RUN_CMD cp -Rf DietPi-"$G_GITBRANCH"/rootfs/. /
 
-			l_message='Set execute permissions for DietPi scripts' G_RUN_CMD chmod -R +x /DietPi /var/lib/dietpi/services /etc/cron.*/dietpi /etc/profile.d/dietpi-*.sh /etc/bashrc.d/dietpi-*.sh 
+			l_message='Set execute permissions for DietPi scripts' G_RUN_CMD chmod -R +x /DietPi /var/lib/dietpi/services /etc/cron.*/dietpi /etc/profile.d/dietpi-*.sh /etc/bashrc.d/dietpi-*.sh
 			systemctl daemon-reload
 
 			#Verify/update dietpi.txt entries:

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -41,7 +41,7 @@
 	#UPDATE Vars
 	#/////////////////////////////////////////////////////////////////////////////////////
 	FP_LOG='/var/tmp/dietpi/logs/dietpi-update.log'
-	FP_TMP_LOG="/tmp/$G_PROGRAM_NAME/dietpi-update.log"
+	FP_TMP_LOG='dietpi-update.log'
 	DIETPIUPDATE_VERSION_CORE=6 # Version of dietpi-update / set server_version-6 line one to value++ and obsolete previous dietpi-update scripts
 
 	CHANGELOG_DOWNLOADED=0 #Prevent redownload of changelog if already done in this session
@@ -59,8 +59,8 @@
 	INFO_SERVER_VERSION=''
 	INFO_VERSIONS_UPDATE(){
 
-		INFO_CURRENT_VERSION="Current Version : v$G_DIETPI_VERSION_CORE.$G_DIETPI_VERSION_SUB.$G_DIETPI_VERSION_RC"
-		INFO_SERVER_VERSION="Latest Version  : v$COREVERSION_SERVER.$SUBVERSION_SERVER.$RCVERSION_SERVER"
+		INFO_CURRENT_VERSION="Current version : v$G_DIETPI_VERSION_CORE.$G_DIETPI_VERSION_SUB.$G_DIETPI_VERSION_RC"
+		INFO_SERVER_VERSION="Latest version  : v$COREVERSION_SERVER.$SUBVERSION_SERVER.$RCVERSION_SERVER"
 
 	}
 
@@ -92,39 +92,34 @@
 		for ((i=0; i<${#URL_MIRROR_SERVERVERSION[@]}; i++))
 		do
 
-			URL_MIRROR_INDEX=$i
-
-			G_DIETPI-NOTIFY 2 "Checking Mirror : ${URL_MIRROR_SERVERVERSION[$i]}"
-			curl -fk -L "${URL_MIRROR_SERVERVERSION[$i]}" > server_version
-			if (( ! $? )); then
+			G_DIETPI-NOTIFY 2 "Checking mirror: ${URL_MIRROR_SERVERVERSION[$i]}"
+			if curl -sL "${URL_MIRROR_SERVERVERSION[$i]}" > server_version; then
 
 				#Get server Version info
 				COREVERSION_SERVER=$(sed -n 1p server_version)
 				SUBVERSION_SERVER=$(sed -n 2p server_version)
-				#Master branch is always X.X.0. RC versions limited to beta/dev branches
-				if [[ $G_DEV_GITBRANCH != 'master' ]]; then
-
-					RCVERSION_SERVER=$(sed -n 3p server_version)
-
-				fi
+				RCVERSION_SERVER=$(sed -n 3p server_version)
 
 				#Check if server_version is a valid interger.
-				if disable_error=1 G_CHECK_VALIDINT $SUBVERSION_SERVER; then
+				if disable_error=1 G_CHECK_VALIDINT $COREVERSION_SERVER &&
+					disable_error=1 G_CHECK_VALIDINT $SUBVERSION_SERVER &&
+					disable_error=1 G_CHECK_VALIDINT $RCVERSION_SERVER; then
 
 					SERVER_ONLINE=1
 					G_DIETPI-NOTIFY 0 "Using update server: ${URL_MIRROR_SERVERVERSION[$i]}"
+					URL_MIRROR_INDEX=$i
 					INFO_VERSIONS_UPDATE
 					break
 
 				else
 
-					G_DIETPI-NOTIFY 2 'Invalid server version and/or update file unavailable'
+					G_DIETPI-NOTIFY 2 "Invalid server version string: ${COREVERSION_SERVER:-NULL}.${SUBVERSION_SERVER:-NULL}.${RCVERSION_SERVER:-NULL}"
 
 				fi
 
 			else
 
-				G_DIETPI-NOTIFY 2 "No response from: ${URL_MIRROR_SERVERVERSION[$i]}"
+				G_DIETPI-NOTIFY 2 "No response from: ${URL_MIRROR_SERVERVERSION[$i]} ($(<server_version))"
 
 			fi
 
@@ -135,7 +130,7 @@
 	Check_Update_Available(){
 
 		#Clear previous .update_available file
-		rm /DietPi/dietpi/.update_available &> /dev/null
+		[[ -f /DietPi/dietpi/.update_available ]] && rm /DietPi/dietpi/.update_available
 
 		#Server online?
 		if (( $SERVER_ONLINE )); then
@@ -358,7 +353,7 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 	Get_Server_Version
 	#----------------------------------------------------------------
 	#Check if update is available
-	#	Reapply current subversion patch, e.g. when using testing branch.
+	#	Reapply current subversion patch, e.g. when using dev branch.
 	if (( $INPUT == -1 )); then
 
 		if (( $G_DIETPI_VERSION_SUB < 0 )); then

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -279,6 +279,7 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 
 		#Applying pre-patch
 		G_RUN_CMD wget "${URL_MIRROR_PREPATCH[$URL_MIRROR_INDEX]}" -O pre-patch_file
+		chmod +x pre-patch_file
 		if ! ./pre-patch_file $G_DIETPI_VERSION_SUB; then
 
 			G_DIETPI-NOTIFY 1 "An error occured during pre-patching. Please check terminal messages for errors, or $FP_LOG, and retry dietpi-update."

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -54,6 +54,8 @@
 	COREVERSION_SERVER=0
 	SUBVERSION_SERVER=0
 	RCVERSION_SERVER=0
+	# Failsafe, in case /DietPi/dietpi/.version did not successfully apply
+	G_DIETPI_VERSION_RC=${G_DIETPI_VERSION_RC:-0}
 
 	INFO_CURRENT_VERSION=''
 	INFO_SERVER_VERSION=''

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -10,8 +10,8 @@
 	#////////////////////////////////////
 	#
 	# Info:
-	# - Updates DietPi from Git
-	# - Uses patch_file for online patching
+	# - Updates DietPi from Git or dietpi.com repo
+	# - Uses patch_file for incremental online patching
 	#
 	# Usage:
 	# - dietpi-update    = Normal
@@ -35,7 +35,7 @@
 	#GIT Owner
 	#/////////////////////////////////////////////////////////////////////////////////////
 	GITFORKOWNER="$(grep -m1 '^[[:blank:]]*DEV_GITOWNER=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
-	[[ ! $GITFORKOWNER ]] && GITFORKOWNER='Fourdee'
+	[[ $GITFORKOWNER ]] || GITFORKOWNER='Fourdee'
 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	#UPDATE Vars
@@ -95,12 +95,12 @@
 			G_DIETPI-NOTIFY 2 "Checking mirror: ${URL_MIRROR_SERVERVERSION[$i]}"
 			if curl -sL "${URL_MIRROR_SERVERVERSION[$i]}" > server_version; then
 
-				#Get server Version info
+				#Get server version info
 				COREVERSION_SERVER=$(sed -n 1p server_version)
 				SUBVERSION_SERVER=$(sed -n 2p server_version)
 				RCVERSION_SERVER=$(sed -n 3p server_version)
 
-				#Check if server_version is a valid interger.
+				#Check if server_version contains valid intergers.
 				if disable_error=1 G_CHECK_VALIDINT $COREVERSION_SERVER &&
 					disable_error=1 G_CHECK_VALIDINT $SUBVERSION_SERVER &&
 					disable_error=1 G_CHECK_VALIDINT $RCVERSION_SERVER; then
@@ -173,9 +173,8 @@
 			for ((i=0; i<${#URL_MIRROR_CHANGELOG[@]}; i++))
 			do
 
-				G_DIETPI-NOTIFY 2 "Checking Mirror : ${URL_MIRROR_CHANGELOG[$i]}"
-				wget "${URL_MIRROR_CHANGELOG[$i]}"
-				if (( ! $? )); then
+				G_DIETPI-NOTIFY 2 "Checking mirror: ${URL_MIRROR_CHANGELOG[$i]}"
+				if wget "${URL_MIRROR_CHANGELOG[$i]}" -O $fp_changelog; then
 
 					CHANGELOG_DOWNLOADED=1
 					break
@@ -196,7 +195,7 @@
 
 		else
 
-			G_WHIP_MSG "Failed to download $fp_changelog, please try again."
+			G_WHIP_MSG 'Failed to download the changelog, please try again.'
 
 		fi
 
@@ -233,11 +232,11 @@ Please select 'Update' option to apply the update."
 
 					G_WHIP_YESNO "
 ------------------------Notice------------------------
-The benefit of DietPi is we use standard linux configurations and commands. The downside is we can't possibly accommodate or predict, every modifcation to Linux configurations files by the end user, during the update.
-Although we test the updates thoroughly, if you have made custom changes to Linux configuration files, outside of the DietPi programs, an update may trigger a potential issue.
+A benefit of DietPi is, that we use standard Linux (Debian) configurations and commands. The downside is, that we can't possibly accommodate or predict every modifcation to Linux configurations files by the end user, during the update.
+Although we test the updates thoroughly, if you made custom changes to Linux configuration files, outside of the DietPi programs, an update may trigger a potential issue.
 ------------------------------------------------------
 
-Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SERVER?"
+Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SERVER.$RCVERSION_SERVER?"
 					if (( $? == 0 )); then
 
 						RUN_UPDATE=1
@@ -275,31 +274,31 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 		G_AGUP
 		G_AGUG
 
-		#git clone Zip method (no need to install GIT)
-		curl -k -L "${URL_MIRROR_ZIP[$URL_MIRROR_INDEX]}" > update.zip
-		if (( ! $? )); then
+		#Git clone Zip method (no need to install Git)
+		if curl -kL "${URL_MIRROR_ZIP[$URL_MIRROR_INDEX]}" > update.zip; then
 
 			l_message='Unpack update archieve' G_RUN_CMD unzip update.zip
-			rm update.zip &> /dev/null
+			rm update.zip
 
-			#Remove setting files from git that are not to be updated on client
-			rm DietPi-"$G_GITBRANCH"/dietpi/.* &> /dev/null
+			#Remove setting files/info from Git that are not to be updated on client
+			rm DietPi-"$G_GITBRANCH"/dietpi/.*
+			rm DietPi-"$G_GITBRANCH"/dietpi/server_version*
 
 			#Remove folders of "non-critical scripts" before updating them. (eg: so we dont need to patch for /conf/* file removals)
 			# rm -R /DietPi/dietpi/conf #:https://github.com/Fourdee/DietPi/issues/905#issuecomment-298241622
 			# rm -R /DietPi/dietpi/func
 			# rm -R /DietPi/dietpi/misc
 
-			l_message='Copy DietPi core files to ramdisk' G_RUN_CMD cp -Rf DietPi-"$G_GITBRANCH"/dietpi /DietPi/
+			l_message='Copy DietPi core files to RAMdisk' G_RUN_CMD cp -Rf DietPi-"$G_GITBRANCH"/dietpi /DietPi/
 			l_message='Copy rootfs files in place' G_RUN_CMD cp -Rf DietPi-"$G_GITBRANCH"/rootfs/. /
 
-			l_message='Set execute permissions for DietPi scripts' G_RUN_CMD chmod -R +x /DietPi /etc/cron.*/dietpi /var/lib/dietpi/services
+			l_message='Set execute permissions for DietPi scripts' G_RUN_CMD chmod -R +x /DietPi /var/lib/dietpi/services /etc/cron.*/dietpi /etc/profile.d/dietpi-*.sh /etc/bashrc.d/dietpi-*.sh 
 			systemctl daemon-reload
 
 			#Verify/update dietpi.txt entries:
 			/DietPi/dietpi/func/dietpi-set_software verify_dietpi.txt
 
-			G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'DietPi-Update Updating DietPi'
+			G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Running incremental patching'
 			G_DIETPI-NOTIFY 2 "$INFO_CURRENT_VERSION"
 			G_DIETPI-NOTIFY 2 "$INFO_SERVER_VERSION"
 
@@ -317,20 +316,19 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 			while (( $G_DIETPI_VERSION_RC < $RCVERSION_SERVER )); do
 
 				G_DIETPI-NOTIFY 2 "Patching $G_DIETPI_VERSION_CORE.$G_DIETPI_VERSION_SUB.$G_DIETPI_VERSION_RC to $G_DIETPI_VERSION_CORE.$G_DIETPI_VERSION_SUB.$RCVERSION_SERVER"
-				/DietPi/dietpi/patch_file $(( $G_DIETPI_VERSION_SUB - 1 )) #rerun current subversion patch for RC's
+				/DietPi/dietpi/patch_file $(( $G_DIETPI_VERSION_SUB - 1 )) #Rerun current subversion patch for RC's
 				export G_DIETPI_VERSION_RC=$RCVERSION_SERVER
 
 			done
 
+			#Remove patch_file
+			rm /DietPi/dietpi/patch_file
+
 			INFO_VERSIONS_UPDATE
 
-			#Update Local Version ID
+			#Update local version ID
 			echo -e "$G_DIETPI_VERSION_CORE\n$G_DIETPI_VERSION_SUB\n$G_DIETPI_VERSION_RC" > /DietPi/dietpi/.version
 			G_DIETPI-NOTIFY 0 "Patch v$G_DIETPI_VERSION_CORE.$G_DIETPI_VERSION_SUB.$G_DIETPI_VERSION_RC completed\n"
-
-			#Remove Patch files.
-			rm /DietPi/dietpi/patch_file &> /dev/null
-			rm /DietPi/dietpi/server_version &> /dev/null
 
 		#Unable to download file.
 		else
@@ -363,7 +361,7 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 		else
 
 			G_DIETPI-NOTIFY 0 'Repatch was requested: Update will reapply the current subversion patch'
-			export G_DIETPI_VERSION_SUB=$((G_DIETPI_VERSION_SUB-1))
+			export G_DIETPI_VERSION_SUB=$(( $G_DIETPI_VERSION_SUB - 1 ))
 
 		fi
 
@@ -391,11 +389,11 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 		#Update available
 		elif (( $UPDATE_AVAILABLE )); then
 
-			# Userdata location verify
+			#Verify userdata location
 			G_CHECK_USERDATA
 
 			#Insufficient free space
-			G_CHECK_FREESPACE / 500 || exit 1
+			G_CHECK_FREESPACE / 100 || exit 1
 
 			#Noninteractive update
 			if (( $INPUT == 1 )); then
@@ -417,7 +415,6 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 			G_DIETPI-NOTIFY 2 "$INFO_CURRENT_VERSION"
 			G_DIETPI-NOTIFY 2 "$INFO_SERVER_VERSION"
 			G_DIETPI-NOTIFY 0 'No updates required, your DietPi installation is up to date.\n'
-			sleep 2
 
 		fi
 
@@ -429,7 +426,7 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 			/DietPi/dietpi/dietpi-services stop
 
 			#Run update and patcher
-			rm $FP_LOG &> /dev/null
+			[[ -f $FP_LOG ]] && rm $FP_LOG
 
 			#Run_Update #: https://github.com/Fourdee/DietPi/issues/1877#issuecomment-403866204
 			Run_Update > >(tee $FP_TMP_LOG) 2>&1
@@ -439,7 +436,7 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 			echo 0 > /DietPi/dietpi/.update_stage
 
 			#Remove update_available file
-			rm /DietPi/dietpi/.update_available &> /dev/null
+			[[ -f /DietPi/dietpi/.update_available ]] && rm /DietPi/dietpi/.update_available
 
 			#Update DietPi-Survey
 			/DietPi/dietpi/dietpi-survey 1
@@ -457,11 +454,7 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 			if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
 
 				G_WHIP_YESNO "Update applied:\n\n - $INFO_CURRENT_VERSION\n\nA system reboot is required to finalize the update. Would you like to reboot the system now?"
-				if (( $? == 0 )); then
-
-					reboot
-
-				fi
+				(( $? == 0 )) && reboot
 
 			fi
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -30,113 +30,28 @@
 	export G_DIETPI_VERSION_SUB=$INPUT
 
 	#/////////////////////////////////////////////////////////////////////////////////////
-	#Critical Patch system
-	#	For changes made to DietPi code, that requires a re-run of dietpi-update (due to it running old code)
+	#Pre-v6.17: Switch to new branch, versioning and pre-patch system
 	#/////////////////////////////////////////////////////////////////////////////////////
 	#Addition of RC version
 	#	As loaded v6.16<= dietpi-update will overwrite this to previous 2 line system, we need to get user to rerun the update manually, ensuring the new dietpi-update code is run.
-	if [[ ! $(sed -n 3p /DietPi/dietpi/.version) ]]; then
+	if (( $G_DIETPI_VERSION_SUB < 17 )) && [[ ! $(sed -n 3p /DietPi/dietpi/.version) ]]; then
 
-		cat << _EOF_ > /DietPi/dietpi/.version
-6
-$G_DIETPI_VERSION_SUB
-0
-_EOF_
+		echo -e "6\n$G_DIETPI_VERSION_SUB\n0" > /DietPi/dietpi/.version
 
 		#Switch from testing to dev branch
-		if grep -q '^DEV_GITBRANCH=testing' /DietPi/dietpi.txt; then
+		if grep -q '^[[:blank:]]*DEV_GITBRANCH=testing' /DietPi/dietpi.txt; then
 
-			export G_DEV_GITBRANCH='dev'
 			G_CONFIG_INJECT 'DEV_GITBRANCH=' 'DEV_GITBRANCH=dev' /DietPi/dietpi.txt
-
-			G_DIETPI-NOTIFY 0 "Switched from 'testing' to 'dev' branch. Please rerun, 'dietpi-update'"
+			local branch=''
+			$branch=' branch and'
 
 		fi
 
-		G_WHIP_MSG 'DietPi has applied a new versioning system to the device. To allow DietPi-Update to use this new versioning system, it must be re-run manually.\n\nPlease re-run "dietpi-update" to resume the update process.'
+		G_WHIP_MSG "DietPi has applied a new$branch versioning system to the device. To allow DietPi-Update to use this new system, it must be re-run manually.\n\nPlease re-run \"dietpi-update\" to resume the update process."
 		killall -w dietpi-update
 		exit 0
 
 	fi
-
-	#/////////////////////////////////////////////////////////////////////////////////////
-	#Emergency Patch System:
-	#	This runs before all standard incremental patches. Useful for when shi* hits the ...
-	#/////////////////////////////////////////////////////////////////////////////////////
-	FP_EMR='/DietPi/dietpi/.patch_emr'
-	EMR_INDEX=0
-
-	Update_EMR_Index(){
-
-		G_DIETPI-NOTIFY 0 "EMR patch $EMR_INDEX: Applied "
-		((EMR_INDEX++))
-		echo $EMR_INDEX > $FP_EMR
-
-	}
-
-	#Obtain current EMR index
-	if [[ ! -f $FP_EMR ]]; then
-
-		echo 0 > $FP_EMR
-
-	else
-
-		EMR_INDEX=$(<$FP_EMR)
-
-	fi
-
-	#Run EMR Patch
-	if (( $EMR_INDEX == 0 )); then
-
-		#Pre-6.9 preparations: Manually copy rootfs files in place: https://github.com/Fourdee/DietPi/pull/1802
-		#	NB: dietpi-update takes over, post v6.9 update completion.
-		G_GITBRANCH="$(grep -m1 '^[[:blank:]]*DEV_GITBRANCH=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
-		if (( $G_DIETPI_VERSION_SUB < 9 )) && [[ -d /tmp/dietpi-update/DietPi-$G_GITBRANCH/rootfs ]]; then
-
-			l_message='Copy rootfs files in place' G_RUN_CMD cp -Rf /tmp/dietpi-update/DietPi-"$G_GITBRANCH"/rootfs/. /
-			l_message='Set execute permissions for DietPi scripts' G_RUN_CMD chmod -R +x /etc/cron.*/dietpi /var/lib/dietpi/services
-			l_message='Clean download location' G_RUN_CMD rm -R /tmp/dietpi-update/DietPi-"$G_GITBRANCH"/rootfs
-
-		fi
-
-		Update_EMR_Index
-
-	fi
-
-	if (( $EMR_INDEX == 1 )); then
-
-		#RAMlog 0 free space check due to issues with failing DietPi cron jobs in v6.11
-		if (( $(G_CHECK_FREESPACE /var/log) < 2 )); then
-
-			G_DIETPI-NOTIFY 2 'EMR: Clearing log files to free up space before patching (<2MB)'
-			/DietPi/dietpi/func/dietpi-logclear 1
-
-		fi
-
-		Update_EMR_Index
-
-	fi
-
-	# if (( $EMR_INDEX == 2 )); then
-
-		#Date fix, due to NTP > systemd-timesyncd, unknown cause: https://github.com/Fourdee/DietPi/issues/2017
-		# if (( $(date +%Y%m%d) < 20180820 )); then
-
-			# G_RUN_CMD wget --no-check-certificate https://dietpi.com/downloads/date -O emr2_date_set
-			# date +%Y%m%d -s "$(cat emr2_date_set)"
-			# rm emr2_date_set
-
-		# fi
-
-		# Update_EMR_Index
-	# fi
-
-	# if (( $EMR_INDEX == 3 )); then
-
-		#echo 'nothing here yet'
-		# Update_EMR_Index
-
-	# fi
 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	#Incremental patch system:
@@ -550,7 +465,7 @@ _EOF_
 			#Add nodered (if installed) to gpio group: https://github.com/Fourdee/DietPi/issues/1687
 			usermod -a -G gpio nodered &> /dev/null
 			#-------------------------------------------------------------------------------
-			#Deluge systemD service update: https://github.com/Fourdee/DietPi/issues/1658
+			#Deluge systemd service update: https://github.com/Fourdee/DietPi/issues/1658
 			# + Service fix for in v6.6 https://github.com/Fourdee/DietPi/issues/1689#issuecomment-379024795
 			rm /DietPi/dietpi/conf/deluge.service &> /dev/null
 			if [[ -f /var/lib/dietpi/dietpi-software/services/deluge.service ||
@@ -649,6 +564,7 @@ _EOF_
 
 				G_DIETPI-NOTIFY 2 'Detected invalid .dietpi-process_tool save file. It has been reset to support updated v6.8 DietPi-Process_Tool codebase'
 				rm /DietPi/dietpi/.dietpi-process_tool
+				rm /boot/dietpi/.dietpi-process_tool
 
 			fi
 			#-------------------------------------------------------------------------------
@@ -1381,6 +1297,10 @@ _EOF_
 			#-------------------------------------------------------------------------------
 			#Failsafe, assure /var/tmp 777 permissions: https://github.com/Fourdee/DietPi/issues/1144#issuecomment-425758727
 			chmod 777 /var/tmp
+			#-------------------------------------------------------------------------------
+			#Remove obsolete EMR patch file
+			[[ -f /DietPi/dietpi/.patch_emr ]] && rm /DietPi/dietpi/.patch_emr
+			[[ -f /boot/dietpi/.patch_emr ]] && rm /boot/dietpi/.patch_emr
 			#-------------------------------------------------------------------------------
 
 		fi

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -467,7 +467,6 @@ _EOF_
 			#-------------------------------------------------------------------------------
 			#Deluge systemd service update: https://github.com/Fourdee/DietPi/issues/1658
 			# + Service fix for in v6.6 https://github.com/Fourdee/DietPi/issues/1689#issuecomment-379024795
-			rm /DietPi/dietpi/conf/deluge.service &> /dev/null
 			if [[ -f /var/lib/dietpi/dietpi-software/services/deluge.service ||
 				-f /etc/systemd/system/deluged.service ]]; then
 
@@ -498,10 +497,10 @@ _EOF_
 
 				/DietPi/dietpi/dietpi-services dietpi_controlled
 
+				[[ -f /var/lib/dietpi/dietpi-software/services/deluge.service ]] && rm /var/lib/dietpi/dietpi-software/services/deluge.service
+
 				# - Enable service run:
 				G_CONFIG_INJECT 'ENABLE_DELUGED=' 'ENABLE_DELUGED=1' /etc/default/deluged
-
-				rm /var/lib/dietpi/dietpi-software/services/deluge.service &> /dev/null
 
 			fi
 			#-------------------------------------------------------------------------------
@@ -538,10 +537,6 @@ _EOF_
 				echo -e "\n#framebuffer_depth=16" >> /DietPi/config.txt
 
 			fi
-			#-------------------------------------------------------------------------------
-			#Scripts moved to /func
-			rm /DietPi/dietpi/dietpi-obtain_hw_model &> /dev/null
-			rm /DietPi/dietpi/dietpi-cpu_set &> /dev/null
 			#-------------------------------------------------------------------------------
 			#RPi UART: https://github.com/Fourdee/DietPi/issues/1759
 			if [[ -f /DietPi/config.txt ]]; then
@@ -993,12 +988,6 @@ _EOF_
 			#Assure absence of dhcpcd5, if dhclient (isc-dhcp-client) is active: https://github.com/Fourdee/DietPi/issues/1560#issuecomment-370136642
 			pgrep 'dhclient' &> /dev/null && G_AGP dhcpcd5
 			#-------------------------------------------------------------------------------
-			#ramlog/disk service updates (moved to /func)
-			rm /DietPi/dietpi/dietpi-ramlog &> /dev/null
-			rm /DietPi/dietpi/dietpi-ramdisk &> /dev/null
-			rm /DietPi/dietpi/dietpi-logclear &> /dev/null
-			rm /DietPi/dietpi/dietpi-banner &> /dev/null
-			#-------------------------------------------------------------------------------
 
 		elif (( $G_DIETPI_VERSION_SUB == 13 )); then
 
@@ -1298,10 +1287,21 @@ _EOF_
 			#Failsafe, assure /var/tmp 777 permissions: https://github.com/Fourdee/DietPi/issues/1144#issuecomment-425758727
 			chmod 777 /var/tmp
 			#-------------------------------------------------------------------------------
-			#Remove obsolete EMR patch file
-			[[ -f /DietPi/dietpi/.patch_emr ]] && rm /DietPi/dietpi/.patch_emr
-			[[ -f /boot/dietpi/.patch_emr ]] && rm /boot/dietpi/.patch_emr
-      #-------------------------------------------------------------------------------
+			#Remove obsolete EMR patch file and redo removal of obsolete script files, as they were not removed from disk: https://github.com/Fourdee/DietPi/pull/2123#issuecomment-428121908
+			for i in /DietPi/dietpi /boot/dietpi
+			do
+
+				[[ -f $i/conf/deluge.service ]] && rm $i/conf/deluge.service
+				[[ -f $i/dietpi-obtain_hw_model ]] && rm $i/dietpi-obtain_hw_model
+				[[ -f $i/dietpi-cpu_set ]] && rm $i/dietpi-cpu_set
+				[[ -f $i/.patch_emr ]] && rm $i/.patch_emr
+				[[ -f $i/dietpi-ramlog ]] && rm $i/dietpi-ramlog &> /dev/null
+				[[ -f $i/dietpi-ramdisk ]] && rm $i/dietpi-ramdisk &> /dev/null
+				[[ -f $i/dietpi-logclear ]] && rm $i/dietpi-logclear &> /dev/null
+				[[ -f $i/dietpi-banner ]] && rm $i/dietpi-banner &> /dev/null
+
+			done
+			#-------------------------------------------------------------------------------
 			#Remove www-data under sudo without PW: https://github.com/Fourdee/DietPi/issues/2121
 			sed -i '/^www-data ALL=NOPASSWD: ALL/d' /etc/sudoers
 			#-------------------------------------------------------------------------------

--- a/dietpi/pre-patch_file
+++ b/dietpi/pre-patch_file
@@ -1,0 +1,51 @@
+#!/bin/bash
+{
+	#////////////////////////////////////
+	# DietPi Patch File Script
+	#
+	#////////////////////////////////////
+	# Created by MichaIng / micha@dietpi.com / dietpi.com
+	#
+	#////////////////////////////////////
+	#
+	# Info:
+	# - Online pre-patching for client system.
+	# - Runs from dietpi-update as very first update step
+	# - NB: Keep this script as simple as possible, do not load/call dietpi-globals, to allow fixing most kinds of DietPi code issues!
+	#
+	# Usage:
+	# - /DietPi/dietpi/pre-patch_file $G_DIETPI_VERSION_SUB
+	#////////////////////////////////////
+
+	# Grab input, being failsafe when applying to $G_DIETPI_VERSION_SUB
+	INPUT=$1
+	[[ $INPUT =~ ^-?[0-9]+$ ]] || INPUT=$(sed -n 2p /DietPi/dietpi/.version)
+	[[ $INPUT =~ ^-?[0-9]+$ ]] || INPUT=$(sed -n 2p /boot/dietpi/.version)
+	[[ $INPUT =~ ^-?[0-9]+$ ]] || INPUT=0
+	export G_DIETPI_VERSION_SUB=$INPUT
+
+	EXIT_CODE=0
+
+	#///////////////////////////////////////////////////////////////////////////////
+	#Pre-patch system
+	#	For changes made to update and critical bug fixes
+	#///////////////////////////////////////////////////////////////////////////////
+
+	echo -e '[ INFO ] Running pre-patch\n\e[90m─────────────────────────────────────────────────────\e[0m'
+
+	#-------------------------------------------------------------------------------
+	#RAMlog 0 free space check due to issues with failing DietPi cron jobs in v6.11
+	if (( $G_DIETPI_VERSION_SUB < 12 && $(df -B1M --output=avail /var/log | sed -n 2p) < 2 )); then
+
+		echo -e '[ WARN ] Clearing /var/log files to free up space before patching (<2MB)'
+		/DietPi/dietpi/func/dietpi-logclear 1
+
+	fi
+	#-------------------------------------------------------------------------------
+
+	echo -e "[ INFO ] Finished pre-patch with exit code: $EXIT_CODE"
+
+	#-------------------------------------------------------------------------------
+	exit $EXIT_CODE
+	#-------------------------------------------------------------------------------
+}


### PR DESCRIPTION
**Status**: Ready
🈯️ Jessie
🈯️ Stretch

**Commit list/description**:
+ DietPi-Update | Allow RC version updates on all branches
  - For simplification and allows us theoretically to apply those on master branch as well.
  - We have full control via: `server_version-6`
+ DietPi-Update | Improved error handling and user output
  - Failsafe: Check all (core, sub and RC) version integers, as those are used in arithmetic and printed later.
+ DietPi-Update | Minor coding and wording
+ DietPi-Update | Reduce required free space to 100M
  - As the update itself does require nearly no disk space (RAMdisk + download/log to RAM), besides `/rootfs` files patching, which are very small, mostly just replaced. DietPi-Software and other script calls do their own space checks.
+ DietPi-Pre-Patch | Implement new pre-patch, that runs prior to incremental patch, APT updates and DietPi archive download
+ DietPi-Patch | Merge EMR patch system into DietPi-Pre-Patch
  - As well, the manual additional update execution renders pre v6.9 rootfs merge obsolete.
+ DietPi-Update | Add new DietPi-Pre-patch system to dietpi-update procedure
+ DietPi-Patch | Redo removal of obsolete DietPi files, if they were not removed from disk as well