### PR TITLE
DietPi-Software | OpenSSH: Host key regeneration quirks

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,8 @@ Changes / Improvements / Optimisations:
 - DietPi-Software | Deluge: UMask 002 applied to all downloads: https://github.com/Fourdee/DietPi/issues/2339
 - DietPi-Software | Netdata: Updated to v1.11.1 and now runs as user "netdata": https://github.com/Fourdee/DietPi/pull/2337
 - DietPi-Software | ownCloud/Nextcloud: Upadated webserver configs to match current recommendations and security hardenings. Only applied on new installs. To apply manually, run "dietpi-software reinstall 47" (owncloud) or "dietpi-software reinstall 114" (Nextcloud). You will be informed about the new configs, which then need to be manually moved to overwrite the old ones, since we don't want to mess with manual changes: https://github.com/Fourdee/DietPi/pull/2361
+- DietPi-Software | OpenSSH: Host keys won't be recreated anymore on reinstall, only on first boot of a fresh image, using now "dpkg-reconfigure openssh-server" to generate default key types based on distro.
+- DietPi-Software | Dropbear: Now installs only the "dropbear-run" package on Stretch (and above), which matches the default DietPi setup on our images and PREP script.
 - DietPi-Update | Added optional ability to automatically update DietPi, when updates are available. Please note, this is disabled by default.
 - DietPi-Sync | Removed the compression option, which has no effect on local sync, since files are not stored compressed, but only transferred compressed through remote sync protocols, which are currently not offered by DietPi-Sync.
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6612,7 +6612,7 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 
 				G_AGI dropbear
 				# ECDSA key is not generated (or converted from OpenSSH) automatically on Jessie
-				dropbearkey -t ecdsa -f /etc/dropbear/dropbear_ecdsa_host_key
+				[[ -f /etc/dropbear/dropbear_ecdsa_host_key ]] || dropbearkey -t ecdsa -f /etc/dropbear/dropbear_ecdsa_host_key
 
 			else
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6614,6 +6614,12 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 
 			Banner_Installing
 
+			# Mark target SSH server choice, if not selected via menu or first run setup
+			INDEX_SSHSERVER_TARGET=-1
+
+			# Stop OpenSSH service to unbind port 22
+			systemctl -q is-active ssh && systemctl stop ssh
+
 			# On Stretch+ Dropbear packages have been split, install "dropbear-run" only, to have active service, but "skip dropbear-initramfs"
 			if (( $G_DISTRO < 4 )); then
 
@@ -6633,12 +6639,23 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 			# Failsafe: Enable Dropbear service
 			systemctl enable dropbear
 
+			# Mark OpenSSH for uninstall and update choice system
+			dpkg-query -s 'openssh-server' &> /dev/null && aSOFTWARE_INSTALL_STATE[105]=-1 && UNINSTALL_REQUIRED=1
+			INDEX_SSHSERVER_CURRENT=-1
+
 		fi
 
 		software_id=105
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
+
+			# Mark target SSH server choice, if not selected via menu or first run setup
+			INDEX_SSHSERVER_TARGET=-2
+
+			# Stop Dropbear service to unbind port 22
+			systemctl -q is-active dropbear && systemctl stop dropbear
+
 			G_AGI openssh-server
 
 			# SSH server package also installs client.
@@ -6652,6 +6669,10 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 
 			# Failsafe: Enable OpenSSH service
 			systemctl enable ssh
+
+			# Mark Dropbear for uninstall and update choice system
+			grep -q '^dropbear[^[:blank:]]*[[:blank:]]' <<< "$(dpkg --get-selections)" && aSOFTWARE_INSTALL_STATE[104]=-1 && UNINSTALL_REQUIRED=1
+			INDEX_SSHSERVER_CURRENT=-2
 
 		fi
 
@@ -6919,38 +6940,26 @@ _EOF_
 		#Work out which SSH server needs removing (if any)
 		if (( $INDEX_SSHSERVER_TARGET != $INDEX_SSHSERVER_CURRENT )); then
 
-			# Run uninstall of old SSH servers, after install loop
-			UNINSTALL_REQUIRED=1
-
 			# - No SSH server
 			if (( $INDEX_SSHSERVER_TARGET == 0 )); then
 
-				(( ${aSOFTWARE_INSTALL_STATE[104]} == 2 )) && aSOFTWARE_INSTALL_STATE[104]=-1
-				(( ${aSOFTWARE_INSTALL_STATE[105]} == 2 )) && aSOFTWARE_INSTALL_STATE[105]=-1
+				# Check currently installed SSH servers via "dpkg --get-selections" to be failsafe
+				local dpkg_out="$(dpkg --get-selections)"
+
+				grep -q '^dropbear[^[:blank:]]*[[:blank:]]' <<< "$dpkg_out" && aSOFTWARE_INSTALL_STATE[104]=-1 && UNINSTALL_REQUIRED=1
+				grep -q '^openssh-server[[:blank:]]' <<< "$dpkg_out" && aSOFTWARE_INSTALL_STATE[105]=-1 && UNINSTALL_REQUIRED=1
 
 			# - Dropbear
 			elif (( $INDEX_SSHSERVER_TARGET == -1 )); then
 
 				aSOFTWARE_INSTALL_STATE[104]=1
-				(( ${aSOFTWARE_INSTALL_STATE[105]} == 2 )) && aSOFTWARE_INSTALL_STATE[105]=-1
 
 			# - OpenSSH
 			elif (( $INDEX_SSHSERVER_TARGET == -2 )); then
 
 				aSOFTWARE_INSTALL_STATE[105]=1
-				(( ${aSOFTWARE_INSTALL_STATE[104]} == 2 )) && aSOFTWARE_INSTALL_STATE[104]=-1
 
 			fi
-
-			# Inform user (From testing, stopping SSH server services does not disconnect user, however, just incase it does in the future)
-			G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Stopping SSH servers'
-
-			# Stop all SSH server services
-			systemctl stop ssh &> /dev/null
-			systemctl stop dropbear &> /dev/null
-
-			# Update current SSH server index
-			INDEX_SSHSERVER_CURRENT=$INDEX_SSHSERVER_TARGET
 
 		fi
 
@@ -15410,9 +15419,8 @@ Once DietPi has completed your software installations, and rebooted, please foll
 			#	NoIp
 			if (( ${aSOFTWARE_INSTALL_STATE[67]} == 1 )); then
 
-				G_WHIP_YESNO 'NoIp can be setup and configured by using DietPi-Config. Would you like to complete this now? \n\n- Once finished, exit DietPi-Config to resume setup.\n
- - More information:\nhttps://dietpi.com/phpbb/viewtopic.php?f=8&t=5&start=10#p58'
-				if (( $? == 0 )); then
+				if G_WHIP_YESNO 'NoIp can be setup and configured by using DietPi-Config. Would you like to complete this now? \n\n- Once finished, exit DietPi-Config to resume setup.\n
+ - More information:\nhttps://dietpi.com/phpbb/viewtopic.php?f=8&t=5&start=10#p58'; then
 
 					#Write installed states to temp
 					Write_InstallFileList temp

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -405,7 +405,7 @@ _EOF_
 		#Before adding, please check 'dietpi-software list | grep null' to list NULL (available) IDs for use.
 
 		#Assign UNIQUE ID to each item
-		local software_id=0
+		local software_id=-1
 
 		#Desktops
 		#--------------------------------------------------------------------------------
@@ -2436,7 +2436,7 @@ _EOF_
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" "Checking for prerequisite software"
 
-		local software_id=0
+		local software_id=-1
 
 		#-------------------------------------------------------------------------
 		#Pre-req software, for items that do not have their own array aSOFTWARE_REQUIRES_SOFTWARENAME
@@ -3195,7 +3195,7 @@ _EOF_
 		#--------------------------------------------------------------
 		#Install Software
 
-		local software_id=0
+		local software_id=-1
 
 		#Desktop LXDE
 		software_id=23
@@ -6257,7 +6257,7 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 
 	Install_Linux_Software(){
 
-		local software_id=0
+		local software_id=-1
 
 		software_id=5
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
@@ -6626,24 +6626,15 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 			Banner_Installing
 			G_AGI openssh-server
 
+			# Allow root login
+			G_CONFIG_INJECT 'PermitRootLogin[[:blank:]]' 'PermitRootLogin yes' /etc/ssh/sshd_config
 
-			# - Remove all references before adding the entry: https://github.com/Fourdee/DietPi/issues/604
-			sed -i '/PermitRootLogin[[:space:]]/d' /etc/ssh/sshd_config
-			echo -e '\n\n#Allow root login over SSH\nPermitRootLogin yes' >> /etc/ssh/sshd_config
-
-			#Generate host keys
-			# - remove all previous
-			rm /etc/ssh/ssh_host_key
-			rm /etc/ssh/ssh_host_rsa_key
-			rm /etc/ssh/ssh_host_dsa_key
+			#Re-generate host keys
+			# - Remove all previous
+			rm -f /etc/ssh/ssh_host_*_key*
 
 			# - Generate
-			ssh-keygen -f /etc/ssh/ssh_host_key -N '' -t rsa1
-			ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa
-			ssh-keygen -f /etc/ssh/ssh_host_dsa_key -N '' -t dsa
-
-			# - Set permissions
-			chmod -R 700 /etc/ssh/
+			dpkg-reconfigure openssh-server
 
 			#Restart ssh server now so root users can login during setup.
 			systemctl restart ssh
@@ -7089,7 +7080,7 @@ _EOF_
 		# Copy/Set optimised Software settings.
 		# Set install states to 2 (installed).
 
-		local software_id=0
+		local software_id=-1
 
 		#DESKTOP_LXDE
 		software_id=23
@@ -12457,7 +12448,7 @@ _EOF_
 
 		#NB: systemctl daemon-reload is executed at the end of this function
 
-		local software_id=0
+		local software_id=-1
 
 		software_id=23
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
@@ -14378,7 +14369,7 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			G_AGP $(dpkg --get-selections dropbear* | awk '{print $1}') #stretch | dropbear-initramfs dropbear-run
+			G_AGP $(dpkg --get-selections dropbear* | awk '{print $1}') # Stretch: dropbear-initramfs dropbear-run
 
 		fi
 
@@ -14388,7 +14379,7 @@ _EOF_
 			Banner_Uninstalling
 			G_AGP $(dpkg --get-selections openssh-* | awk '{print $1}')
 
-			# This also clears Openssh-client
+			# This also clears OpenSSH client
 			aSOFTWARE_INSTALL_STATE[0]=0
 
 		fi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6601,8 +6601,8 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 
 			Banner_Installing
 
-			#Remove information file
-			rm /mnt/nfs_client/readme.txt &> /dev/null
+			# Remove information file
+			[[ -f /mnt/nfs_client/readme.txt ]] && rm /mnt/nfs_client/readme.txt
 
 			# "netbase" is needed for mounting NFSv3: https://github.com/Fourdee/DietPi/issues/1898#issuecomment-406247814
 			G_AGI nfs-common netbase
@@ -6613,10 +6613,25 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-			G_AGI dropbear
 
-			#set to start on next boot
+			# On Stretch+ Dropbear packages have been split, install "dropbear-run" only, to have active service, but "skip dropbear-initramfs"
+			if (( $G_DISTRO < 4 )); then
+
+				G_AGI dropbear
+				# ECDSA key is not generated (or converted from OpenSSH) automatically on Jessie
+				dropbearkey -t ecdsa -f /etc/dropbear/dropbear_ecdsa_host_key
+
+			else
+
+				G_AGI dropbear-run
+
+			fi
+
+			# Enable Dropbear daemon
 			G_CONFIG_INJECT 'NO_START=' 'NO_START=0' /etc/default/dropbear
+
+			# Failsafe: Enable Dropbear service
+			systemctl enable dropbear
 
 		fi
 
@@ -6626,21 +6641,17 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 			Banner_Installing
 			G_AGI openssh-server
 
+			# SSH server package also installs client.
+			aSOFTWARE_INSTALL_STATE[0]=2
+
 			# Allow root login
 			G_CONFIG_INJECT 'PermitRootLogin[[:blank:]]' 'PermitRootLogin yes' /etc/ssh/sshd_config
 
-			#Re-generate host keys
-			# - Remove all previous
-			rm -f /etc/ssh/ssh_host_*_key*
+			# Reload SSH server now so root users can login during setup.
+			systemctl reload ssh
 
-			# - Generate
-			dpkg-reconfigure openssh-server
-
-			#Restart ssh server now so root users can login during setup.
-			systemctl restart ssh
-
-			#SSH server package also installs client.
-			aSOFTWARE_INSTALL_STATE[0]=2
+			# Failsafe: Enable OpenSSH service
+			systemctl enable ssh
 
 		fi
 
@@ -6904,7 +6915,7 @@ _EOF_
 
 	Apply_SSHServer_Choices(){
 
-		#Work out which SSH Server needs installing from IDs (if any)
+		#Work out which SSH server needs installing from IDs (if any)
 		#Work out which SSH server needs removing (if any)
 		if (( $INDEX_SSHSERVER_TARGET != $INDEX_SSHSERVER_CURRENT )); then
 
@@ -6923,7 +6934,7 @@ _EOF_
 				aSOFTWARE_INSTALL_STATE[104]=1
 				(( ${aSOFTWARE_INSTALL_STATE[105]} == 2 )) && aSOFTWARE_INSTALL_STATE[105]=-1
 
-			# - Openssh
+			# - OpenSSH
 			elif (( $INDEX_SSHSERVER_TARGET == -2 )); then
 
 				aSOFTWARE_INSTALL_STATE[105]=1
@@ -6931,14 +6942,14 @@ _EOF_
 
 			fi
 
-			#Inform user (From testing, stopping SSH server services does not disconnect user, however, just incase it does in the future)
+			# Inform user (From testing, stopping SSH server services does not disconnect user, however, just incase it does in the future)
 			G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Stopping SSH servers'
 
-			#stop all SSH server services
+			# Stop all SSH server services
 			systemctl stop ssh &> /dev/null
 			systemctl stop dropbear &> /dev/null
 
-			#Update Current SSHSERVER index
+			# Update current SSH server index
 			INDEX_SSHSERVER_CURRENT=$INDEX_SSHSERVER_TARGET
 
 		fi
@@ -14371,6 +14382,9 @@ _EOF_
 			Banner_Uninstalling
 			G_AGP $(dpkg --get-selections dropbear* | awk '{print $1}') # Stretch: dropbear-initramfs dropbear-run
 
+			# Required on Jessie only, since ECDSA key is not created on install automatically, thus not removed on uninstall
+			[[ -d /etc/dropbear ]] && rm -R /etc/dropbear
+
 		fi
 
 		software_id=105
@@ -15231,9 +15245,8 @@ Once $G_PROGRAM_NAME has finished installation, simply run 'dietpi-drive_manager
 			#Gogs: Requires OpenSSH for ssh-keygen binary: https://github.com/Fourdee/DietPi/issues/442
 			if (( ${aSOFTWARE_INSTALL_STATE[49]} == 1 && $INDEX_SSHSERVER_TARGET != -2 )); then
 
-				G_WHIP_YESNO "Gogs requires OpenSSH server to function.\n\nIf you continue, OpenSSH will be selected for install on your system. OpenSSH will also replace Dropbear (if currently installed).\n
-Would you like to continue with the Gogs installation?"
-				if (( $? == 0 )); then
+				if G_WHIP_YESNO "Gogs requires OpenSSH server to function.\n\nIf you continue, OpenSSH will be selected for install on your system. OpenSSH will also replace Dropbear (if currently installed).\n
+Would you like to continue with the Gogs installation?"; then
 
 					# - Use SSH target index to ensure Dropbear gets removed if installed.
 					INDEX_SSHSERVER_TARGET=-2
@@ -15580,11 +15593,10 @@ This will allow you to choose which program loads automatically, after the syste
 
 					G_WHIP_DEFAULT_ITEM="$index_sshserver_text"
 					G_WHIP_BUTTON_CANCEL_TEXT='Back'
-					G_WHIP_MENU 'Please select desired SSH server:\n
+					if G_WHIP_MENU 'Please select desired SSH server:\n
 - None: Selecting this option will uninstall all SSH servers. This reduces system resources and improves performance. Useful for users who do NOT require networked/remote terminal access.\n
 - Dropbear (Recommended): Lightweight SSH server, installed by default on DietPi systems.\n
-- OpenSSH: A feature rich SSH server with SFTP/SCP support, at the cost of increased resource usage.'
-					if (( $? == 0 )); then
+- OpenSSH: A feature rich SSH server with SFTP/SCP support, at the cost of increased resource usage.'; then
 
 						# - Assign target index
 						if [[ $G_WHIP_RETURNED_VALUE == 'None' ]]; then
@@ -16013,11 +16025,10 @@ When you select any software for install that requires a webserver, DietPi will 
 		done
 
 		#Confirm Software install
-		G_WHIP_YESNO "DietPi is now ready to install your software choices: $string_output\n
+		if G_WHIP_YESNO "DietPi is now ready to install your software choices: $string_output\n
 Software details, usernames, passwords etc:\n - https://dietpi.com/software\n
 NB: Software services will be temporarily controlled (stopped) by DietPi during this process. Please inform connected users, before continuing. SSH is not affected.\n
-Would you like to begin?"
-		if (( $? == 0 )); then
+Would you like to begin?"; then
 
 			#exit menu system
 			TARGETMENUID=-1

--- a/dietpi/preboot
+++ b/dietpi/preboot
@@ -101,9 +101,9 @@
 		if [[ $autoinstall_timezone != $(</etc/timezone) ]]; then
 
 			G_DIETPI-NOTIFY 2 "Setting Timezone $autoinstall_timezone. Please wait..."
-			rm /etc/timezone
-			rm /etc/localtime
-			ln -fs "/usr/share/zoneinfo/$autoinstall_timezone" /etc/localtime
+			[[ -f /etc/timezone ]] && rm /etc/timezone
+			[[ -f /etc/localtime ]] && rm /etc/localtime
+			ln -sf "/usr/share/zoneinfo/$autoinstall_timezone" /etc/localtime
 			dpkg-reconfigure -f noninteractive tzdata
 
 		fi
@@ -169,14 +169,22 @@
 		/DietPi/dietpi/func/dietpi-set_software apt-mirror "$(grep -m1 "^[[:blank:]]*$target_repo=" /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
 
 		# - Generate unique Dropbear host keys:
-		rm /etc/dropbear/*_host_key &> /dev/null
-		dropbearkey -t rsa -f /etc/dropbear/dropbear_rsa_host_key &> /dev/null
-		dropbearkey -t ecdsa -f /etc/dropbear/dropbear_ecdsa_host_key &> /dev/null
-		dropbearkey -t dss -f /etc/dropbear/dropbear_dss_host_key &> /dev/null
+		rm -f /etc/dropbear/*_host_key
+		#	Distro specific package and on Jessie, ECDSA is not created automatically
+		if (( $G_DISTRO < 4 )); then
+
+			dpkg-reconfigure -f noninteractive dropbear
+			dropbearkey -t ecdsa -f /etc/dropbear/dropbear_ecdsa_host_key
+
+		else
+
+			dpkg-reconfigure -f noninteractive dropbear-run
+
+		fi
 
 		# - Recreate machine-id: https://github.com/Fourdee/DietPi/issues/2015
-		rm /etc/machine-id &> /dev/null
-		rm /var/lib/dbus/machine-id &> /dev/null
+		[[ -f /etc/machine-id ]] && rm /etc/machine-id
+		[[ -f /var/lib/dbus/machine-id ]] && rm /var/lib/dbus/machine-id
 		systemd-machine-id-setup
 
 		# - Network setup
@@ -200,7 +208,7 @@
 		local static_gateway="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_NET_STATIC_GATEWAY=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
 		local static_dns="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_NET_STATIC_DNS=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
 
-		#	Wifi
+		#	WiFi
 		if (( $wifi_enabled )); then
 
 			#Enable Wlan, disable Eth
@@ -243,7 +251,7 @@
 
 		fi
 
-		# - IPv6
+		#	IPv6
 		local enable_ipv6=$(grep -ci -m1 '^[[:blank:]]*CONFIG_ENABLE_IPV6=1' /DietPi/dietpi.txt)
 		/DietPi/dietpi/func/dietpi-set_hardware enableipv6 $enable_ipv6
 		(( $enable_ipv6 )) && /DietPi/dietpi/func/dietpi-set_hardware preferipv4 $(grep -ci -m1 '^[[:blank:]]*CONFIG_PREFER_IPV4=1' /DietPi/dietpi.txt)
@@ -287,8 +295,7 @@
 
 			local fp_dietpiautomation_custom_prescript_log='/var/tmp/dietpi/logs/dietpi-automation_custom_prescript.log'
 			chmod +x /boot/Automation_Custom_PreScript.sh
-			/boot/Automation_Custom_PreScript.sh | tee $fp_dietpiautomation_custom_prescript_log
-			if (( $? == 0 )); then
+			if /boot/Automation_Custom_PreScript.sh | tee $fp_dietpiautomation_custom_prescript_log; then
 
 				G_DIETPI-NOTIFY 0 'Custom script'
 

--- a/rootfs/etc/systemd/system/dietpi-preboot.service
+++ b/rootfs/etc/systemd/system/dietpi-preboot.service
@@ -4,7 +4,7 @@ Description=DietPi-PreBoot
 Requires=dietpi-ramdisk.service
 Wants=network-pre.target
 After=dietpi-ramdisk.service dietpi-ramlog.service
-Before=network-pre.target
+Before=network-pre.target dropbear.service ssh.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
**Status**: Ready
- [x] Decide if skipping regeneration on reinstall is even better
- [x] Changelog
- [x] Make `dietpi-software install 104/105` as well stop SSH services and mark the other SSH server for uninstall.

**Testing**:
- 🈯️ Jessie: Install Dropbear => OpenSSH, OpenSSH => Dropbear, boot order
- 🈯️ Stretch: Install Dropbear => OpenSSH, OpenSSH => Dropbear, boot order

**Retest**:
- [x] Stretch: Choice system via menu
- [x] Stretch: Choice system via `dietpi-software install/uninstall`
- [x] Jessie: Choice system via menu
- [x] Jessie: Choice system via `dietpi-software install/uninstall`

**Reference**: https://github.com/Fourdee/DietPi/issues/2375

**Commit list/description**:
+ DietPi-PreBoot | SSH servers: Regenerate distro/version default host keys via "dpkg-reconfigure"
+ DietPi-PreBoot | Start systemd unit before SSH servers, to have fresh SSH host keys for first session; It makes sense anyway to not start SSH servers before even "network-pre.target" has reached. Initramfs integration is another thing outside of systemd.
+ DietPi-Software | Dropbear: On Stretch, only install "dropbear-run", to match PREP as well
+ DietPi-Software | Dropbear: Generate ECDSA host key on Jessie, if not yet done before, since it is not done by default; Remove "/etc/dropbear" on uninstall, since with manually created host key, it is not removed by APT
+ DietPi-Software | OpenSSH: Do not recreate host keys on install, preserve existing ones
+ DietPi-Software | SSH servers: Enable services, just to be failsafe in case it got disabled at some point
+ DietPi-Software | SSH servers: Update SSH choice index, set uninstall marks and stop active SSH services during install step, to assure this is done as well when using: "dietpi-software install 104/105"
+ DietPi-Software | SSH servers: Always check for installed SSH servers via "dpkg", to assure uninstall is done as well for installs outside of dietpi-software
+ CHANGELOG | SSH servers: Host key generation and install rework
+ DietPi-Software | Init "local software_id=-1" to prevent potential issues since "0" is reserved for OpenSSH client