### PR TITLE
DietPi-Software | Mopidy: Installer update

### DIFF
--- a/.conf/dps_118/mopidy.conf
+++ b/.conf/dps_118/mopidy.conf
@@ -1,0 +1,20 @@
+[core]
+cache_dir = /mnt/dietpi_userdata/mopidy/cache
+config_dir = /etc/mopidy
+data_dir = /mnt/dietpi_userdata/mopidy/data
+
+[logging]
+config_file = /etc/mopidy/logging.conf
+debug_file = /var/log/mopidy/mopidy.log
+
+[local]
+media_dir = /mnt
+
+[file]
+media_dirs = /mnt|Mounts
+
+[m3u]
+playlists_dir = /mnt/dietpi_userdata/Music
+
+[http]
+hostname = ::

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,7 @@ Changes / Improvements / Optimisations:
 Bug Fixes:
 - DietPi-Software | ownCloud/Nextcloud (Talk): Resolved an issue, where occ/ncc commands could fail, if Redis server is not running: https://github.com/Fourdee/DietPi/issues/2321
 - DietPi-Software | ownCloud/Nextcloud: Resolved an issue, where during fresh installs on v6.19, Apache configs were not enabled correctly.
+- DietPi-Software | Mopidy: Resolved an issue, where playlist files could not be created due to missing permissions. Further improved handling of existing configs, data and cache directories on (re)install. Thanks to @cyberlussi for reporting this issue: https://github.com/Fourdee/DietPi/issues/2384
 - DietPi-Sync | Resolved an issue, where dry-run and compression options were not applied correctly. Thanks to @WilburWalsh for reporting the issue and identifying the faulty code: https://dietpi.com/phpbb/viewtopic.php?f=11&t=5347
 - DietPi-Sync | Resolved an issue, where daily sync was not applied due to changed settings file scheme.
 - General | Enhanced and fixed some issue with dependencies and boot order of DietPi systemd units: https://github.com/Fourdee/DietPi/pull/2357

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3979,6 +3979,10 @@ _EOF_
 			INSTALL_URL_ADDRESS='https://apt.mopidy.com/mopidy.gpg'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
+			# Install our config file only, if not yet existent, to preserve manual user config.
+			# - This needs to be done prior to APT install, since this would otherwise install a default config file as well.
+			[[ -f /etc/mopidy/mopidy.conf ]] || dps_index=$software_id Download_Install 'mopidy.conf' /etc/mopidy/mopidy.conf
+
 			wget -q -O - "$INSTALL_URL_ADDRESS" | apt-key add -
 			# No Buster list available yet, use stretch.list for testing:
 			if (( $G_DISTRO > 4 )); then
@@ -8636,61 +8640,14 @@ _EOF_
 
 			Banner_Configuration
 
-			useradd -rM mopidy -G dietpi,audio -s /usr/sbin/nologin
-			sed -i "/User=/c\User=mopidy" /lib/systemd/system/mopidy.service
+			usermod -a -G dietpi -d $G_FP_DIETPI_USERDATA/mopidy mopidy
 
 			# - conf
-			mkdir -p $G_FP_DIETPI_USERDATA/mopidy/cache
 			mkdir -p $G_FP_DIETPI_USERDATA/mopidy/data
-
-			mkdir -p ~/.config/mopidy
-
-			G_BACKUP_FP ~/.config/mopidy/mopidy.conf
-			cat << _EOF_ > ~/.config/mopidy/mopidy.conf
-[core]
-cache_dir = $G_FP_DIETPI_USERDATA/mopidy/cache
-config_dir = /etc/mopidy
-data_dir = $G_FP_DIETPI_USERDATA/mopidy/data
-
-[logging]
-config_file = /etc/mopidy/logging.conf
-debug_file = /var/log/mopidy.log
-
-[local]
-library = images
-media_dir = /mnt
-enabled = true
-scan_timeout = 1000
-scan_flush_threshold = 100
-scan_follow_symlinks = false
-excluded_file_extensions =
-  .directory
-  .html
-  .jpeg
-  .jpg
-  .log
-  .nfo
-  .png
-  .txt
-
-[file]
-enabled = true
-media_dirs = /mnt
-
-[m3u]
-playlists_dir = /mnt
-
-[http]
-enabled = true
-hostname = ::
-port = 6680
-static_dir =
-zeroconf = Mopidy HTTP server on $hostname
-
-_EOF_
-
-			#	NB: mopidy uses both config locations, so lets make sure we match them
-			cp ~/.config/mopidy/mopidy.conf /etc/mopidy/mopidy.conf
+			mkdir -p /etc/systemd/system/mopidy.service.d
+			echo -e "[Service]\nGroup=dietpi\nExecStartPre=
+ExecStartPre=/bin/mkdir -p $G_FP_DIETPI_USERDATA/mopidy/cache
+ExecStartPre=/bin/chown mopidy:audio $G_FP_DIETPI_USERDATA/mopidy/cache" > /etc/systemd/system/mopidy.service.d/dietpi.conf
 
 			Download_Test_Media
 
@@ -13143,12 +13100,12 @@ _EOF_
 
 			Banner_Uninstalling
 			G_AGP mopidy
-			rm /etc/apt/sources.list.d/mopidy.list
-			rm -R $G_FP_DIETPI_USERDATA/mopidy
+			[[ -f /etc/apt/sources.list.d/mopidy.list ]] && rm /etc/apt/sources.list.d/mopidy.list
 
-			userdel -rf mopidy
+			which pip &> /dev/null && pip uninstall -y Mopidy-MusicBox-Webclient Mopidy-Local-Images
 
-			pip uninstall -y Mopidy-MusicBox-Webclient Mopidy-Local-Images
+			getent passwd mopidy &> /dev/null && userdel -rf mopidy
+			[[ -d $G_FP_DIETPI_USERDATA/mopidy ]] && rm -R $G_FP_DIETPI_USERDATA/mopidy
 
 		fi
 
@@ -13159,7 +13116,7 @@ _EOF_
 			G_AGP kodi kodi-odroid
 			[[ -f /usr/share/applications/kodi.desktop ]] && rm /usr/share/applications/kodi.desktop
 			[[ -f /root/Desktop/kodi.desktop ]] && rm /root/Desktop/kodi.desktop
-			rm /home/*/Desktop/kodi.desktop &> /dev/null
+			rm -f /home/*/Desktop/kodi.desktop
 			[[ -f /etc/udev/rules.d/99-dietpi-kodi.rules ]] && rm /etc/udev/rules.d/99-dietpi-kodi.rules
 
 		fi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3985,7 +3985,7 @@ _EOF_
 
 			wget -q -O - "$INSTALL_URL_ADDRESS" | apt-key add -
 			# No Buster list available yet, use stretch.list for testing:
-			if (( $G_DISTRO > 4 )); then
+			if (( $G_DISTRO > 3 )); then
 
 				wget https://apt.mopidy.com/stretch.list -O /etc/apt/sources.list.d/mopidy.list
 
@@ -8640,11 +8640,18 @@ _EOF_
 
 			Banner_Configuration
 
-			# - Move existing home/data to dietpi_userdata, if not yet existent
-			if [[ -d /var/lib/mopidy && ! -d $G_FP_DIETPI_USERDATA/mopidy/data ]]; then
+			# Assure user home, data and cache dir as well on custom configs
+			G_CONFIG_INJECT 'data_dir[[:blank:]]*=' 'data_dir = /mnt/dietpi_userdata/mopidy/data' /etc/mopidy/mopidy.conf '\[core\]'
+			G_CONFIG_INJECT 'cache_dir[[:blank:]]*=' 'cache_dir = /mnt/dietpi_userdata/mopidy/cache' /etc/mopidy/mopidy.conf '\[core\]'
 
-				mkdir -p $G_FP_DIETPI_USERDATA/mopidy
-				mv /var/lib/mopidy $G_FP_DIETPI_USERDATA/mopidy/data
+			# - Move existing home+data to dietpi_userdata, if not yet existent
+			if [[ -d /var/lib/mopidy && ! -d $G_FP_DIETPI_USERDATA/mopidy ]]; then
+
+				mv /var/lib/mopidy $G_FP_DIETPI_USERDATA/mopidy
+				mkdir -p $G_FP_DIETPI_USERDATA/mopidy/data
+				# - Non-hidden files/folders are data
+				mv $G_FP_DIETPI_USERDATA/mopidy/* $G_FP_DIETPI_USERDATA/mopidy/data
+				
 
 			else
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8640,14 +8640,37 @@ _EOF_
 
 			Banner_Configuration
 
+			# - Move existing home/data to dietpi_userdata, if not yet existent
+			if [[ -d /var/lib/mopidy && ! -d $G_FP_DIETPI_USERDATA/mopidy/data ]]; then
+
+				mkdir -p $G_FP_DIETPI_USERDATA/mopidy
+				mv /var/lib/mopidy $G_FP_DIETPI_USERDATA/mopidy/data
+
+			else
+
+				mkdir -p $G_FP_DIETPI_USERDATA/mopidy/data
+				[[ -d /var/lib/mopidy ]] && rm -R /var/lib/mopidy
+
+			fi
+
+			# - Move existing cache to dietpi_userdata, if not yet existent
+			if [[ -d /var/cache/mopidy && ! -d $G_FP_DIETPI_USERDATA/mopidy/cache ]]; then
+
+				mv /var/cache/mopidy $G_FP_DIETPI_USERDATA/mopidy/cache
+
+			else
+
+				mkdir -p $G_FP_DIETPI_USERDATA/mopidy/cache
+				[[ -d /var/cache/mopidy ]] && rm -R /var/cache/mopidy
+
+			fi
+
+			# - Adjust user group and home dir
 			usermod -a -G dietpi -d $G_FP_DIETPI_USERDATA/mopidy mopidy
 
-			# - conf
-			mkdir -p $G_FP_DIETPI_USERDATA/mopidy/data
+			# - Adjust systemd unit to match new group and do not pre-create obsolete cache dir
 			mkdir -p /etc/systemd/system/mopidy.service.d
-			echo -e "[Service]\nGroup=dietpi\nExecStartPre=
-ExecStartPre=/bin/mkdir -p $G_FP_DIETPI_USERDATA/mopidy/cache
-ExecStartPre=/bin/chown mopidy:audio $G_FP_DIETPI_USERDATA/mopidy/cache" > /etc/systemd/system/mopidy.service.d/dietpi.conf
+			echo -e '[Service]\nGroup=dietpi\nExecStartPre=' > /etc/systemd/system/mopidy.service.d/dietpi.conf
 
 			Download_Test_Media
 

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -357,7 +357,7 @@ _EOF_
 		chown -R mympd:dietpi /var/lib/mympd
 
 		# - Mopidy
-		chown -R mopidy:dietpi $G_FP_DIETPI_USERDATA/mopidy
+		chown -R mopidy:root $G_FP_DIETPI_USERDATA/mopidy
 
 		# - Minidlna
 		chown -R minidlna:dietpi $G_FP_DIETPI_USERDATA/.MiniDLNA_Cache


### PR DESCRIPTION
**Status**: Ready
- [x] DietPi-Software update
- [x] Handle existing mopidy data/cache dirs.
- [x] `DietPi-Set_Software setpermissions` update
- [x] Changelog

**Testing**:
- [x] Service
- [x] HTTP
- [x] Media dirs scanning and browsing

**Reference**: https://github.com/Fourdee/DietPi/issues/2384

**Commit list/description**:
+ DietPi-Software | Mopidy: Move our "mopidy.conf" into separately downloadable file
+ DietPi-Software | Mopidy: Change playlists dir to `/mnt/dietpi_userdata/Music`, since this must be writeable for `mopidy` user, which `/mnt` is not.
+ DietPi-Software | Mopidy: Only set config values that we do not want to match the defaults, leave all others untouched
+ DietPi-Software | Mopidy: Install our config file only if non-existent, prior to APT install, to preserve user custom config; Only assure cache and data dir within new users home dir within dietpi_userdata
  - `~/.config/mopidy/mopidy.conf` is not required. It is only used when running the `mopidy` command as root user. Since we run it as `mopidy` user and `mopidyctl`, we don't require any other user-specific configs.
+ DietPi-Software | Mopidy: Correctly add user to "dietpi" group; "usermod" needs to be used, since APT install will already create the "mopidy" user
+ DietPi-Software | Mopidy: Add "dietpi" group to systemd unit via drop-in, while leaving the default APT installed systemd unit untouched
+ DietPi-Software | Mopidy: Do not pre-create/chown cache dir on service start, since is located in non-tmp location
+ DietPi-Software | Mopidy: Move obsolete "mopidy" users home and data+cache dirs to new location, if those do not yet exist
+ DietPi-Set_Software | setpermissions: Set Mopidy home/data+cache dir to root group, since no other software must access them (and "mopidy" group is not created)
+ CHANGELOG | Mopidy playlist permission fix and install enhancement