### PR TITLE
DietPi-Software | Reinstalls: Better handle existing configs and install dirs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,7 @@ Bug Fixes:
  - DietPi-Software | OMPD/MyMPD: Resolved inability to update database. Currently we have rolled back the versions of these programs to a working state. We will investigate with the devs to find out the cause for future release: https://github.com/Fourdee/DietPi/issues/2156
  - DietPi-Software | Jackett: Resolved an issue where reinstall created an additional nested install dir. Thanks @msdos for reporting this issue: https://github.com/Fourdee/DietPi/issues/2212
  - DietPi-Software | RoonServer: Resolved an issue where reinstall created an additional nested install dir. Since RoonServer has an automated internal updater, download and install will be skipped, if install already exists.
+ - DietPi-Software | PHP/databases: Resolved an issue where PHP database modules were not installed, when installing a new database while PHP was already installed before.
  - DietPi-Obtain_network_details | Resolved a tiny visual-only error message on non-root logins. Thanks to @AndrewZ for reporting: https://dietpi.com/phpbb/viewtopic.php?f=9&t=5194
  - DietPi-Update | Resolved a visual-only issue, where wrong RC versions could have been shown during incremental patching: https://github.com/Fourdee/DietPi/issues/2190
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,8 @@ Bug Fixes:
  - DietPi-Software | Nextcloud: Resolved an issue with failed installation: https://github.com/Fourdee/DietPi/issues/2184
  - DietPi-Automation | CONFIG_NTP_MODE is now applied after APT cache, and, initial time sync is updated. Due to packages required for some modes: https://github.com/Fourdee/DietPi/issues/2181#issuecomment-433444882
  - DietPi-Software | OMPD/MyMPD: Resolved inability to update database. Currently we have rolled back the versions of these programs to a working state. We will investigate with the devs to find out the cause for future release: https://github.com/Fourdee/DietPi/issues/2156
+ - DietPi-Software | Jackett: Resolved an issue where reinstall created an additional nested install dir. Thanks @msdos for reporting this issue: https://github.com/Fourdee/DietPi/issues/2212
+ - DietPi-Software | RoonServer: Resolved an issue where reinstall created an additional nested install dir. Since RoonServer has an automated internal updater, download and install will be skipped, if install already exists.
  - DietPi-Obtain_network_details | Resolved a tiny visual-only error message on non-root logins. Thanks to @AndrewZ for reporting: https://dietpi.com/phpbb/viewtopic.php?f=9&t=5194
  - DietPi-Update | Resolved a visual-only issue, where wrong RC versions could have been shown during incremental patching: https://github.com/Fourdee/DietPi/issues/2190
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2729,11 +2729,14 @@ NB: We highly recommend choosing 'Retry' first. Failing that, 'mirror' then 'mod
 
 				fi
 
+				# Pretent software requiring PHP, to mark it below, in case webserver ID already passed:
+				aSOFTWARE_REQUIRES_PHP[$i]=1
+
 			fi
 
 			#WEBSERVER_PHP
 			software_id=89
-			if (( ${aSOFTWARE_REQUIRES_PHP[$i]:=0} && aSOFTWARE_INSTALL_STATE[$software_id] !=1 )); then
+			if (( ${aSOFTWARE_REQUIRES_PHP[$i]:=0} && aSOFTWARE_INSTALL_STATE[$software_id] != 1 )); then
 
 				aSOFTWARE_INSTALL_STATE[$software_id]=1
 				G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$software_id]} will be installed"
@@ -2768,6 +2771,9 @@ NB: We highly recommend choosing 'Retry' first. Failing that, 'mirror' then 'mod
 				# - If no desktop is selected or installed (0), default to LXDE
 				aSOFTWARE_INSTALL_STATE[23]=1
 				G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$software_id]} will be installed"
+
+				# Pretent software requiring Xserver, to mark it below, in case desktop ID already passed:
+				aSOFTWARE_REQUIRES_XSERVERXORG[$i]=1
 
 			fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5804,9 +5804,9 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://api.github.com/repos/Radarr/Radarr/releases'
+			INSTALL_URL_ADDRESS='https://api.github.com/repos/Radarr/Radarr/releases/latest'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS" #full filepath below, returns --spider error :(
-			INSTALL_URL_ADDRESS="$( curl -s $INSTALL_URL_ADDRESS | grep 'linux.tar.gz' | grep 'browser_download_url' | head -1 | cut -d \" -f 4 )"
+			INSTALL_URL_ADDRESS="$(curl -s $INSTALL_URL_ADDRESS | grep -m1 'browser_download_url.*linux.tar.gz' | cut -d \" -f 4)"
 
 			DEPS_LIST='mediainfo'
 			no_check_url=1 Download_Install "$INSTALL_URL_ADDRESS" /opt
@@ -5819,9 +5819,9 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://api.github.com/repos/Lidarr/Lidarr/releases'
+			INSTALL_URL_ADDRESS='https://api.github.com/repos/Lidarr/Lidarr/releases/latest'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-			INSTALL_URL_ADDRESS="$( curl -s $INSTALL_URL_ADDRESS | grep 'linux.tar.gz' | grep 'browser_download_url' | head -1 | cut -d \" -f 4 )"
+			INSTALL_URL_ADDRESS="$(curl -s $INSTALL_URL_ADDRESS | grep -m1 'browser_download_url.*linux.tar.gz' | cut -d \" -f 4)"
 
 			DEPS_LIST='mediainfo'
 			no_check_url=1 Download_Install "$INSTALL_URL_ADDRESS" /opt
@@ -5852,14 +5852,21 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://api.github.com/repos/Jackett/Jackett/releases'
+			INSTALL_URL_ADDRESS='https://api.github.com/repos/Jackett/Jackett/releases/latest'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS" #full filepath below, returns --spider error :(
-			INSTALL_URL_ADDRESS="$( curl -s $INSTALL_URL_ADDRESS | grep Jackett.Binaries.Mono.tar.gz | grep browser_download_url | head -1 | cut -d \" -f 4 )"
+			INSTALL_URL_ADDRESS="$(curl -s $INSTALL_URL_ADDRESS | grep -m1 'browser_download_url.*Jackett.Binaries.Mono.tar.gz' | cut -d \" -f 4)"
 
 			no_check_url=1 Download_Install "$INSTALL_URL_ADDRESS" /opt
 
-			cp -R /opt/Jackett /opt/jackett #CP for reinstall support
-			rm -R /opt/Jackett
+			# Move existing configs to unpacked install dir
+			[[ -d /opt/jackett/.mono ]] && mv /opt/jackett/.mono /opt/Jackett/
+			[[ -d /opt/jackett/.config ]] && mv /opt/jackett/.config /opt/Jackett/
+
+			# Remove existing install dir
+			[[ -d /opt/jackett ]] && rm -R /opt/jackett
+
+			# Move unpacked install dir in place
+			mv /opt/Jackett /opt/jackett
 
 		fi
 
@@ -5938,8 +5945,21 @@ _EOF_
 			Banner_Installing
 
 			DEPS_LIST='libav-tools cifs-utils'
-			Download_Install 'http://download.roonlabs.com/builds/RoonServer_linuxx64.tar.bz2'
-			mv RoonServer $G_FP_DIETPI_USERDATA/roonserver
+
+			# Skip download and install, if already existent, manual removal or internal updater can be used:
+			if [[ ! -d $G_FP_DIETPI_USERDATA/roonserver ]]; then
+
+				Download_Install 'http://download.roonlabs.com/builds/RoonServer_linuxx64.tar.bz2' $G_FP_DIETPI_USERDATA
+				mv $G_FP_DIETPI_USERDATA/RoonServer $G_FP_DIETPI_USERDATA/roonserver
+
+			else
+
+				G_WHIP_MSG '[WARNING] Existing install found\n
+The ${aSOFTWARE_WHIP_NAME[$software_id]} target install directory $G_FP_DIETPI_USERDATA/roonserver already exists. This will not be overwritten.\n
+If the existing instance is broken or obsolete, please manually backup config files and data, then remove this directory and rerun "dietpi-software".\n
+If you want to update ${aSOFTWARE_WHIP_NAME[$software_id]}, please use it'\'' internal updater.'
+
+			fi
 
 		fi
 
@@ -11536,7 +11556,7 @@ _EOF_
 
 			Banner_Configuration
 
-			adduser jackett --system --no-create-home --group --shell=/bin/nologin
+			adduser jackett --system --no-create-home --group --shell=/usr/sbin/nologin
 
 			cat << _EOF_ > /etc/systemd/system/jackett.service
 [Unit]
@@ -12903,8 +12923,8 @@ _EOF_
 		if (( aSOFTWARE_INSTALL_STATE[$software_id] == -1 )); then
 
 			Banner_Uninstalling
-			rm -R $G_FP_DIETPI_USERDATA/roonserver
-			rm /etc/systemd/system/roonserver.service
+			[[ -d $G_FP_DIETPI_USERDATA/roonserver ]] && rm -R $G_FP_DIETPI_USERDATA/roonserver
+			[[ -f /etc/systemd/system/roonserver.service ]] && rm /etc/systemd/system/roonserver.service
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1609,15 +1609,9 @@ NB: We highly recommend choosing 'Retry' first. Failing that, 'mirror' then 'mod
 					  aSOFTWARE_TYPE[$software_id]=0
 			 aSOFTWARE_ONLINEDOC_URL[$software_id]='f=8&t=5&start=20#p188'
 
-		# - Currently ARMv6/7 only, so disable all archs
-		for ((i=1; i<=$MAX_G_HW_ARCH; i++))
-		do
-
-			aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,$i]=0
-
-		done
-		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=1
-		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,2]=1
+		# - Currently ARMv6/7 only
+		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,3]=0
+		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,10]=0
 
 		#------------------
 		software_id=138
@@ -2364,11 +2358,13 @@ NB: We highly recommend choosing 'Retry' first. Failing that, 'mirror' then 'mod
 					  aSOFTWARE_TYPE[$software_id]=1
 
 		# - Stretch only
-		if (( $G_DISTRO < 4 )); then
+		for ((i=3; i<=$MAX_G_DISTRO; i++))
+		do
 
-			aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,$G_HW_MODEL]=0
+			aSOFTWARE_AVAIL_G_DISTRO[$software_id,$G_DISTRO]=0
 
 		fi
+		aSOFTWARE_AVAIL_G_DISTRO[$software_id,4]=1
 
 		#------------------
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5975,10 +5975,10 @@ _EOF_
 
 			else
 
-				G_WHIP_MSG '[WARNING] Existing install found\n
+				G_WHIP_MSG "[WARNING] Existing install found\n
 The ${aSOFTWARE_WHIP_NAME[$software_id]} target install directory $G_FP_DIETPI_USERDATA/roonserver already exists. This will not be overwritten.\n
 If the existing instance is broken or obsolete, please manually backup config files and data, then remove this directory and rerun "dietpi-software".\n
-If you want to update ${aSOFTWARE_WHIP_NAME[$software_id]}, please use it'\'' internal updater.'
+If you want to update ${aSOFTWARE_WHIP_NAME[$software_id]}, please use it's internal updater."
 
 			fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8240,7 +8240,7 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 
 			# Run service as "dietpi" group: https://github.com/Fourdee/DietPi/issues/350#issuecomment-423763518
 			mkdir -p /etc/systemd/system/transmission-daemon.service.d
-			echo -e '[Service]\nGroup=dietpi' >> /etc/systemd/system/transmission-daemon.service.d/dietpi-group.conf
+			echo -e '[Service]\nGroup=dietpi' > /etc/systemd/system/transmission-daemon.service.d/dietpi-group.conf
 
 			# Apply optimized settings
 			sed -i '/^}/d' /etc/transmission-daemon/settings.json
@@ -10334,7 +10334,7 @@ location = /.well-known/caldav {
 
 			# Run service as "dietpi" group: https://github.com/Fourdee/DietPi/issues/350#issuecomment-423763518
 			mkdir -p /etc/systemd/system/plexmediaserver.service.d
-			echo -e '[Service]\nGroup=dietpi' >> /etc/systemd/system/plexmediaserver.service.d/dietpi-group.conf
+			echo -e '[Service]\nGroup=dietpi' > /etc/systemd/system/plexmediaserver.service.d/dietpi-group.conf
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3413,7 +3413,22 @@ NB: We highly recommend choosing 'Retry' first. Failing that, 'mirror' then 'mod
 			chown mysql:mysql -h /var/lib/mysql &> /dev/null
 			chown mysql:mysql -RL /var/lib/mysql &> /dev/null
 
-			G_AGI mariadb-server
+			local package_list='mariadb-server'
+			# Install php-mysql module, if PHP was already installed
+			if (( ${aSOFTWARE_INSTALL_STATE[89]} == 2 )); then
+
+				if (( $G_DISTRO < 4 )); then
+					# For <= Jessie, php5-mysqlnd provides the newer mysql client libraries compared to php5-mysql.
+					package_list+=' php5-mysqlnd'
+
+				else
+					# For >= Stretch, php(7.X)-mysqlnd does not exist, thus php-mysql need to be installed: https://packages.debian.org/de/stretch/php-mysql
+					package_list+=" $PHP_APT_PACKAGE_NAME-mysql"
+
+				fi
+
+			fi
+			G_AGI "$package_list"
 
 		fi
 
@@ -3422,7 +3437,10 @@ NB: We highly recommend choosing 'Retry' first. Failing that, 'mirror' then 'mod
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-			G_AGI sqlite3
+			local package_list='sqlite3'
+			# Install php-sqlite module, if PHP was already installed
+			(( ${aSOFTWARE_INSTALL_STATE[89]} == 2 )) && package_list+=" $PHP_APT_PACKAGE_NAME-sqlite*"
+			G_AGI "$package_list"
 
 		fi
 
@@ -3432,13 +3450,8 @@ NB: We highly recommend choosing 'Retry' first. Failing that, 'mirror' then 'mod
 
 			Banner_Installing
 			local package_list='redis-server'
-			#Redis php module | == 2 to check for existing installs, if == 1, then module will be installed together with PHP, to prevent dependency installations
-			if (( ${aSOFTWARE_INSTALL_STATE[89]} == 2 )); then
-
-				package_list+=" $PHP_APT_PACKAGE_NAME-redis"
-
-			fi
-
+			# Install php-redis module, if PHP was already installed
+			(( ${aSOFTWARE_INSTALL_STATE[89]} == 2 )) && package_list+=" $PHP_APT_PACKAGE_NAME-redis"
 			G_AGI $package_list
 
 		fi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2363,7 +2363,7 @@ NB: We highly recommend choosing 'Retry' first. Failing that, 'mirror' then 'mod
 
 			aSOFTWARE_AVAIL_G_DISTRO[$software_id,$G_DISTRO]=0
 
-		fi
+		done
 		aSOFTWARE_AVAIL_G_DISTRO[$software_id,4]=1
 
 		#------------------

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3624,7 +3624,19 @@ We work around this error by running APT a second time. Please do not worry and 
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-			Download_Install 'https://www.phpbb.com/files/release/phpBB-3.2.2.zip' /var/www
+
+			# Skip install, if already present
+			if [[ -d /var/www/phpBB3 ]]; then
+
+				G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$software_id]} install dir \"/var/www/phpBB3\" already exists. Download and install steps will be skipped.
+ - Please manually backup your config files+data, remove the install dir and rerun \"dietpi-software (re)install $software_id\" if you need to reinstall.
+ - If you want to update the ${aSOFTWARE_WHIP_NAME[$software_id]} instance, please follow the instructions from WebUI ACP."
+
+			else
+
+				Download_Install 'https://www.phpbb.com/files/release/phpBB-3.2.3.tar.bz2' /var/www
+
+			fi
 
 		fi
 

--- a/dietpi/func/create_mysql_db
+++ b/dietpi/func/create_mysql_db
@@ -27,13 +27,16 @@
 	# Main Loop
 	#/////////////////////////////////////////////////////////////////////////////////////
 
-	#Start MySQL if not running.
+	# Skip database creation, if already existent
+	[[ -d /var/lib/mysql/$DATABASE_NAME ]] && G_DIETPI-NOTIFY 2 "\"$DATABASE_NAME\" MariaDB database already exists. Aborting..." && exit
+
+	# Start MySQL if not running.
 	(( G_DISTRO < 4 )) && systemctl start mysql &> /dev/null || systemctl start mariadb &> /dev/null
 
 	G_DIETPI-NOTIFY 2 "Creating MariaDB database: $DATABASE_NAME"
 
-	#Generate DB
-	# 'identified by' can overwrite unix_socket authentication, thus use this for non-root users only.
+	# Generate DB
+	# - 'identified by' can overwrite unix_socket authentication, thus use this for non-root users only.
 	grant_privileges=''
 	[[ $DATABASE_USER == root ]] || grant_privileges="grant all privileges on \`$DATABASE_NAME\`.* to $DATABASE_USER@localhost identified by '$DATABASE_PW';flush privileges"
 	mysql -e "create database \`$DATABASE_NAME\`;$grant_privileges"


### PR DESCRIPTION
**Status**: Ready
- [x] Check further install titles
  - Enough for now, this is a larger task, most properly over the next multiple releases.

**Testing**
🈯️ Jackett + reinstall
🈯️ RoonServer + reinstall
🈯️ MariaDB, SQLite and Redis after PHP
🈯️ phpBB + reinstall
```
[ INFO ] DietPi-Software | Forums install dir "/var/www/phpBB3" already exists. Download and install steps will be skipped.
 - Please manually backup your config files+data, remove the install dir and rerun "dietpi-software (re)install 54" if you need to reinstall.
 - If you want to update the Forums instance, please follow the instructions from WebUI ACP.
...
[ INFO ] DietPi-Create_MySQL_DB | "phpbb3" MariaDB database already exists. Aborting...
```

**Reference**:
- https://github.com/Fourdee/DietPi/issues/2212
- https://github.com/Fourdee/DietPi/issues/2187

**Commit list/description**:
+ DietPi-Software | Jackett: Fix reinstall in case of existent install dir
+ DietPi-Software | RoonServer: Skip download and install, if already install dir already exist; Rely on internal auto updater
+ DietPi-Software | Minor coding
+ DietPi-Software | Assure that required database PHP modules are installed as well, if PHP was already installed before
+ DietPi-Software | phpBB: Install v3.2.3, use bzip2 archive => lower download size
+ DietPi-Software | phpBB: Skip Download_Install, if install already exists. Ask user for manual config/data/plugin backup and install dir removal, if reinstall required; Updates should be applied via internal update package method.
+ DietPi-Create_MySQL_DB | Skip database creation, if already existent. Creation anyway fails otherwise.
+ DietPi-Software | Plex/Transmission: Prevent doubled service file entries on reinstall