### PR TITLE
DietPi-Software | Syncthing: (Re)Install optimizations

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,7 @@ Changes / Improvements / Optimisations:
  - DietPi-Software | Radarr/Sonarr/Lidarr: logs (both .txt and .db*) have been moved to DietPi-RAMlog: https://github.com/Fourdee/DietPi/issues/2223
  - DietPi-Software | Pydio: WebUI warnings (security, performance) are now resolved for Nginx and Lighttpd webservers as well. Separate config files are created instead of touching the defaults, to enable required settings for Pydio only. Required PHP modules are installed and enabled, to be failsafe. Preserve existing install dirs on (re)install and inform user to update via WebUI updater: https://github.com/Fourdee/DietPi/issues/1913
  - DietPi-Software | Grafana: Existing database/plugin directory and admin password is now preserved on reinstall: https://github.com/Fourdee/DietPi/issues/2267
+ - DietPi-Software | Syncthing: Updated installer to always pull the latest release and better handle existing installs. Thanks to @joaofl for bringing this to our attention.
 
 Bug Fixes:
  - PREP: Resovled an issue where master.zip would always be downloaded, regardless of selected branch.

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5528,7 +5528,7 @@ _EOF_
 
 			Banner_Installing
 
-			if [[ -d /etc/syncthing]]; then
+			if [[ -d /etc/syncthing ]]; then
 
 				G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$software_id]} install dir \"/etc/syncthing\" already exists. Download and install steps will be skipped.
  - If you want to update ${aSOFTWARE_WHIP_NAME[$software_id]}, please use the internal updater from WebUI.

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5528,31 +5528,38 @@ _EOF_
 
 			Banner_Installing
 
-			# - armv6+
-			if (( $G_HW_ARCH == 1 || $G_HW_ARCH == 2 )); then
+			if [[ -d /etc/syncthing]]; then
 
-				INSTALL_URL_ADDRESS='https://github.com/syncthing/syncthing/releases/download/v0.14.47/syncthing-linux-arm-v0.14.47.tar.gz'
+				G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$software_id]} install dir \"/etc/syncthing\" already exists. Download and install steps will be skipped.
+ - If you want to update ${aSOFTWARE_WHIP_NAME[$software_id]}, please use the internal updater from WebUI.
+ - if you need to reinstall (e.g. broken instance), please manually backup your config files+data, remove the install dir \"/etc/syncthing\" and rerun \"dietpi-software (re)install $software_id\"."
 
-			# - arm64
-			elif (( $G_HW_ARCH == 3 )); then
+			else
 
-				INSTALL_URL_ADDRESS='https://github.com/syncthing/syncthing/releases/download/v0.14.47/syncthing-linux-arm64-v0.14.47.tar.gz'
+				INSTALL_URL_ADDRESS='https://api.github.com/repos/syncthing/syncthing/releases/latest'
+				G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
-			# - x86_64
-			elif (( $G_HW_ARCH == 10 )); then
+				# - armv6+
+				if (( $G_HW_ARCH == 1 || $G_HW_ARCH == 2 )); then
 
-				INSTALL_URL_ADDRESS='https://github.com/syncthing/syncthing/releases/download/v0.14.47/syncthing-linux-amd64-v0.14.47.tar.gz'
+					local arch='arm'
+
+				# - arm64
+				elif (( $G_HW_ARCH == 3 )); then
+
+					local arch='arm64'
+
+				# - x86_64
+				elif (( $G_HW_ARCH == 10 )); then
+
+					local arch='amd64'
+
+				fi
+
+				no_check_url=1 Download_Install "$(curl -s $INSTALL_URL_ADDRESS | grep -m1 "browser_download_url.*linux-$arch-v[0-9.]*tar\.gz" | cut -d \" -f 4)" /etc
+				mv /etc/syncthing-* /etc/syncthing
 
 			fi
-
-			#For some reason checking connection (spider) against the files above fails.
-			G_CHECK_URL https://github.com/syncthing/syncthing
-
-			no_check_url=1 Download_Install "$INSTALL_URL_ADDRESS"
-
-			mkdir -p /etc/syncthing
-			cp -R syncthing-*/syncthing /etc/syncthing/
-			rm -R syncthing-*
 
 		fi
 
@@ -11057,11 +11064,11 @@ _EOF_
 
 			#	Logs/Binary
 			mkdir -p /var/log/syncthing
-   			echo '' > /var/log/syncthing/syncthing.log
+   			>> /var/log/syncthing/syncthing.log
    			chown -R dietpi:dietpi /var/log/syncthing
    			chown -R dietpi:dietpi /etc/syncthing
 
-			# - run syncthing to create cert/config and exit
+			# - Run Syncthing to create cert/config and exit
 			/etc/syncthing/syncthing -generate=$G_FP_DIETPI_USERDATA/syncthing
 
 			# - Disable automatic upgrades
@@ -11095,7 +11102,7 @@ WantedBy=multi-user.target
 _EOF_
 
 			# - Increase open file limit:
-			echo -e "fs.inotify.max_user_watches=204800" | tee -a /etc/sysctl.conf
+			echo 'fs.inotify.max_user_watches=204800' > /etc/sysctl.d/dietpi-syncthing.conf
 
 		fi
 
@@ -13856,12 +13863,13 @@ _EOF_
 
 			Banner_Uninstalling
 
-			rm /etc/systemd/system/syncthing.service
+			[[ -f /etc/systemd/system/syncthing.service ]] && rm /etc/systemd/system/syncthing.service
+			[[ -f dietpi-syncthing.conf ]] && rm /etc/sysctl.d/dietpi-syncthing.conf # DietPi post-v6.18
 
-			rm /usr/bin/syncthing &> /dev/null # DietPi v158 <=
-			rm -R /etc/syncthing
+			[[ -f /usr/bin/syncthing ]] && rm /usr/bin/syncthing # DietPi pre-v158
+			[[ -d /etc/syncthing ]] && rm -R /etc/syncthing
 
-			rm -R $G_FP_DIETPI_USERDATA/syncthing
+			[[ -d $G_FP_DIETPI_USERDATA/syncthing ]] && rm -R $G_FP_DIETPI_USERDATA/syncthing
 
 		fi
 


### PR DESCRIPTION
**Status**: Ready
🈯️ Reinstall
🈯️ Uninstall
🈯️ Fresh install
- [x] Changelog

**References**:
- https://github.com/Fourdee/DietPi/pull/2278
- https://github.com/Fourdee/DietPi/issues/422

**Commit list/description**:
+ DietPi-Software | Syncthing: Switch to always up-to-date download URL
+ DietPi-Software | Syncthing: Preserve existing install dir, skipping download&install and inform user instead
+ DietPi-Software | Syncthing: Install full download dir (especially readme and license) instead of just the binary
+ DietPi-Software | Syncthing: Place sysctl setting(s) into own sysctl.d/ file
