### PR TITLE
DietPi-Software | Add Medusa as replacement for SickRage

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Changes / Improvements / Optimisations:
 - DietPi-PREP | Removed the option to install a Jessie system. Removed the option to install DietPi on top of a Wheezy image, since an upgrade over two distro version would be required, which is not reliable. It is still possible to install DietPi on top of a Jessie image, where a distro upgrade to Stretch would be applied: https://github.com/Fourdee/DietPi/issues/2332
 - DietPi-Config | RPi: Improved available options for HDMI boost setting: https://github.com/Fourdee/DietPi/issues/2350
 - DietPi-Drive_Manager | Now allows to check & repair the boot file system and trigger it for root file system on next reboot: https://github.com/Fourdee/DietPi/issues/1740#issuecomment-388325204
+- DietPi-Software | SickRage has been replaced by Medusa, which is now available for install: https://github.com/Fourdee/DietPi/issues/2239
 - DietPi-Software | Blynk: Reinstalls now preserve existing config files; New directory structure and blynk user (v6.19) is patched now as well to existing installs: https://github.com/Fourdee/DietPi/pull/2324
 - DietPi-Software | Plex Media Server: Updated to v1.14.0 on x86 images, switch to HTTPS ARM repo and automated locale switch to en_US.UTF-8: https://github.com/Fourdee/DietPi/issues/2294
 - DietPi-Software | Nextcloud Talk: Disabled the very verbose coturn logging by default to reduce disk I/O. This can be overridden via /etc/turnserver.conf: https://github.com/Fourdee/DietPi/issues/2321

--- a/README.md
+++ b/README.md
@@ -225,3 +225,4 @@ Links to additional software used in DietPi and their source and build instructi
 - [FreshRSS](https://github.com/FreshRSS/FreshRSS)
 - [Folding@Home](https://github.com/FoldingAtHome)
 - [OpenBazaar](https://github.com/OpenBazaar/openbazaar-go)
+- [Medusa](https://github.com/pymedusa/Medusa)

--- a/dietpi/dietpi-process_tool
+++ b/dietpi/dietpi-process_tool
@@ -50,8 +50,6 @@
 	#/////////////////////////////////////////////////////////////////////////////////////
 	EXIT_CODE=0
 
-	MAX_PROGRAMS=0
-
 	aNICE=()
 	aAFFINITY=()
 	aSCHEDULE_POLICY=()
@@ -76,7 +74,7 @@
 		local print_info=1
 		(( $HIERARCHY > 1 )) && print_info=0
 
-		for ((i=0; i<$MAX_PROGRAMS; i++))
+		for i in ${!aNAME[@]}
 		do
 
 			if (( ${aAVAILABLE[$i]} )); then
@@ -269,12 +267,10 @@
 		aNAME[$index]='Pi-hole FTL';aPROCESS_NAME[$index]='pihole-FTL';((index++))
 		aNAME[$index]='PiJuice';aPROCESS_NAME[$index]='pijuice_sys.py';((index++))
 		aNAME[$index]='Pi-SPC';aPROCESS_NAME[$index]='sds.sh';((index++))
-
 		aNAME[$index]='Plex Media Server';aPROCESS_NAME[$index]='Plex Media Server';((index++))
 		#aNAME[$index]='Plex Plug-in';aPROCESS_NAME[$index]='Plex Plug-in';((index++))
 		aNAME[$index]='Plex DLNA Server';aPROCESS_NAME[$index]='Plex DLNA Server';((index++))
 		aNAME[$index]='Plex Tuner Service';aPROCESS_NAME[$index]='Plex Tuner Service';((index++))
-
 		aNAME[$index]='ProFTP';aPROCESS_NAME[$index]='proftpd';((index++))
 		aNAME[$index]='qBitTorrent';aPROCESS_NAME[$index]='qbittorrent-nox';((index++))
 		aNAME[$index]='Radarr';aPROCESS_NAME[$index]='Radarr.exe';((index++))
@@ -290,7 +286,7 @@
 		aNAME[$index]='Samba Server (Daemon)';aPROCESS_NAME[$index]='smbd';((index++))
 		aNAME[$index]='Samba Server (NetBios)';aPROCESS_NAME[$index]='nmbd';((index++))
 		aNAME[$index]='Shairport Sync';aPROCESS_NAME[$index]='shairport-sync';((index++))
-		aNAME[$index]='SickRage';aPROCESS_NAME[$index]='SiCKRAGE.py';((index++))
+		aNAME[$index]='Medusa';aPROCESS_NAME[$index]='medusa/start.py';((index++))
 		aNAME[$index]='Sonarr';aPROCESS_NAME[$index]='NzbDrone.exe';((index++))
 		aNAME[$index]='Spotify Connect Web';aPROCESS_NAME[$index]='spotify-connect-web';((index++))
 		aNAME[$index]='Supervisor';aPROCESS_NAME[$index]='supervisor';((index++))
@@ -332,22 +328,17 @@
 			done < $fp_include
 
 		fi
-		MAX_PROGRAMS=${#aNAME[@]}
 
 		# - Enable affinity for all cores and all programs by default
 		local init_affinity_value=0
-		if (( $G_HW_CPU_CORES > 1 )); then
-
-			init_affinity_value="0-$(( $G_HW_CPU_CORES - 1 ))"
-
-		fi
+		(( $G_HW_CPU_CORES > 1 )) && init_affinity_value="0-$(( $G_HW_CPU_CORES - 1 ))"
 
 		# - Find out which programs are running (impies installed) | exclude kernel threads ([])
 		#	NB: -L to list all threads in ps output
 		ps ax --no-headers -o pid -o cmd | sed '/\]$/d' > $FP_PS_LIST
 
 		# - Init other arrays
-		for ((i=0; i<$MAX_PROGRAMS; i++))
+		for i in ${!aNAME[@]}
 		do
 
 			aNICE[$i]=0
@@ -462,7 +453,7 @@
 		rm $FP_SETTINGS &> /dev/null
 
 		local save_index=0
-		for ((i=0; i<$MAX_PROGRAMS; i++))
+		for i in ${!aNAME[@]}
 		do
 
 			if (( ${aAVAILABLE[$i]} )); then
@@ -513,7 +504,7 @@ _EOF_
 
 		G_WHIP_MENU_ARRAY=()
 
-		for ((i=0; i<$MAX_PROGRAMS; i++))
+		for i in ${!aNAME[@]}
 		do
 
 			if (( ${aAVAILABLE[$i]} )); then
@@ -532,7 +523,7 @@ _EOF_
 
 			#Find selected program index
 			local index_current=0
-			for ((i=0; i<$MAX_PROGRAMS; i++))
+			for i in ${!aNAME[@]}
 			do
 
 				if [[ ${aNAME[$i]} == $G_WHIP_RETURNED_VALUE ]]; then
@@ -553,7 +544,7 @@ _EOF_
 			else
 
 				#return back to this section.
-				while true
+				while :
 				do
 
 					#menu, choose nice/affinity etc
@@ -578,7 +569,7 @@ _EOF_
 
 								G_WHIP_MENU_ARRAY=()
 
-								for ((i=-20; i<20; i++))
+								for i in {-20..20}
 								do
 									local desc=''
 									if (( $i == -20 )); then
@@ -668,11 +659,7 @@ _EOF_
 									done
 
 									#Update affinity array with new value, if at least 1 item was selected.
-									if [[ $new_affinity ]] ; then
-
-										aAFFINITY[$index_current]="$new_affinity"
-
-									fi
+									[[ $new_affinity ]] && aAFFINITY[$index_current]="$new_affinity"
 
 									#Apply
 									Apply_Process_Tool
@@ -850,11 +837,7 @@ _EOF_
 
 			printf '\ec' # clear current terminal screen
 
-			if (( $TARGETMENUID == 0 )); then
-
-				Menu_Main
-
-			fi
+			(( $TARGETMENUID == 0 )) && Menu_Main
 
 		done
 
@@ -871,6 +854,6 @@ _EOF_
 	fi
 
 	#-----------------------------------------------------------------------------------
-	exit ${EXIT_CODE:=0}
+	exit ${EXIT_CODE:-0}
 	#-----------------------------------------------------------------------------------
 }

--- a/dietpi/dietpi-process_tool
+++ b/dietpi/dietpi-process_tool
@@ -245,6 +245,7 @@
 		aNAME[$index]='Jackett';aPROCESS_NAME[$index]='JackettConsole.exe';((index++))
 		aNAME[$index]='Jack Server';aPROCESS_NAME[$index]='jackd';((index++))
 		aNAME[$index]='Jconvolver';aPROCESS_NAME[$index]='jconvolver';((index++))
+		aNAME[$index]='Medusa';aPROCESS_NAME[$index]='medusa/start.py';((index++))
 		aNAME[$index]='Minio';aPROCESS_NAME[$index]='minio';((index++))
 		aNAME[$index]='MiniDLNA';aPROCESS_NAME[$index]='minidlna';((index++))
 		aNAME[$index]='Mopidy';aPROCESS_NAME[$index]='mopidy';((index++))
@@ -286,7 +287,8 @@
 		aNAME[$index]='Samba Server (Daemon)';aPROCESS_NAME[$index]='smbd';((index++))
 		aNAME[$index]='Samba Server (NetBios)';aPROCESS_NAME[$index]='nmbd';((index++))
 		aNAME[$index]='Shairport Sync';aPROCESS_NAME[$index]='shairport-sync';((index++))
-		aNAME[$index]='Medusa';aPROCESS_NAME[$index]='medusa/start.py';((index++))
+		aNAME[$index]='SiCKRAGE';aPROCESS_NAME[$index]='SiCKRAGE.py';((index++)) # pre-v6.20 compatibility
+		aNAME[$index]='SickRage';aPROCESS_NAME[$index]='SickBeard.py';((index++)) # pre-v6.17 compatibility
 		aNAME[$index]='Sonarr';aPROCESS_NAME[$index]='NzbDrone.exe';((index++))
 		aNAME[$index]='Spotify Connect Web';aPROCESS_NAME[$index]='spotify-connect-web';((index++))
 		aNAME[$index]='Supervisor';aPROCESS_NAME[$index]='supervisor';((index++))

--- a/dietpi/dietpi-process_tool
+++ b/dietpi/dietpi-process_tool
@@ -569,7 +569,7 @@ _EOF_
 
 								G_WHIP_MENU_ARRAY=()
 
-								for i in {-20..20}
+								for i in {-20..19}
 								do
 									local desc=''
 									if (( $i == -20 )); then

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -117,7 +117,7 @@
 		#'moode-worker'
 
 		# - Download/BitTorrent
-		'sickrage'
+		'medusa'
 		'aria2'
 		'sabnzbd'
 		'couchpotato'

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -117,6 +117,7 @@
 		#'moode-worker'
 
 		# - Download/BitTorrent
+		'sickrage' # pre-v6.20 compatibility
 		'medusa'
 		'aria2'
 		'sabnzbd'

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11083,7 +11083,7 @@ _EOF_
 
 		fi
 
-		#SICKRAGE
+		#Medusa
 		software_id=116
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
@@ -11094,8 +11094,7 @@ _EOF_
 			cp $G_FP_DIETPI_USERDATA/medusa/runscripts/init.systemd /etc/systemd/system/medusa.service
 			G_CONFIG_INJECT 'Group=' 'Group=dietpi' /etc/systemd/system/medusa.service '\[Service\]'
 			G_CONFIG_INJECT 'ExecStart=' "ExecStart=$(which python) $G_FP_DIETPI_USERDATA/medusa/start.py -q --daemon --nolaunch --datadir=$G_FP_DIETPI_USERDATA/medusa" /etc/systemd/system/medusa.service
-
-			chown -R medusa:dietpi $G_FP_DIETPI_USERDATA/medusa # also applied in /DietPi/dietpi/func/dietpi-set_software setpermissions
+			chmod 644 /etc/systemd/system/medusa.service
 
 		fi
 
@@ -13825,7 +13824,7 @@ _EOF_
 
 		fi
 
-		software_id=116
+		software_id=116 # Medusa
 		if (( aSOFTWARE_INSTALL_STATE[$software_id] == -1 )); then
 
 			Banner_Uninstalling

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10604,7 +10604,7 @@ Bittorrent\MaxUploads=$(Optimize_BitTorrent 3)
 Bittorrent\MaxUploadsPerTorrent=$(Optimize_BitTorrent 3)
 WebUI\Port=1340
 WebUI\Enabled=true
-General\Locale=en_GB
+General\Locale=en
 Downloads\SavePath=$G_FP_DIETPI_USERDATA/downloads
 Downloads\TempPathEnabled=false
 Downloads\TempPath=$G_FP_DIETPI_USERDATA/downloads
@@ -10666,11 +10666,7 @@ program=
 _EOF_
 
 			#Jessie WebUI\Password_ha1 breaks login with m5dsum generated pw, revert to default 'adminadmin': https://github.com/Fourdee/DietPi/issues/1499#issuecomment-364769146
-			if (( $G_DISTRO == 3 )); then
-
-				sed -i '/Password_ha1=/d' $HOME/.config/qBittorrent/qBittorrent.conf
-
-			fi
+			(( $G_DISTRO == 3 )) && sed -i '/Password_ha1=/d' $HOME/.config/qBittorrent/qBittorrent.conf
 
 			# - service
 			cat << _EOF_ > /etc/systemd/system/qbittorrent.service

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5445,7 +5445,7 @@ _EOF_
 				G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$software_id]} install dir \"$G_FP_DIETPI_USERDATA/medusa\" already exists. Download and install steps will be skipped.
  - If you want to update ${aSOFTWARE_WHIP_NAME[$software_id]}, please use the internal updater from WebUI.
  - if you need to reinstall (e.g. broken instance), please manually backup your config files+data, remove the install dir and rerun \"dietpi-software (re)install $software_id\"."
- 
+
  			else
 
 				Download_Install 'https://github.com/pymedusa/Medusa/archive/master.zip' $G_FP_DIETPI_USERDATA

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5435,7 +5435,7 @@ _EOF_
 
 		fi
 
- 		#Medusa
+		#Medusa
 		software_id=116
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
@@ -5450,7 +5450,7 @@ _EOF_
  - If you want to update ${aSOFTWARE_WHIP_NAME[$software_id]}, please use the internal updater from WebUI.
  - if you need to reinstall (e.g. broken instance), please manually backup your config files+data, remove the install dir and rerun \"dietpi-software (re)install $software_id\"."
 
- 			else
+			else
 
 				Download_Install 'https://github.com/pymedusa/Medusa/archive/master.zip' $G_FP_DIETPI_USERDATA
 				mv $G_FP_DIETPI_USERDATA/Medusa-master $G_FP_DIETPI_USERDATA/medusa
@@ -5715,16 +5715,10 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://github.com/CouchPotato/CouchPotatoServer/archive/master.zip'
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
+			DEPS_LIST='libffi-dev libssl-dev python-lxml python3-lxml'
+			Download_Install 'https://github.com/CouchPotato/CouchPotatoServer/archive/master.zip'
 
-			G_AGI libffi-dev libssl-dev python-lxml python3-lxml
-
-			wget "$INSTALL_URL_ADDRESS" -O package.zip
-			G_RUN_CMD unzip -o package.zip
-			rm package.zip
-
-			rm -R /etc/couchpotato &> /dev/null
+			[[ -d /etc/couchpotato ]] && rm -R /etc/couchpotato
 			mv CouchPotato* /etc/couchpotato
 
 			pip install --upgrade pyopenssl

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5367,9 +5367,14 @@ _EOF_
 
 			DEPS_LIST='rtorrent screen' #mediainfo
 			# On Jessie, nginx-full is needed for SCGI module: https://github.com/Fourdee/DietPi/issues/1240
-			(( $G_DISTRO < 4 && ${aSOFTWARE_INSTALL_STATE[85]} >= 1 )) && DEPS_LIST+=' nginx-full'
+			(( $G_DISTRO < 4 && ${aSOFTWARE_INSTALL_STATE[85]} > 0 )) && DEPS_LIST+=' nginx-full'
 
-			Download_Install 'http://bintray.com/novik65/generic/download_file?file_path=ruTorrent-3.7.zip'
+			# Get current version string
+			INSTALL_URL_ADDRESS='https://api.github.com/repos/Novik/ruTorrent/releases/latest'
+			G_CHECK_URL "$INSTALL_URL_ADDRESS"
+			local version_string=$(curl -s "$INSTALL_URL_ADDRESS" | grep -m1 '^[[:blank:]]*"tag_name":' | cut -d \" -f 4)
+
+			Download_Install "https://github.com/Novik/ruTorrent/archive/$version_string.tar.gz"
 
 			mkdir -p /var/www/rutorrent
 			mv ruTorrent-*/* /var/www/rutorrent/
@@ -5437,7 +5442,7 @@ _EOF_
 
 			Banner_Installing
 
-			DEPS_LIST='python libssl-dev'
+			DEPS_LIST='python'
 
 			if [[ -d $G_FP_DIETPI_USERDATA/medusa ]]; then
 
@@ -8277,7 +8282,7 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 			Banner_Configuration
 
 			# Remove obsolete init.d service
-			rm /etc/init.d/transmission-daemon &> /dev/null
+			[[ -f /etc/init.d/transmission-daemon ]] && rm /etc/init.d/transmission-daemon
 
 			# Run service as "dietpi" group: https://github.com/Fourdee/DietPi/issues/350#issuecomment-423763518
 			mkdir -p /etc/systemd/system/transmission-daemon.service.d
@@ -13804,8 +13809,8 @@ _EOF_
 
 			userdel -rf qbittorrent
 
-			rm /etc/systemd/system/qbittorrent.service
-			rm -R /home/qbittorrent
+			[[ -f /etc/systemd/system/qbittorrent.service ]] && rm /etc/systemd/system/qbittorrent.service
+			[[ -d /home/qbittorrent ]] && rm -R /home/qbittorrent
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11092,6 +11092,7 @@ _EOF_
 			useradd -rM medusa -G dietpi -d $G_FP_DIETPI_USERDATA/medusa -s /usr/sbin/nologin
 
 			cp $G_FP_DIETPI_USERDATA/medusa/runscripts/init.systemd /etc/systemd/system/medusa.service
+			G_CONFIG_INJECT 'Group=' 'Group=dietpi' /etc/systemd/system/medusa.service '\[Service\]'
 			G_CONFIG_INJECT 'ExecStart=' "ExecStart=$(which python) $G_FP_DIETPI_USERDATA/medusa/start.py -q --daemon --nolaunch --datadir=$G_FP_DIETPI_USERDATA/medusa" /etc/systemd/system/medusa.service
 
 			chown -R medusa:dietpi $G_FP_DIETPI_USERDATA/medusa # also applied in /DietPi/dietpi/func/dietpi-set_software setpermissions

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -959,12 +959,11 @@ _EOF_
 		#------------------
 		software_id=116
 
-				 aSOFTWARE_WHIP_NAME[$software_id]='SiCKRAGE'
-				 aSOFTWARE_WHIP_DESC[$software_id]='automatically download TV shows'
+				 aSOFTWARE_WHIP_NAME[$software_id]='Medusa'
+				 aSOFTWARE_WHIP_DESC[$software_id]='Automatic Video Library Manager for TV Shows'
 			aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-					  aSOFTWARE_TYPE[$software_id]=-1
-   aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
-			 aSOFTWARE_ONLINEDOC_URL[$software_id]='f=8&t=5&p=3327#p3327'
+					  aSOFTWARE_TYPE[$software_id]=0
+			 aSOFTWARE_ONLINEDOC_URL[$software_id]='p=3327#p3327'
 
 		#------------------
 		software_id=132
@@ -2282,6 +2281,13 @@ _EOF_
 			aSOFTWARE_CATEGORY_INDEX[$software_id]=6
 					  aSOFTWARE_TYPE[$software_id]=1
 		#------------------
+		software_id=170
+
+				 aSOFTWARE_WHIP_NAME[$software_id]='Unrar'
+				 aSOFTWARE_WHIP_DESC[$software_id]='unarchiver for .rar files'
+			aSOFTWARE_CATEGORY_INDEX[$software_id]=6
+					  aSOFTWARE_TYPE[$software_id]=1
+		#------------------
 
 		#Text Editors
 		#--------------------------------------------------------------------------------
@@ -2593,6 +2599,20 @@ _EOF_
 		software_id=91
 		if (( ${aSOFTWARE_INSTALL_STATE[47]} == 1 ||
 			${aSOFTWARE_INSTALL_STATE[114]} == 1 )); then
+
+			aSOFTWARE_INSTALL_STATE[$software_id]=1
+			G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$software_id]} will be installed"
+
+		fi
+
+		#Software that requires unrar
+		#	rtorrent
+		#	Medusa
+		#	SABnzbd
+		software_id=170
+		if (( ${aSOFTWARE_INSTALL_STATE[107]} == 1 ||
+			${aSOFTWARE_INSTALL_STATE[116]} == 1 ||
+			${aSOFTWARE_INSTALL_STATE[139]} == 1 )); then
 
 			aSOFTWARE_INSTALL_STATE[$software_id]=1
 			G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$software_id]} will be installed"
@@ -5355,18 +5375,6 @@ _EOF_
 			mv ruTorrent-*/* /var/www/rutorrent/
 			rm -R ruTorrent-*
 
-			#Raspbian "unrar-free" only available in repos
-			if (( $G_HW_MODEL < 10 )); then
-
-				#G_AGI unrar-free #Does not support all rar formats, better use "unrar-nonfree" from Debian repo
-				Download_Install "https://dietpi.com/downloads/binaries/rpi/unrar-armhf-$G_DISTRO_NAME.deb"
-
-			else
-
-				G_AGI unrar #https://github.com/Fourdee/DietPi/issues/176#issuecomment-240101365
-
-			fi
-
 		fi
 
 		#Aria2
@@ -5423,35 +5431,27 @@ _EOF_
 
 		fi
 
- 		#SICKRAGE
+ 		#Medusa
 		software_id=116
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
 
-			DEPS_LIST='python python-pip python-dev python-setuptools libffi-dev libssl-dev libxmlsec1-dev libxml2-dev'
-			Download_Install 'https://github.com/SiCKRAGE/SiCKRAGE/archive/master.zip'
+			DEPS_LIST='python libssl-dev'
 
-			mkdir -p $G_FP_DIETPI_USERDATA/sickrage
-			cp -R SiCKRAGE-*/* $G_FP_DIETPI_USERDATA/sickrage/
-			rm -R SiCKRAGE-*
+			if [[ -d $G_FP_DIETPI_USERDATA/medusa ]]; then
 
-			#Raspbian "unrar-free" only available in repos
-			if (( $G_HW_MODEL < 10 )); then
+				G_AGI $DEPS_LIST
+				G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$software_id]} install dir \"$G_FP_DIETPI_USERDATA/medusa\" already exists. Download and install steps will be skipped.
+ - If you want to update ${aSOFTWARE_WHIP_NAME[$software_id]}, please use the internal updater from WebUI.
+ - if you need to reinstall (e.g. broken instance), please manually backup your config files+data, remove the install dir and rerun \"dietpi-software (re)install $software_id\"."
+ 
+ 			else
 
-				#G_AGI unrar-free #Does not support all rar formats, better use "unrar-nonfree" from Debian repo
-				Download_Install "https://dietpi.com/downloads/binaries/rpi/unrar-armhf-$G_DISTRO_NAME.deb"
-
-			else
-
-				G_AGI unrar #https://github.com/Fourdee/DietPi/issues/176#issuecomment-240101365
+				Download_Install 'https://github.com/pymedusa/Medusa/archive/master.zip' $G_FP_DIETPI_USERDATA
+				mv $G_FP_DIETPI_USERDATA/Medusa-master $G_FP_DIETPI_USERDATA/medusa
 
 			fi
-
-			G_RUN_CMD pip install wheel
-
-			G_DIETPI-NOTIFY 2 'Installing/building pre-reqs for SiCKRAGE, this can take up to 10 minutes on a NanoPC-T4/RK3399, please wait and do NOT interrupt the process...'
-			G_RUN_CMD pip install -r $G_FP_DIETPI_USERDATA/sickrage/requirements.txt
 
 		fi
 
@@ -5687,18 +5687,6 @@ _EOF_
 
 			mv /etc/sabnzbd/sabnzbd-"$version"/* /etc/sabnzbd/
 			rm -R /etc/sabnzbd/sabnzbd-"$version"
-
-			#Raspbian "unrar-free" only available in repos
-			if (( $G_HW_MODEL < 10 )); then
-
-				#G_AGI unrar-free #Does not support all rar formats, better use "unrar-nonfree" from Debian repo
-				Download_Install "https://dietpi.com/downloads/binaries/rpi/unrar-armhf-$G_DISTRO_NAME.deb"
-
-			else
-
-				G_AGI unrar #https://github.com/Fourdee/DietPi/issues/176#issuecomment-240101365
-
-			fi
 
 			pip install cheetah cryptography sabyenc
 
@@ -6902,6 +6890,26 @@ _EOF_
 			echo "hass -c \"$ha_userroot/.homeassistant\"" >> $ha_srvroot/homeassistant-start.sh
 			#su --shell /bin/bash --command "/srv/homeassistant/homeassistant-start.sh" homeassistant
 			chmod +x /srv/homeassistant/homeassistant-start.sh
+
+		fi
+
+		#Unrar
+		software_id=170
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			#Raspbian "unrar-free" only available in repos
+			if (( $G_HW_MODEL < 10 )); then
+
+				#G_AGI unrar-free #Does not support all rar formats, better use "unrar-nonfree" from Debian repo
+				Download_Install "https://dietpi.com/downloads/binaries/rpi/unrar-armhf-$G_DISTRO_NAME.deb"
+
+			else
+
+				G_AGI unrar #https://github.com/Fourdee/DietPi/issues/176#issuecomment-240101365
+
+			fi
 
 		fi
 
@@ -11081,30 +11089,12 @@ _EOF_
 
 			Banner_Configuration
 
-			useradd -rM sickrage -G dietpi -s /usr/sbin/nologin
+			useradd -rM medusa -G dietpi -d $G_FP_DIETPI_USERDATA/medusa -s /usr/sbin/nologin
 
-			cat << _EOF_ > /etc/systemd/system/sickrage.service
-[Unit]
-Description=SickRage (DietPi)
+			cp $G_FP_DIETPI_USERDATA/medusa/runscripts/init.systemd /etc/systemd/system/medusa.service
+			G_CONFIG_INJECT 'ExecStart=' "ExecStart=$(which python) $G_FP_DIETPI_USERDATA/medusa/start.py -q --daemon --nolaunch --datadir=$G_FP_DIETPI_USERDATA/medusa" /etc/systemd/system/medusa.service
 
-[Service]
-User=sickrage
-Group=dietpi
-Type=forking
-GuessMainPID=no
-WorkingDirectory=$G_FP_DIETPI_USERDATA/sickrage
-TimeoutSec=infinity
-TimeoutStopSec=20
-Restart=always
-ExecStart=$(which python) $G_FP_DIETPI_USERDATA/sickrage/SiCKRAGE.py -d --nolaunch --datadir=$G_FP_DIETPI_USERDATA/sickrage
-
-[Install]
-WantedBy=multi-user.target
-_EOF_
-
-			chown -R sickrage:dietpi $G_FP_DIETPI_USERDATA/sickrage # also applied in /DietPi/dietpi/func/dietpi-set_software setpermissions
-			> /var/log/sickrage.log
-			chown sickrage:dietpi /var/log/sickrage.log # also applied in /DietPi/dietpi/func/dietpi-set_software setpermissions
+			chown -R medusa:dietpi $G_FP_DIETPI_USERDATA/medusa # also applied in /DietPi/dietpi/func/dietpi-set_software setpermissions
 
 		fi
 
@@ -13838,13 +13828,10 @@ _EOF_
 		if (( aSOFTWARE_INSTALL_STATE[$software_id] == -1 )); then
 
 			Banner_Uninstalling
-
-			rm /etc/systemd/system/sickrage.service
-
-			rm -R  /etc/sickrage &> /dev/null # v6.11<
-			rm -R $G_FP_DIETPI_USERDATA/sickrage
-
-			userdel -rf sickrage
+			rm /etc/systemd/system/medusa.service
+			rm -R $G_FP_DIETPI_USERDATA/medusa
+			userdel -rf medusa
+			#apt-mark auto python libssl-dev
 
 		fi
 
@@ -14489,6 +14476,14 @@ _EOF_
 
 			Banner_Uninstalling
 			G_AGP vifm
+
+		fi
+
+		software_id=170
+		if (( aSOFTWARE_INSTALL_STATE[$software_id] == -1 )); then
+
+			Banner_Uninstalling
+			G_AGP unrar
 
 		fi
 

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -419,9 +419,8 @@ _EOF_
 		# - cubrite
 		chown -R cuberite:dietpi $G_FP_DIETPI_USERDATA/cubrite
 
-		# - sickrage
-		chown -R sickrage:dietpi $G_FP_DIETPI_USERDATA/sickrage
-		chown sickrage:dietpi /var/log/sickrage.log
+		# - Medusa
+		chown -R medusa:dietpi $G_FP_DIETPI_USERDATA/medusa
 
 		# - Sonarr
 		chown -R sonarr:dietpi $G_FP_DIETPI_USERDATA/sonarr

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -419,6 +419,10 @@ _EOF_
 		# - cubrite
 		chown -R cuberite:dietpi $G_FP_DIETPI_USERDATA/cubrite
 
+		# - sickrage # pre-v6.20 compatibility
+		[[ -d $G_FP_DIETPI_USERDATA/sickrage ]] && chown -R sickrage:dietpi $G_FP_DIETPI_USERDATA/sickrage
+		[[ -f /var/log/sickrage.log ]] && chown sickrage:dietpi /var/log/sickrage.log
+
 		# - Medusa
 		chown -R medusa:dietpi $G_FP_DIETPI_USERDATA/medusa
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1519,6 +1519,14 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 			#-------------------------------------------------------------------------------
 			#Clear install state for Medusa
 			(( $G_DIETPI_VERSION_RC == 0 && $G_DIETPI_INSTALL_STAGE == 2 )) && G_CONFIG_INJECT 'aSOFTWARE_INSTALL_STATE\[116\]=' 'aSOFTWARE_INSTALL_STATE[116]=0' /DietPi/dietpi/.installed
+			# - Inform user about SickRage being replaced by Medusa
+			if [[ -d /etc/sickrage || -d $G_FP_DIETPI_USERDATA/sickrage ]]; then
+
+				G_WHIP_MSG '[WARNING] We found an existing SickRage install on your system\n
+We already dropped SickRage from DietPi-Software install options with v6.18, now it has been fully replaced with "Medusa", an older stabilized fork.
+DietPi will still handle your SickRage service and directory permissions, but this might change soon.\n
+We encourage everyone to use Medusa instead. There are guides for migrating your SickRage TV shows and settings, but the most general advice is to do a fresh install of Medusa: dietpi-software install 116\n
+Also have a look at "Sonarr", another alternative TV show manager, available for install via DietPi-Software.'
 			#-------------------------------------------------------------------------------
 
 		fi

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1518,7 +1518,7 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 			[[ -f /etc/apache2/sites-available/dietpi-nextcloud.conf ]] && a2ensite dietpi-nextcloud
 			#-------------------------------------------------------------------------------
 			#Clear install state for Medusa
-			(( $G_DIETPI_VERSION_RC == 0 && $G_DIETPI_INSTALL_STAGE == 2 )) && G_CONFIG_INJECT 'aSOFTWARE_INSTALL_STATE\[116\]=' 'aSOFTWARE_INSTALL_STATE[116]=0' /DietPi/dietpi/.installed
+			(( $G_DIETPI_INSTALL_STAGE == 2 )) && [[ ! -d $G_FP_DIETPI_USERDATA/medusa ]] && G_CONFIG_INJECT 'aSOFTWARE_INSTALL_STATE\[116\]=' 'aSOFTWARE_INSTALL_STATE[116]=0' /DietPi/dietpi/.installed
 			# - Inform user about SickRage being replaced by Medusa
 			if [[ -d /etc/sickrage || -d $G_FP_DIETPI_USERDATA/sickrage ]]; then
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -649,29 +649,6 @@ _EOF_
 			#	# => v6.19 Xserver: https://github.com/Fourdee/DietPi/issues/1823
 			(( $G_DIETPI_INSTALL_STAGE == 2 )) && /DietPi/dietpi/dietpi-software reinstall 23 27 28 34 119 120 137
 			#-------------------------------------------------------------------------------
-			#Sickrage service update: https://github.com/Fourdee/DietPi/issues/1762
-			if [[ -f /etc/systemd/system/sickrage.service ]]; then
-
-				cat << _EOF_ > /etc/systemd/system/sickrage.service
-[Unit]
-Description=SickRage
-
-[Service]
-User=root
-Group=root
-Type=forking
-GuessMainPID=no
-TimeoutSec=infinity
-TimeoutStopSec=20
-Restart=always
-ExecStart=/usr/bin/python /etc/sickrage/SickBeard.py -q --daemon --nolaunch --datadir=$G_FP_DIETPI_USERDATA/sickrage
-
-[Install]
-WantedBy=multi-user.target
-_EOF_
-
-			fi
-			#-------------------------------------------------------------------------------
 			#Initially allow non-root users to obtain network details as well: https://github.com/Fourdee/DietPi/commit/15c0d495c33d3091e219c87bb2d09a22f8d27e9c
 			[[ -f /DietPi/dietpi/.network ]] && chmod 666 /DietPi/dietpi/.network
 			[[ -f /boot/dietpi/.network ]] && chmod 666 /boot/dietpi/.network
@@ -804,7 +781,6 @@ _EOF_
 			#	# => v6.17 MPD
 			#	minidlna
 			#	AirSonic
-			#	Sickrage
 			#	# => v6.18 Sonarr
 			#	# => v6.18 Radarr
 			#	NZBget
@@ -819,16 +795,6 @@ _EOF_
 			#		qBitTorrent
 			#		tonido
 			if (( $G_DIETPI_INSTALL_STAGE == 2 )); then
-
-				#Moved to userdata folder, pre-reinstall to keep existing settings
-				if [[ -d '/etc/sickrage' ]]; then
-
-					G_RUN_CMD mv /etc/sickrage/* $G_FP_DIETPI_USERDATA/sickrage/
-					rm -R /etc/sickrage
-
-					G_WHIP_MSG "INFO:\n\nSickrage has been moved to the DietPi userdata directory:\n\n - /etc/sickrage > $G_FP_DIETPI_USERDATA/sickrage"
-
-				fi
 
 				if [[ -d '/root/.config/NzbDrone' ]]; then
 
@@ -853,7 +819,7 @@ _EOF_
 
 				fi
 
-				/DietPi/dietpi/dietpi-software reinstall 32 33 39 116 143 149 154
+				/DietPi/dietpi/dietpi-software reinstall 32 33 39 143 149 154
 
 				#	O!MPD requires libary refresh by end user
 				if grep -q '^aSOFTWARE_INSTALL_STATE\[129\]=2' /DietPi/dietpi/.installed; then
@@ -1551,6 +1517,9 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 			#Re-enable owncloud/Nextcloud Apache configs, to fix faulty v6.19 installs: https://github.com/Fourdee/DietPi/pull/2361/commits/e33ca150cf29a4f278f5df2defc495053700a91e
 			[[ -f /etc/apache2/sites-available/dietpi-owncloud.conf ]] && a2ensite dietpi-owncloud
 			[[ -f /etc/apache2/sites-available/dietpi-nextcloud.conf ]] && a2ensite dietpi-nextcloud
+			#-------------------------------------------------------------------------------
+			#Clear install state for Medusa
+			(( $G_DIETPI_VERSION_RC == 0 && $G_DIETPI_INSTALL_STAGE == 2 )) && G_CONFIG_INJECT 'aSOFTWARE_INSTALL_STATE\[116\]=' 'aSOFTWARE_INSTALL_STATE[116]=0' /DietPi/dietpi/.installed
 			#-------------------------------------------------------------------------------
 
 		fi


### PR DESCRIPTION
**Status**: Testing
- [x] DietPi-Set_Software permissions
- [x] DietPi-Services
- [x] DietPi-Process_tool
- [x] Patch reset install state
- [x] Handle existing SickRage installs (still apply permissions, enable service)? 
- [x] Changelog
- [x] Online docs

**Testing**:
- [x] Jessie
- [x] Stretch
- [x] Buster
- [x] HTTPS
- [x] Update searches and database updates (first login)
- [x] Actual download test

### 🈺 Internal updater without Git:
**Still unsure. On first run Medusa complains unknown version and offers to update, if already on master, and if on older version. It updates by downloading master tarball which works without errors. But afterwards version string remains unknown. So I am not sure if it will recognize, when there is a new update after first run. Manual update check leads to log entry, that no update is required: `Thread_9 :: [918cfe7] No update needed`
- Perhaps it just compares the commit string, which shows up in info page 🤔. This then again would work reliable. User can find out about their version when checking the changelog.**
- [x] Without `libssl-dev`

**Reference**: https://github.com/Fourdee/DietPi/issues/2239

**Commit list/description**:
+ DietPi-Software | Make unrar an own install ID
+ DietPi-Software | Add medusa as replacement for SickRage
+ DietPi-Set_Software | Apply Medusa permissions
+ DietPi-Services | Control Meduse service
+ DietPi-Process_tool | Add Medusa process control
+ DietPi-Process_tool | Minor coding
+ DietPi-Patch | Remove SickRage patches and clear install ID state for Medusa
+ CHANGELOG | Medusa ready for install
+ DietPi-Software | Medusa: Skip libssl-dev install
+ DietPi-Software | rTorrent: Install latest ruTorrent from GitHub automatically
+ DietPi-Software | qBitTorrent: Use default "en" language instead of "en_GB", where several strings and WebUI elements were missing