### PR TITLE
#2326 port to dev

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12382,11 +12382,6 @@ _EOF_
 		fi
 
 		#------------------------------------------------------------------
-		# - Webservers reload configs, so reboot is not required to load them.
-		[[ $(which lighttpd) ]] && G_RUN_CMD systemctl restart lighttpd
-		[[ $(which nginx) ]] && G_RUN_CMD systemctl restart nginx
-		[[ $(which apache2) ]] && G_RUN_CMD systemctl restart apache2
-		#------------------------------------------------------------------
 
 	}
 
@@ -16474,8 +16469,8 @@ You should have received a copy of the GNU General Public License along with thi
 
 		if (( $DISABLE_REBOOT )); then
 
-			# - Start services
-			/DietPi/dietpi/dietpi-services start
+			# - Start services (restart to reload webserver confs)
+			/DietPi/dietpi/dietpi-services restart
 
 		else
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12383,9 +12383,9 @@ _EOF_
 
 		#------------------------------------------------------------------
 		# - Webservers reload configs, so reboot is not required to load them.
-		[[ $(which lighttpd) ]] && G_RUN_CMD systemctl force-reload lighttpd
-		[[ $(which nginx) ]] && G_RUN_CMD systemctl force-reload nginx
-		[[ $(which apache2) ]] && G_RUN_CMD systemctl force-reload apache2
+		[[ $(which lighttpd) ]] && G_RUN_CMD systemctl restart lighttpd
+		[[ $(which nginx) ]] && G_RUN_CMD systemctl restart nginx
+		[[ $(which apache2) ]] && G_RUN_CMD systemctl restart apache2
 		#------------------------------------------------------------------
 
 	}

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1375,6 +1375,7 @@ You will not face any practical differences, since both services start the same 
 			unset afp_config_remove
 			#-------------------------------------------------------------------------------
 			#conf renaming: https://github.com/Fourdee/DietPi/pull/2312/files
+			# - Apache
 			if [[ -f /etc/apache2/sites-available/owncloud.conf ]]; then
 
 				a2dissite owncloud
@@ -1396,10 +1397,11 @@ You will not face any practical differences, since both services start the same 
 				a2ensite dietpi-rutorrent
 
 			fi
+			# - Nginx
 			[[ -f /etc/nginx/sites-dietpi/owncloud.config ]] && mv /etc/nginx/sites-dietpi/owncloud.config /etc/nginx/sites-dietpi/dietpi-owncloud.conf
 			[[ -f /etc/nginx/sites-dietpi/nextcloud.config ]] && mv /etc/nginx/sites-dietpi/nextcloud.config /etc/nginx/sites-dietpi/dietpi-nextcloud.conf
 			[[ -f /etc/nginx/sites-dietpi/rutorrent.config ]] && mv /etc/nginx/sites-dietpi/rutorrent.config /etc/nginx/sites-dietpi/dietpi-rutorrent.conf
-			# - Failsafe and custom entries
+			#	- Failsafe and custom entries
 			for i in /etc/nginx/sites-dietpi/*.config
 			do
 
@@ -1407,6 +1409,9 @@ You will not face any practical differences, since both services start the same 
 				mv $i ${i%ig}
 
 			done
+			#	- Apply to Nginx vhost
+			grep -q 'include /etc/nginx/sites-dietpi/\*\.config;' /etc/nginx/sites-available/default && G_CONFIG_INJECT 'include /etc/nginx/sites-dietpi/\*\.config;' 'include /etc/nginx/sites-dietpi/*.conf;' /etc/nginx/sites-available/default
+			# - Kodi input rules
 			[[ -f /etc/udev/rules.d/99-input.rules ]] && mv /etc/udev/rules.d/99-input.rules /etc/udev/rules.d/99-dietpi-kodi.rules
 			#-------------------------------------------------------------------------------
 			#Asus TB 2.0.8 image, fix corrupt characters in desktops


### PR DESCRIPTION
**Status**: Ready
- [x] DietPi-Software

**Reference**: https://github.com/Fourdee/DietPi/pull/2326

**Commit list/description**:
+ DietPi-Patch | Add Nginx default vhost patch
+ DietPi-Software | Avoid "systemctl force-reload" errors, in case of service not running