### PR TITLE
DietPi-Software | Nextcloud: Fix failed install due to "config.sample.php"

### DIFF
--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -397,8 +397,8 @@
 		# Control ownCloud and Nextcloud maintenance mode:
 		if [[ $target_state == 'stop' || $target_state == 'restart' ]]; then
 
-			grep -q "'maintenance' => false," /var/www/owncloud/config/config.php &> /dev/null && G_RUN_CMD occ maintenance:mode --on
-			grep -q "'maintenance' => false," /var/www/nextcloud/config/config.php &> /dev/null && G_RUN_CMD ncc maintenance:mode --on
+			grep -q "'maintenance' => false," /var/www/owncloud/config/config.php &> /dev/null && G_USER_INPUTS=0 G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD occ maintenance:mode --on
+			grep -q "'maintenance' => false," /var/www/nextcloud/config/config.php &> /dev/null && G_USER_INPUTS=0 G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD ncc maintenance:mode --on
 
 		fi
 
@@ -445,8 +445,8 @@
 			#	Control ownCloud and Nextcloud maintenance mode:
 			if [[ $target_state == 'restart' || $target_state == 'start' ]]; then
 
-				grep -q "'maintenance' => true," /var/www/owncloud/config/config.php &> /dev/null && G_RUN_CMD occ maintenance:mode --off
-				grep -q "'maintenance' => true," /var/www/nextcloud/config/config.php &> /dev/null && G_RUN_CMD ncc maintenance:mode --off
+				grep -q "'maintenance' => true," /var/www/owncloud/config/config.php &> /dev/null && G_USER_INPUTS=0 G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD occ maintenance:mode --off
+				grep -q "'maintenance' => true," /var/www/nextcloud/config/config.php &> /dev/null && G_USER_INPUTS=0 G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD ncc maintenance:mode --off
 
 			fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8143,7 +8143,6 @@ _EOF_
 
 			# Adjusting config file:
 			local config_php='/var/www/nextcloud/config/config.php'
-			cp '/var/www/nextcloud/config/config.sample.php' $config_php
 
 			local datadir="$(grep -m1 '^[[:blank:]]*SOFTWARE_NEXTCLOUD_DATADIR=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
 			[[ $datadir ]] || datadir="$G_FP_DIETPI_USERDATA/nextcloud_data"
@@ -8153,6 +8152,26 @@ _EOF_
 			if [[ -d $G_FP_DIETPI_USERDATA/mysql/nextcloud ]]; then
 
 				G_DIETPI-NOTIFY 2 'Nextcloud database found, will NOT overwrite.'
+				if [[ ! -f $config_php ]]; then
+
+					G_WHIP_MSG '[WARNING] Existing Nextcloud database was found, but no related install directory\n
+A remaining MariaDB "nextcloud" database from an earlier installed instance was found. But the related install directory "/var/www/nextcloud/config/config.php" does not exist.
+Since running a fresh install with an existing database can produce data corruption, if the versions do not exactly match, you either need to remove the database or find and place the related install directory.\n
+We cannot predict your aim and do not want to mess or break your data, so please do this manually.\n
+To remove the existing database (including e.g. contacts, calendar, file tags etc.):
+	# mysqladmin drop nextcloud
+Otherwise to copy an existing instance in place:
+	# rm -R /var/www/nextcloud
+	# cp -a /path/to/existing/nextcloud/. /var/www/nextcloud
+	# chown -R www-data:www-data /var/www/nextcloud\n
+The install script will now exit. After applying one of the the above, rerun dietpi-software, e.g.:
+	# dietpi-software install 114'
+
+					[[ -f /var/www/nextcloud/occ ]] && rm /var/www/nextcloud/occ
+					/DietPi/dietpi/dietpi-services start
+					exit 1
+
+				fi
 
 			else
 


### PR DESCRIPTION
**Status**: WIP
- [x] Allow ncc/occ commands to fail without prompt+breaking `dietpi-services`

**Reference**: https://github.com/Fourdee/DietPi/issues/XXXX

**Commit list/description**:
+ DietPi-Software | Nextcloud: Do not copy `config.sample.php`, which must break the install/instance. This is a documentation file, but no working default config.
+ DietPi-Software | Nextcloud: Warn user in case of existing database but non-existent finished install. Ask user for manual fix and exit script.
+ DietPi-Services | ownCloud/Nextcloud: Allow occ/ncc commands to fail without prompt or exit, info only similar to other service failures