### PR TITLE
DietPi-Software | Tautulli: Fix (re)install

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -42,6 +42,7 @@ Bug Fixes:
  - DietPi-Software | Resolved an issue where a global password with special characters lead to failing installs, due to missing escaping within our internal function G_CONFIG_INJECT. Thanks to @MistahDarcy for reporting this issue: https://github.com/Fourdee/DietPi/issues/2215
  - DietPi-Software | Docker: Resolved an issue where the Docker daemon failes to start due to invalid command argument. Thanks to @mspieth376 for reporting this issue: https://github.com/Fourdee/DietPi/issues/2238
  - DietPi-Software | Grafana: Resolved an issue, where WebUI password is not applied correctly, when containing ";" or "#". Thanks to @Warmbadger for reporting this issue and solution: https://dietpi.com/phpbb/viewtopic.php?f=11&t=5248
+ - DietPi-Software | Tautulli: Resolved an issue where Tautulli service failed to start up. As well improved reinstall, if install dir is already existent. Thanks to @Comfubar for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?f=11&t=5256
  - DietPi-Obtain_network_details | Resolved a tiny visual-only error message on non-root logins. Thanks to @AndrewZ for reporting: https://dietpi.com/phpbb/viewtopic.php?f=9&t=5194
  - DietPi-Update | Resolved a visual-only issue, where wrong RC versions could have been shown during incremental patching: https://github.com/Fourdee/DietPi/issues/2190
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7001,9 +7001,12 @@ _EOF_
 
 	Apply_SSHServer_Choices(){
 
-		#Work out which SSH Server needs installing from Indexs (if any)
-		#Work out which SSH server needs removing (if any), and, create a temp script file
+		#Work out which SSH Server needs installing from IDs (if any)
+		#Work out which SSH server needs removing (if any)
 		if (( $INDEX_SSHSERVER_TARGET != $INDEX_SSHSERVER_CURRENT )); then
+
+			# Run uninstall of old SSH servers, after install loop
+			uninstall_required=1
 
 			# - No SSH server
 			if (( $INDEX_SSHSERVER_TARGET == 0 )); then
@@ -7041,9 +7044,12 @@ _EOF_
 
 	Apply_FileServer_Choices(){
 
-		#Work out which File Server needs installing from Indexs (if any)
-		#Work out which File server needs removing (if any), and, create a temp script file
+		#Work out which File Server needs installing from IDs (if any)
+		#Work out which File server needs removing (if any)
 		if (( $INDEX_FILESERVER_TARGET != $INDEX_FILESERVER_CURRENT )); then
+
+			# Run uninstall of old file servers, after install loop
+			uninstall_required=1
 
 			#No File server
 			if (( $INDEX_FILESERVER_TARGET == 0 )); then
@@ -7074,9 +7080,12 @@ _EOF_
 
 	Apply_Logging_Choices(){
 
-		#Work out which Logging system needs installing from Indexs (if any)
-		#Work out which Logging system needs removing (if any), and, create a temp script file
+		#Work out which Logging system needs installing from IDs (if any)
+		#Work out which Logging system needs removing (if any)
 		if (( $INDEX_LOGGING_TARGET != $INDEX_LOGGING_CURRENT )); then
+
+			# Run uninstall of old logging systems, after install loop
+			uninstall_required=1
 
 			#None
 			if (( $INDEX_LOGGING_TARGET == 0 )); then
@@ -7123,12 +7132,6 @@ _EOF_
 			INDEX_WEBSERVER_CURRENT=$INDEX_WEBSERVER_TARGET
 
 		fi
-
-	}
-
-	Install_Apply_Permissions(){
-
-		/DietPi/dietpi/func/dietpi-set_software setpermissions
 
 	}
 
@@ -10372,7 +10375,7 @@ _EOF_
 
 			Banner_Configuration
 
-			Install_Apply_Permissions &> /dev/null
+			/DietPi/dietpi/func/dietpi-set_software setpermissions &> /dev/null
 
 			# - install/run composer | Also run for ampache. Move this to a global function....
 			php -r "readfile('https://getcomposer.org/installer');" > composer-setup.php
@@ -11140,9 +11143,9 @@ ExecStart=$(which python) $G_FP_DIETPI_USERDATA/sickrage/SiCKRAGE.py -d --nolaun
 WantedBy=multi-user.target
 _EOF_
 
-			chown -R sickrage:dietpi $G_FP_DIETPI_USERDATA/sickrage # also applied in Install_Apply_Permissions()
+			chown -R sickrage:dietpi $G_FP_DIETPI_USERDATA/sickrage # also applied in /DietPi/dietpi/func/dietpi-set_software setpermissions
 			> /var/log/sickrage.log
-			chown sickrage:dietpi /var/log/sickrage.log # also applied in Install_Apply_Permissions()
+			chown sickrage:dietpi /var/log/sickrage.log # also applied in /DietPi/dietpi/func/dietpi-set_software setpermissions
 
 		fi
 
@@ -11744,7 +11747,6 @@ _EOF_
 			mkdir -p $G_FP_DIETPI_USERDATA/plexpy
 
 			useradd -rM plexpy -G dietpi -s /usr/sbin/nologin
-			chown -R plexpy:plexpy /opt/plexpy
 
 			cat << _EOF_ > /etc/systemd/system/plexpy.service
 [Unit]
@@ -14607,6 +14609,8 @@ _EOF_
 		# Disable software installation, if user input is required for automated installs
 		Install_Disable_Requires_UserInput
 
+		local uninstall_required=0
+
 		# Apply DietPi choice systems
 		Apply_FileServer_Choices
 		Apply_SSHServer_Choices
@@ -14626,15 +14630,16 @@ _EOF_
 		/DietPi/dietpi/dietpi-services stop
 		Install_Dietpi_Software
 
-		# Apply Uninstall script created by DietPi choice system
-		Uninstall_Software
+		# Apply Uninstall script, if required by e.g. DietPi choice system
+		(( $uninstall_required )) && Uninstall_Software
+		unset uninstall_required
 
 		# Apply DietPi configurations and optimizations
 		/DietPi/dietpi/dietpi-services stop
 		Banner_Configs
 		Install_Apply_Configs
 
-		Install_Apply_Permissions &> /dev/null
+		/DietPi/dietpi/func/dietpi-set_software setpermissions &> /dev/null
 
 		# Apply autostart index
 		local autostart_current="$(</DietPi/dietpi/.dietpi-autostart_index)"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3655,12 +3655,12 @@ We work around this error by running APT a second time. Please do not worry and 
 			if [[ -d /var/www/phpBB3 ]]; then
 
 				G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$software_id]} install dir \"/var/www/phpBB3\" already exists. Download and install steps will be skipped.
- - Please manually backup your config files+data, remove the install dir and rerun \"dietpi-software (re)install $software_id\" if you need to reinstall.
- - If you want to update the ${aSOFTWARE_WHIP_NAME[$software_id]} instance, please follow the instructions from WebUI ACP."
+ - If you want to update ${aSOFTWARE_WHIP_NAME[$software_id]}, please follow the instructions from WebUI ACP.
+ - if you need to reinstall (e.g. broken instance), please manually backup your config files+data, remove the install dir and rerun \"dietpi-software (re)install $software_id\"."
 
 			else
 
-				Download_Install 'https://www.phpbb.com/files/release/phpBB-3.2.3.tar.bz2' /var/www
+				Download_Install 'https://www.phpbb.com/files/release/phpBB-3.2.4.tar.bz2' /var/www
 
 			fi
 
@@ -5879,15 +5879,23 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://github.com/JonnyWong16/plexpy.git'
+			if [[ -d /opt/plexpy ]]; then
 
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-			G_THREAD_START git clone --depth=1 "$INSTALL_URL_ADDRESS"
+				G_AGI python python-setuptools
+				G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$software_id]} install dir \"/opt/plexpy\" already exists. Download and install steps will be skipped.
+ - If you want to update ${aSOFTWARE_WHIP_NAME[$software_id]}, please use the internal updater from WebUI.
+ - if you need to reinstall (e.g. broken instance), please manually backup your config files+data, remove the install dir \"/opt/plexpy\" and rerun \"dietpi-software (re)install $software_id\"."
 
-			G_AGI python python-setuptools
+			else
 
-			G_THREAD_WAIT
-			mv plexpy /opt/
+				INSTALL_URL_ADDRESS='https://github.com/JonnyWong16/plexpy.git'
+				G_CHECK_URL "$INSTALL_URL_ADDRESS"
+				G_THREAD_START git clone --depth=1 "$INSTALL_URL_ADDRESS"
+				G_AGI python python-setuptools
+				G_THREAD_WAIT
+				mv plexpy /opt/
+
+			fi
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11736,6 +11736,7 @@ _EOF_
 			mkdir -p $G_FP_DIETPI_USERDATA/plexpy
 
 			useradd -rM plexpy -G dietpi -s /usr/sbin/nologin
+			chown -R plexpy:plexpy /opt/plexpy
 
 			cat << _EOF_ > /etc/systemd/system/plexpy.service
 [Unit]

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -445,7 +445,8 @@ _EOF_
 		chown gmrender:dietpi /var/log/gmrender.log
 
 		# - PlexPy
-		chown plexpy:dietpi $G_FP_DIETPI_USERDATA/plexpy
+		chown -R plexpy:plexpy /opt/plexpy
+		chown -R plexpy:dietpi $G_FP_DIETPI_USERDATA/plexpy
 
 		# - Deluge
 		chown -R deluge:dietpi $G_FP_DIETPI_USERDATA/deluge


### PR DESCRIPTION
**Status**: Ready
🈯️ Fresh install
🈯️ Uninstall loop (especially confusing "Finalize uninstall") skipped
🈯️ Reinstall skips download & install
🈯️ Switching SSH server successfully triggers uninstall loop.
🈯️ PuTTY connection to OpenSSH after reboot
  - Btw, since this was a question within another topic, works well with running SSH connection. It will stay alive, even that SSH server are stopped, OpenSSH successfully installed, Dropbear purged, everything on active PuTTY terminal until final reboot 👍.
- [x] DietPi-Set_Software | setpermissions: chown Tautulli userdata
- [x] Fix reinstall, dependent on internal update option or using git
  - According to: https://github.com/Tautulli/Tautulli-Wiki/wiki/Frequently-Asked-Questions#q-tautulli-is-not-updating-it-just-goes-back-to-the-homepage-without-updating
Internal updater available, using the Git client. So keep Git requirement, skip download&install, if install dir existent.
- [x] Changelog

**Reference**: https://github.com/Fourdee/DietPi/issues/2273

**Commit list/description**:
+ DietPi-Software | Tautulli: Chown "/opt/plexpy" to allow "plexpy" user creating "/opt/plexpy/config.ini"
