### PR TITLE
DietPi-Services | MariaDB: Switch to "mariadb" systemd service on Stretch+

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,7 +3,8 @@ v6.18
 (xx/11/18)
 
 Changes / Improvements / Optimisations:
-- General | Concurrent execution detection: Now has a 5 second buffer to wait for exit (G_INIT_WAIT_CONCURRENT), before failing: https://github.com/Fourdee/DietPi/issues/2159#issuecomment-433619721
+ - General | Concurrent execution detection: Now has a 5 second buffer to wait for exit (G_INIT_WAIT_CONCURRENT), before failing: https://github.com/Fourdee/DietPi/issues/2159#issuecomment-433619721
+ - DietPi-Services | MariaDB: DietPi now uses the pre-installed "mariadb" systemd service instead of obsoleve "mysql" init.d service: https://github.com/Fourdee/DietPi/pull/2196
 
 Bug Fixes:
  - PREP: Resolved failed rootFS resize: https://github.com/Fourdee/DietPi/issues/2181#issuecomment-433715556

--- a/dietpi/dietpi-process_tool
+++ b/dietpi/dietpi-process_tool
@@ -306,9 +306,10 @@
 		aNAME[$index]='Webserver Apache2';aPROCESS_NAME[$index]='apache2';((index++))
 		aNAME[$index]='Webserver Nginx';aPROCESS_NAME[$index]='nginx';((index++))
 		aNAME[$index]='Webserver Lighttpd';aPROCESS_NAME[$index]='lighttpd';((index++))
+		aNAME[$index]='Webserver MariaDB';aPROCESS_NAME[$index]='mysqld';((index++))
+		# - Failsafe, in case MariaDB binary changes
 		aNAME[$index]='Webserver MariaDB';aPROCESS_NAME[$index]='mariadb';((index++))
-		aNAME[$index]='Webserver MySql';aPROCESS_NAME[$index]='mysqld';((index++))
-		aNAME[$index]='Webserver Php-fpm';aPROCESS_NAME[$index]='php-fpm';((index++))
+		aNAME[$index]='Webserver PHP-FPM';aPROCESS_NAME[$index]='php-fpm';((index++))
 		aNAME[$index]='Webserver Redis';aPROCESS_NAME[$index]='redis-server';((index++))
 		aNAME[$index]='WiFi Hotspot';aPROCESS_NAME[$index]='hostapd';((index++))
 		aNAME[$index]='WiFi Monitor';aPROCESS_NAME[$index]='dietpi-wifi-monitor.sh';((index++))

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -33,11 +33,7 @@
 
 	#Import DietPi-Globals ---------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
-	if (( $G_DIETPI_SERVICES_DISABLE )); then
-
-		exit 0
-
-	fi
+	(( $G_DIETPI_SERVICES_DISABLE )) && exit 0
 	G_PROGRAM_NAME='DietPi-Services'
 	G_CHECK_ROOT_USER
 	G_INIT
@@ -65,8 +61,7 @@
 		#Backends --------------------------------------------------------------
 		# - MySQL/Databases
 		'redis-server'
-		'mysql'
-		#'mariadb' #: https://github.com/Fourdee/DietPi/issues/1000#issuecomment-30776051
+		'mariadb' # 'mysql' applied on Jessie systems during availablility check: https://github.com/Fourdee/DietPi/issues/1000#issuecomment-30776051
 
 		# - PHP
 		'php5-fpm'
@@ -305,6 +300,9 @@
 			aSERVICE_AVAILABLE[$i]=0
 
 			if [[ ${aSERVICE_NAME[$i]} ]]; then
+
+				# Below Stretch, "mariadb" systemd service does not exist, thus "mysql" init.d service will be used.
+				[[ ${aSERVICE_NAME[$i]} == 'mariadb' ]] && (( $G_DISTRO < 4 )) && aSERVICE_NAME[$i]='mysql'
 
 				if [[ -f /etc/systemd/system/${aSERVICE_NAME[$i]}.service ||
 					-f /lib/systemd/system/${aSERVICE_NAME[$i]}.service ||

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7893,7 +7893,7 @@ innodb_file_per_table=1
 character-set-server=utf8mb4
 collation-server=utf8mb4_general_ci
 _EOF_
-			G_RUN_CMD systemctl restart mysql
+			G_RUN_CMD systemctl restart $MARIADB_SERVICE
 
 			# Initially add occ command shortcut, will be done by Dietpi-Globals automatically, if occ file exist:
 			occ(){ sudo -u www-data php /var/www/owncloud/occ "$@"; }
@@ -8142,7 +8142,7 @@ innodb_file_per_table=1
 character-set-server=utf8mb4
 collation-server=utf8mb4_general_ci
 _EOF_
-			G_RUN_CMD systemctl restart mysql
+			G_RUN_CMD systemctl restart $MARIADB_SERVICE
 
 			# Initially add occ command shortcut, will be done by Dietpi-Globals automatically, if occ file exist:
 			ncc(){ sudo -u www-data php /var/www/nextcloud/occ "$@"; }

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -301,12 +301,15 @@ _EOF_
 	USER_LINUX_AUTOINSTALL_PROMPT_DISPLAYED=0
 
 	#PHP5/7 specific directories, apt package-, module- and command names
+	# - and Distro specific MariaDB service name
 	FP_PHP_BASE_DIR='/etc/php/7.0'
 	PHP_APT_PACKAGE_NAME='php'
+	MARIADB_SERVICE='mariadb'
 	if (( $G_DISTRO < 4 )); then
 
 		FP_PHP_BASE_DIR='/etc/php5'
 		PHP_APT_PACKAGE_NAME='php5'
+		MARIADB_SERVICE='mysql'
 
 	elif (( $G_DISTRO > 4 )); then
 
@@ -3715,7 +3718,7 @@ _EOF_
 			Banner_Installing
 
 			#MySQL must be running during install to allow debconf setup.
-			G_RUN_CMD systemctl start mysql
+			G_RUN_CMD systemctl start $MARIADB_SERVICE
 
 			# Set password parameters before installing
 			debconf-set-selections <<< 'phpmyadmin phpmyadmin/dbconfig-install boolean true'
@@ -7627,7 +7630,7 @@ _EOF_
 			# On Jessie assure unix_socket authentication:
 			if (( $G_DISTRO < 4 )); then
 
-				G_RUN_CMD systemctl start mysql
+				G_RUN_CMD systemctl start $MARIADB_SERVICE
 				mysql -e "install plugin unix_socket soname 'auth_socket';" &> /dev/null
 				mysql -e "grant all privileges on *.* to 'root'@'localhost' identified via unix_socket with grant option;flush privileges"
 				# Drop unnecessary root user children.
@@ -7665,7 +7668,7 @@ _EOF_
 			# Due to MariaDB unix_socket authentication, "root" cannot be used to login the web ui.
 			# Thus default "phpmyadmin" user need to be used, who on Jessie does not have all privileges:
 			# https://dietpi.com/phpbb/viewtopic.php?f=8&t=5&p=54#p54
-			systemctl start mysql
+			systemctl start $MARIADB_SERVICE
 			mysql -e 'grant all privileges on *.* to phpmyadmin@localhost with grant option'
 
 		fi
@@ -11175,7 +11178,7 @@ _EOF_
 
 			/DietPi/dietpi/func/create_mysql_db ompd ompd "$GLOBAL_PW"
 
-			G_RUN_CMD systemctl start mysql
+			G_RUN_CMD systemctl start $MARIADB_SERVICE
 			mysql ompd < /var/www/ompd/sql/ompd*.sql
 			systemctl stop mysql
 
@@ -12394,7 +12397,7 @@ _EOF_
 			# - Find datadir for backups
 			local datadir=$(grep -m1 "^[[:blank:]]*'datadirectory'" /var/www/owncloud/config/config.php | awk '{print $3}' | sed "s/[',]//g")
 			[[ $datadir ]] || datadir=$G_FP_DIETPI_USERDATA/owncloud_data
-			systemctl start mysql
+			systemctl start $MARIADB_SERVICE
 			mysql -e "drop user $dbuser@$dbhost"
 			mysql -e "drop user $dbuser" 2> /dev/null
 			# - Perform database backup if existent, otherwise skip to not overwrite existing one
@@ -12440,7 +12443,7 @@ _EOF_
 			# - Find datadir for backups
 			local datadir=$(grep -m1 "^[[:blank:]]*'datadirectory'" /var/www/nextcloud/config/config.php | awk '{print $3}' | sed "s/[',]//g")
 			[[ $datadir ]] || datadir=$G_FP_DIETPI_USERDATA/nextcloud_data
-			systemctl start mysql
+			systemctl start $MARIADB_SERVICE
 			mysql -e "drop user $dbuser@$dbhost"
 			mysql -e "drop user $dbuser" 2> /dev/null
 			# - Perform database backup if existent, otherwise skip to not overwrite existing one
@@ -12531,7 +12534,7 @@ _EOF_
 		if (( aSOFTWARE_INSTALL_STATE[$UNINSTALLING_INDEX] == -1 )); then
 
 			Banner_Uninstalling
-			systemctl start mysql
+			systemctl start $MARIADB_SERVICE
 			mysqladmin drop phpmyadmin -f
 			mysql -e "drop user 'phpmyadmin'@'localhost'"
 			G_AGP phpmyadmin
@@ -12542,7 +12545,7 @@ _EOF_
 		if (( aSOFTWARE_INSTALL_STATE[$UNINSTALLING_INDEX] == -1 )); then
 
 			Banner_Uninstalling
-			systemctl start mysql
+			systemctl start $MARIADB_SERVICE
 			mysqladmin drop phpbb3 -f
 			mysql -e "drop user 'phpbb3'@'localhost'"
 			rm -R /var/www/phpBB3
@@ -12644,7 +12647,7 @@ _EOF_
 
 			Banner_Uninstalling
 			rm -R /var/www/ompd
-			systemctl start mysql
+			systemctl start $MARIADB_SERVICE
 			mysqladmin drop ompd -f
 			mysql -e "drop user 'ompd'@'localhost'"
 
@@ -12804,7 +12807,7 @@ _EOF_
 
 			userdel -rf koel
 
-			systemctl start mysql
+			systemctl start $MARIADB_SERVICE
 			mysqladmin drop koel -f
 			mysql -e "drop user 'koel'@'localhost'"
 
@@ -13227,7 +13230,7 @@ _EOF_
 		if (( aSOFTWARE_INSTALL_STATE[$UNINSTALLING_INDEX] == -1 )); then
 
 			Banner_Uninstalling
-			systemctl start mysql
+			systemctl start $MARIADB_SERVICE
 			mysqladmin drop wordpress -f
 			mysql -e "drop user 'wordpress'@'localhost'"
 
@@ -13245,7 +13248,7 @@ _EOF_
 			a2disconf dietpi-freshrss &> /dev/null
 			rm /etc/apache2/conf-available/dietpi-freshrss.conf &> /dev/null
 
-			systemctl start mysql
+			systemctl start $MARIADB_SERVICE
 			mysqladmin drop freshrss -f
 			mysql -e "drop user 'freshrss'@'localhost'"
 
@@ -13306,7 +13309,7 @@ _EOF_
 			rm -R /var/www/ampache
 
 			#drop database
-			systemctl start mysql
+			systemctl start $MARIADB_SERVICE
 			mysqladmin drop ampache -f
 			mysql -e "drop user 'ampache'@'localhost'"
 
@@ -13453,7 +13456,7 @@ _EOF_
 			rm -R /var/www/pydio
 
 			#drop database
-			systemctl start mysql
+			systemctl start $MARIADB_SERVICE
 			mysqladmin drop pydio -f
 			mysql -e "drop user pydio@localhost"
 
@@ -13495,7 +13498,7 @@ _EOF_
 			rm -R /var/www/baikal
 
 			#drop database
-			systemctl start mysql
+			systemctl start $MARIADB_SERVICE
 			mysqladmin drop baikal -f
 			mysql -e "drop user 'baikal'@'localhost'"
 
@@ -13622,7 +13625,7 @@ _EOF_
 			rm /etc/systemd/system/gogs.service
 			rm -R /var/log/gogs
 
-			systemctl start mysql
+			systemctl start $MARIADB_SERVICE
 			mysqladmin drop gogs -f
 			mysql -e "drop user 'gogs'@'localhost'"
 
@@ -13764,7 +13767,7 @@ _EOF_
 			rm -R /var/log/gitea
 
 			# drop/delete database
-			systemctl start mysql
+			systemctl start $MARIADB_SERVICE
 			mysqladmin drop gitea -f
 			mysql -e "drop user 'gitea'@'localhost'"
 
@@ -13904,7 +13907,7 @@ _EOF_
 			rm -R /var/www/allo
 			userdel -rf allo
 			rm /etc/sudoers.d/allo
-			systemctl start mysql
+			systemctl start $MARIADB_SERVICE
 			mysqladmin drop allo_db -f
 			mysql -e "drop user 'allo_db'@'localhost'"
 
@@ -13915,7 +13918,7 @@ _EOF_
 
 			Banner_Uninstalling
 			G_WHIP_MSG "Creating MariaDB database backup before uninstallation:\n\nIn case of accident, we create a database backup for you. You can remove it manually, if you are sure, that you don't need it any more.\n\n$G_FP_DIETPI_USERDATA/mariadb-database-backup.sql"
-			G_RUN_CMD systemctl start mysql
+			G_RUN_CMD systemctl start $MARIADB_SERVICE
 			mysqldump --all-databases > $G_FP_DIETPI_USERDATA/mariadb-database-backup.sql
 			# On Jessie, purging MariaDB server with unix_socket authentication fails, thus revert to password:
 			(( $G_DISTRO < 4 )) && mysql -e "grant all privileges on *.* to 'root'@'localhost' identified by '$GLOBAL_PW' with grant option;flush privileges"

--- a/dietpi/func/create_mysql_db
+++ b/dietpi/func/create_mysql_db
@@ -7,10 +7,10 @@
 	# Created by Daniel Knight / daniel.knight@dietpi.com / dietpi.com
 	#////////////////////////////////////
 	# Usage:
-	# - /DietPi/dietpi/func/create_mysql_db DATABASE_NAME DATABASE_USER DATABASE_PW
+	# - /DietPi/dietpi/func/create_mysql_db <DATABASE_NAME> <DATABASE_USER> <DATABASE_PW>
 	#
 	# Drop database:
-	# - mysqladmin -uroot drop phpbb3 -f
+	# - mysqladmin drop phpbb3 -f
 	#////////////////////////////////////
 
 	DATABASE_NAME="$1"
@@ -18,8 +18,8 @@
 	DATABASE_PW="$3"
 	#Import DietPi-Globals ---------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
-	G_CHECK_ROOT_USER
 	G_PROGRAM_NAME='DietPi-Create_MySQL_DB'
+	G_CHECK_ROOT_USER
 	G_INIT
 	#Import DietPi-Globals ---------------------------------------------------------------
 
@@ -28,12 +28,12 @@
 	#/////////////////////////////////////////////////////////////////////////////////////
 
 	#Start MySQL if not running.
-	systemctl start mysql &> /dev/null
+	(( G_DISTRO < 4 )) && systemctl start mysql &> /dev/null || systemctl start mariadb &> /dev/null
 
 	G_DIETPI-NOTIFY 2 "Creating MariaDB database: $DATABASE_NAME"
 
 	#Generate DB
-	# 'identified by' can overwrite unix_socket authentication, thus just use this for non-root users.
+	# 'identified by' can overwrite unix_socket authentication, thus use this for non-root users only.
 	grant_privileges=''
 	[[ $DATABASE_USER == root ]] || grant_privileges="grant all privileges on \`$DATABASE_NAME\`.* to $DATABASE_USER@localhost identified by '$DATABASE_PW';flush privileges"
 	mysql -e "create database \`$DATABASE_NAME\`;$grant_privileges"

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1279,6 +1279,14 @@ _EOF_
 			if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
 
 				/DietPi/dietpi/dietpi-software reinstall 129 148
+				# - Switch to "mariadb" systemd service on Stretch+: https://github.com/Fourdee/DietPi/pull/2196
+				if (( $G_DISTRO > 3 )) && grep -q '^aSOFTWARE_INSTALL_STATE\[88\]=2' /DietPi/dietpi/.installed; then
+
+					G_WHIP_MSG '[ INFO ] Switch from "mysql" to "mariadb" service\n
+On Stretch (and above) systems, DietPi-Services will use the pre-installed "mariadb" systemd service now, instead of the obsolete "mysql" init.d service.\n
+You will not face any practical differences, since both services start the same MariaDB binary. In case you manually want to handle the service, use "systemctl start|stop|restart mariadb" from now on.'
+
+				fi
 
 			fi
 			#-------------------------------------------------------------------------------


### PR DESCRIPTION
**Status**: Ready
🈯️ VM Stretch
🈯️ VM Jessie
- [x] Inform user on update
- [x] Check process_tool
- [x] Adjust manual MariaDB service starts within scripts
- [x] Changelog

Something I wanted to do already a long time. I don't like the obsolete init.d service to be used, which runs 3 background processes instead of 1. I manually switch the dietpi-services string after every update currently on my production system 🤣.
- The started daemon binary is exactly the same "mysqld", so also nothing needs to be changed about process_tool settings etc.

**Commit list/description**:
+ DietPi-Services | MariaDB: Switch to "mariadb" systemd service on Stretch+, replace by "mysql" init.d service on Jessie only
+ DietPi-Patch | MariaDB: Inform user that dietpi-services starts "mariadb" systemd service on Stretch+ from now on
+ DietPi-Process_tool | Remove "MySql" process name, since "mysqld" is MariaDB on all supported Debian versions
+ DietPi-Create_MySQL_DB | Start "mariadb" systemd service on Stretch+
+ DietPi-Software | Start "mariadb" systemd service on Stretch+ instead of "mysql" init.d service