### PR TITLE
DietPi-Software | Blynk: Preserve config file on reinstall, patch new dir structure

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ v6.20
 (xx/12/18)
 
 Changes / Improvements / Optimisations:
+- DietPi-Software | Blynk: Reinstalls now preserve existing config files; New directory structure and blynk user (v6.19) is patched now as well to existing installs: https://github.com/Fourdee/DietPi/pull/2324 
 
 Bug Fixes:
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12866,7 +12866,7 @@ _EOF_
 			Banner_Uninstalling
 			[[ -f /etc/systemd/system/blynkserver.service ]] && rm /etc/systemd/system/blynkserver.service
 			[[ -d $G_FP_DIETPI_USERDATA/blynk ]] && rm -R $G_FP_DIETPI_USERDATA/blynk
-			[[ -d rm -R /etc/blynkserver ]] && rm -R /etc/blynkserver #pre v6.19
+			[[ -d /etc/blynkserver ]] && rm -R /etc/blynkserver #pre v6.19
 
 			userdel -rf blynk
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -306,7 +306,6 @@ NB: We highly recommend choosing "Retry" first. Failing that, "NTP mirror" then 
 
 	fi
 
-	#
 	USBDRIVE=0
 
 	#Choices Made?
@@ -4467,11 +4466,9 @@ _EOF_
 			INSTALL_URL_ADDRESS='https://api.github.com/repos/blynkkk/blynk-server/releases/latest'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
-			useradd -rM blynk -G dietpi -s /usr/sbin/nologin
-			mkdir -p $G_FP_DIETPI_USERDATA/blynk
-
-			INSTALL_URL_ADDRESS=$(curl -s $INSTALL_URL_ADDRESS | grep -m1 'browser_download_url' | cut -d \" -f 4)
-			G_RUN_CMD wget "$INSTALL_URL_ADDRESS" -O $G_FP_DIETPI_USERDATA/blynk/blynkserver.jar
+			INSTALL_URL_ADDRESS="$(curl -s $INSTALL_URL_ADDRESS | grep -m1 'browser_download_url' | cut -d \" -f 4)"
+			mkdir -p $G_FP_DIETPI_USERDATA/blynk/data
+			G_THREAD_START wget "$INSTALL_URL_ADDRESS" -O $G_FP_DIETPI_USERDATA/blynk/blynkserver.jar
 
 			# - Install Blynk JS Libary
 			G_AGI python
@@ -4761,7 +4758,7 @@ _EOF_
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			curl -sL "$INSTALL_URL_ADDRESS" | apt-key add -
-			echo -e "deb https://repos.influxdata.com/debian $G_DISTRO_NAME stable" > /etc/apt/sources.list.d/influxdb.list
+			echo "deb https://repos.influxdata.com/debian $G_DISTRO_NAME stable" > /etc/apt/sources.list.d/influxdb.list
 			G_AGUP
 
 			G_AGI influxdb
@@ -11355,7 +11352,7 @@ public        = no
 #localDumpFile = $G_FP_DIETPI_USERDATA/darkice_recording.ogg
 _EOF_
 
-			#SystemD service for Darkice
+			#Systemd service for Darkice
 			rm /etc/init.d/darkice
 			cat << _EOF_ > /etc/systemd/system/darkice.service
 [Unit]
@@ -11382,7 +11379,7 @@ _EOF_
 			rm /etc/init.d/mosquitto
 			cat << _EOF_ > /etc/systemd/system/mosquitto.service
 [Unit]
-Description=Mosquitto
+Description=Mosquitto (DietPi)
 After=network.target
 
 [Service]
@@ -11401,15 +11398,22 @@ _EOF_
 
 			Banner_Configuration
 
-			local config_file_url_address='https://raw.githubusercontent.com/blynkkk/blynk-server/master/server/core/src/main/resources/server.properties'
-			G_RUN_CMD wget "$config_file_url_address" -O $G_FP_DIETPI_USERDATA/blynk/server.properties
-			G_CONFIG_INJECT 'data.folder=' "data.folder=$G_FP_DIETPI_USERDATA/blynk/data" $G_FP_DIETPI_USERDATA/blynk/server.properties
+			# - Preserve existing config
+			if [[ ! -f $G_FP_DIETPI_USERDATA/blynk/server.properties ]]; then
 
-			# - service
+				local config_file_url_address='https://raw.githubusercontent.com/blynkkk/blynk-server/master/server/core/src/main/resources/server.properties'
+				G_RUN_CMD wget "$config_file_url_address" -O $G_FP_DIETPI_USERDATA/blynk/server.properties
+				G_CONFIG_INJECT 'data.folder=' "data.folder=$G_FP_DIETPI_USERDATA/blynk/data" $G_FP_DIETPI_USERDATA/blynk/server.properties
+
+			fi
+
+			# - User
+			useradd -rM blynk -G dietpi -s /usr/sbin/nologin
+
+			# - Service
 			cat << _EOF_ > /etc/systemd/system/blynkserver.service
-
 [Unit]
-Description=Blynk Server
+Description=Blynk Server (DietPi)
 After=network.target
 
 [Service]
@@ -12860,11 +12864,11 @@ _EOF_
 		if (( aSOFTWARE_INSTALL_STATE[$software_id] == -1 )); then
 
 			Banner_Uninstalling
-			rm /etc/systemd/system/blynkserver.service
-			rm -R $G_FP_DIETPI_USERDATA/blynk
-			rm -R /etc/blynkserver #pre v6.19
+			[[ -f /etc/systemd/system/blynkserver.service ]] && rm /etc/systemd/system/blynkserver.service
+			[[ -d $G_FP_DIETPI_USERDATA/blynk ]] && rm -R $G_FP_DIETPI_USERDATA/blynk
+			[[ -d rm -R /etc/blynkserver ]] && rm -R /etc/blynkserver #pre v6.19
 
-			userdel -f blynk
+			userdel -rf blynk
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4475,6 +4475,8 @@ _EOF_
 			npm i -g --unsafe-perm onoff
 			npm i -g --unsafe-perm blynk-library
 
+			G_THREAD_WAIT
+
 		fi
 
 		#NAA Daemon
@@ -6817,6 +6819,7 @@ _EOF_
 
 			wget "$INSTALL_URL_ADDRESS" -O node_install.sh
 			chmod +x node_install.sh
+			mkdir -p /usr/local # failsafe
 			./node_install.sh
 			rm node_install.sh
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1442,6 +1442,7 @@ You will not face any practical differences, since both services start the same 
 				mv $G_FP_DIETPI_USERDATA/blynk/server.jar $G_FP_DIETPI_USERDATA/blynk/blynkserver.jar
 				mv $G_FP_DIETPI_USERDATA/blynk_bak/server.properties $G_FP_DIETPI_USERDATA/blynk/
 				mv $G_FP_DIETPI_USERDATA/blynk_bak $G_FP_DIETPI_USERDATA/blynk/data
+				G_CONFIG_INJECT 'data.folder=' "data.folder=$G_FP_DIETPI_USERDATA/blynk/data" $G_FP_DIETPI_USERDATA/blynk/server.properties
 
 			fi
 			#-------------------------------------------------------------------------------

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1438,8 +1438,8 @@ You will not face any practical differences, since both services start the same 
 				[[ -d $G_FP_DIETPI_USERDATA/blynk && ! -d $G_FP_DIETPI_USERDATA/blynk/data ]]; then
 
 				mv $G_FP_DIETPI_USERDATA/blynk $G_FP_DIETPI_USERDATA/blynk_bak
-				mkdir -p $G_FP_DIETPI_USERDATA/blynk
-				mv $G_FP_DIETPI_USERDATA/blynk_bak/blynkserver.jar $G_FP_DIETPI_USERDATA/blynk/
+				mv /etc/blynkserver $G_FP_DIETPI_USERDATA/blynk
+				mv $G_FP_DIETPI_USERDATA/blynk/server.jar $G_FP_DIETPI_USERDATA/blynk/blynkserver.jar
 				mv $G_FP_DIETPI_USERDATA/blynk_bak/server.properties $G_FP_DIETPI_USERDATA/blynk/
 				mv $G_FP_DIETPI_USERDATA/blynk_bak $G_FP_DIETPI_USERDATA/blynk/data
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1426,13 +1426,28 @@ You will not face any practical differences, since both services start the same 
 			#	Allo GUI: https://github.com/Fourdee/DietPi/issues/2305
 			#	GMrender: Due to Allo GUI service enable failure.
 			#	Xorg: XU4 conf
+			#	Pydio: https://github.com/Fourdee/DietPi/issues/2308
 			(( $G_DIETPI_INSTALL_STAGE == 1 )) && /DietPi/dietpi/dietpi-software reinstall 48 113 160 163 6
 			#-------------------------------------------------------------------------------
 
 		elif (( $G_DIETPI_VERSION_SUB == 19 )); then
 
 			#-------------------------------------------------------------------------------
-			echo 0
+			#Migrate Blynk to new dir structure: https://github.com/Fourdee/DietPi/issues/2322
+			if (( $G_DIETPI_INSTALL_STAGE == 1 )) && grep -q '^aSOFTWARE_INSTALL_STATE\[131\]=2' /DietPi/dietpi/.installed &&
+				[[ -d $G_FP_DIETPI_USERDATA/blynk && ! -d $G_FP_DIETPI_USERDATA/blynk/data ]]; then
+
+				mv $G_FP_DIETPI_USERDATA/blynk $G_FP_DIETPI_USERDATA/blynk_bak
+				mkdir -p $G_FP_DIETPI_USERDATA/blynk
+				mv $G_FP_DIETPI_USERDATA/blynk_bak/blynkserver.jar $G_FP_DIETPI_USERDATA/blynk/
+				mv $G_FP_DIETPI_USERDATA/blynk_bak/server.properties $G_FP_DIETPI_USERDATA/blynk/
+				mv $G_FP_DIETPI_USERDATA/blynk_bak $G_FP_DIETPI_USERDATA/blynk/data
+
+			fi
+			#-------------------------------------------------------------------------------
+			# - Reinstalls
+			#	Blynk: Apply new run user, update binary (jar)
+			(( $G_DIETPI_INSTALL_STAGE == 1 )) && /DietPi/dietpi/dietpi-software reinstall 131
 			#-------------------------------------------------------------------------------
 
 		fi


### PR DESCRIPTION
**Status**: Ready
- [x] Patch new dir structure
- [x] Changelog

🈯️ VM Jessie: Patch v6.18.12 => v6.20.0 + reinstall
🈯️ VM Buster: Patch v6.18.12 => v6.20.0 + reinstall
🈯️ VM Stretch: Fresh install + reinstall

**Reference**: https://github.com/Fourdee/DietPi/issues/2322

**Commit list/description**:
+ DietPi-Software | Blynk: Preserve existing config file on reinstall + minor
  - @Fourdee what you think about `(DietPi)` behind software names in custom systemd units? Seems to me cleanest way to show this is added by us, but do not mess systemctl/journalctl/boot output. Or `(by DietPi)`? Minor anyway 😆!
+ DietPi-Patch | Blynk: Patch new dir structure from v6.19
+ CHANGELOG | Blynk: Patch new dir structure and reinstall to update jar, blynk user and service file