### PR TITLE
DietPi-Globals | G_CONFIG_INJECT: Auto escaping of special characters

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,15 +13,16 @@ Changes / Improvements / Optimisations:
 Bug Fixes:
  - PREP: Resolved failed rootFS resize: https://github.com/Fourdee/DietPi/issues/2181#issuecomment-433715556
  - DietPi-Config | Locale: Resolved an issue where DietPi would always display en_GB as the current locale: https://github.com/Fourdee/DietPi/issues/2216#issuecomment-435599419
+ - DietPi-Automation | CONFIG_NTP_MODE is now applied after APT cache, and, initial time sync is updated. Due to packages required for some modes: https://github.com/Fourdee/DietPi/issues/2181#issuecomment-433444882
  - DietPi-Software | Roon Bridge: Resolved an issue where the remote update would fail due to underpriv permissions: https://community.roonlabs.com/t/dietpi-allo-units-not-getting-the-roonbridge-b167-update-from-b164/52503/6
  - DietPi-Software | Nextcloud: Resolved an issue with failed installation: https://github.com/Fourdee/DietPi/issues/2184
  - DietPi-Software | Nextcloud/Owncloud: Resolved an issue where userdata located on external drive would fail the installation: https://github.com/Fourdee/DietPi/issues/2221
- - DietPi-Automation | CONFIG_NTP_MODE is now applied after APT cache, and, initial time sync is updated. Due to packages required for some modes: https://github.com/Fourdee/DietPi/issues/2181#issuecomment-433444882
  - DietPi-Software | OMPD/MyMPD: Resolved inability to update database. Currently we have rolled back the versions of these programs to a working state. We will investigate with the devs to find out the cause for future release: https://github.com/Fourdee/DietPi/issues/2156
  - DietPi-Software | Jackett: Resolved an issue where reinstall created an additional nested install dir. Thanks @msdos for reporting this issue: https://github.com/Fourdee/DietPi/issues/2212
  - DietPi-Software | RoonServer: Resolved an issue where reinstall created an additional nested install dir. Since RoonServer has an automated internal updater, download and install will be skipped, if install already exists.
  - DietPi-Software | PHP/databases: Resolved an issue where PHP database modules were not installed, when installing a new database and PHP was already installed before.
  - DietPi-Software | OpenBazaar: Resolved an issue where remote OB clients could not connect to server with default configuration: https://github.com/Fourdee/DietPi/pull/2224
+ - DietPi-Software | Resolved an issue where a global password with special characters lead to failing installs, due to missing escaping within our internal function G_CONFIG_INJECT. Thanks to @MistahDarcy for reporting this issue: https://github.com/Fourdee/DietPi/issues/2215
  - DietPi-Obtain_network_details | Resolved a tiny visual-only error message on non-root logins. Thanks to @AndrewZ for reporting: https://dietpi.com/phpbb/viewtopic.php?f=9&t=5194
  - DietPi-Update | Resolved a visual-only issue, where wrong RC versions could have been shown during incremental patching: https://github.com/Fourdee/DietPi/issues/2190
 

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -958,7 +958,7 @@ _EOF_
 		rm /etc/profile.d/99-dietpi* &> /dev/null
 
 		# - Enable /etc/bashrc.d/ support for custom interactive non-login shell scripts:
-		G_CONFIG_INJECT '.*/etc/bashrc\.d/.*' 'for i in /etc/bashrc\.d/\*\.sh; do \[ -r "\$i" \] \&\& \. \$i; done' /etc/bash.bashrc
+		G_CONFIG_INJECT '.*/etc/bashrc\.d/.*' 'for i in /etc/bashrc.d/*.sh; do [ -r "$i" ] && . $i; done' /etc/bash.bashrc
 
 		# - Enable bash-completion for non-login shells:
 		#	- NB: It is called twice on login shells then, but breaks directly if called already once.
@@ -1056,7 +1056,7 @@ _EOF_
 		G_DIETPI-NOTIFY 2 'Add dietpi.com SSH pub host key for DietPi-Survey and -Bugreport upload:'
 		mkdir -p /root/.ssh
 		>> /root/.ssh/known_hosts
-		G_CONFIG_INJECT 'ssh.dietpi.com ' 'ssh.dietpi.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDE6aw3r6aOEqendNu376iiCHr9tGBIWPgfrLkzjXjEsHGyVSUFNnZt6pftrDeK7UX\+qX4FxOwQlugG4fymOHbimRCFiv6cf7VpYg1Ednquq9TLb7/cIIbX8a6AuRmX4fjdGuqwmBq3OG7ZksFcYEFKt5U4mAJIaL8hXiM2iXjgY02LqiQY/QWATsHI4ie9ZOnwrQE\+Rr6mASN1BVFuIgyHIbwX54jsFSnZ/7CdBMkuAd9B8JkxppWVYpYIFHE9oWNfjh/epdK8yv9Oo6r0w5Rb\+4qaAc5g\+RAaknHeV6Gp75d2lxBdCm5XknKKbGma2\+/DfoE8WZTSgzXrYcRlStYN' /root/.ssh/known_hosts
+		G_CONFIG_INJECT 'ssh.dietpi.com ' 'ssh.dietpi.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDE6aw3r6aOEqendNu376iiCHr9tGBIWPgfrLkzjXjEsHGyVSUFNnZt6pftrDeK7UX+qX4FxOwQlugG4fymOHbimRCFiv6cf7VpYg1Ednquq9TLb7/cIIbX8a6AuRmX4fjdGuqwmBq3OG7ZksFcYEFKt5U4mAJIaL8hXiM2iXjgY02LqiQY/QWATsHI4ie9ZOnwrQE+Rr6mASN1BVFuIgyHIbwX54jsFSnZ/7CdBMkuAd9B8JkxppWVYpYIFHE9oWNfjh/epdK8yv9Oo6r0w5Rb+4qaAc5g+RAaknHeV6Gp75d2lxBdCm5XknKKbGma2+/DfoE8WZTSgzXrYcRlStYN' /root/.ssh/known_hosts
 
 		#-----------------------------------------------------------------------------------
 		#MISC
@@ -1116,7 +1116,7 @@ _EOF_
 		#	ASUS TB WiFi: https://github.com/Fourdee/DietPi/issues/1760
 		elif (( $G_HW_MODEL == 52 )); then
 
-			G_CONFIG_INJECT '^8723bs' '8723bs' /etc/modules
+			G_CONFIG_INJECT '8723bs' '8723bs' /etc/modules
 
 		fi
 
@@ -1431,8 +1431,8 @@ _EOF_
 			# - Finalize GRUB
 			if [[ -f '/etc/default/grub' ]]; then
 
-				G_CONFIG_INJECT 'GRUB_CMDLINE_LINUX_DEFAULT=' 'GRUB_CMDLINE_LINUX_DEFAULT=\"consoleblank=0 quiet\"' /etc/default/grub
-				G_CONFIG_INJECT 'GRUB_CMDLINE_LINUX=' 'GRUB_CMDLINE_LINUX=\"net\.ifnames=0\"' /etc/default/grub
+				G_CONFIG_INJECT 'GRUB_CMDLINE_LINUX_DEFAULT=' 'GRUB_CMDLINE_LINUX_DEFAULT="consoleblank=0 quiet"' /etc/default/grub
+				G_CONFIG_INJECT 'GRUB_CMDLINE_LINUX=' 'GRUB_CMDLINE_LINUX="net.ifnames=0"' /etc/default/grub
 				G_CONFIG_INJECT 'GRUB_TIMEOUT=' 'GRUB_TIMEOUT=3' /etc/default/grub
 				l_message='Finalizing GRUB' G_RUN_CMD update-grub
 

--- a/dietpi/dietpi-letsencrypt
+++ b/dietpi/dietpi-letsencrypt
@@ -146,7 +146,7 @@ _EOF_
 			fi
 
 			# Allow adding environment variables via: setenv.add-environment
-			G_CONFIG_INJECT '"mod_setenv"' '	"mod_setenv",' /etc/lighttpd/lighttpd.conf '"mod_.+",'
+			G_CONFIG_INJECT '"mod_setenv"' '	"mod_setenv",' /etc/lighttpd/lighttpd.conf '"mod_..*",'
 
 			cat << _EOF_ > /etc/lighttpd/conf-enabled/letsencrypt.conf
 # Based on: https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=lighttpd-1.4.35&openssl=1.0.1t&hsts=yes&profile=intermediate

--- a/dietpi/dietpi-letsencrypt
+++ b/dietpi/dietpi-letsencrypt
@@ -146,7 +146,7 @@ _EOF_
 			fi
 
 			# Allow adding environment variables via: setenv.add-environment
-			G_CONFIG_INJECT '"mod_setenv"' '	"mod_setenv",' /etc/lighttpd/lighttpd.conf '"mod_..*",'
+			G_CONFIG_INJECT '"mod_setenv"' '	"mod_setenv",' /etc/lighttpd/lighttpd.conf '"mod_.+",'
 
 			cat << _EOF_ > /etc/lighttpd/conf-enabled/letsencrypt.conf
 # Based on: https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=lighttpd-1.4.35&openssl=1.0.1t&hsts=yes&profile=intermediate

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7897,7 +7897,7 @@ _EOF_
 			# Set pretty URLs (without /index.php/) on Apache:
 			if (( ${aSOFTWARE_INSTALL_STATE[83]} >= 1 )); then
 
-				CGI_PRESERVE=1 G_CONFIG_INJECT "'htaccess.RewriteBase'" "'htaccess.RewriteBase' => '/owncloud'," $config_php "'overwrite.cli.url'"
+				GCI_PRESERVE=1 G_CONFIG_INJECT "'htaccess.RewriteBase'" "'htaccess.RewriteBase' => '/owncloud'," $config_php "'overwrite.cli.url'"
 				occ maintenance:update:htaccess
 
 			fi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7903,7 +7903,7 @@ _EOF_
 			fi
 
 			# APCu Memcache
-			PRESERVE=1 G_CONFIG_INJECT "'memcache.local'" "'memcache.local' => '\\OC\\Memcache\\APCu'," $config_php "'version'"
+			PRESERVE=1 G_CONFIG_INJECT "'memcache.local'" "'memcache.local' => '\\\\OC\\\\Memcache\\\\APCu'," $config_php "'version'"
 
 			# Redis for transactional file locking:
 			G_DIETPI-NOTIFY 2 'Enabling Redis for transactional file locking.' # https://doc.owncloud.org/server/latest/admin_manual/configuration/server/caching_configuration.html#configuring-transactional-file-locking
@@ -7917,7 +7917,7 @@ _EOF_
 			G_RUN_CMD systemctl restart redis-server
 			# - Enable ownCloud to use Redis socket for transactional file locking:
 			G_CONFIG_INJECT "'filelocking.enabled'" "'filelocking.enabled' => true," $config_php "'memcache.local'"
-			PRESERVE=1 G_CONFIG_INJECT "'memcache.locking'" "'memcache.locking' => '\\OC\\Memcache\\Redis',\n'redis' => array ('host' => '$redis_sock', 'port' => 0,)," $config_php "'filelocking.enabled'"
+			PRESERVE=1 G_CONFIG_INJECT "'memcache.locking'" "'memcache.locking' => '\\\\OC\\\\Memcache\\\\Redis',\n'redis' => array ('host' => '$redis_sock', 'port' => 0,)," $config_php "'filelocking.enabled'"
 
 			# Enable ownCloud background cron job:
 			crontab -u www-data -l 2>/dev/null | grep -q '/var/www/owncloud/cron.php' || ( crontab -u www-data -l 2>/dev/null ; echo "*/15 * * * * php /var/www/owncloud/cron.php" ) | crontab -u www-data -
@@ -7982,7 +7982,7 @@ Redirect permanent /.well-known/caldav /nextcloud/remote.php/dav' > /etc/apache2
 				G_DIETPI-NOTIFY 2 'Lighttpd webserver found, enabling Nextcloud specific configuration.'
 
 				# Enable mod_setenv
-				G_CONFIG_INJECT '"mod_setenv",' '	"mod_setenv",' /etc/lighttpd/lighttpd.conf '"mod_..*",'
+				G_CONFIG_INJECT '"mod_setenv",' '	"mod_setenv",' /etc/lighttpd/lighttpd.conf '"mod_.+",'
 
 				# Move Nextcloud configuration file in place and activate it
 				nextcloud_conf='/etc/lighttpd/conf-available/99-dietpi-nextcloud.conf'
@@ -8183,7 +8183,7 @@ The install script will now exit. After applying one of the the above, rerun die
 			fi
 
 			# APCu Memcache
-			PRESERVE=1 G_CONFIG_INJECT "'memcache.local'" "'memcache.local' => '\\OC\\Memcache\\APCu'," $config_php "'version'"
+			PRESERVE=1 G_CONFIG_INJECT "'memcache.local'" "'memcache.local' => '\\\\OC\\\\Memcache\\\\APCu'," $config_php "'version'"
 
 			# Redis for transactional file locking:
 			G_DIETPI-NOTIFY 2 'Enabling Redis for transactional file locking.' # https://docs.nextcloud.com/server/14/admin_manual/configuration_files/files_locking_transactional.html
@@ -8197,7 +8197,7 @@ The install script will now exit. After applying one of the the above, rerun die
 			G_RUN_CMD systemctl restart redis-server
 			# - Enable Nextloud to use Redis socket:
 			G_CONFIG_INJECT "'filelocking.enabled'" "'filelocking.enabled' => true," $config_php "'memcache.local'"
-			PRESERVE=1 G_CONFIG_INJECT "'memcache.locking'" "'memcache.locking' => '\\OC\\Memcache\\Redis',\n'redis' => array ('host' => '$redis_sock', 'port' => 0,)," $config_php "'filelocking.enabled'"
+			PRESERVE=1 G_CONFIG_INJECT "'memcache.locking'" "'memcache.locking' => '\\\\OC\\\\Memcache\\\\Redis',\n'redis' => array ('host' => '$redis_sock', 'port' => 0,)," $config_php "'filelocking.enabled'"
 
 			# Enable Nextcloud background cron job:
 			crontab -u www-data -l 2>/dev/null | grep -q '/var/www/nextcloud/cron.php' || ( crontab -u www-data -l 2>/dev/null ; echo "*/15 * * * * php /var/www/nextcloud/cron.php" ) | crontab -u www-data -

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7611,7 +7611,7 @@ This is required, since the ${aSOFTWARE_WHIP_NAME[$software_id]} server node by 
 					fi
 
 				done
-				G_CONFIG_INJECT '"AllowedIPs":' "    \"AllowedIPs\": [\n      \"$ob_client_ip\"\n    ]," $G_FP_DIETPI_USERDATA/openbazaar/config
+				GCI_NEWLINE=1 G_CONFIG_INJECT '"AllowedIPs":' "    \"AllowedIPs\": [\n      \"$ob_client_ip\"\n    ]," $G_FP_DIETPI_USERDATA/openbazaar/config
 
 			else
 
@@ -7897,27 +7897,27 @@ _EOF_
 			# Set pretty URLs (without /index.php/) on Apache:
 			if (( ${aSOFTWARE_INSTALL_STATE[83]} >= 1 )); then
 
-				PRESERVE=1 G_CONFIG_INJECT "'htaccess.RewriteBase'" "'htaccess.RewriteBase' => '/owncloud'," $config_php "'overwrite.cli.url'"
+				CGI_PRESERVE=1 G_CONFIG_INJECT "'htaccess.RewriteBase'" "'htaccess.RewriteBase' => '/owncloud'," $config_php "'overwrite.cli.url'"
 				occ maintenance:update:htaccess
 
 			fi
 
 			# APCu Memcache
-			PRESERVE=1 G_CONFIG_INJECT "'memcache.local'" "'memcache.local' => '\\\\OC\\\\Memcache\\\\APCu'," $config_php "'version'"
+			GCI_PRESERVE=1 G_CONFIG_INJECT "'memcache.local'" "'memcache.local' => '\\\\OC\\\\Memcache\\\\APCu'," $config_php "'version'"
 
 			# Redis for transactional file locking:
 			G_DIETPI-NOTIFY 2 'Enabling Redis for transactional file locking.' # https://doc.owncloud.org/server/latest/admin_manual/configuration/server/caching_configuration.html#configuring-transactional-file-locking
 			local redis_conf="/etc/redis/redis*.conf"
 			# - Enable Redis socket and grant www-data access to it:
 			#	- NB: To allow wildcard expansion, do not use quotes around $redis_conf!
-			PRESERVE=1 G_CONFIG_INJECT 'unixsocket[[:blank:]]' 'unixsocket /var/run/redis/redis-server.sock' $redis_conf
+			GCI_PRESERVE=1 G_CONFIG_INJECT 'unixsocket[[:blank:]]' 'unixsocket /var/run/redis/redis-server.sock' $redis_conf
 			G_CONFIG_INJECT 'unixsocketperm[[:blank:]]' 'unixsocketperm 770' $redis_conf
 			local redis_sock=$(grep -m1 '^[[:blank:]]*unixsocket[[:blank:]]' $redis_conf | awk '{print $2}')
 			usermod -a -G redis www-data
 			G_RUN_CMD systemctl restart redis-server
 			# - Enable ownCloud to use Redis socket for transactional file locking:
 			G_CONFIG_INJECT "'filelocking.enabled'" "'filelocking.enabled' => true," $config_php "'memcache.local'"
-			PRESERVE=1 G_CONFIG_INJECT "'memcache.locking'" "'memcache.locking' => '\\\\OC\\\\Memcache\\\\Redis',\n'redis' => array ('host' => '$redis_sock', 'port' => 0,)," $config_php "'filelocking.enabled'"
+			GCI_PRESERVE=1 GCI_NEWLINE=1 G_CONFIG_INJECT "'memcache.locking'" "'memcache.locking' => '\\\\OC\\\\Memcache\\\\Redis',\n'redis' => array ('host' => '$redis_sock', 'port' => 0,)," $config_php "'filelocking.enabled'"
 
 			# Enable ownCloud background cron job:
 			crontab -u www-data -l 2>/dev/null | grep -q '/var/www/owncloud/cron.php' || ( crontab -u www-data -l 2>/dev/null ; echo "*/15 * * * * php /var/www/owncloud/cron.php" ) | crontab -u www-data -
@@ -8177,27 +8177,27 @@ The install script will now exit. After applying one of the the above, rerun die
 			# Set pretty URLs (without /index.php/) on Apache:
 			if (( ${aSOFTWARE_INSTALL_STATE[83]} >= 1 )); then
 
-				PRESERVE=1 G_CONFIG_INJECT "'htaccess.RewriteBase'" "'htaccess.RewriteBase' => '/nextcloud'," $config_php "'overwrite.cli.url'"
+				GCI_PRESERVE=1 G_CONFIG_INJECT "'htaccess.RewriteBase'" "'htaccess.RewriteBase' => '/nextcloud'," $config_php "'overwrite.cli.url'"
 				ncc maintenance:update:htaccess
 
 			fi
 
 			# APCu Memcache
-			PRESERVE=1 G_CONFIG_INJECT "'memcache.local'" "'memcache.local' => '\\\\OC\\\\Memcache\\\\APCu'," $config_php "'version'"
+			GCI_PRESERVE=1 G_CONFIG_INJECT "'memcache.local'" "'memcache.local' => '\\\\OC\\\\Memcache\\\\APCu'," $config_php "'version'"
 
 			# Redis for transactional file locking:
 			G_DIETPI-NOTIFY 2 'Enabling Redis for transactional file locking.' # https://docs.nextcloud.com/server/14/admin_manual/configuration_files/files_locking_transactional.html
 			local redis_conf="/etc/redis/redis*.conf"
 			# - Enable Redis socket and grant www-data access to it:
 			#	- NB: To allow wildcard expansion, do not use quotes around $redis_conf!
-			PRESERVE=1 G_CONFIG_INJECT 'unixsocket[[:blank:]]' 'unixsocket /var/run/redis/redis-server.sock' $redis_conf
+			GCI_PRESERVE=1 G_CONFIG_INJECT 'unixsocket[[:blank:]]' 'unixsocket /var/run/redis/redis-server.sock' $redis_conf
 			G_CONFIG_INJECT 'unixsocketperm[[:blank:]]' 'unixsocketperm 770' $redis_conf
 			local redis_sock=$(grep -m1 '^[[:blank:]]*unixsocket[[:blank:]]' $redis_conf | awk '{print $2}')
 			usermod -a -G redis www-data
 			G_RUN_CMD systemctl restart redis-server
 			# - Enable Nextloud to use Redis socket:
 			G_CONFIG_INJECT "'filelocking.enabled'" "'filelocking.enabled' => true," $config_php "'memcache.local'"
-			PRESERVE=1 G_CONFIG_INJECT "'memcache.locking'" "'memcache.locking' => '\\\\OC\\\\Memcache\\\\Redis',\n'redis' => array ('host' => '$redis_sock', 'port' => 0,)," $config_php "'filelocking.enabled'"
+			GCI_PRESERVE=1 GCI_NEWLINE=1 G_CONFIG_INJECT "'memcache.locking'" "'memcache.locking' => '\\\\OC\\\\Memcache\\\\Redis',\n'redis' => array ('host' => '$redis_sock', 'port' => 0,)," $config_php "'filelocking.enabled'"
 
 			# Enable Nextcloud background cron job:
 			crontab -u www-data -l 2>/dev/null | grep -q '/var/www/nextcloud/cron.php' || ( crontab -u www-data -l 2>/dev/null ; echo "*/15 * * * * php /var/www/nextcloud/cron.php" ) | crontab -u www-data -
@@ -8264,8 +8264,8 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 			G_CONFIG_INJECT 'lt-cred-mech' 'lt-cred-mech' /etc/turnserver.conf
 			G_CONFIG_INJECT 'use-auth-secret' 'use-auth-secret' /etc/turnserver.conf
 			G_CONFIG_INJECT 'realm=' "realm=$domain" /etc/turnserver.conf
-			PRESERVE=1 G_CONFIG_INJECT 'total-quota=' 'total-quota=100' /etc/turnserver.conf
-			PRESERVE=1 G_CONFIG_INJECT 'bps-capacity=' 'bps-capacity=0' /etc/turnserver.conf
+			GCI_PRESERVE=1 G_CONFIG_INJECT 'total-quota=' 'total-quota=100' /etc/turnserver.conf
+			GCI_PRESERVE=1 G_CONFIG_INJECT 'bps-capacity=' 'bps-capacity=0' /etc/turnserver.conf
 			G_CONFIG_INJECT 'stale-nonce' 'stale-nonce' /etc/turnserver.conf
 			G_CONFIG_INJECT 'no-loopback-peers' 'no-loopback-peers' /etc/turnserver.conf
 			G_CONFIG_INJECT 'no-multicast-peers' 'no-multicast-peers' /etc/turnserver.conf
@@ -8300,7 +8300,7 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 			ncc config:app:set spreed stun_servers --value="[\"$domain:$port\"]"
 			#	Generate random secret to secure TURN server access
 			local secret=$(openssl rand -hex 32)
-			PRESERVE=1 G_CONFIG_INJECT 'static-auth-secret=' "static-auth-secret=$secret" /etc/turnserver.conf
+			GCI_PRESERVE=1 G_CONFIG_INJECT 'static-auth-secret=' "static-auth-secret=$secret" /etc/turnserver.conf
 			#	Scrape existing secret, in case user manually chose/edited it
 			secret="$(grep -m1 '^[[:blank:]]*static-auth-secret=' /etc/turnserver.conf)"
 			secret="${secret#*static-auth-secret=}"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7482,7 +7482,7 @@ _EOF_
 			fi
 
 			# - Set UTF-8
-			G_CONFIG_INJECT 'default_charset[[:blank:]]*=' 'default_charset=\"UTF-8\"' $target_php_ini
+			G_CONFIG_INJECT 'default_charset[[:blank:]]*=' 'default_charset="UTF-8"' $target_php_ini
 
 			# Enable all installed and available PHP modules.
 			local modules_to_enable=$(ls "$FP_PHP_BASE_DIR"/mods-available | grep '.ini' | sed 's/.ini//')
@@ -7903,7 +7903,7 @@ _EOF_
 			fi
 
 			# APCu Memcache
-			PRESERVE=1 G_CONFIG_INJECT "'memcache.local'" "'memcache.local' => '\\\\OC\\\\Memcache\\\\APCu'," $config_php "'version'"
+			PRESERVE=1 G_CONFIG_INJECT "'memcache.local'" "'memcache.local' => '\\OC\\Memcache\\APCu'," $config_php "'version'"
 
 			# Redis for transactional file locking:
 			G_DIETPI-NOTIFY 2 'Enabling Redis for transactional file locking.' # https://doc.owncloud.org/server/latest/admin_manual/configuration/server/caching_configuration.html#configuring-transactional-file-locking
@@ -7917,7 +7917,7 @@ _EOF_
 			G_RUN_CMD systemctl restart redis-server
 			# - Enable ownCloud to use Redis socket for transactional file locking:
 			G_CONFIG_INJECT "'filelocking.enabled'" "'filelocking.enabled' => true," $config_php "'memcache.local'"
-			PRESERVE=1 G_CONFIG_INJECT "'memcache.locking'" "'memcache.locking' => '\\\\OC\\\\Memcache\\\\Redis',\n'redis' => array ('host' => '$redis_sock', 'port' => 0,)," $config_php "'filelocking.enabled'"
+			PRESERVE=1 G_CONFIG_INJECT "'memcache.locking'" "'memcache.locking' => '\\OC\\Memcache\\Redis',\n'redis' => array ('host' => '$redis_sock', 'port' => 0,)," $config_php "'filelocking.enabled'"
 
 			# Enable ownCloud background cron job:
 			crontab -u www-data -l 2>/dev/null | grep -q '/var/www/owncloud/cron.php' || ( crontab -u www-data -l 2>/dev/null ; echo "*/15 * * * * php /var/www/owncloud/cron.php" ) | crontab -u www-data -
@@ -7982,7 +7982,7 @@ Redirect permanent /.well-known/caldav /nextcloud/remote.php/dav' > /etc/apache2
 				G_DIETPI-NOTIFY 2 'Lighttpd webserver found, enabling Nextcloud specific configuration.'
 
 				# Enable mod_setenv
-				G_CONFIG_INJECT '"mod_setenv",' '	"mod_setenv",' /etc/lighttpd/lighttpd.conf '"mod_.+",'
+				G_CONFIG_INJECT '"mod_setenv",' '	"mod_setenv",' /etc/lighttpd/lighttpd.conf '"mod_..*",'
 
 				# Move Nextcloud configuration file in place and activate it
 				nextcloud_conf='/etc/lighttpd/conf-available/99-dietpi-nextcloud.conf'
@@ -8183,7 +8183,7 @@ The install script will now exit. After applying one of the the above, rerun die
 			fi
 
 			# APCu Memcache
-			PRESERVE=1 G_CONFIG_INJECT "'memcache.local'" "'memcache.local' => '\\\\OC\\\\Memcache\\\\APCu'," $config_php "'version'"
+			PRESERVE=1 G_CONFIG_INJECT "'memcache.local'" "'memcache.local' => '\\OC\\Memcache\\APCu'," $config_php "'version'"
 
 			# Redis for transactional file locking:
 			G_DIETPI-NOTIFY 2 'Enabling Redis for transactional file locking.' # https://docs.nextcloud.com/server/14/admin_manual/configuration_files/files_locking_transactional.html
@@ -8197,7 +8197,7 @@ The install script will now exit. After applying one of the the above, rerun die
 			G_RUN_CMD systemctl restart redis-server
 			# - Enable Nextloud to use Redis socket:
 			G_CONFIG_INJECT "'filelocking.enabled'" "'filelocking.enabled' => true," $config_php "'memcache.local'"
-			PRESERVE=1 G_CONFIG_INJECT "'memcache.locking'" "'memcache.locking' => '\\\\OC\\\\Memcache\\\\Redis',\n'redis' => array ('host' => '$redis_sock', 'port' => 0,)," $config_php "'filelocking.enabled'"
+			PRESERVE=1 G_CONFIG_INJECT "'memcache.locking'" "'memcache.locking' => '\\OC\\Memcache\\Redis',\n'redis' => array ('host' => '$redis_sock', 'port' => 0,)," $config_php "'filelocking.enabled'"
 
 			# Enable Nextcloud background cron job:
 			crontab -u www-data -l 2>/dev/null | grep -q '/var/www/nextcloud/cron.php' || ( crontab -u www-data -l 2>/dev/null ; echo "*/15 * * * * php /var/www/nextcloud/cron.php" ) | crontab -u www-data -
@@ -8347,7 +8347,7 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 			G_CONFIG_INJECT '"message-level"' '"message-level": 0,' /etc/transmission-daemon/settings.json
 
 			# To allow access for download managers and media software, files need to be created with 77X permissions.
-			G_CONFIG_INJECT '\"umask\":' '    \"umask\": 7,' /etc/transmission-daemon/settings.json
+			G_CONFIG_INJECT '\"umask\":' '    "umask": 7,' /etc/transmission-daemon/settings.json
 
 			echo '}' >> /etc/transmission-daemon/settings.json
 
@@ -12141,8 +12141,8 @@ ExecStart=/bin/bash -c '/var/lib/dietpi/dietpi-software/installed/pi-spc/sds.sh'
 WantedBy=multi-user.target
 _EOF_
 
-			# G_CONFIG_INJECT	'^dtoverlay=gpio-shutdown' 'dtoverlay=gpio-shutdown,gpio_pin=22,active_low=0' /DietPi/config.txt
-			# G_CONFIG_INJECT	'^dtoverlay=gpio-poweroff' 'dtoverlay=gpio-poweroff,gpio_pin=17' /DietPi/config.txt
+			# G_CONFIG_INJECT	'dtoverlay=gpio-shutdown' 'dtoverlay=gpio-shutdown,gpio_pin=22,active_low=0' /DietPi/config.txt
+			# G_CONFIG_INJECT	'dtoverlay=gpio-poweroff' 'dtoverlay=gpio-poweroff,gpio_pin=17' /DietPi/config.txt
 
 		fi
 

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -2336,17 +2336,18 @@ $print_logfile_info
 	#	- PRESERVE=1 G_CONFIG_INJECT allows to keep current setting, if present.
 	#	- BACKUP=1 G_CONFIG_INJECT allows to backup to file before editing, if backup does not yet exist.
 	# - Example: G_CONFIG_INJECT 'prefer-family[[:blank:]=]' 'prefer-family = IPv4' /etc/wgetrc
-	#	- grep/sed basic regex are supported, related special characters will be escaped internally.
-	#	- Thus no special character escaping is required when adding arguments via variables.
-	#	- Within double quotes "", as usual, escape literally meant double quotes and dollar signs $ with leading backslash \.
-	#	- Within single quotes '', as usual, escape literally meant single quotes via: '\'' # End leading string; Add escaped single quote; Start trailing string
+	#	- grep basic regex is supported for $1 and $4, thus related special characters need to be escaped manually via leading backslash \, if wanted literally:
+	#		\ . * [ ^ & $ |
+	#	- For setting $2 special character escaping is done internally, thus only single/double quote related escaping is required, if wanted literally:
+	#		- Within double quotes "", as usual, escape literally meant double quotes and dollar signs $ with leading backslash \.
+	#		- Within single quotes '', as usual, escape literally meant single quotes via: '\'' # End leading string; Add escaped single quote; Start trailing string
 	G_CONFIG_INJECT(){
 
 		[[ $G_PROGRAM_NAME ]] || local G_PROGRAM_NAME='G_CONFIG_INJECT'
-		local pattern="${1//\\/\\\\}"; pattern="${pattern//./\\.}"; pattern="${pattern//\*/\\\*}"; pattern="${pattern//[/\\[}"; pattern="${pattern//^/\\^}"; pattern="${pattern//&/\\&}"; pattern="${pattern//$/\\$}"; pattern="${pattern//|/\\|}"
+		local pattern="$1"
 		local setting="${2//\\/\\\\}"; setting="${setting//./\\.}"; setting="${setting//\*/\\\*}"; setting="${setting//[/\\[}"; setting="${setting//^/\\^}"; setting="${setting//&/\\&}"; setting="${setting//$/\\$}"; setting="${setting//|/\\|}"
 		local file="$3"
-		local after="${4//\\/\\\\}"; after="${after//./\\.}"; after="${after//\*/\\\*}"; after="${after//[/\\[}"; after="${after//^/\\^}"; after="${after//&/\\&}"; after="${after//$/\\$}"; after="${after//|/\\|}"
+		local after="$4"
 		local error=''
 
 		syntax_error(){
@@ -2362,10 +2363,11 @@ into file \$3
 	$file
 $after
 NB:
- - grep/sed basic regex are supported, related special characters will be escaped internally.
- - Thus no special character escaping is required when adding arguments via variables.
- - Within double quotes \"\", as usual, escape literally meant double quotes, backslashes \ and dollar signs $ via leading backslash.
- - Within single quotes '', as usual, escape literally meant single quotes via: '\'' # End leading string; Add escaped single quote; Start trailing string"
+ - grep basic regex is supported for matching patterns \$1 and \$4, thus related special characters need to be escaped manually via leading backslash \\, if wanted literally:
+ 	\\ . * [ ^ & \$ |
+ - For setting \$2 special character escaping is done internally, thus only single/double quote related escaping is required, if wanted literally:
+	- Within double quotes "", as usual, escape literally meant double quotes and dollar signs \$ with leading backslash \\.
+	- Within single quotes '', as usual, escape literally meant single quotes via: '\\'' # End leading string; Add escaped single quote; Start trailing string"
 
 			unset syntax_error
 

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -2330,22 +2330,29 @@ $print_logfile_info
 
 	}
 
-	# Inject setting into config file
-	# - First tries to replace old setting, else commented setting and otherwise adds it to end of file.
-	#	- Optionally adds argument to new line after specified pattern $4.
-	#	- PRESERVE=1 G_CONFIG_INJECT allows to keep current setting, if present.
-	#	- BACKUP=1 G_CONFIG_INJECT allows to backup to file before editing, if backup does not yet exist.
-	# - Example: G_CONFIG_INJECT 'prefer-family[[:blank:]=]' 'prefer-family = IPv4' /etc/wgetrc
-	#	- grep basic regex is supported for $1 and $4, thus related special characters need to be escaped manually via leading backslash \, if wanted literally:
-	#		\ . * [ ^ & $ |
-	#	- For setting $2 special character escaping is done internally, thus only single/double quote related escaping is required, if wanted literally:
-	#		- Within double quotes "", as usual, escape literally meant double quotes and dollar signs $ with leading backslash \.
-	#		- Within single quotes '', as usual, escape literally meant single quotes via: '\'' # End leading string; Add escaped single quote; Start trailing string
+	# Inject setting into config file: First tries to replace old setting, else commented setting and otherwise adds to end of file.
+	# Usage:
+	# - $1 Setting pattern to find existing setting with grep extended regular expression support
+	# - $2 Target setting + value, to inject into config file: After bash string expansion (e.g. variables), everything else will be taken literally, thus no further escaping is required.
+	# - $3 Path to config file
+	# - Optional: $4 Line pattern after which the setting will be added instead of end of file with grep extended regular expression support
+	# - GCI_PRESERVE=1 G_CONFIG_INJECT preserves current setting, if present.
+	# - GCI_BACKUP=1 G_CONFIG_INJECT creates a backup before editing the file, if backup does not yet exist, to: $3.bak
+	# - GCI_NEWLINE=1 G_CONFIG_INJECT explicitly expands newlines \n within $2, which by default are taken literally
+	# NB:
+	# - Within double quotes "", as usual, escape literally meant double quotes and dollar signs $ with leading backslash \.
+	# - Within single quotes '', as usual, escape literally meant single quotes via: '\'' # End leading string; Add escaped single quote; Start trailing string
+	# - Additionally in case of extended regular expression support ($1 and $4), the following characters need to be escaped via backslash \, if wanted literally:
+	#	\ . + * ? [ ( { ^ & $ |
+	# Example:
+	# - G_CONFIG_INJECT 'prefer-family[[:blank:]=]' 'prefer-family = IPv4' /etc/wgetrc
 	G_CONFIG_INJECT(){
 
 		[[ $G_PROGRAM_NAME ]] || local G_PROGRAM_NAME='G_CONFIG_INJECT'
 		local pattern="$1"
-		local setting="${2//\\/\\\\}"; setting="${setting//./\\.}"; setting="${setting//\*/\\\*}"; setting="${setting//[/\\[}"; setting="${setting//^/\\^}"; setting="${setting//&/\\&}"; setting="${setting//$/\\$}"; setting="${setting//|/\\|}"
+		local setting="${2//\\/\\\\}"; setting="${setting//./\\.}"; setting="${setting//+/\\+}"; "setting="${setting//\*/\\\*}"; "setting="${setting//\?/\\\?}"; setting="${setting//[/\\[}"
+		setting="${setting//\(/\\\(}"; setting="${setting//{/\\{}"; setting="${setting//^/\\^}"; setting="${setting//&/\\&}"; setting="${setting//$/\\$}"; setting="${setting//|/\\|}"
+		[[ $GCI_NEWLINE == 1 ]] && setting="${setting//\\\\n/\\n}"
 		local file="$3"
 		local after="$4"
 		local error=''
@@ -2363,11 +2370,10 @@ into file \$3
 	$file
 $after
 NB:
- - grep basic regex is supported for matching patterns \$1 and \$4, thus related special characters need to be escaped manually via leading backslash \\, if wanted literally:
- 	\\ . * [ ^ & \$ |
- - For setting \$2 special character escaping is done internally, thus only single/double quote related escaping is required, if wanted literally:
-	- Within double quotes "", as usual, escape literally meant double quotes and dollar signs \$ with leading backslash \\.
-	- Within single quotes '', as usual, escape literally meant single quotes via: '\\'' # End leading string; Add escaped single quote; Start trailing string"
+ - Within double quotes "", as usual, escape literally meant double quotes and dollar signs $ with leading backslash \.
+ - Within single quotes '', as usual, escape literally meant single quotes via: '\'' # End leading string; Add escaped single quote; Start trailing string
+ - Additionally in case of extended regular expression support (\$1 and \$4), the following characters need to be escaped via backslash \, if wanted literally:
+	\ . + * ? [ ( { ^ & $ |
 
 			unset syntax_error
 
@@ -2379,81 +2385,81 @@ NB:
 Please verify the existence of the file \$3
 	$file\n
 Retry with proper permissions or apply the setting manually:
-	$(sed "c\\$setting" <<< '')"
+	$(sed -E "c\\$setting" <<< '')"
 
-		elif error=$(grep -q "^[[:blank:]]*$pattern" $file 2>&1); then
+		elif error=$(grep -Eq "^[[:blank:]]*$pattern" $file 2>&1); then
 			# As an error within the condition leads to result "false", it can be caught only in next "elif"/"else" statement.
 
-			if [[ $PRESERVE == 1 ]]; then
+			if [[ $GCI_PRESERVE == 1 ]]; then
 
-				G_DIETPI-NOTIFY 0 "Current setting in \e[33m$file\e[0m will be preserved: \e[33m$(grep -m1 "^[[:blank:]]*$pattern" $file | sed 's|\\|\\\\|g')\e[0m"
+				G_DIETPI-NOTIFY 0 "Current setting in \e[33m$file\e[0m will be preserved: \e[33m$(grep -Em1 "^[[:blank:]]*$pattern" $file | sed 's|\\|\\\\|g')\e[0m"
 
-			elif error=$(grep -q "^[[:blank:]]*$setting\([[:space:]]\|$\)" $file 2>&1); then
+			elif error=$(grep -Eq "^[[:blank:]]*$setting([[:space:]]|$)" $file 2>&1); then
 
-				G_DIETPI-NOTIFY 0 "Desired setting in \e[33m$file\e[0m was already set: \e[33m$(grep -m1 "^[[:blank:]]*$pattern" $file | sed 's|\\|\\\\|g')\e[0m"
+				G_DIETPI-NOTIFY 0 "Desired setting in \e[33m$file\e[0m was already set: \e[33m$(grep -Em1 "^[[:blank:]]*$pattern" $file | sed 's|\\|\\\\|g')\e[0m"
 
-			elif error=$( (( $(grep -c "^[[:blank:]]*$pattern" $file 2>&1) > 1 )) 2>&1); then
+			elif error=$( (( $(grep -Ec "^[[:blank:]]*$pattern" $file 2>&1) > 1 )) 2>&1); then
 				[[ $error ]] && { syntax_error; return 1; }
 
 				G_WHIP_MSG "[FAILED] Setting was found multiple times\n
 The pattern \$1
-	$(sed "c\\$pattern" <<< '')
+	$(sed -E "c\\$pattern" <<< '')
 was found multiple times in file \$3
 	$file\n
 ____________
-$(grep -n "^[[:blank:]]*$pattern" $file) 
+$(grep -En "^[[:blank:]]*$pattern" $file) 
 ____________\n
 Either the pattern \$1 needs to be more specific or the desired setting can appear multiple times by design and it cannot be predicted which instance to edit.
 Please retry with more specific parameter \$1 or apply the setting manually:
-	$(sed "c\\$setting" <<< '')"
+	$(sed -E "c\\$setting" <<< '')"
 
 			else
 				[[ $error ]] && { syntax_error; return 1; }
 
-				[[ $BACKUP == 1 && ! -f $file.bak ]] && cp -a $file $file.bak && G_DIETPI-NOTIFY 2 "Config file backup created: \e[33m$file.bak\e[0m"
-				error=$(sed -i "0,\|^[[:blank:]]*$pattern.*$|s||$setting|" $file 2>&1) || { syntax_error; return 1; }
-				G_DIETPI-NOTIFY 0 "Setting in \e[33m$file\e[0m adjusted: \e[33m$(sed "c\\$setting" <<< '' | sed 's|\\|\\\\|g')\e[0m"
+				[[ $GCI_BACKUP == 1 && ! -f $file.bak ]] && cp -a $file $file.bak && G_DIETPI-NOTIFY 2 "Config file backup created: \e[33m$file.bak\e[0m"
+				error=$(sed -Ei "0,\|^[[:blank:]]*$pattern|s||$setting|" $file 2>&1) || { syntax_error; return 1; }
+				G_DIETPI-NOTIFY 0 "Setting in \e[33m$file\e[0m adjusted: \e[33m$(sed -E "c\\$setting" <<< '' | sed 's|\\|\\\\|g')\e[0m"
 
 			fi
 
-		elif error=$(grep -q "^[[:blank:]#;]*$pattern" $file 2>&1); then
+		elif error=$(grep -Eq "^[[:blank:]#;]*$pattern" $file 2>&1); then
 			[[ $error ]] && { syntax_error; return 1; }
 
-			[[ $BACKUP == 1 && ! -f $file.bak ]] && cp -a $file $file.bak && G_DIETPI-NOTIFY 2 "Config file backup created: \e[33m$file\e[0m"
-			error=$(sed -i "0,\|^[[:blank:]#;]*$pattern.*$|s||$setting|" $file 2>&1) || { syntax_error; return 1; }
-			G_DIETPI-NOTIFY 0 "Comment in \e[33m$file\e[0m converted to setting: \e[33m$(sed "c\\$setting" <<< '' | sed 's|\\|\\\\|g')\e[0m"
+			[[ $GCI_BACKUP == 1 && ! -f $file.bak ]] && cp -a $file $file.bak && G_DIETPI-NOTIFY 2 "Config file backup created: \e[33m$file\e[0m"
+			error=$(sed -Ei "0,\|^[[:blank:]#;]*$pattern|s||$setting|" $file 2>&1) || { syntax_error; return 1; }
+			G_DIETPI-NOTIFY 0 "Comment in \e[33m$file\e[0m converted to setting: \e[33m$(sed -E "c\\$setting" <<< '' | sed 's|\\|\\\\|g')\e[0m"
 
 		else
 			[[ $error ]] && { syntax_error; return 1; }
 
 			if [[ $after ]]; then
 
-				if error=$(grep -q "^[[:blank:]]*$after" $file 2>&1); then
+				if error=$(grep -Eq "^[[:blank:]]*$after" $file 2>&1); then
 
-					[[ $BACKUP == 1 && ! -f $file.bak ]] && cp -a $file $file.bak && G_DIETPI-NOTIFY 2 "Config file backup created: \e[33m$file.bak\e[0m"
-					error=$(sed -i "0,\|^[[:blank:]]*$after.*$|s||&\n$setting|" $file 2>&1) || { syntax_error; return 1; }
-					G_DIETPI-NOTIFY 0 "Added setting \e[33m$(sed "c\\$setting" <<< '' | sed 's|\\|\\\\|g')\e[0m to \e[33m$file\e[0m after line \e[33m$(grep -m1 "^[[:blank:]]*$after" $file | sed 's|\\|\\\\|g')\e[0m"
+					[[ $GCI_BACKUP == 1 && ! -f $file.bak ]] && cp -a $file $file.bak && G_DIETPI-NOTIFY 2 "Config file backup created: \e[33m$file.bak\e[0m"
+					error=$(sed -Ei "0,\|^[[:blank:]]*$after|s||&\n$setting|" $file 2>&1) || { syntax_error; return 1; }
+					G_DIETPI-NOTIFY 0 "Added setting \e[33m$(sed -E "c\\$setting" <<< '' | sed 's|\\|\\\\|g')\e[0m to \e[33m$file\e[0m after line \e[33m$(grep -Em1 "^[[:blank:]]*$after" $file | sed 's|\\|\\\\|g')\e[0m"
 
 				else
 					[[ $error ]] && { syntax_error; return 1; }
 
 					G_WHIP_MSG "[FAILED] Setting could not be added after desired line\n
 The pattern \$4
-	$(sed "c\\$after" <<< '')
+	$(sed -E "c\\$after" <<< '')
 could not be found in file \$3
 	$file\n
 Please retry with valid parameter \$4 or apply the setting manually:
-	$(sed "c\\$setting" <<< '')"
+	$(sed -E "c\\$setting" <<< '')"
 
 				fi
 
 			else
 
-				[[ $BACKUP == 1 && ! -f $file.bak ]] && cp -a $file $file.bak && G_DIETPI-NOTIFY 2 "Config file backup created: \e[33m$file.bak\e[0m"
+				[[ $GCI_BACKUP == 1 && ! -f $file.bak ]] && cp -a $file $file.bak && G_DIETPI-NOTIFY 2 "Config file backup created: \e[33m$file.bak\e[0m"
 				# The following sed does not work on empty files:
 				[[ ! -s $file ]] && echo '# Added by DietPi:' >> $file
-				error=$(sed -i "\$s|\$|\n$setting|" $file 2>&1) || { syntax_error; return 1; }
-				G_DIETPI-NOTIFY 0 "Added setting \e[33m$(sed "c\\$setting" <<< '' | sed 's|\\|\\\\|g')\e[0m to end of file \e[33m$file\e[0m"
+				error=$(sed -Ei "\$s|\$|\n$setting|" $file 2>&1) || { syntax_error; return 1; }
+				G_DIETPI-NOTIFY 0 "Added setting \e[33m$(sed -E "c\\$setting" <<< '' | sed 's|\\|\\\\|g')\e[0m to end of file \e[33m$file\e[0m"
 
 			fi
 

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -2418,7 +2418,7 @@ Please retry with more specific parameter \$1 or apply the setting manually:
 				[[ $error ]] && { syntax_error; return 1; }
 
 				[[ $GCI_BACKUP == 1 && ! -f $file.bak ]] && cp -a $file $file.bak && G_DIETPI-NOTIFY 2 "Config file backup created: \e[33m$file.bak\e[0m"
-				error=$(sed -Ei "0,\|^[[:blank:]]*$pattern|s||$setting|" $file 2>&1) || { syntax_error; return 1; }
+				error=$(sed -Ei "0,\|^[[:blank:]]*$pattern.*|s||$setting|" $file 2>&1) || { syntax_error; return 1; }
 				G_DIETPI-NOTIFY 0 "Setting in \e[33m$file\e[0m adjusted: \e[33m$(sed -E "c\\$setting" <<< '' | sed 's|\\|\\\\|g')\e[0m"
 
 			fi
@@ -2427,7 +2427,7 @@ Please retry with more specific parameter \$1 or apply the setting manually:
 			[[ $error ]] && { syntax_error; return 1; }
 
 			[[ $GCI_BACKUP == 1 && ! -f $file.bak ]] && cp -a $file $file.bak && G_DIETPI-NOTIFY 2 "Config file backup created: \e[33m$file\e[0m"
-			error=$(sed -Ei "0,\|^[[:blank:]#;]*$pattern|s||$setting|" $file 2>&1) || { syntax_error; return 1; }
+			error=$(sed -Ei "0,\|^[[:blank:]#;]*$pattern.*|s||$setting|" $file 2>&1) || { syntax_error; return 1; }
 			G_DIETPI-NOTIFY 0 "Comment in \e[33m$file\e[0m converted to setting: \e[33m$(sed -E "c\\$setting" <<< '' | sed 's|\\|\\\\|g')\e[0m"
 
 		else
@@ -2438,7 +2438,7 @@ Please retry with more specific parameter \$1 or apply the setting manually:
 				if error=$(grep -Eq "^[[:blank:]]*$after" $file 2>&1); then
 
 					[[ $GCI_BACKUP == 1 && ! -f $file.bak ]] && cp -a $file $file.bak && G_DIETPI-NOTIFY 2 "Config file backup created: \e[33m$file.bak\e[0m"
-					error=$(sed -Ei "0,\|^[[:blank:]]*$after|s||&\n$setting|" $file 2>&1) || { syntax_error; return 1; }
+					error=$(sed -Ei "0,\|^[[:blank:]]*$after.*|s||&\n$setting|" $file 2>&1) || { syntax_error; return 1; }
 					G_DIETPI-NOTIFY 0 "Added setting \e[33m$(sed -E "c\\$setting" <<< '' | sed 's|\\|\\\\|g')\e[0m to \e[33m$file\e[0m after line \e[33m$(grep -Em1 "^[[:blank:]]*$after" $file | sed 's|\\|\\\\|g')\e[0m"
 
 				else

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -2332,39 +2332,40 @@ $print_logfile_info
 
 	# Inject setting into config file
 	# - First tries to replace old setting, else commented setting and otherwise adds it to end of file.
-	#	- Optionally adds argument to new line after speficied pattern $4.
+	#	- Optionally adds argument to new line after specified pattern $4.
 	#	- PRESERVE=1 G_CONFIG_INJECT allows to keep current setting, if present.
 	#	- BACKUP=1 G_CONFIG_INJECT allows to backup to file before editing, if backup does not yet exist.
 	# - Example: G_CONFIG_INJECT 'prefer-family[[:blank:]=]' 'prefer-family = IPv4' /etc/wgetrc
-	# - Extended regular expressions can be used for the identifying patterns $1 and $4.
-	#	- Escape any of: ".+*?&\|^$()[]{}
-	#	- Escape baskashes doubled within double quotes.
+	#	- grep/sed basic regex are supported, related special characters will be escaped internally.
+	#	- Thus no special character escaping is required when adding arguments via variables.
+	#	- Within double quotes "", as usual, escape literally meant double quotes and dollar signs $ with leading backslash \.
+	#	- Within single quotes '', as usual, escape literally meant single quotes via: '\'' # End leading string; Add escaped single quote; Start trailing string
 	G_CONFIG_INJECT(){
 
 		[[ $G_PROGRAM_NAME ]] || local G_PROGRAM_NAME='G_CONFIG_INJECT'
-		local pattern="$1"
-		local setting="$2"
+		local pattern="${1//\\/\\\\}"; pattern="${pattern//./\\.}"; pattern="${pattern//\*/\\\*}"; pattern="${pattern//[/\\[}"; pattern="${pattern//^/\\^}"; pattern="${pattern//&/\\&}"; pattern="${pattern//$/\\$}"
+		local setting="${2//\\/\\\\}"; setting="${setting//./\\.}"; setting="${setting//\*/\\\*}"; setting="${setting//[/\\[}"; setting="${setting//^/\\^}"; setting="${setting//&/\\&}"; setting="${setting//$/\\$}"
 		local file="$3"
-		local after="$4"
+		local after="${4//\\/\\\\}"; after="${after//./\\.}"; after="${after//\*/\\\*}"; after="${after//[/\\[}"; after="${after//^/\\^}"; after="${after//&/\\&}"; after="${after//$/\\$}"
 		local error=''
 
 		syntax_error(){
 
-			[[ $after ]] && after='after line\n	'.$after.' ($4)\n'
-			[[ $error ]] && error="\n\"grep\" reported the following error:\n	$error\n"
+			[[ $after ]] && after='after line $4\n	'.$after.'\n'
+			[[ $error ]] && error="\n\"grep\" or \"sed\" reported the following error:\n	$error\n"
 
 			G_WHIP_MSG "[FAILED] Syntax error
 $error
-Couldn't add setting (\$2)
+Couldn't add setting \$2
 	$setting
-into file (\$3)
+into file \$3
 	$file
 $after
 NB:
-- Please escape any of the following characters with leading backslash (\):
-	\".+*?\\|^\$()[]{}
-- Within double quotes (\"\"), please escape backslashes (\) doubled:
-	\"\\\\\\\\\" results in \"\\\""
+ - grep/sed basic regex are supported, related special characters will be escaped internally.
+ - Thus no special character escaping is required when adding arguments via variables.
+ - Within double quotes \"\", as usual, escape literally meant double quotes, backslashes \ and dollar signs $ via leading backslash.
+ - Within single quotes '', as usual, escape literally meant single quotes via: '\'' # End leading string; Add escaped single quote; Start trailing string"
 
 			unset syntax_error
 
@@ -2372,72 +2373,85 @@ NB:
 
 		if [[ ! -w $file ]]; then
 
-			G_WHIP_MSG "[FAILED] '$file' does not exist or cannot be written to by current user.\n
-Please verify the existance of the file, retry with proper permissions or apply the setting manually:
-	$(sed -E "c\\$setting" <<< '')"
+			G_WHIP_MSG "[FAILED] File does not exist or cannot be written to by current user\n
+Please verify the existence of the file \$3
+	$file\n
+Retry with proper permissions or apply the setting manually:
+	$(sed "c\\$setting" <<< '')"
 
-		elif error=$(grep -qE "^[[:blank:]]*$pattern" $file 2>&1); then
-			# As an error within the condition leads to "false", it can be catched only after next condition match
+		elif error=$(grep -q "^[[:blank:]]*$pattern" $file 2>&1); then
+			# As an error within the condition leads to result "false", it can be caught only in next "elif"/"else" statement.
 
 			if [[ $PRESERVE == 1 ]]; then
 
-				G_DIETPI-NOTIFY 0 "Current setting in \e[33m$file\e[0m will be preserved: \e[33m$(grep -Em1 "^[[:blank:]]*$pattern" $file | sed 's|\\|\\\\|g')\e[0m"
+				G_DIETPI-NOTIFY 0 "Current setting in \e[33m$file\e[0m will be preserved: \e[33m$(grep -m1 "^[[:blank:]]*$pattern" $file | sed 's|\\|\\\\|g')\e[0m"
 
-			elif error=$(grep -qE "^[[:blank:]]*$setting([[:space:]]|$)" $file 2>&1); then
+			elif error=$(grep -q "^[[:blank:]]*$setting\([[:space:]]\|$\)" $file 2>&1); then
 
-				G_DIETPI-NOTIFY 0 "Desired setting in \e[33m$file\e[0m was already set: \e[33m$(grep -Em1 "^[[:blank:]]*$pattern" $file | sed 's|\\|\\\\|g')\e[0m"
+				G_DIETPI-NOTIFY 0 "Desired setting in \e[33m$file\e[0m was already set: \e[33m$(grep -m1 "^[[:blank:]]*$pattern" $file | sed 's|\\|\\\\|g')\e[0m"
+
+			elif error=$( (( $(grep -c "^[[:blank:]]*$pattern" $file 2>&1) > 1 )) 2>&1); then
+				[[ $error ]] && { syntax_error; return 1; }
+
+				G_WHIP_MSG "[FAILED] Setting was found multiple times\n
+The pattern \$1
+	$(sed "c\\$pattern" <<< '')
+was found multiple times in file \$3
+	$file\n
+____________
+$(grep -n "^[[:blank:]]*$pattern" $file) 
+____________\n
+Either the pattern \$1 needs to be more specific or the desired setting can appear multiple times by design and it cannot be predicted which instance to edit.
+Please retry with more specific parameter \$1 or apply the setting manually:
+	$(sed "c\\$setting" <<< '')"
 
 			else
-				[[ $error ]] && syntax_error && return 1
+				[[ $error ]] && { syntax_error; return 1; }
 
-				[[ $BACKUP == 1 && ! -f $file.bak ]] && cp -a $file $file.bak && G_DIETPI-NOTIFY 2 "Config file backup created: \e[33m$file\e[0m"
-				sed -Ei "0,\|^[[:blank:]]*$pattern.*$|s||$setting|" $file
-				(( $? )) && syntax_error && return 1
-				G_DIETPI-NOTIFY 0 "Setting in \e[33m$file\e[0m adjusted: \e[33m$(sed -E "c\\$setting" <<< '' | sed 's|\\|\\\\|g')\e[0m"
+				[[ $BACKUP == 1 && ! -f $file.bak ]] && cp -a $file $file.bak && G_DIETPI-NOTIFY 2 "Config file backup created: \e[33m$file.bak\e[0m"
+				error=$(sed -i "0,\|^[[:blank:]]*$pattern.*$|s||$setting|" $file 2>&1) || { syntax_error; return 1; }
+				G_DIETPI-NOTIFY 0 "Setting in \e[33m$file\e[0m adjusted: \e[33m$(sed "c\\$setting" <<< '' | sed 's|\\|\\\\|g')\e[0m"
 
 			fi
 
-		elif error=$(grep -qE "^[[:blank:]#;]*$pattern" $file 2>&1); then
-			[[ $error ]] && syntax_error && return 1
+		elif error=$(grep -q "^[[:blank:]#;]*$pattern" $file 2>&1); then
+			[[ $error ]] && { syntax_error; return 1; }
 
 			[[ $BACKUP == 1 && ! -f $file.bak ]] && cp -a $file $file.bak && G_DIETPI-NOTIFY 2 "Config file backup created: \e[33m$file\e[0m"
-			sed -Ei "0,\|^[[:blank:]#;]*$pattern.*$|s||$setting|" $file
-			(( $? )) && syntax_error && return 1
-			G_DIETPI-NOTIFY 0 "Comment in \e[33m$file\e[0m converted to setting: \e[33m$(sed -E "c\\$setting" <<< '' | sed 's|\\|\\\\|g')\e[0m"
+			error=$(sed -i "0,\|^[[:blank:]#;]*$pattern.*$|s||$setting|" $file 2>&1) || { syntax_error; return 1; }
+			G_DIETPI-NOTIFY 0 "Comment in \e[33m$file\e[0m converted to setting: \e[33m$(sed "c\\$setting" <<< '' | sed 's|\\|\\\\|g')\e[0m"
 
 		else
-			[[ $error ]] && syntax_error && return 1
+			[[ $error ]] && { syntax_error; return 1; }
 
 			if [[ $after ]]; then
 
-				if error=$(grep -qE "^[[:blank:]]*$after" $file 2>&1); then
+				if error=$(grep -q "^[[:blank:]]*$after" $file 2>&1); then
 
-					[[ $BACKUP == 1 && ! -f $file.bak ]] && cp -a $file $file.bak && G_DIETPI-NOTIFY 2 "Config file backup created: \e[33m$file\e[0m"
-					sed -Ei "0,\|^[[:blank:]]*$after.*$|s||&\n$setting|" $file
-					(( $? )) && syntax_error && return 1
-					G_DIETPI-NOTIFY 0 "Added setting \e[33m$(sed -E "c\\$setting" <<< '' | sed 's|\\|\\\\|g')\e[0m to \e[33m$file\e[0m after line \e[33m$(grep -Em1 "^[[:blank:]]*$after" $file | sed 's|\\|\\\\|g')\e[0m"
+					[[ $BACKUP == 1 && ! -f $file.bak ]] && cp -a $file $file.bak && G_DIETPI-NOTIFY 2 "Config file backup created: \e[33m$file.bak\e[0m"
+					error=$(sed -i "0,\|^[[:blank:]]*$after.*$|s||&\n$setting|" $file 2>&1) || { syntax_error; return 1; }
+					G_DIETPI-NOTIFY 0 "Added setting \e[33m$(sed "c\\$setting" <<< '' | sed 's|\\|\\\\|g')\e[0m to \e[33m$file\e[0m after line \e[33m$(grep -m1 "^[[:blank:]]*$after" $file | sed 's|\\|\\\\|g')\e[0m"
 
 				else
-					[[ $error ]] && syntax_error && return 1
+					[[ $error ]] && { syntax_error; return 1; }
 
-					G_WHIP_MSG "[FAILED] Setting could not be added after desired line.\n
-The pattern
-	$(sed -E "c\\$after" <<< '')
-could not be found in file
+					G_WHIP_MSG "[FAILED] Setting could not be added after desired line\n
+The pattern \$4
+	$(sed "c\\$after" <<< '')
+could not be found in file \$3
 	$file\n
-Please retry with valid parameter (\$4) or apply the setting manually:
-	$(sed -E "c\\$setting" <<< '')"
+Please retry with valid parameter \$4 or apply the setting manually:
+	$(sed "c\\$setting" <<< '')"
 
 				fi
 
 			else
 
-				[[ $BACKUP == 1 && ! -f $file.bak ]] && cp -a $file $file.bak && G_DIETPI-NOTIFY 2 "Config file backup created: \e[33m$file\e[0m"
+				[[ $BACKUP == 1 && ! -f $file.bak ]] && cp -a $file $file.bak && G_DIETPI-NOTIFY 2 "Config file backup created: \e[33m$file.bak\e[0m"
 				# The following sed does not work on empty files:
 				[[ ! -s $file ]] && echo '# Added by DietPi:' >> $file
-				sed -Ei "\$s|\$|\n$setting|" $file
-				(( $? )) && syntax_error && return 1
-				G_DIETPI-NOTIFY 0 "Added setting \e[33m$(sed -E "c\\$setting" <<< '' | sed 's|\\|\\\\|g')\e[0m to end of file \e[33m$file\e[0m"
+				error=$(sed -i "\$s|\$|\n$setting|" $file 2>&1) || { syntax_error; return 1; }
+				G_DIETPI-NOTIFY 0 "Added setting \e[33m$(sed "c\\$setting" <<< '' | sed 's|\\|\\\\|g')\e[0m to end of file \e[33m$file\e[0m"
 
 			fi
 

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -2408,7 +2408,7 @@ The pattern \$1
 was found multiple times in file \$3
 	$file\n
 ____________
-$(grep -En "^[[:blank:]]*$pattern" $file) 
+$(grep -En "^[[:blank:]]*$pattern" $file)
 ____________\n
 Either the pattern \$1 needs to be more specific or the desired setting can appear multiple times by design and it cannot be predicted which instance to edit.
 Please retry with more specific parameter \$1 or apply the setting manually:
@@ -2426,7 +2426,7 @@ Please retry with more specific parameter \$1 or apply the setting manually:
 		elif error=$(grep -Eq "^[[:blank:]#;]*$pattern" $file 2>&1); then
 			[[ $error ]] && { syntax_error; return 1; }
 
-			[[ $GCI_BACKUP == 1 && ! -f $file.bak ]] && cp -a $file $file.bak && G_DIETPI-NOTIFY 2 "Config file backup created: \e[33m$file\e[0m"
+			[[ $GCI_BACKUP == 1 && ! -f $file.bak ]] && cp -a $file $file.bak && G_DIETPI-NOTIFY 2 "Config file backup created: \e[33m$file.bak\e[0m"
 			error=$(sed -Ei "0,\|^[[:blank:]#;]*$pattern.*|s||$setting|" $file 2>&1) || { syntax_error; return 1; }
 			G_DIETPI-NOTIFY 0 "Comment in \e[33m$file\e[0m converted to setting: \e[33m$(sed -E "c\\$setting" <<< '' | sed 's|\\|\\\\|g')\e[0m"
 

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -2343,21 +2343,21 @@ $print_logfile_info
 	G_CONFIG_INJECT(){
 
 		[[ $G_PROGRAM_NAME ]] || local G_PROGRAM_NAME='G_CONFIG_INJECT'
-		local pattern="${1//\\/\\\\}"; pattern="${pattern//./\\.}"; pattern="${pattern//\*/\\\*}"; pattern="${pattern//[/\\[}"; pattern="${pattern//^/\\^}"; pattern="${pattern//&/\\&}"; pattern="${pattern//$/\\$}"
-		local setting="${2//\\/\\\\}"; setting="${setting//./\\.}"; setting="${setting//\*/\\\*}"; setting="${setting//[/\\[}"; setting="${setting//^/\\^}"; setting="${setting//&/\\&}"; setting="${setting//$/\\$}"
+		local pattern="${1//\\/\\\\}"; pattern="${pattern//./\\.}"; pattern="${pattern//\*/\\\*}"; pattern="${pattern//[/\\[}"; pattern="${pattern//^/\\^}"; pattern="${pattern//&/\\&}"; pattern="${pattern//$/\\$}"; pattern="${pattern//|/\\|}"
+		local setting="${2//\\/\\\\}"; setting="${setting//./\\.}"; setting="${setting//\*/\\\*}"; setting="${setting//[/\\[}"; setting="${setting//^/\\^}"; setting="${setting//&/\\&}"; setting="${setting//$/\\$}"; setting="${setting//|/\\|}"
 		local file="$3"
-		local after="${4//\\/\\\\}"; after="${after//./\\.}"; after="${after//\*/\\\*}"; after="${after//[/\\[}"; after="${after//^/\\^}"; after="${after//&/\\&}"; after="${after//$/\\$}"
+		local after="${4//\\/\\\\}"; after="${after//./\\.}"; after="${after//\*/\\\*}"; after="${after//[/\\[}"; after="${after//^/\\^}"; after="${after//&/\\&}"; after="${after//$/\\$}"; after="${after//|/\\|}"
 		local error=''
 
 		syntax_error(){
 
-			[[ $after ]] && after='after line $4\n	'.$after.'\n'
+			[[ $after ]] && after="after line \$4\n	$after (raw escaped input)\n"
 			[[ $error ]] && error="\n\"grep\" or \"sed\" reported the following error:\n	$error\n"
 
 			G_WHIP_MSG "[FAILED] Syntax error
 $error
 Couldn't add setting \$2
-	$setting
+	$setting (raw escaped input)
 into file \$3
 	$file
 $after

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -2339,6 +2339,7 @@ $print_logfile_info
 	# - GCI_PRESERVE=1 G_CONFIG_INJECT preserves current setting, if present.
 	# - GCI_BACKUP=1 G_CONFIG_INJECT creates a backup before editing the file, if backup does not yet exist, to: $3.bak
 	# - GCI_NEWLINE=1 G_CONFIG_INJECT explicitly expands newlines \n within $2, which by default are taken literally
+	#	- Be careful with this, since pattern matching is only done per line which can lead to doubled lines when applying G_CONFIG_INJECT a second time.
 	# NB:
 	# - Within double quotes "", as usual, escape literally meant double quotes and dollar signs $ with leading backslash \.
 	# - Within single quotes '', as usual, escape literally meant single quotes via: '\'' # End leading string; Add escaped single quote; Start trailing string
@@ -2370,10 +2371,10 @@ into file \$3
 	$file
 $after
 NB:
- - Within double quotes "", as usual, escape literally meant double quotes and dollar signs $ with leading backslash \.
+ - Within double quotes \"\", as usual, escape literally meant double quotes and dollar signs $ with leading backslash \.
  - Within single quotes '', as usual, escape literally meant single quotes via: '\'' # End leading string; Add escaped single quote; Start trailing string
  - Additionally in case of extended regular expression support (\$1 and \$4), the following characters need to be escaped via backslash \, if wanted literally:
-	\ . + * ? [ ( { ^ & $ |
+	\ . + * ? [ ( { ^ & $ |"
 
 			unset syntax_error
 

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -2351,7 +2351,7 @@ $print_logfile_info
 
 		[[ $G_PROGRAM_NAME ]] || local G_PROGRAM_NAME='G_CONFIG_INJECT'
 		local pattern="$1"
-		local setting="${2//\\/\\\\}"; setting="${setting//./\\.}"; setting="${setting//+/\\+}"; "setting="${setting//\*/\\\*}"; "setting="${setting//\?/\\\?}"; setting="${setting//[/\\[}"
+		local setting="${2//\\/\\\\}"; setting="${setting//./\\.}"; setting="${setting//+/\\+}"; setting="${setting//\*/\\\*}"; setting="${setting//\?/\\\?}"; setting="${setting//[/\\[}"
 		setting="${setting//\(/\\\(}"; setting="${setting//{/\\{}"; setting="${setting//^/\\^}"; setting="${setting//&/\\&}"; setting="${setting//$/\\$}"; setting="${setting//|/\\|}"
 		[[ $GCI_NEWLINE == 1 ]] && setting="${setting//\\\\n/\\n}"
 		local file="$3"

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -91,8 +91,8 @@
 			#	consoleblank disable x86_64
 			if [[ -f /etc/default/grub ]]; then
 
-				G_CONFIG_INJECT 'GRUB_CMDLINE_LINUX_DEFAULT=' 'GRUB_CMDLINE_LINUX_DEFAULT=\"consoleblank=0 quiet\"' /etc/default/grub
-				G_CONFIG_INJECT 'GRUB_CMDLINE_LINUX=' 'GRUB_CMDLINE_LINUX=\"net\.ifnames=0\"' /etc/default/grub
+				G_CONFIG_INJECT 'GRUB_CMDLINE_LINUX_DEFAULT=' 'GRUB_CMDLINE_LINUX_DEFAULT="consoleblank=0 quiet"' /etc/default/grub
+				G_CONFIG_INJECT 'GRUB_CMDLINE_LINUX=' 'GRUB_CMDLINE_LINUX="net.ifnames=0"' /etc/default/grub
 				G_CONFIG_INJECT 'GRUB_TIMEOUT=' 'GRUB_TIMEOUT=0' /etc/default/grub
 				update-grub
 
@@ -582,7 +582,7 @@ _EOF_
 			#-------------------------------------------------------------------------------
 			#Move DietPi globals and login scripts into new /etc/bashrc.d location to load on all interactive shells:
 			mkdir -p /etc/bashrc.d
-			G_CONFIG_INJECT '.*/etc/bashrc\.d/.*' 'for i in /etc/bashrc\.d/\*\.sh; do \[ -r "\$i" \] \&\& \. \$i; done' /etc/bash.bashrc
+			G_CONFIG_INJECT '.*/etc/bashrc\.d/.*' 'for i in /etc/bashrc.d/*.sh; do [ -r "\$i" ] && . \$i; done' /etc/bash.bashrc
 			sed -i '/\/DietPi/d' /root/.bashrc #should already be removed, failsafe start clean
 			for i in /home/*/.bashrc; do sed -i '/\/DietPi/d' $i; done #should already be removed, failsafe start clean
 			rm /etc/profile.d/99-dietpi* &> /dev/null
@@ -765,7 +765,7 @@ _EOF_
 			sed -i '/^aSOFTWARE_INSTALL_STATE\[148\]=/c\aSOFTWARE_INSTALL_STATE\[148\]=0' /DietPi/dietpi/.installed &> /dev/null
 			#-------------------------------------------------------------------------------
 			#ASUS TB WiFi: https://github.com/Fourdee/DietPi/issues/1760
-			(( $G_HW_MODEL == 52 )) && G_CONFIG_INJECT '^8723bs' '8723bs' /etc/modules
+			(( $G_HW_MODEL == 52 )) && G_CONFIG_INJECT '8723bs' '8723bs' /etc/modules
 			#-------------------------------------------------------------------------------
 			#Software reinstalls:
 			#	https://github.com/Fourdee/DietPi/issues/1877#issuecomment-403421942
@@ -1184,7 +1184,7 @@ We strongly recommend you select "0 : Re-enable IPv6 on kernel level". By doing 
 
 					mkdir -p /etc/systemd/system/transmission-daemon.service.d
 					echo -e '[Service]\nGroup=dietpi' >> /etc/systemd/system/transmission-daemon.service.d/dietpi-group.conf
-					G_CONFIG_INJECT '\"umask\":' '    \"umask\": 7,' /etc/transmission-daemon/settings.json
+					G_CONFIG_INJECT '\"umask\":' '    "umask": 7,' /etc/transmission-daemon/settings.json
 
 				fi
 				if grep -q '^aSOFTWARE_INSTALL_STATE\[42\]=2' /DietPi/dietpi/.installed; then

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -582,7 +582,7 @@ _EOF_
 			#-------------------------------------------------------------------------------
 			#Move DietPi globals and login scripts into new /etc/bashrc.d location to load on all interactive shells:
 			mkdir -p /etc/bashrc.d
-			G_CONFIG_INJECT '.*/etc/bashrc\.d/.*' 'for i in /etc/bashrc.d/*.sh; do [ -r "\$i" ] && . \$i; done' /etc/bash.bashrc
+			G_CONFIG_INJECT '.*/etc/bashrc\.d/.*' 'for i in /etc/bashrc.d/*.sh; do [ -r "$i" ] && . $i; done' /etc/bash.bashrc
 			sed -i '/\/DietPi/d' /root/.bashrc #should already be removed, failsafe start clean
 			for i in /home/*/.bashrc; do sed -i '/\/DietPi/d' $i; done #should already be removed, failsafe start clean
 			rm /etc/profile.d/99-dietpi* &> /dev/null
@@ -1097,7 +1097,7 @@ _EOF_
 			>> /root/.ssh/known_hosts
 			sed -i '/^dietpi.com/d' /root/.ssh/known_hosts
 			sed -i '/^185.101.93.93/d' /root/.ssh/known_hosts
-			G_CONFIG_INJECT 'ssh.dietpi.com[[:blank:]]' 'ssh.dietpi.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDE6aw3r6aOEqendNu376iiCHr9tGBIWPgfrLkzjXjEsHGyVSUFNnZt6pftrDeK7UX\+qX4FxOwQlugG4fymOHbimRCFiv6cf7VpYg1Ednquq9TLb7/cIIbX8a6AuRmX4fjdGuqwmBq3OG7ZksFcYEFKt5U4mAJIaL8hXiM2iXjgY02LqiQY/QWATsHI4ie9ZOnwrQE\+Rr6mASN1BVFuIgyHIbwX54jsFSnZ/7CdBMkuAd9B8JkxppWVYpYIFHE9oWNfjh/epdK8yv9Oo6r0w5Rb\+4qaAc5g\+RAaknHeV6Gp75d2lxBdCm5XknKKbGma2\+/DfoE8WZTSgzXrYcRlStYN' /root/.ssh/known_hosts
+			G_CONFIG_INJECT 'ssh.dietpi.com[[:blank:]]' 'ssh.dietpi.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDE6aw3r6aOEqendNu376iiCHr9tGBIWPgfrLkzjXjEsHGyVSUFNnZt6pftrDeK7UX+qX4FxOwQlugG4fymOHbimRCFiv6cf7VpYg1Ednquq9TLb7/cIIbX8a6AuRmX4fjdGuqwmBq3OG7ZksFcYEFKt5U4mAJIaL8hXiM2iXjgY02LqiQY/QWATsHI4ie9ZOnwrQE+Rr6mASN1BVFuIgyHIbwX54jsFSnZ/7CdBMkuAd9B8JkxppWVYpYIFHE9oWNfjh/epdK8yv9Oo6r0w5Rb+4qaAc5g+RAaknHeV6Gp75d2lxBdCm5XknKKbGma2+/DfoE8WZTSgzXrYcRlStYN' /root/.ssh/known_hosts
 			#-------------------------------------------------------------------------------
 			#Rock64, remove HW accell config, as its not currently functional: https://github.com/Fourdee/DietPi/issues/2086
 			(( $G_HW_MODEL == 43 )) && rm /etc/X11/xorg.conf.d/20-armsoc.conf &> /dev/null


### PR DESCRIPTION
**Status**: Testing
- [x] Check all DietPi code internal calls for extended regular expression use
- [x] Check all DietPi code internal calls for escaping within $2
- [x] Check newline support
- [x] Changelog

**Reference**: https://github.com/Fourdee/DietPi/issues/2215

**Commit list/description**:
+ DietPi-Globals | G_CONFIG_INJECT: Minor wording and error catching enhancements
  - Now shows `sed` error output in whiptail prompt as well
+ DietPi-Globals | G_CONFIG_INJECT: Do required special character escaping (**on $2 only!**) function internally
  - Only the usual single and double quote string escaping needs to be done, when not adding via variable.
+ DietPi-Globals | G_CONFIG_INJECT: Remove extended regular expression support
  - The ext regex support doesn't outweigh the way larger escaping effort and bug vulnerability. And even with basic regex only, `(pattern1|pattern2)` or `[char]+` can be done via `\(pattern1\|pattern2\)` resp. `[char]\+`.
+ DietPi-Globals | G_CONFIG_INJECT: Use more individual option variable names