### PR TITLE
DietPi-Config | RPi: Enhance and replace some obsolete dietpi.txt settings

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Image lineup:
 Changes / Improvements / Optimisations:
 - DietPi-PREP | Removed the option to install a Jessie system. Removed the option to install DietPi on top of a Wheezy image, since an upgrade over two distro version would be required, which is not reliable. It is still possible to install DietPi on top of a Jessie image, where a distro upgrade to Stretch would be applied: https://github.com/Fourdee/DietPi/issues/2332
 - DietPi-Config | RPi: Improved available options for HDMI boost setting: https://github.com/Fourdee/DietPi/issues/2350
+- DietPi-Config | RPi: Headless display mode is now applied via undocumented config.txt setting. Removed/Replaced some other obsolete config.txt entries: https://github.com/Fourdee/DietPi/pull/2402
 - DietPi-Config | WiFi Hotspot: You can now toggle support for 802.11 N. Please note this is device and compatibility dependent, milage may vary.
 - DietPi-Drive_Manager | Now allows to check & repair the boot file system and trigger it for root file system on next reboot: https://github.com/Fourdee/DietPi/issues/1740#issuecomment-388325204
 - DietPi-Software | DietPi-NordVPN: Now available for installation. Includes a GUI which allows for easy connection to a list of NordVPN servers 'dietpi-nordvpn'. If you need a NordVPN subscription, please use this link: https://go.nordvpn.net/aff_c?offer_id=15&aff_id=5305&url_id=902

--- a/config.txt
+++ b/config.txt
@@ -24,7 +24,7 @@ framebuffer_height=720
 #sdtv_mode=0
 
 # Rotation
-display_rotate=0
+display_hdmi_rotate=0
 lcd_rotate=0
 
 # Uncomment if HDMI display is not detected and composite is being outputted.
@@ -54,14 +54,8 @@ gpu_mem_1024=16
 #-------Max USB current---------
 max_usb_current=1
 
-#-------Disable RAM temp refresh every 500ms-------
-disable_pvt=1
-
 #-------Disable Pi splash screen on boot-----------
 disable_splash=1
-
-#-------Remove dedicated pll for PWM audio---------
-avoid_pwm_pll=1
 
 #-------SoundCard-------
 dtparam=audio=off

--- a/dietpi.txt
+++ b/dietpi.txt
@@ -127,7 +127,7 @@ AUTO_SETUP_CUSTOM_SCRIPT_EXEC=0
 # D I E T - P I
 # DietPi-Config settings
 #------------------------------------------------------------------------------------------------------
-#RPi HDMI output (if 0, sets tvservice -o and framebuffer 16x 16y 8z on boot, headless)
+#RPi only: Toogle video functionality (if 0, disables HDMI, composite and framebuffer, headless mode)
 CONFIG_HDMI_OUTPUT=1
 
 #Cpu Governor | ondemand | powersave | performance | conservative

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -944,7 +944,7 @@ Re-enabling HDMI requires a reboot. If you need emergency HDMI output, comment o
 More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p105008
       and here: https://github.com/raspberrypi/userland/issues/447#issuecomment-404399670'
 
-					G_CONFIG_INJECT 'CONFIG_HDMI_OUTPUT=' 'CONFIG_HDMI_OUTPUT=0' /DietPi/config.txt
+					G_CONFIG_INJECT 'CONFIG_HDMI_OUTPUT=' 'CONFIG_HDMI_OUTPUT=0' /DietPi/dietpi.txt
 					sed -i 's/^[[:blank:]]*framebuffer_width=/c\#framebuffer_width=0' /DietPi/config.txt
 					sed -i 's/^[[:blank:]]*framebuffer_height=/c\#framebuffer_height=0' /DietPi/config.txt
 					sed -i 's/^[[:blank:]]*max_framebuffer_width=/c\#max_framebuffer_width=0' /DietPi/config.txt

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -279,7 +279,7 @@
 			local rpi_camera_led_text='[Off]'
 			(( $rpi_camera_led_enabled )) && rpi_camera_led_text='[On]'
 
-			local rotation_hdmi_current=$(grep -m1 '^[[:blank:]]*display_rotate=' /DietPi/config.txt | sed 's/^[^=]*=//')
+			local rotation_hdmi_current=$(grep -m1 '^[[:blank:]]*display_hdmi_rotate=' /DietPi/config.txt | sed 's/^[^=]*=//')
 			local rotation_lcd_current=$(grep -m1 '^[[:blank:]]*lcd_rotate=' /DietPi/config.txt | sed 's/^[^=]*=//')
 
 			local vc1_key_current=$(grep -m1 '^[[:blank:]]*decode_WVC1=' /DietPi/config.txt | sed 's/^[^=]*=//')

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -945,14 +945,22 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
       and here: https://github.com/raspberrypi/userland/issues/447#issuecomment-404399670'
 
 					G_CONFIG_INJECT 'CONFIG_HDMI_OUTPUT=' 'CONFIG_HDMI_OUTPUT=0' /DietPi/dietpi.txt
+					# - Framebuffer dimensions should not play a role here, but
+					#	if NOT set, they appear as "0" by asking "vcgencmd get_config (max_)?framebuffer_(width|height)"
+					#	otherwise vcgencmd shows the set value. So we simply comment it.
 					sed -i 's/^[[:blank:]]*framebuffer_width=/c\#framebuffer_width=0' /DietPi/config.txt
 					sed -i 's/^[[:blank:]]*framebuffer_height=/c\#framebuffer_height=0' /DietPi/config.txt
 					sed -i 's/^[[:blank:]]*max_framebuffer_width=/c\#max_framebuffer_width=0' /DietPi/config.txt
 					sed -i 's/^[[:blank:]]*max_framebuffer_height=/c\#max_framebuffer_height=0' /DietPi/config.txt
+					# - framebuffer_depth defaults to a set value of 16, even with HDMI disabled, so we manually reduce it to min 8
 					G_CONFIG_INJECT 'framebuffer_depth=' 'framebuffer_depth=8' /DietPi/config.txt
+					# - Splash cannot be seen anyway, without video output
 					G_CONFIG_INJECT 'disable_splash=' 'disable_splash=1' /DietPi/config.txt
+					# - hdmi_blanking should not play a role, however mode 1 should be generally preferred, which on idle disables HDMI output completely instead of just blanking the screen
 					G_CONFIG_INJECT 'hdmi_blanking=' 'hdmi_blanking=1' /DietPi/config.txt
+					# - Disable HDMI hotplug, which requires it to be generally responsive/active
 					G_CONFIG_INJECT 'hdmi_ignore_hotplug=' 'hdmi_ignore_hotplug=1' /DietPi/config.txt
+					# - Disable composite hotplug, which then allows to completely disable the video pipeline + framebuffer
 					G_CONFIG_INJECT 'hdmi_ignore_composite=' 'hdmi_ignore_composite=1' /DietPi/config.txt
 
 				else

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -196,34 +196,26 @@
 
 		if (( $G_HW_MODEL < 10 )); then
 
-			local framebuffer_x=$(grep -m1 'framebuffer_width=' /DietPi/config.txt | sed 's/^[^=]*=//')
-			local framebuffer_y=$(grep -m1 'framebuffer_height=' /DietPi/config.txt | sed 's/^[^=]*=//')
+			local framebuffer_x=$(vcgencmd get_config framebuffer_width); framebuffer_x=${framebuffer_x#*=}; framebuffer_x=${framebuffer_x:-0}
+			local framebuffer_y=$(vcgencmd get_config framebuffer_height); framebuffer_y=${framebuffer_y#*=}; framebuffer_y=${framebuffer_y:-0}
 
-			#	0/180
+			#	0/180 landscape
 			if (( $input == 0 )); then
 
 				if (( $framebuffer_x < $framebuffer_y )); then
 
-					local temp=$framebuffer_x
-					framebuffer_x=$framebuffer_y
-					framebuffer_y=$temp
-
-					G_CONFIG_INJECT 'framebuffer_width=' "framebuffer_width=$framebuffer_x" /DietPi/config.txt
-					G_CONFIG_INJECT 'framebuffer_height=' "framebuffer_height=$framebuffer_y" /DietPi/config.txt
+					G_CONFIG_INJECT 'framebuffer_width=' "framebuffer_width=$framebuffer_y" /DietPi/config.txt
+					G_CONFIG_INJECT 'framebuffer_height=' "framebuffer_height=$framebuffer_x" /DietPi/config.txt
 
 				fi
 
-			#	90/270 | flip XY FB values
+			#	90/270 portrait | flip XY FB values
 			elif (( $input == 1 )); then
 
 				if (( $framebuffer_x > $framebuffer_y )); then
 
-					local temp=$framebuffer_x
-					framebuffer_x=$framebuffer_y
-					framebuffer_y=$temp
-
-					G_CONFIG_INJECT 'framebuffer_width=' "framebuffer_width=$framebuffer_x" /DietPi/config.txt
-					G_CONFIG_INJECT 'framebuffer_height=' "framebuffer_height=$framebuffer_y" /DietPi/config.txt
+					G_CONFIG_INJECT 'framebuffer_width=' "framebuffer_width=$framebuffer_y" /DietPi/config.txt
+					G_CONFIG_INJECT 'framebuffer_height=' "framebuffer_height=$framebuffer_x" /DietPi/config.txt
 
 				fi
 
@@ -303,8 +295,8 @@
 
 			fi
 
-			G_WHIP_MENU_ARRAY+=('4' ": Rotation (HDMI)     : [$rotation_hdmi_current]")
-			G_WHIP_MENU_ARRAY+=('5' ": Rotation (LCD)      : [$rotation_lcd_current]")
+			G_WHIP_MENU_ARRAY+=('4' ": Rotation (HDMI)     : [${rotation_hdmi_current:=0}]")
+			G_WHIP_MENU_ARRAY+=('5' ": Rotation (LCD)      : [${rotation_lcd_current:=0}]")
 			G_WHIP_MENU_ARRAY+=('6' ": Overscan            : $overscan_text")
 			if (( $overscan_enabled )); then
 
@@ -321,7 +313,7 @@
 				local overscan_right=$(grep -m1 '^[[:blank:]]*overscan_right=' /DietPi/config.txt | sed 's/^[^=]*=//')
 				local overscan_top=$(grep -m1 '^[[:blank:]]*overscan_top=' /DietPi/config.txt | sed 's/^[^=]*=//')
 				local overscan_bottom=$(grep -m1 '^[[:blank:]]*overscan_bottom=' /DietPi/config.txt | sed 's/^[^=]*=//')
-				G_WHIP_MENU_ARRAY+=('15' ": Overscan Compensation [L:$overscan_left] [R:$overscan_right] [T:$overscan_top] [B:$overscan_bottom]")
+				G_WHIP_MENU_ARRAY+=('15' ": Overscan Compensation [L:${overscan_left:=0}] [R:${overscan_right:=0}] [T:${overscan_top:=0}] [B:${overscan_bottom:=0}]")
 
 			fi
 
@@ -632,7 +624,7 @@
 				if G_WHIP_MENU "Please select an option:
 \nNB: If you have the RPi touchscreen, please set this to 0 and use LCD rotation option."; then
 
-					G_CONFIG_INJECT 'display_rotate=' "display_rotate=$G_WHIP_RETURNED_VALUE" /DietPi/config.txt
+					G_CONFIG_INJECT 'display_hdmi_rotate=' "display_hdmi_rotate=$G_WHIP_RETURNED_VALUE" /DietPi/config.txt
 
 					#	rotation 90/270 | invert x/y on FB (Y > X)
 					if [[ $G_WHIP_RETURNED_VALUE == '1' || $G_WHIP_RETURNED_VALUE == '3' ]]; then
@@ -645,7 +637,6 @@
 						Display_Rotation_Calc_XY_Invert 0
 
 					fi
-
 
 					REBOOT_REQUIRED=1
 
@@ -702,7 +693,7 @@
 
 				done
 
-				if disable_error=1 G_CHECK_VALIDINT $current_brightness; then
+				if disable_error=1 G_CHECK_VALIDINT "$current_brightness"; then
 
 					G_WHIP_DEFAULT_ITEM=$current_brightness
 					G_WHIP_INPUTBOX "Please enter a brightness value:\n - Min = $MIN_VALUE | Max = $MAX_VALUE"
@@ -882,9 +873,9 @@
 		#RPI
 		elif (( $G_HW_MODEL < 10 )); then
 
-			local framebuffer_x=$(grep -m1 'framebuffer_width=' /DietPi/config.txt | sed 's/^[^=]*=//')
-			local framebuffer_y=$(grep -m1 'framebuffer_height=' /DietPi/config.txt | sed 's/^[^=]*=//')
-			local current_value=$(grep -m1 '^dtoverlay=vc4-' /DietPi/config.txt | sed 's/^[^=]*=//') #OpenGL check 1st
+			local framebuffer_x=$(vcgencmd get_config framebuffer_width); framebuffer_x=${framebuffer_x#*=}; framebuffer_x=${framebuffer_x:-0}
+			local framebuffer_y=$(vcgencmd get_config framebuffer_height); framebuffer_y=${framebuffer_y#*=}; framebuffer_y=${framebuffer_y:-0}
+			local current_value=$(grep -m1 '^[[:blank:]]*dtoverlay=vc4-' /DietPi/config.txt | sed 's/^[^=]*=//') #OpenGL check 1st
 			if [[ ! $current_value ]]; then
 
 				# - FB
@@ -927,7 +918,7 @@
 				G_CONFIG_INJECT 'CONFIG_HDMI_OUTPUT=' 'CONFIG_HDMI_OUTPUT=1' /DietPi/dietpi.txt
 
 				# - Always set default depth to 16
-				G_CONFIG_INJECT 'framebuffer_depth=' 'framebuffer_depth=16' /DietPi/config.txt
+				sed -i 's/^[[:blank:]]*framebuffer_depth=/c\#framebuffer_depth=16' /DietPi/config.txt
 
 				# - Always disable composite by default
 				sed -i '/sdtv_mode=/c\#sdtv_mode=0' /DietPi/config.txt
@@ -939,17 +930,42 @@
 
 					/DietPi/dietpi/func/dietpi-set_hardware rpi-opengl $G_WHIP_RETURNED_VALUE
 
-				elif [[ $G_WHIP_RETURNED_VALUE == 'sdtv_mode'* ]]; then
+				elif [[ $G_WHIP_RETURNED_VALUE == 'Headless' ]]; then
 
-					sed -i "/sdtv_mode=/c $G_WHIP_RETURNED_VALUE" /DietPi/config.txt
-					framebuffer_x=720
-					framebuffer_y=576
-					G_CONFIG_INJECT 'framebuffer_width=' "framebuffer_width=$framebuffer_x" /DietPi/config.txt
-					G_CONFIG_INJECT 'framebuffer_height=' "framebuffer_height=$framebuffer_y" /DietPi/config.txt
+					G_WHIP_MSG 'Using the Headless option will:
+ - Disable HDMI and composite output
+ - Disable the framebuffer
+ - Lower energy consumption by 0.1+ Watts
+ - Improve RAM performance by 1-5% (VideoCore shares RAM bandwidth)
+ - Lead to some kernel error messages on boot, that can be ignored\n
+Re-enabling HDMI requires a reboot. If you need emergency HDMI output, comment or remove the following lines within "config.txt" on first partition of the SDcard from external system:
+ - hdmi_ignore_hotplug=1
+ - hdmi_ignore_composite=1\n
+More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p105008
+      and here: https://github.com/raspberrypi/userland/issues/447#issuecomment-404399670'
+
+					G_CONFIG_INJECT 'CONFIG_HDMI_OUTPUT=' 'CONFIG_HDMI_OUTPUT=0' /DietPi/config.txt
+					sed -i 's/^[[:blank:]]*framebuffer_width=/c\#framebuffer_width=0' /DietPi/config.txt
+					sed -i 's/^[[:blank:]]*framebuffer_height=/c\#framebuffer_height=0' /DietPi/config.txt
+					sed -i 's/^[[:blank:]]*max_framebuffer_width=/c\#max_framebuffer_width=0' /DietPi/config.txt
+					sed -i 's/^[[:blank:]]*max_framebuffer_height=/c\#max_framebuffer_height=0' /DietPi/config.txt
+					G_CONFIG_INJECT 'framebuffer_depth=' 'framebuffer_depth=8' /DietPi/config.txt
+					G_CONFIG_INJECT 'disable_splash=' 'disable_splash=1' /DietPi/config.txt
+					G_CONFIG_INJECT 'hdmi_blanking=' 'hdmi_blanking=1' /DietPi/config.txt
+					G_CONFIG_INJECT 'hdmi_ignore_hotplug=' 'hdmi_ignore_hotplug=1' /DietPi/config.txt
+					G_CONFIG_INJECT 'hdmi_ignore_composite=' 'hdmi_ignore_composite=1' /DietPi/config.txt
 
 				else
 
 					case "$G_WHIP_RETURNED_VALUE" in
+
+						'sdtv_mode'*)
+
+							sed -i "/sdtv_mode=/c $G_WHIP_RETURNED_VALUE" /DietPi/config.txt
+							framebuffer_x=720
+							framebuffer_y=576
+
+						;;
 
 						'DietPi-Cloudshell')
 
@@ -1004,17 +1020,6 @@
 
 							framebuffer_x=640
 							framebuffer_y=480
-
-						;;
-
-						'Headless')
-
-							framebuffer_x=16
-							framebuffer_y=16
-
-							G_WHIP_MSG "Using the Headless option will: \n - Disable HDMI output \n - Lower energy consumption by 0.1+ Watts \n - Set framebuffer to 16x16xD8 \n - Improve RAM performance by 1-5% (VideoCore shares RAM bandwidth) \n - More info here : https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p105008"
-							sed -i "/CONFIG_HDMI_OUTPUT=/c\CONFIG_HDMI_OUTPUT=0" /DietPi/dietpi.txt
-							sed -i '/framebuffer_depth=/c\framebuffer_depth=8' /DietPi/config.txt
 
 						;;
 

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -1578,8 +1578,6 @@ _EOF_
 		#	onboard blacklist module
 		echo 'blacklist snd-bcm2835' > /etc/modprobe.d/rpi-bcm2708.conf
 
-		G_CONFIG_INJECT 'avoid_pwm_pll=' 'avoid_pwm_pll=1' $FP_RPI_CONFIG
-
 		# - Disable forced analogue out
 		systemctl disable rpi-bcm2835_forced_3.5mm.service &> /dev/null
 		rm /etc/systemd/system/rpi-bcm2835_forced_3.5mm.service &> /dev/null
@@ -1780,16 +1778,6 @@ _EOF_
 
 				# - remove from blacklist to enable:
 				rm /etc/modprobe.d/rpi-bcm2708.conf
-
-				# - Enable HQ audio
-				G_CONFIG_INJECT 'avoid_pwm_pll=' 'avoid_pwm_pll=0' $FP_RPI_CONFIG
-
-				# - Expermental UltraHQ audio: https://www.raspberrypi.org/forums/viewtopic.php?p=907075#p907075
-				if [[ $INPUT_DEVICE_VALUE == *'ultrahq'* ]]; then
-
-					sed -i '/avoid_pwm_pll=/c\avoid_pwm_pll=2' $FP_RPI_CONFIG
-
-				fi
 
 				# - Force 3.5mm out?
 				if [[ $INPUT_DEVICE_VALUE == *'3.5mm'* ]]; then

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1522,10 +1522,30 @@ Also have a look at "Sonarr", another alternative TV show manager, available for
 
 			fi
 			#-------------------------------------------------------------------------------
-			#Remove/Replace obsolete RPi config.txt settings: https://github.com/Fourdee/DietPi/pull/2402
-			sed -i 's/display_rotate/display_hdmi_rotate/' /DietPi/dietpi.txt
-			sed -i '/disable_pvt/d' /DietPi/dietpi.txt
-			sed -i '/avoid_pwm_pll/d' /DietPi/dietpi.txt
+			#RPi changes: https://github.com/Fourdee/DietPi/pull/2402
+			if (( $G_HW_MODEL < 10 )); then
+
+				# - Remove/Replace obsolete RPi config.txt settings
+				sed -i 's/display_rotate/display_hdmi_rotate/' /DietPi/dietpi.txt
+				sed -i '/disable_pvt/d' /DietPi/dietpi.txt
+				sed -i '/avoid_pwm_pll/d' /DietPi/dietpi.txt
+
+				# - Apply new headless mode method
+				if grep -q '^[[:blank:]]*CONFIG_HDMI_OUTPUT=0' /DietPi/config.txt; then
+
+					sed -i 's/^[[:blank:]]*framebuffer_width=/c\#framebuffer_width=0' /DietPi/config.txt
+					sed -i 's/^[[:blank:]]*framebuffer_height=/c\#framebuffer_height=0' /DietPi/config.txt
+					sed -i 's/^[[:blank:]]*max_framebuffer_width=/c\#max_framebuffer_width=0' /DietPi/config.txt
+					sed -i 's/^[[:blank:]]*max_framebuffer_height=/c\#max_framebuffer_height=0' /DietPi/config.txt
+					G_CONFIG_INJECT 'framebuffer_depth=' 'framebuffer_depth=8' /DietPi/config.txt
+					G_CONFIG_INJECT 'disable_splash=' 'disable_splash=1' /DietPi/config.txt
+					G_CONFIG_INJECT 'hdmi_blanking=' 'hdmi_blanking=1' /DietPi/config.txt
+					G_CONFIG_INJECT 'hdmi_ignore_hotplug=' 'hdmi_ignore_hotplug=1' /DietPi/config.txt
+					G_CONFIG_INJECT 'hdmi_ignore_composite=' 'hdmi_ignore_composite=1' /DietPi/config.txt
+
+				fi
+
+			fi
 			#-------------------------------------------------------------------------------
 
 		fi

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1522,6 +1522,11 @@ Also have a look at "Sonarr", another alternative TV show manager, available for
 
 			fi
 			#-------------------------------------------------------------------------------
+			#Remove/Replace obsolete RPi config.txt settings: https://github.com/Fourdee/DietPi/pull/2402
+			sed -i 's/display_rotate/display_hdmi_rotate/' /DietPi/dietpi.txt
+			sed -i '/disable_pvt/d' /DietPi/dietpi.txt
+			sed -i '/avoid_pwm_pll/d' /DietPi/dietpi.txt
+			#-------------------------------------------------------------------------------
 
 		fi
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1526,12 +1526,12 @@ Also have a look at "Sonarr", another alternative TV show manager, available for
 			if (( $G_HW_MODEL < 10 )); then
 
 				# - Remove/Replace obsolete RPi config.txt settings
-				sed -i 's/display_rotate/display_hdmi_rotate/' /DietPi/dietpi.txt
-				sed -i '/disable_pvt/d' /DietPi/dietpi.txt
-				sed -i '/avoid_pwm_pll/d' /DietPi/dietpi.txt
+				sed -i 's/display_rotate/display_hdmi_rotate/' /DietPi/config.txt
+				sed -i '/disable_pvt/d' /DietPi/config.txt
+				sed -i '/avoid_pwm_pll/d' /DietPi/config.txt
 
 				# - Apply new headless mode method
-				if grep -q '^[[:blank:]]*CONFIG_HDMI_OUTPUT=0' /DietPi/config.txt; then
+				if grep -q '^[[:blank:]]*CONFIG_HDMI_OUTPUT=0' /DietPi/dietpi.txt; then
 
 					sed -i 's/^[[:blank:]]*framebuffer_width=/c\#framebuffer_width=0' /DietPi/config.txt
 					sed -i 's/^[[:blank:]]*framebuffer_height=/c\#framebuffer_height=0' /DietPi/config.txt

--- a/dietpi/preboot
+++ b/dietpi/preboot
@@ -268,19 +268,8 @@
 	#Apply LED triggers if set
 	G_THREAD_START /DietPi/dietpi/func/dietpi-led_control 1
 
-	#RPi Specials
-	#	set volume to -0.1db | We have to do it here because sound card modules (dietpi-set_hardware) are not enabled on the fly, requires a reboot.
-	#	Disable RPi hdmi output if set in dietpi.txt
-	if (( $G_HW_MODEL < 10 )); then
-
-		which amixer &> /dev/null && amixer set PCM -- -010
-		if grep -qi '^[[:blank:]]*CONFIG_HDMI_OUTPUT=0' /DietPi/dietpi.txt; then
-
-			/opt/vc/bin/tvservice -o &> /dev/null
-
-		fi
-
-	fi
+	#RPi: Set volume to -0.1db | We have to do it here because sound card modules (dietpi-set_hardware) are not enabled on the fly, requires a reboot.
+	(( $G_HW_MODEL < 10 )) && which amixer &> /dev/null && amixer set PCM -- -010
 	#-----------------------------------------------------------------------------------
 	#First run prep
 	if (( $G_DIETPI_INSTALL_STAGE == -1 )); then


### PR DESCRIPTION
**Status**: Testing

**Reference**: https://github.com/Fourdee/DietPi/issues/2401

**Commit list/description**:
+ DietPi-Config | RPi: Disable display output via undocumented config.txt setting instead of tvservice -o
  - https://github.com/raspberrypi/userland/issues/447#issuecomment-404399670
+ DietPi-Config | RPi: Estimate current console resolution via vcgencmd instead of config.txt entry
+ DietPi-Config | RPi: Allow some config.txt settings to be missing, by using default values in case
+ DietPi-Config | RPi: Replace deprecated config.txt setting "display_rotate" by new "display_hdmi_rotate"
  - https://www.raspberrypi.org/documentation/configuration/config-txt/video.md
+ DietPi-Config | RPi: Minor coding
+ RPi | config.txt: Replace deprecated setting "display_rotate" by new "display_hdmi_rotate"
+ RPi | config.txt: Remove obsolete settings: "disable_pvt", "avoid_pwm_pll"
  - https://github.com/raspberrypi/firmware/issues/640
  - https://github.com/raspberrypi/firmware/commit/ba7a8fb709adab287495f4e836b1cd3e5c9db409
+ DietPi-Patch | Remove/Replace obsolete RPi config.txt settings
+ DietPi-Set_Hardware | RPi: Remove edits of obsolete config.txt setting: "avoid_pwm_pll"
+ DietPi-PreBoot | Remove "tvservice -o", which is not achieved via new config.txt entry#
+ DietPi-Patch | RPi: If headless display mode was selected, apply new dietpi.txt entry
+ CHANGELOG | DietPi-Config | RPi: Enhance and replace some obsolete dietpi.txt settings
+ dietpi.txt | RPi: Update CONFIG_HDMI_OUTPUT explanation