### PR TITLE
DietPi-Software | Docker: Set docker data via config file instead of systemd unit

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -32,6 +32,7 @@ Bug Fixes:
  - DietPi-Software | PHP/databases: Resolved an issue where PHP database modules were not installed, when installing a new database and PHP was already installed before.
  - DietPi-Software | OpenBazaar: Resolved an issue where remote OB clients could not connect to server with default configuration: https://github.com/Fourdee/DietPi/pull/2224
  - DietPi-Software | Resolved an issue where a global password with special characters lead to failing installs, due to missing escaping within our internal function G_CONFIG_INJECT. Thanks to @MistahDarcy for reporting this issue: https://github.com/Fourdee/DietPi/issues/2215
+ - DietPi-Software | Docker: Resolved an issue where the Docker daemon failes to start due to invalid command argument. Thanks to @mspieth376 for reporting this issue: https://github.com/Fourdee/DietPi/issues/2238
  - DietPi-Obtain_network_details | Resolved a tiny visual-only error message on non-root logins. Thanks to @AndrewZ for reporting: https://dietpi.com/phpbb/viewtopic.php?f=9&t=5194
  - DietPi-Update | Resolved a visual-only issue, where wrong RC versions could have been shown during incremental patching: https://github.com/Fourdee/DietPi/issues/2190
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11868,14 +11868,17 @@ _EOF_
 
 			Banner_Configuration
 
-			# Create directory for docker containers
+			# Move docker containers to dietpi_userdata
 			mkdir $G_FP_DIETPI_USERDATA/docker-data
+			if [[ -f /etc/docker/daemon.json ]]; then
 
-			# stop service
-			systemctl stop docker.service
+				GCI_PRESERVE=1 G_CONFIG_INJECT '"data-root":' "    \"data-root\": \"$G_FP_DIETPI_USERDATA/docker-data\"," /etc/docker/daemon.json '^\{([[:space:]]|$)'
 
-			# Set container(s) locations in /lib/systemd/system/docker.service
-			sed -i "/ExecStart=\/usr\/bin\/dockerd/c\ExecStart=\/usr\/bin\/dockerd -g $G_FP_DIETPI_USERDATA\/docker-data -H fd:\/\/" /lib/systemd/system/docker.service
+			else
+
+				echo -e "{\n    \"data-root\": \"$G_FP_DIETPI_USERDATA/docker-data\"\n}" > /etc/docker/daemon.json
+
+			fi
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11869,10 +11869,10 @@ _EOF_
 			Banner_Configuration
 
 			# Move docker containers to dietpi_userdata
-			mkdir $G_FP_DIETPI_USERDATA/docker-data
+			mkdir -p $G_FP_DIETPI_USERDATA/docker-data
 			if [[ -f /etc/docker/daemon.json ]]; then
 
-				GCI_PRESERVE=1 G_CONFIG_INJECT '"data-root":' "    \"data-root\": \"$G_FP_DIETPI_USERDATA/docker-data\"," /etc/docker/daemon.json '^\{([[:space:]]|$)'
+				GCI_PRESERVE=1 G_CONFIG_INJECT '"data-root":' "    \"data-root\": \"$G_FP_DIETPI_USERDATA/docker-data\"," /etc/docker/daemon.json '^\{([[:space:]]\|$)'
 
 			else
 


### PR DESCRIPTION
**Status**: Ready
- [x] Jessie
- [x] Stretch
  - [x] Fresh install
  - [x] Reinstall
  - [x] Reinstall with custom `daemon.json` -- fix applied
- [x] Buster
- [x] Changelog

**Reference**: https://github.com/Fourdee/DietPi/issues/2238

**Commit list/description**:
+ DietPi-Software | Docker: Set docker data via config file instead of systemd unit dockerd argument, to not mess with possible systemd unit changes