### PR TITLE
DietPi-Software | NoMachine: Update to v6.4.6 and enable for ARMv8

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,7 @@ Changes / Improvements / Optimisations:
 - DietPi-Software | Samba: Moved disk cache to RAM to reduce disk I/O. Thanks to @WolfganP for suggesting this enhancement: https://github.com/Fourdee/DietPi/issues/2396
 - DietPi-Software | Kodi RPi: Default GPU memory split is now 320MB for 1GB devices. This should improve overall performance and stability: https://github.com/Fourdee/DietPi/issues/2365
 - DietPi-Software | You will now recieve a whiptail prompt, if config files are overwritten during software installations: https://github.com/Fourdee/DietPi/issues/2325
+- DietPi-Software | NoMachine: Enabled ARMv8 support and will now install current version 6.4.6: https://github.com/Fourdee/DietPi/pull/2408
 - DietPi-Update | Added optional ability to automatically update DietPi, when updates are available. Please note, this is disabled by default.
 - DietPi-Sync | Removed the compression option, which has no effect on local sync, since files are not stored compressed, but only transferred compressed through remote sync protocols, which are currently not offered by DietPi-Sync.
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -519,10 +519,7 @@ _EOF_
 			aSOFTWARE_CATEGORY_INDEX[$software_id]=1
 					  aSOFTWARE_TYPE[$software_id]=0
 		  aSOFTWARE_REQUIRES_DESKTOP[$software_id]=1
-			 aSOFTWARE_ONLINEDOC_URL[$software_id]='f=8&t=5&start=60#p2071'
-
-		# - ARMv8
-		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,3]=0
+			 aSOFTWARE_ONLINEDOC_URL[$software_id]='p=2071#p2071'
 
 		#------------------
 		software_id=120
@@ -3330,26 +3327,7 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-
-			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/nomachine_6.1.6_'
-			#x86_64
-			if (( $G_HW_ARCH == 10 )); then
-
-				INSTALL_URL_ADDRESS+='9_amd64.deb'
-
-			#arm6 (RPi1)
-			elif (( $G_HW_ARCH == 1 )); then
-
-				INSTALL_URL_ADDRESS+='4_armv6hf.deb'
-
-			#arm7+ (RPi 2/3)
-			elif (( $G_HW_ARCH == 2 )); then
-
-				INSTALL_URL_ADDRESS+='4_armhf.deb'
-
-			fi
-
-			Download_Install "$INSTALL_URL_ADDRESS"
+			Download_Install "https://dietpi.com/downloads/binaries/all/nomachine_6.4.6_$G_HW_ARCH_DESCRIPTION.deb"
 
 		fi
 


### PR DESCRIPTION
**Status**: Ready
- [x] Changelog
- [x] Update software list: https://github.com/Fourdee/DietPi/wiki/DietPi-Software-list

**Testing**:
- [x] Stretch VM
- [x] Jessie VM
- [x] Buster VM
- [x] ARMv8 test

**Commit list/description**:
+ DietPi-Software | NoMachine: Update installs to v6.4.6; Enable ARMv8 support, testing required!