### PR TITLE
DietPi-Config | Firmware update fine tuning

### DIFF
--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -1402,13 +1402,8 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 				local old_firmware=$(ls /lib/modules/)
 
-				#RPi
-				if (( $G_HW_MODEL < 10 )); then
-
-					G_WHIP_MSG '[INFO] RPi Kernel updates are applied via APT.\n\nThis will be completed automatically during software installations and DietPi-Updates.'
-
 				#PineA64
-				elif (( $G_HW_MODEL == 40 )); then
+				if (( $G_HW_MODEL == 40 )); then
 
 					if G_WHIP_YESNO "Would you like to update the firmware/kernel for $G_HW_MODEL_DESCRIPTION?
  - This will run longsleep's update scripts to update the U-Boot and kernel."; then

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -1961,45 +1961,44 @@ _EOF_
 			#	i-sabre-k2m
 			i-sabre-k2m)
 
-				if [[ ! -f '/var/lib/dietpi/.compiled_i-sabre-k2m' ]]; then
+				# - Sourcebuild, update kernel packages and install headers
+				local old_firmware=$(ls /lib/modules/)
+				local rpi_firmware='raspberrypi-bootloader raspberrypi-kernel libraspberrypi-bin libraspberrypi0'
+				G_AGUP
+				apt-mark unhold $rpi_firmware # Should be not required, since we did that on v6.20 patch, but better be failsafe
+				G_AGI $rpi_firmware raspberrypi-kernel-headers
 
-					# - Sourcebuild, update kernel packages and install headers
-					local old_firmware=$(ls /lib/modules/)
-					local rpi_firmware='raspberrypi-bootloader raspberrypi-kernel libraspberrypi-bin libraspberrypi0'
-					G_AGUP
-					apt-mark unhold $rpi_firmware
-					G_AGI $rpi_firmware raspberrypi-kernel-headers
+				if [[ $old_firmware != $(ls /lib/modules/) ]]; then
 
-					if [[ $old_firmware != $(ls /lib/modules/) ]]; then
-
-						G_CONFIG_INJECT 'CONFIG_SOUNDCARD=' 'CONFIG_SOUNDCARD=none' /DietPi/dietpi.txt
-						G_WHIP_MSG "Stage 1 completed (ni-sabre-k2m_build):\n\nThe device will now reboot.\n\nOnce rebooted, please run dietpi-config > Audio Options again. Reselect the soundcard (i-sabre-k2m) to complete installation."
-						reboot
-
-					fi
-
-					mkdir -p i-sabre-k2m_build
-					cd i-sabre-k2m_build
-					install_url_address='https://dietpi.com/downloads/sourcebuild/I-Sabre-K2M.7z'
-					G_CHECK_URL "$install_url_address"
-					wget "$install_url_address" -O package.7z
-					7z x -y package.7z
-					rm package.7z
-
-					G_RUN_CMD make
-					G_RUN_CMD make modules_install
-					G_RUN_CMD make dtbs
-					G_RUN_CMD make install_dtbo
-
-					cd /tmp/$G_PROGRAM_NAME
-					rm -R i-sabre-k2m_build
-
-					> /var/lib/dietpi/.compiled_i-sabre-k2m
+					G_CONFIG_INJECT 'CONFIG_SOUNDCARD=' 'CONFIG_SOUNDCARD=none' /DietPi/dietpi.txt
+					G_WHIP_MSG '[  OK  ] Stage 1 completed: Kernel upgraded\n\nThe device will now reboot.\n
+Once rebooted, please rerun dietpi-config > Audio Options. Re-select the sound card (i-sabre-k2m) to complete installation.'
+					reboot
 
 				fi
 
+				mkdir -p i-sabre-k2m_build
+				cd i-sabre-k2m_build
+				install_url_address='https://dietpi.com/downloads/sourcebuild/I-Sabre-K2M.7z'
+				G_CHECK_URL "$install_url_address"
+				wget "$install_url_address" -O package.7z
+				7z x -y package.7z
+				rm package.7z
+
+				G_RUN_CMD make
+				G_RUN_CMD make modules_install
+				G_RUN_CMD make dtbs
+				G_RUN_CMD make install_dtbo
+
+				cd /tmp/$G_PROGRAM_NAME
+				rm -R i-sabre-k2m_build
+
 				# - enable dtoverlay
+				dtoverlay $INPUT_DEVICE_VALUE
 				echo "dtoverlay=$INPUT_DEVICE_VALUE" >> $FP_RPI_CONFIG
+
+				G_WHIP_MSG '[  OK  ] i-sabre-k2m module successfully installed\n
+NB: The module must be rebuilt each time the kernel is upgraded. For this, simply re-select the sound card via dietpi-config > Audio Options.'
 
 			;;
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1547,8 +1547,10 @@ Also have a look at "Sonarr", another alternative TV show manager, available for
 
 			fi
 			#-------------------------------------------------------------------------------
-			#Remove obsolete rpi-update flag: https://github.com/Fourdee/DietPi/pull/2398#issuecomment-452398770
+			#Remove obsolete flags: https://github.com/Fourdee/DietPi/pull/2398#issuecomment-452398770
 			[[ -f /var/lib/dietpi/.G_RPI_UPDATE ]] && rm /var/lib/dietpi/.G_RPI_UPDATE
+			#https://github.com/Fourdee/DietPi/pull/2407/commits/5b7ad8bddc9dd5ffe89a2614615eb936333c8d41
+			[[ -f /var/lib/dietpi/.compiled_i-sabre-k2m ]] && rm /var/lib/dietpi/.compiled_i-sabre-k2m
 			#-------------------------------------------------------------------------------
 			#RPi changes: https://github.com/Fourdee/DietPi/pull/2402
 			if (( $G_HW_MODEL < 10 )); then

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1424,11 +1424,11 @@ You will not face any practical differences, since both services start the same 
 
 			#-------------------------------------------------------------------------------
 			#rpi-update drop support info
-			if [[ $(which rpi-update) ]] && G_WHIP_YESNO '[INFO] RPi-Update:\n\nIn our effort to improve system stability, and, offer software installations which build custom modules (eg: Wireguard), we can not longer support systems with non-stock-APT kernel installed (eg: rpi-update).\n\nWould you like to revert to the APT kernel now, ensuring stability and official DietPi system support?'; then
+			if [[ $(which rpi-update) ]] && G_WHIP_YESNO '[INFO] RPi-Update detected\n\nIn our effort to improve system stability, and, offer software installations which build custom modules (eg: WireGuard), we can no longer support systems with non-stock-APT kernel installed (eg: rpi-update).\n\nWould you like to revert to the APT kernel now, ensuring stability and official DietPi system support?'; then
 
 				local rpi_firmware='raspberrypi-bootloader raspberrypi-kernel libraspberrypi-bin libraspberrypi0'
 				G_AGP rpi-update
-				G_AGUP
+				which rpi-source &> /dev/null && rm $(which rpi-source)
 				apt-mark unhold $rpi_firmware
 				G_AGI --reinstall $rpi_firmware
 


### PR DESCRIPTION
**Status**: WIP

@Fourdee 
- Btw good think to remove `rpi-update` completely from support. ~I think we should also allow to purge it on update automatically.~ Ah already the case 👍
- Can't we use APT based kernel update for RockA64 as well via `linux-rock64`, or is something missing there?
- Same for RockPro64 with `linux-rockpro64`, does this include all firmware or do we need to use the script that we currently run on RockA64 a well?

**Reference**: https://github.com/Fourdee/DietPi/pull/2398#issuecomment-453648294

**Commit list/description**:
+ DietPi-Config | Allow firmware update via G_AGDUG for RPi as well, so user is not forced to run dietpi-update/software or APT upgrade manually; Otherwise menu option should be hidden on RPi.
+ DietPi-Patch | RPi-Update: Do no call G_AGUP again within patch, since it was already called on update start
+ DietPi-Patch | RPi-Update: Remove rpi-source as well, if found
+ DietPi-Set_Hardware | i-sabre-k2m: Rebuild the kernel module each time, the sound card is selected, in case the kernel got upgraded and inform user about this requirement
+ DietPi-Patch | Remove obsolete .compiled_i-sabre-k2m flag as well