### PR TITLE
DietPi-Software | Pydio: Install rework

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ Changes / Improvements / Optimisations:
  - DietPi-Software | Docker: Now runs under 'simple' service type (previously 'notify'), to prevent service start delay which can occur on ARM based devices (eg: RPi), from delaying other applications starting on the system: https://github.com/Fourdee/DietPi/issues/2238#issuecomment-439474766
  - DietPi-Software | Mosquito: Service updated to systemd: https://github.com/Fourdee/DietPi/issues/2243
  - DietPi-Software | Radarr/Sonarr/Lidarr: logs (both .txt and .db*) have been moved to DietPi-RAMlog: https://github.com/Fourdee/DietPi/issues/2223
+ - DietPi-Software | Pydio: WebUI warnings (security, performance) are now resolved for Nginx and Lighttpd webservers as well. Separate config files are created instead of touching the defaults, to enable required settings for Pydio only. Required PHP modules are installed and enabled, to be failsafe. Preserve existing install dirs on (re)install and inform user to update via WebUI updater: https://github.com/Fourdee/DietPi/issues/1913
 
 Bug Fixes:
  - PREP: Resovled an issue where master.zip would always be downloaded, regardless of selected branch.
@@ -34,6 +35,7 @@ Bug Fixes:
  - DietPi-Software | Jackett: Resolved an issue where reinstall created an additional nested install dir. Thanks @msdos for reporting this issue: https://github.com/Fourdee/DietPi/issues/2212
  - DietPi-Software | RoonServer: Resolved an issue where reinstall created an additional nested install dir. Since RoonServer has an automated internal updater, download and install will be skipped, if install already exists.
  - DietPi-Software | PHP/databases: Resolved an issue where PHP database modules were not installed, when installing a new database and PHP was already installed before.
+ - DietPi-Software | PHP: On Buster, moved to PHP7.3, since php-apcu and php-redis are not available for PHP7.2 any more. This resolves both PHP versions being installed concurrently.
  - DietPi-Software | OpenBazaar: Resolved an issue where remote OB clients could not connect to server with default configuration: https://github.com/Fourdee/DietPi/pull/2224
  - DietPi-Software | Resolved an issue where a global password with special characters lead to failing installs, due to missing escaping within our internal function G_CONFIG_INJECT. Thanks to @MistahDarcy for reporting this issue: https://github.com/Fourdee/DietPi/issues/2215
  - DietPi-Software | Docker: Resolved an issue where the Docker daemon failes to start due to invalid command argument. Thanks to @mspieth376 for reporting this issue: https://github.com/Fourdee/DietPi/issues/2238

--- a/dietpi/conf/apache.pydio.conf
+++ b/dietpi/conf/apache.pydio.conf
@@ -1,0 +1,11 @@
+<Directory /var/www/pydio/>
+	# Allow symlinks (pydio/data)
+	Options +FollowSymlinks
+
+	# Parse .htaccess (e.g. pydio/data access denial)
+	AllowOverride All
+
+	# Disable PHP output buffering, recommended by Pydio
+ 	php_admin_value output_buffering Off
+
+ </Directory>

--- a/dietpi/conf/lighttpd.pydio.conf
+++ b/dietpi/conf/lighttpd.pydio.conf
@@ -1,0 +1,8 @@
+$HTTP["url"] =~ "^/pydio($|/)" {
+	$HTTP["url"] =~ "^/pydio/data" {
+		url.access-deny = ("")
+	}
+	setenv.add-environment += (
+		"PHP_ADMIN_VALUE" => "output_buffering=Off",
+	)
+}

--- a/dietpi/conf/lighttpd.pydio.conf
+++ b/dietpi/conf/lighttpd.pydio.conf
@@ -1,8 +1,12 @@
 $HTTP["url"] =~ "^/pydio($|/)" {
+	# Deny access to pydio/data dir
 	$HTTP["url"] =~ "^/pydio/data" {
 		url.access-deny = ("")
 	}
+
+	# Disable PHP output buffering, recommended by Pydio
 	setenv.add-environment += (
 		"PHP_ADMIN_VALUE" => "output_buffering=Off",
 	)
+
 }

--- a/dietpi/conf/nginx.sites-dietpi.pydio.config
+++ b/dietpi/conf/nginx.sites-dietpi.pydio.config
@@ -4,9 +4,6 @@ location ^~ /pydio {
 		deny all;
 	}
 
-	# Disable PHP output buffering, recommended by Pydio
-	fastcgi_param PHP_ADMIN_VALUE "output_buffering=Off";
-
 	# Enable PHP handling, which is not inherited from parent location
 	location ~ \.php(?:$|/) {
 		fastcgi_split_path_info ^(.+\.php)(/.+)$;
@@ -15,6 +12,8 @@ location ^~ /pydio {
 		fastcgi_index index.php;
 		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 		include fastcgi_params;
+		# Disable PHP output buffering, recommended by Pydio
+		fastcgi_param PHP_ADMIN_VALUE "output_buffering=Off";
 	}
 
 }

--- a/dietpi/conf/nginx.sites-dietpi.pydio.config
+++ b/dietpi/conf/nginx.sites-dietpi.pydio.config
@@ -1,0 +1,20 @@
+location ^~ /pydio {
+	# Deny access to pydio/data dir
+	location ~ ^/pydio/data/ {
+		deny all;
+	}
+
+	# Disable PHP output buffering, recommended by Pydio
+	fastcgi_param PHP_ADMIN_VALUE "output_buffering=Off";
+
+	# Enable PHP handling, which is not inherited from parent location
+	location ~ \.php(?:$|/) {
+		fastcgi_split_path_info ^(.+\.php)(/.+)$;
+		fastcgi_param PATH_INFO $fastcgi_path_info;
+		fastcgi_pass php;
+		fastcgi_index index.php;
+		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+		include fastcgi_params;
+	}
+
+}

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5084,9 +5084,24 @@ _EOF_
 
 			Banner_Installing
 
-			DEPS_LIST="$PHP_APT_PACKAGE_NAME-intl"
-			Download_Install 'https://download.pydio.com/pub/core/archives/pydio-core-8.0.2.zip' /var/www
-			mv /var/www/pydio-core-* /var/www/pydio
+			DEPS_LIST="$PHP_APT_PACKAGE_NAME-apcu $PHP_APT_PACKAGE_NAME-gd $PHP_APT_PACKAGE_NAME-intl"
+			(( $G_DISTRO >= 4 )) && DEPS_LIST+=" $PHP_APT_PACKAGE_NAME-mbstring $PHP_APT_PACKAGE_NAME-opcache $PHP_APT_PACKAGE_NAME-xml"
+
+			# Skip install, if already present
+			if [[ -d /var/www/pydio ]]; then
+
+				G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$software_id]} install dir \"/var/www/pydio\" already exists. Download and install steps will be skipped.
+ - Please manually backup your config files+data, remove the install dir and rerun \"dietpi-software (re)install $software_id\" if you need to reinstall.
+ - If you want to update the ${aSOFTWARE_WHIP_NAME[$software_id]} instance, please use the internal updater from WebUI."
+				G_AGI $DEPS_LIST
+				unset DEPS_LIST
+
+			else
+
+				Download_Install 'https://download.pydio.com/pub/core/ci/pydio-latest.tar.gz' /var/www
+				mv /var/www/pydio-latest /var/www/pydio
+
+			fi
 
 		fi
 
@@ -10135,30 +10150,87 @@ _EOF_
 
 			Banner_Configuration
 
-			#Configure apache2
-			# - Disable php output_buffering =
-			sed -i '/output_buffering = /c\output_buffering = Off/' "$FP_PHP_BASE_DIR"/apache2/php.ini
-			# - Allow overrides and redirects
-			sed -i "/AllowOverride /c\    AllowOverride All" /etc/apache2/sites-enabled/000-default*
-			# - +Jessie
-			sed -i "/AllowOverride /c\    AllowOverride All" /etc/apache2/apache2.conf
+			# PHP configuration
+			${PHP_APT_PACKAGE_NAME}enmod apcu dom gd intl mbstring pdo_mysql xml
 
-			# - Enable apache2 rewrite engine
-			a2enmod rewrite
+			# Webserver config
+			# - Apache2
+			if (( $aSOFTWARE_INSTALL_STATE[83] > 0 )); then
 
-			#Create Mysql DB
+				# - Enable apache2 rewrite engine
+				a2enmod rewrite
+
+				# - Create Pydio Apache2 config:
+				#	- /data access denial is done via .htaccess
+				cat << _EOF_ > /etc/apache2/sites-available/dietpi-pydio.conf
+<Directory /var/www/pydio/>
+	Options +FollowSymlinks
+	AllowOverride All
+
+	php_admin_value output_buffering Off
+
+</Directory>
+_EOF_
+
+				a2ensite dietpi-pydio
+
+			# - Lighttpd
+			elif (( $aSOFTWARE_INSTALL_STATE[84] > 0 )); then
+
+				# - Enable Lighttpd setenv and access modules
+				G_CONFIG_INJECT '"mod_access",' '	"mod_access",' /etc/lighttpd/lighttpd.conf '"mod_.+",'
+				G_CONFIG_INJECT '"mod_setenv",' '	"mod_setenv",' /etc/lighttpd/lighttpd.conf '"mod_.+",'
+
+				# - Create Pydio Lighttpd config:
+				cat << _EOF_ > /etc/lighttpd/conf-available/99-dietpi-pydio.conf
+$HTTP["url"] =~ "^/pydio($|/)" {
+	$HTTP["url"] =~ "^/pydio/data" {
+		url.access-deny = ("")
+	}
+	setenv.add-environment += (
+		"PHP_ADMIN_VALUE" => "output_buffering=Off",
+	)
+}
+_EOF_
+
+				lighttpd-enable-mod dietpi-pydio
+
+			# - Nginx
+			elif (( $aSOFTWARE_INSTALL_STATE[85] > 0 )); then
+
+				# - Create Pydio Nginx config:
+				cat << _EOF_ > /etc/nginx/sites-dietpi/dietpi-pydio.config
+location ^~ /pydio {
+	location ~ ^/pydio/data/ {
+		deny all;
+	}
+	fastcgi_param PHP_ADMIN_VALUE "output_buffering=Off";
+}
+_EOF_
+
+			fi
+
+			# Create MySQL DB
 			/DietPi/dietpi/func/create_mysql_db pydio pydio "$GLOBAL_PW"
 
-			#Setup Data directory
-			local target_data_dir="$G_FP_DIETPI_USERDATA/pydio_data"
+			# Setup Data directory
+			# - Skip if already existent
+			local target_data_dir=$G_FP_DIETPI_USERDATA/pydio_data
+			if [[ -d $target_data_dir ]]; then
 
-			# - Generate user data dir
-			mkdir -p "$target_data_dir"
+				G_DIETPI-NOTIFY 2 "Existing $target_data_dir found, will migrate..."
+				[[ -e /var/www/pydio/data ]] && rm -R /var/www/pydio/data
 
-			# - move data structure
-			mv /var/www/pydio/data/* "$target_data_dir"/
-			rm -R /var/www/pydio/data
-			ln -sf "$target_data_dir" /var/www/pydio/data
+			else
+
+				# - Move data structure
+				[[ -e $target_data_dir ]] && rm -R $target_data_dir
+				mv /var/www/pydio/data $target_data_dir
+
+			fi
+
+			# Create symlink
+			ln -sf $target_data_dir /var/www/pydio/data
 
 		fi
 
@@ -11659,7 +11731,7 @@ WantedBy=multi-user.target
 _EOF_
 
 			# - logs to RAM
-			rm -R $G_FP_DIETPI_USERDATA/lidarr/logs &> /dev/null
+			rm -R $G_FP_DIETPI_USERDATA/lidarr/logs* &> /dev/null
 			mkdir -p /var/log/lidarr
 			ln -sf /var/log/lidarr $G_FP_DIETPI_USERDATA/lidarr/logs
 			ln -sf /var/log/lidarr/logs.db $G_FP_DIETPI_USERDATA/lidarr/logs.db
@@ -13577,7 +13649,14 @@ _EOF_
 			Banner_Uninstalling
 			rm -R /var/www/pydio
 
-			#drop database
+			# Remove webserver configs
+			[[ $(which a2dissite) ]] && a2dissite dietpi-pydio
+			[[ -f /etc/apache2/conf-available/dietpi-pydio.conf ]] && rm /etc/apache2/conf-available/dietpi-pydio.conf
+			[[ -f /etc/nginx/sites-dietpi/dietpi-pydio.config ]] && rm /etc/nginx/sites-dietpi/dietpi-pydio.config
+			[[ $(which lighttpd-disable-mod) ]] && lighttpd-disable-mod dietpi-pydio
+			[[ -f /etc/lighttpd/conf-available/99-dietpi-pydio.conf ]] && rm /etc/lighttpd/conf-available/99-dietpi-pydio.conf
+
+			# Drop database
 			systemctl start $MARIADB_SERVICE
 			mysqladmin drop pydio -f
 			mysql -e "drop user pydio@localhost"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3509,11 +3509,11 @@ NB: We highly recommend choosing 'Retry' first. Failing that, 'mirror' then 'mod
 			# php-common modules, used by most web software
 			package_list+=" $PHP_APT_PACKAGE_NAME-curl $PHP_APT_PACKAGE_NAME-gd $PHP_APT_PACKAGE_NAME-apcu"
 
-			# + stretch extras
-			(( $G_DISTRO >= 4 )) && package_list+=" $PHP_APT_PACKAGE_NAME-mbstring $PHP_APT_PACKAGE_NAME-opcache $PHP_APT_PACKAGE_NAME-zip $PHP_APT_PACKAGE_NAME-xml"
+			# + Stretch extras
+			(( $G_DISTRO > 3 )) && package_list+=" $PHP_APT_PACKAGE_NAME-mbstring $PHP_APT_PACKAGE_NAME-opcache $PHP_APT_PACKAGE_NAME-zip $PHP_APT_PACKAGE_NAME-xml"
 
 			# Current Buster workaround: "php-opcache" choice does not automatically install "php7.2-opcache", since php7.3-opcache (alpha) is available
-			(( $G_DISTRO >= 5 )) && package_list=${package_list/php-opcache/php7.2-opcache}
+			(( $G_DISTRO > 4 )) && package_list=${package_list/php-opcache/php7.2-opcache}
 
 			# PHP7.2/Buster dropped support for mcrypt: https://liorkaplan.wordpress.com/2017/09/10/php-7-2-is-coming-mcrypt-extension-isnt/
 			(( $G_DISTRO < 5 )) && package_list+=" $PHP_APT_PACKAGE_NAME-mcrypt"
@@ -5084,8 +5084,14 @@ _EOF_
 
 			Banner_Installing
 
+			# Install required PHP modules
 			DEPS_LIST="$PHP_APT_PACKAGE_NAME-apcu $PHP_APT_PACKAGE_NAME-gd $PHP_APT_PACKAGE_NAME-intl"
-			(( $G_DISTRO >= 4 )) && DEPS_LIST+=" $PHP_APT_PACKAGE_NAME-mbstring $PHP_APT_PACKAGE_NAME-opcache $PHP_APT_PACKAGE_NAME-xml"
+
+			# - Stretch extras
+			(( $G_DISTRO > 3 )) && DEPS_LIST+=" $PHP_APT_PACKAGE_NAME-mbstring $PHP_APT_PACKAGE_NAME-opcache $PHP_APT_PACKAGE_NAME-xml"
+
+			# - Current Buster workaround: "php-opcache" choice does not automatically install "php7.2-opcache", since php7.3-opcache (alpha) is available
+			(( $G_DISTRO > 4 )) && package_list=${package_list/php-opcache/php7.2-opcache}
 
 			# Skip install, if already present
 			if [[ -d /var/www/pydio ]]; then
@@ -10151,7 +10157,8 @@ _EOF_
 			Banner_Configuration
 
 			# PHP configuration
-			${PHP_APT_PACKAGE_NAME}enmod apcu dom gd intl mbstring pdo_mysql xml
+			${PHP_APT_PACKAGE_NAME}enmod apcu gd intl pdo_mysql
+			(( $G_DISTRO > 3 )) && phpenmod dom mbstring xml
 
 			# Webserver config
 			# - Apache2

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10155,7 +10155,7 @@ _EOF_
 
 			# Webserver config
 			# - Apache2
-			if (( $aSOFTWARE_INSTALL_STATE[83] > 0 )); then
+			if (( ${aSOFTWARE_INSTALL_STATE[83]} > 0 )); then
 
 				# - Enable apache2 rewrite engine
 				a2enmod rewrite
@@ -10175,7 +10175,7 @@ _EOF_
 				a2ensite dietpi-pydio
 
 			# - Lighttpd
-			elif (( $aSOFTWARE_INSTALL_STATE[84] > 0 )); then
+			elif (( ${aSOFTWARE_INSTALL_STATE[84]} > 0 )); then
 
 				# - Enable Lighttpd setenv and access modules
 				G_CONFIG_INJECT '"mod_access",' '	"mod_access",' /etc/lighttpd/lighttpd.conf '"mod_.+",'
@@ -10183,8 +10183,8 @@ _EOF_
 
 				# - Create Pydio Lighttpd config:
 				cat << _EOF_ > /etc/lighttpd/conf-available/99-dietpi-pydio.conf
-$HTTP["url"] =~ "^/pydio($|/)" {
-	$HTTP["url"] =~ "^/pydio/data" {
+\$HTTP["url"] =~ "^/pydio(\$|/)" {
+	\$HTTP["url"] =~ "^/pydio/data" {
 		url.access-deny = ("")
 	}
 	setenv.add-environment += (
@@ -10196,7 +10196,7 @@ _EOF_
 				lighttpd-enable-mod dietpi-pydio
 
 			# - Nginx
-			elif (( $aSOFTWARE_INSTALL_STATE[85] > 0 )); then
+			elif (( ${aSOFTWARE_INSTALL_STATE[85]} > 0 )); then
 
 				# - Create Pydio Nginx config:
 				cat << _EOF_ > /etc/nginx/sites-dietpi/dietpi-pydio.config

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10160,18 +10160,8 @@ _EOF_
 				# - Enable apache2 rewrite engine
 				a2enmod rewrite
 
-				# - Create Pydio Apache2 config:
-				#	- /data access denial is done via .htaccess
-				cat << _EOF_ > /etc/apache2/sites-available/dietpi-pydio.conf
-<Directory /var/www/pydio/>
-	Options +FollowSymlinks
-	AllowOverride All
-
-	php_admin_value output_buffering Off
-
-</Directory>
-_EOF_
-
+				# - Move Pydio Apache2 config in place:
+				mv /DietPi/dietpi/conf/apache.pydio.conf /etc/apache2/sites-available/dietpi-pydio.conf
 				a2ensite dietpi-pydio
 
 			# - Lighttpd
@@ -10181,32 +10171,15 @@ _EOF_
 				G_CONFIG_INJECT '"mod_access",' '	"mod_access",' /etc/lighttpd/lighttpd.conf '"mod_.+",'
 				G_CONFIG_INJECT '"mod_setenv",' '	"mod_setenv",' /etc/lighttpd/lighttpd.conf '"mod_.+",'
 
-				# - Create Pydio Lighttpd config:
-				cat << _EOF_ > /etc/lighttpd/conf-available/99-dietpi-pydio.conf
-\$HTTP["url"] =~ "^/pydio(\$|/)" {
-	\$HTTP["url"] =~ "^/pydio/data" {
-		url.access-deny = ("")
-	}
-	setenv.add-environment += (
-		"PHP_ADMIN_VALUE" => "output_buffering=Off",
-	)
-}
-_EOF_
-
+				# - Move Pydio Lighttpd config in place:
+				mv /DietPi/dietpi/conf/lighttpd.pydio.conf /etc/lighttpd/conf-available/99-dietpi-pydio.conf
 				lighttpd-enable-mod dietpi-pydio
 
 			# - Nginx
 			elif (( ${aSOFTWARE_INSTALL_STATE[85]} > 0 )); then
 
-				# - Create Pydio Nginx config:
-				cat << _EOF_ > /etc/nginx/sites-dietpi/dietpi-pydio.config
-location ^~ /pydio {
-	location ~ ^/pydio/data/ {
-		deny all;
-	}
-	fastcgi_param PHP_ADMIN_VALUE "output_buffering=Off";
-}
-_EOF_
+				# - Move Pydio Nginx config in place:
+				mv /DietPi/dietpi/conf/nginx.sites-dietpi.pydio.config /etc/nginx/sites-dietpi/dietpi-pydio.config
 
 			fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -295,16 +295,19 @@ NB: We highly recommend choosing 'Retry' first. Failing that, 'mirror' then 'mod
 	# - and Distro specific MariaDB service name
 	FP_PHP_BASE_DIR='/etc/php/7.0'
 	PHP_APT_PACKAGE_NAME='php'
+	PHP_BINARY='php'
 	MARIADB_SERVICE='mariadb'
 	if (( $G_DISTRO < 4 )); then
 
 		FP_PHP_BASE_DIR='/etc/php5'
 		PHP_APT_PACKAGE_NAME='php5'
+		PHP_BINARY='php5'
 		MARIADB_SERVICE='mysql'
 
 	elif (( $G_DISTRO > 4 )); then
 
-		FP_PHP_BASE_DIR='/etc/php/7.2'
+		FP_PHP_BASE_DIR='/etc/php/7.3'
+		PHP_APT_PACKAGE_NAME='php7.3'
 
 	fi
 
@@ -3507,7 +3510,7 @@ NB: We highly recommend choosing 'Retry' first. Failing that, 'mirror' then 'mod
 			fi
 
 			# php-common modules, used by most web software
-			package_list+=" $PHP_APT_PACKAGE_NAME-curl $PHP_APT_PACKAGE_NAME-gd $PHP_APT_PACKAGE_NAME-apcu"
+			package_list+=" $PHP_APT_PACKAGE_NAME-curl $PHP_APT_PACKAGE_NAME-gd $PHP_BINARY-apcu"
 
 			# + Stretch extras
 			(( $G_DISTRO > 3 )) && package_list+=" $PHP_APT_PACKAGE_NAME-mbstring $PHP_APT_PACKAGE_NAME-opcache $PHP_APT_PACKAGE_NAME-zip $PHP_APT_PACKAGE_NAME-xml"
@@ -3537,7 +3540,7 @@ NB: We highly recommend choosing 'Retry' first. Failing that, 'mirror' then 'mod
 			(( ${aSOFTWARE_INSTALL_STATE[87]} >= 1 )) && package_list+=" $PHP_APT_PACKAGE_NAME-sqlite*" # Wildcard for version (eg:3)
 
 			# Redis php module
-			(( ${aSOFTWARE_INSTALL_STATE[91]} >= 1 )) && package_list+=" $PHP_APT_PACKAGE_NAME-redis"
+			(( ${aSOFTWARE_INSTALL_STATE[91]} >= 1 )) && package_list+=" $PHP_BINARY-redis"
 
 			G_AGI $package_list
 
@@ -5085,7 +5088,7 @@ _EOF_
 			Banner_Installing
 
 			# Install required PHP modules
-			DEPS_LIST="$PHP_APT_PACKAGE_NAME-apcu $PHP_APT_PACKAGE_NAME-gd $PHP_APT_PACKAGE_NAME-intl"
+			DEPS_LIST="$PHP_BINARY-apcu $PHP_APT_PACKAGE_NAME-gd $PHP_APT_PACKAGE_NAME-intl"
 
 			# - Stretch extras
 			(( $G_DISTRO > 3 )) && DEPS_LIST+=" $PHP_APT_PACKAGE_NAME-mbstring $PHP_APT_PACKAGE_NAME-opcache $PHP_APT_PACKAGE_NAME-xml"
@@ -7486,7 +7489,7 @@ _EOF_
 
 			# Enable all installed and available PHP modules.
 			local modules_to_enable=$(ls "$FP_PHP_BASE_DIR"/mods-available | grep '.ini' | sed 's/.ini//')
-			${PHP_APT_PACKAGE_NAME}enmod "$modules_to_enable"
+			${PHP_BINARY}enmod "$modules_to_enable"
 
 			# Create PHP info pages within webroot, if webserver is installed.
 			if (( ${aSOFTWARE_INSTALL_STATE[83]} >= 1 ||
@@ -7566,7 +7569,7 @@ _EOF_
 			Banner_Configuration
 
 			# Enable redis php module, if installed:
-			"$PHP_APT_PACKAGE_NAME"enmod redis 2> /dev/null
+			${PHP_BINARY}enmod redis 2> /dev/null
 
 		fi
 
@@ -7705,7 +7708,7 @@ _EOF_
 			Banner_Configuration
 
 			G_DIETPI-NOTIFY 2 'Enabling needed PHP modules.' # https://doc.owncloud.org/server/latest/admin_manual/installation/source_installation.html#php-extensions
-			"$PHP_APT_PACKAGE_NAME"enmod curl gd intl json pdo_mysql opcache apcu redis
+			${PHP_BINARY}enmod curl gd intl json pdo_mysql opcache apcu redis
 			# Following modules are switchable since Stretch:
 			if (( $G_DISTRO > 3 )); then
 
@@ -7935,7 +7938,7 @@ _EOF_
 			Banner_Configuration
 
 			G_DIETPI-NOTIFY 2 'Enabling needed PHP modules.' # https://docs.nextcloud.com/server/14/admin_manual/installation/source_installation.html#prerequisites-label
-			"$PHP_APT_PACKAGE_NAME"enmod curl gd intl json pdo_mysql opcache apcu redis
+			${PHP_BINARY}enmod curl gd intl json pdo_mysql opcache apcu redis
 			# Following modules are switchable since Stretch:
 			if (( $G_DISTRO > 3 )); then
 
@@ -9407,7 +9410,7 @@ _EOF_
 			Banner_Configuration
 
 			# Enable required PHP modules: https://github.com/FreshRSS/FreshRSS#requirements
-			${PHP_APT_PACKAGE_NAME}enmod curl gmp intl json pdo_mysql
+			${PHP_BINARY}enmod curl gmp intl json pdo_mysql
 			(( $G_DISTRO > 3 )) && phpenmod ctype dom mbstring xml zip
 
 			# Apache configuration
@@ -10157,7 +10160,7 @@ _EOF_
 			Banner_Configuration
 
 			# PHP configuration
-			${PHP_APT_PACKAGE_NAME}enmod apcu gd intl pdo_mysql
+			${PHP_BINARY}enmod apcu gd intl pdo_mysql
 			(( $G_DISTRO > 3 )) && phpenmod dom mbstring xml
 
 			# Webserver config
@@ -10222,7 +10225,7 @@ _EOF_
 			Banner_Configuration
 
 			# - Replace Sysinit service with SystemD
-			echo -e "#This file is no longer used as service has been upgraded to SystemD.\n#Please see /etc/systemd/system/squeezelite.service to set start options" > /etc/default/squeezelite
+			echo -e "#This file is no longer used as service has been upgraded to systemd.\n#Please see /etc/systemd/system/squeezelite.service to set start options" > /etc/default/squeezelite
 			rm /etc/init.d/squeezelite
 			cp /DietPi/dietpi/conf/squeezelite.service /etc/systemd/system/squeezelite.service
 
@@ -12681,7 +12684,7 @@ _EOF_
 		if (( aSOFTWARE_INSTALL_STATE[$software_id] == -1 )); then
 
 			Banner_Uninstalling
-			G_AGP "$PHP_APT_PACKAGE_NAME"-redis redis-server redis-tools
+			G_AGP "$PHP_BINARY"-redis redis-server redis-tools
 
 		fi
 
@@ -12691,7 +12694,7 @@ _EOF_
 			Banner_Uninstalling
 			rm $FP_PHP_BASE_DIR/fpm/pool.d/www.conf 2> /dev/null
 			rm $FP_PHP_BASE_DIR/mods-available/dietpi.ini 2> /dev/null
-			G_AGP $(dpkg --get-selections "$PHP_APT_PACKAGE_NAME"-* | awk '{print $1}') libapache2-mod-"$PHP_APT_PACKAGE_NAME"
+			G_AGP $(dpkg --get-selections | grep -E '(php[0-9]?\.?[0-9]?-*|libapache2-mod-php*)' | awk '{print $1}')
 			rm /var/www/phpinfo.php
 			rm /var/www/apc.php
 			rm /var/www/opcache.php

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3515,9 +3515,6 @@ NB: We highly recommend choosing 'Retry' first. Failing that, 'mirror' then 'mod
 			# + Stretch extras
 			(( $G_DISTRO > 3 )) && package_list+=" $PHP_APT_PACKAGE_NAME-mbstring $PHP_APT_PACKAGE_NAME-opcache $PHP_APT_PACKAGE_NAME-zip $PHP_APT_PACKAGE_NAME-xml"
 
-			# Current Buster workaround: "php-opcache" choice does not automatically install "php7.2-opcache", since php7.3-opcache (alpha) is available
-			(( $G_DISTRO > 4 )) && package_list=${package_list/php-opcache/php7.2-opcache}
-
 			# PHP7.2/Buster dropped support for mcrypt: https://liorkaplan.wordpress.com/2017/09/10/php-7-2-is-coming-mcrypt-extension-isnt/
 			(( $G_DISTRO < 5 )) && package_list+=" $PHP_APT_PACKAGE_NAME-mcrypt"
 
@@ -5092,9 +5089,6 @@ _EOF_
 
 			# - Stretch extras
 			(( $G_DISTRO > 3 )) && DEPS_LIST+=" $PHP_APT_PACKAGE_NAME-mbstring $PHP_APT_PACKAGE_NAME-opcache $PHP_APT_PACKAGE_NAME-xml"
-
-			# - Current Buster workaround: "php-opcache" choice does not automatically install "php7.2-opcache", since php7.3-opcache (alpha) is available
-			(( $G_DISTRO > 4 )) && package_list=${package_list/php-opcache/php7.2-opcache}
 
 			# Skip install, if already present
 			if [[ -d /var/www/pydio ]]; then
@@ -7330,7 +7324,7 @@ _EOF_
 
 			elif (( $G_DISTRO > 4 )); then
 
-				sed -i "s#/run/php5-fpm.sock#/run/php/php7.2-fpm.sock#g" /etc/nginx/nginx.conf
+				sed -i "s#/run/php5-fpm.sock#/run/php/php7.3-fpm.sock#g" /etc/nginx/nginx.conf
 
 			fi
 
@@ -7364,7 +7358,7 @@ _EOF_
 
 			elif (( $G_DISTRO > 4 )); then
 
-				fp_php_fpm_sock='/var/run/php/php7.2-fpm.sock'
+				fp_php_fpm_sock='/var/run/php/php7.3-fpm.sock'
 
 			fi
 


### PR DESCRIPTION
**Status**: Ready
🈯️ Stretch reinstall
🈯️ Stretch install Lighttpd
🈯️ Stretch install Apache
🈯️ Stretch install Nginx
🈯️ Jessie install Nginx
🈯️ Jessie install Apache
🈯️ Jessie install Lighttpd
🈯️ Buster install Lighttpd
🈯️ Retest: Stretch install Nginx
- [x] Changelog

**Reference**: https://github.com/Fourdee/DietPi/issues/1913

**Commit list/description**:
+ DietPi-Software | Pydio: Install rework, enable Nginx + Lighttpd configs, being less intrusive on Apache2 config
+ DietPi-Software | PHP: On Buster, move to PHP7.3 to not end up with mixed PHP versions. php-apcu and php-redis are not available for PHP7.2 any more...
  - Required `$APT_BINARY`. Allows to install php7.0-* packages on Stretch, but I didn't want to touch this now. Would skip the unnecessary php-* meta packages and by this assures that really PHP7.0 is installed, that we rely on. Only php-redis (+php-igbinary) and php-apcu are available like this, sadly a bid inconsistent 🤔...