### PR TITLE
DietPi-Patch | Autorun 2nd pre-v6.17 update

### DIFF
--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -43,16 +43,11 @@
 		fi
 
 		# - Addition of RC version
-		G_GITBRANCH="$(grep -m1 '^[[:blank:]]*DEV_GITBRANCH=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
-		G_GITBRANCH="${G_GITBRANCH:-master}"
-		G_GITOWNER="$(grep -m1 '^[[:blank:]]*DEV_GITOWNER=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
-		G_GITOWNER="${G_GITOWNER:-Fourdee}"
 		G_VERSIONDB_SAVE
 
-		G_WHIP_MSG "DietPi has applied a new$BRANCH_INFO versioning system to the device. To allow DietPi-Update to use this new system, it must be re-run manually.\n
-Please re-run \"dietpi-update\" to resume the update process."
-
-		# - As loaded pre-v6.17 dietpi-update will overwrite .version to previous 2 line system, we need to get user to rerun the update manually, ensuring the new dietpi-update code is run.
+		# - As loaded pre-v6.17 dietpi-update will overwrite .version to previous 2 line system, we need to rerun dietpi-update.
+		#	- Add dietpi-update rerun as exit trap
+		G_EXIT_CUSTOM(){ dietpi-update 1; }
 		killall -w dietpi-update
 		exit
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -48,6 +48,8 @@
 		# - As loaded pre-v6.17 dietpi-update will overwrite .version to previous 2 line system, we need to rerun dietpi-update.
 		#	- Add dietpi-update rerun as exit trap
 		G_EXIT_CUSTOM(){ /DietPi/dietpi/dietpi-update 1; }
+		#	- Inform user to avoid confusion
+		G_DIETPI-NOTIFY 0 "DietPi has applied a new$BRANCH_INFO versioning system to the device. To allow DietPi-Update to use this new system, it will now restart."
 		killall -w dietpi-update
 		exit
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -47,10 +47,14 @@
 
 		# - As loaded pre-v6.17 dietpi-update will overwrite .version to previous 2 line system, we need to rerun dietpi-update.
 		#	- Remove DietPi-Update and DietPi-Patchfile working directories do allow concurrent execution
+		cd /tmp
 		rm -R /tmp/DietPi-Update /tmp/DietPi-Patchfile
 		#	- Inform user to avoid confusion
-		G_DIETPI-NOTIFY 0 "DietPi has applied a new$BRANCH_INFO versioning system to the device. To allow DietPi-Update to use this new system, it will now restart."
+		echo ''
+		G_DIETPI-NOTIFY 0 "DietPi has applied a new$BRANCH_INFO versioning system to the device. To allow DietPi-Update to use this new system, it will now restart.\n"
+		#	- Apply update forcefully, since user has already chosen to do so
 		/DietPi/dietpi/dietpi-update 1
+		#	- Kill parental dietpi-update instance and exit this script to avoid obsolete update finish
 		kill $PPID
 		exit
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -47,7 +47,7 @@
 
 		# - As loaded pre-v6.17 dietpi-update will overwrite .version to previous 2 line system, we need to rerun dietpi-update.
 		#	- Add dietpi-update rerun as exit trap
-		G_EXIT_CUSTOM(){ dietpi-update 1; }
+		G_EXIT_CUSTOM(){ /DietPi/dietpi/dietpi-update 1; }
 		killall -w dietpi-update
 		exit
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -46,11 +46,12 @@
 		G_VERSIONDB_SAVE
 
 		# - As loaded pre-v6.17 dietpi-update will overwrite .version to previous 2 line system, we need to rerun dietpi-update.
-		#	- Add dietpi-update rerun as exit trap
-		G_EXIT_CUSTOM(){ /DietPi/dietpi/dietpi-update 1; }
+		#	- Remove DietPi-Update and DietPi-Patchfile working directories do allow concurrent execution
+		rm -R /tmp/DietPi-Update /tmp/DietPi-Patchfile
 		#	- Inform user to avoid confusion
 		G_DIETPI-NOTIFY 0 "DietPi has applied a new$BRANCH_INFO versioning system to the device. To allow DietPi-Update to use this new system, it will now restart."
-		killall -w dietpi-update
+		/DietPi/dietpi/dietpi-update 1
+		kill $PPID
 		exit
 
 	fi


### PR DESCRIPTION
**Status**: Ready

**Reference**: https://github.com/Fourdee/DietPi/issues/2144

**Commit list/description**:
- Skip updating G_GIT* variables, leave default values from dietpi-globals. dietpi.txt entries do not necessarily match currently installed version and G_GIT* values do not affect target branch for update.
- Run 2nd dietpi-update execution automatically and nested. This can be allowed by removing current working directories. Scripts need to be killed then afterwards to avoid doubled patching and update finish.