### PR TITLE
DietPi-Update | Switch applying pre-patch and new versioning system between patch_file and pre-patch_file

### DIFF
--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -12,6 +12,7 @@
 	# Info:
 	# - Updates DietPi from Git or dietpi.com repo
 	# - Uses patch_file for incremental online patching
+	# - Uses pre-patch_file for critical fixes and update related changes
 	#
 	# Usage:
 	# - dietpi-update    = Normal
@@ -284,11 +285,7 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 		#Applying pre-patch
 		G_RUN_CMD wget "${URL_MIRROR_PREPATCH[$URL_MIRROR_INDEX]}" -O pre-patch_file
 		chmod +x pre-patch_file
-		if ! ./pre-patch_file $G_DIETPI_VERSION_SUB; then
-
-			G_DIETPI-NOTIFY 1 "An error occured during pre-patching. Please check terminal messages for errors, or $FP_LOG, and retry dietpi-update."
-
-		fi
+		./pre-patch_file $G_DIETPI_VERSION_SUB || G_DIETPI-NOTIFY 1 "An error occured during pre-patch $?. Please check terminal messages for errors, or $FP_LOG, and retry dietpi-update in case of follow-up errors."
 
 		#Update APT packages
 		G_AGUP

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1300,6 +1300,7 @@ _EOF_
 				[[ -f $i/dietpi-ramdisk ]] && rm $i/dietpi-ramdisk &> /dev/null
 				[[ -f $i/dietpi-logclear ]] && rm $i/dietpi-logclear &> /dev/null
 				[[ -f $i/dietpi-banner ]] && rm $i/dietpi-banner &> /dev/null
+				[[ -f $i/pre-patch_file ]] && rm $i/pre-patch_file &> /dev/null
 
 			done
 			#-------------------------------------------------------------------------------

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -30,28 +30,9 @@
 	export G_DIETPI_VERSION_SUB=$INPUT
 
 	#/////////////////////////////////////////////////////////////////////////////////////
-	#Pre-v6.17: Switch to new branch, versioning and pre-patch system
+	#Pre-v6.17: Manually run new pre-patch_file; Applies new branch and versioning system as well
+	(( $G_DIETPI_VERSION_SUB < 17 )) && [[ $(find /DietPi/dietpi/pre-patch_file) ]] && /DietPi/dietpi/pre-patch_file
 	#/////////////////////////////////////////////////////////////////////////////////////
-	#Addition of RC version
-	#	As loaded v6.16<= dietpi-update will overwrite this to previous 2 line system, we need to get user to rerun the update manually, ensuring the new dietpi-update code is run.
-	if (( $G_DIETPI_VERSION_SUB < 17 )) && [[ ! $(sed -n 3p /DietPi/dietpi/.version) ]]; then
-
-		echo -e "6\n$G_DIETPI_VERSION_SUB\n0" > /DietPi/dietpi/.version
-
-		#Switch from testing to dev branch
-		if grep -q '^[[:blank:]]*DEV_GITBRANCH=testing' /DietPi/dietpi.txt; then
-
-			G_CONFIG_INJECT 'DEV_GITBRANCH=' 'DEV_GITBRANCH=dev' /DietPi/dietpi.txt
-			local branch=''
-			$branch=' branch and'
-
-		fi
-
-		G_WHIP_MSG "DietPi has applied a new$branch versioning system to the device. To allow DietPi-Update to use this new system, it must be re-run manually.\n\nPlease re-run \"dietpi-update\" to resume the update process."
-		killall -w dietpi-update
-		exit 0
-
-	fi
 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	#Incremental patch system:

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -36,23 +36,23 @@
 		# - Addition of RC version
 		echo -e "6\n$G_DIETPI_VERSION_SUB\n0" > /DietPi/dietpi/.version
 
- 		# - Switch from obsolete testing to new dev branch
+		# - Switch from obsolete testing to new dev branch
 		local branch_info=''
 		if grep -q '^[[:blank:]]*DEV_GITBRANCH=testing$' /DietPi/dietpi.txt; then
 
- 			G_CONFIG_INJECT 'DEV_GITBRANCH=' 'DEV_GITBRANCH=dev' /DietPi/dietpi.txt
+			G_CONFIG_INJECT 'DEV_GITBRANCH=' 'DEV_GITBRANCH=dev' /DietPi/dietpi.txt
 			branch_info=' branch and'
 
- 		fi
+		fi
 
- 		G_WHIP_MSG "DietPi has applied a new$branch_info versioning system to the device. To allow DietPi-Update to use this new system, it must be re-run manually.\n
+		G_WHIP_MSG "DietPi has applied a new$branch_info versioning system to the device. To allow DietPi-Update to use this new system, it must be re-run manually.\n
 Please re-run \"dietpi-update\" to resume the update process."
 
- 		# - As loaded pre-v6.17 dietpi-update will overwrite .version to previous 2 line system, we need to get user to rerun the update manually, ensuring the new dietpi-update code is run.
+		# - As loaded pre-v6.17 dietpi-update will overwrite .version to previous 2 line system, we need to get user to rerun the update manually, ensuring the new dietpi-update code is run.
 		killall -w dietpi-update
 		exit
 
- 	fi
+	fi
 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	#Incremental patch system:

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1296,11 +1296,11 @@ _EOF_
 				[[ -f $i/dietpi-obtain_hw_model ]] && rm $i/dietpi-obtain_hw_model
 				[[ -f $i/dietpi-cpu_set ]] && rm $i/dietpi-cpu_set
 				[[ -f $i/.patch_emr ]] && rm $i/.patch_emr
-				[[ -f $i/dietpi-ramlog ]] && rm $i/dietpi-ramlog &> /dev/null
-				[[ -f $i/dietpi-ramdisk ]] && rm $i/dietpi-ramdisk &> /dev/null
-				[[ -f $i/dietpi-logclear ]] && rm $i/dietpi-logclear &> /dev/null
-				[[ -f $i/dietpi-banner ]] && rm $i/dietpi-banner &> /dev/null
-				[[ -f $i/pre-patch_file ]] && rm $i/pre-patch_file &> /dev/null
+				[[ -f $i/dietpi-ramlog ]] && rm $i/dietpi-ramlog
+				[[ -f $i/dietpi-ramdisk ]] && rm $i/dietpi-ramdisk
+				[[ -f $i/dietpi-logclear ]] && rm $i/dietpi-logclear
+				[[ -f $i/dietpi-banner ]] && rm $i/dietpi-banner
+				[[ -f $i/pre-patch_file ]] && rm $i/pre-patch_file
 
 			done
 			#-------------------------------------------------------------------------------

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -30,9 +30,29 @@
 	export G_DIETPI_VERSION_SUB=$INPUT
 
 	#/////////////////////////////////////////////////////////////////////////////////////
-	#Pre-v6.17: Manually run new pre-patch_file; Applies new branch and versioning system as well
-	(( $G_DIETPI_VERSION_SUB < 17 )) && [[ $(find /DietPi/dietpi/pre-patch_file) ]] && /DietPi/dietpi/pre-patch_file
-	#/////////////////////////////////////////////////////////////////////////////////////
+	#Pre-v6.17: Switch to new branch and versioning system
+	if (( $G_DIETPI_VERSION_SUB < 17 )) && [[ ! $(sed -n 3p /DietPi/dietpi/.version) ]]; then
+
+		# - Addition of RC version
+		echo -e "6\n$G_DIETPI_VERSION_SUB\n0" > /DietPi/dietpi/.version
+
+ 		# - Switch from obsolete testing to new dev branch
+		local branch_info=''
+		if grep -q '^[[:blank:]]*DEV_GITBRANCH=testing$' /DietPi/dietpi.txt; then
+
+ 			G_CONFIG_INJECT 'DEV_GITBRANCH=' 'DEV_GITBRANCH=dev' /DietPi/dietpi.txt
+			branch_info=' branch and'
+
+ 		fi
+
+ 		G_WHIP_MSG "DietPi has applied a new$branch_info versioning system to the device. To allow DietPi-Update to use this new system, it must be re-run manually.\n
+Please re-run \"dietpi-update\" to resume the update process."
+
+ 		# - As loaded pre-v6.17 dietpi-update will overwrite .version to previous 2 line system, we need to get user to rerun the update manually, ensuring the new dietpi-update code is run.
+		killall -w dietpi-update
+		exit
+
+ 	fi
 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	#Incremental patch system:

--- a/dietpi/pre-patch_file
+++ b/dietpi/pre-patch_file
@@ -33,7 +33,7 @@
 	#	For changes made to update and critical bug fixes
 	#///////////////////////////////////////////////////////////////////////////////
 
-	echo -e "\e[1m $G_PROGRAM_NAME\e[0m
+	echo -e "\n\e[1m $G_PROGRAM_NAME\e[0m
 \e[90m─────────────────────────────────────────────────────\e[0m
 [ INFO ] Applying critical pre-patches\n"
 
@@ -76,7 +76,7 @@ Please re-run \"dietpi-update\" to resume the update process." 12 60
 
 	echo -e "\e[1m $G_PROGRAM_NAME\e[0m
 \e[90m─────────────────────────────────────────────────────\e[0m
-[ INFO ] Completed pre-patches with exit code: $EXIT_CODE"
+[ INFO ] Completed pre-patches with exit code: $EXIT_CODE\n"
 
 	#-------------------------------------------------------------------------------
 	exit $EXIT_CODE

--- a/dietpi/pre-patch_file
+++ b/dietpi/pre-patch_file
@@ -17,6 +17,8 @@
 	# - /DietPi/dietpi/pre-patch_file $G_DIETPI_VERSION_SUB
 	#////////////////////////////////////
 
+	export $G_PROGRAM_NAME='DietPi-Pre-patch'
+
 	# Grab input, being failsafe when applying to $G_DIETPI_VERSION_SUB
 	INPUT=$1
 	[[ $INPUT =~ ^-?[0-9]+$ ]] || INPUT=$(sed -n 2p /DietPi/dietpi/.version)
@@ -31,19 +33,50 @@
 	#	For changes made to update and critical bug fixes
 	#///////////////////////////////////////////////////////////////////////////////
 
-	echo -e '[ INFO ] Running pre-patch\n\e[90m─────────────────────────────────────────────────────\e[0m'
+	echo -e "\e[1m $G_PROGRAM_NAME\e[0m
+\e[90m─────────────────────────────────────────────────────\e[0m
+[ INFO ] Applying critical pre-patches\n"
 
 	#-------------------------------------------------------------------------------
 	#RAMlog 0 free space check due to issues with failing DietPi cron jobs in v6.11
 	if (( $G_DIETPI_VERSION_SUB < 12 && $(df -B1M --output=avail /var/log | sed -n 2p) < 2 )); then
 
-		echo -e '[ WARN ] Clearing /var/log files to free up space before patching (<2MB)'
-		/DietPi/dietpi/func/dietpi-logclear 1
+		echo -e '[ \e[33mWARN\e[0m ] Pre-Patch 1 | Clearing /var/log files to free up RAMlog space (<2MB) before update will continue'
+		/DietPi/dietpi/func/dietpi-logclear 1 || EXIT_CODE=1
+
+	fi
+	#-------------------------------------------------------------------------------
+	#Pre-v6.17: Switch to new branch and versioning system
+	if (( $G_DIETPI_VERSION_SUB < 17 )) && [[ ! $(sed -n 3p /DietPi/dietpi/.version) ]]; then
+
+		echo '[ INFO ] Pre-Patch 2 | Adding release candidate (RC) version string to /DietPi/dietpi/.version'
+	
+		# - Addition of RC version
+		echo -e "6\n$G_DIETPI_VERSION_SUB\n0" > /DietPi/dietpi/.version || EXIT_CODE=2
+
+		# - Switch from testing to dev branch
+		if grep -q '^[[:blank:]]*DEV_GITBRANCH=testing' /DietPi/dietpi.txt; then
+
+			echo '[ INFO ] Pre-Patch 2 | Switching from obsolete "testing" branch to "dev"'
+			sed -i '/^[[:blank:]]*DEV_GITBRANCH=testing/c\DEV_GITBRANCH=dev' /DietPi/dietpi.txt || EXIT_CODE=2
+			local branch=''
+			$branch=' branch and'
+
+		fi
+
+		whiptail --msgbox "DietPi has applied a new$branch versioning system to the device. To allow DietPi-Update to use this new system, it must be re-run manually.\n
+Please re-run \"dietpi-update\" to resume the update process." 12 60
+
+		# - As loaded v6.16<= dietpi-update will overwrite this to previous 2 line system, we need to get user to rerun the update manually, ensuring the new dietpi-update code is run.
+		killall -w dietpi-update
+		exit $EXIT_CODE
 
 	fi
 	#-------------------------------------------------------------------------------
 
-	echo -e "[ INFO ] Finished pre-patch with exit code: $EXIT_CODE"
+	echo -e "\e[1m $G_PROGRAM_NAME\e[0m
+\e[90m─────────────────────────────────────────────────────\e[0m
+[ INFO ] Completed pre-patches with exit code: $EXIT_CODE"
 
 	#-------------------------------------------------------------------------------
 	exit $EXIT_CODE

--- a/dietpi/pre-patch_file
+++ b/dietpi/pre-patch_file
@@ -1,7 +1,7 @@
 #!/bin/bash
 {
 	#////////////////////////////////////
-	# DietPi Pre-patch File Script
+	# DietPi Pre-patch script
 	#
 	#////////////////////////////////////
 	# Created by MichaIng / micha@dietpi.com / dietpi.com
@@ -9,12 +9,13 @@
 	#////////////////////////////////////
 	#
 	# Info:
-	# - Online pre-patching for client system.
+	# - Online pre-patching for client system for changes made to update system and critical bug fixes
 	# - Runs from dietpi-update as very first update step
+	# - In case of failure, returns related pre-patch ID as exit code
 	# - NB: Keep this script as simple as possible, do not load/call dietpi-globals, to allow fixing most kinds of DietPi code issues!
 	#
 	# Usage:
-	# - /DietPi/dietpi/pre-patch_file $G_DIETPI_VERSION_SUB
+	# - ./pre-patch_file $G_DIETPI_VERSION_SUB
 	#////////////////////////////////////
 
 	export G_PROGRAM_NAME='DietPi-Pre-patch'
@@ -29,8 +30,7 @@
 	EXIT_CODE=0
 
 	#///////////////////////////////////////////////////////////////////////////////
-	#Pre-patch system
-	#	For changes made to update system and critical bug fixes
+	# Main loop
 	#///////////////////////////////////////////////////////////////////////////////
 
 	echo -e "\n\e[1m $G_PROGRAM_NAME\e[0m
@@ -38,38 +38,11 @@
 [ INFO ] Applying critical pre-patches\n"
 
 	#-------------------------------------------------------------------------------
-	#RAMlog 0 free space check due to issues with failing DietPi cron jobs in v6.11
+	# Pre-patch 1: RAMlog 0 free space check due to issues with failing DietPi cron jobs in v6.11
 	if (( $G_DIETPI_VERSION_SUB < 12 && $(df -B1M --output=avail /var/log | sed -n 2p) < 2 )); then
 
 		echo -e '[ \e[33mWARN\e[0m ] Pre-patch 1 | Clearing /var/log files to free up RAMlog space (<2MB) before update will continue'
 		/DietPi/dietpi/func/dietpi-logclear 1 || EXIT_CODE=1
-
-	fi
-	#-------------------------------------------------------------------------------
-	#Pre-v6.17: Switch to new branch and versioning system
-	if (( $G_DIETPI_VERSION_SUB < 17 )) && [[ ! $(sed -n 3p /DietPi/dietpi/.version) ]]; then
-
-		echo '[ INFO ] Pre-patch 2 | Adding release candidate (RC) version string to /DietPi/dietpi/.version'
-	
-		# - Addition of RC version
-		echo -e "6\n$G_DIETPI_VERSION_SUB\n0" > /DietPi/dietpi/.version || EXIT_CODE=2
-
-		# - Switch from testing to dev branch
-		local branch_info=''
-		if grep -q '^[[:blank:]]*DEV_GITBRANCH=testing' /DietPi/dietpi.txt; then
-
-			echo '[ INFO ] Pre-patch 2 | Switching from obsolete "testing" branch to "dev"'
-			sed -i '/^[[:blank:]]*DEV_GITBRANCH=testing/c\DEV_GITBRANCH=dev' /DietPi/dietpi.txt || EXIT_CODE=2
-			branch_info=' branch and'
-
-		fi
-
-		whiptail --msgbox "DietPi has applied a new$branch_info versioning system to the device. To allow DietPi-Update to use this new system, it must be re-run manually.\n
-Please re-run \"dietpi-update\" to resume the update process." 12 60
-
-		# - As loaded v6.16<= dietpi-update will overwrite this to previous 2 line system, we need to get user to rerun the update manually, ensuring the new dietpi-update code is run.
-		killall -w dietpi-update
-		exit $EXIT_CODE
 
 	fi
 	#-------------------------------------------------------------------------------

--- a/dietpi/pre-patch_file
+++ b/dietpi/pre-patch_file
@@ -55,16 +55,16 @@
 		echo -e "6\n$G_DIETPI_VERSION_SUB\n0" > /DietPi/dietpi/.version || EXIT_CODE=2
 
 		# - Switch from testing to dev branch
+		local branch_info=''
 		if grep -q '^[[:blank:]]*DEV_GITBRANCH=testing' /DietPi/dietpi.txt; then
 
 			echo '[ INFO ] Pre-patch 2 | Switching from obsolete "testing" branch to "dev"'
 			sed -i '/^[[:blank:]]*DEV_GITBRANCH=testing/c\DEV_GITBRANCH=dev' /DietPi/dietpi.txt || EXIT_CODE=2
-			local branch=''
-			$branch=' branch and'
+			branch_info=' branch and'
 
 		fi
 
-		whiptail --msgbox "DietPi has applied a new$branch versioning system to the device. To allow DietPi-Update to use this new system, it must be re-run manually.\n
+		whiptail --msgbox "DietPi has applied a new$branch_info versioning system to the device. To allow DietPi-Update to use this new system, it must be re-run manually.\n
 Please re-run \"dietpi-update\" to resume the update process." 12 60
 
 		# - As loaded v6.16<= dietpi-update will overwrite this to previous 2 line system, we need to get user to rerun the update manually, ensuring the new dietpi-update code is run.

--- a/dietpi/pre-patch_file
+++ b/dietpi/pre-patch_file
@@ -1,7 +1,7 @@
 #!/bin/bash
 {
 	#////////////////////////////////////
-	# DietPi Patch File Script
+	# DietPi Pre-patch File Script
 	#
 	#////////////////////////////////////
 	# Created by MichaIng / micha@dietpi.com / dietpi.com
@@ -17,7 +17,7 @@
 	# - /DietPi/dietpi/pre-patch_file $G_DIETPI_VERSION_SUB
 	#////////////////////////////////////
 
-	export $G_PROGRAM_NAME='DietPi-Pre-patch'
+	export G_PROGRAM_NAME='DietPi-Pre-patch'
 
 	# Grab input, being failsafe when applying to $G_DIETPI_VERSION_SUB
 	INPUT=$1
@@ -30,7 +30,7 @@
 
 	#///////////////////////////////////////////////////////////////////////////////
 	#Pre-patch system
-	#	For changes made to update and critical bug fixes
+	#	For changes made to update system and critical bug fixes
 	#///////////////////////////////////////////////////////////////////////////////
 
 	echo -e "\n\e[1m $G_PROGRAM_NAME\e[0m
@@ -41,7 +41,7 @@
 	#RAMlog 0 free space check due to issues with failing DietPi cron jobs in v6.11
 	if (( $G_DIETPI_VERSION_SUB < 12 && $(df -B1M --output=avail /var/log | sed -n 2p) < 2 )); then
 
-		echo -e '[ \e[33mWARN\e[0m ] Pre-Patch 1 | Clearing /var/log files to free up RAMlog space (<2MB) before update will continue'
+		echo -e '[ \e[33mWARN\e[0m ] Pre-patch 1 | Clearing /var/log files to free up RAMlog space (<2MB) before update will continue'
 		/DietPi/dietpi/func/dietpi-logclear 1 || EXIT_CODE=1
 
 	fi
@@ -49,7 +49,7 @@
 	#Pre-v6.17: Switch to new branch and versioning system
 	if (( $G_DIETPI_VERSION_SUB < 17 )) && [[ ! $(sed -n 3p /DietPi/dietpi/.version) ]]; then
 
-		echo '[ INFO ] Pre-Patch 2 | Adding release candidate (RC) version string to /DietPi/dietpi/.version'
+		echo '[ INFO ] Pre-patch 2 | Adding release candidate (RC) version string to /DietPi/dietpi/.version'
 	
 		# - Addition of RC version
 		echo -e "6\n$G_DIETPI_VERSION_SUB\n0" > /DietPi/dietpi/.version || EXIT_CODE=2
@@ -57,7 +57,7 @@
 		# - Switch from testing to dev branch
 		if grep -q '^[[:blank:]]*DEV_GITBRANCH=testing' /DietPi/dietpi.txt; then
 
-			echo '[ INFO ] Pre-Patch 2 | Switching from obsolete "testing" branch to "dev"'
+			echo '[ INFO ] Pre-patch 2 | Switching from obsolete "testing" branch to "dev"'
 			sed -i '/^[[:blank:]]*DEV_GITBRANCH=testing/c\DEV_GITBRANCH=dev' /DietPi/dietpi.txt || EXIT_CODE=2
 			local branch=''
 			$branch=' branch and'


### PR DESCRIPTION
This is just an alternative. Perhaps looks a bid cleaner and allows applying pre-patches before applying new versioning system. Either way is okay for me, the way it is currently in dev and the way this PR does.

**Status**: Ready

**Commit list/description**:
+ DietPi-Pre-patch | Minor coding, visual and exit code info
+ DietPi-Patch | Minor coding and wording