### PR TITLE
DietPi-Software | Nextcloud Talk: Minor install fix/enhancement and disable logging

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,9 +3,11 @@ v6.20
 (xx/12/18)
 
 Changes / Improvements / Optimisations:
-- DietPi-Software | Blynk: Reinstalls now preserve existing config files; New directory structure and blynk user (v6.19) is patched now as well to existing installs: https://github.com/Fourdee/DietPi/pull/2324 
+- DietPi-Software | Blynk: Reinstalls now preserve existing config files; New directory structure and blynk user (v6.19) is patched now as well to existing installs: https://github.com/Fourdee/DietPi/pull/2324
+- DietPi-Software | Nextcloud Talk: Disable the very verbose coturn logging by default to reduce disk I/O. This can be overridden via /etc/turnserver.conf: https://github.com/Fourdee/DietPi/issues/2321
 
 Bug Fixes:
+- DietPi-Software | ownCloud/Nextcloud (Talk): Resolved an issue, where occ/ncc commands could fail, if Redis server is not running: https://github.com/Fourdee/DietPi/issues/2321
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/Fourdee/DietPi/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+base%3Amaster
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8280,7 +8280,7 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 				# - Disable non-TLS listening port, enable TLS listening port:
 				G_CONFIG_INJECT 'listening-port=' "#listening-port=$port" /etc/turnserver.conf
 				G_CONFIG_INJECT 'tls-listening-port=' "tls-listening-port=$port" /etc/turnserver.conf
-				local fp_cert_dir="/etc/letsencrypt/live/$(sed -n 1p /DietPi/dietpi/.dietpi-letsencrypt)/cert.pem"
+				local fp_cert_dir="/etc/letsencrypt/live/$(sed -n 1p /DietPi/dietpi/.dietpi-letsencrypt)"
 				G_CONFIG_INJECT 'cert=' "cert=$fp_cert_dir/cert.pem" /etc/turnserver.conf
 				G_CONFIG_INJECT 'pkey=' "pkey=$fp_cert_dir/privkey.pem" /etc/turnserver.conf
 				# - Proven working default cipher, but thus should be properly reworked, e.g. to match webserver settings?

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7817,6 +7817,9 @@ collation-server=utf8mb4_general_ci
 _EOF_
 			G_RUN_CMD systemctl restart $MARIADB_SERVICE
 
+			# Start redis-server, which is required for ncc command:
+			G_RUN_CMD systemctl start redis-server
+
 			# Initially add occ command shortcut, will be done by Dietpi-Globals automatically, if occ file exist:
 			occ(){ sudo -u www-data php /var/www/owncloud/occ "$@"; }
 
@@ -8066,6 +8069,9 @@ collation-server=utf8mb4_general_ci
 _EOF_
 			G_RUN_CMD systemctl restart $MARIADB_SERVICE
 
+			# Start redis-server, which is required for ncc command:
+			G_RUN_CMD systemctl start redis-server
+
 			# Initially add occ command shortcut, will be done by Dietpi-Globals automatically, if occ file exist:
 			ncc(){ sudo -u www-data php /var/www/nextcloud/occ "$@"; }
 
@@ -8211,6 +8217,8 @@ The install script will now exit. After applying one of the the above, rerun die
 			G_DIETPI-NOTIFY 2 'Configuring TURN server:'
 			# - Enable init.d service
 			G_CONFIG_INJECT 'TURNSERVER_ENABLED=' 'TURNSERVER_ENABLED=1' /etc/default/coturn
+			# - Disable coturn logging by default, this can be overridden via /etc/turnserver.conf
+			G_CONFIG_INJECT 'DAEMON_ARGS=' "DAEMON_ARGS='-c /etc/turnserver.conf -o -l stdout --no-stdout-log --simple-log'" /etc/default/coturn
 
 			# - Ask user for server domain and desired TURN server port
 			local invalid_text=''
@@ -8269,8 +8277,8 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 				-f /etc/letsencrypt/live/$(sed -n 1p /DietPi/dietpi/.dietpi-letsencrypt)/cert.pem ]]; then
 
 				G_DIETPI-NOTIFY 2 'LetsEncrypt certificate found, will configure coturn TURN server to accept TLS connections'
-				# - Comment matching non-TLS port, to avoid doubled port use:
-				G_CONFIG_INJECT "listening-port=$port" "#listening-port=$port" /etc/turnserver.conf
+				# - Disable non-TLS listening port, enable TLS listening port:
+				G_CONFIG_INJECT 'listening-port=' "#listening-port=$port" /etc/turnserver.conf
 				G_CONFIG_INJECT 'tls-listening-port=' "tls-listening-port=$port" /etc/turnserver.conf
 				local fp_cert_dir="/etc/letsencrypt/live/$(sed -n 1p /DietPi/dietpi/.dietpi-letsencrypt)/cert.pem"
 				G_CONFIG_INJECT 'cert=' "cert=$fp_cert_dir/cert.pem" /etc/turnserver.conf
@@ -8286,6 +8294,7 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 
 			# - Install Nextcloud Talk app
 			G_RUN_CMD systemctl start $MARIADB_SERVICE
+			G_RUN_CMD systemctl start redis-server
 			G_RUN_CMD ncc maintenance:mode --off
 			G_RUN_CMD ncc app:install spreed
 			ncc app:enable spreed


### PR DESCRIPTION
**Status**: Ready
- [x] DietPi-LetsEncrypt check
- [x] Changelog
- [x] <s>Forum docs</s> **€: Add those after solution is tested and feedback from Beta phase**
- [x] Jessie
- [x] Stretch
- [x] Buster

**Reference**: https://github.com/Fourdee/DietPi/issues/2321

**Commit list/description**:
+ DietPi-Software | Nextcloud Talk: Disable logging by default
  - By default log goes to stdout and log file.
  - `log-file=stdout` merges logs to stdout only.
  - `no-stdout-log` disables stdout log.
  - With above command arguments, only coturn startup output is done once to syslog (journalctl respectively /var/log/syslog+daemon.log). This is okay, since those targets are in RAM/handled/rotated anyway and it ensures, that startup log can always be checked. Those are not logged to the configured log target in `/etc/turnserver.conf`, which is applied afterwards.
  - `simple-log` disables internal log rotation, which is bad for `DietPi-RAMlog`, since a new file is created on every service start. In case of non-RAMlog, `logrotate` handling should be preferred, for consistency reasons. This is only relevant, if an actual log file is chosen of course.
+ DietPi-Software | Nextcloud Talk: Disable non-TLS port, if TLS is enabled
+ DietPi-Software | ownCloud/Nextcloud (Talk): Start redis-server before running occ/ncc command, which is required in some cases
+ DietPi-Software | Nextcloud Talk: Fix wrong certificate directory