### PR TITLE
DietPi-WiFiDB | Enhancements

### DIFF
--- a/dietpi/func/dietpi-wifidb
+++ b/dietpi/func/dietpi-wifidb
@@ -13,20 +13,20 @@
 	FP_SCRIPT='/DietPi/dietpi/func/dietpi-wifidb'
 	AVAIABLE_COMMANDS="
 Available commands
-$FP_SCRIPT 						Menu
-$FP_SCRIPT 		1				Applys WiFi creds from DB store to system
+$FP_SCRIPT						Menu
+$FP_SCRIPT		1				Applies WiFi creds from DB store to system
 "
 	#////////////////////////////////////
 
 	#Grab Input
 	INPUT="${@,,}"
-	ERROR_CODE=1
+	ERROR_CODE=0
 
 	#Import DietPi-Globals ---------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
+	G_PROGRAM_NAME='DietPi-WiFiDB'
 	G_CHECK_ROOT_USER
 	G_CHECK_ROOTFS_RW
-	G_PROGRAM_NAME='DietPi-wifidb'
 	G_INIT
 	#Import DietPi-Globals ---------------------------------------------------------------
 
@@ -87,7 +87,7 @@ $FP_SCRIPT 		1				Applys WiFi creds from DB store to system
 
 		mkdir -p /etc/wpa_supplicant
 		cat << _EOF_ > /etc/wpa_supplicant/wpa_supplicant.conf
-country=$(grep -m1 '^CONFIG_WIFI_COUNTRY_CODE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
+country=$(grep -m1 '^[[:blank:]]*CONFIG_WIFI_COUNTRY_CODE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
 update_config=1
 _EOF_
@@ -108,7 +108,6 @@ network={
 ssid="${aWIFI_SSID[$i]}"
 scan_ssid=1
 _EOF_
-
 				# - Add KEY and type
 				if [[ ${aWIFI_KEYMGR[$i]^^} == 'NONE' ]]; then
 
@@ -121,7 +120,6 @@ _EOF_
 key_mgmt=${aWIFI_KEYMGR[$i]}
 psk="${aWIFI_KEY[$i]}"
 _EOF_
-
 				elif [[ ${aWIFI_KEYMGR[$i]^^} == 'WEP' ]]; then
 
 					aWIFI_KEYMGR[$i]='NONE'
@@ -171,30 +169,29 @@ _EOF_
 }
 
 _EOF_
-
 			fi
 
-			# - Update db
+			# - Update DB
 			cat << _EOF_ >> /var/lib/dietpi/dietpi-wifi.db
 #---------------------------------------------------------------
 # - Entry $i
 #	WiFi SSID (Case Sensitive)
-aWIFI_SSID[$i]="${aWIFI_SSID[$i]//\\/\\\\\\}"
+aWIFI_SSID[$i]='${aWIFI_SSID[$i]//\'/\'\\\'\'}'
 #	Key options: If no key (open), leave this blank
-aWIFI_KEY[$i]="${aWIFI_KEY[$i]//\\/\\\\\\}"
+aWIFI_KEY[$i]='${aWIFI_KEY[$i]//\'/\'\\\'\'}'
 #	Available options: NONE (no key/open) | WPA-PSK | WEP | WPA-EAP (then use settings below)
-aWIFI_KEYMGR[$i]="${aWIFI_KEYMGR[$i]}"
+aWIFI_KEYMGR[$i]='${aWIFI_KEYMGR[$i]}'
 # - WPA-EAP Options
-aWIFI_PROTO[$i]="${aWIFI_PROTO[$i]}"
-aWIFI_PAIRWISE[$i]="${aWIFI_PAIRWISE[$i]}"
-aWIFI_AUTH_ALG[$i]="${aWIFI_AUTH_ALG[$i]}"
-aWIFI_EAP[$i]="${aWIFI_EAP[$i]}"
-aWIFI_IDENTITY[$i]="${aWIFI_IDENTITY[$i]}"
-aWIFI_PASSWORD[$i]="${aWIFI_PASSWORD[$i]}"
-aWIFI_PHASE1[$i]="${aWIFI_PHASE1[$i]}"
-aWIFI_PHASE2[$i]="${aWIFI_PHASE2[$i]}"
+aWIFI_PROTO[$i]='${aWIFI_PROTO[$i]}'
+aWIFI_PAIRWISE[$i]='${aWIFI_PAIRWISE[$i]}'
+aWIFI_AUTH_ALG[$i]='${aWIFI_AUTH_ALG[$i]}'
+aWIFI_EAP[$i]='${aWIFI_EAP[$i]}'
+aWIFI_IDENTITY[$i]='${aWIFI_IDENTITY[$i]//\'/\'\\\'\'}'
+aWIFI_PASSWORD[$i]='${aWIFI_PASSWORD[$i]//\'/\'\\\'\'}'
+aWIFI_PHASE1[$i]='${aWIFI_PHASE1[$i]}'
+aWIFI_PHASE2[$i]='${aWIFI_PHASE2[$i]}'
 #	Location of the certificate file (eg: /boot/mycert.cer)
-aWIFI_CERT[$i]="${aWIFI_CERT[$i]}"
+aWIFI_CERT[$i]='${aWIFI_CERT[$i]}'
 _EOF_
 
 			G_DIETPI-NOTIFY 2 "WiFi SSID DB slot applied ($i): ${aWIFI_SSID[$i]}"
@@ -221,12 +218,12 @@ _EOF_
 		G_DIETPI-NOTIFY 0 'Scanning SSIDs, please wait....'
 
 		G_WHIP_MENU_ARRAY=()
-		while read line
+		while read -r line
 		do
 
 			[[ $line ]] && G_WHIP_MENU_ARRAY+=("$line" '')
 
-		done <<< "$(iwlist wlan$wifi_dev_index scan | grep 'ESSID:' | sed 's/[ \t]*ESSID:"\(.*\)"/\1/')"
+		done <<< "$(iwlist wlan$wifi_dev_index scan | grep '^[[:blank:]]*ESSID:' | sed 's/^[[:blank:]]*ESSID:"\(.*\)"/\1/')"
 
 		if G_WHIP_MENU 'Please select a WiFi SSID'; then
 
@@ -240,11 +237,8 @@ _EOF_
 	Change_WifiSsid(){
 
 		G_WHIP_DEFAULT_ITEM="${aWIFI_SSID[$WIFI_SSID_INDEX]}"
-		if G_WHIP_INPUTBOX 'Please enter the SSID name to connect to.'; then
-
-			aWIFI_SSID[$WIFI_SSID_INDEX]="$G_WHIP_RETURNED_VALUE"
-
-		fi
+		G_WHIP_INPUTBOX 'Please enter the SSID name to connect to.' && aWIFI_SSID[$WIFI_SSID_INDEX]="$G_WHIP_RETURNED_VALUE"
+		return $?
 
 	}
 
@@ -259,24 +253,22 @@ _EOF_
 		)
 
 		G_WHIP_DEFAULT_ITEM="${aWIFI_KEYMGR[$WIFI_SSID_INDEX]}"
-		G_WHIP_MENU 'Please select a WiFi encryption mode.\n\nNB: If unsure, its most likely WPA-PSK.'
-		if (( $? == 0 )); then
+		G_WHIP_MENU 'Please select a WiFi encryption mode.\n\nNB: If unsure, its most likely WPA-PSK.'; local EXIT_CODE=$?
+		if (( $EXIT_CODE == 0 )); then
 
 			aWIFI_KEYMGR[$WIFI_SSID_INDEX]="$G_WHIP_RETURNED_VALUE"
 
 			if [[ ${aWIFI_KEYMGR[$WIFI_SSID_INDEX]} != 'NONE' ]]; then
 
 				G_WHIP_DEFAULT_ITEM="${aWIFI_KEY[$WIFI_SSID_INDEX]}"
-				G_WHIP_INPUTBOX 'Please enter the Access Key.\n\nNB: the following characters require a backslash \ before their entry\n\`$"\n\nEG: This\\is\`my\$key\"itrocks'
-				if (( $? == 0 )); then
-
-					aWIFI_KEY[$WIFI_SSID_INDEX]="$G_WHIP_RETURNED_VALUE"
-
-				fi
+				G_WHIP_INPUTBOX 'Please enter the access key.\n\nNB: Please do NOT escape any magic characters. The script does this as required.'; EXIT_CODE=$?
+				(( $EXIT_CODE )) || aWIFI_KEY[$WIFI_SSID_INDEX]="$G_WHIP_RETURNED_VALUE"
 
 			fi
 
 		fi
+		(( $EXIT_CODE )) && Init_Wifi_Db_Slot $WIFI_SSID_INDEX
+		return $EXIT_CODE
 
 	}
 
@@ -302,7 +294,7 @@ _EOF_
 			done
 
 			G_WHIP_DEFAULT_ITEM=$WIFI_SSID_INDEX
-			G_WHIP_BUTTON_CANCEL_TEXT='Back'
+			G_WHIP_BUTTON_CANCEL_TEXT='Done'
 			G_WHIP_MENU 'Please select a WiFi slot to configure:'
 			if (( $? == 0 )) && [[ $G_WHIP_RETURNED_VALUE ]]; then
 
@@ -340,8 +332,7 @@ _EOF_
 
 					elif [[ $G_WHIP_RETURNED_VALUE == 'Manual' ]]; then
 
-						Change_WifiSsid
-						Change_WifiKey
+						Change_WifiSsid && Change_WifiKey
 
 					fi
 
@@ -375,7 +366,7 @@ _EOF_
 	else
 
 		G_DIETPI-NOFITY 1 "Unknown input argument: $INPUT\n$AVAIABLE_COMMANDS"
-		ERROR_CODE=0
+		ERROR_CODE=1
 
 	fi
 

--- a/dietpi/func/dietpi-wifidb
+++ b/dietpi/func/dietpi-wifidb
@@ -244,6 +244,8 @@ _EOF_
 
 	Change_WifiKey(){
 
+		local return_code=1
+
 		G_WHIP_MENU_ARRAY=(
 
 			'WPA-PSK' ': Default (recommended)'
@@ -253,22 +255,22 @@ _EOF_
 		)
 
 		G_WHIP_DEFAULT_ITEM="${aWIFI_KEYMGR[$WIFI_SSID_INDEX]}"
-		G_WHIP_MENU 'Please select a WiFi encryption mode.\n\nNB: If unsure, its most likely WPA-PSK.'; local EXIT_CODE=$?
-		if (( $EXIT_CODE == 0 )); then
+		G_WHIP_MENU 'Please select a WiFi encryption mode.\n\nNB: If unsure, its most likely WPA-PSK.'; return_code=$?
+		if (( $return_code == 0 )); then
 
 			aWIFI_KEYMGR[$WIFI_SSID_INDEX]="$G_WHIP_RETURNED_VALUE"
 
 			if [[ ${aWIFI_KEYMGR[$WIFI_SSID_INDEX]} != 'NONE' ]]; then
 
 				G_WHIP_DEFAULT_ITEM="${aWIFI_KEY[$WIFI_SSID_INDEX]}"
-				G_WHIP_INPUTBOX 'Please enter the access key.\n\nNB: Please do NOT escape any magic characters. The script does this as required.'; EXIT_CODE=$?
-				(( $EXIT_CODE )) || aWIFI_KEY[$WIFI_SSID_INDEX]="$G_WHIP_RETURNED_VALUE"
+				G_WHIP_INPUTBOX 'Please enter the access key.\n\nNB: Please do NOT escape any magic characters. The script does this as required.'; return_code=$?
+				(( $return_code )) || aWIFI_KEY[$WIFI_SSID_INDEX]="$G_WHIP_RETURNED_VALUE"
 
 			fi
 
 		fi
-		(( $EXIT_CODE )) && Init_Wifi_Db_Slot $WIFI_SSID_INDEX
-		return $EXIT_CODE
+		(( $return_code )) && Init_Wifi_Db_Slot $WIFI_SSID_INDEX
+		return $return_code
 
 	}
 


### PR DESCRIPTION
**Status**: Testing
🈯️ Native x86_64 Stretch
- [ ] A quick test on Jessie would be great with double quote inside SSID and/or key. Just to assure that .conf parsing did not change in between.

**Reference**: https://github.com/Fourdee/DietPi/pull/2177#issuecomment-433071910

**Commit list/description**:
+ DietPi-WiFiDB | Switch to store WiFiDB with single quotes to reduce escape effort
  - Tested it up and down on notebook with Stretch. Script internal input box and variable handling does not need any escaping. Storing strings to source-able `dietpi-wifi.db` requires "escaping" of single quote only, which is only possible via `'\''` to close single quoted literal string, insert escaped single quote and reopen literal single quoted string till the end. Inside `wpa_supplicant.conf`, double quotes for SSID, key, user and password are required, but no escaping, not even of double quote, required, since the values are parsed from first till last double quote 😃, intelligent solution. Single and double quotes and backslashes within bash variable manipulation `${VAR//<old>/<new}` need to be escaped by backslash. This is then how the code came out, e.g.: `'${aWIFI_SSID[$i]//\'/\'\\\'\'}'`
+ DietPi-WiFiDB | Do required escaping script internally, to save user from doing this and us to maintain documentation about it
+ DietPi-WiFiDB | Only ask for WiFi key, if SSID and key manager was successfully chosen, otherwise reset values of the slot and return to slot overview
  - On the long term we could also implement a completed 'manual' + slot menu where one can select SSID, key manager, key and as well `EAP` settings, in case chosen as key manager. 
+ DietPi-WiFiDB | Set ERROR_CODE=0 as default, as currently it always exits with ERROR_CODE=1, if valid INPUT was set.
  - As said, currently exit code is always `1`, only `0` if invalid input was given. I guess this should have been the other way round 😆. But at least should not break anything, since this error code is never used so far.
+ DietPi-WiFiDB | Minor wording and coding