### PR TITLE
DietPi-Software | MPD: Update installer

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,6 +28,7 @@ Bug Fixes:
 - DietPi-Software | Nextcloud: Resolved an issue, where the Nextcloud Apache config was not downloaded correctly. Thanks to @Stefan3v for reporting this issue: https://github.com/Fourdee/DietPi/issues/2383
 - DietPi-Software | ownCloud/Nextcloud (Talk): Resolved an issue, where occ/ncc commands could fail, if Redis server is not running: https://github.com/Fourdee/DietPi/issues/2321
 - DietPi-Software | ownCloud/Nextcloud: Resolved an issue, where during fresh installs on v6.19, Apache configs were not enabled correctly.
+- DietPi-Software | MPD: Resolved an issue on Stretch, where the mpd binary could not find the configuration file without giving it explicitely as argument. Thanks to @mfeif for reporting this issue: https://github.com/Fourdee/DietPi/issues/2378
 - DietPi-Sync | Resolved an issue, where dry-run and compression options were not applied correctly. Thanks to @WilburWalsh for reporting the issue and identifying the faulty code: https://dietpi.com/phpbb/viewtopic.php?f=11&t=5347
 - DietPi-Sync | Resolved an issue, where daily sync was not applied due to changed settings file scheme.
 - General | Enhanced and fixed some issue with dependencies and boot order of DietPi systemd units: https://github.com/Fourdee/DietPi/pull/2357

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,6 +20,7 @@ Changes / Improvements / Optimisations:
 - DietPi-Software | Dropbear: Now installs only the "dropbear-run" package on Stretch (and above), which matches the default DietPi setup on our images and PREP script.
 - DietPi-Software | NAA Daemon: Updated to 3.5.5-39. Thanks to @volpone for the heads up: https://github.com/Fourdee/DietPi/issues/2387#issue-395321320
 - DietPi-Software | MPD: Updated to 0.20.23-1. Includes support for NFS and Samba: https://github.com/Fourdee/DietPi/issues/2377
+- DietPi-Software | MPD: Now runs as "mpd" user again, updated systemd unit to match official one and better handle existing cache and log files on reinstall: https://github.com/Fourdee/DietPi/issues/2378
 - DietPi-Update | Added optional ability to automatically update DietPi, when updates are available. Please note, this is disabled by default.
 - DietPi-Sync | Removed the compression option, which has no effect on local sync, since files are not stored compressed, but only transferred compressed through remote sync protocols, which are currently not offered by DietPi-Sync.
 

--- a/dietpi/conf/mpd.conf
+++ b/dietpi/conf/mpd.conf
@@ -6,7 +6,7 @@ pid_file "/var/run/mpd/pid"
 state_file "/mnt/dietpi_userdata/.mpd_cache/state"
 sticker_file "/mnt/dietpi_userdata/.mpd_cache/sticker.sql"
 
-user "root"
+user "mpd"
 group "dietpi"
 
 bind_to_address "localhost"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3821,6 +3821,32 @@ _EOF_
 
 			Banner_Installing
 
+			# Jessie: https://github.com/Fourdee/DietPi/issues/1620#issuecomment-373086888
+			if (( $G_DISTRO == 3 )); then
+
+				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/libssl1.1_1.1.0f-3+deb9u1_'
+
+				# - ARMv7
+				if (( $G_HW_ARCH < 3 )); then
+
+					INSTALL_URL_ADDRESS+='armhf.deb'
+
+				# - ARM64
+				elif (( $G_HW_ARCH == 3 )); then
+
+					INSTALL_URL_ADDRESS+='arm64.deb'
+
+				# - x86_64
+				elif (( $G_HW_ARCH == 10 )); then
+
+					INSTALL_URL_ADDRESS+='amd64.deb'
+
+				fi
+
+				Download_Install "$INSTALL_URL_ADDRESS"
+
+			fi
+
 			Download_Install 'https://dietpi.com/downloads/binaries/all/ympd_1.2.3.7z'
 
 			local binary_name='ympd_'
@@ -3845,7 +3871,17 @@ _EOF_
 				binary_name+='amd64'
 
 			fi
-			binary_name+="_$G_DISTRO_NAME"
+
+			# Buster workaround, since we have no Buster binaries yet
+			if (( $G_DISTRO > 3 )); then
+
+				binary_name+='_stretch'
+
+			else
+
+				binary_name+="_$G_DISTRO_NAME"
+
+			fi
 
 			mv "$binary_name" /usr/bin/ympd
 			chmod +x /usr/bin/ympd
@@ -5018,7 +5054,7 @@ _EOF_
 				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/libssl1.1_1.1.0f-3+deb9u1_'
 
 				# - ARMv7
-				if (( $G_HW_ARCH == 2 )); then
+				if (( $G_HW_ARCH < 3 )); then
 
 					INSTALL_URL_ADDRESS+='armhf.deb'
 
@@ -8494,7 +8530,7 @@ After=mpd.service
 
 [Service]
 Type=simple
-User=root # Changes to ympd during run
+#User=ympd # Changes to ympd during run
 Group=dietpi
 ExecStart=/usr/bin/ympd --user ympd --webport 1337
 
@@ -8510,7 +8546,9 @@ _EOF_
 
 			Banner_Configuration
 
-			useradd -rM mympd -G dietpi,audio -s /usr/sbin/nologin
+			usercmd='useradd -rM'
+			getent passwd mympd &> /dev/null && usercmd='usermod'
+			$usercmd mympd -G dietpi,audio -s /usr/sbin/nologin
 
 			cat << _EOF_ > /lib/systemd/system/mympd.service
 [Unit]
@@ -8519,7 +8557,7 @@ After=mpd.service
 
 [Service]
 Type=simple
-User=root # Changes at runlevel
+#User=mympd # Changes at runlevel
 Group=dietpi
 ExecStart=$(which mympd) /etc/mympd/mympd.conf
 
@@ -8876,7 +8914,6 @@ Description=AmiBerry Amiga Emulator (DietPi)
 
 [Service]
 Type=simple
-User=root
 #StandardOutput=tty
 #StandardInput=tty
 #TTYPath=/dev/tty1
@@ -9483,7 +9520,6 @@ After=dietpi-boot.service dietpi-ramdisk.service dietpi-ramlog.service
 
 [Service]
 Type=simple
-User=root
 RemainAfterExit=yes
 PAMName=login
 ExecStart=/bin/bash /usr/local/bin/vncserver start
@@ -10809,7 +10845,6 @@ Description=rTorrent (DietPi)
 After=network.target
 
 [Service]
-User=root
 Type=forking
 KillMode=none
 ExecStart=/usr/bin/screen -d -m -fa -S rtorrent /usr/bin/rtorrent
@@ -11858,7 +11893,6 @@ Description=OctoPrint (DietPi)
 
 [Service]
 Type=simple
-User=root
 ExecStart=$(which octoprint) serve --iknowwhatimdoing
 
 [Install]
@@ -11880,7 +11914,6 @@ After=network.target
 
 [Service]
 Type=simple
-User=root
 Environment=ROON_DATAROOT=$G_FP_DIETPI_USERDATA/roonserver
 ExecStart=$G_FP_DIETPI_USERDATA/roonserver/start.sh
 
@@ -12234,7 +12267,6 @@ Description=AudioPhonics Pi-SPC (DietPi)
 [Service]
 Type=simple
 StandardOutput=tty
-User=root
 
 ExecStart=/bin/bash -c '/var/lib/dietpi/dietpi-software/installed/pi-spc/sds.sh'
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12781,6 +12781,8 @@ _EOF_
 			getent passwd mpd &> /dev/null && userdel -rf mpd
 			[[ -f /lib/systemd/system/mpd.service ]] && rm /lib/systemd/system/mpd.service
 			[[ -d $G_FP_DIETPI_USERDATA/.mpd_cache ]] && rm -R $G_FP_DIETPI_USERDATA/.mpd_cache
+			[[ -f /etc/mpd.conf ]] && rm /etc/mpd.conf
+			[[ -f /usr/local/etc/mpd.conf ]] && rm /usr/local/etc/mpd.conf && rmdir --ignore-fail-on-non-empty /usr/local/etc
 			[[ -f /etc/default/mpd ]] && rm /etc/default/mpd # pre-v6.20
 
 		fi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8520,7 +8520,9 @@ _EOF_
 
 			Banner_Configuration
 
-			useradd -rM ympd -G dietpi -s /usr/sbin/nologin
+			usercmd='useradd -rM'
+			getent passwd ympd &> /dev/null && usercmd='usermod'
+			$usercmd ympd -G dietpi -s /usr/sbin/nologin
 
 			#YMPD service
 			cat << _EOF_ > /etc/systemd/system/ympd.service

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3596,12 +3596,13 @@ We work around this error by running APT a second time. Please do not worry and 
 			#Jessie-
 			if (( $G_DISTRO < 4 )); then
 
-				#MPD not available in Jessie Repo for ARMv8
+				# MPD not available in Jessie Repo for ARMv8
 				if (( $G_HW_ARCH == 3 )); then
 
-					#libupnp6 for net discov with upnp/avahi
+					# libupnp6 for net discov with upnp/avahi
 					DEPS_LIST='libupnp6 libwrap0 libmpdclient2 libao-common libao4 libasound2 libasound2-data libasyncns0 libaudiofile1 libavahi-client3 libavahi-common-data libavahi-common3 libavcodec56 libavformat56 libavresample2 libavutil54 libbinio1ldbl libcaca0 libcdio-cdda1 libcdio-paranoia1 libcdio13 libcups2 libcurl3-gnutls libdirectfb-1.2-9 libdnet libfaad2 libflac8 libfluidsynth1 libgme0 libgomp1 libgsm1 libice6 libid3tag0 libiso9660-8 libjack-jackd2-0 libjson-c2 libldb1 libmad0 libmikmod3 libmms0 libmodplug1 libmp3lame0 libmpcdec6 libmpg123-0 libnfs4 libntdb1 libogg0 libopenal-data libopenal1 libopenjpeg5 libopus0 liborc-0.4-0 libpulse0 libresid-builder0c2a libroar2 libsamplerate0 libschroedinger-1.0-0 libsdl1.2debian libshout3 libsidplay2 libsidutils0 libslp1 libsm6 libsmbclient libsndfile1 libsoxr0 libspeex1 libspeexdsp1 libsqlite3-0 libtalloc2 libtdb1 libtevent0 libtheora0 libupnp6 libva1 libvorbis0a libvorbisenc2 libvorbisfile3 libvpx1 libwavpack1 libwbclient0 libwildmidi-config libwildmidi1 libx11-6 libx11-data libx11-xcb1 libx264-142 libxau6 libxcb1 libxdmcp6 libxext6 libxi6 libxtst6 libxvidcore4 libyajl2 libzzip-0-13 mime-support python python-talloc python2.7 samba-libs x11-common file'
-					Download_Install 'https://dietpi.com/downloads/binaries/all/mpd_0.19.21_arm64.deb'
+					# ARMv7 binary works
+					Download_Install 'https://dietpi.com/downloads/binaries/all/mpd_0.20.18-1_armv7.deb'
 
 				else
 
@@ -3612,39 +3613,16 @@ We work around this error by running APT a second time. Please do not worry and 
 			#Stretch
 			elif (( $G_DISTRO == 4 )); then
 
-				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/mpd_0.20.23-1_'
-				#armv6
-				if (( $G_HW_ARCH == 1 )); then
-
-					INSTALL_URL_ADDRESS+='armv6.deb'
-
-				#armv7+
-				elif (( $G_HW_ARCH == 2 )); then
-
-					INSTALL_URL_ADDRESS+='armv7.deb'
-
-				#ARMv8
-				elif (( $G_HW_ARCH == 3 )); then
-
-					INSTALL_URL_ADDRESS+='armv8.deb'
-
-				#x86_64
-				elif (( $G_HW_ARCH == 10 )); then
-
-					INSTALL_URL_ADDRESS+='amd64.deb'
-
-				fi
-
 				DEPS_LIST='libnfs8 libsmbclient libsqlite3-0 libupnp6 libwrap0 libmpdclient2 libflac8 libyajl2 libavahi-client3 libvorbisfile3 libwavpack1 libmad0 libmpg123-0 libopus0 libavformat57 libfaad2 libcdio-paranoia1 libiso9660-8 libshout3 libid3tag0'
-				Download_Install "$INSTALL_URL_ADDRESS"
-
-				apt-mark hold mpd # prevent repo updates from overwriting
+				Download_Install "https://dietpi.com/downloads/binaries/all/mpd_0.20.23-1_$G_HW_ARCH_DESCRIPTION"
+				# Prevent APT repo updates from overwriting
+				apt-mark hold mpd
 
 			#Buster+
 			else
 
 				# libcdio-paranoia1 and libiso9660-8 not available, but ibcdio-paranoia2 and libiso9660-11 instead
-				# Buster repo version > 0.20.18, thus stay with APT for now:
+				# Buster repo version >= 0.20.23, thus stay with APT for now:
 				G_AGI mpd
 
 			fi
@@ -8339,7 +8317,7 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 			# Create MPD user
 			local usercmd='useradd -rM'
 			getent passwd mpd &> /dev/null && usercmd='usermod'
-			$usercmd mpd -G dietpi,audio -d /var/lib/mpd -s /usr/sbin/nologin
+			$usercmd mpd -G dietpi,audio -d $G_FP_DIETPI_USERDATA/.mpd_cache -s /usr/sbin/nologin
 
 			# - Runtime folders/files
 			#	log

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3615,8 +3615,6 @@ We work around this error by running APT a second time. Please do not worry and 
 
 				fi
 
-				apt-mark unhold mpd &> /dev/null #??? Not required for dpkg -i installs
-
 				DEPS_LIST='libsqlite3-0 libupnp6 libwrap0 libmpdclient2 libflac8 libyajl2 libavahi-client3 libvorbisfile3 libwavpack1 libmad0 libmpg123-0 libopus0 libavformat57 libfaad2 libcdio-paranoia1 libiso9660-8 libshout3 libid3tag0'
 				Download_Install "$INSTALL_URL_ADDRESS"
 
@@ -6268,10 +6266,10 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 
 			#Apply soundcard
 			local soundcard="$(grep -m1 '^[[:blank:]]*CONFIG_SOUNDCARD=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
+			soundcard=${soundcard:-none}
 
 			# - RPi enable internal HDMI+Analogue if currently set to 'none'
-			if (( $G_HW_MODEL < 10 )) &&
-				[[ $soundcard == 'none' || $soundcard == 'default' ]]; then
+			if (( $G_HW_MODEL < 10 )) && [[ $soundcard == 'none' || $soundcard == 'default' ]]; then
 
 				soundcard='rpi-bcm2835-ultrahq'
 
@@ -8321,21 +8319,26 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 			Banner_Configuration
 
 			# Create MPD user
-			#useradd -rM mpd -G dietpi,audio -s /usr/sbin/nologin
+			local usercmd='useradd -rM'
+			getent passwd mpd &> /dev/null && usercmd='usermod'
+			$usercmd mpd -G dietpi,audio -d /var/lib/mpd -s /usr/sbin/nologin
 
 			# - Runtime folders/files
 			#	log
 			mkdir -p /var/log/mpd
-			> /var/log/mpd/mpd.log
-
+			>> /var/log/mpd/mpd.log
 			#	cache
 			mkdir -p $G_FP_DIETPI_USERDATA/.mpd_cache
-			> $G_FP_DIETPI_USERDATA/.mpd_cache/db_file
-			> $G_FP_DIETPI_USERDATA/.mpd_cache/state
-			> $G_FP_DIETPI_USERDATA/.mpd_cache/sticker.sql
-
+			>> $G_FP_DIETPI_USERDATA/.mpd_cache/db_file
+			>> $G_FP_DIETPI_USERDATA/.mpd_cache/state
+			>> $G_FP_DIETPI_USERDATA/.mpd_cache/sticker.sql
 			#	Symlink from MPD defaults that applications may still expect/use.
-			rm -R /var/lib/mpd &> /dev/null
+			[[ -L /var/lib/mpd/music ]] || mv /var/lib/mpd/music/* $G_FP_DIETPI_USERDATA/Music/
+			[[ -L /var/lib/mpd/playlists ]] || mv /var/lib/mpd/playlists/* $G_FP_DIETPI_USERDATA/Music/
+			[[ -L /var/lib/mpd/mpd.db ]] || mv /var/lib/mpd/mpd.db $G_FP_DIETPI_USERDATA/.mpd_cache/db_file
+			[[ -L /var/lib/mpd/state ]] || mv /var/lib/mpd/state $G_FP_DIETPI_USERDATA/.mpd_cache/state
+			[[ -L /var/lib/mpd/sticker.sql ]] || mv /var/lib/mpd/sticker.sql $G_FP_DIETPI_USERDATA/.mpd_cache/sticker.sql
+			[[ -d /var/lib/mpd ]] && rm -R /var/lib/mpd
 			mkdir -p /var/lib/mpd
 			ln -sf $G_FP_DIETPI_USERDATA/Music /var/lib/mpd/music
 			ln -sf $G_FP_DIETPI_USERDATA/Music /var/lib/mpd/playlists
@@ -8348,31 +8351,54 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 			cp /DietPi/dietpi/conf/mpd.conf /etc/mpd.conf
 
 			# - MPD service/confs
-			cat << _EOF_ > /etc/default/mpd
-#Even though we declare the conf location in our service, MPD will fail to start if this file does not exist.
-## The configuration file location for mpd:
-MPDCONF=/etc/mpd.conf
-_EOF_
+			[[ -f /etc/default/mpd ]] && rm /etc/default/mpd
 
+			#	Upsteam systemd unit: https://github.com/MusicPlayerDaemon/MPD/blob/master/systemd/system/mpd.service.in
+			#	Debian package systemd unit: https://deb.debian.org/debian/pool/main/m/mpd/
 			cat << _EOF_ > /lib/systemd/system/mpd.service
 [Unit]
 Description=Music Player Daemon (DietPi)
+Documentation=man:mpd(1) man:mpd.conf(5)
+Documentation=file:///usr/share/doc/mpd/user-manual.html
 After=network.target sound.target
 
 [Service]
-#User=root #forks its own process under user set in /etc/mpd.conf (mpd)
-Type=simple
-LimitRTPRIO=infinity
+#User=mpd # Forks its own process under user set in /etc/mpd.conf (mpd)
 RuntimeDirectory=/var/run/mpd
-EnvironmentFile=/etc/default/mpd
 ExecStartPre=$(which mkdir) -p /var/run/mpd
-ExecStartPre=$(which chown) -R root:dietpi /var/run/mpd
+ExecStartPre=$(which chown) -R mpd:dietpi /var/run/mpd
 ExecStart=$(which mpd) --no-daemon /etc/mpd.conf
+
+# allow MPD to use real-time priority 50
+LimitRTPRIO=50
+LimitRTTIME=infinity
+
+# disallow writing to /usr, /bin, /sbin, ...
+ProtectSystem=yes
+
+# more paranoid security settings
+NoNewPrivileges=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+ProtectKernelModules=yes
+# AF_NETLINK is required by libsmbclient, or it will exit() .. *sigh*
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
+RestrictNamespaces=yes
 
 [Install]
 WantedBy=multi-user.target
-
+Also=mpd.socket
 _EOF_
+
+			#	Jessie: Remove unsupported systemd unit settings
+			if (( $G_DISTRO < 4 )); then
+
+				sed -i '/ProtectKernelTunables/d' /lib/systemd/system/mpd.service
+				sed -i '/ProtectControlGroups/d' /lib/systemd/system/mpd.service
+				sed -i '/ProtectKernelModules/d' /lib/systemd/system/mpd.service
+				sed -i '/RestrictNamespaces/d' /lib/systemd/system/mpd.service
+
+			fi
 
 			#JustBoom specials
 			if grep -qi '^[[:blank:]]*CONFIG_SOUNDCARD=justboom' /DietPi/dietpi.txt; then
@@ -12750,9 +12776,10 @@ _EOF_
 			#apt-mark auto libavformat57 libupnp6 libao-common libao4 libasound2 libasound2-data libasyncns0 libaudiofile1 libavahi-client3 libavahi-common-data libavahi-common3 libavcodec56 libavformat56 libavresample2 libavutil54 libbinio1ldbl libcaca0 libcdio-cdda1 libcdio-paranoia1 libcdio13 libcups2 libcurl3-gnutls libdirectfb-1.2-9 libdnet libfaad2 libflac8 libfluidsynth1 libgme0 libgomp1 libgsm1 libice6 libid3tag0 libiso9660-8 libjack-jackd2-0 libjson-c2 libldb1 libmad0 libmikmod3 libmms0 libmodplug1 libmp3lame0 libmpcdec6 libmpg123-0 libnfs4 libntdb1 libogg0 libopenal-data libopenal1 libopenjpeg5 libopus0 liborc-0.4-0 libpulse0 libresid-builder0c2a libroar2 libsamplerate0 libschroedinger-1.0-0 libsdl1.2debian libshout3 libsidplay2 libsidutils0 libslp1 libsm6 libsmbclient libsndfile1 libsoxr0 libspeex1 libspeexdsp1 libsqlite3-0 libtalloc2 libtdb1 libtevent0 libtheora0 libupnp6 libva1 libvorbis0a libvorbisenc2 libvorbisfile3 libvpx1 libwavpack1 libwbclient0 libwildmidi-config libwildmidi1 libx11-6 libx11-data libx11-xcb1 libx264-142 libxau6 libxcb1 libxdmcp6 libxext6 libxi6 libxtst6 libxvidcore4 libyajl2 libzzip-0-13 mime-support python python-talloc python2.7 samba-libs x11-common file &> /dev/null
 			apt-mark unhold mpd 1> /dev/null
 			G_AGP mpd libmpdclient2
-			userdel -rf mpd
-			rm /lib/systemd/system/mpd.service
-			rm -R $G_FP_DIETPI_USERDATA/.mpd_cache
+			getent passwd mpd &> /dev/null && userdel -rf mpd
+			[[ -f /lib/systemd/system/mpd.service ]] && rm /lib/systemd/system/mpd.service
+			[[ -d $G_FP_DIETPI_USERDATA/.mpd_cache ]] && rm -R $G_FP_DIETPI_USERDATA/.mpd_cache
+			[[ -f /etc/default/mpd ]] && rm /etc/default/mpd # pre-v6.20
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8381,6 +8381,13 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 			# - default config
 			G_BACKUP_FP /etc/mpd.conf
 			cp /DietPi/dietpi/conf/mpd.conf /etc/mpd.conf
+			#	On Stretch (custom build), symlink /etc/mpd.conf to /usr/local/etc/mpd.conf, where /usr/local/bin/mpd by default searches
+			if (( $G_DISTRO == 4 )); then
+
+				mkdir -p /usr/local/etc
+				ln -sf /etc/mpd.conf /usr/local/etc/mpd.conf
+
+			fi
 
 			# - MPD service/confs
 			[[ -f /etc/default/mpd ]] && rm /etc/default/mpd

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8329,11 +8329,11 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 			>> $G_FP_DIETPI_USERDATA/.mpd_cache/state
 			>> $G_FP_DIETPI_USERDATA/.mpd_cache/sticker.sql
 			#	Symlink from MPD defaults that applications may still expect/use.
-			[[ -L /var/lib/mpd/music ]] || mv /var/lib/mpd/music/* $G_FP_DIETPI_USERDATA/Music/
-			[[ -L /var/lib/mpd/playlists ]] || mv /var/lib/mpd/playlists/* $G_FP_DIETPI_USERDATA/Music/
-			[[ -L /var/lib/mpd/mpd.db ]] || mv /var/lib/mpd/mpd.db $G_FP_DIETPI_USERDATA/.mpd_cache/db_file
-			[[ -L /var/lib/mpd/state ]] || mv /var/lib/mpd/state $G_FP_DIETPI_USERDATA/.mpd_cache/state
-			[[ -L /var/lib/mpd/sticker.sql ]] || mv /var/lib/mpd/sticker.sql $G_FP_DIETPI_USERDATA/.mpd_cache/sticker.sql
+			[[ ! -e /var/lib/mpd/music || -L /var/lib/mpd/music ]] || mv -n /var/lib/mpd/music/* $G_FP_DIETPI_USERDATA/Music/ &> /dev/null
+			[[ ! -e /var/lib/mpd/playlists || -L /var/lib/mpd/playlists ]] || mv -n /var/lib/mpd/playlists/* $G_FP_DIETPI_USERDATA/Music/ &> /dev/null
+			[[ ! -e /var/lib/mpd/mpd.db || -L /var/lib/mpd/mpd.db ]] || mv -n /var/lib/mpd/mpd.db $G_FP_DIETPI_USERDATA/.mpd_cache/db_file
+			[[ ! -e /var/lib/mpd/state || -L /var/lib/mpd/state ]] || mv -n /var/lib/mpd/state $G_FP_DIETPI_USERDATA/.mpd_cache/state
+			[[ ! -e /var/lib/mpd/sticker.sql || -L /var/lib/mpd/sticker.sql ]] || mv -n /var/lib/mpd/sticker.sql $G_FP_DIETPI_USERDATA/.mpd_cache/sticker.sql
 			[[ -d /var/lib/mpd ]] && rm -R /var/lib/mpd
 			mkdir -p /var/lib/mpd
 			ln -sf $G_FP_DIETPI_USERDATA/Music /var/lib/mpd/music

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3614,7 +3614,7 @@ We work around this error by running APT a second time. Please do not worry and 
 			elif (( $G_DISTRO == 4 )); then
 
 				DEPS_LIST='libnfs8 libsmbclient libsqlite3-0 libupnp6 libwrap0 libmpdclient2 libflac8 libyajl2 libavahi-client3 libvorbisfile3 libwavpack1 libmad0 libmpg123-0 libopus0 libavformat57 libfaad2 libcdio-paranoia1 libiso9660-8 libshout3 libid3tag0'
-				Download_Install "https://dietpi.com/downloads/binaries/all/mpd_0.20.23-1_$G_HW_ARCH_DESCRIPTION"
+				Download_Install "https://dietpi.com/downloads/binaries/all/mpd_0.20.23-1_$G_HW_ARCH_DESCRIPTION.deb"
 				# Prevent APT repo updates from overwriting
 				apt-mark hold mpd
 

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -347,11 +347,9 @@ _EOF_
 		chmod -R 777 /var/www/ompd/cache #(required for downloading files)
 
 		# - MPD
-		chmod 644 /var/log/mpd/mpd.log
-		chmod 0666 /etc/mpd.conf
-		chmod -R 777 /var/lib/mpd $G_FP_DIETPI_USERDATA/.mpd_cache
-
-		chown -R root:dietpi /etc/mpd.conf /var/log/mpd $G_FP_DIETPI_USERDATA/.mpd_cache /var/lib/mpd
+		chmod 0664 /var/log/mpd/mpd.log /etc/mpd.conf
+		chmod -R 775 /var/lib/mpd $G_FP_DIETPI_USERDATA/.mpd_cache
+		chown -R mpd:dietpi /etc/mpd.conf /var/log/mpd $G_FP_DIETPI_USERDATA/.mpd_cache /var/lib/mpd
 
 		# - MyMPD
 		chown -R mympd:dietpi /var/lib/mympd


### PR DESCRIPTION
**Status**: Ready
- ~[ ] Install and use (?) mpd.socket~ **€: Handle as separate request**
- [x] Update deb packages with current version, enabled NFS+SMB plugins and hardcoded default config path?
- [x] Changelog

**Testing**:
- [x] Jessie
- [x] Stretch
- [x] Buster
- [x] YMPD connect

**Reference**: https://github.com/Fourdee/DietPi/issues/2378

**Commit list/description**:
+ DietPi-Software | MPD: Use "mpd" user again
+ DietPi-Software | MPD/YMPD/myMPD: useradd "((m)y)mpd" if non-existent, otherwise usermod according to our needs
+ DietPi-Software | MPD: Update systemd unit to match current upstream/Debian package, which also addresses non-root permissions/capabilities; Remove unsupported settings on Jessie
+ DietPi-Software | MPD: Preserve existing log and cache files; Move from /var/lib/mpd, if those are not yet symlinks
+ DietPi-Software | MPD: "apt-mark unhold" not required for "dpkg -i", which will even remove the "hold" tag
+ DietPi-Software | YMPD: Install Stretch binary on Buster, until we have build a Buster binary
+ DietPi-Software | YMPD: Install required libssl1.1 from Stretch repo on Jessie
+ DietPi-Software | YMPD/Shairport-Sync: On Jessie+ARMv6, install armhf libssl1.1 binary, TESTING required!
+ DietPi-Software | YMPD/myMPD: Within systemd units on Buster, comments in same line after User= is not allowed
+ DietPi-Software | Remove User=root entries from all systemd units, which is default anyway
+ DietPi-Software | MPD: On Stretch (custom build), symlink /etc/mpd.conf to /usr/local/etc/mpd.conf, where /usr/local/bin/mpd by default searches