### PR TITLE
DietPi-Sync | Resolve rsync option string bug

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,7 @@ Changes / Improvements / Optimisations:
 
 Bug Fixes:
 - DietPi-Software | ownCloud/Nextcloud (Talk): Resolved an issue, where occ/ncc commands could fail, if Redis server is not running: https://github.com/Fourdee/DietPi/issues/2321
+- DietPi-Sync | Resolved an issue, where dry-run and compression options were not applied correctly. Thanks to @WilburWalsh for reporting the issue and identifying the faulty code: https://dietpi.com/phpbb/viewtopic.php?f=11&t=5347
 - General | Enhanced and fixed some issue with dependencies and boot order of DietPi systemd units: https://github.com/Fourdee/DietPi/pull/2357
 - General | AudioPhonics I-Sabre-K2M: Once the driver is compiled, it will no longer be recompiled. This prevents ALSA installs from re-compiling the driver each time.
 - General | Resolved an issue, where login with non-bash session caused an error message. Thanks to @Elijahg for reporting this issue: https://github.com/Fourdee/DietPi/issues/2347

--- a/dietpi/dietpi-sync
+++ b/dietpi/dietpi-sync
@@ -83,7 +83,7 @@ _EOF_
 		do
 
 			# - Exclude only, if inside source location, via path, relative to source location
-			[[ $i == ${FP_SOURCE}/* ]] && echo "- $(realpath --relative-to=$FP_SOURCE $i)" >> $FP_FILTER_INCLUDE_EXCLUDE
+			[[ $i == ${FP_SOURCE}/* ]] && echo "- $(realpath --relative-to="$FP_SOURCE" "$i")" >> $FP_FILTER_INCLUDE_EXCLUDE
 
 		done
 

--- a/dietpi/dietpi-sync
+++ b/dietpi/dietpi-sync
@@ -25,6 +25,10 @@
 	G_INIT
 	#Import DietPi-Globals ---------------------------------------------------------------
 
+	#Restart rsync service, if stopped during DietPi-Sync run: https://github.com/Fourdee/DietPi/issues/1869
+	SERVICE_CONTROL=0
+	G_EXIT_CUSTOM(){ (( $SERVICE_CONTROL )) && systemctl start rsync; }
+
 	#Grab Input (valid interger)
 	INPUT=0
 	disable_error=1 G_CHECK_VALIDINT "$1" && INPUT=$1
@@ -33,23 +37,17 @@
 	# Sync System
 	#/////////////////////////////////////////////////////////////////////////////////////
 	EXIT_CODE=0
-	FP_LOG='/var/log/dietpi-sync.log'
 
-	#Sync Filepaths
+	#File paths
+	FP_SETTINGS='/DietPi/dietpi/.dietpi-sync_settings'
+	FP_FILTER_INCLUDE_EXCLUDE='.dietpi-sync_include_exclude'
+	FP_USER_FILTER_INCLUDE_EXCLUDE='/DietPi/dietpi/.dietpi-sync_inc_exc'
+	FP_LOG='.dietpi-sync.log'
+	FP_SAMBA_MOUNT='/mnt/samba'
 	FP_SOURCE='/mnt/Source'
 	FP_TARGET='/mnt/Target'
 
-	#DietPi Mounts
-	FP_SAMBA_MOUNT='/mnt/samba'
-
-	#file applied to successful Sync (stored in $FP_TARGET/$SYNC_STATS_FILENAME)
-	SYNC_STATS_FILENAME='.dietpi-sync_stats'
-
-	#Exclude/include file
-	FP_FILTER_INCLUDE_EXCLUDE='.dietpi-sync_include_exclude'
-	FP_USER_FILTER_INCLUDE_EXCLUDE='/DietPi/dietpi/.dietpi-sync_inc_exc'
-
-	#Extra options
+	#Extra settings
 	SYNC_DELETE_MODE=0
 	SYNC_CRONDAILY=0
 
@@ -57,23 +55,23 @@
 
 		#Exclude files by name
 		cat << _EOF_ > $FP_FILTER_INCLUDE_EXCLUDE
-- $SYNC_STATS_FILENAME
+- $FP_LOG
+- $FP_FILTER_INCLUDE_EXCLUDE
 - .swap*
 - *.tmp
 # - MS Windows specific
 - Thumbs.db
 - desktop.ini
 - SyncToy* # MS SyncToy
-- System Volume Information #  - causes error code 23 (permission denied)
-
+- System Volume Information # causes error code 23 (permission denied)
 _EOF_
 
 		#Exclude specific files/dirs by path
 		local aexclude=(
 
 			"$FP_TARGET"
-			"$FP_LOG"
-			"$FP_DIETPISYNC_SETTINGS"
+			$FP_SETTINGS
+			$FP_USER_FILTER_INCLUDE_EXCLUDE
 			/boot/dietpi/
 			/var/swap
 
@@ -97,7 +95,6 @@ _EOF_
 	Banner_Start(){
 
 		local mode='Sync'
-		#Dry Run?
 		(( $SYNC_DRY_RUN )) && mode='Dry Run'
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" "$mode"
@@ -109,10 +106,9 @@ _EOF_
 		Banner_Start
 
 		#Stop rsync service: https://github.com/Fourdee/DietPi/issues/1869
-		local control_rsync_service=0
 		if systemctl is-active rsync &> /dev/null; then
 
-			control_rsync_service=1
+			SERVICE_CONTROL=1
 			systemctl stop rsync
 
 		fi
@@ -121,17 +117,17 @@ _EOF_
 		#Pre-create target dir
 		mkdir -p "$FP_TARGET"
 
-		#Error: Folder not found
+		#Error: Dir not found
 		if [[ ! -d $FP_TARGET ]]; then
 
 			G_WHIP_MSG "[FAILED] Unable to pre-create target directory: $FP_TARGET"
-			echo "$(date +"%d-%m-%Y_%T") [FAILED] Unable to pre-create target directory: $FP_TARGET" >> $FP_LOG
 
 		#Error: Rsync is already running
 		elif pgrep '[r]sync' &> /dev/null; then
 
 			G_WHIP_MSG '[FAILED] Rsync is already running'
-			echo "$(date +"%d-%m-%Y_%T") [FAILED] Rsync is already running" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
+			# Add info to target log location directly, preserve previous rsync log
+			echo "$(date +"%d-%m-%Y_%T") [FAILED] Rsync is already running" >> "$FP_TARGET/$FP_LOG"
 
 		#Start sync
 		else
@@ -140,15 +136,14 @@ _EOF_
 			Create_Filter_Include_Exclude
 
 			#Rsync options
-			local rync_options="-aHP4h --info=name0 --info=progress2 --delete-excluded --exclude-from=$FP_FILTER_INCLUDE_EXCLUDE --log-file=$FP_LOG"
-
+			local rsync_options="-aHP4h --info=name0 --info=progress2 --delete-excluded --exclude-from=$FP_FILTER_INCLUDE_EXCLUDE --log-file=$FP_LOG"
 			# - Delete mode?
-			(( $SYNC_DELETE_MODE )) && rync_options+=' --delete'
+			(( $SYNC_DELETE_MODE )) && rsync_options+=' --delete'
 
-			#Verify enough space
-			rsync --dry-run --stats $rync_options "$FP_SOURCE"/ "$FP_TARGET"/ > .dietpi-sync_result
+			#Dry Run and verify enough space, in case if real sync
+			rsync --dry-run --stats $rsync_options "$FP_SOURCE"/ "$FP_TARGET"/ > .dietpi-sync_result
 			EXIT_CODE=$?
-			if (( ! $EXIT_CODE )); then
+			if ! (( $SYNC_DRY_RUN || $EXIT_CODE )); then
 
 				# - NB: working in KiB until end MiB conversion, as, don't like using long long int, and, KiB should offer a good end result.
 				local old_backup_size=$(du -ks "$FP_TARGET" | awk '{print $1}')
@@ -167,55 +162,50 @@ _EOF_
 However, this check is a rough estimation in reasonable time, thus it could be marginally incorrect.\n
 Would you like to override this warning and continue with the backup?'; then
 
-						echo "$(date +"%d-%m-%Y_%T") [FAILED] Insufficient free space" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
+						echo "$(date +"%d-%m-%Y_%T") [FAILED] Insufficient free space" >> $FP_LOG
+						mv $FP_LOG "$FP_TARGET"/
 						return 1
 
 					fi
 
 				fi
 
-			fi
-			rm .dietpi-sync_result
-
-			if ! (( $SYNC_DRY_RUN || $EXIT_CODE )); then
-
+				#Real sync
 				G_DIETPI-NOTIFY 2 "Sync | $FP_SOURCE > $FP_TARGET: in progress, please wait..."
-
-				rsync $rync_options "$FP_SOURCE"/ "$FP_TARGET"/
+				# - Clear log file from space check
+				> $FP_LOG
+				rsync $rsync_options "$FP_SOURCE"/ "$FP_TARGET"/
 				EXIT_CODE=$?
 
 			fi
 
 			G_DIETPI-NOTIFY -1 $EXIT_CODE "$G_PROGRAM_NAME"
-			if (( $EXIT_CODE == 0 )); then
+
+			if (( ! $EXIT_CODE )); then
 
 				if (( ! $SYNC_DRY_RUN )); then
 
-					echo "$(date +"%d-%m-%Y_%T") [  OK  ] Sync completed" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
+					echo "$(date +"%d-%m-%Y_%T") [  OK  ] Sync completed" >> $FP_LOG
 					G_WHIP_MSG "[  OK  ] Sync completed:\n - $FP_SOURCE > $FP_TARGET"
 
 				else
 
-					echo "$(date +"%d-%m-%Y_%T") [  OK  ] Dry run completed" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
+					echo "$(date +"%d-%m-%Y_%T") [  OK  ] Dry run completed" >> $FP_LOG
 					G_WHIP_MSG "[  OK  ] Dry Run Sync completed (NO modifications):\n - $FP_SOURCE > $FP_TARGET"
 
 				fi
 
 			else
 
-				echo "$(date +"%d-%m-%Y_%T") [FAILED] Please see the log file for more information: $FP_LOG" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
+				echo "$(date +"%d-%m-%Y_%T") [FAILED] Please see the log file for more information: $FP_TARGET/$FP_LOG" >> $FP_LOG
 				G_WHIP_MSG "[FAILED] $FP_SOURCE > $FP_TARGET\n\nYou will given an option to view the logfile on the next screen. Please check it for information and/or errors."
 
 			fi
 
 			log=1 G_WHIP_VIEWFILE $FP_LOG
-
-			#return to main menu
-			TARGETMENUID=0
+			mv $FP_LOG "$FP_TARGET"/
 
 		fi
-
-		(( $control_rsync_service )) && systemctl start rsync # https://github.com/Fourdee/DietPi/issues/1869
 
 	}
 
@@ -241,12 +231,9 @@ Would you like to override this warning and continue with the backup?'; then
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Settings File
 	#/////////////////////////////////////////////////////////////////////////////////////
-	#Settings File
-	FP_DIETPISYNC_SETTINGS='/DietPi/dietpi/.dietpi-sync_settings'
-
 	Write_Settings_File(){
 
-		cat << _EOF_ > $FP_DIETPISYNC_SETTINGS
+		cat << _EOF_ > $FP_SETTINGS
 FP_SOURCE=$FP_SOURCE
 FP_TARGET=$FP_TARGET
 SYNC_DELETE_MODE=$SYNC_DELETE_MODE
@@ -257,7 +244,7 @@ _EOF_
 
 	Read_Settings_File(){
 
-		[[ -f $FP_DIETPISYNC_SETTINGS ]] && . $FP_DIETPISYNC_SETTINGS
+		[[ -f $FP_SETTINGS ]] && . $FP_SETTINGS
 
 	}
 
@@ -284,7 +271,7 @@ _EOF_
 		(( $SYNC_CRONDAILY )) && SYNC_CRONDAILY_TEXT='[On]'
 
 		local sync_last_status='No previous sync found in target directory.'
-		[[ -f $FP_TARGET/$SYNC_STATS_FILENAME ]] && sync_last_status=$(tail -1 "$FP_TARGET/$SYNC_STATS_FILENAME")
+		[[ -f $FP_TARGET/$FP_LOG ]] && sync_last_status=$(tail -1 "$FP_TARGET/$FP_LOG")
 
 		G_WHIP_MENU_ARRAY=(
 
@@ -302,8 +289,7 @@ _EOF_
 		)
 
 		G_WHIP_BUTTON_CANCEL_TEXT='Exit'
-		G_WHIP_MENU "Source location:\n  $FP_SOURCE\n\nTarget location:\n  $FP_TARGET\n\nLast sync status:\n  $sync_last_status"
-		if (( $? == 0 )); then
+		if G_WHIP_MENU "Source location:\n  $FP_SOURCE\n\nTarget location:\n  $FP_TARGET\n\nLast sync status:\n  $sync_last_status"; then
 
 			case "$G_WHIP_RETURNED_VALUE" in
 
@@ -321,22 +307,22 @@ _EOF_
 
 				'Help')
 
-					G_WHIP_MSG "DietPi-Sync is a program that allows you to duplicate a directory from one location (Source) to another (Target).\n
+					G_WHIP_MSG 'DietPi-Sync is a program that allows you to duplicate a directory from one location (Source) to another (Target).\n
 For example: If we want to duplicate (sync) the data on our external USB HDD to another location, we simply select the USB HDD as the source, then, select a target location.
 The target location can be anything from a networked samba fileserver, or even a FTP server.\n
-If you would like to test a sync without modifiying any data, simply select Dry Run.\n\nMore information:\n - https://dietpi.com/phpbb/viewtopic.php?p=256#p256"
+If you would like to test a sync without modifiying any data, simply select Dry Run.\n\nMore information:\n - https://dietpi.com/phpbb/viewtopic.php?p=256#p256'
 
 				;;
 
 				'Delete Mode')
 
-					TARGETMENUID=3
+					Menu_Set_Sync_Delete_Mode
 
 				;;
 
 				'Sync: Daily')
 
-					TARGETMENUID=4
+					Menu_Set_CronDaily
 
 				;;
 
@@ -381,20 +367,17 @@ A copy of all the files and folders inside your Source location, will be created
 
 	}
 
-	#TARGETMENUID=1 && TARGETMENUID=2
+	#TARGETMENUID=1 (Target) && TARGETMENUID=2 (Source)
 	Menu_Set_Directories(){
-
-		#TARGETMENUID
-		#2=Source | 1=Target
 
 		local current_directory="$FP_TARGET"
 		local current_mode_text='Target'
-		local whip_description_text="Please select the $current_mode_text location.\nA copy of all the files and folders in the Source location will be created here.\n\nCurrent Target location:\n$FP_TARGET"
+		local whip_description_text="Please select the $current_mode_text location.\nA copy of all the files and folders in the Source location will be created here.\n\nCurrent $current_mode_text location:\n$current_directory"
 		if (( $TARGETMENUID == 2 )); then
 
 			current_directory="$FP_SOURCE"
 			current_mode_text='Source'
-			whip_description_text="Please select the $current_mode_text location.\nA copy of all the files and folder in this Source location, will be created at the Target location.\n\nCurrent Source location:\n$FP_SOURCE"
+			whip_description_text="Please select the $current_mode_text location.\nA copy of all the files and folder in this Source location, will be created at the Target location.\n\nCurrent $current_mode_text location:\n$current_directory"
 
 		fi
 
@@ -446,11 +429,11 @@ A copy of all the files and folders inside your Source location, will be created
 
 						if (( $TARGETMENUID == 2 )); then
 
-							FP_SOURCE="$FP_SAMBA_MOUNT"
+							FP_SOURCE=$FP_SAMBA_MOUNT
 
 						else
 
-							FP_TARGET="$FP_SAMBA_MOUNT/dietpi-sync"
+							FP_TARGET=$FP_SAMBA_MOUNT/dietpi-sync
 
 						fi
 
@@ -459,15 +442,6 @@ A copy of all the files and folders inside your Source location, will be created
 					else
 
 						Prompt_Setup_Samba_Mount
-						if (( $TARGETMENUID == 2 )); then
-
-							FP_SOURCE="$current_directory"
-
-						else
-
-							FP_TARGET="$current_directory"
-
-						fi
 
 					fi
 
@@ -484,7 +458,6 @@ A copy of all the files and folders inside your Source location, will be created
 
 	}
 
-	#TARGETMENUID=3
 	Menu_Set_Sync_Delete_Mode(){
 
 		G_WHIP_MENU_ARRAY=(
@@ -495,28 +468,24 @@ A copy of all the files and folders inside your Source location, will be created
 		)
 
 		G_WHIP_DEFAULT_ITEM="$SYNC_MODE_TEXT"
-		if G_WHIP_MENU "Please select the Sync delete mode.\n
+		if G_WHIP_MENU 'Please select the Sync delete mode.\n
 [Off]: (safe)\nIf files and folders exist in the Target location, that are not in the Source, they will be left alone.\n
 [On]: (WARNING, if in doubt, DO NOT enable)\nAn exact copy of the Source location will be created at the Target location.
-If files are in the Target location that don't exist in the Source, they will be DELETED."; then
+If files are in the Target location that do not exist in the Source, they will be DELETED.'; then
 
 			SYNC_DELETE_MODE=0
 			[[ $G_WHIP_RETURNED_VALUE == '[On]' ]] && SYNC_DELETE_MODE=1
 
 		fi
 
-		#Return to main menu
-		TARGETMENUID=0
-
 	}
 
-	#TARGETMENUID=4
 	Menu_Set_CronDaily(){
 
 		G_WHIP_MENU_ARRAY=(
 
-			'[Off]' 'Manual sync.'
-			'[On]' 'Automatically sync once a day.'
+			'[Off]' ': Manual sync'
+			'[On]' ': Automatically sync once a day'
 
 		)
 
@@ -530,9 +499,6 @@ If files are in the Target location that don't exist in the Source, they will be
 
 		fi
 
-		#Return to main menu
-		TARGETMENUID=0
-
 	}
 
 	Input_User_Directory(){
@@ -544,7 +510,7 @@ If files are in the Target location that don't exist in the Source, they will be
 		(( $TARGETMENUID == 2 )) && mode='source'
 		local fp_mode="FP_${mode^^}"
 		G_WHIP_DEFAULT_ITEM=${!fp_mode}
-		local text="Please enter a new filepath for the $mode directory.\neg: /mnt/$mode"
+		local text="Please enter a new file path for the $mode directory.\neg: /mnt/$mode"
 
 		while :
 		do
@@ -638,14 +604,6 @@ _EOF_
 			elif (( $TARGETMENUID == 1 || $TARGETMENUID == 2 )); then
 
 				Menu_Set_Directories
-
-			elif (( $TARGETMENUID == 3 )); then
-
-				Menu_Set_Sync_Delete_Mode
-
-			elif (( $TARGETMENUID == 4 )); then
-
-				Menu_Set_CronDaily	
 
 			fi
 

--- a/dietpi/dietpi-sync
+++ b/dietpi/dietpi-sync
@@ -27,7 +27,7 @@
 
 	#Restart rsync service, if stopped during DietPi-Sync run: https://github.com/Fourdee/DietPi/issues/1869
 	SERVICE_CONTROL=0
-	G_EXIT_CUSTOM(){ (( $SERVICE_CONTROL )) && systemctl start rsync; }
+	G_EXIT_CUSTOM(){ (( $SERVICE_CONTROL )) && G_RUN_CMD systemctl start rsync; }
 
 	#Grab Input (valid interger)
 	INPUT=0
@@ -43,7 +43,6 @@
 	FP_FILTER_INCLUDE_EXCLUDE='.dietpi-sync_include_exclude'
 	FP_USER_FILTER_INCLUDE_EXCLUDE='/DietPi/dietpi/.dietpi-sync_inc_exc'
 	FP_LOG='.dietpi-sync.log'
-	FP_SAMBA_MOUNT='/mnt/samba'
 	FP_SOURCE='/mnt/Source'
 	FP_TARGET='/mnt/Target'
 
@@ -95,7 +94,7 @@ _EOF_
 	Banner_Start(){
 
 		local mode='Sync'
-		(( $SYNC_DRY_RUN )) && mode='Dry Run'
+		(( ${SYNC_DRY_RUN:=0} )) && mode='Dry Run'
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" "$mode"
 
@@ -109,25 +108,29 @@ _EOF_
 		if systemctl is-active rsync &> /dev/null; then
 
 			SERVICE_CONTROL=1
-			systemctl stop rsync
+			G_RUN_CMD systemctl stop rsync
 
 		fi
 		killall -qw rsync
 
-		#Pre-create target dir
-		mkdir -p "$FP_TARGET"
+		#Pre-create target dir to check R/W access
+                # - Remove previous mkdir log
+		[[ -f /var/log/dietpi-sync.log ]] && rm /var/log/dietpi-sync.log
+		mkdir -p "$FP_TARGET" &> $FP_TMP
 
 		#Error: Dir not found
 		if [[ ! -d $FP_TARGET ]]; then
 
-			G_WHIP_MSG "[FAILED] Unable to pre-create target directory: $FP_TARGET"
+			G_WHIP_MSG "[FAILED] Unable to pre-create target directory: $FP_TARGET\n\n\"mkdir\" reported the following error:\n$(<$FP_TMP)"
+			echo "$(date +"%d-%m-%Y_%T") [FAILED] Unable to pre-create target directory: $FP_TARGET" >> $FP_LOG
+			mv $FP_LOG /var/log/dietpi-sync.log
 
 		#Error: Rsync is already running
 		elif pgrep '[r]sync' &> /dev/null; then
 
-			G_WHIP_MSG '[FAILED] Rsync is already running'
+			G_WHIP_MSG '[FAILED] Rsync is already running and failed to stop gracefully'
 			# Add info to target log location directly, preserve previous rsync log
-			echo "$(date +"%d-%m-%Y_%T") [FAILED] Rsync is already running" >> "$FP_TARGET/$FP_LOG"
+			echo "$(date +"%d-%m-%Y_%T") [FAILED] Rsync is already running and failed to stop gracefully" >> "$FP_TARGET/$FP_LOG"
 
 		#Start sync
 		else
@@ -211,20 +214,13 @@ Would you like to override this warning and continue with the backup?'; then
 
 	Check_Available_DietPi_Mounts(){
 
-		local temp_file_mounts='.dietpi-sync_dietpi_mounts'
-		df -h > $temp_file_mounts
+		local samba_mount_out=$(df -h | grep "$fp_samba_mount")
+		if [[ $samba_mount_out ]]; then
 
-		#Samba Client
-		SAMBA_MOUNT_AVAILABLE=0
-		SAMBA_MOUNT_TEXT="Not mounted ($FP_SAMBA_MOUNT). Select to setup."
-		if grep -qi '/mnt/samba' $temp_file_mounts; then
-
-			SAMBA_MOUNT_AVAILABLE=1
-			SAMBA_MOUNT_TEXT="Size: $(df -h | grep /mnt/samba | awk '{print $2}')B | Available: $(df -h | grep /mnt/samba | awk '{print $4}')B"
+			samba_mount_available=1
+			samba_mount_text=$(awk '{print "Size: "$2"B | Available: "$4"B"}' <<< $samba_mount_out)
 
 		fi
-
-		rm $temp_file_mounts
 
 	}
 
@@ -242,21 +238,12 @@ _EOF_
 
 	}
 
-	Read_Settings_File(){
-
-		[[ -f $FP_SETTINGS ]] && . $FP_SETTINGS
-
-	}
+	Read_Settings_File(){ [[ -f $FP_SETTINGS ]] && . $FP_SETTINGS; }
 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# MENUS
 	#/////////////////////////////////////////////////////////////////////////////////////
 	TARGETMENUID=0
-
-	SAMBA_MOUNT_AVAILABLE=0
-	SAMBA_MOUNT_TEXT='Not available'
-
-	SYNC_DRY_RUN=0
 
 	SYNC_MODE_TEXT=''
 	SYNC_CRONDAILY_TEXT=''
@@ -270,8 +257,19 @@ _EOF_
 		SYNC_CRONDAILY_TEXT='[Off]'
 		(( $SYNC_CRONDAILY )) && SYNC_CRONDAILY_TEXT='[On]'
 
-		local sync_last_status='No previous sync found in target directory.'
-		[[ -f $FP_TARGET/$FP_LOG ]] && sync_last_status=$(tail -1 "$FP_TARGET/$FP_LOG")
+		if [[ -f $FP_TARGET/$FP_LOG ]]; then
+
+			local sync_last_status=$(tail -1 "$FP_TARGET/$FP_LOG")
+
+		elif [[ -f /var/log/dietpi-sync.log ]]; then
+
+			local sync_last_status=$(tail -1 /var/log/dietpi-sync.log)
+
+		else
+
+			local sync_last_status='No previous sync found in target directory.'
+
+		fi
 
 		G_WHIP_MENU_ARRAY=(
 
@@ -331,8 +329,7 @@ If you would like to test a sync without modifiying any data, simply select Dry 
 					if G_WHIP_YESNO "Start dry run sync?\n\nSource location:\n$FP_SOURCE/*\n\nTarget location:\n$FP_TARGET/*\n
 This is a Dry Run for testing. No data will be modified.\n\nDo you wish to continue?"; then
 
-						SYNC_DRY_RUN=1
-						Run_Sync
+						SYNC_DRY_RUN=1 Run_Sync
 
 					fi
 
@@ -343,8 +340,7 @@ This is a Dry Run for testing. No data will be modified.\n\nDo you wish to conti
 					if G_WHIP_YESNO "Start sync?\n\nSource location:\n$FP_SOURCE/*\n\nTarget location:\n$FP_TARGET/*\n
 A copy of all the files and folders inside your Source location, will be created at the Target location.\n\nDo you wish to continue?"; then
 
-						SYNC_DRY_RUN=0
-						Run_Sync
+						SYNC_DRY_RUN=0 Run_Sync
 
 					fi
 
@@ -381,13 +377,17 @@ A copy of all the files and folders inside your Source location, will be created
 
 		fi
 
+		# Check for samba mount
+		local fp_samba_mount='/mnt/samba'
+		local samba_mount_available=0
+		local samba_mount_text="Not mounted ($fp_samba_mount). Select to setup."
 		Check_Available_DietPi_Mounts
 
 		G_WHIP_MENU_ARRAY=(
 
 			'Manual' ": Manually type your $current_mode_text directory."
 			'List' ': Select from a list of available mounts/drives'
-			'Samba Client' ": [$SAMBA_MOUNT_TEXT]"
+			'Samba Client' ": [$samba_mount_text]"
 
 		)
 
@@ -425,15 +425,15 @@ A copy of all the files and folders inside your Source location, will be created
 
 				'Samba Client')
 
-					if (( $SAMBA_MOUNT_AVAILABLE )); then
+					if (( $samba_mount_available )); then
 
 						if (( $TARGETMENUID == 2 )); then
 
-							FP_SOURCE=$FP_SAMBA_MOUNT
+							FP_SOURCE=$fp_samba_mount
 
 						else
 
-							FP_TARGET=$FP_SAMBA_MOUNT/dietpi-sync
+							FP_TARGET=$fp_samba_mount/dietpi-sync
 
 						fi
 
@@ -550,7 +550,7 @@ If files are in the Target location that do not exist in the Source, they will b
 
 	Prompt_Setup_Samba_Mount(){
 
-		G_WHIP_YESNO "$SAMBA_MOUNT_TEXT\n\nWould you like to run DietPi-Drive_Manager and setup your Samba Client Mount now?"
+		G_WHIP_YESNO "$samba_mount_text\n\nWould you like to run DietPi-Drive_Manager and setup your Samba Client Mount now?"
 		(( $? == 0 )) && /DietPi/dietpi/dietpi-drive_manager
 
 	}

--- a/dietpi/dietpi-sync
+++ b/dietpi/dietpi-sync
@@ -141,9 +141,6 @@ _EOF_
 			# - Compression?
 			(( $SYNC_COMPRESSION )) && rync_options+='z'
 
-			# - Dry Run?
-			(( $SYNC_DRY_RUN )) && rync_options+='n'
-
 			# - Delete mode?
 			(( $SYNC_DELETE_MODE )) && rync_options+=' --delete'
 
@@ -154,6 +151,7 @@ _EOF_
 			local old_backup_size=$(du -ks "$FP_TARGET" | awk '{print $1}')
 
 			rsync --dry-run --stats $rync_options "$FP_SOURCE"/ "$FP_TARGET"/ > /tmp/dietpi-sync_result
+			EXIT_CODE=$?
 			local new_backup_size=$(( $(grep -m1 'Total file size' /tmp/dietpi-sync_result | sed 's/[^0-9]*//g') / 1024 ))
 			local total_file_count=$(( $(grep -m1 'Number of files' /tmp/dietpi-sync_result | awk '{print $6}' | sed 's/[^0-9]*//g') ))
 			local total_folder_count=$(( $(grep -m1 'Number of files' /tmp/dietpi-sync_result | awk '{print $8}' | sed 's/[^0-9]*//g') ))
@@ -169,28 +167,33 @@ _EOF_
 				G_WHIP_YESNO 'The system sync target location appears to have insufficient free space to successfully finish the backup.\nHowever, this check is a rough estimation in reasonable time, thus it could be marginally incorrect.\n\nWould you like to override this warning and continue with the backup?'
 				if (( $? )); then
 
-					echo -e "$(date +"%d-%m-%Y_%H%M") [FAILED] Insufficient free space" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
+					echo "$(date +"%d-%m-%Y_%H%M") [FAILED] Insufficient free space" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
 					break
 
 				fi
 
 			fi
 
-			G_DIETPI-NOTIFY 2 "Sync | $FP_SOURCE > $FP_TARGET: in progress, please wait..."
+			if (( ! $SYNC_DRY_RUN )); then
 
-			#Sync
-			rsync $rync_options "$FP_SOURCE"/ "$FP_TARGET"/
-			EXIT_CODE=$?
+				G_DIETPI-NOTIFY 2 "Sync | $FP_SOURCE > $FP_TARGET: in progress, please wait..."
+
+				rsync $rync_options "$FP_SOURCE"/ "$FP_TARGET"/
+				EXIT_CODE=$?
+
+			fi
+
 			G_DIETPI-NOTIFY -1 $EXIT_CODE "$G_PROGRAM_NAME"
 			if (( $EXIT_CODE == 0 )); then
 
-				echo -e "$(date +"%d-%m-%Y_%H%M") [  OK  ] Sync completed" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
 				if (( ! $SYNC_DRY_RUN )); then
 
+					echo -e "$(date +"%d-%m-%Y_%H%M") [  OK  ] Sync completed" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
 					G_WHIP_MSG "[  OK  ] Sync completed:\n - $FP_SOURCE > $FP_TARGET"
 
 				else
 
+					echo -e "$(date +"%d-%m-%Y_%H%M") [  OK  ] Dry run completed" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
 					G_WHIP_MSG "[  OK  ] Dry Run Sync completed (NO modifications):\n - $FP_SOURCE > $FP_TARGET"
 
 				fi
@@ -568,13 +571,13 @@ _EOF_
 		if (( $TARGETMENUID == 1 )); then
 
 			G_WHIP_DEFAULT_ITEM="$FP_TARGET"
-			G_WHIP_INPUTBOX 'Please enter a new filepath for the Target directory.\neg: /mnt/target' && FP_TARGET="$G_WHIP_RETURNED_VALUE"
+			G_WHIP_INPUTBOX 'Please enter a new filepath for the Target directory.\neg: /mnt/target' && FP_TARGET="${G_WHIP_RETURNED_VALUE%/}"
 
 		#Source
 		elif (( $TARGETMENUID == 2 )); then
 
 			G_WHIP_DEFAULT_ITEM="$FP_SOURCE"
-			G_WHIP_INPUTBOX 'Please enter a new filepath for the Source directory.\neg: /mnt/source' && FP_SOURCE="$G_WHIP_RETURNED_VALUE"
+			G_WHIP_INPUTBOX 'Please enter a new filepath for the Source directory.\neg: /mnt/source' && FP_SOURCE="${G_WHIP_RETURNED_VALUE%/}"
 
 		fi
 

--- a/dietpi/dietpi-sync
+++ b/dietpi/dietpi-sync
@@ -551,7 +551,7 @@ If files are in the Target location that do not exist in the Source, they will b
 	Prompt_Setup_Samba_Mount(){
 
 		G_WHIP_YESNO "$samba_mount_text\n\nWould you like to run DietPi-Drive_Manager and setup your Samba Client Mount now?"
-		(( $? == 0 )) && /DietPi/dietpi/dietpi-drive_manager
+		(( $? )) || /DietPi/dietpi/dietpi-drive_manager
 
 	}
 

--- a/dietpi/dietpi-sync
+++ b/dietpi/dietpi-sync
@@ -125,13 +125,13 @@ _EOF_
 		if [[ ! -d $FP_TARGET ]]; then
 
 			G_WHIP_MSG "[FAILED] Unable to pre-create target directory: $FP_TARGET"
-			echo "$(date +"%d-%m-%Y_%H%M") [FAILED] Unable to pre-create target directory: $FP_TARGET" >> $FP_LOG
+			echo "$(date +"%d-%m-%Y_%T") [FAILED] Unable to pre-create target directory: $FP_TARGET" >> $FP_LOG
 
 		#Error: Rsync is already running
 		elif pgrep '[r]sync' &> /dev/null; then
 
 			G_WHIP_MSG '[FAILED] Rsync is already running'
-			echo "$(date +"%d-%m-%Y_%H%M") [FAILED] Rsync is already running" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
+			echo "$(date +"%d-%m-%Y_%T") [FAILED] Rsync is already running" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
 
 		#Start sync
 		else
@@ -167,7 +167,7 @@ _EOF_
 However, this check is a rough estimation in reasonable time, thus it could be marginally incorrect.\n
 Would you like to override this warning and continue with the backup?'; then
 
-						echo "$(date +"%d-%m-%Y_%H%M") [FAILED] Insufficient free space" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
+						echo "$(date +"%d-%m-%Y_%T") [FAILED] Insufficient free space" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
 						return 1
 
 					fi
@@ -191,19 +191,19 @@ Would you like to override this warning and continue with the backup?'; then
 
 				if (( ! $SYNC_DRY_RUN )); then
 
-					echo "$(date +"%d-%m-%Y_%H%M") [  OK  ] Sync completed" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
+					echo "$(date +"%d-%m-%Y_%T") [  OK  ] Sync completed" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
 					G_WHIP_MSG "[  OK  ] Sync completed:\n - $FP_SOURCE > $FP_TARGET"
 
 				else
 
-					echo "$(date +"%d-%m-%Y_%H%M") [  OK  ] Dry run completed" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
+					echo "$(date +"%d-%m-%Y_%T") [  OK  ] Dry run completed" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
 					G_WHIP_MSG "[  OK  ] Dry Run Sync completed (NO modifications):\n - $FP_SOURCE > $FP_TARGET"
 
 				fi
 
 			else
 
-				echo "$(date +"%d-%m-%Y_%H%M") [FAILED] Please see the log file for more information: $FP_LOG" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
+				echo "$(date +"%d-%m-%Y_%T") [FAILED] Please see the log file for more information: $FP_LOG" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
 				G_WHIP_MSG "[FAILED] $FP_SOURCE > $FP_TARGET\n\nYou will given an option to view the logfile on the next screen. Please check it for information and/or errors."
 
 			fi
@@ -283,12 +283,8 @@ _EOF_
 		SYNC_CRONDAILY_TEXT='[Off]'
 		(( $SYNC_CRONDAILY )) && SYNC_CRONDAILY_TEXT='[On]'
 
-		local sync_last_completed='No previous sync found in target directory.'
-		if [[ -f $FP_TARGET/$SYNC_STATS_FILENAME ]]; then
-
-			sync_last_completed=$(grep '^Sync completed' "$FP_TARGET/$SYNC_STATS_FILENAME" | tail -1 | awk '{print $3}')
-
-		fi
+		local sync_last_status='No previous sync found in target directory.'
+		[[ -f $FP_TARGET/$SYNC_STATS_FILENAME ]] && sync_last_status=$(tail -1 "$FP_TARGET/$SYNC_STATS_FILENAME")
 
 		G_WHIP_MENU_ARRAY=(
 
@@ -306,7 +302,7 @@ _EOF_
 		)
 
 		G_WHIP_BUTTON_CANCEL_TEXT='Exit'
-		G_WHIP_MENU "Source location:\n  $FP_SOURCE\n\nTarget location:\n  $FP_TARGET\n\nMost recent successful sync date:\n  $sync_last_completed"
+		G_WHIP_MENU "Source location:\n  $FP_SOURCE\n\nTarget location:\n  $FP_TARGET\n\nLast sync status:\n  $sync_last_status"
 		if (( $? == 0 )); then
 
 			case "$G_WHIP_RETURNED_VALUE" in

--- a/dietpi/dietpi-sync
+++ b/dietpi/dietpi-sync
@@ -19,19 +19,15 @@
 
 	#Import DietPi-Globals ---------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
+	G_PROGRAM_NAME='DietPi-Sync'
 	G_CHECK_ROOT_USER
 	G_CHECK_ROOTFS_RW
-	G_PROGRAM_NAME='DietPi-Sync'
 	G_INIT
 	#Import DietPi-Globals ---------------------------------------------------------------
 
 	#Grab Input (valid interger)
 	INPUT=0
-	if disable_error=1 G_CHECK_VALIDINT $1; then
-
-		INPUT=$1
-
-	fi
+	disable_error=1 G_CHECK_VALIDINT "$1" && INPUT=$1
 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Sync System
@@ -87,11 +83,7 @@
 _EOF_
 
 		#Add users additional list
-		if [[ -f $FP_USER_FILTER_INCLUDE_EXCLUDE ]]; then
-
-			cat $FP_USER_FILTER_INCLUDE_EXCLUDE >> $FP_FILTER_INCLUDE_EXCLUDE
-
-		fi
+		[[ -f $FP_USER_FILTER_INCLUDE_EXCLUDE ]] && cat $FP_USER_FILTER_INCLUDE_EXCLUDE >> $FP_FILTER_INCLUDE_EXCLUDE
 
 	}
 
@@ -99,11 +91,7 @@ _EOF_
 
 		local mode='Sync'
 		#Dry Run?
-		if (( $SYNC_DRY_RUN )); then
-
-			mode='Dry Run'
-
-		fi
+		(( $SYNC_DRY_RUN )) && mode='Dry Run'
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" "$mode"
 
@@ -119,19 +107,27 @@ _EOF_
 		#Generate Target dir.
 		mkdir -p "$FP_TARGET"
 
-		systemctl stop rsync &> /dev/null # : https://github.com/Fourdee/DietPi/issues/1869
-		killall -w rsync &> /dev/null
+		# https://github.com/Fourdee/DietPi/issues/1869
+		local control_rsync_service=0
+		if systemctl is-active rsync &> /dev/null; then
+
+			control_rsync_service=1
+			systemctl stop rsync
+
+		fi
+		killall -qw rsync
 
 		#Error: Folder not found
 		if [[ ! -d $FP_TARGET ]]; then
 
-			G_WHIP_MSG "Error:\n\nSync failed, unable to create Target directory $FP_TARGET"
+			G_WHIP_MSG "[FAILED] Unable to create target directory: $FP_TARGET"
+			echo -e "$(date +"%d-%m-%Y_%H%M") [FAILED] Unable to create target directory: $FP_TARGET" >> $FP_LOG
 
 		#Error: Rsync is already running
-		elif (( $(ps aux | grep -ci -m1 "[r]sync") )); then
+		elif pgrep '[r]sync' &> /dev/null; then
 
-			G_WHIP_MSG 'Sync Failed:\n\nA sync job could not be started as rsync is already running.'
-			echo -e "Sync failed: $(date +"%d-%m-%Y_%H%M"). Rsync is already running." >> "$FP_TARGET/$SYNC_STATS_FILENAME"
+			G_WHIP_MSG '[FAILED] Rsync is already running'
+			echo -e "$(date +"%d-%m-%Y_%H%M") [FAILED] Rsync is already running" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
 
 		#Start sync
 		else
@@ -140,28 +136,18 @@ _EOF_
 			Create_Filter_Include_Exclude
 
 			#Rsync options
-			local rync_options+="-aHP4 --info=name0 --info=progress2 --human-readable --delete-excluded --exclude-from=$FP_FILTER_INCLUDE_EXCLUDE --log-file=$FP_LOG "
+			local rync_options='-aHP4h'
 
 			# - Compression?
-			if (( $SYNC_COMPRESSION )); then
-
-				rync_options+='z'
-
-			fi
+			(( $SYNC_COMPRESSION )) && rync_options+='z'
 
 			# - Dry Run?
-			if (( $SYNC_DRY_RUN )); then
-
-				rync_options+='n'
-
-			fi
+			(( $SYNC_DRY_RUN )) && rync_options+='n'
 
 			# - Delete mode?
-			if (( $SYNC_DELETE_MODE )); then
+			(( $SYNC_DELETE_MODE )) && rync_options+=' --delete'
 
-				rync_options+=' --delete'
-
-			fi
+			rsync_options+=" --info=name0 --info=progress2 --delete-excluded --exclude-from=$FP_FILTER_INCLUDE_EXCLUDE --log-file=$FP_LOG"
 
 			#Verify enough space
 			#	NB: working in KiB until end MiB conversion, as, don't like using long long int, and, KiB should offer a good end result.
@@ -183,7 +169,7 @@ _EOF_
 				G_WHIP_YESNO 'The system sync target location appears to have insufficient free space to successfully finish the backup.\nHowever, this check is a rough estimation in reasonable time, thus it could be marginally incorrect.\n\nWould you like to override this warning and continue with the backup?'
 				if (( $? )); then
 
-					echo -e "Sync canceled: due to insufficient free space: $(date +"%d-%m-%Y_%H%M")" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
+					echo -e "$(date +"%d-%m-%Y_%H%M") [FAILED] Insufficient free space" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
 					break
 
 				fi
@@ -198,21 +184,21 @@ _EOF_
 			G_DIETPI-NOTIFY -1 $EXIT_CODE "$G_PROGRAM_NAME"
 			if (( $EXIT_CODE == 0 )); then
 
-				echo -e "Sync completed: $(date +"%d-%m-%Y_%H%M")" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
+				echo -e "$(date +"%d-%m-%Y_%H%M") [  OK  ] Sync completed" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
 				if (( ! $SYNC_DRY_RUN )); then
 
-					G_WHIP_MSG "Sync completed:\n - $FP_SOURCE > $FP_TARGET"
+					G_WHIP_MSG "[  OK  ] Sync completed:\n - $FP_SOURCE > $FP_TARGET"
 
 				else
 
-					G_WHIP_MSG "Dry Run Sync completed (NO modifications):\n - $FP_SOURCE > $FP_TARGET"
+					G_WHIP_MSG "[  OK  ] Dry Run Sync completed (NO modifications):\n - $FP_SOURCE > $FP_TARGET"
 
 				fi
 
 			else
 
-				echo -e "Sync failed: please see the log file for more information ($FP_LOG): $(date +"%d-%m-%Y_%H%M")" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
-				G_WHIP_MSG "Sync failed:\n - $FP_SOURCE > $FP_TARGET\n\nYou will given an option to view the logfile on the next screen. Please check it for information and/or errors."
+				echo -e "$(date +"%d-%m-%Y_%H%M") [FAILED] Please see the log file for more information: $FP_LOG" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
+				G_WHIP_MSG "[FAILED] $FP_SOURCE > $FP_TARGET\n\nYou will given an option to view the logfile on the next screen. Please check it for information and/or errors."
 
 			fi
 
@@ -223,19 +209,19 @@ _EOF_
 
 		fi
 
-		systemctl start rsync &> /dev/null # : https://github.com/Fourdee/DietPi/issues/1869
+		(( $control_rsync_service )) && systemctl start rsync # https://github.com/Fourdee/DietPi/issues/1869
 
 	}
 
 	Check_Available_DietPi_Mounts(){
 
 		local temp_file_mounts='.dietpi-sync_dietpi_mounts'
-		df -h > "$temp_file_mounts"
+		df -h > $temp_file_mounts
 
 		#Samba Client
 		SAMBA_MOUNT_AVAILABLE=0
 		SAMBA_MOUNT_TEXT="Not mounted ($FP_SAMBA_MOUNT). Select to setup."
-		if (( $(grep -ci -m1 "/mnt/samba" $temp_file_mounts) )); then
+		if grep -qi '/mnt/samba' $temp_file_mounts; then
 
 			SAMBA_MOUNT_AVAILABLE=1
 			SAMBA_MOUNT_TEXT="Size: $(df -h | grep /mnt/samba | awk '{print $2}')B | Available: $(df -h | grep /mnt/samba | awk '{print $4}')B"
@@ -266,11 +252,7 @@ _EOF_
 
 	Read_Settings_File(){
 
-		if [[ -f $FP_DIETPISYNC_SETTINGS ]]; then
-
-			. $FP_DIETPISYNC_SETTINGS
-
-		fi
+		[[ -f $FP_DIETPISYNC_SETTINGS ]] && . $FP_DIETPISYNC_SETTINGS
 
 	}
 
@@ -292,25 +274,13 @@ _EOF_
 	Menu_Main(){
 
 		SYNC_MODE_TEXT='[Off]'
-		if (( $SYNC_DELETE_MODE )); then
-
-			SYNC_MODE_TEXT='[On]'
-
-		fi
+		(( $SYNC_DELETE_MODE )) && SYNC_MODE_TEXT='[On]'
 
 		SYNC_COMPRESSION_TEXT='[Off]'
-		if (( $SYNC_COMPRESSION )); then
-
-			SYNC_COMPRESSION_TEXT='[On]'
-
-		fi
+		(( $SYNC_COMPRESSION )) && SYNC_COMPRESSION_TEXT='[On]'
 
 		SYNC_CRONDAILY_TEXT='[Off]'
-		if (( $SYNC_CRONDAILY )); then
-
-			SYNC_CRONDAILY_TEXT='[On]'
-
-		fi
+		(( $SYNC_CRONDAILY )) && YNC_CRONDAILY_TEXT='[On]'
 
 		local sync_last_completed='No previous sync found in target directory.'
 		if [[ -f $FP_TARGET/$SYNC_STATS_FILENAME ]]; then
@@ -414,12 +384,7 @@ _EOF_
 	Menu_Exit(){
 
 		G_WHIP_SIZE_X_MAX=50
-		G_WHIP_YESNO "Exit $G_PROGRAM_NAME?"
-		if (( $? == 0 )); then
-
-			TARGETMENUID=-1
-
-		fi
+		G_WHIP_YESNO "Exit $G_PROGRAM_NAME?" && TARGETMENUID=-1
 
 	}
 
@@ -451,8 +416,7 @@ _EOF_
 		)
 
 		G_WHIP_BUTTON_CANCEL_TEXT='Back'
-		G_WHIP_MENU "$whip_description_text"
-		if (( $? == 0 )); then
+		if G_WHIP_MENU "$whip_description_text"; then
 
 			case "$G_WHIP_RETURNED_VALUE" in
 
@@ -461,11 +425,7 @@ _EOF_
 					/DietPi/dietpi/dietpi-drive_manager 1
 
 					local return_value=$(</tmp/dietpi-drive_manager_selmnt)
-					if [[ $return_value == '/' ]]; then
-
-						return_value='/mnt'
-
-					fi
+					[[ $return_value == '/' ]] && return_value='/mnt'
 
 					if (( $TARGETMENUID == 2 )); then
 
@@ -542,11 +502,7 @@ _EOF_
 		if (( $? == 0 )); then
 
 			SYNC_DELETE_MODE=0
-			if [[ $G_WHIP_RETURNED_VALUE == 'Enabled' ]]; then
-
-				SYNC_DELETE_MODE=1
-
-			fi
+			[[ $G_WHIP_RETURNED_VALUE == 'Enabled' ]] && SYNC_DELETE_MODE=1
 
 		fi
 
@@ -570,11 +526,7 @@ _EOF_
 		if (( $? == 0 )); then
 
 			SYNC_COMPRESSION=0
-			if [[ $G_WHIP_RETURNED_VALUE == 'Enabled' ]]; then
-
-				SYNC_COMPRESSION=1
-
-			fi
+			[[ $G_WHIP_RETURNED_VALUE == 'Enabled' ]] && SYNC_COMPRESSION=1
 
 		fi
 
@@ -598,11 +550,7 @@ _EOF_
 		if (( $? == 0 )); then
 
 			SYNC_CRONDAILY=0
-			if [[ $G_WHIP_RETURNED_VALUE == 'Enabled' ]]; then
-
-				SYNC_CRONDAILY=1
-
-			fi
+			[[ $G_WHIP_RETURNED_VALUE == 'Enabled' ]] && SYNC_CRONDAILY=1
 
 		fi
 
@@ -620,23 +568,13 @@ _EOF_
 		if (( $TARGETMENUID == 1 )); then
 
 			G_WHIP_DEFAULT_ITEM="$FP_TARGET"
-			G_WHIP_INPUTBOX 'Please enter a new filepath for the Target directory. \neg: /mnt/target'
-			if (( $? == 0 )); then
-
-				FP_TARGET="$G_WHIP_RETURNED_VALUE"
-
-			fi
+			G_WHIP_INPUTBOX 'Please enter a new filepath for the Target directory.\neg: /mnt/target' && FP_TARGET="$G_WHIP_RETURNED_VALUE"
 
 		#Source
 		elif (( $TARGETMENUID == 2 )); then
 
 			G_WHIP_DEFAULT_ITEM="$FP_SOURCE"
-			G_WHIP_INPUTBOX 'Please enter a new filepath for the Source directory. \neg: /mnt/source'
-			if (( $? == 0 )); then
-
-				FP_SOURCE="$G_WHIP_RETURNED_VALUE"
-
-			fi
+			G_WHIP_INPUTBOX 'Please enter a new filepath for the Source directory.\neg: /mnt/source' && FP_SOURCE="$G_WHIP_RETURNED_VALUE"
 
 		fi
 
@@ -645,11 +583,7 @@ _EOF_
 	Prompt_Setup_Samba_Mount(){
 
 		G_WHIP_YESNO "$SAMBA_MOUNT_TEXT\n\nWould you like to run DietPi-Drive_Manager and setup your Samba Client Mount now?"
-		if (( $? == 0 )); then
-
-			/DietPi/dietpi/dietpi-drive_manager
-
-		fi
+		(( $? == 0 )) && /DietPi/dietpi/dietpi-drive_manager
 
 	}
 
@@ -723,9 +657,6 @@ _EOF_
 
 	fi
 
-	#-----------------------------------------------------------------------------------
-	#Cleaup left over tmp files
-	rm $FP_FILTER_INCLUDE_EXCLUDE &> /dev/null
 	#-----------------------------------------------------------------------------------
 	exit $EXIT_CODE
 	#-----------------------------------------------------------------------------------

--- a/dietpi/dietpi-sync
+++ b/dietpi/dietpi-sync
@@ -51,7 +51,6 @@
 
 	#Extra options
 	SYNC_DELETE_MODE=0
-	SYNC_COMPRESSION=0
 	SYNC_CRONDAILY=0
 
 	Create_Filter_Include_Exclude(){
@@ -136,15 +135,10 @@ _EOF_
 			Create_Filter_Include_Exclude
 
 			#Rsync options
-			local rync_options='-aHP4h'
-
-			# - Compression?
-			(( $SYNC_COMPRESSION )) && rync_options+='z'
+			local rync_options="-aHP4h --info=name0 --info=progress2 --delete-excluded --exclude-from=$FP_FILTER_INCLUDE_EXCLUDE --log-file=$FP_LOG"
 
 			# - Delete mode?
 			(( $SYNC_DELETE_MODE )) && rync_options+=' --delete'
-
-			rsync_options+=" --info=name0 --info=progress2 --delete-excluded --exclude-from=$FP_FILTER_INCLUDE_EXCLUDE --log-file=$FP_LOG"
 
 			#Verify enough space
 			#	NB: working in KiB until end MiB conversion, as, don't like using long long int, and, KiB should offer a good end result.
@@ -152,29 +146,33 @@ _EOF_
 
 			rsync --dry-run --stats $rync_options "$FP_SOURCE"/ "$FP_TARGET"/ > /tmp/dietpi-sync_result
 			EXIT_CODE=$?
-			local new_backup_size=$(( $(grep -m1 'Total file size' /tmp/dietpi-sync_result | sed 's/[^0-9]*//g') / 1024 ))
-			local total_file_count=$(( $(grep -m1 'Number of files' /tmp/dietpi-sync_result | awk '{print $6}' | sed 's/[^0-9]*//g') ))
-			local total_folder_count=$(( $(grep -m1 'Number of files' /tmp/dietpi-sync_result | awk '{print $8}' | sed 's/[^0-9]*//g') ))
-			local target_fs_blocksize=$(stat -fc %s "$FP_TARGET")
-			new_backup_size=$(( $new_backup_size + ( $total_file_count + $total_folder_count ) * $target_fs_blocksize / 1024 ))
-			local end_result=$(( ( $new_backup_size - $old_backup_size ) / 1024 + 1 ))
-			rm /tmp/dietpi-sync_result
+			if (( ! $EXIT_CODE )); then
 
-			if ! G_CHECK_FREESPACE "$FP_TARGET" $end_result; then
+				local new_backup_size=$(( $(grep -m1 'Total file size' /tmp/dietpi-sync_result | sed 's/[^0-9]*//g') / 1024 ))
+				local total_file_count=$(( $(grep -m1 'Number of files' /tmp/dietpi-sync_result | awk '{print $6}' | sed 's/[^0-9]*//g') ))
+				local total_folder_count=$(( $(grep -m1 'Number of files' /tmp/dietpi-sync_result | awk '{print $8}' | sed 's/[^0-9]*//g') ))
+				local target_fs_blocksize=$(stat -fc %s "$FP_TARGET")
+				new_backup_size=$(( $new_backup_size + ( $total_file_count + $total_folder_count ) * $target_fs_blocksize / 1024 ))
+				local end_result=$(( ( $new_backup_size - $old_backup_size ) / 1024 + 1 ))
+				rm /tmp/dietpi-sync_result
 
-				G_WHIP_BUTTON_OK_TEXT='Ignore'
-				G_WHIP_BUTTON_CANCEL_TEXT='Exit'
-				G_WHIP_YESNO 'The system sync target location appears to have insufficient free space to successfully finish the backup.\nHowever, this check is a rough estimation in reasonable time, thus it could be marginally incorrect.\n\nWould you like to override this warning and continue with the backup?'
-				if (( $? )); then
+				if ! G_CHECK_FREESPACE "$FP_TARGET" $end_result; then
 
-					echo "$(date +"%d-%m-%Y_%H%M") [FAILED] Insufficient free space" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
-					break
+					G_WHIP_BUTTON_OK_TEXT='Ignore'
+					G_WHIP_BUTTON_CANCEL_TEXT='Exit'
+					G_WHIP_YESNO 'The system sync target location appears to have insufficient free space to successfully finish the backup.\nHowever, this check is a rough estimation in reasonable time, thus it could be marginally incorrect.\n\nWould you like to override this warning and continue with the backup?'
+					if (( $? )); then
+
+						echo "$(date +"%d-%m-%Y_%H%M") [FAILED] Insufficient free space" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
+						break
+
+					fi
 
 				fi
 
 			fi
 
-			if (( ! $SYNC_DRY_RUN )); then
+			if ! (( $SYNC_DRY_RUN || $EXIT_CODE )); then
 
 				G_DIETPI-NOTIFY 2 "Sync | $FP_SOURCE > $FP_TARGET: in progress, please wait..."
 
@@ -247,7 +245,6 @@ _EOF_
 FP_SOURCE=$FP_SOURCE
 FP_TARGET=$FP_TARGET
 SYNC_DELETE_MODE=$SYNC_DELETE_MODE
-SYNC_COMPRESSION=$SYNC_COMPRESSION
 SYNC_CRONDAILY=$SYNC_CRONDAILY
 _EOF_
 
@@ -270,7 +267,6 @@ _EOF_
 	SYNC_DRY_RUN=0
 
 	SYNC_MODE_TEXT=''
-	SYNC_COMPRESSION_TEXT=''
 	SYNC_CRONDAILY_TEXT=''
 
 	#TARGETMENUID=0
@@ -278,9 +274,6 @@ _EOF_
 
 		SYNC_MODE_TEXT='[Off]'
 		(( $SYNC_DELETE_MODE )) && SYNC_MODE_TEXT='[On]'
-
-		SYNC_COMPRESSION_TEXT='[Off]'
-		(( $SYNC_COMPRESSION )) && SYNC_COMPRESSION_TEXT='[On]'
 
 		SYNC_CRONDAILY_TEXT='[Off]'
 		(( $SYNC_CRONDAILY )) && YNC_CRONDAILY_TEXT='[On]'
@@ -300,7 +293,6 @@ _EOF_
 			'Source Location' ': Change the Source directory.'
 			'Target Location' ': Change the Target directory.'
 			"Delete Mode" ": $SYNC_MODE_TEXT"
-			"Compression" ": $SYNC_COMPRESSION_TEXT"
 			"Sync: Daily" ": $SYNC_CRONDAILY_TEXT"
 			'' '●─ Run '
 			'Sync: Dry Run' ': Run a test Sync without modifying any data.'
@@ -338,15 +330,9 @@ _EOF_
 
 				;;
 
-				'Compression')
-
-					TARGETMENUID=4
-
-				;;
-
 				"Sync: Daily")
 
-					TARGETMENUID=5
+					TARGETMENUID=4
 
 				;;
 
@@ -515,30 +501,6 @@ _EOF_
 	}
 
 	#TARGETMENUID=4
-	Menu_Set_Compression(){
-
-		G_WHIP_MENU_ARRAY=(
-
-			'Disabled' ': Transfer data in its original state.'
-			'Enabled' ': Compress the data during transfer.'
-
-		)
-
-		G_WHIP_DEFAULT_ITEM="$SYNC_COMPRESSION_TEXT"
-		G_WHIP_MENU "Please select the compression mode.\n\nDisabled:\nNo compression will be used during data transfer.\n\nEnabled:\nData will be compressed when its being transfered. Useful for slow connections, however, its CPU intensive."
-		if (( $? == 0 )); then
-
-			SYNC_COMPRESSION=0
-			[[ $G_WHIP_RETURNED_VALUE == 'Enabled' ]] && SYNC_COMPRESSION=1
-
-		fi
-
-		#Return to main menu
-		TARGETMENUID=0
-
-	}
-
-	#TARGETMENUID=5
 	Menu_Set_CronDaily(){
 
 		G_WHIP_MENU_ARRAY=(
@@ -645,11 +607,7 @@ _EOF_
 
 			elif (( $TARGETMENUID == 4 )); then
 
-				Menu_Set_Compression
-
-			elif (( $TARGETMENUID == 5 )); then
-
-				Menu_Set_CronDaily
+				Menu_Set_CronDaily	
 
 			fi
 

--- a/dietpi/dietpi-sync
+++ b/dietpi/dietpi-sync
@@ -55,22 +55,9 @@
 
 	Create_Filter_Include_Exclude(){
 
+		#Exclude files by name
 		cat << _EOF_ > $FP_FILTER_INCLUDE_EXCLUDE
-#Global - Folders
-- $FP_TARGET
-- /boot/dietpi/
-- /DietPi/
-- /dev/
-- /proc/
-- /sys/
-- /tmp/
-- /run/
-
-#Global - Files
-- $FP_LOG
-- $FP_DIETPISYNC_SETTINGS
 - $SYNC_STATS_FILENAME
-- /var/swap
 - .swap*
 - *.tmp
 # - MS Windows specific
@@ -80,6 +67,27 @@
 - System Volume Information #  - causes error code 23 (permission denied)
 
 _EOF_
+
+		#Exclude specific files/dirs by path
+		local aexclude=(
+
+			"$FP_TARGET"
+			"$FP_LOG"
+			"$FP_DIETPISYNC_SETTINGS"
+			/boot/dietpi/
+			/var/swap
+
+		)
+
+		for i in "${aexclude[@]}"
+		do
+
+			# - Exclude only, if inside source location, via path, relative to source location
+			[[ $i == ${FP_SOURCE}/* ]] && echo "- $(realpath --relative-to=$FP_SOURCE $i)" >> $FP_FILTER_INCLUDE_EXCLUDE
+
+		done
+
+		unset aexclude
 
 		#Add users additional list
 		[[ -f $FP_USER_FILTER_INCLUDE_EXCLUDE ]] && cat $FP_USER_FILTER_INCLUDE_EXCLUDE >> $FP_FILTER_INCLUDE_EXCLUDE
@@ -100,13 +108,7 @@ _EOF_
 
 		Banner_Start
 
-		# Userdata location verify
-		G_CHECK_USERDATA
-
-		#Generate Target dir.
-		mkdir -p "$FP_TARGET"
-
-		# https://github.com/Fourdee/DietPi/issues/1869
+		#Stop rsync service: https://github.com/Fourdee/DietPi/issues/1869
 		local control_rsync_service=0
 		if systemctl is-active rsync &> /dev/null; then
 
@@ -116,17 +118,20 @@ _EOF_
 		fi
 		killall -qw rsync
 
+		#Pre-create target dir
+		mkdir -p "$FP_TARGET"
+
 		#Error: Folder not found
 		if [[ ! -d $FP_TARGET ]]; then
 
-			G_WHIP_MSG "[FAILED] Unable to create target directory: $FP_TARGET"
-			echo -e "$(date +"%d-%m-%Y_%H%M") [FAILED] Unable to create target directory: $FP_TARGET" >> $FP_LOG
+			G_WHIP_MSG "[FAILED] Unable to pre-create target directory: $FP_TARGET"
+			echo "$(date +"%d-%m-%Y_%H%M") [FAILED] Unable to pre-create target directory: $FP_TARGET" >> $FP_LOG
 
 		#Error: Rsync is already running
 		elif pgrep '[r]sync' &> /dev/null; then
 
 			G_WHIP_MSG '[FAILED] Rsync is already running'
-			echo -e "$(date +"%d-%m-%Y_%H%M") [FAILED] Rsync is already running" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
+			echo "$(date +"%d-%m-%Y_%H%M") [FAILED] Rsync is already running" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
 
 		#Start sync
 		else
@@ -141,36 +146,36 @@ _EOF_
 			(( $SYNC_DELETE_MODE )) && rync_options+=' --delete'
 
 			#Verify enough space
-			#	NB: working in KiB until end MiB conversion, as, don't like using long long int, and, KiB should offer a good end result.
-			local old_backup_size=$(du -ks "$FP_TARGET" | awk '{print $1}')
-
-			rsync --dry-run --stats $rync_options "$FP_SOURCE"/ "$FP_TARGET"/ > /tmp/dietpi-sync_result
+			rsync --dry-run --stats $rync_options "$FP_SOURCE"/ "$FP_TARGET"/ > .dietpi-sync_result
 			EXIT_CODE=$?
 			if (( ! $EXIT_CODE )); then
 
-				local new_backup_size=$(( $(grep -m1 'Total file size' /tmp/dietpi-sync_result | sed 's/[^0-9]*//g') / 1024 ))
-				local total_file_count=$(( $(grep -m1 'Number of files' /tmp/dietpi-sync_result | awk '{print $6}' | sed 's/[^0-9]*//g') ))
-				local total_folder_count=$(( $(grep -m1 'Number of files' /tmp/dietpi-sync_result | awk '{print $8}' | sed 's/[^0-9]*//g') ))
+				# - NB: working in KiB until end MiB conversion, as, don't like using long long int, and, KiB should offer a good end result.
+				local old_backup_size=$(du -ks "$FP_TARGET" | awk '{print $1}')
+				local new_backup_size=$(( $(grep -m1 'Total file size' .dietpi-sync_result | sed 's/[^0-9]*//g') / 1024 ))
+				local total_file_count=$(( $(grep -m1 'Number of files' .dietpi-sync_result | awk '{print $6}' | sed 's/[^0-9]*//g') ))
+				local total_folder_count=$(( $(grep -m1 'Number of files' .dietpi-sync_result | awk '{print $8}' | sed 's/[^0-9]*//g') ))
 				local target_fs_blocksize=$(stat -fc %s "$FP_TARGET")
 				new_backup_size=$(( $new_backup_size + ( $total_file_count + $total_folder_count ) * $target_fs_blocksize / 1024 ))
 				local end_result=$(( ( $new_backup_size - $old_backup_size ) / 1024 + 1 ))
-				rm /tmp/dietpi-sync_result
 
 				if ! G_CHECK_FREESPACE "$FP_TARGET" $end_result; then
 
 					G_WHIP_BUTTON_OK_TEXT='Ignore'
 					G_WHIP_BUTTON_CANCEL_TEXT='Exit'
-					G_WHIP_YESNO 'The system sync target location appears to have insufficient free space to successfully finish the backup.\nHowever, this check is a rough estimation in reasonable time, thus it could be marginally incorrect.\n\nWould you like to override this warning and continue with the backup?'
-					if (( $? )); then
+					if ! G_WHIP_YESNO 'The system sync target location appears to have insufficient free space to successfully finish the backup.
+However, this check is a rough estimation in reasonable time, thus it could be marginally incorrect.\n
+Would you like to override this warning and continue with the backup?'; then
 
 						echo "$(date +"%d-%m-%Y_%H%M") [FAILED] Insufficient free space" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
-						break
+						return 1
 
 					fi
 
 				fi
 
 			fi
+			rm .dietpi-sync_result
 
 			if ! (( $SYNC_DRY_RUN || $EXIT_CODE )); then
 
@@ -186,19 +191,19 @@ _EOF_
 
 				if (( ! $SYNC_DRY_RUN )); then
 
-					echo -e "$(date +"%d-%m-%Y_%H%M") [  OK  ] Sync completed" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
+					echo "$(date +"%d-%m-%Y_%H%M") [  OK  ] Sync completed" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
 					G_WHIP_MSG "[  OK  ] Sync completed:\n - $FP_SOURCE > $FP_TARGET"
 
 				else
 
-					echo -e "$(date +"%d-%m-%Y_%H%M") [  OK  ] Dry run completed" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
+					echo "$(date +"%d-%m-%Y_%H%M") [  OK  ] Dry run completed" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
 					G_WHIP_MSG "[  OK  ] Dry Run Sync completed (NO modifications):\n - $FP_SOURCE > $FP_TARGET"
 
 				fi
 
 			else
 
-				echo -e "$(date +"%d-%m-%Y_%H%M") [FAILED] Please see the log file for more information: $FP_LOG" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
+				echo "$(date +"%d-%m-%Y_%H%M") [FAILED] Please see the log file for more information: $FP_LOG" >> "$FP_TARGET/$SYNC_STATS_FILENAME"
 				G_WHIP_MSG "[FAILED] $FP_SOURCE > $FP_TARGET\n\nYou will given an option to view the logfile on the next screen. Please check it for information and/or errors."
 
 			fi
@@ -320,26 +325,29 @@ _EOF_
 
 				'Help')
 
-					G_WHIP_MSG "DietPi-Sync is a program that allows you to duplicate a directory from one location (Source) to another (Target).\n\nFor example: If we want to duplicate (sync) the data on our external USB HDD to another location, we simply select the USB HDD as the source, then, select a target location. The target location can be anything from a networked samba fileserver, or even a FTP server.\n\nIf you would like to test a sync without modifiying any data, simply select Dry Run.\n\nMore information:\n - https://dietpi.com/phpbb/viewtopic.php?f=8&t=5&p=256#p256"
+					G_WHIP_MSG "DietPi-Sync is a program that allows you to duplicate a directory from one location (Source) to another (Target).\n
+For example: If we want to duplicate (sync) the data on our external USB HDD to another location, we simply select the USB HDD as the source, then, select a target location.
+The target location can be anything from a networked samba fileserver, or even a FTP server.\n
+If you would like to test a sync without modifiying any data, simply select Dry Run.\n\nMore information:\n - https://dietpi.com/phpbb/viewtopic.php?p=256#p256"
 
 				;;
 
-				"Delete Mode")
+				'Delete Mode')
 
 					TARGETMENUID=3
 
 				;;
 
-				"Sync: Daily")
+				'Sync: Daily')
 
 					TARGETMENUID=4
 
 				;;
 
-				"Sync: Dry Run")
+				'Sync: Dry Run')
 
-					G_WHIP_YESNO "Start dry run sync?\n\nSource location:\n$FP_SOURCE/*\n\nTarget location:\n$FP_TARGET/*\n\nThis is a Dry Run for testing. No data will be modified.\n\nDo you wish to continue?"
-					if (( $? == 0 )); then
+					if G_WHIP_YESNO "Start dry run sync?\n\nSource location:\n$FP_SOURCE/*\n\nTarget location:\n$FP_TARGET/*\n
+This is a Dry Run for testing. No data will be modified.\n\nDo you wish to continue?"; then
 
 						SYNC_DRY_RUN=1
 						Run_Sync
@@ -348,10 +356,10 @@ _EOF_
 
 				;;
 
-				"Sync: Now")
+				'Sync: Now')
 
-					G_WHIP_YESNO "Start sync?\n\nSource location:\n$FP_SOURCE/*\n\nTarget location:\n$FP_TARGET/*\n\nA copy of all the files and folders inside your Source location, will be created at the Target location.\n\nDo you wish to continue?"
-					if (( $? == 0 )); then
+					if G_WHIP_YESNO "Start sync?\n\nSource location:\n$FP_SOURCE/*\n\nTarget location:\n$FP_TARGET/*\n
+A copy of all the files and folders inside your Source location, will be created at the Target location.\n\nDo you wish to continue?"; then
 
 						SYNC_DRY_RUN=0
 						Run_Sync
@@ -481,14 +489,16 @@ _EOF_
 
 		G_WHIP_MENU_ARRAY=(
 
-			'Disabled' ': Ignores data that exists at Target Location and not Source.'
-			'Enabled' ': Deletes data at Target location if not in Source Location.'
+			'Disabled' ': Only add/update, but never remove data on target location'
+			'Enabled' ': Sync removals from source to target as well => Exact copy'
 
 		)
 
 		G_WHIP_DEFAULT_ITEM="$SYNC_MODE_TEXT"
-		G_WHIP_MENU "Please select the Sync delete mode.\n\nDisabled: (safe)\nIf files and folders exist in the Target location, that are not in the Source, they will be left alone.\n\nEnabled: (WARNING, if in doubt, DO NOT enable)\nAn exact copy of the Source location will be created at the Target location. If files are in the Target location that dont exist in the Source, they will be DELETED."
-		if (( $? == 0 )); then
+		if G_WHIP_MENU "Please select the Sync delete mode.\n
+Disabled: (safe)\nIf files and folders exist in the Target location, that are not in the Source, they will be left alone.\n
+Enabled: (WARNING, if in doubt, DO NOT enable)\nAn exact copy of the Source location will be created at the Target location.
+If files are in the Target location that don't exist in the Source, they will be DELETED."; then
 
 			SYNC_DELETE_MODE=0
 			[[ $G_WHIP_RETURNED_VALUE == 'Enabled' ]] && SYNC_DELETE_MODE=1
@@ -511,8 +521,9 @@ _EOF_
 		)
 
 		G_WHIP_DEFAULT_ITEM="$SYNC_CRONDAILY_TEXT"
-		G_WHIP_MENU "Disabled:\nThe user must manually sync using dietpi-sync.\n\nEnabled:\nA cron job will be created that automatically runs dietpi-sync, once a day.\n\n(NOTICE):\nBefore enabling this feature, please run a test sync (Dry Run) to verify what will happen."
-		if (( $? == 0 )); then
+		if _WHIP_MENU 'Disabled:\nThe user must manually sync using dietpi-sync.\n
+Enabled:\nA cron job will be created that automatically runs dietpi-sync, once a day.\n
+(NOTICE):\nBefore enabling this feature, please run a test sync (Dry Run) to verify what will happen.'; then
 
 			SYNC_CRONDAILY=0
 			[[ $G_WHIP_RETURNED_VALUE == 'Enabled' ]] && SYNC_CRONDAILY=1
@@ -529,19 +540,44 @@ _EOF_
 		#TARGETMENUID
 		#2=Source | 1=Target
 
-		#Target
-		if (( $TARGETMENUID == 1 )); then
+		local mode='target'
+		(( $TARGETMENUID == 2 )) && mode='source'
+		local fp_mode="FP_${mode^^}"
+		G_WHIP_DEFAULT_ITEM=${!fp_mode}
+		local text="Please enter a new filepath for the $mode directory.\neg: /mnt/$mode"
 
-			G_WHIP_DEFAULT_ITEM="$FP_TARGET"
-			G_WHIP_INPUTBOX 'Please enter a new filepath for the Target directory.\neg: /mnt/target' && FP_TARGET="${G_WHIP_RETURNED_VALUE%/}"
+		while :
+		do
 
-		#Source
-		elif (( $TARGETMENUID == 2 )); then
+			if G_WHIP_INPUTBOX "$text"; then
 
-			G_WHIP_DEFAULT_ITEM="$FP_SOURCE"
-			G_WHIP_INPUTBOX 'Please enter a new filepath for the Source directory.\neg: /mnt/source' && FP_SOURCE="${G_WHIP_RETURNED_VALUE%/}"
+				# Sanity checks
+				# - Full path required
+				if [[ $G_WHIP_RETURNED_VALUE != /* ]]; then
 
-		fi
+					text="ERROR: Please enter the $mode location as full path with leading slash: /\n\n - eg: /mnt/$mode"
+
+				# - Do not allow to sync from or to root
+				elif [[ $G_WHIP_RETURNED_VALUE == / ]]; then
+
+					text="ERROR: You entered the root directory as $mode location: /\n\n - Please use \"dietpi-backup\" instead for system backups and recoveries."
+
+				else
+
+					declare $fp_mode="${G_WHIP_RETURNED_VALUE%/}"
+					break
+
+				fi
+
+			else
+
+				break
+
+			fi
+
+			G_WHIP_DEFAULT_ITEM="$G_WHIP_RETURNED_VALUE"
+
+		done
 
 	}
 
@@ -564,19 +600,20 @@ _EOF_
 		cat << _EOF_ > $FP_USER_FILTER_INCLUDE_EXCLUDE
 #$G_PROGRAM_NAME | Custom include/exclude filters
 #
-#To INCLUDE (+) a file/folder:
-#+ /location/to/my/file
-#+ /location/to/my/directory/
+#To EXCLUDE (-) all files by name:
+#- file
+#To EXCLUDE (-) a single file by path, relative to source directory:
+#- /relative/path/to/file
+#To EXCLUDE (-) a specific directory by path, relative to source directory:
+#- /relative/path/to/directory/
 #
-#To EXCLUDE (-) a file/folder:
-#- /location/to/my/file
-#- /location/to/my/directory/
+#To INCLUDE (+) something from within an otherwise excluded directory:
+#+ /relative/path/to/directory/include_this
 
 _EOF_
 
 	fi
 
-	#Read settings file
 	Read_Settings_File
 
 	#-----------------------------------------------------------------------------

--- a/dietpi/dietpi-sync
+++ b/dietpi/dietpi-sync
@@ -276,7 +276,7 @@ _EOF_
 		(( $SYNC_DELETE_MODE )) && SYNC_MODE_TEXT='[On]'
 
 		SYNC_CRONDAILY_TEXT='[Off]'
-		(( $SYNC_CRONDAILY )) && YNC_CRONDAILY_TEXT='[On]'
+		(( $SYNC_CRONDAILY )) && SYNC_CRONDAILY_TEXT='[On]'
 
 		local sync_last_completed='No previous sync found in target directory.'
 		if [[ -f $FP_TARGET/$SYNC_STATS_FILENAME ]]; then

--- a/dietpi/dietpi-sync
+++ b/dietpi/dietpi-sync
@@ -13,8 +13,8 @@
 	# - Allows user to sync a Source and Target directory.
 	#
 	# Usage:
-	# - /DietPi/dietpi/dietpi-sync  0 = Menu
-	# - /DietPi/dietpi/dietpi-sync  1 = Sync
+	# - /DietPi/dietpi/dietpi-sync		= Menu
+	# - /DietPi/dietpi/dietpi-sync 1	= Sync
 	#////////////////////////////////////
 
 	#Import DietPi-Globals ---------------------------------------------------------------
@@ -489,19 +489,19 @@ A copy of all the files and folders inside your Source location, will be created
 
 		G_WHIP_MENU_ARRAY=(
 
-			'Disabled' ': Only add/update, but never remove data on target location'
-			'Enabled' ': Sync removals from source to target as well => Exact copy'
+			'[Off]' ': Only add/update, but never remove data in target location'
+			'[On]' ': Sync removals from source to target as well => Exact copy'
 
 		)
 
 		G_WHIP_DEFAULT_ITEM="$SYNC_MODE_TEXT"
 		if G_WHIP_MENU "Please select the Sync delete mode.\n
-Disabled: (safe)\nIf files and folders exist in the Target location, that are not in the Source, they will be left alone.\n
-Enabled: (WARNING, if in doubt, DO NOT enable)\nAn exact copy of the Source location will be created at the Target location.
+[Off]: (safe)\nIf files and folders exist in the Target location, that are not in the Source, they will be left alone.\n
+[On]: (WARNING, if in doubt, DO NOT enable)\nAn exact copy of the Source location will be created at the Target location.
 If files are in the Target location that don't exist in the Source, they will be DELETED."; then
 
 			SYNC_DELETE_MODE=0
-			[[ $G_WHIP_RETURNED_VALUE == 'Enabled' ]] && SYNC_DELETE_MODE=1
+			[[ $G_WHIP_RETURNED_VALUE == '[On]' ]] && SYNC_DELETE_MODE=1
 
 		fi
 
@@ -515,18 +515,18 @@ If files are in the Target location that don't exist in the Source, they will be
 
 		G_WHIP_MENU_ARRAY=(
 
-			'Disabled' 'Manual sync.'
-			'Enabled' 'Automatically sync once a day.'
+			'[Off]' 'Manual sync.'
+			'[On]' 'Automatically sync once a day.'
 
 		)
 
 		G_WHIP_DEFAULT_ITEM="$SYNC_CRONDAILY_TEXT"
-		if G_WHIP_MENU 'Disabled:\nThe user must manually sync using dietpi-sync.\n
-Enabled:\nA cron job will be created that automatically runs dietpi-sync, once a day.\n
+		if G_WHIP_MENU '[Off]:\nThe user must manually sync using dietpi-sync.\n
+[On]:\nA cron job will be created that automatically runs dietpi-sync, once a day.\n
 (NOTICE):\nBefore enabling this feature, please run a test sync (Dry Run) to verify what will happen.'; then
 
 			SYNC_CRONDAILY=0
-			[[ $G_WHIP_RETURNED_VALUE == 'Enabled' ]] && SYNC_CRONDAILY=1
+			[[ $G_WHIP_RETURNED_VALUE == '[On]' ]] && SYNC_CRONDAILY=1
 
 		fi
 

--- a/dietpi/dietpi-sync
+++ b/dietpi/dietpi-sync
@@ -408,7 +408,7 @@ A copy of all the files and folders inside your Source location, will be created
 
 			'Manual' ": Manually type your $current_mode_text directory."
 			'List' ': Select from a list of available mounts/drives'
-			"Samba Client" ": [$SAMBA_MOUNT_TEXT]"
+			'Samba Client' ": [$SAMBA_MOUNT_TEXT]"
 
 		)
 
@@ -434,6 +434,8 @@ A copy of all the files and folders inside your Source location, will be created
 
 					fi
 
+					TARGETMENUID=0
+
 				;;
 
 				'Manual')
@@ -455,6 +457,8 @@ A copy of all the files and folders inside your Source location, will be created
 							FP_TARGET="$FP_SAMBA_MOUNT/dietpi-sync"
 
 						fi
+
+						TARGETMENUID=0
 
 					else
 
@@ -521,7 +525,7 @@ If files are in the Target location that don't exist in the Source, they will be
 		)
 
 		G_WHIP_DEFAULT_ITEM="$SYNC_CRONDAILY_TEXT"
-		if _WHIP_MENU 'Disabled:\nThe user must manually sync using dietpi-sync.\n
+		if G_WHIP_MENU 'Disabled:\nThe user must manually sync using dietpi-sync.\n
 Enabled:\nA cron job will be created that automatically runs dietpi-sync, once a day.\n
 (NOTICE):\nBefore enabling this feature, please run a test sync (Dry Run) to verify what will happen.'; then
 
@@ -564,14 +568,15 @@ Enabled:\nA cron job will be created that automatically runs dietpi-sync, once a
 
 				else
 
-					declare $fp_mode="${G_WHIP_RETURNED_VALUE%/}"
-					break
+					declare -g $fp_mode="${G_WHIP_RETURNED_VALUE%/}"
+					TARGETMENUID=0
+					return
 
 				fi
 
 			else
 
-				break
+				return
 
 			fi
 
@@ -650,7 +655,6 @@ _EOF_
 
 		done
 
-		#Save settings
 		Write_Settings_File
 
 	fi

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1076,7 +1076,6 @@ _EOF_
 FP_SOURCE=$(sed -n 1p /DietPi/dietpi/.dietpi-sync_settings_bk)
 FP_TARGET=$(sed -n 2p /DietPi/dietpi/.dietpi-sync_settings_bk)
 SYNC_DELETE_MODE=$(sed -n 3p /DietPi/dietpi/.dietpi-sync_settings_bk)
-SYNC_COMPRESSION=$(sed -n 4p /DietPi/dietpi/.dietpi-sync_settings_bk)
 SYNC_CRONDAILY=$(sed -n 5p /DietPi/dietpi/.dietpi-sync_settings_bk)
 _EOF_
 

--- a/rootfs/etc/cron.daily/dietpi
+++ b/rootfs/etc/cron.daily/dietpi
@@ -39,7 +39,7 @@
 	#----------------------------------------------------------------
 	#DietPi-Sync daily
 	if [[ -f /DietPi/dietpi/.dietpi-sync_settings ]] &&
-		(( $(sed -n 5p /DietPi/dietpi/.dietpi-sync_settings) == 1 )); then
+		grep -qi 'SYNC_CRONDAILY=1' /DietPi/dietpi/.dietpi-sync_settings; then
 
 		/DietPi/dietpi/dietpi-sync 1 &> /dev/null &
 

--- a/rootfs/etc/cron.hourly/dietpi
+++ b/rootfs/etc/cron.hourly/dietpi
@@ -10,12 +10,12 @@
 	#
 	#////////////////////////////////////
 
-	LOGGING_MODE=0
 	if [[ -f '/DietPi/dietpi/.installed' ]]; then
 
 		LOGGING_MODE=$(grep -m1 '^[[:blank:]]*INDEX_LOGGING_CURRENT=' /DietPi/dietpi/.installed | sed 's/^[^=]*=//')
 
 	fi
+	LOGGING_MODE=${LOGGING_MODE:-0}
 
 	#----------------------------------------------------------------
 	# Main Loop


### PR DESCRIPTION
**Status**: Ready
- [x] Changelog
- [x] Fix inc_excl paths, which need to be relative to source dir

**Testing**:
- [x] VM Jessie
- [x] VM Stretch
- [x] VM Buster

**Reference**: https://dietpi.com/phpbb/viewtopic.php?f=11&t=5347

**Commit list/description**:
+ DietPi-Sync | Resolved an issue with wrong created rsync_options string
+ DietPi-Cron.daily | Fix daily dietpi-sync based on new settings file scheme
+ DietPi-Sync | Resolved doubled dry run due to dry run required for space check
+ DietPi-Sync | Removed compression option, since this is only relevant for remote transfer, which we do not support yet. This might have led to wrong end user assumptions and confusion.
+ DietPi-Sync | Only run real sync, if prior dry run was successful
+ DietPi-Sync | Show now last log entry instead of last sync date only in main menu
+ DietPi-Sync | Simplify logging: Log to $FP_TARGET only, create tmp log first, move to $FP_TARGET afterwards; Return after insufficient space, to skip obsolete final whip and log file view.
+ DietPi-Sync | Be more verbose when target dir pre-creation fails, printing and logging "mkdir" error
+ DietPi-Sync | Exclude specific files/dirs only, if they are actually inside the source dir, and, correctly via relative path. Update info on exclude/include user file
+ DietPi-Sync | Do not allow to choose root "/" as source or target dir, point user towards DietPi-Backup. As well check for correct full path entry with leading slash.
+ DietPi-Sync | Do not check for existing dietpi_userdata which is not necessarily required
+ DietPi-Sync | Return to main menu, if directory selection was successful
+ DietPi-Sync | Removed separate "delete mode" and "cron choice" menu IDs. Those are too simple to require an own ID and we always want to go back to main menu afterwards.
+ DietPi-Sync | Turn $SYNC_DRY_RUN and samba related variables into local ones
+ DietPi-Sync | Minor coding and wording consistency
+ CHANGELOG | Entries