### PR TITLE
DietPi-Software | Airsonic: Update installer to latest version

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,6 +28,7 @@ Changes / Improvements / Optimisations:
 - DietPi-Software | MPD: Now runs as "mpd" user again, updated systemd unit to match official one and better handle existing cache and log files on reinstall: https://github.com/Fourdee/DietPi/issues/2378
 - DietPi-Software | Samba: Moved disk cache to RAM to reduce disk I/O. Thanks to @WolfganP for suggesting this enhancement: https://github.com/Fourdee/DietPi/issues/2396
 - DietPi-Software | Kodi RPi: Default GPU memory split is now 320MB for 1GB devices. This should improve overall performance and stability: https://github.com/Fourdee/DietPi/issues/2365
+- DietPi-Software | Airsonic: Now installs the latest upstream version automatically: https://github.com/Fourdee/DietPi/pull/2410
 - DietPi-Software | You will now recieve a whiptail prompt, if config files are overwritten during software installations: https://github.com/Fourdee/DietPi/issues/2325
 - DietPi-Update | Added optional ability to automatically update DietPi, when updates are available. Please note, this is disabled by default.
 - DietPi-Sync | Removed the compression option, which has no effect on local sync, since files are not stored compressed, but only transferred compressed through remote sync protocols, which are currently not offered by DietPi-Sync.

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4338,8 +4338,7 @@ _EOF_
 
 		fi
 
-		#PIHOLE
-		software_id=93
+		software_id=93 # Pi-hole
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -6859,7 +6858,7 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 
 		fi
 
-		software_id=8
+		software_id=8 # Java
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -6868,19 +6867,16 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 			if (( $G_DISTRO == 3 )); then
 
 				cat << _EOF_ > /etc/apt/preferences.d/99-dietpi-openjdk-8-jdk
-Package: openjdk-8-jdk
+Package: ca-certificates-java java-common openjdk-8-*
 Pin: release a=jessie-backports
 Pin-Priority: 990
 _EOF_
 
-				G_AGI openjdk-8-jdk -t jessie-backports
+				G_AGI openjdk-8-jre-headless openjdk-8-jdk-headless -t jessie-backports
 
 			else
 
-				# - Workaround to allow install: https://github.com/Fourdee/DietPi/issues/1340#issuecomment-389902031
-				local packages='ca-certificates-java openjdk-8-jre-headless openjdk-8-jdk-headless'
-				apt-get install -y -qq $packages
-				G_AGI $packages
+				G_AGI openjdk-8-jre-headless openjdk-8-jdk-headless
 
 			fi
 
@@ -9323,7 +9319,7 @@ ExecStart=$(which java) -Xmx$airsonic_memory_max -Dairsonic.home=$G_FP_DIETPI_US
 WantedBy=multi-user.target
 _EOF_
 
-			#Symlink ffmpeg to subsonic transcoder
+			#Symlink FFmpeg to Airsonic transcoder
 			ln -sf $(which ffmpeg) $G_FP_DIETPI_USERDATA/airsonic/transcode
 
 			#Grab our test media for user
@@ -9346,14 +9342,14 @@ _EOF_
 
 			cat << _EOF_ > /etc/default/subsonic
 SUBSONIC_USER=root
-SUBSONIC_ARGS="--quiet --pidfile=/run/subsonic.pid --max-memory=$subsonic_memory_max --default-music-folder=$G_FP_DIETPI_USERDATA/$FOLDER_MUSIC --default-podcast-folder=$G_FP_DIETPI_USERDATA/$FOLDER_MUSIC --default-playlist-folder=$G_FP_DIETPI_USERDATA/$FOLDER_MUSIC"
+SUBSONIC_ARGS='--quiet --pidfile=/run/subsonic.pid --max-memory=$subsonic_memory_max --default-music-folder=$G_FP_DIETPI_USERDATA/$FOLDER_MUSIC --default-podcast-folder=$G_FP_DIETPI_USERDATA/$FOLDER_MUSIC --default-playlist-folder=$G_FP_DIETPI_USERDATA/$FOLDER_MUSIC'
 _EOF_
+
+			#Symlink FFmpeg to Subsonic transcoder
+			ln -fs $(which ffmpeg) /var/subsonic/transcode
 
 			#Grab our test media for user
 			Download_Test_Media
-
-			#Symlink ffmpeg to subsonic transcoder
-			ln -fs $(which ffmpeg) /var/subsonic/transcode
 
 		fi
 
@@ -14651,8 +14647,8 @@ _EOF_
 
 			Banner_Uninstalling
 
-			apt-mark auto $(dpkg --get-selections default-jre* default-jdk* openjdk-8-jre* openjdk-8-jdk* | awk '{print $1}') ca-certificates-java
-			rm /etc/apt/preferences.d/99-dietpi-openjdk-8-jdk &> /dev/null
+			apt-mark auto $(dpkg --get-selections default-jre* default-jdk* openjdk-* | awk '{print $1}') ca-certificates-java
+			[[ -f /etc/apt/preferences.d/99-dietpi-openjdk-8-jdk ]] && rm /etc/apt/preferences.d/99-dietpi-openjdk-8-jdk
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4375,7 +4375,8 @@ _EOF_
 			G_CHECK_URL "$INSTALL_URL_ADDRESS" #full filepath below, returns --spider error :(
 			INSTALL_URL_ADDRESS=$(curl -s "$INSTALL_URL_ADDRESS" | grep -m1 'browser_download_url.*\.war"' | cut -d \" -f 4)
 
-			no_check_url=1 Download_Install "$INSTALL_URL_ADDRESS" $G_FP_DIETPI_USERDATA/airsonic
+			mkdir -p $G_FP_DIETPI_USERDATA/airsonic
+			wget "$INSTALL_URL_ADDRESS" -O $G_FP_DIETPI_USERDATA/airsonic
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4376,7 +4376,7 @@ _EOF_
 			INSTALL_URL_ADDRESS=$(curl -s "$INSTALL_URL_ADDRESS" | grep -m1 'browser_download_url.*\.war"' | cut -d \" -f 4)
 
 			mkdir -p $G_FP_DIETPI_USERDATA/airsonic
-			wget "$INSTALL_URL_ADDRESS" -O $G_FP_DIETPI_USERDATA/airsonic
+			wget "$INSTALL_URL_ADDRESS" -O $G_FP_DIETPI_USERDATA/airsonic/airsonic.war
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -605,26 +605,26 @@ _EOF_
 		#------------------
 		software_id=33
 
-				 aSOFTWARE_WHIP_NAME[$software_id]='AirSonic'
+				 aSOFTWARE_WHIP_NAME[$software_id]='Airsonic'
 				 aSOFTWARE_WHIP_DESC[$software_id]='web interface media streaming server'
 			aSOFTWARE_CATEGORY_INDEX[$software_id]=2
 					  aSOFTWARE_TYPE[$software_id]=0
 			 aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 	   aSOFTWARE_REQUIRES_JAVA_JRE_JDK[$software_id]=1
 		   aSOFTWARE_REQUIRES_FFMPEG[$software_id]=1
-			 aSOFTWARE_ONLINEDOC_URL[$software_id]='f=8&t=5&p=11280#p11280'
+			 aSOFTWARE_ONLINEDOC_URL[$software_id]='p=11280#p11280'
 
 		#------------------
 		software_id=34
 
-				 aSOFTWARE_WHIP_NAME[$software_id]='SubSonic 6'
+				 aSOFTWARE_WHIP_NAME[$software_id]='Subsonic'
 				 aSOFTWARE_WHIP_DESC[$software_id]='web interface media streaming server'
 			aSOFTWARE_CATEGORY_INDEX[$software_id]=2
 					  aSOFTWARE_TYPE[$software_id]=0
 			 aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		   aSOFTWARE_REQUIRES_FFMPEG[$software_id]=1
 	   aSOFTWARE_REQUIRES_JAVA_JRE_JDK[$software_id]=1
-			 aSOFTWARE_ONLINEDOC_URL[$software_id]='f=8&t=5&start=30#p213'
+			 aSOFTWARE_ONLINEDOC_URL[$software_id]='p=213#p213'
 
 		#------------------
 		software_id=35
@@ -4132,17 +4132,17 @@ _EOF_
 			#x32 x64
 			if (( $G_HW_MODEL == 20 || $G_HW_MODEL == 21 )); then
 
-				INSTALL_URL_ADDRESS="https://dietpi.com/downloads/binaries/all/noip_x32_x64.zip"
+				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/noip_x32_x64.zip'
 
 			#ARMv8
 			elif (( ( $G_HW_MODEL == 12 ) || ( $G_HW_MODEL >= 40 && $G_HW_MODEL < 50 ) )); then
 
-				INSTALL_URL_ADDRESS="https://dietpi.com/downloads/binaries/all/noip_arm64.zip"
+				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/noip_arm64.zip'
 
 			#armv6+
 			else
 
-				INSTALL_URL_ADDRESS="https://dietpi.com/downloads/binaries/all/noip_armhf.zip"
+				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/noip_armhf.zip'
 
 			fi
 
@@ -4366,17 +4366,20 @@ _EOF_
 
 		fi
 
-		#AirSonic
-		software_id=33
+		software_id=33 # Airsonic
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-			Download_Install 'https://dietpi.com/downloads/binaries/all/airsonic.7z' $G_FP_DIETPI_USERDATA/airsonic
+
+			INSTALL_URL_ADDRESS='https://api.github.com/repos/airsonic/airsonic/releases/latest'
+			G_CHECK_URL "$INSTALL_URL_ADDRESS" #full filepath below, returns --spider error :(
+			INSTALL_URL_ADDRESS=$(curl -s "$INSTALL_URL_ADDRESS" | grep -m1 'browser_download_url.*\.war"' | cut -d \" -f 4)
+
+			no_check_url=1 Download_Install "$INSTALL_URL_ADDRESS" $G_FP_DIETPI_USERDATA/airsonic
 
 		fi
 
-		#SUBSONIC 6
-		software_id=34
+		software_id=34 # Subsonic
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -4396,11 +4399,7 @@ _EOF_
 		fi
 
 		#WEBIOPI requires RPIGPIO
-		if (( ${aSOFTWARE_INSTALL_STATE[71]} == 1 )); then
-
-			aSOFTWARE_INSTALL_STATE[69]=1
-
-		fi
+		(( ${aSOFTWARE_INSTALL_STATE[71]} == 1 )) && aSOFTWARE_INSTALL_STATE[69]=1
 
 		#RPIGPIO
 		software_id=69
@@ -4464,11 +4463,7 @@ _EOF_
 
 			local package_list='python python3'
 			# - RPi, pre-reqs GPIO control for Node-Red
-			if (( $G_HW_MODEL < 10 )); then
-
-				package_list+=' python-rpi.gpio'
-
-			fi
+			(( $G_HW_MODEL < 10 )) && package_list+=' python-rpi.gpio'
 			G_AGI $package_list
 
 			# - Serialport fails to build unless below flags are provided
@@ -4494,7 +4489,7 @@ _EOF_
 			INSTALL_URL_ADDRESS='https://api.github.com/repos/blynkkk/blynk-server/releases/latest'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
-			INSTALL_URL_ADDRESS="$(curl -s $INSTALL_URL_ADDRESS | grep -m1 'browser_download_url' | cut -d \" -f 4)"
+			INSTALL_URL_ADDRESS=$(curl -s "$INSTALL_URL_ADDRESS" | grep -m1 'browser_download_url' | cut -d \" -f 4)
 			mkdir -p $G_FP_DIETPI_USERDATA/blynk/data
 			G_THREAD_START wget "$INSTALL_URL_ADDRESS" -O $G_FP_DIETPI_USERDATA/blynk/blynkserver.jar
 
@@ -4618,11 +4613,7 @@ _EOF_
 
 			#LCD panels can be enabled in Dietpi-config > display options
 			#	XU4 enable cloudshell
-			if (( $G_HW_MODEL == 11 )); then
-
-				/DietPi/dietpi/func/dietpi-set_hardware lcdpanel odroid-cloudshell
-
-			fi
+			(( $G_HW_MODEL == 11 )) && /DietPi/dietpi/func/dietpi-set_hardware lcdpanel odroid-cloudshell
 
 		fi
 
@@ -5935,7 +5926,7 @@ _EOF_
 
 			INSTALL_URL_ADDRESS='https://api.github.com/repos/Radarr/Radarr/releases'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS" #full filepath below, returns --spider error :(
-			INSTALL_URL_ADDRESS="$(curl -s $INSTALL_URL_ADDRESS | grep -m1 'browser_download_url.*linux.tar.gz' | cut -d \" -f 4)"
+			INSTALL_URL_ADDRESS=$(curl -s "$INSTALL_URL_ADDRESS" | grep -m1 'browser_download_url.*linux.tar.gz' | cut -d \" -f 4)
 
 			DEPS_LIST='mediainfo'
 			no_check_url=1 Download_Install "$INSTALL_URL_ADDRESS" /opt
@@ -5950,7 +5941,7 @@ _EOF_
 
 			INSTALL_URL_ADDRESS='https://api.github.com/repos/Lidarr/Lidarr/releases'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-			INSTALL_URL_ADDRESS="$(curl -s $INSTALL_URL_ADDRESS | grep -m1 'browser_download_url.*linux.tar.gz' | cut -d \" -f 4)"
+			INSTALL_URL_ADDRESS=$(curl -s "$INSTALL_URL_ADDRESS" | grep -m1 'browser_download_url.*linux.tar.gz' | cut -d \" -f 4)
 
 			DEPS_LIST='mediainfo'
 			no_check_url=1 Download_Install "$INSTALL_URL_ADDRESS" /opt
@@ -5991,7 +5982,7 @@ _EOF_
 
 			INSTALL_URL_ADDRESS='https://api.github.com/repos/Jackett/Jackett/releases'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS" #full filepath below, returns --spider error :(
-			INSTALL_URL_ADDRESS="$(curl -s $INSTALL_URL_ADDRESS | grep -m1 'browser_download_url.*Jackett.Binaries.Mono.tar.gz' | cut -d \" -f 4)"
+			INSTALL_URL_ADDRESS=$(curl -s "$INSTALL_URL_ADDRESS" | grep -m1 'browser_download_url.*Jackett.Binaries.Mono.tar.gz' | cut -d \" -f 4)
 
 			no_check_url=1 Download_Install "$INSTALL_URL_ADDRESS" /opt
 
@@ -9301,21 +9292,18 @@ Do you want to enable the Pi-hole blocking page?'; then
 
 		fi
 
-		#AirSonic
-		software_id=33
+		software_id=33 # Airsonic
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
 
-			useradd -rM airsonic -G dietpi,audio -s /usr/sbin/nologin
+			local usercmd='useradd -rM'
+			getent passwd airsonic &> /dev/null && usercmd='usermod'
+			$usercmd airsonic -G dietpi,audio -d $G_FP_DIETPI_USERDATA/airsonic -s /usr/sbin/nologin
 
 			#Optimize memory limit
 			local airsonic_memory_max=$(( $RAM_TOTAL / 5 ))
-			if (( $airsonic_memory_max < 200 )); then
-
-				airsonic_memory_max='200'
-
-			fi
+			(( $airsonic_memory_max < 200 )) && airsonic_memory_max=200
 			airsonic_memory_max+='m'
 
 			cat << _EOF_ > /etc/systemd/system/airsonic.service
@@ -9326,6 +9314,7 @@ After=remote-fs.target network.target
 [Service]
 Type=simple
 User=airsonic
+Group=dietpi
 WorkingDirectory=$G_FP_DIETPI_USERDATA/airsonic
 ExecStart=$(which java) -Xmx$airsonic_memory_max -Dairsonic.home=$G_FP_DIETPI_USERDATA/airsonic -Dserver.context-path=/airsonic -Dserver.port=8080 -jar $G_FP_DIETPI_USERDATA/airsonic/airsonic.war
 
@@ -9334,15 +9323,14 @@ WantedBy=multi-user.target
 _EOF_
 
 			#Symlink ffmpeg to subsonic transcoder
-			ln -fs $(which ffmpeg) $G_FP_DIETPI_USERDATA/airsonic/transcode
+			ln -sf $(which ffmpeg) $G_FP_DIETPI_USERDATA/airsonic/transcode
 
 			#Grab our test media for user
 			Download_Test_Media
 
 		fi
 
-		#SUBSONIC 6
-		software_id=34
+		software_id=34 # Subsonic
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -13584,23 +13572,22 @@ _EOF_
 
 		fi
 
-		software_id=33
+		software_id=33 # Airsonic
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			rm -R $G_FP_DIETPI_USERDATA/airsonic
-			rm /etc/systemd/system/airsonic.service
-
-			userdel -rf airsonic
+			getent passwd airsonic &> /dev/null && userdel -rf airsonic
+			[[ -d $G_FP_DIETPI_USERDATA/airsonic ]] && rm -R $G_FP_DIETPI_USERDATA/airsonic
+			[[ -f /etc/systemd/system/airsonic.service ]] && rm /etc/systemd/system/airsonic.service
 
 		fi
 
-		software_id=34
+		software_id=34 # Subsonic
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
 			G_AGP subsonic
-			rm -R /var/subsonic
+			[[ -d /var/subsonic ]] && rm -R /var/subsonic
 
 		fi
 
@@ -14979,7 +14966,7 @@ _EOF_
 			# - Custom 1st run Script (Online file)
 			elif [[ $AUTOINSTALL_CUSTOMSCRIPTURL != '0' ]]; then
 
-				INSTALL_URL_ADDRESS="$AUTOINSTALL_CUSTOMSCRIPTURL"
+				INSTALL_URL_ADDRESS=$AUTOINSTALL_CUSTOMSCRIPTURL
 				G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 				#Get script and execute


### PR DESCRIPTION
**Status**: Ready
- [x] Changelog
- [x] DietPi-Software list: https://github.com/Fourdee/DietPi/wiki/DietPi-Software-list

**Testing**:
- Everything with JRE only: https://github.com/Fourdee/DietPi/issues/2400#issuecomment-453847053
- [x] Stretch VM
- [x] Buster VM
- [x] Jessie VM

**Commit list/description**:
+ DietPi-Software | Airsonic: Install latest version via api.github.com
+ DietPi-Software | Airsonic: If user already exists, update via usermod instead of attempting useradd
+ DietPi-Software | Airsonic: Move airsonic user home dir to dietpi_userdata as well
+ DietPi-Software | Minor coding
+ DietPi-Software | Java: "ca-certificates-java" is now dependency of "openjdk-8-jre-headless" on all distro versions, so do not manually install
+ DietPi-Software | Java: "ca-certificates-java" dependencies now allow Java 8 only on all distro versions, Java 9+10 have been dropped mostly, so we don't require reinstall workaround anymore
+ DietPi-Software | Java: Install headless packages on Jessie as well
+ DietPi-Software | Java: Add all Java related packages to backports priority pin on Jessie, to allow automated APT upgrades for all of them