### PR TITLE
RPi | Outsource headless mode to DietPi-Set_Hardware + minor enhancements

### DIFF
--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -914,25 +914,9 @@
 				#Return to This Menu
 				TARGETMENUID=2
 
-				# - Always enable HDMI output by default
-				G_CONFIG_INJECT 'CONFIG_HDMI_OUTPUT=' 'CONFIG_HDMI_OUTPUT=1' /DietPi/dietpi.txt
+				if [[ $G_WHIP_RETURNED_VALUE == 'Headless' ]]; then
 
-				# - Always set default depth to 16
-				sed -i 's/^[[:blank:]]*framebuffer_depth=/c\#framebuffer_depth=16' /DietPi/config.txt
-
-				# - Always disable composite by default
-				sed -i '/sdtv_mode=/c\#sdtv_mode=0' /DietPi/config.txt
-
-				# - Always disable OpenGL by default:
-				/DietPi/dietpi/func/dietpi-set_hardware rpi-opengl disable
-
-				if [[ $G_WHIP_RETURNED_VALUE == 'vc4-'* ]]; then
-
-					/DietPi/dietpi/func/dietpi-set_hardware rpi-opengl $G_WHIP_RETURNED_VALUE
-
-				elif [[ $G_WHIP_RETURNED_VALUE == 'Headless' ]]; then
-
-					G_WHIP_MSG 'Using the Headless option will:
+					G_WHIP_YESNO 'Using the Headless option will:
  - Disable HDMI and composite output
  - Disable the framebuffer
  - Lower energy consumption by 0.1+ Watts
@@ -942,34 +926,33 @@ Re-enabling HDMI requires a reboot. If you need emergency HDMI output, comment o
  - hdmi_ignore_hotplug=1
  - hdmi_ignore_composite=1\n
 More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p105008
-      and here: https://github.com/raspberrypi/userland/issues/447#issuecomment-404399670'
+      and here: https://github.com/raspberrypi/userland/issues/447#issuecomment-404399670' || { REBOOT_REQUIRED=0; return; }
 
-					G_CONFIG_INJECT 'CONFIG_HDMI_OUTPUT=' 'CONFIG_HDMI_OUTPUT=0' /DietPi/dietpi.txt
-					# - Framebuffer dimensions should not play a role here, but
-					#	if NOT set, they appear as "0" by asking "vcgencmd get_config (max_)?framebuffer_(width|height)"
-					#	otherwise vcgencmd shows the set value. So we simply comment it.
-					sed -i 's/^[[:blank:]]*framebuffer_width=/c\#framebuffer_width=0' /DietPi/config.txt
-					sed -i 's/^[[:blank:]]*framebuffer_height=/c\#framebuffer_height=0' /DietPi/config.txt
-					sed -i 's/^[[:blank:]]*max_framebuffer_width=/c\#max_framebuffer_width=0' /DietPi/config.txt
-					sed -i 's/^[[:blank:]]*max_framebuffer_height=/c\#max_framebuffer_height=0' /DietPi/config.txt
-					# - framebuffer_depth defaults to a set value of 16, even with HDMI disabled, so we manually reduce it to min 8
-					G_CONFIG_INJECT 'framebuffer_depth=' 'framebuffer_depth=8' /DietPi/config.txt
-					# - Splash cannot be seen anyway, without video output
-					G_CONFIG_INJECT 'disable_splash=' 'disable_splash=1' /DietPi/config.txt
-					# - hdmi_blanking should not play a role, however mode 1 should be generally preferred, which on idle disables HDMI output completely instead of just blanking the screen
-					G_CONFIG_INJECT 'hdmi_blanking=' 'hdmi_blanking=1' /DietPi/config.txt
-					# - Disable HDMI hotplug, which requires it to be generally responsive/active
-					G_CONFIG_INJECT 'hdmi_ignore_hotplug=' 'hdmi_ignore_hotplug=1' /DietPi/config.txt
-					# - Disable composite hotplug, which then allows to completely disable the video pipeline + framebuffer
-					G_CONFIG_INJECT 'hdmi_ignore_composite=' 'hdmi_ignore_composite=1' /DietPi/config.txt
+					/DietPi/dietpi/func/dietpi-set_hardware rpi-headless 1
 
 				else
+
+					/DietPi/dietpi/func/dietpi-set_hardware rpi-headless 0
+
+				fi
+
+				# - Always disable composite by default
+				[[ $G_WHIP_RETURNED_VALUE == 'sdtv_mode'* ]] || sed -i '/sdtv_mode=/c\#sdtv_mode=0' /DietPi/config.txt
+
+				# - Always disable OpenGL by default
+				[[ $G_WHIP_RETURNED_VALUE == 'vc4-'* ]] || /DietPi/dietpi/func/dietpi-set_hardware rpi-opengl disable
+
+				if [[ $G_WHIP_RETURNED_VALUE == 'vc4-'* ]]; then
+
+					/DietPi/dietpi/func/dietpi-set_hardware rpi-opengl $G_WHIP_RETURNED_VALUE
+
+				elif [[ $G_WHIP_RETURNED_VALUE != 'Headless' ]]; then
 
 					case "$G_WHIP_RETURNED_VALUE" in
 
 						'sdtv_mode'*)
 
-							sed -i "/sdtv_mode=/c $G_WHIP_RETURNED_VALUE" /DietPi/config.txt
+							sed -i "/sdtv_mode=/c\\$G_WHIP_RETURNED_VALUE" /DietPi/config.txt
 							framebuffer_x=720
 							framebuffer_y=576
 

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -13,28 +13,29 @@
 	FP_SCRIPT='/DietPi/dietpi/func/dietpi-set_hardware'
 	AVAIABLE_COMMANDS="
 Available commands
-$FP_SCRIPT		rpi3_usb_boot		enable
-$FP_SCRIPT		rpi-camera		enable/disable
-$FP_SCRIPT		gpumemsplit		64/128/256 #RPi only
-$FP_SCRIPT		remoteir		odroid_remote/justboom_ir_remote
-$FP_SCRIPT		eth-forcespeed		10/100/1000/disable
-$FP_SCRIPT		rpi-opengl		vc4-kms-v3d/vc4-fkms-v3d/disable
-$FP_SCRIPT		i2c			enable/disable/khz
-$FP_SCRIPT		wificountrycode		GB/US/DE
-$FP_SCRIPT		wifimodules		enable/disable/onboard_enable/onboard_disable
 $FP_SCRIPT		enableipv6		enable/disable
 $FP_SCRIPT		preferipv4		enable/disable
+$FP_SCRIPT		eth-forcespeed		10/100/1000/disable
+$FP_SCRIPT		wifimodules		enable/disable/onboard_enable/onboard_disable
+$FP_SCRIPT		wificountrycode		GB/US/DE
 $FP_SCRIPT		bluetooth		enable/disable
 $FP_SCRIPT		serialconsole		enable/disable
-$FP_SCRIPT		soundcard 		target_card (non-matching name for reset to default) add '-eq' to target_card string, enable alsa eq on card. HW:x,x (specify target card and device index eg: HW:9,1)
+$FP_SCRIPT		i2c			enable/disable/khz
+$FP_SCRIPT		soundcard		target_card (non-matching name for reset to default) add '-eq' to target_card string, enable alsa eq on card. HW:x,x (specify target card and device index eg: HW:9,1)
+$FP_SCRIPT		remoteir		odroid_remote/justboom_ir_remote # Odroid/RPi only
 $FP_SCRIPT		lcdpanel		target_panel (none to remove all)
+$FP_SCRIPT		gpumemsplit		64/128/256 # RPi only
+$FP_SCRIPT		rpi-headless		enable/disable
+$FP_SCRIPT		rpi-camera		enable/disable
+$FP_SCRIPT		rpi-opengl		vc4-kms-v3d/vc4-fkms-v3d/disable
+$FP_SCRIPT		rpi3_usb_boot		enable
 "
 	#////////////////////////////////////
 
 	#Grab Inputs
 	INPUT_DEVICE_NAME="${1,,}"
 	INPUT_DEVICE_VALUE="${2,,}"
-	# - support for 0/1 inputs for enable/disable
+	# - Support for 1/0 inputs for enable/disable
 	if [[ $INPUT_DEVICE_VALUE == '1' ]]; then
 
 		INPUT_DEVICE_VALUE='enable'
@@ -69,8 +70,7 @@ $FP_SCRIPT		lcdpanel		target_panel (none to remove all)
 
 		EXIT_CODE=1
 		G_DIETPI-NOTIFY 2 "Unknown input name ($INPUT_DEVICE_NAME). Nothing has been applied."
-
-		echo -e "$AVAIABLE_COMMANDS"
+		echo "$AVAIABLE_COMMANDS"
 
 	}
 
@@ -78,8 +78,21 @@ $FP_SCRIPT		lcdpanel		target_panel (none to remove all)
 
 		EXIT_CODE=1
 		G_DIETPI-NOTIFY 2 "Unknown input value ($INPUT_DEVICE_VALUE). Nothing has been applied."
+		echo "$AVAIABLE_COMMANDS"
 
-		echo -e "$AVAIABLE_COMMANDS"
+	}
+
+	Unsupported_Input_Name(){
+
+		EXIT_CODE=1
+		G_DIETPI-NOTIFY 2 "Input name ($INPUT_DEVICE_NAME) is not available for $G_HW_MODEL_DESCRIPTION. Nothing has been applied."
+
+	}
+
+	Unsupported_Input_Mode(){
+
+		EXIT_CODE=1
+		G_DIETPI-NOTIFY 2 "Input value ($INPUT_DEVICE_VALUE) is not available for $G_HW_MODEL_DESCRIPTION. Nothing has been applied."
 
 	}
 
@@ -88,7 +101,8 @@ $FP_SCRIPT		lcdpanel		target_panel (none to remove all)
 	#/////////////////////////////////////////////////////////////////////////////////////
 	RPi_Camera_Main(){
 
-		# - int, assume RPi
+		(( $G_HW_MODEL > 9 )) && Unsupported_Input_Name # Exit path for non-RPi
+
 		if [[ $INPUT_DEVICE_VALUE == 'enable' ]]; then
 
 			# - Enable RPi Camera module
@@ -97,8 +111,9 @@ $FP_SCRIPT		lcdpanel		target_panel (none to remove all)
 			# - v4l2 module (motioneye /dev/video0)
 			G_CONFIG_INJECT 'bcm2835-v4l2' 'bcm2835-v4l2' /etc/modules
 
+			local gpu_mem=$(sed -n '/^[[:blank:]]*gpu_mem/{s/^[^=]*=//p;q}' $FP_RPI_CONFIG)
 			# - requires 128MB memory split min.
-			if (( $(grep -m1 'gpu_mem_' $FP_RPI_CONFIG | sed 's/^.*=//g') < 128 )); then
+			if (( ${gpu_mem:-0} < 128 )); then
 
 				local tmp=$INPUT_DEVICE_VALUE
 				INPUT_DEVICE_VALUE=128
@@ -109,6 +124,7 @@ $FP_SCRIPT		lcdpanel		target_panel (none to remove all)
 				unset tmp
 
 			fi
+			unset gpu_mem
 
 		elif [[ $INPUT_DEVICE_VALUE == 'disable' ]]; then
 
@@ -128,6 +144,8 @@ $FP_SCRIPT		lcdpanel		target_panel (none to remove all)
 	#/////////////////////////////////////////////////////////////////////////////////////
 	RPi_USB_Boot_Main(){
 
+		(( $G_HW_MODEL > 9 )) && Unsupported_Input_Name # Exit path for non-RPi
+
 		if [[ $INPUT_DEVICE_VALUE == 'enable' ]]; then
 
 			G_CONFIG_INJECT 'program_usb_boot_mode=' 'program_usb_boot_mode=1' $FP_RPI_CONFIG
@@ -140,9 +158,9 @@ After=dietpi-boot.service
 [Service]
 Type=simple
 RemainAfterExit=yes
-ExecStartPre=/bin/sed -i '/program_usb_boot_mode=/d' $FP_RPI_CONFIG
-ExecStartPre=/bin/systemctl disable dietpi-rm_program_usb_boot_mode
-ExecStart=/bin/systemctl daemon-reload
+ExecStartPre=$(which sed) -i '/program_usb_boot_mode=/d' $FP_RPI_CONFIG
+ExecStartPre=$(which systemctl) disable dietpi-rm_program_usb_boot_mode
+ExecStart=$(which systemctl) daemon-reload
 
 [Install]
 WantedBy=multi-user.target
@@ -167,8 +185,9 @@ systemctl enable dietpi-rm_program_usb_boot_mode
 	#/////////////////////////////////////////////////////////////////////////////////////
 	Gpu_Memory_Split_Main(){
 
-		# - int, assume RPi
-		if disable_error=1 G_CHECK_VALIDINT $INPUT_DEVICE_VALUE; then
+		(( $G_HW_MODEL > 9 )) && Unsupported_Input_Name # Exit path for non-RPi
+
+		if disable_error=1 G_CHECK_VALIDINT "$INPUT_DEVICE_VALUE"; then
 
 			G_CONFIG_INJECT 'gpu_mem_256=' "gpu_mem_256=$INPUT_DEVICE_VALUE" $FP_RPI_CONFIG
 			G_CONFIG_INJECT 'gpu_mem_512=' "gpu_mem_512=$INPUT_DEVICE_VALUE" $FP_RPI_CONFIG
@@ -183,14 +202,54 @@ systemctl enable dietpi-rm_program_usb_boot_mode
 	}
 
 	#/////////////////////////////////////////////////////////////////////////////////////
-	#remoteir
+	#rpi-headless
 	#/////////////////////////////////////////////////////////////////////////////////////
-	RemoteIR_Prereqs(){
+	RPi_Headless_Main(){
 
-		# - LIRC
-		G_AG_CHECK_INSTALL_PREREQ lirc
+		(( $G_HW_MODEL > 9 )) && Unsupported_Input_Name # Exit path for non-RPi
+
+		if [[ $INPUT_DEVICE_VALUE == 'enable' ]]; then
+
+			# - Framebuffer dimensions should not play a role here, but
+			#	if NOT set, they appear as "0" by asking "vcgencmd get_config (max_)?framebuffer_(width|height)"
+			#	otherwise vcgencmd shows the set value. So we simply comment it.
+			sed -i 's/^[[:blank:]]*framebuffer_width=/c\#framebuffer_width=0' /DietPi/config.txt
+			sed -i 's/^[[:blank:]]*framebuffer_height=/c\#framebuffer_height=0' /DietPi/config.txt
+			sed -i 's/^[[:blank:]]*max_framebuffer_width=/c\#max_framebuffer_width=0' /DietPi/config.txt
+			sed -i 's/^[[:blank:]]*max_framebuffer_height=/c\#max_framebuffer_height=0' /DietPi/config.txt
+			# - framebuffer_depth defaults to a set value of 16, even with HDMI disabled, so we manually reduce it to min 8
+			G_CONFIG_INJECT 'framebuffer_depth=' 'framebuffer_depth=8' /DietPi/config.txt
+			# - Splash cannot be seen anyway, without video output
+			G_CONFIG_INJECT 'disable_splash=' 'disable_splash=1' /DietPi/config.txt
+			# - hdmi_blanking should not play a role, however mode 1 should be generally preferred, which on idle disables HDMI output completely instead of just blanking the screen
+			G_CONFIG_INJECT 'hdmi_blanking=' 'hdmi_blanking=1' /DietPi/config.txt
+			# - Disable HDMI hotplug, which requires it to be generally responsive/active
+			G_CONFIG_INJECT 'hdmi_ignore_hotplug=' 'hdmi_ignore_hotplug=1' /DietPi/config.txt
+			# - Disable composite hotplug, which then allows to completely disable the video pipeline + framebuffer
+			G_CONFIG_INJECT 'hdmi_ignore_composite=' 'hdmi_ignore_composite=1' /DietPi/config.txt
+
+			G_CONFIG_INJECT 'CONFIG_HDMI_OUTPUT=' 'CONFIG_HDMI_OUTPUT=0' /DietPi/dietpi.txt
+
+		elif [[ $INPUT_DEVICE_VALUE == 'disable' ]]; then
+
+			sed -i 's/^[[:blank:]]*framebuffer_depth=/c\#framebuffer_depth=16' /DietPi/config.txt
+			sed -i 's/^[[:blank:]]*hdmi_ignore_hotplug=/c\#hdmi_ignore_hotplug=0' /DietPi/config.txt
+			sed -i 's/^[[:blank:]]*hdmi_ignore_composite=/c\#hdmi_ignore_composite=0' /DietPi/config.txt
+
+			G_CONFIG_INJECT 'CONFIG_HDMI_OUTPUT=' 'CONFIG_HDMI_OUTPUT=1' /DietPi/dietpi.txt
+
+		else
+
+			Unknown_Input_Mode
+
+		fi
 
 	}
+
+	#/////////////////////////////////////////////////////////////////////////////////////
+	#remoteir
+	#/////////////////////////////////////////////////////////////////////////////////////
+	RemoteIR_Prereqs(){ G_AG_CHECK_INSTALL_PREREQ lirc; }
 
 	RemoteIR_Reset_All(){
 
@@ -217,7 +276,11 @@ systemctl enable dietpi-rm_program_usb_boot_mode
 
 	RemoteIR_Main(){
 
+		(( $G_HW_MODEL > 19 )) && Unsupported_Input_Name # Exit path for non-Odroid/RPi
+
 		if [[ $INPUT_DEVICE_VALUE == 'odroid_remote' ]]; then
+
+			(( $G_HW_MODEL < 10 )) && Unsupported_Input_Mode # Exit path for non-Odroid
 
 			RemoteIR_Prereqs
 			RemoteIR_Reset_All &> /dev/null
@@ -301,6 +364,8 @@ end remote
 _EOF_
 
 		elif [[ $INPUT_DEVICE_VALUE == 'justboom_ir_remote' ]]; then
+
+			(( $G_HW_MODEL > 9 )) && Unsupported_Input_Mode # Exit path for non-RPi
 
 			RemoteIR_Prereqs
 			RemoteIR_Reset_All &> /dev/null
@@ -414,14 +479,14 @@ _EOF_
 			#	service
 			cat << _EOF_ > /etc/systemd/system/justboom-ir-mpd.service
 [Unit]
-Description=justboom-ir-mpd
+Description=justboom-ir-mpd (DietPi)
 After=sound.target lirc.service
 
 [Service]
 User=$USER
 Type=simple
 
-ExecStart=/usr/bin/irexec
+ExecStart=$(which irexec)
 
 [Install]
 WantedBy=default.target
@@ -447,19 +512,19 @@ _EOF_
 	#/////////////////////////////////////////////////////////////////////////////////////
 	Eth_Force_Speed_Main(){
 
-		if (( $INPUT_DEVICE_VALUE > 0 )); then
+		if disable_error=1 G_CHECK_VALIDINT "$INPUT_DEVICE_VALUE" 1; then
 
 			local eth_force_speed=$INPUT_DEVICE_VALUE
 			local eth_adapter="eth$(sed -n 1p /DietPi/dietpi/.network)"
 
 			cat << _EOF_ > /etc/systemd/system/ethtool_force_speed.service
 [Unit]
-Description=ethtool force speed
+Description=ethtool force speed (DietPi)
 After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/sbin/ethtool -s $eth_adapter speed $eth_force_speed duplex full autoneg off
+ExecStart=$(which ethtool) -s $eth_adapter speed $eth_force_speed duplex full autoneg off
 
 [Install]
 WantedBy=ifup@$eth_adapter.service
@@ -470,7 +535,7 @@ _EOF_
 
 		elif [[ $INPUT_DEVICE_VALUE == 'disable' ]]; then #0 is converted to 'disabled'
 
-			rm /etc/systemd/system/ethtool_force_speed.service &> /dev/null
+			[[ -f /etc/systemd/system/ethtool_force_speed.service ]] && rm /etc/systemd/system/ethtool_force_speed.service
 			systemctl daemon-reload
 
 		else
@@ -486,35 +551,25 @@ _EOF_
 	#/////////////////////////////////////////////////////////////////////////////////////
 	RPi_OpenGL_Main(){
 
+		(( $G_HW_MODEL > 9 )) && Unsupported_Input_Name # Exit path for non-RPi
+
 		#Always remove previous vc4 overlay entry
 		sed -i '/dtoverlay=vc4-/d' $FP_RPI_CONFIG
 
 		if [[ $INPUT_DEVICE_VALUE == "vc4-"* ]]; then
 
-			#RPi 2/3+ only
-			if (( $G_HW_MODEL >= 2 && $G_HW_MODEL < 10 )); then
+			(( $G_HW_MODEL < 2 )) && Unsupported_Input_Mode # RPi 2/3+ only
 
-				# - GL packages
-				G_AG_CHECK_INSTALL_PREREQ libgl1-mesa-dri libgles2-mesa mesa-utils
+			# - GL packages
+			G_AG_CHECK_INSTALL_PREREQ libgl1-mesa-dri libgles2-mesa mesa-utils
 
-				echo -e "\ndtoverlay=$INPUT_DEVICE_VALUE" >> $FP_RPI_CONFIG
+			echo "dtoverlay=$INPUT_DEVICE_VALUE" >> $FP_RPI_CONFIG
 
-				# - set 1080p by default
-				G_CONFIG_INJECT 'framebuffer_width=' 'framebuffer_width=1920' $FP_RPI_CONFIG
-				G_CONFIG_INJECT 'framebuffer_height=' 'framebuffer_height=1080' $FP_RPI_CONFIG
+			# - set 1080p by default
+			G_CONFIG_INJECT 'framebuffer_width=' 'framebuffer_width=1920' $FP_RPI_CONFIG
+			G_CONFIG_INJECT 'framebuffer_height=' 'framebuffer_height=1080' $FP_RPI_CONFIG
 
-			else
-
-				G_DIETPI-NOTIFY 1 'OpenGL requires an RPi 2 or higher'
-				sleep 2
-
-			fi
-
-		elif [[ $INPUT_DEVICE_VALUE == 'disable' ]]; then
-
-			echo -e 'already done' &> /dev/null
-
-		else
+		elif [[ $INPUT_DEVICE_VALUE != 'disable' ]]; then
 
 			Unknown_Input_Mode
 
@@ -525,13 +580,6 @@ _EOF_
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# lcdpanel eg: All non-HDMI/VGA based displays and monitors.
 	#/////////////////////////////////////////////////////////////////////////////////////
-	Lcd_Panel_Not_Available_For_Device(){
-
-		EXIT_CODE=1
-		G_DIETPI-NOTIFY 2 "$INPUT_DEVICE_VALUE is not available for this device. Nothing has been applied."
-
-	}
-
 	Lcd_Panel_Main(){
 
 		local update_dietpitxt=1
@@ -568,11 +616,7 @@ _EOF_
 		fi
 
 		#Update dietpi.txt entry?
-		if (( $update_dietpitxt )); then
-
-			G_CONFIG_INJECT 'CONFIG_LCDPANEL=' "CONFIG_LCDPANEL=$INPUT_DEVICE_VALUE" /DietPi/dietpi.txt
-
-		fi
+		(( $update_dietpitxt )) && G_CONFIG_INJECT 'CONFIG_LCDPANEL=' "CONFIG_LCDPANEL=$INPUT_DEVICE_VALUE" /DietPi/dietpi.txt
 
 	}
 
@@ -721,7 +765,7 @@ _EOF_
 
 		else
 
-			Lcd_Panel_Not_Available_For_Device
+			Unsupported_Input_Mode
 
 		fi
 
@@ -738,7 +782,7 @@ _EOF_
 		#RPi
 		if (( $G_HW_MODEL < 10 )); then
 
-			rm /boot/overlays/waveshare32b.dtbo  &> /dev/null
+			[[ -f /boot/overlays/waveshare32b.dtbo ]] && rm /boot/overlays/waveshare32b.dtbo
 			sed -i 's/ fbcon=map:10 fbcon=font:ProFont6x11 logo.nologo//' /boot/cmdline.txt
 
 			sed -i '/Waveshare 32 LCD/d' $FP_RPI_CONFIG
@@ -756,10 +800,10 @@ _EOF_
 		#Odroids
 		elif (( $G_HW_MODEL >= 10 && $G_HW_MODEL < 20 )); then
 
-			rm /etc/systemd/system/con2fbmap.service &> /dev/null
+			[[ -f /etc/systemd/system/con2fbmap.service ]] && rm /etc/systemd/system/con2fbmap.service
 			systemctl daemon-reload
 
-			rm /etc/modprobe.d/waveshare32.conf &> /dev/null
+			[[ -f /etc/modprobe.d/waveshare32.conf ]] && rm /etc/modprobe.d/waveshare32.conf
 			sed -i '/^spicc/d' /etc/modules
 			sed -i '/^fbtft_device/d' /etc/modules
 
@@ -782,7 +826,7 @@ _EOF_
 
 	Lcd_Panel_Odroidcloudshell_Disable(){
 
-		rm /etc/modprobe.d/odroid-cloudshell.conf
+		[[ -f /etc/modprobe.d/odroid-cloudshell.conf ]] && rm /etc/modprobe.d/odroid-cloudshell.conf
 		sed -i '/^spi_s3c64xx/d' /etc/modules
 		sed -i '/^fbtft_device/d' /etc/modules
 
@@ -891,7 +935,7 @@ _EOF_
 			systemctl enable odroid-lcd35.service
 
 			#XORG
-			rm /etc/X11/xorg.conf.d/exynos.conf #XU4
+			[[ -f /etc/X11/xorg.conf.d/exynos.conf ]] && rm /etc/X11/xorg.conf.d/exynos.conf #XU4
 
 			mkdir -p /etc/X11/xorg.conf.d
 			cat << _EOF_ > /etc/X11/xorg.conf.d/99-odroid-lcd35.conf
@@ -914,7 +958,7 @@ _EOF_
 
 		else
 
-			Lcd_Panel_Not_Available_For_Device
+			Unsupported_Input_Mode
 
 		fi
 
@@ -934,8 +978,9 @@ _EOF_
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# i2c
 	#/////////////////////////////////////////////////////////////////////////////////////
-	# Currently only for RPi.
 	I2c_Main(){
+
+		(( $G_HW_MODEL > 9 )) && Unsupported_Input_Name # Exit path for non-RPi
 
 		if [[ $INPUT_DEVICE_VALUE == 'enable' ]]; then
 
@@ -943,16 +988,8 @@ _EOF_
 			G_AG_CHECK_INSTALL_PREREQ python-smbus i2c-tools
 
 			#Kernel modules
-			# - Remove all previous line references (includes commented ones)
-			sed -i '/i2c-bcm2708/d' /etc/modules &> /dev/null
-			sed -i '/i2c-dev/d' /etc/modules &> /dev/null
-			# - Add modules
 			G_CONFIG_INJECT 'i2c-bcm2708' 'i2c-bcm2708' /etc/modules
 			G_CONFIG_INJECT 'i2c-dev' 'i2c-dev' /etc/modules
-
-			#Remove from blacklist (Wheezy only. Jessie doesnt exist)
-			sed -i '/blacklist spi-bcm2708/d' /etc/modprobe.d/raspi-blacklist.conf &> /dev/null
-			sed -i '/blacklist i2c-bcm2708/d' /etc/modprobe.d/raspi-blacklist.conf &> /dev/null
 
 			#config.txt
 			G_CONFIG_INJECT 'dtparam=i2c_arm=' 'dtparam=i2c_arm=on' $FP_RPI_CONFIG
@@ -963,19 +1000,19 @@ _EOF_
 
 		elif [[ $INPUT_DEVICE_VALUE == 'disable' ]]; then
 
-			sed -i '/i2c-bcm2708/d' /etc/modules &> /dev/null
-			sed -i '/i2c-dev/d' /etc/modules &> /dev/null
+			sed -i '/i2c-bcm2708/d' /etc/modules
+			sed -i '/i2c-dev/d' /etc/modules
 			G_CONFIG_INJECT 'dtparam=i2c_arm=' 'dtparam=i2c_arm=off' $FP_RPI_CONFIG
 			G_CONFIG_INJECT 'dtparam=i2c1=' 'dtparam=i2c1=off' $FP_RPI_CONFIG
 			G_CONFIG_INJECT 'i2c_arm_baudrate=' 'i2c_arm_baudrate=100000' $FP_RPI_CONFIG
 
 		#Set baudrate (khz) | valid int
-		elif disable_error=1 G_CHECK_VALIDINT $INPUT_DEVICE_VALUE 2 10000000; then
+		elif disable_error=1 G_CHECK_VALIDINT "$INPUT_DEVICE_VALUE" 2 10000000; then
 
 			G_CONFIG_INJECT 'i2c_arm_baudrate=' "i2c_arm_baudrate=$(( $INPUT_DEVICE_VALUE * 1000 ))" $FP_RPI_CONFIG
 
 			#inform user
-			INPUT_DEVICE_VALUE+="Khz"
+			INPUT_DEVICE_VALUE+='Khz'
 
 		else
 
@@ -1003,7 +1040,7 @@ _EOF_
 
 		aBLUETOOTH_MODULES+=('hci_uart')
 
-		rm /etc/modprobe.d/disable_bt.conf &> /dev/null
+		[[ -f /etc/modprobe.d/disable_bt.conf ]] && rm /etc/modprobe.d/disable_bt.conf
 
 		# - Disable
 		if [[ $INPUT_DEVICE_VALUE == 'disable' ]]; then
@@ -1033,7 +1070,7 @@ _EOF_
 			do
 
 				modprobe -rf "${aBLUETOOTH_MODULES[$i]}" 2> /dev/null
-				echo -e "blacklist ${aBLUETOOTH_MODULES[$i]}" >> /etc/modprobe.d/disable_bt.conf
+				echo "blacklist ${aBLUETOOTH_MODULES[$i]}" >> /etc/modprobe.d/disable_bt.conf
 
 			done
 
@@ -1050,11 +1087,7 @@ _EOF_
 
 			#Pre-Reqs
 			G_AG_CHECK_INSTALL_PREREQ bluetooth bluez-firmware
-			if (( $G_HW_MODEL < 10 )); then
-
-				G_AG_CHECK_INSTALL_PREREQ pi-bluetooth
-
-			fi
+			(( $G_HW_MODEL < 10 )) && G_AG_CHECK_INSTALL_PREREQ pi-bluetooth
 
 			#bluetooth first
 			for ((i=0; i<${#aBLUETOOTH_MODULES[@]}; i++))
@@ -1225,11 +1258,7 @@ _EOF_
 		elif (( $G_HW_MODEL == 35 || $G_HW_MODEL == 64 )); then
 
 			#4.9 uses brcm, only enable dhd for 3.x
-			if [[ ! -d '/boot/dtb' ]]; then
-
-				aWIFI_MODULES+=('dhd')
-
-			fi
+			[[ ! -d '/boot/dtb' ]] && aWIFI_MODULES+=('dhd')
 
 		fi
 
@@ -1239,14 +1268,14 @@ _EOF_
 		# - Disable
 		if [[ $INPUT_DEVICE_VALUE == 'disable' ]]; then
 
-			rm /etc/modprobe.d/disable_wifi.conf &> /dev/null
+			[[ -f /etc/modprobe.d/disable_wifi.conf ]] && rm /etc/modprobe.d/disable_wifi.conf
 
 			#cfg80211 last
 			for ((i=$(( ${#aWIFI_MODULES[@]} - 1 )); i>=0; i--))
 			do
 
 				modprobe -rf "${aWIFI_MODULES[$i]}" 2> /dev/null
-				echo -e "blacklist ${aWIFI_MODULES[$i]}" >> /etc/modprobe.d/disable_wifi.conf
+				echo "blacklist ${aWIFI_MODULES[$i]}" >> /etc/modprobe.d/disable_wifi.conf
 
 			done
 
@@ -1257,11 +1286,7 @@ _EOF_
 			local pre_req_packages='crda iw rfkill wireless-tools wpasupplicant'
 
 			G_AG_CHECK_INSTALL_PREREQ $pre_req_packages
-			if (( $? != 0 )); then
-
-				exit 1
-
-			fi
+			(( $? )) && exit 1
 
 			rm /etc/modprobe.d/disable_wifi.conf &> /dev/null
 
@@ -1304,8 +1329,8 @@ _EOF_
 			#NB: Do not change filenames, -f check used by DietPi-Config to obtain state
 
 			# - RPi 3/ZeroW
-			echo -e "blacklist brcmfmac" > /etc/modprobe.d/disable_wifi_rpi3_onboard.conf
-			echo -e "blacklist brcmutil" >> /etc/modprobe.d/disable_wifi_rpi3_onboard.conf
+			echo 'blacklist brcmfmac' > /etc/modprobe.d/disable_wifi_rpi3_onboard.conf
+			echo 'blacklist brcmutil' >> /etc/modprobe.d/disable_wifi_rpi3_onboard.conf
 
 		else
 
@@ -1376,7 +1401,7 @@ _EOF_
 
 				# - Allow root login for known TTY's not in /etc/securetty by default
 				#	NanoPC-T4
-				G_CONFIG_INJECT "^ttyFIQ$i" "ttyFIQ$i" /etc/securetty
+				G_CONFIG_INJECT "ttyFIQ$i" "ttyFIQ$i" /etc/securetty
 
 			done
 
@@ -1589,7 +1614,7 @@ _EOF_
 
 	Soundcard_Reset_Odroid(){
 
-		rm /var/lib/dietpi/postboot.d/c2_smp.sh &> /dev/null
+		[[ -f /var/lib/dietpi/postboot.d/c2_smp.sh ]] && rm /var/lib/dietpi/postboot.d/c2_smp.sh
 
 		# - hifi shield plus
 		sed -i '/snd-soc-pcm5102/d' /etc/modules
@@ -1644,13 +1669,13 @@ _EOF_
 		sed -i 's/aotg.aotg1_speed=1/aotg.aotg1_speed=0/' /DietPi/uEnv.txt
 
 		# - auto unmute
-		rm /var/lib/dietpi/postboot.d/sparky_unmute.sh &> /dev/null
+		[[ -f /var/lib/dietpi/postboot.d/sparky_unmute.sh ]] && rm /var/lib/dietpi/postboot.d/sparky_unmute.sh
 
 	}
 
 	Soundcard_Reset_PineA64(){
 
-		rm /etc/modules-load.d/pine64-audiojack.conf
+		[[ -f /etc/modules-load.d/pine64-audiojack.conf ]] && rm /etc/modules-load.d/pine64-audiojack.conf
 		SOUNDCARD_TARGET_CARD=1
 
 	}
@@ -1689,15 +1714,10 @@ _EOF_
 		fi
 
 		# - Update DietPi global soundcard var
-		sed -i "/^CONFIG_SOUNDCARD=/c\CONFIG_SOUNDCARD=$INPUT_DEVICE_VALUE" /DietPi/dietpi.txt
+		G_CONFIG_INJECT 'CONFIG_SOUNDCARD=' "CONFIG_SOUNDCARD=$INPUT_DEVICE_VALUE" /DietPi/dietpi.txt
 
 		# - RPi: Enable DTPARAM audio setting
-		if (( $G_HW_MODEL < 10 )); then
-
-			# - Enable dtparam audio
-			G_CONFIG_INJECT 'dtparam=audio=' 'dtparam=audio=on' $FP_RPI_CONFIG
-
-		fi
+		(( $G_HW_MODEL < 10 )) && G_CONFIG_INJECT 'dtparam=audio=' 'dtparam=audio=on' $FP_RPI_CONFIG
 
 		#Cards
 		case "$INPUT_DEVICE_VALUE" in
@@ -1718,7 +1738,7 @@ _EOF_
 
 				# - detect card
 				local usb_detection_card_index=$(aplay -l | grep -m1 'USB Audio' | awk '{print $2}' | sed 's/://g')
-				if disable_error=1 G_CHECK_VALIDINT $usb_detection_card_index; then
+				if disable_error=1 G_CHECK_VALIDINT "$usb_detection_card_index"; then
 
 					SOUNDCARD_TARGET_CARD=$usb_detection_card_index
 
@@ -1777,7 +1797,7 @@ _EOF_
 			rpi-bcm2835*)
 
 				# - remove from blacklist to enable:
-				rm /etc/modprobe.d/rpi-bcm2708.conf
+				[[ -f /etc/modprobe.d/rpi-bcm2708.conf ]] && rm /etc/modprobe.d/rpi-bcm2708.conf
 
 				# - Force 3.5mm out?
 				if [[ $INPUT_DEVICE_VALUE == *'3.5mm'* ]]; then
@@ -1814,7 +1834,7 @@ _EOF_
 			hifiberry-*)
 
 				# - enable dtoverlay
-				echo -e "\ndtoverlay=$INPUT_DEVICE_VALUE" >> $FP_RPI_CONFIG
+				echo "dtoverlay=$INPUT_DEVICE_VALUE" >> $FP_RPI_CONFIG
 
 			;;
 
@@ -1837,7 +1857,7 @@ _EOF_
 			justboom-*)
 
 				# - enable dtoverlay
-				echo -e "\ndtoverlay=$INPUT_DEVICE_VALUE" >> $FP_RPI_CONFIG
+				echo "dtoverlay=$INPUT_DEVICE_VALUE" >> $FP_RPI_CONFIG
 
 			;;
 
@@ -1858,7 +1878,7 @@ _EOF_
 
 				fi
 
-				echo -e "\ndtoverlay=$INPUT_DEVICE_VALUE" >> $FP_RPI_CONFIG
+				echo "dtoverlay=$INPUT_DEVICE_VALUE" >> $FP_RPI_CONFIG
 
 			;;
 
@@ -1878,7 +1898,7 @@ _EOF_
 
 				fi
 
-				echo -e "$INPUT_DEVICE_VALUE" >> /etc/modules
+				echo "$INPUT_DEVICE_VALUE" >> /etc/modules
 				SOUNDCARD_TARGET_CARD=1
 				SOUNDCARD_TARGET_DEVICE=0
 				amixer -c 0 sset 'audio output mode switch' 'i2s'
@@ -1916,7 +1936,7 @@ _EOF_
 			allo-*)
 
 				# - enable dtoverlay
-				echo -e "\ndtoverlay=$INPUT_DEVICE_VALUE" >> $FP_RPI_CONFIG
+				echo "dtoverlay=$INPUT_DEVICE_VALUE" >> $FP_RPI_CONFIG
 
 				if [[ $INPUT_DEVICE_VALUE == 'allo-katana-dac-audio' && ! -d '/var/www/allo' ]]; then
 
@@ -1931,7 +1951,7 @@ _EOF_
 			rpi-dac)
 
 				# - enable dtoverlay
-				echo -e "\ndtoverlay=$INPUT_DEVICE_VALUE" >> $FP_RPI_CONFIG
+				echo "dtoverlay=$INPUT_DEVICE_VALUE" >> $FP_RPI_CONFIG
 
 			;;
 
@@ -1981,7 +2001,7 @@ _EOF_
 				fi
 
 				# - enable dtoverlay
-				echo -e "\ndtoverlay=$INPUT_DEVICE_VALUE" >> $FP_RPI_CONFIG
+				echo "dtoverlay=$INPUT_DEVICE_VALUE" >> $FP_RPI_CONFIG
 
 			;;
 
@@ -1990,14 +2010,14 @@ _EOF_
 			applepi*)
 
 				# - enable dtoverlay
-				echo -e "\ndtoverlay=$INPUT_DEVICE_VALUE" >> $FP_RPI_CONFIG
+				echo "dtoverlay=$INPUT_DEVICE_VALUE" >> $FP_RPI_CONFIG
 
 			;;
 
 			iqaudio-*)
 
 				# - enable dtoverlay
-				echo -e "\ndtoverlay=$INPUT_DEVICE_VALUE" >> $FP_RPI_CONFIG
+				echo "dtoverlay=$INPUT_DEVICE_VALUE" >> $FP_RPI_CONFIG
 
 			;;
 
@@ -2006,7 +2026,7 @@ _EOF_
 			dionaudio-loco*)
 
 				# - enable dtoverlay
-				echo -e "\ndtoverlay=$INPUT_DEVICE_VALUE" >> $FP_RPI_CONFIG
+				echo "dtoverlay=$INPUT_DEVICE_VALUE" >> $FP_RPI_CONFIG
 
 			;;
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1525,23 +1525,15 @@ Also have a look at "Sonarr", another alternative TV show manager, available for
 			#RPi changes: https://github.com/Fourdee/DietPi/pull/2402
 			if (( $G_HW_MODEL < 10 )); then
 
-				# - Remove/Replace obsolete RPi config.txt settings
+				# - Remove/Replace obsolete config.txt settings
 				sed -i 's/display_rotate/display_hdmi_rotate/' /DietPi/config.txt
 				sed -i '/disable_pvt/d' /DietPi/config.txt
 				sed -i '/avoid_pwm_pll/d' /DietPi/config.txt
 
-				# - Apply new headless mode method
+				# - Apply new headless mode method, if set
 				if grep -q '^[[:blank:]]*CONFIG_HDMI_OUTPUT=0' /DietPi/dietpi.txt; then
 
-					sed -i 's/^[[:blank:]]*framebuffer_width=/c\#framebuffer_width=0' /DietPi/config.txt
-					sed -i 's/^[[:blank:]]*framebuffer_height=/c\#framebuffer_height=0' /DietPi/config.txt
-					sed -i 's/^[[:blank:]]*max_framebuffer_width=/c\#max_framebuffer_width=0' /DietPi/config.txt
-					sed -i 's/^[[:blank:]]*max_framebuffer_height=/c\#max_framebuffer_height=0' /DietPi/config.txt
-					G_CONFIG_INJECT 'framebuffer_depth=' 'framebuffer_depth=8' /DietPi/config.txt
-					G_CONFIG_INJECT 'disable_splash=' 'disable_splash=1' /DietPi/config.txt
-					G_CONFIG_INJECT 'hdmi_blanking=' 'hdmi_blanking=1' /DietPi/config.txt
-					G_CONFIG_INJECT 'hdmi_ignore_hotplug=' 'hdmi_ignore_hotplug=1' /DietPi/config.txt
-					G_CONFIG_INJECT 'hdmi_ignore_composite=' 'hdmi_ignore_composite=1' /DietPi/config.txt
+					/DietPi/dietpi/func/dietpi-set_hardware rpi-headless 1
 
 				fi
 

--- a/dietpi/preboot
+++ b/dietpi/preboot
@@ -26,61 +26,53 @@
 
 	RPi_Set_Clock_Speeds(){
 
-		#RPi's
-		if (( $G_HW_MODEL < 10 )); then
+		#If no overclocking is set. set values to current (used in dietpi-config as reference for overclocking / current values)
+		if ! grep -q '^[[:blank:]]*over_voltage=' /DietPi/config.txt &&
+			! grep -q '^[[:blank:]]*arm_freq=' /DietPi/config.txt &&
+			! grep -q '^[[:blank:]]*core_freq=' /DietPi/config.txt &&
+			! grep -q '^[[:blank:]]*sdram_freq=' /DietPi/config.txt; then
 
-			#If no overclocking is set. set values to current (used in dietpi-config as reference for overclocking / current values)
-			if grep -q '^#over_voltage=' /DietPi/config.txt &&
-				grep -q '^#arm_freq=' /DietPi/config.txt &&
-				grep -q '^#core_freq=' /DietPi/config.txt &&
-				grep -q '^#sdram_freq=' /DietPi/config.txt; then
+			#Zero
+			if [[ ${G_HW_MODEL_DESCRIPTION,,} == *'zero'* ]]; then
 
-				#RPi v1 - Set safe clock
-				if (( $G_HW_MODEL < 2 )); then
+				sed -i '/over_voltage=/c\#over_voltage=0' /DietPi/config.txt
+				sed -i '/arm_freq=/c\#arm_freq=1000' /DietPi/config.txt
+				sed -i '/core_freq=/c\#core_freq=400' /DietPi/config.txt
+				sed -i '/sdram_freq=/c\#sdram_freq=450' /DietPi/config.txt
 
-					sed -i '/over_voltage=/c\over_voltage=2' /DietPi/config.txt
-					sed -i '/arm_freq=/c\arm_freq=900' /DietPi/config.txt
-					sed -i '/core_freq=/c\#core_freq=250' /DietPi/config.txt
-					sed -i '/sdram_freq=/c\#sdram_freq=400' /DietPi/config.txt
+			#RPi v1 - Set safe clock
+			elif (( $G_HW_MODEL < 2 )); then
 
-					#Zero
-					if [[ ${G_HW_MODEL_DESCRIPTION,,} == *'zero'* ]]; then
+				G_CONFIG_INJECT 'over_voltage=' 'over_voltage=2' /DietPi/config.txt
+				G_CONFIG_INJECT 'arm_freq=' 'arm_freq=900' /DietPi/config.txt
+				sed -i '/core_freq=/c\#core_freq=250' /DietPi/config.txt
+				sed -i '/sdram_freq=/c\#sdram_freq=400' /DietPi/config.txt
 
-						sed -i '/over_voltage=/c\#over_voltage=0' /DietPi/config.txt
-						sed -i '/arm_freq=/c\#arm_freq=1000' /DietPi/config.txt
-						sed -i '/core_freq=/c\#core_freq=400' /DietPi/config.txt
-						sed -i '/sdram_freq=/c\#sdram_freq=450' /DietPi/config.txt
+			#RPi v2
+			elif (( $G_HW_MODEL == 2 )); then
 
-					fi
+				sed -i '/over_voltage=/c\#over_voltage=0' /DietPi/config.txt
+				sed -i '/arm_freq=/c\#arm_freq=900' /DietPi/config.txt
+				sed -i '/core_freq=/c\#core_freq=250' /DietPi/config.txt
+				sed -i '/sdram_freq=/c\#sdram_freq=450' /DietPi/config.txt
 
-				#RPi v2
-				elif (( $G_HW_MODEL == 2 )); then
+			#RPi v3 B+
+			elif [[ ${G_HW_MODEL_DESCRIPTION,,} == *'rpi 3 model b+'* ]]; then
 
-					sed -i '/over_voltage=/c\#over_voltage=0' /DietPi/config.txt
-					sed -i '/arm_freq=/c\#arm_freq=900' /DietPi/config.txt
-					sed -i '/core_freq=/c\#core_freq=250' /DietPi/config.txt
-					sed -i '/sdram_freq=/c\#sdram_freq=450' /DietPi/config.txt
+				sed -i '/over_voltage=/c\#over_voltage=0' /DietPi/config.txt
+				sed -i '/core_freq=/c\#core_freq=400' /DietPi/config.txt
+				G_CONFIG_INJECT '/temp_limit=' 'temp_limit=75' /DietPi/config.txt # https://github.com/Fourdee/DietPi/issues/356
+				sed -i '/arm_freq=/c\#arm_freq=1400' /DietPi/config.txt
+				sed -i '/sdram_freq=/c\#sdram_freq=500' /DietPi/config.txt
 
-				#RPi v3
-				elif (( $G_HW_MODEL == 3 )); then
+			#RPi v3
+			elif (( $G_HW_MODEL == 3 )); then
 
-					sed -i '/over_voltage=/c\#over_voltage=0' /DietPi/config.txt
-					sed -i '/core_freq=/c\#core_freq=400' /DietPi/config.txt
-					sed -i "/temp_limit=/c\temp_limit=75" /DietPi/config.txt # https://github.com/Fourdee/DietPi/issues/356
-
-					local arm_freq=1200
-					local sdram_freq=450
-					if [[ ${G_HW_MODEL_DESCRIPTION,,} == *'rpi 3 model b+'* ]]; then
-
-						arm_freq=1400
-						sdram_freq=500
-
-					fi
-
-					sed -i "/arm_freq=/c\#arm_freq=$arm_freq" /DietPi/config.txt
-					sed -i "/sdram_freq=/c\#sdram_freq=$sdram_freq" /DietPi/config.txt
-
-				fi
+				sed -i '/over_voltage=/c\#over_voltage=0' /DietPi/config.txt
+				sed -i '/core_freq=/c\#core_freq=400' /DietPi/config.txt
+				G_CONFIG_INJECT '/temp_limit=' 'temp_limit=75' /DietPi/config.txt # https://github.com/Fourdee/DietPi/issues/356
+				sed -i '/arm_freq=/c\#arm_freq=1200' /DietPi/config.txt
+				sed -i '/sdram_freq=/c\#sdram_freq=450' /DietPi/config.txt
 
 			fi
 
@@ -133,7 +125,10 @@
 
 		fi
 
-		# - Apply forced eth speed if set in dietpi.txt
+		# - Apply RPi headless mode, if set in dietpi.txt
+		(( $G_HW_MODEL < 10 )) && /DietPi/dietpi/func/dietpi-set_hardware rpi-headless $(grep -ci -m1 '^[[:blank:]]*CONFIG_HDMI_OUTPUT=0' /DietPi/dietpi.txt)
+
+		# - Apply forced eth speed, if set in dietpi.txt
 		/DietPi/dietpi/func/dietpi-set_hardware eth-forcespeed $(grep -m1 '^[[:blank:]]*AUTO_SETUP_NET_ETH_FORCE_SPEED=' /DietPi/dietpi.txt | sed 's/^[^=]*=//' )
 
 		# - Set hostname
@@ -274,8 +269,8 @@
 	#First run prep
 	if (( $G_DIETPI_INSTALL_STAGE == -1 )); then
 
-		# - Set RPi v1 safe overclocking profile (900mhz)
-		RPi_Set_Clock_Speeds
+		# - Set RPi v1 safe overclocking profile (900MHz) and apply commented defaults based on RPi model
+		(( $G_HW_MODEL < 10 )) && RPi_Set_Clock_Speeds
 
 		# - End user automated script
 		if [[ -f /boot/Automation_Custom_PreScript.sh ]]; then


### PR DESCRIPTION
**Status**: Testing

**Reference**: https://github.com/Fourdee/DietPi/pull/2402#issuecomment-453088049

**Commit list/description**:
+ DietPi-Set_Hardware | Add RPi headless mode option, outsourced from dietpi-config
+ DietPi-Set_Hardware | Add more exit paths, if input args are not supported by current device
+ DietPi-Set_Hardware | Minor coding
+ DietPi-Config | Use new DietPi-Set_Hardware rpi-headless option to apply headless video mode
+ DietPi-PreBoot | Apply RPi headless mode on 1st run setup, if chosen
+ DietPi-Patch | Use new DietPi-Set_Hardware rpi-headless option to apply headless mode, if set