### PR TITLE
DietPi-Globals | Allow to override $WHIP_SIZE_* values

### DIFF
--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -466,7 +466,11 @@ Please download the latest DietPi image:\n - https://dietpi.com/#download \n\n -
 			[[ -f $FP_LOG ]] && rm $FP_LOG
 
 			#Run_Update #: https://github.com/Fourdee/DietPi/issues/1877#issuecomment-403866204
+			# - Pre-estimate and override terminal size variables, since they cannot be estimated, if STOUT and STERR are redirected: https://github.com/Fourdee/DietPi/issues/2105
+			export G_WHIP_SIZE_X_OVERRIDE=$(tput cols)
+			export G_WHIP_SIZE_Y_OVERRIDE=$(tput lines)
 			Run_Update > >(tee $FP_TMP_LOG) 2>&1
+			unset G_WHIP_SIZE_X_OVERRIDE G_WHIP_SIZE_Y_OVERRIDE
 			mv $FP_TMP_LOG $FP_LOG
 
 			#.update file stage (only used on 1st run of dietpi-software to check/apply updates, 0 tells dietpi-software to reboot)

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -624,7 +624,11 @@ $(ps f -eo pid,user,tty,cmd | grep -i [d]ietpi)"; then
 		local lines_required_whip_z=0
 
 		#Set current screen dimensions ( - outside margin)
-		WHIP_SIZE_X=$(( $(tput cols) - 6 ))
+		# - G_WHIP_SIZE_X_OVERRIDE allows to estimate and export terminal sizes outside of script/function
+		#	This is required in case both, STOUT and STERR are redirected ( e.g. 2>&1 | tee file.log )
+		#	Until ncurses-bin v6.0 (current on Stretch repo), tput can not estimate terminal dimensions then.
+		#	With ncurses-bin v6.1 (current on Buster repo) this issue is resolved.
+		WHIP_SIZE_X=$(( ${G_WHIP_SIZE_X_OVERRIDE:-$(tput cols)} - 6 ))
 		if (( $G_WHIP_SIZE_X_MAX > 0 && $G_WHIP_SIZE_X_MAX <= $WHIP_SIZE_X )); then
 
 			WHIP_SIZE_X=$G_WHIP_SIZE_X_MAX
@@ -635,7 +639,7 @@ $(ps f -eo pid,user,tty,cmd | grep -i [d]ietpi)"; then
 
 		fi
 
-		WHIP_SIZE_Y=$(( $(tput lines) - 4 ))
+		WHIP_SIZE_Y=$(( ${G_WHIP_SIZE_Y_OVERRIDE:-$(tput lines)} - 4 ))
 		(( $WHIP_SIZE_Y > 40 )) && WHIP_SIZE_Y=40
 
 		WHIP_SIZE_Z=2


### PR DESCRIPTION
**Status**: Ready

**Reference**: https://github.com/Fourdee/DietPi/issues/2105

**Commit list/description**:
+ DietPi-Globals | Allow to override $WHIP_SIZE_* values, in case STOUT + STERR needs to be redirected
+ DietPi-Update | Pre-estimate and override terminal size variables, since they cannot be estimated, if STOUT and STERR are redirected