### PR TITLE
DietPi-Drive_Manager | Fix blocking of swap partition, if swap size is zero

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,6 +20,7 @@ Changes / Improvements / Optimizations:
 Bug Fixes:
  - DietPi-Config | WiFi-Monitor: Resolved an issue with syntax, and, incorrectly pinging the default gateway, instead of whats assigned to the wlan interface: https://github.com/Fourdee/DietPi/issues/2103
  - DietPi-Config | dietpi-wifi.db code has been optimized, and, also resolves an issue where '/var/lib/dietpi/dietpi-wifi.db' was not generated automatically: https://github.com/Fourdee/DietPi/issues/2087#issuecomment-423836528
+ - DietPi-Drive_Manager | Resolved an issue, where the swapfile partition was blocked for unmount, format and read-only mode selection, even if the swapfile was disabled (size set to zero). Thanks to @dummylabs for reporting this issue: https://github.com/Fourdee/DietPi/issues/2127
  - DietPi-Survey | Resolved an issue where dietpi-survey under mode 1 would not generate the survey file.
  - DietPi-Software | MPD: Now runs under the group 'dietpi' and user 'root', allowing access to music directories when contained on samba networked drives: https://github.com/Fourdee/DietPi/issues/2092
  - DietPi-Software | Fixed an issue where software uninstalls could have failed due to dependant packages. Thanks to @dynobot for reporting this issue: https://github.com/Fourdee/DietPi/issues/2091

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -122,7 +122,9 @@
 		FP_USERDATA_CURRENT="$(readlink -f $G_FP_DIETPI_USERDATA)"
 
 		# - Swapfile location
-		FP_SWAPFILE_CURRENT="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_SWAPFILE_LOCATION=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
+		SWAPFILE_SIZE_CURRENT="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_SWAPFILE_SIZE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
+		FP_SWAPFILE_CURRENT='N/A'
+		(( $SWAPFILE_SIZE_CURRENT )) && FP_SWAPFILE_CURRENT="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_SWAPFILE_LOCATION=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
 
 		# - ROOTFS location
 		FP_ROOTFS_SOURCE=$(findmnt / -o source -n)
@@ -1282,13 +1284,11 @@ aDRIVE_ISPARTITIONTABLE ${aDRIVE_ISPARTITIONTABLE[$i]}
 
 							# - Swapfile
 							#	NB: / rootfs will always be detected in this check, however, no rootFS options for umount and format...
-							local swapfile_location="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_SWAPFILE_LOCATION=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
-							local swapfile_size=$(grep -m1 '^[[:blank:]]*AUTO_SETUP_SWAPFILE_SIZE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
-							if [[ $swapfile_location == ${aDRIVE_MOUNT_TARGET[$INDEX_DRIVE_BEING_EDITED]}* && ${aDRIVE_MOUNT_TARGET[$INDEX_DRIVE_BEING_EDITED]} != '/' ]] ||
-								[[ $swapfile_location == '/var/swap' && ${aDRIVE_MOUNT_TARGET[$INDEX_DRIVE_BEING_EDITED]} == '/' ]]; then
+							if [[ $FP_SWAPFILE_CURRENT == ${aDRIVE_MOUNT_TARGET[$INDEX_DRIVE_BEING_EDITED]}* && ${aDRIVE_MOUNT_TARGET[$INDEX_DRIVE_BEING_EDITED]} != '/' ]] ||
+								[[ $FP_SWAPFILE_CURRENT == '/var/swap' && ${aDRIVE_MOUNT_TARGET[$INDEX_DRIVE_BEING_EDITED]} == '/' ]]; then
 
 								partition_contains_swapfile=1
-								G_WHIP_MENU_ARRAY+=('Swapfile' ": [X] | ${swapfile_size}MB used on this drive, select to change size")
+								G_WHIP_MENU_ARRAY+=('Swapfile' ": [X] | ${SWAPFILE_SIZE_CURRENT}MB used on this drive, select to change size")
 
 							else
 


### PR DESCRIPTION
**Status**: Testing
- [ ] Should be tested, if somewhere in drive manager, an existent swap file path is expected

**Reference**: https://github.com/Fourdee/DietPi/issues/2127

**Commit list/description**:
+ DietPi-Drive_Manager | Use non-local swap variables, estimated during init loop, within drive edit menu as well
+ DietPi-Drive_Manager | Use dummy swap location, if swap size is zero, to avoid blocking the related partition
  - Do not port dummy location to `dietpi.txt`, to keep old swap location stored
