### PR TITLE
DietPi-Software | ownCloud/Nextcloud: Config updates

### DIFF
--- a/.conf/dps_114/apache.nextcloud.conf
+++ b/.conf/dps_114/apache.nextcloud.conf
@@ -1,3 +1,5 @@
+# Based on: https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#apache-web-server-configuration
+
 <Directory /var/www/nextcloud/>
         Options +FollowSymlinks
         AllowOverride All

--- a/.conf/dps_114/lighttpd.nextcloud.conf
+++ b/.conf/dps_114/lighttpd.nextcloud.conf
@@ -12,7 +12,7 @@ $HTTP["url"] =~ "^/nextcloud($|/)" {
 	# - Directory listing
 	dir-listing.active = "disable"
 	# - Cache control and security headers for static resources
-	$HTTP["url"] =~ "^/nextcloud/\.(css|js|woff2?|svg|gif)$" {
+	$HTTP["url"] =~ "^/nextcloud/.*\.(css|js|woff2?|svg|gif)$" {
 		setenv.add-response-header += (
 			"Cache-Control" => "public, max-age=15778463",
 			"X-Content-Type-Options" => "nosniff",

--- a/.conf/dps_114/lighttpd.nextcloud.conf
+++ b/.conf/dps_114/lighttpd.nextcloud.conf
@@ -1,9 +1,30 @@
-# Solve OPcache settings warning on Nextcloud admin panel:
-$HTTP["url"] =~ "^/nextcloud($|/)" {
-  setenv.add-environment += (
-    "PHP_ADMIN_VALUE" => "opcache.memory_consumption=128",
-  )
-}
+# Derived from:
+# - Apache: https://github.com/nextcloud/server/blob/master/.htaccess
+# - Nginx:  https://docs.nextcloud.com/server/stable/admin_manual/installation/nginx.html
 
-# Set "Referrer-Policy" = "no-referrer" security header
-setenv.add-response-header = ( "Referrer-Policy" => "no-referrer" )
+$HTTP["url"] =~ "^/nextcloud($|/)" {
+
+	# Hardening
+	# - Directories
+	$HTTP["url"] =~ "^/nextcloud/(build|tests|config|lib|3rdparty|templates|data)($|/)" { url.access-deny = ("") }
+	# - Files
+	$HTTP["url"] =~ "^/nextcloud/(\.|autotest|occ|issue|indie|db_|console)" { url.access-deny = ("") }
+	# - Directory listing
+	dir-listing.active = "disable"
+	# - Cache control and security headers for static resources
+	$HTTP["url"] =~ "^/nextcloud/\.(css|js|woff2?|svg|gif)$" {
+		setenv.add-response-header += (
+			"Cache-Control" => "public, max-age=15778463",
+			"X-Content-Type-Options" => "nosniff",
+			"X-XSS-Protection" => "1; mode=block",
+			"X-Robots-Tag" => "none",
+			"X-Download-Options" => "noopen",
+			"X-Permitted-Cross-Domain-Policies" => "none",
+			"Referrer-Policy" => "no-referrer",
+		)
+	}
+
+	# Solve OPcache settings warning on Nextcloud admin panel
+	setenv.add-environment += ( "PHP_ADMIN_VALUE" => "opcache.memory_consumption=128" )
+
+}

--- a/.conf/dps_114/nginx.nextcloud.conf
+++ b/.conf/dps_114/nginx.nextcloud.conf
@@ -1,16 +1,20 @@
+# Based on: https://docs.nextcloud.com/server/stable/admin_manual/installation/nginx.html
+
 location ^~ /nextcloud {
 
-	# Security headers
-	add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;";
+	# Add headers to serve security related headers
+	#add_header Strict-Transport-Security "max-age=15768000; includeSubDomains;";
 	add_header X-Content-Type-Options nosniff;
 	add_header X-XSS-Protection "1; mode=block";
 	add_header X-Robots-Tag none;
 	add_header X-Download-Options noopen;
 	add_header X-Permitted-Cross-Domain-Policies none;
-	#add_header X-Frame-Options "SAMEORIGIN";
-	add_header Referrer-Policy "no-referrer";
+	add_header Referrer-Policy no-referrer;
 
-	# set max upload size
+	# Remove X-Powered-By, which is an information leak
+	fastcgi_hide_header X-Powered-By;
+
+	# Set max upload size
 	client_max_body_size 1048576M;
 	fastcgi_buffers 64 4K;
 
@@ -25,9 +29,6 @@ location ^~ /nextcloud {
 	# Uncomment if your server is build with the ngx_pagespeed module
 	# This module is currently not supported.
 	#pagespeed off;
-
-	error_page 403 /nextcloud/core/templates/403.php;
-	error_page 404 /nextcloud/core/templates/404.php;
 
 	location /nextcloud {
 		rewrite ^ /nextcloud/index.php$request_uri;
@@ -49,13 +50,12 @@ location ^~ /nextcloud {
 		#fastcgi_param HTTPS on;
 		# Avoid sending the security headers twice
 		fastcgi_param modHeadersAvailable true;
-		# Front controller enables pretty URLs without /index.php/, which works fine since Nextcloud 13!
 		fastcgi_param front_controller_active true;
 		fastcgi_pass php;
 		fastcgi_intercept_errors on;
-		# Disable on Jessie, because Jessie Nginx does not support that parameter
+		# Disable on Jessie, because Jessie Nginx does not support this directive
 		#fastcgi_request_buffering off;
-		# Hard coding 128M OPCache size, only for /nextcloud, to suppress warning on nextcloud admin panel.
+		# Hard coding 128M OPCache size to suppress warning on Nextcloud admin panel.
 		fastcgi_param PHP_ADMIN_VALUE "opcache.memory_consumption=128";
         }
 
@@ -71,15 +71,14 @@ location ^~ /nextcloud {
 		add_header Cache-Control "public, max-age=15778463";
 		# Add headers to serve security related headers  (It is intended
 		# to have those duplicated to the ones above)
-		# Before enabling Strict-Transport-Security headers please read
-		# into this topic first.
-		add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;";
+		#add_header Strict-Transport-Security "max-age=15768000; includeSubDomains;";
 		add_header X-Content-Type-Options nosniff;
 		add_header X-XSS-Protection "1; mode=block";
 		add_header X-Robots-Tag none;
 		add_header X-Download-Options noopen;
-		#add_header X-Frame-Options "SAMEORIGIN";
 		add_header X-Permitted-Cross-Domain-Policies none;
+		add_header Referrer-Policy no-referrer;
+
 		# Optional: Don't log access to assets
 		access_log off;
 	}

--- a/.conf/dps_114/nginx.nextcloud.conf
+++ b/.conf/dps_114/nginx.nextcloud.conf
@@ -47,7 +47,7 @@ location ^~ /nextcloud {
 		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 		fastcgi_param PATH_INFO $fastcgi_path_info;
 		# HTTPS forces redirection from http://, thus has to be enabled only on active HTTPS environment.
-		#fastcgi_param HTTPS on;
+		fastcgi_param HTTPS $https;
 		# Avoid sending the security headers twice
 		fastcgi_param modHeadersAvailable true;
 		fastcgi_param front_controller_active true;

--- a/.conf/dps_47/apache.owncloud.conf
+++ b/.conf/dps_47/apache.owncloud.conf
@@ -1,3 +1,5 @@
+# Based on: https://doc.owncloud.org/server/administration_manual/installation/manual_installation.html#configure-apache-web-server
+
 <Directory /var/www/owncloud/>
 	Options +FollowSymlinks
 	AllowOverride All

--- a/.conf/dps_47/lighttpd.owncloud.conf
+++ b/.conf/dps_47/lighttpd.owncloud.conf
@@ -1,0 +1,28 @@
+# Derived from:
+# - Apache: https://github.com/owncloud/core/blob/master/.htaccess
+# - Nginx:  https://doc.owncloud.org/server/administration_manual/installation/nginx_configuration.html
+
+$HTTP["url"] =~ "^/owncloud($|/)" {
+
+	# Hardening
+	# - Directories
+	$HTTP["url"] =~ "^/owncloud/(build|tests|config|lib|3rdparty|templates|data)($|/)" { url.access-deny = ("") }
+	# - Files
+	$HTTP["url"] =~ "^/owncloud/(\.|autotest|occ|issue|indie|db_|console)" { url.access-deny = ("") }
+	# - Directory listing
+	dir-listing.active = "disable"
+	# - Cache control and security headers for static resources
+	$HTTP["url"] =~ "^/owncloud/.+\.(css|js)" {
+		setenv.add-response-header += (
+			"Cache-Control" => "public, max-age=15778463",
+			"X-Frame-Options" => "SAMEORIGIN",
+			"X-Content-Type-Options" => "nosniff",
+			"X-XSS-Protection" => "1; mode=block",
+			"X-Robots-Tag" => "none",
+			"X-Download-Options" => "noopen",
+			"X-Permitted-Cross-Domain-Policies" => "none",
+			"Referrer-Policy" => "no-referrer",
+		)
+	}
+
+}

--- a/.conf/dps_47/nginx.owncloud.conf
+++ b/.conf/dps_47/nginx.owncloud.conf
@@ -1,95 +1,94 @@
+# Based on: https://doc.owncloud.org/server/administration_manual/installation/nginx_configuration.html
+
 location ^~ /owncloud {
 
-    # Add headers to serve security related headers
-    # Before enabling Strict-Transport-Security headers please read into this topic first.
-    add_header Strict-Transport-Security "max-age=15552000; includeSubDomains";
-    add_header X-Content-Type-Options nosniff;
-    add_header X-Frame-Options "SAMEORIGIN";
-    add_header X-XSS-Protection "1; mode=block";
-    add_header X-Robots-Tag none;
-    add_header X-Download-Options noopen;
-    add_header X-Permitted-Cross-Domain-Policies none;
-    add_header Referrer-Policy "no-referrer";
+	# Add headers to serve security related headers
+	#add_header Strict-Transport-Security "max-age=15552000; includeSubDomains";
+	add_header X-Content-Type-Options nosniff;
+	add_header X-Frame-Options "SAMEORIGIN";
+	add_header X-XSS-Protection "1; mode=block";
+	add_header X-Robots-Tag none;
+	add_header X-Download-Options noopen;
+	add_header X-Permitted-Cross-Domain-Policies none;
+	add_header Referrer-Policy no-referrer;
 
-    # set max upload size
-    client_max_body_size 1048576M;
-    # Do not set the number of buffers over 63, in our example it is set to 8.
-    # When exeeding, big file downloads can possibly consume a lot of system memory over time and cause problems especially on low-mem systems.
-    fastcgi_buffers 8 4K;
-    # From ownCloud version 10.0.4 on, a header statement will be sent to nginx not to use buffers to avoid problems with problematic fastcgi_buffers values. See note above.
-    # If these values are properly set and no problems are expected, you can turn on this statement to reenable buffering overriding the sent header.
-    # In case you use an earlier version of ownCloud or can´t change the buffers, or you can´t remove a existing ignore header statement, you can explicitly set fastcgi_buffering off;
-    # These statements are used either or but not together.
-    fastcgi_ignore_headers X-Accel-Buffering;
+	# Set max upload size
+	client_max_body_size 1048576M;
+	# Do not set the number of buffers over 63, in our example it is set to 8.
+	# When exeeding, big file downloads can possibly consume a lot of system memory over time and cause problems especially on low-mem systems.
+	fastcgi_buffers 8 4K;
+	# From ownCloud version 10.0.4 on, a header statement will be sent to nginx not to use buffers to avoid problems with problematic fastcgi_buffers values. See note above.
+	# If these values are properly set and no problems are expected, you can turn on this statement to reenable buffering overriding the sent header.
+	# In case you use an earlier version of ownCloud or can´t change the buffers, or you can´t remove a existing ignore header statement, you can explicitly set fastcgi_buffering off;
+	# These statements are used either or but not together.
+	fastcgi_ignore_headers X-Accel-Buffering;
 
-    # Disable gzip to avoid the removal of the ETag header
-    # Enabling gzip would also make your server vulnerable to BREACH
-    # if no additional measures are done. See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=773332
-    gzip off;
+	# Disable gzip to avoid the removal of the ETag header
+	# Enabling gzip would also make your server vulnerable to BREACH
+	# if no additional measures are done. See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=773332
+	gzip off;
 
-    # Uncomment if your server is build with the ngx_pagespeed module
-    # This module is currently not supported.
-    #pagespeed off;
+	# Uncomment if your server is build with the ngx_pagespeed module
+	# This module is currently not supported.
+	#pagespeed off;
 
-    error_page 403 /owncloud/core/templates/403.php;
-    error_page 404 /owncloud/core/templates/404.php;
+	error_page 403 /owncloud/core/templates/403.php;
+	error_page 404 /owncloud/core/templates/404.php;
 
-    location /owncloud {
-        rewrite ^ /owncloud/index.php$uri;
-    }
+	location /owncloud {
+		rewrite ^ /owncloud/index.php$uri;
+	}
 
-    location ~ ^/owncloud/(?:build|tests|config|lib|3rdparty|templates|data)/ {
-        return 404;
-    }
+	location ~ ^/owncloud/(?:build|tests|config|lib|3rdparty|templates|data)/ {
+		return 404;
+	}
+	location ~ ^/owncloud/(?:\.|autotest|occ|issue|indie|db_|console) {
+		return 404;
+	}
 
-    location ~ ^/owncloud/(?:\.|autotest|occ|issue|indie|db_|console) {
-        return 404;
-    }
+	location ~ ^/owncloud/(?:index|remote|public|cron|core/ajax/update|status|ocs/v[12]|updater/.+|ocs-provider/.+|core/templates/40[34])\.php(?:$|/) {
+		fastcgi_split_path_info ^(.+\.php)(/.*)$;
+		include fastcgi_params;
+		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+		fastcgi_param SCRIPT_NAME $fastcgi_script_name; # necessary for owncloud to detect the contextroot https://github.com/owncloud/core/blob/v10.0.0/lib/private/AppFramework/Http/Request.php#L603
+		fastcgi_param PATH_INFO $fastcgi_path_info;
+		#fastcgi_param HTTPS on;
+		fastcgi_param modHeadersAvailable true; #Avoid sending the security headers twice
+		# EXPERIMENTAL: active the following if you need to get rid of the 'index.php' in the URLs
+		fastcgi_param front_controller_active true;
+		fastcgi_read_timeout 180; # increase default timeout e.g. for long running carddav/ caldav syncs with 1000+ entries
+		fastcgi_pass php;
+		fastcgi_intercept_errors on;
+		#fastcgi_request_buffering off; #Available since NGINX 1.7.11
+	}
 
-    location ~ ^/owncloud/(?:index|remote|public|cron|core/ajax/update|status|ocs/v[12]|updater/.+|ocs-provider/.+|core/templates/40[34])\.php(?:$|/) {
-        fastcgi_split_path_info ^(.+\.php)(/.*)$;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_param SCRIPT_NAME $fastcgi_script_name; # necessary for owncloud to detect the contextroot https://github.com/owncloud/core/blob/v10.0.0/lib/private/AppFramework/Http/Request.php#L603
-        fastcgi_param PATH_INFO $fastcgi_path_info;
-        #fastcgi_param HTTPS on;
-        fastcgi_param modHeadersAvailable true; #Avoid sending the security headers twice
-        # EXPERIMENTAL: active the following if you need to get rid of the 'index.php' in the URLs
-        fastcgi_param front_controller_active true;
-        fastcgi_read_timeout 180; # increase default timeout e.g. for long running carddav/ caldav syncs with 1000+ entries
-        fastcgi_pass php;
-        fastcgi_intercept_errors on;
-        #fastcgi_request_buffering off; #Available since NGINX 1.7.11
-    }
+	location ~ ^/owncloud/(?:updater|ocs-provider)(?:$|/) {
+		try_files $uri $uri/ =404;
+		index index.php;
+	}
 
-    location ~ ^/owncloud/(?:updater|ocs-provider)(?:$|/) {
-        try_files $uri $uri/ =404;
-        index index.php;
-    }
+	# Adding the cache control header for js and css files
+	# Make sure it is BELOW the PHP block
+	location ~ /owncloud(\/.*\.(?:css|js)) {
+		try_files $uri /owncloud/index.php$uri$is_args$args;
+		add_header Cache-Control "max-age=15778463";
+		# Add headers to serve security related headers  (It is intended to have those duplicated to the ones above)
+		#add_header Strict-Transport-Security "max-age=15552000; includeSubDomains";
+		add_header X-Content-Type-Options nosniff;
+		add_header X-Frame-Options "SAMEORIGIN";
+		add_header X-XSS-Protection "1; mode=block";
+		add_header X-Robots-Tag none;
+		add_header X-Download-Options noopen;
+		add_header X-Permitted-Cross-Domain-Policies none;
+		add_header Referrer-Policy no-referrer;
+		# Optional: Don't log access to assets
+		access_log off;
+	}
 
-    # Adding the cache control header for js and css files
-    # Make sure it is BELOW the PHP block
-    location ~ /owncloud(\/.*\.(?:css|js)) {
-        try_files $uri /owncloud/index.php$uri$is_args$args;
-        add_header Cache-Control "max-age=15778463";
-        # Add headers to serve security related headers  (It is intended to have those duplicated to the ones above)
-        # Before enabling Strict-Transport-Security headers please read into this topic first.
-        add_header Strict-Transport-Security "max-age=15552000; includeSubDomains";
-        add_header X-Content-Type-Options nosniff;
-        add_header X-Frame-Options "SAMEORIGIN";
-        add_header X-XSS-Protection "1; mode=block";
-        add_header X-Robots-Tag none;
-        add_header X-Download-Options noopen;
-        add_header X-Permitted-Cross-Domain-Policies none;
-        # Optional: Don't log access to assets
-        access_log off;
-    }
-
-    location ~ /owncloud(/.*\.(?:svg|gif|png|html|ttf|woff|ico|jpg|jpeg|map)) {
-        try_files $uri /owncloud/index.php$uri$is_args$args;
-        add_header Cache-Control "public, max-age=7200";
-        # Optional: Don't log access to other assets
-        access_log off;
-    }
-
+	location ~ /owncloud(/.*\.(?:svg|gif|png|html|ttf|woff|ico|jpg|jpeg|map)) {
+		try_files $uri /owncloud/index.php$uri$is_args$args;
+		add_header Cache-Control "public, max-age=7200";
+		# Optional: Don't log access to other assets
+		access_log off;
+	}
   }

--- a/.conf/dps_47/nginx.owncloud.conf
+++ b/.conf/dps_47/nginx.owncloud.conf
@@ -52,7 +52,7 @@ location ^~ /owncloud {
 		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 		fastcgi_param SCRIPT_NAME $fastcgi_script_name; # necessary for owncloud to detect the contextroot https://github.com/owncloud/core/blob/v10.0.0/lib/private/AppFramework/Http/Request.php#L603
 		fastcgi_param PATH_INFO $fastcgi_path_info;
-		#fastcgi_param HTTPS on;
+		fastcgi_param HTTPS $https;
 		fastcgi_param modHeadersAvailable true; #Avoid sending the security headers twice
 		# EXPERIMENTAL: active the following if you need to get rid of the 'index.php' in the URLs
 		fastcgi_param front_controller_active true;

--- a/.conf/dps_85/nginx.conf
+++ b/.conf/dps_85/nginx.conf
@@ -6,6 +6,11 @@ user www-data;
 # As a thumb rule: One per CPU.
 worker_processes 1;
 
+pid /run/nginx.pid;
+
+# Load dynamic modules
+include /etc/nginx/modules-enabled/*.conf;
+
 # Maximum file descriptors that can be opened per process
 # This should be > worker_connections
 worker_rlimit_nofile 100;
@@ -15,8 +20,6 @@ events {
 }
 
 error_log /var/log/nginx/error.log;
-
-pid /run/nginx.pid;
 
 http {
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,10 +14,12 @@ Changes / Improvements / Optimisations:
 - DietPi-Software | Nextcloud Talk: Disabled the very verbose coturn logging by default to reduce disk I/O. This can be overridden via /etc/turnserver.conf: https://github.com/Fourdee/DietPi/issues/2321
 - DietPi-Software | Deluge: UMask 002 applied to all downloads: https://github.com/Fourdee/DietPi/issues/2339
 - DietPi-Software | Netdata: Updated to v1.11.1 and now runs as user "netdata": https://github.com/Fourdee/DietPi/pull/2337
+- DietPi-Software | ownCloud/Nextcloud: Upadated webserver configs to match current recommendations and security hardenings. Only applied on new installs. To apply manually, run "dietpi-software reinstall 47" (owncloud) or "dietpi-software reinstall 114" (Nextcloud). You will be informed about the new configs, which then need to be manually moved to overwrite the old ones, since we don't want to mess with manual changes: https://github.com/Fourdee/DietPi/pull/2361
 - DietPi-Update | Added optional ability to automatically update DietPi, when updates are available. Please note, this is disabled by default.
 
 Bug Fixes:
 - DietPi-Software | ownCloud/Nextcloud (Talk): Resolved an issue, where occ/ncc commands could fail, if Redis server is not running: https://github.com/Fourdee/DietPi/issues/2321
+- DietPi-Software | ownCloud/Nextcloud: Resolved an issue, where during fresh installs on v6.19, Apache configs were not enabled correctly.
 - General | Enhanced and fixed some issue with dependencies and boot order of DietPi systemd units: https://github.com/Fourdee/DietPi/pull/2357
 - General | AudioPhonics I-Sabre-K2M: Once the driver is compiled, it will no longer be recompiled. This prevents ALSA installs from re-compiling the driver each time.
 - General | Resolved an issue, where login with non-bash session caused an error message. Thanks to @Elijahg for reporting this issue: https://github.com/Fourdee/DietPi/issues/2347

--- a/dietpi/dietpi-letsencrypt
+++ b/dietpi/dietpi-letsencrypt
@@ -27,7 +27,7 @@
 
 	#Grab Input
 	INPUT=0
-	disable_error=1 G_CHECK_VALIDINT $1 && INPUT=$1
+	disable_error=1 G_CHECK_VALIDINT "$1" && INPUT=$1
 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	#Globals
@@ -200,7 +200,7 @@ _EOF_
 
 				cat << _EOF_ > /etc/lighttpd/conf-available/99-dietpi-hsts.conf
 \$HTTP["scheme"] == "https" {
-	setenv.add-response-header = ( "Strict-Transport-Security" => "max-age=31536000; includeSubdomains; preload;" )
+	setenv.add-response-header = ( "Strict-Transport-Security" => "max-age=31536000; includeSubdomains;" )
 }
 _EOF_
 				lighttpd-enable-mod dietpi-hsts
@@ -247,6 +247,20 @@ _EOF_
 				echo -e "[FAILURE] CertBot failed with error code ($exit_code), please check it's terminal output. Aborting..." | tee "$FP_LOGFILE"
 				(( ! $INPUT )) && G_WHIP_MSG "[FAILURE] CertBot failed with error code ($exit_code), please check it's terminal output. Aborting..."
 				return 1
+
+			fi
+
+			#Apply settings to ownCloud/Nextcloud
+			if (( $LETSENCRYPT_REDIRECT )); then
+
+				[[ -f /etc/nginx/sites-dietpi/dietpi-owncloud.conf ]] && sed -i 's/#fastcgi_param HTTPS on;/fastcgi_param HTTPS on;/g' /etc/nginx/sites-dietpi/dietpi-owncloud.conf
+				[[ -f /etc/nginx/sites-dietpi/dietpi-nextcloud.conf ]] && sed -i 's/#fastcgi_param HTTPS on;/fastcgi_param HTTPS on;/g' /etc/nginx/sites-dietpi/dietpi-nextcloud.conf
+
+			fi
+			if (( $LETSENCRYPT_HSTS )); then
+
+				[[ -f /etc/nginx/sites-dietpi/dietpi-owncloud.conf ]] && sed -i 's/#add_header Strict-Transport-Security/add_header Strict-Transport-Security/g' /etc/nginx/sites-dietpi/dietpi-owncloud.conf
+				[[ -f /etc/nginx/sites-dietpi/dietpi-nextcloud.conf ]] && sed -i 's/#add_header Strict-Transport-Security/add_header Strict-Transport-Security/g' /etc/nginx/sites-dietpi/dietpi-nextcloud.conf
 
 			fi
 
@@ -458,8 +472,7 @@ _EOF_
 	Menu_Exit(){
 
 		G_WHIP_SIZE_X_MAX=50
-		G_WHIP_YESNO "Exit $G_PROGRAM_NAME?"
-		if (( $? == 0 )); then
+		if G_WHIP_YESNO "Exit $G_PROGRAM_NAME?"; then
 
 			#exit
 			TARGETMENUID=-1
@@ -477,18 +490,10 @@ _EOF_
 	Menu_Main(){
 
 		local hsts_text='[Off] | No HTTP Strict Transport Security'
-		if (( $LETSENCRYPT_HSTS )); then
-
-			hsts_text='[On] | HTTP Strict Transport Security'
-
-		fi
+		(( $LETSENCRYPT_HSTS )) && hsts_text='[On] | HTTP Strict Transport Security'
 
 		local redirect_text='[Off] | Allows http and https usage'
-		if (( $LETSENCRYPT_REDIRECT )); then
-
-			redirect_text='[On] | Forces http redirects to https'
-
-		fi
+		(( $LETSENCRYPT_REDIRECT )) && redirect_text='[On] | Forces http redirects to https'
 
 		G_WHIP_MENU_ARRAY=(
 
@@ -503,8 +508,7 @@ _EOF_
 
 		G_WHIP_DEFAULT_ITEM="$PREVIOUS_MENU_SELECTION"
 		G_WHIP_BUTTON_CANCEL_TEXT='Exit'
-		G_WHIP_MENU 'Please select an option:'
-		if (( ! $? )); then
+		if G_WHIP_MENU 'Please select an option:'; then
 
 			PREVIOUS_MENU_SELECTION=$G_WHIP_RETURNED_VALUE
 
@@ -512,7 +516,8 @@ _EOF_
 
 				'Domain')
 
-					while true; do
+					while :
+					do
 
 						LETSENCRYPT_DOMAIN="$(Input_Box $LETSENCRYPT_DOMAIN Website-Domain)"
 						[[ $LETSENCRYPT_DOMAIN == *?.?* && ! $(sed 's/\.//g' <<< $LETSENCRYPT_DOMAIN) =~ ^[0-9]*$ ]] && break
@@ -575,11 +580,7 @@ Are you sure that you want to enable HTTP Strict Transport Security?'
 				'Redirect')
 
 					((LETSENCRYPT_REDIRECT++))
-					if (( $LETSENCRYPT_REDIRECT > 1 )); then
-
-						LETSENCRYPT_REDIRECT=0
-
-					fi
+					(( $LETSENCRYPT_REDIRECT > 1 )) && LETSENCRYPT_REDIRECT=0
 
 				;;
 
@@ -613,17 +614,12 @@ Are you sure that you want to enable HTTP Strict Transport Security?'
 		local input_desc=$2
 
 		G_WHIP_DEFAULT_ITEM="$input_value"
-		G_WHIP_INPUTBOX "Please enter a value for $input_desc"
-		if (( ! $? )); then
+		if G_WHIP_INPUTBOX "Please enter a value for $input_desc"; then
 
 			input_value="$G_WHIP_RETURNED_VALUE"
 
 			# - Prevent null values
-			if [[ -z $input_value ]]; then
-
-				input_value='NULL'
-
-			fi
+			[[ -z $input_value ]] && input_value='NULL'
 
 		fi
 
@@ -658,7 +654,7 @@ Are you sure that you want to enable HTTP Strict Transport Security?'
 
 		else
 
-			echo -e "[FAILURE] CertBot binary not found ( $FP_BINARY ), please install it with DietPi-Software. Aborting..." | tee "$FP_LOGFILE"
+			echo "[FAILURE] CertBot binary not found ( $FP_BINARY ), please install it with DietPi-Software. Aborting..." | tee "$FP_LOGFILE"
 
 		fi
 
@@ -670,11 +666,7 @@ Are you sure that you want to enable HTTP Strict Transport Security?'
 
 			printf '\ec' # clear current terminal screen
 
-			if (( $TARGETMENUID == 0 )); then
-
-				Menu_Main
-
-			fi
+			(( $TARGETMENUID == 0 )) && Menu_Main
 
 		done
 

--- a/dietpi/dietpi-letsencrypt
+++ b/dietpi/dietpi-letsencrypt
@@ -250,13 +250,7 @@ _EOF_
 
 			fi
 
-			#Apply settings to ownCloud/Nextcloud
-			if (( $LETSENCRYPT_REDIRECT )); then
-
-				[[ -f /etc/nginx/sites-dietpi/dietpi-owncloud.conf ]] && sed -i 's/#fastcgi_param HTTPS on;/fastcgi_param HTTPS on;/g' /etc/nginx/sites-dietpi/dietpi-owncloud.conf
-				[[ -f /etc/nginx/sites-dietpi/dietpi-nextcloud.conf ]] && sed -i 's/#fastcgi_param HTTPS on;/fastcgi_param HTTPS on;/g' /etc/nginx/sites-dietpi/dietpi-nextcloud.conf
-
-			fi
+			#Apply HSTS header to ownCloud/Nextcloud config
 			if (( $LETSENCRYPT_HSTS )); then
 
 				[[ -f /etc/nginx/sites-dietpi/dietpi-owncloud.conf ]] && sed -i 's/#add_header Strict-Transport-Security/add_header Strict-Transport-Security/g' /etc/nginx/sites-dietpi/dietpi-owncloud.conf

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -363,7 +363,9 @@
 					'lighttpd'
 					'php5-fpm'
 					'php7.0-fpm'
+					'php7.1-fpm'
 					'php7.2-fpm'
+					'php7.3-fpm'
 					'mysql'
 					'avahi-daemon'
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1069,6 +1069,8 @@ _EOF_
 			  aSOFTWARE_REQUIRES_PHP[$software_id]=1
 			aSOFTWARE_REQUIRES_MYSQL[$software_id]=1
 			 aSOFTWARE_ONLINEDOC_URL[$software_id]='p=47#p47'
+			 # Current ownCloud 10.0.10 does not support PHP7.3 (Buster): https://doc.owncloud.org/server/administration_manual/installation/system_requirements.html
+			 aSOFTWARE_AVAIL_G_DISTRO[$software_id,5]=0
 
 		#------------------
 		software_id=114
@@ -7243,7 +7245,7 @@ _EOF_
 			Banner_Configuration
 
 			# Custom confs, included by sites-enabled/default within server directive, while nginx/(conf.d|sites-enabled) is included by nginx.conf outside server directive
-			mkdir /etc/nginx/sites-dietpi
+			mkdir -p /etc/nginx/sites-dietpi
 
 			G_BACKUP_FP /etc/nginx/nginx.conf
 			dps_index=$software_id Download_Install 'nginx.conf' /etc/nginx/nginx.conf

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7718,13 +7718,11 @@ url.redirect = (
 				# Stretch: Set 'fastcgi_request_buffering off';
 				(( $G_DISTRO > 3 )) && sed -i 's/#fastcgi_request_buffering off;/fastcgi_request_buffering off;/g' $owncloud_conf
 
-				# Set HTTPS on, if SSL connection is available, even with self-signed/untrusted certificate.
-				# - Only apply, if related dietpi-letsencrypt settings were found
-				wget -q --spider --timeout=10 --tries=2 https://localhost &> /dev/null
-				if (( $? == 0 || $? == 5)) && [[ -f /DietPi/dietpi/.dietpi-letsencrypt ]]; then
+				# Uncomment HSTS header, if chosen via dietpi-letsencrypt and HTTPS connection test succeeds (incl. self-singed cert => exit code 5)
+				if [[ -f /DietPi/dietpi/.dietpi-letsencrypt && $(sed -n 4p /DietPi/dietpi/.dietpi-letsencrypt) == 1 ]]; then
 
-					[[ $(sed -n 3p /DietPi/dietpi/.dietpi-letsencrypt) == 1 ]] && sed -i 's/#fastcgi_param HTTPS on;/fastcgi_param HTTPS on;/g' $owncloud_conf
-					[[ $(sed -n 4p /DietPi/dietpi/.dietpi-letsencrypt) == 1 ]] && sed -i 's/#add_header Strict-Transport-Security/add_header Strict-Transport-Security/g' $owncloud_conf
+					wget -q --spider --timeout=10 --tries=2 https://localhost &> /dev/null
+					(( $? == 0 || $? == 5)) && sed -i 's/#add_header Strict-Transport-Security/add_header Strict-Transport-Security/g' $owncloud_conf
 
 				fi
 
@@ -7974,13 +7972,11 @@ url.redirect = (
 				# Stretch: Set 'fastcgi_request_buffering off';
 				(( $G_DISTRO > 3 )) && sed -i 's/#fastcgi_request_buffering off;/fastcgi_request_buffering off;/g' $nextcloud_conf
 
-				# Set HTTPS on, if SSL connection is available, even with self-signed/untrusted certificate.
-				# - Only apply, if related dietpi-letsencrypt settings were found
-				wget -q --spider --timeout=10 --tries=2 https://localhost &> /dev/null
-				if (( $? == 0 || $? == 5)) && [[ -f /DietPi/dietpi/.dietpi-letsencrypt ]]; then
+				# Uncomment HSTS header, if chosen via dietpi-letsencrypt and HTTPS connection test succeeds (incl. self-singed cert => exit code 5)
+				if [[ -f /DietPi/dietpi/.dietpi-letsencrypt && $(sed -n 4p /DietPi/dietpi/.dietpi-letsencrypt) == 1 ]]; then
 
-					[[ $(sed -n 3p /DietPi/dietpi/.dietpi-letsencrypt) == 1 ]] && sed -i 's/#fastcgi_param HTTPS on;/fastcgi_param HTTPS on;/g' $nextcloud_conf
-					[[ $(sed -n 4p /DietPi/dietpi/.dietpi-letsencrypt) == 1 ]] && sed -i 's/#add_header Strict-Transport-Security/add_header Strict-Transport-Security/g' $nextcloud_conf
+					wget -q --spider --timeout=10 --tries=2 https://localhost &> /dev/null
+					(( $? == 0 || $? == 5)) && sed -i 's/#add_header Strict-Transport-Security/add_header Strict-Transport-Security/g' $nextcloud_conf
 
 				fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1062,25 +1062,25 @@ _EOF_
 		software_id=47
 
 				 aSOFTWARE_WHIP_NAME[$software_id]='ownCloud'
-				 aSOFTWARE_WHIP_DESC[$software_id]='your very own cloud (eg: dropbox)'
+				 aSOFTWARE_WHIP_DESC[$software_id]='File sync, sharing and collaboration platform'
 			aSOFTWARE_CATEGORY_INDEX[$software_id]=4
 					  aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_REQUIRES_WEBSERVER[$software_id]=1
 			  aSOFTWARE_REQUIRES_PHP[$software_id]=1
 			aSOFTWARE_REQUIRES_MYSQL[$software_id]=1
-			 aSOFTWARE_ONLINEDOC_URL[$software_id]='f=8&t=5#p47'
+			 aSOFTWARE_ONLINEDOC_URL[$software_id]='p=47#p47'
 
 		#------------------
 		software_id=114
 
 				 aSOFTWARE_WHIP_NAME[$software_id]='Nextcloud'
-				 aSOFTWARE_WHIP_DESC[$software_id]='A safe home for all your data'
+				 aSOFTWARE_WHIP_DESC[$software_id]='File sync, sharing and collaboration platform'
 			aSOFTWARE_CATEGORY_INDEX[$software_id]=4
 					  aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_REQUIRES_WEBSERVER[$software_id]=1
 			  aSOFTWARE_REQUIRES_PHP[$software_id]=1
 			aSOFTWARE_REQUIRES_MYSQL[$software_id]=1
-			 aSOFTWARE_ONLINEDOC_URL[$software_id]='f=8&t=5&p=3026#p3026'
+			 aSOFTWARE_ONLINEDOC_URL[$software_id]='p=3026#p3026'
 
 		#------------------
 		software_id=168
@@ -1092,7 +1092,7 @@ _EOF_
 		#Currently requires manual domain and TURN server port input.
 		# - To resolve: Default port 5349 could be used, but reliable method to get external domain/static IP is required.
 		aSOFTWARE_REQUIRES_USERINPUT[$software_id]=1
-			 aSOFTWARE_ONLINEDOC_URL[$software_id]='f=8&t=5&p=15227#p15227'
+			 aSOFTWARE_ONLINEDOC_URL[$software_id]='p=15227#p15227'
 
 		#------------------
 		software_id=48
@@ -3735,7 +3735,7 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-			DEPS_LIST="$PHP_APT_PACKAGE_NAME-intl" # https://doc.owncloud.org/server/latest/admin_manual/installation/source_installation.html#php-extensions
+			DEPS_LIST="$PHP_APT_PACKAGE_NAME-intl" # https://doc.owncloud.org/server/administration_manual/installation/manual_installation.html#php-extensions
 
 			if [[ -f /var/www/owncloud/occ ]]; then
 
@@ -3771,7 +3771,7 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-			DEPS_LIST="$PHP_APT_PACKAGE_NAME-intl" # https://docs.nextcloud.com/server/13/admin_manual/installation/source_installation.html#prerequisites-label
+			DEPS_LIST="$PHP_APT_PACKAGE_NAME-intl" # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
 
 			if [[ -f /var/www/nextcloud/occ ]]; then
 
@@ -7629,21 +7629,17 @@ _EOF_
 
 			Banner_Configuration
 
-			G_DIETPI-NOTIFY 2 'Enabling needed PHP modules.' # https://doc.owncloud.org/server/latest/admin_manual/installation/source_installation.html#php-extensions
+			G_DIETPI-NOTIFY 2 'Enabling needed PHP modules.' # https://doc.owncloud.org/server/administration_manual/installation/manual_installation.html#php-extensions
 			${PHP_BINARY}enmod curl gd intl json pdo_mysql opcache apcu redis
 			# Following modules are switchable since Stretch:
-			if (( $G_DISTRO > 3 )); then
-
-				phpenmod ctype dom fileinfo iconv mbstring posix simplexml xmlwriter xmlreader zip exif
-
-			fi
+			(( $G_DISTRO > 3 )) && phpenmod ctype dom fileinfo iconv mbstring posix simplexml xmlwriter xmlreader zip exif
 
 			G_DIETPI-NOTIFY 2 'Enabling APCu memory cache for PHP command line usage (CLI) as well, including ownCloud occ command and cron jobs.'
 			G_CONFIG_INJECT 'apc.enable_cli[[:blank:]=]' 'apc.enable_cli=1' "$FP_PHP_BASE_DIR/mods-available/apcu.ini"
 
 			if (( ${aSOFTWARE_INSTALL_STATE[83]} > 0 )); then
 
-				G_DIETPI-NOTIFY 2 'Apache webserver found, enabling ownCloud specific configuration.' # https://doc.owncloud.org/server/latest/admin_manual/installation/source_installation.html#configure-apache-web-server
+				G_DIETPI-NOTIFY 2 'Apache webserver found, enabling ownCloud specific configuration.' # https://doc.owncloud.org/server/administration_manual/installation/manual_installation.html#configure-apache-web-server
 				a2enmod rewrite headers env dir mime 1> /dev/null
 				local owncloud_conf='/etc/apache2/sites-available/dietpi-owncloud.conf'
 				if [[ -f $owncloud_conf ]]; then
@@ -7653,7 +7649,7 @@ _EOF_
 
 				fi
 				dps_index=$software_id Download_Install 'apache.owncloud.conf' $owncloud_conf
-				a2ensite owncloud 1> /dev/null
+				a2ensite dietpi-owncloud 1> /dev/null
 				# Cal/CardDAV redirects to ownCloud DAV endpoint
 				if [[ ! -f /etc/apache2/conf-available/dietpi-dav_redirect.conf ]]; then
 
@@ -7667,6 +7663,31 @@ Redirect permanent /.well-known/caldav /owncloud/remote.php/dav' > /etc/apache2/
 			elif (( ${aSOFTWARE_INSTALL_STATE[84]} > 0 )); then
 
 				G_DIETPI-NOTIFY 2 'Lighttpd webserver found, enabling ownCloud specific configuration.'
+
+				# Enable required modules
+				G_CONFIG_INJECT '"mod_access",' '	"mod_access",' /etc/lighttpd/lighttpd.conf '"mod_.+",'
+				G_CONFIG_INJECT '"mod_setenv",' '	"mod_setenv",' /etc/lighttpd/lighttpd.conf '"mod_.+",'
+				if (( $G_DISTRO < 4 )); then
+
+					G_CONFIG_INJECT '"mod_rewrite",' '	"mod_rewrite",' /etc/lighttpd/lighttpd.conf '"mod_.+",'
+
+				else
+
+					lighttpd-enable-mod rewrite
+
+				fi
+
+				# Move ownCloud configuration file in place and activate it
+				owncloud_conf='/etc/lighttpd/conf-available/99-dietpi-owncloud.conf'
+				if [[ -f $owncloud ]]; then
+
+					owncloud_conf+='.dietpi-new'
+					G_WHIP_MSG "Existing ownCloud Lighttpd configuration found, will preserve the old one and save the new one for review and comparison to: $nextcloud_conf"
+
+				fi
+				dps_index=$software_id Download_Install 'lighttpd.owncloud.conf' $owncloud_conf
+				lighttpd-enable-mod dietpi-owncloud
+
 				# Cal/CardDAV redirects to ownCloud DAV endpoint
 				if [[ ! -f /etc/lighttpd/conf-enabled/99-dietpi-dav_redirect.conf ]]; then
 
@@ -7681,7 +7702,7 @@ url.redirect = (
 
 			elif (( ${aSOFTWARE_INSTALL_STATE[85]} > 0 )); then
 
-				G_DIETPI-NOTIFY 2 'Nginx webserver found, enabling ownCloud specific configuration.' # https://doc.owncloud.org/server/latest/admin_manual/installation/nginx_configuration.html#owncloud-in-a-subdir-of-nginx
+				G_DIETPI-NOTIFY 2 'Nginx webserver found, enabling ownCloud specific configuration.' # https://doc.owncloud.org/server/administration_manual/installation/nginx_configuration.html
 				local owncloud_conf='/etc/nginx/sites-dietpi/dietpi-owncloud.conf'
 				if [[ -f $owncloud_conf ]]; then
 
@@ -7693,11 +7714,7 @@ url.redirect = (
 				dps_index=$software_id Download_Install 'nginx.owncloud.conf' $owncloud_conf
 
 				# Stretch: Set 'fastcgi_request_buffering off';
-				if (( $G_DISTRO > 3 )); then
-
-					sed -i 's/#fastcgi_request_buffering off;/fastcgi_request_buffering off;/g' $owncloud_conf
-
-				fi
+				(( $G_DISTRO > 3 )) && sed -i 's/#fastcgi_request_buffering off;/fastcgi_request_buffering off;/g' $owncloud_conf
 
 				# Set HTTPS on, if SSL connection is available, even with self-signed/untrusted certificate.
 				wget -q --spider --timeout=10 --tries=2 https://localhost &> /dev/null
@@ -7729,7 +7746,7 @@ location = /.well-known/caldav {
 
 			fi
 
-			G_DIETPI-NOTIFY 2 'Enable 4-byte support for MariaDB.' # https://doc.owncloud.org/server/latest/admin_manual/configuration/database/linux_database_configuration.html#configure-mysql-for-4-byte-unicode-support
+			G_DIETPI-NOTIFY 2 'Enable 4-byte support for MariaDB.' # https://doc.owncloud.org/server/administration_manual/configuration/database/linux_database_configuration.html#configure-mysql-for-4-byte-unicode-support
 			local fp_mariadb_conf='/etc/mysql/mariadb.conf.d'
 			# On Jessie (MariaDB 10.0), /etc/mysql/mariadb.conf.d does not yet exist
 			(( G_DISTRO < 4 )) && fp_mariadb_conf='/etc/mysql/conf.d'
@@ -7831,7 +7848,7 @@ _EOF_
 			GCI_PRESERVE=1 G_CONFIG_INJECT "'memcache.local'" "'memcache.local' => '\\\\OC\\\\Memcache\\\\APCu'," $config_php "'version'"
 
 			# Redis for transactional file locking:
-			G_DIETPI-NOTIFY 2 'Enabling Redis for transactional file locking.' # https://doc.owncloud.org/server/latest/admin_manual/configuration/server/caching_configuration.html#configuring-transactional-file-locking
+			G_DIETPI-NOTIFY 2 'Enabling Redis for transactional file locking.' # https://doc.owncloud.org/server/administration_manual/configuration/server/caching_configuration.html#configuring-transactional-file-locking
 			local redis_conf="/etc/redis/redis*.conf"
 			# - Enable Redis socket and grant www-data access to it:
 			#	- NB: To allow wildcard expansion, do not use quotes around $redis_conf!
@@ -7859,19 +7876,15 @@ _EOF_
 
 			Banner_Configuration
 
-			G_DIETPI-NOTIFY 2 'Enabling needed PHP modules.' # https://docs.nextcloud.com/server/14/admin_manual/installation/source_installation.html#prerequisites-label
+			G_DIETPI-NOTIFY 2 'Enabling needed PHP modules.' # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
 			${PHP_BINARY}enmod curl gd intl json pdo_mysql opcache apcu redis
 			# Following modules are switchable since Stretch:
-			if (( $G_DISTRO > 3 )); then
-
-				phpenmod ctype dom fileinfo iconv mbstring posix simplexml xmlwriter xmlreader zip exif
-
-			fi
+			(( $G_DISTRO > 3 )) && phpenmod ctype dom fileinfo iconv mbstring posix simplexml xmlwriter xmlreader zip exif
 
 			G_DIETPI-NOTIFY 2 'Enabling APCu memory cache for PHP command line usage (CLI) as well, including Nextcloud ncc command and cron jobs.'
 			G_CONFIG_INJECT 'apc.enable_cli[[:blank:]=]' 'apc.enable_cli=1' "$FP_PHP_BASE_DIR/mods-available/apcu.ini"
 
-			G_DIETPI-NOTIFY 2 'Enabling and configuring OPcache for Nextcloud.' # https://docs.nextcloud.com/server/14/admin_manual/configuration_server/server_tuning.html#enable-php-opcache
+			G_DIETPI-NOTIFY 2 'Enabling and configuring OPcache for Nextcloud.' # https://docs.nextcloud.com/server/stable/admin_manual/configuration_server/server_tuning.html#enable-php-opcache
 			G_CONFIG_INJECT 'opcache.enable[[:blank:]=]' 'opcache.enable=1' "$FP_PHP_BASE_DIR/mods-available/opcache.ini"
 			G_CONFIG_INJECT 'opcache.enable_cli[[:blank:]=]' 'opcache.enable_cli=1' "$FP_PHP_BASE_DIR/mods-available/opcache.ini"
 			G_CONFIG_INJECT 'opcache.interned_strings_buffer[[:blank:]=]' 'opcache.interned_strings_buffer=8' "$FP_PHP_BASE_DIR/mods-available/opcache.ini"
@@ -7879,9 +7892,9 @@ _EOF_
 			G_CONFIG_INJECT 'opcache.save_comments[[:blank:]=]' 'opcache.save_comments=1' "$FP_PHP_BASE_DIR/mods-available/opcache.ini"
 			G_CONFIG_INJECT 'opcache.revalidate_freq[[:blank:]=]' 'opcache.revalidate_freq=1' "$FP_PHP_BASE_DIR/mods-available/opcache.ini"
 
-			if (( ${aSOFTWARE_INSTALL_STATE[83]} >= 1 )); then
+			if (( ${aSOFTWARE_INSTALL_STATE[83]} > 0 )); then
 
-				G_DIETPI-NOTIFY 2 'Apache webserver found, enabling Nextcloud specific configuration.' # https://docs.nextcloud.com/server/14/admin_manual/installation/source_installation.html#apache-web-server-configuration
+				G_DIETPI-NOTIFY 2 'Apache webserver found, enabling Nextcloud specific configuration.' # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#apache-web-server-configuration
 				a2enmod rewrite headers env dir mime 1> /dev/null
 				local nextcloud_conf='/etc/apache2/sites-available/dietpi-nextcloud.conf'
 				if [[ -f $nextcloud_conf ]]; then
@@ -7891,7 +7904,7 @@ _EOF_
 
 				fi
 				G_RUN_CMD cp -f /DietPi/dietpi/conf/apache.nextcloud.conf $nextcloud_conf
-				a2ensite nextcloud 1> /dev/null
+				a2ensite dietpi-nextcloud 1> /dev/null
 				# Cal/CardDAV redirects to Nextcloud DAV endpoint
 				if [[ ! -f /etc/apache2/conf-available/dietpi-dav_redirect.conf ]]; then
 
@@ -7902,12 +7915,22 @@ Redirect permanent /.well-known/caldav /nextcloud/remote.php/dav' > /etc/apache2
 
 				fi
 
-			elif (( ${aSOFTWARE_INSTALL_STATE[84]} >= 1 )); then
+			elif (( ${aSOFTWARE_INSTALL_STATE[84]} > 0 )); then
 
 				G_DIETPI-NOTIFY 2 'Lighttpd webserver found, enabling Nextcloud specific configuration.'
 
-				# Enable mod_setenv
+				# Enable required modules
+				G_CONFIG_INJECT '"mod_access",' '	"mod_access",' /etc/lighttpd/lighttpd.conf '"mod_.+",'
 				G_CONFIG_INJECT '"mod_setenv",' '	"mod_setenv",' /etc/lighttpd/lighttpd.conf '"mod_.+",'
+				if (( $G_DISTRO < 4 )); then
+
+					G_CONFIG_INJECT '"mod_rewrite",' '	"mod_rewrite",' /etc/lighttpd/lighttpd.conf '"mod_.+",'
+
+				else
+
+					lighttpd-enable-mod rewrite
+
+				fi
 
 				# Move Nextcloud configuration file in place and activate it
 				nextcloud_conf='/etc/lighttpd/conf-available/99-dietpi-nextcloud.conf'
@@ -7934,7 +7957,7 @@ url.redirect = (
 
 			elif (( ${aSOFTWARE_INSTALL_STATE[85]} > 0 )); then
 
-				G_DIETPI-NOTIFY 2 'Nginx webserver found, enabling Nextcloud specific configuration.' # https://docs.nextcloud.com/server/14/admin_manual/installation/nginx.html#nextcloud-in-a-subdir-of-nginx
+				G_DIETPI-NOTIFY 2 'Nginx webserver found, enabling Nextcloud specific configuration.' # https://docs.nextcloud.com/server/stable/admin_manual/installation/nginx.html
 				local nextcloud_conf='/etc/nginx/sites-dietpi/dietpi-nextcloud.conf'
 				if [[ -f $nextcloud_conf ]]; then
 
@@ -7945,11 +7968,7 @@ url.redirect = (
 				dps_index=$software_id Download_Install 'nginx.nextcloud.conf' $nextcloud_conf
 
 				# Stretch: Set 'fastcgi_request_buffering off';
-				if (( $G_DISTRO > 3 )); then
-
-					sed -i 's/#fastcgi_request_buffering off;/fastcgi_request_buffering off;/g' $nextcloud_conf
-
-				fi
+				(( $G_DISTRO > 3 )) && sed -i 's/#fastcgi_request_buffering off;/fastcgi_request_buffering off;/g' $nextcloud_conf
 
 				# Set HTTPS on, if SSL connection is available, even with self-signed/untrusted certificate.
 				wget -q --spider --timeout=10 --tries=2 https://localhost &> /dev/null
@@ -7959,7 +7978,7 @@ url.redirect = (
 
 				fi
 
-				# Disable pretty URLs (front controller), if Nextcloud version is lower than 13:
+				# Disable pretty URLs (front controller), if Nextcloud version is lower than 13
 				if (( $(grep '$OC_VersionString' /var/www/nextcloud/version.php | sed "s/^.*= '//" | sed "s/\..*$//") < 13 )); then
 
 					sed -i 's/^[[:blank:]]*fastcgi_param front_controller_active true;/\t#fastcgi_param front_controller_active true;/g' $nextcloud_conf
@@ -7981,7 +8000,7 @@ location = /.well-known/caldav {
 
 			fi
 
-			G_DIETPI-NOTIFY 2 'Enable 4-byte support for MariaDB' # https://docs.nextcloud.com/server/14/admin_manual/configuration_database/mysql_4byte_support.html
+			G_DIETPI-NOTIFY 2 'Enable 4-byte support for MariaDB' # https://docs.nextcloud.com/server/stable/admin_manual/configuration_database/mysql_4byte_support.html
 			local fp_mariadb_conf='/etc/mysql/mariadb.conf.d'
 			# On Jessie (MariaDB 10.0), /etc/mysql/mariadb.conf.d does not yet exist
 			(( G_DISTRO < 4 )) && fp_mariadb_conf='/etc/mysql/conf.d'
@@ -8112,7 +8131,7 @@ The install script will now exit. After applying one of the the above, rerun die
 			GCI_PRESERVE=1 G_CONFIG_INJECT "'memcache.local'" "'memcache.local' => '\\\\OC\\\\Memcache\\\\APCu'," $config_php "'version'"
 
 			# Redis for transactional file locking:
-			G_DIETPI-NOTIFY 2 'Enabling Redis for transactional file locking.' # https://docs.nextcloud.com/server/14/admin_manual/configuration_files/files_locking_transactional.html
+			G_DIETPI-NOTIFY 2 'Enabling Redis for transactional file locking.' # https://docs.nextcloud.com/server/stable/admin_manual/configuration_files/files_locking_transactional.html
 			local redis_conf="/etc/redis/redis*.conf"
 			# - Enable Redis socket and grant www-data access to it:
 			#	- NB: To allow wildcard expansion, do not use quotes around $redis_conf!

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7717,17 +7717,19 @@ url.redirect = (
 				(( $G_DISTRO > 3 )) && sed -i 's/#fastcgi_request_buffering off;/fastcgi_request_buffering off;/g' $owncloud_conf
 
 				# Set HTTPS on, if SSL connection is available, even with self-signed/untrusted certificate.
+				# - Only apply, if related dietpi-letsencrypt settings were found
 				wget -q --spider --timeout=10 --tries=2 https://localhost &> /dev/null
-				if (( $? == 0 || $? == 5)); then
+				if (( $? == 0 || $? == 5)) && [[ -f /DietPi/dietpi/.dietpi-letsencrypt ]]; then
 
-					sed -i 's/#fastcgi_param HTTPS on;/fastcgi_param HTTPS on;/g' $owncloud_conf
+					[[ $(sed -n 3p /DietPi/dietpi/.dietpi-letsencrypt) == 1 ]] && sed -i 's/#fastcgi_param HTTPS on;/fastcgi_param HTTPS on;/g' $owncloud_conf
+					[[ $(sed -n 4p /DietPi/dietpi/.dietpi-letsencrypt) == 1 ]] && sed -i 's/#add_header Strict-Transport-Security/add_header Strict-Transport-Security/g' $owncloud_conf
 
 				fi
 
 				# Disable pretty URLs (front controller), if ownCloud version is lower than 10:
 				if (( $(grep '$OC_VersionString' /var/www/owncloud/version.php | sed "s/^.*= '//" | sed "s/\..*$//") < 10 )); then
 
-					sed -i 's/^[[:blank:]]*fastcgi_param front_controller_active true;/\t#fastcgi_param front_controller_active true;/g' $owncloud_conf
+					sed -i 's/^[[:blank:]]*fastcgi_param front_controller_active true;/\t\t#fastcgi_param front_controller_active true;/g' $owncloud_conf
 
 				fi
 
@@ -7971,17 +7973,19 @@ url.redirect = (
 				(( $G_DISTRO > 3 )) && sed -i 's/#fastcgi_request_buffering off;/fastcgi_request_buffering off;/g' $nextcloud_conf
 
 				# Set HTTPS on, if SSL connection is available, even with self-signed/untrusted certificate.
+				# - Only apply, if related dietpi-letsencrypt settings were found
 				wget -q --spider --timeout=10 --tries=2 https://localhost &> /dev/null
-				if (( $? == 0 || $? == 5)); then
+				if (( $? == 0 || $? == 5)) && [[ -f /DietPi/dietpi/.dietpi-letsencrypt ]]; then
 
-					sed -i 's/#fastcgi_param HTTPS on;/fastcgi_param HTTPS on;/g' $nextcloud_conf
+					[[ $(sed -n 3p /DietPi/dietpi/.dietpi-letsencrypt) == 1 ]] && sed -i 's/#fastcgi_param HTTPS on;/fastcgi_param HTTPS on;/g' $nextcloud_conf
+					[[ $(sed -n 4p /DietPi/dietpi/.dietpi-letsencrypt) == 1 ]] && sed -i 's/#add_header Strict-Transport-Security/add_header Strict-Transport-Security/g' $nextcloud_conf
 
 				fi
 
 				# Disable pretty URLs (front controller), if Nextcloud version is lower than 13
 				if (( $(grep '$OC_VersionString' /var/www/nextcloud/version.php | sed "s/^.*= '//" | sed "s/\..*$//") < 13 )); then
 
-					sed -i 's/^[[:blank:]]*fastcgi_param front_controller_active true;/\t#fastcgi_param front_controller_active true;/g' $nextcloud_conf
+					sed -i 's/^[[:blank:]]*fastcgi_param front_controller_active true;/\t\t#fastcgi_param front_controller_active true;/g' $nextcloud_conf
 
 				fi
 
@@ -8147,6 +8151,9 @@ The install script will now exit. After applying one of the the above, rerun die
 			# Enable Nextcloud background cron job:
 			crontab -u www-data -l 2>/dev/null | grep -q '/var/www/nextcloud/cron.php' || ( crontab -u www-data -l 2>/dev/null ; echo "*/15 * * * * php /var/www/nextcloud/cron.php" ) | crontab -u www-data -
 			ncc background:cron
+
+			# Convert filecache tables to bigint, which is not done anymore automatically by Nextcloud since v15
+			ncc db:convert-filecache-bigint
 
 			# Enable maintenance mode to allow handling by dietpi-services:
 			grep -q "^[[:blank:]]*'maintenance' => true," $config_php || ncc maintenance:mode --on

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8153,7 +8153,7 @@ The install script will now exit. After applying one of the the above, rerun die
 			ncc background:cron
 
 			# Convert filecache tables to bigint, which is not done anymore automatically by Nextcloud since v15
-			ncc db:convert-filecache-bigint
+			ncc db:convert-filecache-bigint -n
 
 			# Enable maintenance mode to allow handling by dietpi-services:
 			grep -q "^[[:blank:]]*'maintenance' => true," $config_php || ncc maintenance:mode --on

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1413,14 +1413,12 @@ You will not face any practical differences, since both services start the same 
 
 				a2dissite owncloud
 				mv /etc/apache2/sites-available/owncloud.conf /etc/apache2/sites-available/dietpi-owncloud.conf
-				a2ensite dietpi-owncloud
 
 			fi
 			if [[ -f /etc/apache2/sites-available/nextcloud.conf ]]; then
 
 				a2dissite nextcloud
 				mv /etc/apache2/sites-available/nextcloud.conf /etc/apache2/sites-available/dietpi-nextcloud.conf
-				a2ensite dietpi-nextcloud
 
 			fi
 			if [[ -f /etc/apache2/sites-available/rutorrent.conf ]]; then
@@ -1549,6 +1547,10 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 			sed -i '\|[[:blank:]]/boot[[:blank:]]|s|,x-systemd.automount||' /etc/fstab
 			sed -i '\|[[:blank:]]/boot[[:blank:]]|s|,nofail||' /etc/fstab
 			systemctl daemon-reload
+			#-------------------------------------------------------------------------------
+			#Re-enable owncloud/Nextcloud Apache configs, to fix faulty v6.19 installs: https://github.com/Fourdee/DietPi/pull/2361/commits/e33ca150cf29a4f278f5df2defc495053700a91e
+			[[ -f /etc/apache2/sites-available/dietpi-owncloud.conf ]] && a2ensite dietpi-owncloud
+			[[ -f /etc/apache2/sites-available/dietpi-nextcloud.conf ]] && a2ensite dietpi-nextcloud
 			#-------------------------------------------------------------------------------
 
 		fi


### PR DESCRIPTION
**Status**: Ready
- [x] Lighttpd Nextcloud
- [x] Lighttpd ownCloud
- [x] DietPi-Software | Install Lighttpd ownCloud config
- [x] Lighttpd access, setenv and rewrite module check
- [x] Nginx Nextcloud
- [x] Nginx ownCloud
- [x] Enable HSTS header in Nginx configs within `dietpi-letsencrypt`, if chosen
- [x] Enable HSTS header in Nginx configs during install, if `dietpi-letsencrypt` HSTS setting was chosen
- [x] Nextcloud: Update doc links to new scheme without version string
- [x] Nextcloud: Run `ncc db:convert-filecache-bigint` during config step:
  > Some columns in the database are missing a conversion to big int. Due to the fact that changing column types on big tables could take some time they were not changed automatically. By running 'occ db:convert-filecache-bigint' those pending changes could be applied manually. This operation needs to be made while the instance is offline. For further details read the documentation page about this.
  >   - filecache.mtime
  >   - filecache.storage_mtime
- [x] Repatch enabling ownCloud/Nextcloud Apache config, to fix faulty v6.19 installs. Not urgent since on default DietPi setup does not require those configs.
+ [x] Changelog

**Testing** (on VM):
- [x] Jessie ownCloud+Nextcloud Lighttpd install without HTTPS
- [x] Stretch ownCloud+Nextcloud Lighttpd install without HTTPS
- [x] Jessie ownCloud+Nextcloud Nginx install without HTTPS
- [x] Stretch ownCloud+Nextcloud Nginx install without HTTPS
- [x] DietPi-LetsEncrypt GUI
- [x] Nginx HTTPS setting => Indeed it results in automated redirection, so do not enable, if HTTPS redirection was not chosen actively. Currently check via `.dietpi-letsencrypt`, mid-term check via webserver config paste. Or have this done automatically based on current port (better: protocol?): https://stackoverflow.com/a/4855374
- [x] Buster Nextcloud Nginx without HTTPS
- 🈴 Buster ownCloud not compatible with PHP7.3:
```
This version of ownCloud is not compatible with PHP 7.3
You are currently running PHP 7.3.0-2.
```
- [x] Disable ownCloud support on Buster: https://github.com/Fourdee/DietPi/pull/2361/commits/a454034c0060f815e88deee8048bb89404b43ac2

**Commit list/description**:
+ DietPi-Software | ownCloud/Nextcloud: Add Lighttpd security hardenings based on official Apache and Nginx configs
+ DietPi-Software | Nextcloud: Remove "Referrer-Policy" header from Lighttpd, which is set internally since NC15 and not checked on NC13 (Jessie)
+ DietPi-Software | ownCloud/Nextcloud: Update Nginx config to match current official docs
+ DietPi-Software | ownCloud/Nextcloud: Remove "preload" from HSTS header. Users should decide this by themselves, since removal from preload list can take a long time, if not wanted. Further only enable HSTS header, if chosen via dietpi-letsencrypt.
+ DietPi-Software | ownCloud/Nextcloud: Add link to docs with Apache config
+ DietPi-Software | ownCloud/Nextcloud: Fix enabling old Apache site; Enable required Lighttpd modules; Update doc links
+ DietPi-Software | ownCloud/Nextcloud: Minor coding and wording + use shortest possible forum docs links with post ID + jump label only
+ DietPi-Software | ownCloud/Nextcloud: Enable HSTS header in Nginx configs, if dietpi-letsencrypt HSTS setting was chosen
+ DietPi-Software | ownCloud/Nextcloud: Enable HTTPS param (strictly requires HTTPS then) only, if redirection was chosen
+ DietPi-Software | Nextcloud: Run "ncc db:convert-filecache-bigint -n" which is required manually one time after fresh Nextcloud install
+ DietPi-LetsEncrypt | Enable related ownCloud/Nextcloud Nginx settings, if HTTPS redirect resp. HSTS was chosen
+ DietPi-LetsEncrypt | Do not add preload flag to HSTS header. This should be actively decided by user, since once added, removing a domain from the list can take a long time.
+ DietPi-LetsEncrypt | Minor coding
+ DietPi-Software | ownCloud: Disable on Buster, since PHP7.3 is currently not yet supported
+ DietPi-Software | Nextcloud: Apply correct "fastcgi_param HTTPS" automatically based on $https variable
+ DietPi-Software | ownCloud: Apply correct "fastcgi_param HTTPS" automatically based on $https variable
+ DietPi-LetsEncrypt | HTTPS fastcgi_param is now applied automatically based on Nginx $https variable
+ DietPi-Software | ownCloud/Nextcloud: fastcgi_param HTTPS is now sed automatically correctly based on Nginx $https variable
+ DietPi-Software | Nginx: Include /etc/nginx/modules-enabled/*.conf; to load dynamic Nginx modules, available since Stretch. On Jessie, however the directive does not hurt.
+ DietPi-Software | ownCloud: Disable on Buster, since PHP7.3 is currently not yet supported
+ DietPi-Services | Add PHP7.3 for Buster and PHP7.1 to be more flexible on custom upgrades

**NB:**
- Lighttpd pretty URL rewrite does not work reliable as expected with `url.rewrite-if-not-file`: `remote.php` requests are for some reason still rewritten, at least if dots are not explicitly excluded by rule: `"^/nextcloud/([^.]+)/?$"`. For updater and ocs-provider rewrite rules need to be overridden, which overall leads to a complex rule set, similar to what is done in official Nginx config: https://docs.nextcloud.com/server/stable/admin_manual/installation/nginx.html. Since Nextcloud internally does not use these pretty URLs (compared to Apache and Nginx), it is not worth the effort. Not pretty, but at least security hardening is on current stage.