### PR TITLE
DietPi-Software | OpenBazaar: Pre-configure to allow client connection

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,7 +20,8 @@ Bug Fixes:
  - DietPi-Software | OMPD/MyMPD: Resolved inability to update database. Currently we have rolled back the versions of these programs to a working state. We will investigate with the devs to find out the cause for future release: https://github.com/Fourdee/DietPi/issues/2156
  - DietPi-Software | Jackett: Resolved an issue where reinstall created an additional nested install dir. Thanks @msdos for reporting this issue: https://github.com/Fourdee/DietPi/issues/2212
  - DietPi-Software | RoonServer: Resolved an issue where reinstall created an additional nested install dir. Since RoonServer has an automated internal updater, download and install will be skipped, if install already exists.
- - DietPi-Software | PHP/databases: Resolved an issue where PHP database modules were not installed, when installing a new database while PHP was already installed before.
+ - DietPi-Software | PHP/databases: Resolved an issue where PHP database modules were not installed, when installing a new database and PHP was already installed before.
+ - DietPi-Software | OpenBazaar: Resolved an issue where remote OB clients could not connect to server with default configuration: https://github.com/Fourdee/DietPi/pull/2224
  - DietPi-Obtain_network_details | Resolved a tiny visual-only error message on non-root logins. Thanks to @AndrewZ for reporting: https://dietpi.com/phpbb/viewtopic.php?f=9&t=5194
  - DietPi-Update | Resolved a visual-only issue, where wrong RC versions could have been shown during incremental patching: https://github.com/Fourdee/DietPi/issues/2190
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3674,17 +3674,17 @@ We work around this error by running APT a second time. Please do not worry and 
 			#	x86_64
 			if (( $G_HW_ARCH == 10 )); then
 
-				INSTALL_URL_ADDRESS='https://dl.google.com/go/go1.11.linux-amd64.tar.gz'
+				INSTALL_URL_ADDRESS='https://dl.google.com/go/go1.11.2.linux-amd64.tar.gz'
 
 			#	ARMv8
 			elif (( $G_HW_ARCH == 3 )); then
 
-				INSTALL_URL_ADDRESS='https://dl.google.com/go/go1.11.linux-arm64.tar.gz'
+				INSTALL_URL_ADDRESS='https://dl.google.com/go/go1.11.2.linux-arm64.tar.gz'
 
 			#	ARMv6/7
 			else
 
-				INSTALL_URL_ADDRESS='https://dl.google.com/go/go1.11.linux-armv6l.tar.gz'
+				INSTALL_URL_ADDRESS='https://dl.google.com/go/go1.11.2.linux-armv6l.tar.gz'
 
 			fi
 
@@ -4855,7 +4855,7 @@ _EOF_
 			useradd pivpn
 			mkdir -p /home/pivpn
 
-			while true
+			while :
 			do
 
 				wget "$INSTALL_URL_ADDRESS" -O pivpn_install.sh
@@ -7578,6 +7578,48 @@ _EOF_
 			# - Data dir
 			mkdir -p $G_FP_DIETPI_USERDATA/openbazaar
 
+			# - Init OB to have config file available, if not yet the case, and edit to allow remote client access
+			if [[ ! -f $G_FP_DIETPI_USERDATA/openbazaar/config ]]; then
+
+				go run $G_FP_DIETPI_USERDATA/go/src/github.com/OpenBazaar/openbazaar-go/openbazaard.go init -d $G_FP_DIETPI_USERDATA/openbazaar
+
+				# - Add current IP as gateway to allow external client connection
+				G_CONFIG_INJECT '"Gateway": "' "    \"Gateway\": \"/ip4/$(sed -n 4p /DietPi/dietpi/.network)/tcp/4002\"," $G_FP_DIETPI_USERDATA/openbazaar/config
+
+				# - Client connection user/password
+				G_DIETPI-NOTIFY 2 "Please enter username and password for your ${aSOFTWARE_WHIP_NAME[$software_id]} client connection:"
+				go run $G_FP_DIETPI_USERDATA/go/src/github.com/OpenBazaar/openbazaar-go/openbazaard.go setapicreds -d $G_FP_DIETPI_USERDATA/openbazaar
+
+				# - Client IP needs to be added to allowed IP list
+				local ob_client_ip=''
+				local invalid_entry=''
+				while :
+				do
+
+					G_WHIP_INPUTBOX "Please enter the IP address of your ${aSOFTWARE_WHIP_NAME[$software_id]} client machine
+This is required, since the ${aSOFTWARE_WHIP_NAME[$software_id]} server node by default does not allow any remote connection."
+					if (( ! $? )) && [[ $G_WHIP_RETURNED_VALUE =~ ^[0-9.]+$ ]]; then
+
+						ob_client_ip=$G_WHIP_RETURNED_VALUE
+						break
+
+					else
+
+						invalid_entry='[FAILED] Please enter a valid IP address\n\n'
+
+					fi
+
+				done
+				G_CONFIG_INJECT '"AllowedIPs":' "    \"AllowedIPs\": [
+      \"$ob_client_ip\"
+    ]," $G_FP_DIETPI_USERDATA/openbazaar/config
+
+			else
+
+				G_DIETPI-NOTIFY 2 "Existing ${aSOFTWARE_WHIP_NAME[$software_id]} config found. Skipping pre-configuration..."
+
+			fi
+
 			# - service
 			cat << _EOF_ > /etc/systemd/system/openbazaar.service
 [Unit]
@@ -7587,7 +7629,7 @@ Description=OpenBazaar
 Type=simple
 Environment=GOPATH=$G_FP_DIETPI_USERDATA/go
 WorkingDirectory=$G_FP_DIETPI_USERDATA/go
-ExecStart=$(which go) run $G_FP_DIETPI_USERDATA/go/src/github.com/OpenBazaar/openbazaar-go/openbazaard.go start -a 0.0.0.0 -d $G_FP_DIETPI_USERDATA/openbazaar
+ExecStart=$(which go) run $G_FP_DIETPI_USERDATA/go/src/github.com/OpenBazaar/openbazaar-go/openbazaard.go start -d $G_FP_DIETPI_USERDATA/openbazaar
 
 [Install]
 WantedBy=multi-user.target
@@ -12064,7 +12106,7 @@ gpio -g write 17 0
 gpio -g mode 22 out
 gpio -g write 22 1
 
-while true
+while :
 do
 
 	if (( \$(gpio -g read 17) == 1 )); then

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3695,7 +3695,7 @@ We work around this error by running APT a second time. Please do not worry and 
 			cat << _EOF_ > /etc/bashrc.d/go.sh
 #!/bin/bash
 export GOPATH=$G_FP_DIETPI_USERDATA/go
-export PATH=\$PATH:/usr/local/go/bin
+export PATH=\$PATH:/usr/local/go/bin:$G_FP_DIETPI_USERDATA/go/bin
 _EOF_
 
 			. /etc/bashrc.d/go.sh
@@ -7582,14 +7582,14 @@ _EOF_
 			# - Init OB to have config file available, if not yet the case, and edit to allow remote client access
 			if [[ ! -f $G_FP_DIETPI_USERDATA/openbazaar/config ]]; then
 
-				go run $G_FP_DIETPI_USERDATA/go/src/github.com/OpenBazaar/openbazaar-go/openbazaard.go init -d $G_FP_DIETPI_USERDATA/openbazaar
+				openbazaar-go init -d $G_FP_DIETPI_USERDATA/openbazaar
 
 				# - Add current IP as gateway to allow external client connection
 				G_CONFIG_INJECT '"Gateway": "' "    \"Gateway\": \"/ip4/$(sed -n 4p /DietPi/dietpi/.network)/tcp/4002\"," $G_FP_DIETPI_USERDATA/openbazaar/config
 
 				# - Client connection user/password
 				G_DIETPI-NOTIFY 2 "Please enter username and password for your ${aSOFTWARE_WHIP_NAME[$software_id]} client connection:"
-				go run $G_FP_DIETPI_USERDATA/go/src/github.com/OpenBazaar/openbazaar-go/openbazaard.go setapicreds -d $G_FP_DIETPI_USERDATA/openbazaar
+				openbazaar-go setapicreds -d $G_FP_DIETPI_USERDATA/openbazaar
 
 				# - Client IP needs to be added to allowed IP list
 				local ob_client_ip=''
@@ -7628,7 +7628,7 @@ Description=OpenBazaar
 Type=simple
 Environment=GOPATH=$G_FP_DIETPI_USERDATA/go
 WorkingDirectory=$G_FP_DIETPI_USERDATA/go
-ExecStart=$(which go) run $G_FP_DIETPI_USERDATA/go/src/github.com/OpenBazaar/openbazaar-go/openbazaard.go start -d $G_FP_DIETPI_USERDATA/openbazaar
+ExecStart=$(which openbazaar-go) start -d $G_FP_DIETPI_USERDATA/openbazaar
 
 [Install]
 WantedBy=multi-user.target
@@ -13634,7 +13634,6 @@ _EOF_
 			Banner_Uninstalling
 
 			rm /etc/systemd/system/openbazaar.service
-
 			rm -R $G_FP_DIETPI_USERDATA/go/src/github.com/OpenBazaar
 			rm -R /etc/openbazaar-server &> /dev/null # Pre v6.15 OB1.0
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1428,6 +1428,7 @@ NB: We highly recommend choosing 'Retry' first. Failing that, 'mirror' then 'mod
 					  aSOFTWARE_TYPE[$software_id]=0
    aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
 			  aSOFTWARE_REQUIRES_GIT[$software_id]=1
+		  aSOFTWARE_REQUIRES_USERINPUT[$software_id]=1
 			 aSOFTWARE_ONLINEDOC_URL[$software_id]='f=8&t=5&p=1796#p1796'
 
 		#------------------
@@ -7596,7 +7597,7 @@ _EOF_
 				while :
 				do
 
-					G_WHIP_INPUTBOX "Please enter the IP address of your ${aSOFTWARE_WHIP_NAME[$software_id]} client machine
+					G_WHIP_INPUTBOX "${invalid_entry}Please enter the IP address of your ${aSOFTWARE_WHIP_NAME[$software_id]} client machine
 This is required, since the ${aSOFTWARE_WHIP_NAME[$software_id]} server node by default does not allow any remote connection."
 					if (( ! $? )) && [[ $G_WHIP_RETURNED_VALUE =~ ^[0-9.]+$ ]]; then
 
@@ -7610,9 +7611,7 @@ This is required, since the ${aSOFTWARE_WHIP_NAME[$software_id]} server node by 
 					fi
 
 				done
-				G_CONFIG_INJECT '"AllowedIPs":' "    \"AllowedIPs\": [
-      \"$ob_client_ip\"
-    ]," $G_FP_DIETPI_USERDATA/openbazaar/config
+				G_CONFIG_INJECT '"AllowedIPs":' "    \"AllowedIPs\": [\n      \"$ob_client_ip\"\n    ]," $G_FP_DIETPI_USERDATA/openbazaar/config
 
 			else
 


### PR DESCRIPTION
**Status**: Ready
🈯️ Jessie
🈯️ Stretch
🈯️ Buster

**ToDo**
- [x] Add user input requirement
- [x] Test and in case revert to Go v1.9 🈯️ With Go v1.9.7 compilation is done in a few seconds.
- [x] Possibility to hard code data dir in config to resolve `-d $G_FP_DIETPI_USERDATA/openbazaar` requirement? 🈴 Checked everything up and down... no chance 😢.

**Reference**: https://github.com/Fourdee/DietPi/issues/1090#issuecomment-435725023

**Commit list/description**:
+ DietPi-Software | OpenBazaar: Pre-configure to allow client connection
