### PR TITLE
DietPi-Software | WireGuard: Install fine tuning

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ Changes / Improvements / Optimisations:
 - DietPi-Config | WiFi Hotspot: You can now toggle support for 802.11 N. Please note this is device and compatibility dependent, mileage may vary.
 - DietPi-Drive_Manager | Now allows to check & repair the boot file system and trigger it for root file system on next reboot: https://github.com/Fourdee/DietPi/issues/1740#issuecomment-388325204
 - DietPi-Software | DietPi-NordVPN: Now available for installation. Includes a GUI which allows for easy connection to a list of NordVPN servers 'dietpi-nordvpn'. If you need a NordVPN subscription, please use this link: https://go.nordvpn.net/aff_c?offer_id=15&aff_id=5305&url_id=902
+- DietPi-Software | WireGuard VPN is now available for installation. Is can be easily configured as client or as server, passing either all client traffic through the tunnel, local network access only, or server access only, e.g. as well in combination with Pi-hole, to have remote ad blocking.
 - DietPi-Software | SickRage has been replaced by Medusa, which is now available for install: https://github.com/Fourdee/DietPi/issues/2239
 - DietPi-Software | Blynk: Reinstalls now preserve existing config files; New directory structure and blynk user (v6.19) is patched now as well to existing installs: https://github.com/Fourdee/DietPi/pull/2324
 - DietPi-Software | Plex Media Server: Updated to v1.14.0 on x86 images, switch to HTTPS ARM repo and automated locale switch to en_US.UTF-8: https://github.com/Fourdee/DietPi/issues/2294

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10058,61 +10058,85 @@ _EOF_
 		software_id=172
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
-			# User inputs: Ask user for servers public IP/domain and desired WireGuard server port
-			local invalid_text=''
-			local domain=$(hostname)
-			while :
+			# Try to enable module, if it fails, a reboot is required
+			local module_active=0
+			modprobe wireguard 2> /dev/null && module_active=1
+
+			# Server/Client choice
+			G_WHIP_MENU_ARRAY=(
+
+				'Server' ': Use this machine as VPN server and allow clients to connect to it.'
+				'Client' ': Use this machine as VPN client, e.g. to connect to a VPN service provider.'
+
+			)
+
+			local choice_required=''
+			while:
 			do
 
-				G_WHIP_DEFAULT_ITEM="$domain"
-				G_WHIP_INPUTBOX "${invalid_text}Please enter your servers public IP/domain for WireGuard client access:"
-				if (( $? == 0 )) && [[ $G_WHIP_RETURNED_VALUE ]]; then
-
-					domain="${G_WHIP_RETURNED_VALUE#http*://}"
-					break
-
-				else
-
-					invalid_text='[ERROR] No valid entry found. Please retry...\n\n'
-
-				fi
+				G_WHIP_MENU "${choice_required}Please choose, if this machine should be set up as VPN server or client:" && break
+				choice_required='[ERROR] A choice is required to finish the WireGuard install.\n\n'
 
 			done
-			invalid_text=''
-			local port=51820
-			while :
-			do
 
-				G_WHIP_DEFAULT_ITEM=$port
-				G_WHIP_INPUTBOX "${invalid_text}Please enter the network port, that should be used to access your WireGuard server:\n
+			# Server choice
+			if [[ $G_WHIP_RETURNED_VALUE == 'Server' ]]; then
+
+				# - Public IP/domain and desired WireGuard server port
+				local invalid_text=''
+				local domain=$(hostname)
+				while :
+				do
+
+					G_WHIP_DEFAULT_ITEM="$domain"
+					G_WHIP_INPUTBOX "${invalid_text}Please enter your servers public IP/domain for WireGuard client access:"
+					if (( $? == 0 )) && [[ $G_WHIP_RETURNED_VALUE ]]; then
+
+						domain="${G_WHIP_RETURNED_VALUE#http*://}"
+						break
+
+					else
+
+						invalid_text='[ERROR] No valid entry found. Please retry...\n\n'
+
+					fi
+
+				done
+				invalid_text=''
+				local port=51820
+				while :
+				do
+
+					G_WHIP_DEFAULT_ITEM=$port
+					G_WHIP_INPUTBOX "${invalid_text}Please enter the network port, that should be used to access your WireGuard server:\n
 NB: This port needs to be forwarded by your router and/or opened in your firewall settings. Default value is: 51820"
-				if (( $? == 0 )) && disable_error=1 G_CHECK_VALIDINT "$G_WHIP_RETURNED_VALUE" 0; then
+					if (( $? == 0 )) && disable_error=1 G_CHECK_VALIDINT "$G_WHIP_RETURNED_VALUE" 0; then
 
-					port=$G_WHIP_RETURNED_VALUE
-					break
+						port=$G_WHIP_RETURNED_VALUE
+						break
 
-				else
+					else
 
-					invalid_text='[ERROR] No valid entry found, value needs to be a sequence of integers. Please retry...\n\n'
+						invalid_text='[ERROR] No valid entry found, value needs to be a sequence of integers. Please retry...\n\n'
 
-				fi
+					fi
 
-			done
+				done
 
-			# Create everything inside WireGuard config dir
-			cd /etc/wireguard
+				# - Create everything inside WireGuard config dir
+				cd /etc/wireguard
 
-			# For securiy reasons set umask to 077
-			umask 077
+				# - For securiy reasons set umask to 077
+				umask 077
 
-			# Create server and client keys
-			[[ -f server_private.key ]] || wg genkey > server_private.key
-			[[ -f server_public.key ]] || wg pubkey < server_private.key > server_public.key
-			[[ -f client_private.key ]] || wg genkey > client_private.key
-			[[ -f client_public.key ]] || wg pubkey < client_private.key > client_public.key
+				# - Create server and client keys
+				[[ -f server_private.key ]] || wg genkey > server_private.key
+				[[ -f server_public.key ]] || wg pubkey < server_private.key > server_public.key
+				[[ -f client_private.key ]] || wg genkey > client_private.key
+				[[ -f client_public.key ]] || wg pubkey < client_private.key > client_public.key
 
-			# Server config
-			[[ -f wg0.conf ]] || cat << _EOF_ > wg0.conf
+				# - Server config
+				[[ -f wg0.conf ]] || cat << _EOF_ > wg0.conf
 [Interface]
 Address = 10.8.0.1/24
 PrivateKey = $(<server_private.key)
@@ -10126,11 +10150,11 @@ PublicKey = $(<client_public.key)
 AllowedIPs = 10.8.0.0/24
 _EOF_
 
-			# Server local network IP
-			local server_ip=$(sed -n 4p /DietPi/dietpi/.network)
+				# - Server local network IP
+				local server_ip=$(sed -n 4p /DietPi/dietpi/.network)
 
-			# Client config
-			[[ -f wg0-client.conf ]] || cat << _EOF_ > wg0-client.conf
+				# - Client config
+				[[ -f wg0-client.conf ]] || cat << _EOF_ > wg0-client.conf
 [Interface]
 # The address must be unique for each client, use "10.8.0.3/24" for the second client and so on.
 Address = 10.8.0.2/24
@@ -10153,27 +10177,43 @@ Endpoint = $domain:51820
 #PersistentKeepalive = 25
 _EOF_
 
-			# Try to enable module, if it fails, a reboot is required
-			local module_active=1
-			modprobe wireguard 2> /dev/null || { module_active=0; [[ $DISABLE_REBOOT == 1 ]] && G_WHIP_MSG '[[ INFO ]] WireGuard\n\nWireGuard has been successfully installed, but a reboot is required, before it can be started.'; }
+				# - Enable IPv4 + IPv6 forwarding
+				(( $module_active )) && sysctl net.ipv4.ip_forward=1 net.ipv6.conf.all.forwarding=1 net.ipv6.conf.default.forwarding=1
+				#	persistent
+				echo -e 'net.ipv4.ip_forward=1\nnet.ipv6.conf.all.forwarding=1\nnet.ipv6.conf.default.forwarding=1' > /etc/sysctl.d/dietpi-wireguard.conf
 
-			# Enable IPv4 + IPv6 forwarding
-			(( $module_active )) && sysctl net.ipv4.ip_forward=1 net.ipv6.conf.all.forwarding=1 net.ipv6.conf.default.forwarding=1
-			# - persistent
-			echo -e 'net.ipv4.ip_forward=1\nnet.ipv6.conf.all.forwarding=1\nnet.ipv6.conf.default.forwarding=1' > /etc/sysctl.d/dietpi-wireguard.conf
+				# - Start WireGuard interface via systemd unit
+				(( $module_active )) && systemctl start wg-quick@wg0
+				#	persistent
+				systemctl enable wg-quick@wg0
 
-			# Start WireGuard interface via systemd unit
-			(( $module_active )) && systemctl start wg-quick@wg0
-			# - persistent
-			systemctl enable wg-quick@wg0
+				# - Set umask back to default 022
+				umask 022
 
-			# Set umask back to default 022
-			umask 022
+				# - Navigate back to DietPi-Software working dir
+				cd /tmp/$G_PROGRAM_NAME
 
-			# Navigate back to DietPi-Software working dir
-			cd /tmp/$G_PROGRAM_NAME
+			# Client choice
+			elif [[ $G_WHIP_RETURNED_VALUE == 'Client' ]]; then
 
-			unset domain port invalid_text server_ip module_active
+				G_WHIP_MSG '[ INFO ] WireGuard client setup has been chosen\n
+Please follow the instructions of your VPN provider to configure WireGuard.\n
+If no WireGuard (auto)start is included, but you require it, please do the following:
+1. Check for the created config file/interface name:
+	ls -Al /etc/wireguard/
+   It has a ".conf" file ending, lets assume "wg0-client.conf".
+2. To start the VPN interface, run:
+	systemctl start wg0-client
+3. To autostart the VPN interface on boot, run:
+	systemctl enable wg0-client
+4. To disable autostart again, run:
+	systemctl disable wg0-client'
+
+			fi
+
+			(( $module_active )) || { [[ $DISABLE_REBOOT == 1 ]] && G_WHIP_MSG '[[ INFO ]] WireGuard install finished\n\nNB: WireGuard has been successfully installed, but a reboot is required, before it can be started.'; }
+
+			unset module_active choice_required domain port invalid_text server_ip
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10071,7 +10071,7 @@ _EOF_
 			)
 
 			local choice_required=''
-			while:
+			while :
 			do
 
 				G_WHIP_MENU "${choice_required}Please choose, if this machine should be set up as VPN server or client:" && break

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4921,10 +4921,7 @@ _EOF_
 
 			Banner_Installing
 
-			local kernel_version_active=$(ls /lib/modules/)
-
 			# Kernel headers and matching kernel image required for wireguard-dkms to build the wireguard kernel module
-			# - Since G_AGUG does not upgrade packages with changed dependencies, in case of kernel image meta packages, those need to be installed via G_AGI.
 			local kernel_packages=''
 			# - x86_64
 			if (( $G_HW_ARCH == 10 )); then
@@ -4951,14 +4948,18 @@ _EOF_
 
 				kernel_packages='linux-image-arm64-odroid-c2 linux-headers-arm64-odroid-c2'
 
-			#	Odroid N1
+			# - Odroid N1
 			elif (( $G_HW_MODEL == 14 )); then
 
 				kernel_packages='linux-image-arm64-odroid-n1 linux-headers-arm64-odroid-n1'
 
 			fi
 
-			G_RUN_CMD apt-mark unhold $kernel_packages
+			# Odroids need to purge before we install, else, does not update to latest version...
+			(( $G_HW_MODEL >= 10 && $G_HW_MODEL < 20 )) && G_AGP $kernel_packages
+
+			# Since G_AGUG does not upgrade packages with changed dependencies, in case of kernel image meta packages, those need to be installed via G_AGI.
+			G_AGI $kernel_packages # apt-get install overrides hold state
 
 			# Add Debian "sid" repo, which contains the wireguard packages
 			echo 'deb https://deb.debian.org/debian/ sid main' > /etc/apt/sources.list.d/dietpi-wireguard.list
@@ -4966,29 +4967,18 @@ _EOF_
 			echo -e 'Package: *\nPin: release n=sid\nPin-Priority: 99' > /etc/apt/preferences.d/dietpi-wireguard
 			G_AGUP
 
-			# - Odroids need to purge before we install, else, does not update to latest version...
-			(( $G_HW_MODEL >= 10 && $G_HW_MODEL < 20 )) && G_AGP $kernel_packages
+			# Check for existing WireGuard install
+			local existing_install=0
+			dpkg-query -s wireguard-dkms &> /dev/null && existing_install=1
 
-			G_AGI $kernel_packages
+			# iptables required to forward incoming VPN traffic to internet interface
+			# qrencode required to print client config QR code to console
+			G_AGI wireguard iptables qrencode
 
-			if [[ $kernel_version_active != $(ls /lib/modules/) ]]; then
+			# If no fresh install, reconfigure to rebuild WireGuard kernel module against current kernel headers
+			(( $existing_install )) && G_RUN_CMD dpkg-reconfigure wireguard-dkms
 
-				G_WHIP_MSG '[INFO] Wireguard:\n\nKernel update detected, a reboot is required before Wireguard module can be built with latest kernel.\n\nOnce the system has rebooted, please reselect "Wireguard" for installation in "DietPi-Software" to continue.'
-				aSOFTWARE_INSTALL_STATE[$software_id]=0
-
-			else
-
-				# iptables required to forward incoming VPN traffic to internet interface
-				# qrencode required to create client config QR code on console
-				# reinstall to rebuild kernel modules via wireguard-dkms, failsafe.
-				G_AGI --reinstall wireguard wireguard-dkms iptables qrencode
-
-				# Enable the kernel module | exit on failure
-				G_RUN_CMD modprobe wireguard
-
-			fi
-
-			unset kernel_packages
+			unset kernel_packages existing_install
 
 		fi
 
@@ -10096,7 +10086,7 @@ _EOF_
 				G_WHIP_DEFAULT_ITEM=$port
 				G_WHIP_INPUTBOX "${invalid_text}Please enter the network port, that should be used to access your WireGuard server:\n
 NB: This port needs to be forwarded by your router and/or opened in your firewall settings. Default value is: 51820"
-				if (( $? == 0 )) && disable_error=1 G_CHECK_VALIDINT "$G_WHIP_RETURNED_VALUE"; then
+				if (( $? == 0 )) && disable_error=1 G_CHECK_VALIDINT "$G_WHIP_RETURNED_VALUE" 0; then
 
 					port=$G_WHIP_RETURNED_VALUE
 					break
@@ -10116,13 +10106,13 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 			umask 077
 
 			# Create server and client keys
-			wg genkey > server_private.key
-			wg pubkey < server_private.key > server_public.key
-			wg genkey > client_private.key
-			wg pubkey < client_private.key > client_public.key
+			[[ -f server_private.key ]] || wg genkey > server_private.key
+			[[ -f server_public.key ]] || wg pubkey < server_private.key > server_public.key
+			[[ -f client_private.key ]] || wg genkey > client_private.key
+			[[ -f client_public.key ]] || wg pubkey < client_private.key > client_public.key
 
 			# Server config
-			cat << _EOF_ > wg0.conf
+			[[ -f wg0.conf ]] || cat << _EOF_ > wg0.conf
 [Interface]
 Address = 10.8.0.1/24
 PrivateKey = $(<server_private.key)
@@ -10136,31 +10126,44 @@ PublicKey = $(<client_public.key)
 AllowedIPs = 10.8.0.0/24
 _EOF_
 
+			# Server local network IP
+			local server_ip=$(sed -n 4p /DietPi/dietpi/.network)
+
 			# Client config
-			cat << _EOF_ > wg0-client.conf
+			[[ -f wg0-client.conf ]] || cat << _EOF_ > wg0-client.conf
 [Interface]
+# The address must be unique for each client, use "10.8.0.3/24" for the second client and so on.
 Address = 10.8.0.2/24
 PrivateKey = $(<client_private.key)
+# Comment the following to preserve the clients default DNS server, or force a desired one.
 DNS = $(awk '/nameserver/ {print $2;exit}' /etc/resolv.conf)
 
 [Peer]
 PublicKey = $(<server_public.key)
-AllowedIPs = 0.0.0.0/0
+# Tunnel all network traffic through the VPN:
+#	AllowedIPs = 0.0.0.0/0, ::/0
+# Tunnel access to server-side local network only:
+#	AllowedIPs = ${server_ip%.*}.0/24
+# Tunnel access to VPN server only:
+#	AllowedIPs = $server_ip/32
+AllowedIPs = 0.0.0.0/0, ::/0
 Endpoint = $domain:51820
 
 # Uncomment the following, if you're behind a NAT and want the connection to be kept alive.
 #PersistentKeepalive = 25
 _EOF_
 
-			unset domain port invalid_text
+			# Try to enable module, if it fails, a reboot is required
+			local module_active=1
+			modprobe wireguard 2> /dev/null || { module_active=0; [[ $DISABLE_REBOOT == 1 ]] && G_WHIP_MSG '[[ INFO ]] WireGuard\n\nWireGuard has been successfully installed, but a reboot is required, before it can be started.'; }
 
-			# Enable IPv4 forwarding
-			sysctl net.ipv4.ip_forward=1
+			# Enable IPv4 + IPv6 forwarding
+			(( $module_active )) && sysctl net.ipv4.ip_forward=1 net.ipv6.conf.all.forwarding=1 net.ipv6.conf.default.forwarding=1
 			# - persistent
-			echo 'net.ipv4.ip_forward=1' > /etc/sysctl.d/dietpi-wireguard.conf
+			echo -e 'net.ipv4.ip_forward=1\nnet.ipv6.conf.all.forwarding=1\nnet.ipv6.conf.default.forwarding=1' > /etc/sysctl.d/dietpi-wireguard.conf
 
 			# Start WireGuard interface via systemd unit
-			systemctl start wg-quick@wg0
+			(( $module_active )) && systemctl start wg-quick@wg0
 			# - persistent
 			systemctl enable wg-quick@wg0
 
@@ -10169,6 +10172,8 @@ _EOF_
 
 			# Navigate back to DietPi-Software working dir
 			cd /tmp/$G_PROGRAM_NAME
+
+			unset domain port invalid_text server_ip module_active
 
 		fi
 


### PR DESCRIPTION
**Status**: Ready
- [x] Changelog

**Testing**:
- [x] Jessie install
- [x] Jessie reinstall
- [x] Stretch install
- [x] Stretch reinstall
- [x] Buster install
- [x] Buster reinstall

Print QR code to console to scan with mobile client: `qrencode -t ansiutf8 < /etc/wireguard/wg0-client.conf`

**Commit list/description**:
+ DietPi-Software | WireGuard: Unmasking kernel packages is not required, since overridden by apt-get install. As well it fails and breaks install (G_RUN_CMD), if one package is not yet installed.
+ DietPi-Software | WireGuard: Do not force reboot after kernel updates, instead inform user via prompt, if no automated reboot is triggered.
+ DietPi-Software | WireGuard: Do not reinstall wireguard-dkms to rebuild the kernel module, instead use dpkg-reconfigure, and, only if it was no fresh install.
+ DietPi-Software | WireGuard: Estimate required reboot by checking modprobe exit code; Enable IP forwarding and start service for current session only, if WireGuard module has been successfully enabled
+ DietPi-Software | WireGuard: Do not overwrite any existing keys or configs
+ DietPi-Software | WireGuard: Enable IPv6 tunnel and forwarding
+ DietPi-Software | WireGuard: Add comments to default client config about how to tunnel local network or server access only, DNS server choice and multiple clients
+ DietPi-Software | WireGuard: Allow choice between server and client setup. In case of client setup, skip all config steps, instead inform user to follow VPN provider instructions. Add VPN (auto)start info as well, in case the VPN provider does not include it.
+ CHANGELOG | WireGuard VPN is now available for installation.