### PR TITLE
DietPi-Software | Samba: Move disk cache to RAM

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,10 +22,10 @@ Changes / Improvements / Optimisations:
 - DietPi-Software | NAA Daemon: Updated to 3.5.5-39. Thanks to @volpone for the heads up: https://github.com/Fourdee/DietPi/issues/2387#issue-395321320
 - DietPi-Software | MPD: Updated to 0.20.23-1. Includes support for NFS and Samba: https://github.com/Fourdee/DietPi/issues/2377
 - DietPi-Software | MPD: Now runs as "mpd" user again, updated systemd unit to match official one and better handle existing cache and log files on reinstall: https://github.com/Fourdee/DietPi/issues/2378
+- DietPi-Software | Samba: Moved disk cache to RAM to reduce disk I/O. Thanks to @WolfganP for suggesting this enhancement: https://github.com/Fourdee/DietPi/issues/2396
 - DietPi-Update | Added optional ability to automatically update DietPi, when updates are available. Please note, this is disabled by default.
 - DietPi-Sync | Removed the compression option, which has no effect on local sync, since files are not stored compressed, but only transferred compressed through remote sync protocols, which are currently not offered by DietPi-Sync.
 - General | Moved the remaining conf/* files located on DietPi-RAMdisk to /var/lib/dietpi or into DietPi-PREP, and removed /DietPi/dietpi/conf completely. These files were only used once or never, thus have no business inside the RAMdisk.
-- General | Reduced disk write count: fake-hwclock.data now stored in RAM. Many thanks to @WolfganP! https://github.com/Fourdee/DietPi/issues/2396
 
 Bug Fixes:
 - DietPi-Software | Nextcloud: Resolved an issue, where the Nextcloud Apache config was not downloaded correctly. Thanks to @Stefan3v for reporting this issue: https://github.com/Fourdee/DietPi/issues/2383

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3344,6 +3344,17 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
+
+			# Link disk cache to RAM: https://github.com/Fourdee/DietPi/issues/2396
+			# - Remove previous disk cache dir or symlink
+			[[ -e /var/cache/samba ]] && rm -R /var/cache/samba
+			# - Pre-create RAM cache dir
+			mkdir -p /var/run/samba-cache
+			# - Link disk cache to RAM
+			ln -s /var/run/samba-cache /var/cache/samba
+			# - Create RAM cache dir automatically on boot
+			echo 'd /var/run/samba-cache - - - - -' > /etc/tmpfiles.d/dietpi-samba_cache.conf
+
 			G_AGI samba
 
 		fi
@@ -13274,6 +13285,8 @@ _EOF_
 
 			Banner_Uninstalling
 			G_AGP samba samba-common-bin
+			[[ -f /etc/tmpfiles.d/dietpi-samba_cache.conf ]] && rm /etc/tmpfiles.d/dietpi-samba_cache.conf
+			[[ -d /var/run/samba-cache ]] && rm -R /var/run/samba-cache
 
 		fi
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1446,7 +1446,8 @@ You will not face any practical differences, since both services start the same 
 			#	Netdata: https://github.com/Fourdee/DietPi/pull/2337
 			#	NAA Daemon: https://github.com/Fourdee/DietPi/issues/2387#issue-395321320
 			#	MPD: https://github.com/Fourdee/DietPi/issues/2377
-			(( $G_DIETPI_INSTALL_STAGE == 2 )) && /DietPi/dietpi/dietpi-software reinstall 45 65 124 128 131
+			#	Samba: https://github.com/Fourdee/DietPi/issues/2396#issuecomment-451701569
+			(( $G_DIETPI_INSTALL_STAGE == 2 )) && /DietPi/dietpi/dietpi-software reinstall 45 65 124 128 131 96
 			#-------------------------------------------------------------------------------
 			#Docker fix on RPi due to faulty current "docker-ce" repo version: https://github.com/Fourdee/DietPi/issues/2282
 			local dpkg_out=''


### PR DESCRIPTION
**Status**: Ready
- [x] Changelog

**Testing**:
- [x] Install
- [x] Service
- [x] Reboot
- [x] Reinstall
- [x] Uninstall

🈯️ Passed on Jessie, Stretch and Buster

**Reference**: https://github.com/Fourdee/DietPi/issues/2396