### PR TITLE
DietPi-(Pre-)Boot | Rework network init workarounds

### DIFF
--- a/dietpi/boot
+++ b/dietpi/boot
@@ -38,7 +38,7 @@
 		# - Wait mode, max time
 		local boot_wait_for_network=$(grep -m1 '^[[:blank:]]*CONFIG_BOOT_WAIT_FOR_NETWORK=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 		local max_loops=-1
-		(( $boot_wait_for_network == 1 )) && max_loops=10
+		(( $boot_wait_for_network )) && max_loops=10
 
 		local loop_count=0
 		while (( $loop_count <= $max_loops ))

--- a/dietpi/boot
+++ b/dietpi/boot
@@ -36,46 +36,37 @@
 	Wait_For_Valid_Network_Connection(){
 
 		#Attempt to wait for a valid network connection
-		local max_loops=1
+		local max_loops=0
 
 		#	Wait mode, max time
 		local boot_wait_for_network=$(grep -m1 '^[[:blank:]]*CONFIG_BOOT_WAIT_FOR_NETWORK=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
-		if (( $boot_wait_for_network == 1 )); then
-
-			max_loops=10
-
-		fi
+		(( $boot_wait_for_network == 1 )) && max_loops=10
 
 		local loop_count=0
-		while :
+		while (( $loop_count <= $max_loops ))
 		do
+
+			G_DIETPI-NOTIFY 2 "$(date) | Waiting for valid network connection, before continuing boot | Mode=$boot_wait_for_network"
+
+			(( $boot_wait_for_network < 2 && loop_count++ ))
 
 			if [[ $(ip r) =~ ' via ' ]]; then
 
-				G_DIETPI-NOTIFY 0 "$(date) | Valid connection found."
+				G_DIETPI-NOTIFY 0 "$(date) | Valid network connection found"
 				# - Update network details (for IP in dietpi-banner etc..)
 				/DietPi/dietpi/func/obtain_network_details
 				# - Mount all drives again (eg: network shares)
 				mount -a
 				break
 
-			elif (( $loop_count < $max_loops )); then
+			elif (( $loop_count > $max_loops )); then
 
-				G_DIETPI-NOTIFY 2 "$(date) | Waiting for valid connection, before continuing boot | Mode=$boot_wait_for_network"
-				sleep 1
-
-			else
-
-				G_DIETPI-NOTIFY 1 "$(date) | Valid connection wait timed out."
+				G_DIETPI-NOTIFY 1 "$(date) | Valid network connection wait timed out"
 				break
 
 			fi
 
-			if (( $boot_wait_for_network < 2 )); then
-
-				((loop_count++))
-
-			fi
+			sleep 1
 
 		done
 

--- a/dietpi/boot
+++ b/dietpi/boot
@@ -20,13 +20,13 @@
 	#Import DietPi-Globals ---------------------------------------------------------------
 
 	#/////////////////////////////////////////////////////////////////////////////////////
-	#Globals
+	# Globals
 	#/////////////////////////////////////////////////////////////////////////////////////
 
 	Apply_DietPi_FirstRun_Settings(){
 
 		#----------------------------------------------------------------
-		#Automation
+		# Automation
 		# - Set NTPD mode
 		/DietPi/dietpi/func/dietpi-set_software ntpd-mode $(grep -m1 '^[[:blank:]]*CONFIG_NTP_MODE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 		#----------------------------------------------------------------
@@ -35,11 +35,9 @@
 
 	Wait_For_Valid_Network_Connection(){
 
-		#Attempt to wait for a valid network connection
-		local max_loops=0
-
-		#	Wait mode, max time
+		# - Wait mode, max time
 		local boot_wait_for_network=$(grep -m1 '^[[:blank:]]*CONFIG_BOOT_WAIT_FOR_NETWORK=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
+		local max_loops=-1
 		(( $boot_wait_for_network == 1 )) && max_loops=10
 
 		local loop_count=0
@@ -48,14 +46,12 @@
 
 			G_DIETPI-NOTIFY 2 "$(date) | Waiting for valid network connection, before continuing boot | Mode=$boot_wait_for_network"
 
-			(( $boot_wait_for_network < 2 && loop_count++ ))
-
 			if [[ $(ip r) =~ ' via ' ]]; then
 
 				G_DIETPI-NOTIFY 0 "$(date) | Valid network connection found"
 				break
 
-			elif (( $loop_count > $max_loops )); then
+			elif (( $loop_count >= $max_loops )); then
 
 				G_DIETPI-NOTIFY 1 "$(date) | Valid network connection wait timed out"
 				break
@@ -63,6 +59,7 @@
 			fi
 
 			sleep 1
+			(( $boot_wait_for_network < 2 && loop_count++ ))
 
 		done
 
@@ -71,10 +68,10 @@
 	Run_Init(){
 
 		#----------------------------------------------------------------
-		#WiFi Country | Additional fallback for (older kernel?) devices that fail with wpa_supplicant.conf https://github.com/Fourdee/DietPi/issues/838
+		# WiFi Country | Additional fallback for (older kernel?) devices that fail with wpa_supplicant.conf https://github.com/Fourdee/DietPi/issues/838
 		which iw &> /dev/null && iw reg set "$(grep -m1 '^[[:blank:]]*CONFIG_WIFI_COUNTRY_CODE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')" &
 		#----------------------------------------------------------------
-		#Network failure workarounds
+		# Network failure workarounds
 		# - Jessie service fails to start: https://github.com/Fourdee/DietPi/issues/2075#issuecomment-424747579
 		(( $G_DISTRO == 3 )) && systemctl start networking
 
@@ -97,13 +94,13 @@
 		#----------------------------------------------------------------
 		Wait_For_Valid_Network_Connection
 		#----------------------------------------------------------------
-		#Grab IP data
+		# Grab IP data
 		/DietPi/dietpi/func/obtain_network_details
 		#----------------------------------------------------------------
-		#Mount all drives again (eg: network shares)
+		# Mount all drives again (eg: network shares)
 		mount -a
 		#----------------------------------------------------------------
-		#Lower dmesg print level (mostly for Odroid C2 where HiFi Shield prints info when starting/stopping stream on tty1)
+		# Lower dmesg print level (mostly for Odroid C2 where HiFi Shield prints info when starting/stopping stream on tty1)
 		dmesg -n 1
 		#----------------------------------------------------------------
 
@@ -118,7 +115,7 @@
 	Run_Init
 
 	#----------------------------------------------------------------
-	#Pre-Installed image, 1st run
+	# Pre-installed image, 1st run
 	if (( $G_DIETPI_INSTALL_STAGE == 2 )); then
 
 		# - Set swap
@@ -134,33 +131,27 @@
 
 	fi
 
-	#Normal Boot
+	# Normal boot
 	if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
 
+		# - Run time sync
 		/DietPi/dietpi/func/run_ntpd 1 &
 
+		# - Check for updates
 		if grep -qi '^[[:blank:]]*CONFIG_CHECK_DIETPI_UPDATES=1' /DietPi/dietpi.txt; then
 
 			/DietPi/dietpi/dietpi-update 2 &
 
 		fi
 
-		/DietPi/dietpi/func/dietpi-banner 1
-
 	#----------------------------------------------------------------
-	#First run prep
+	# First run prep
 	elif (( $G_DIETPI_INSTALL_STAGE == -1 )); then
-
-		/DietPi/dietpi/func/dietpi-banner 0
 
 		# - Activate and apply any 1st run settings
 		Apply_DietPi_FirstRun_Settings
 
-		# - Finished
-		/DietPi/dietpi/func/dietpi-banner 0
-		echo -e ' Default Login:\n Username = root\n Password = dietpi\n'
-
-		# - Set Install Stage index to trigger DietPi-Software installation on login
+		# - Set Install stage index to trigger DietPi-Software installation on login
 		echo 0 > /DietPi/dietpi/.install_stage
 
 	fi

--- a/dietpi/boot
+++ b/dietpi/boot
@@ -53,10 +53,6 @@
 			if [[ $(ip r) =~ ' via ' ]]; then
 
 				G_DIETPI-NOTIFY 0 "$(date) | Valid network connection found"
-				# - Update network details (for IP in dietpi-banner etc..)
-				/DietPi/dietpi/func/obtain_network_details
-				# - Mount all drives again (eg: network shares)
-				mount -a
 				break
 
 			elif (( $loop_count > $max_loops )); then
@@ -88,7 +84,7 @@
 			local wlan_index=$(sed -n 2p /DietPi/dietpi/.network)
 			# - Workaround: Wlan currently fails to connect during boot, so, manually drop and reconnect: https://github.com/Fourdee/DietPi/issues/602#issuecomment-262806470
 			#	OPi Zero 2 / Neo Air
-			(( $G_HW_MODEL == 35 || $G_HW_MODEL == 64 )) ifdown wlan$wlan_index 2> /dev/null
+			(( $G_HW_MODEL == 35 || $G_HW_MODEL == 64 )) && ifdown wlan$wlan_index 2> /dev/null
 
 			ifup wlan$wlan_index 2> /dev/null
 
@@ -104,7 +100,10 @@
 		#Grab IP data
 		/DietPi/dietpi/func/obtain_network_details
 		#----------------------------------------------------------------
-		# - Lower dmesg print level (mostly for Odroid C2 where HiFi Shield prints info when starting/stopping stream on tty1)
+		#Mount all drives again (eg: network shares)
+		mount -a
+		#----------------------------------------------------------------
+		#Lower dmesg print level (mostly for Odroid C2 where HiFi Shield prints info when starting/stopping stream on tty1)
 		dmesg -n 1
 		#----------------------------------------------------------------
 

--- a/dietpi/boot
+++ b/dietpi/boot
@@ -78,7 +78,26 @@
 		#WiFi Country | Additional fallback for (older kernel?) devices that fail with wpa_supplicant.conf https://github.com/Fourdee/DietPi/issues/838
 		which iw &> /dev/null && iw reg set "$(grep -m1 '^[[:blank:]]*CONFIG_WIFI_COUNTRY_CODE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')" &
 		#----------------------------------------------------------------
-		Workaround_WiFi
+		#Network failure workarounds
+		# - Jessie service fails to start: https://github.com/Fourdee/DietPi/issues/2075#issuecomment-424747579
+		(( $G_DISTRO == 3 )) && systemctl start networking
+
+		# - Failsafe, bring up interfaces, if somehow not done by networking.service. If those are up already, nothing will happen.
+		if grep -qiE '^[[:blank:]]*(allow-hotplug|auto)[[:blank:]]+wlan' /etc/network/interfaces; then
+
+			local wlan_index=$(sed -n 2p /DietPi/dietpi/.network)
+			# - Workaround: Wlan currently fails to connect during boot, so, manually drop and reconnect: https://github.com/Fourdee/DietPi/issues/602#issuecomment-262806470
+			#	OPi Zero 2 / Neo Air
+			(( $G_HW_MODEL == 35 || $G_HW_MODEL == 64 )) ifdown wlan$wlan_index 2> /dev/null
+
+			ifup wlan$wlan_index 2> /dev/null
+
+		if
+		if grep -qiE '^[[:blank:]]*(allow-hotplug|auto)[[:blank:]]+eth' /etc/network/interfaces; then
+
+			ifup eth$(sed -n 1p /DietPi/dietpi/.network) 2> /dev/null
+
+		fi
 		#----------------------------------------------------------------
 		Wait_For_Valid_Network_Connection
 		#----------------------------------------------------------------
@@ -88,20 +107,6 @@
 		# - Lower dmesg print level (mostly for Odroid C2 where HiFi Shield prints info when starting/stopping stream on tty1)
 		dmesg -n 1
 		#----------------------------------------------------------------
-
-	}
-
-	Workaround_WiFi(){
-
-		#Workaround: Wlan currently fails to connect during boot, so, manually drop and reconnect: https://github.com/Fourdee/DietPi/issues/602#issuecomment-262806470
-		#	OPi Zero 2 / Neo Air
-		if (( $G_HW_MODEL == 35 || $G_HW_MODEL == 64 )) &&
-			grep -qE '^[[:blank:]]*(allow-hotplug|auto)[[:blank:]]+wlan0' /etc/network/interfaces; then
-
-			ifdown wlan0
-			ifup wlan0
-
-		fi
 
 	}
 
@@ -121,8 +126,8 @@
 		/DietPi/dietpi/func/dietpi-set_dphys-swapfile $(grep -m1 '^[[:blank:]]*AUTO_SETUP_SWAPFILE_SIZE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//') "$(grep -m1 '^[[:blank:]]*AUTO_SETUP_SWAPFILE_LOCATION=' /DietPi/dietpi.txt | sed 's/.*=//')"
 
 		# - Run survey
-		rm /DietPi/dietpi/.dietpi-survey &> /dev/null
-		/DietPi/dietpi/dietpi-survey 1 &> /dev/null &
+		[[ -f /DietPi/dietpi/.dietpi-survey ]] && rm /DietPi/dietpi/.dietpi-survey
+		/DietPi/dietpi/dietpi-survey 1 &
 
 		# - Continue with normal boot
 		export G_DIETPI_INSTALL_STAGE=1
@@ -133,11 +138,11 @@
 	#Normal Boot
 	if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
 
-		/DietPi/dietpi/func/run_ntpd 1 &> /dev/null &
+		/DietPi/dietpi/func/run_ntpd 1 &
 
 		if grep -qi '^[[:blank:]]*CONFIG_CHECK_DIETPI_UPDATES=1' /DietPi/dietpi.txt; then
 
-			/DietPi/dietpi/dietpi-update 2 &> /dev/null &
+			/DietPi/dietpi/dietpi-update 2 &
 
 		fi
 

--- a/dietpi/boot
+++ b/dietpi/boot
@@ -123,7 +123,7 @@
 
 		# - Run survey
 		[[ -f /DietPi/dietpi/.dietpi-survey ]] && rm /DietPi/dietpi/.dietpi-survey
-		/DietPi/dietpi/dietpi-survey 1 &
+		/DietPi/dietpi/dietpi-survey 1 &> /dev/null &
 
 		# - Continue with normal boot
 		export G_DIETPI_INSTALL_STAGE=1
@@ -135,12 +135,12 @@
 	if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
 
 		# - Run time sync
-		/DietPi/dietpi/func/run_ntpd 1 &
+		/DietPi/dietpi/func/run_ntpd 1 &> /dev/null &
 
 		# - Check for updates
 		if grep -qi '^[[:blank:]]*CONFIG_CHECK_DIETPI_UPDATES=1' /DietPi/dietpi.txt; then
 
-			/DietPi/dietpi/dietpi-update 2 &
+			/DietPi/dietpi/dietpi-update 2 &> /dev/null &
 
 		fi
 

--- a/dietpi/boot
+++ b/dietpi/boot
@@ -88,7 +88,7 @@
 
 			ifup wlan$wlan_index 2> /dev/null
 
-		if
+		fi
 		if grep -qiE '^[[:blank:]]*(allow-hotplug|auto)[[:blank:]]+eth' /etc/network/interfaces; then
 
 			ifup eth$(sed -n 1p /DietPi/dietpi/.network) 2> /dev/null

--- a/dietpi/func/dietpi-wifidb
+++ b/dietpi/func/dietpi-wifidb
@@ -20,6 +20,7 @@ $FP_SCRIPT 		1				Applys WiFi creds from DB store to system
 
 	#Grab Input
 	INPUT="${@,,}"
+	ERROR_CODE=1
 
 	#Import DietPi-Globals ---------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
@@ -86,7 +87,7 @@ $FP_SCRIPT 		1				Applys WiFi creds from DB store to system
 
 		mkdir -p /etc/wpa_supplicant
 		cat << _EOF_ > /etc/wpa_supplicant/wpa_supplicant.conf
-country=$(grep -m1 '^CONFIG_WIFI_COUNTRY_CODE=' /DietPi/dietpi.txt | sed 's/.*=//')
+country=$(grep -m1 '^CONFIG_WIFI_COUNTRY_CODE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
 update_config=1
 _EOF_
@@ -217,22 +218,17 @@ _EOF_
 		ifup wlan$wifi_dev_index
 
 		#Get all ssids
-		G_DIETPI-NOTIFY 0 'Scanning SSIDS, please wait....'
+		G_DIETPI-NOTIFY 0 'Scanning SSIDs, please wait....'
 
 		G_WHIP_MENU_ARRAY=()
 		while read line
 		do
 
-			if [[ $line ]]; then
-
-				G_WHIP_MENU_ARRAY+=("$line" '')
-
-			fi
+			[[ $line ]] && G_WHIP_MENU_ARRAY+=("$line" '')
 
 		done <<< "$(iwlist wlan$wifi_dev_index scan | grep 'ESSID:' | sed 's/[ \t]*ESSID:"\(.*\)"/\1/')"
 
-		G_WHIP_MENU 'Please select a Wifi SSID'
-		if (( $? == 0 )); then
+		if G_WHIP_MENU 'Please select a WiFi SSID'; then
 
 			aWIFI_SSID[$WIFI_SSID_INDEX]="$G_WHIP_RETURNED_VALUE"
 			Change_WifiKey
@@ -244,8 +240,7 @@ _EOF_
 	Change_WifiSsid(){
 
 		G_WHIP_DEFAULT_ITEM="${aWIFI_SSID[$WIFI_SSID_INDEX]}"
-		G_WHIP_INPUTBOX 'Please enter the SSID name to connect to.'
-		if (( $? == 0 )); then
+		if G_WHIP_INPUTBOX 'Please enter the SSID name to connect to.'; then
 
 			aWIFI_SSID[$WIFI_SSID_INDEX]="$G_WHIP_RETURNED_VALUE"
 
@@ -291,7 +286,7 @@ _EOF_
 		do
 
 			G_WHIP_MENU_ARRAY=('' '●─ WiFi Slots')
-			for (( i=0; i<5; i++ ))
+			for (( i=0; i<$MAX_SSID_SLOTS; i++ ))
 			do
 
 				if [[ ${aWIFI_SSID[$i]} ]]; then
@@ -311,47 +306,46 @@ _EOF_
 			G_WHIP_MENU 'Please select a WiFi slot to configure:'
 			if (( $? == 0 )) && [[ $G_WHIP_RETURNED_VALUE ]]; then
 
-					WIFI_SSID_INDEX=$G_WHIP_RETURNED_VALUE
+				WIFI_SSID_INDEX=$G_WHIP_RETURNED_VALUE
 
-					G_WHIP_MENU_ARRAY=()
-					if [[ ${aWIFI_SSID[$WIFI_SSID_INDEX]} ]]; then
+				G_WHIP_MENU_ARRAY=()
+				if [[ ${aWIFI_SSID[$WIFI_SSID_INDEX]} ]]; then
 
-						G_WHIP_MENU_ARRAY+=('Remove' ": Delete '${aWIFI_SSID[$WIFI_SSID_INDEX]}' from the database")
+					G_WHIP_MENU_ARRAY+=('Remove' ": Delete '${aWIFI_SSID[$WIFI_SSID_INDEX]}' from the database")
 
-					else
+				else
 
-						G_WHIP_MENU_ARRAY+=('Scan' ': Scan and configure an SSID')
-						G_WHIP_MENU_ARRAY+=('Manual' ': Manually enter all WiFi creds')
+					G_WHIP_MENU_ARRAY+=('Scan' ': Scan and configure an SSID')
+					G_WHIP_MENU_ARRAY+=('Manual' ': Manually enter all WiFi creds')
 
-					fi
+				fi
 
-					local message_text="Please select an option for slot $WIFI_SSID_INDEX."
-					if [[ ${aWIFI_SSID[$WIFI_SSID_INDEX]} ]]; then
+				local message_text="Please select an option for slot $WIFI_SSID_INDEX."
+				if [[ ${aWIFI_SSID[$WIFI_SSID_INDEX]} ]]; then
 
-						message_text+="\n\nCurrent details:\n - SSID = ${aWIFI_SSID[$WIFI_SSID_INDEX]}\n - Key = ${aWIFI_KEY[$WIFI_SSID_INDEX]}"
+					message_text+="\n\nCurrent details:\n - SSID = ${aWIFI_SSID[$WIFI_SSID_INDEX]}\n - Key = ${aWIFI_KEY[$WIFI_SSID_INDEX]}"
 
-					fi
+				fi
 
-					G_WHIP_MENU "$message_text"
-					if (( $? == 0 )); then
+				if G_WHIP_MENU "$message_text"; then
 
-						if [[ $G_WHIP_RETURNED_VALUE == 'Remove' ]]; then
+					if [[ $G_WHIP_RETURNED_VALUE == 'Remove' ]]; then
 
-							aWIFI_SSID[$WIFI_SSID_INDEX]=''
-							aWIFI_KEY[$WIFI_SSID_INDEX]=''
+						aWIFI_SSID[$WIFI_SSID_INDEX]=''
+						aWIFI_KEY[$WIFI_SSID_INDEX]=''
 
-						elif [[ $G_WHIP_RETURNED_VALUE == 'Scan' ]]; then
+					elif [[ $G_WHIP_RETURNED_VALUE == 'Scan' ]]; then
 
-							Scan_Wifi
+						Scan_Wifi
 
-						elif [[ $G_WHIP_RETURNED_VALUE == 'Manual' ]]; then
+					elif [[ $G_WHIP_RETURNED_VALUE == 'Manual' ]]; then
 
-							Change_WifiSsid
-							Change_WifiKey
-
-						fi
+						Change_WifiSsid
+						Change_WifiKey
 
 					fi
+
+				fi
 
 			else
 
@@ -378,9 +372,14 @@ _EOF_
 
 		Wifi_Db_Apply
 
+	else
+
+		G_DIETPI-NOFITY 1 "Unknown input argument: $INPUT\n$AVAIABLE_COMMANDS"
+		ERROR_CODE=0
+
 	fi
 
 	#-----------------------------------------------------------------------------------
-	exit 0
+	exit $ERROR_CODE
 	#-----------------------------------------------------------------------------------
 }

--- a/dietpi/func/obtain_network_details
+++ b/dietpi/func/obtain_network_details
@@ -34,13 +34,12 @@
 	# Global
 	#/////////////////////////////////////////////////////////////////////////////////////
 
-	FP_TEMP='/tmp/dietpi-ip_list'
 	FP_NETFILE='/DietPi/dietpi/.network'
 
 	ETH_INDEX=0
 	WLAN_INDEX=0
 
-	ACTIVE_DEVICE='NULL'
+	ACTIVE_DEVICE='NONE'
 	ETH_IP=''
 	WLAN_IP=''
 	IP_ADDRESS='Use dietpi-config to setup a connection'
@@ -52,15 +51,14 @@
 		for (( i=0; i<=$DEV_MAX; i++ ))
 		do
 
-			ETH_IP=$(ip -o a s eth$i 2>/dev/null)
-			if (( $? == 0 )); then
+			if ETH_IP=$(ip -o a s eth$i 2>/dev/null); then
 
 				ETH_INDEX=$i
 				ETH_IP=${ETH_IP#*inet* }
 				ETH_IP=${ETH_IP%%/*}
 				if [[ $ETH_IP ]]; then
 
-					ACTIVE_DEVICE='eth'$ETH_INDEX
+					ACTIVE_DEVICE="eth$ETH_INDEX"
 					IP_ADDRESS=$ETH_IP
 					break
 
@@ -74,8 +72,7 @@
 		for (( i=0; i<=$DEV_MAX; i++ ))
 		do
 
-			WLAN_IP=$(ip -o a s wlan$i 2>/dev/null)
-			if (( $? == 0 )); then
+			if WLAN_IP=$(ip -o a s wlan$i 2>/dev/null); then
 
 				WLAN_INDEX=$i
 				WLAN_IP=${WLAN_IP#*inet* }
@@ -113,8 +110,9 @@ $IP_ADDRESS
 ETH_IP=$ETH_IP
 WLAN_IP=$WLAN_IP
 _EOF_
-	# Assure that non-root user can read file:
-	chmod 666 $FP_NETFILE &> /dev/null
+
+	#Assure that non-root user can read file:
+	chmod 666 $FP_NETFILE
 
 	#-----------------------------------------------------------------------------------
 	exit

--- a/dietpi/preboot
+++ b/dietpi/preboot
@@ -14,7 +14,7 @@
 	#////////////////////////////////////
 
 	#Import DietPi-Globals ---------------------------------------------------------------
-	/DietPi/dietpi/func/dietpi-obtain_hw_model # Running for the 1st time
+	/DietPi/dietpi/func/dietpi-obtain_hw_model # Runs every boot to allow e.g. switching SDcards between devices and to be failsafe
 	. /DietPi/dietpi/func/dietpi-globals
 	export G_PROGRAM_NAME='DietPi-PreBoot'
 	G_INIT

--- a/dietpi/preboot
+++ b/dietpi/preboot
@@ -93,9 +93,6 @@
 		#----------------------------------------------------------------
 		#Automation
 		#----------------------------------------------------------------
-		# - Grab available network devices
-		/DietPi/dietpi/func/obtain_network_details
-
 		# - Generate Swapfile
 		/DietPi/dietpi/func/dietpi-set_dphys-swapfile $(grep -m1 '^[[:blank:]]*AUTO_SETUP_SWAPFILE_SIZE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//') "$(grep -m1 '^[[:blank:]]*AUTO_SETUP_SWAPFILE_LOCATION=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
 
@@ -119,11 +116,7 @@
 			G_DIETPI-NOTIFY 2 "Setting Locale $autoinstall_language. Please wait..."
 
 			#	Sanity, wrong result, revert back to default
-			if [[ ! $autoinstall_language =~ 'UTF-8' ]]; then
-
-				autoinstall_language='en_GB.UTF-8'
-
-			fi
+			[[ ! $autoinstall_language =~ 'UTF-8' ]] && autoinstall_language='en_GB.UTF-8'
 
 			# - Re-apply locale + auto install en_GB.UTF-8 alongside
 			/DietPi/dietpi/func/dietpi-set_software locale "$autoinstall_language"
@@ -186,15 +179,16 @@
 		rm /var/lib/dbus/machine-id &> /dev/null
 		systemd-machine-id-setup
 
-		#	Failsafe
-		killall -w dhclient &> /dev/null
+		# - Network setup
+		#	Grab available network devices
+		/DietPi/dietpi/func/obtain_network_details
 
 		local index_eth=$(sed -n 1p /DietPi/dietpi/.network)
 		local index_wlan=$(sed -n 2p /DietPi/dietpi/.network)
 
 		#	Replace all eth0 and wlan0 values to the indices DietPi has found.
-		sed -i "s/eth0/eth$index_eth/g" /etc/network/interfaces
-		sed -i "s/wlan0/wlan$index_wlan/g" /etc/network/interfaces
+		sed -i "s/eth[0-9]/eth$index_eth/g" /etc/network/interfaces
+		sed -i "s/wlan[0-9]/wlan$index_wlan/g" /etc/network/interfaces
 
 		#	Grab user requested settings from /dietpi.txt
 		local ethernet_enabled=$(grep -ci -m1 '^[[:blank:]]*AUTO_SETUP_NET_ETHERNET_ENABLED=1' /DietPi/dietpi.txt)
@@ -232,9 +226,6 @@
 		#	Static IPs
 		if (( $use_static )); then
 
-			#enable dns-nameservers
-			sed -i 's/^#dns-nameservers/dns-nameservers/g' /etc/network/interfaces
-
 			if (( $wifi_enabled )); then
 
 				sed -i "/iface wlan/c\iface wlan$index_wlan inet static" /etc/network/interfaces
@@ -252,31 +243,10 @@
 
 		fi
 
-		#	Failsafe
-		systemctl stop networking
-		killall -w dhclient &> /dev/null
-
 		# - IPv6
 		local enable_ipv6=$(grep -ci -m1 '^[[:blank:]]*CONFIG_ENABLE_IPV6=1' /DietPi/dietpi.txt)
 		/DietPi/dietpi/func/dietpi-set_hardware enableipv6 $enable_ipv6
 		(( $enable_ipv6 )) && /DietPi/dietpi/func/dietpi-set_hardware preferipv4 $(grep -ci -m1 '^[[:blank:]]*CONFIG_PREFER_IPV4=1' /DietPi/dietpi.txt)
-
-		# - reload networking
-		systemctl daemon-reload
-
-		# - Jessie service fails to start: https://github.com/Fourdee/DietPi/issues/2075#issuecomment-424747579
-		(( $G_DISTRO == 3 )) && systemctl start networking
-
-		# - Bring up networking (this is required, not sure what systemd isn't doing here, as this service runs before networking?!!?)
-		if (( $wifi_enabled )); then
-
-			ifup wlan$index_wlan
-
-		elif (( $ethernet_enabled )); then
-
-			ifup eth$index_eth
-
-		fi
 
 	}
 


### PR DESCRIPTION
**Status**: Ready
🈯️ VM Jessie, see: https://github.com/Fourdee/DietPi/pull/2125#issuecomment-428344919
🈯️ VM Stretch

**Reference**: https://github.com/Fourdee/DietPi/issues/2122#issuecomment-428196236

**Commit list/description**:
+ DietPi-Boot | Do not wait even a single second for network, if disabled && minor code improvements
+ DietPi-Obtain_network_details | Minor
+ DietPi-WiFiDB | Minor
+ DietPi-PreBoot | Move all network bring up workarounds to DietPi-Boot
  - Removed `killall -w dhclient` calls as well. Should be not up, before interface start, otherwise would have no effect on config file edit, what we now only do on PreBoot.
+ DietPi-PreBoot | Minor coding
+ DietPi-Boot | Move all network bring up workarounds into DietPi-Boot
+ DietPi-Boot | Minor coding
+ DietPi-Boot | Whoopsie, syntax!
+ DietPi-Boot | Removed doubled obtain_network_details after valid connection found
+ DietPi-Boot | Remove doubled dietpi-banner/login info calls. Leave it to dietpi-postboot, where users will clealy see it.