### PR TITLE
DietPi-Config/Set_Hardware | Headless mode fine tuning and coding

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -3,7 +3,7 @@
 # - Please ensure you edit from the DietPi-RAMdisk location: /DietPi/config.txt
 
 #-------Display---------
-# If you get no picture, set the following to "1" to apply most compatible HDMI settings
+# If you get no picture, set the following to "1" to apply most compatible HDMI settings.
 #hdmi_safe=1
 
 # Uncomment to adjust the HDMI signal strength if you have interferences, blanking, or no display.
@@ -14,7 +14,7 @@
 # Uncomment if HDMI display is not detected and composite is being outputted.
 #hdmi_force_hotplug=1
 
-# Set the following two settings to "1", to disable video output and framebuffer completely.
+# Set the following two settings to "1" to disable video output and framebuffer completely.
 # NB: This will lead to some error messages on boot, which can be safely ignored.
 #hdmi_ignore_hotplug=1
 #hdmi_ignore_composite=1
@@ -33,6 +33,11 @@
 
 # Uncomment to force an HDMI mode rather than DVI. This can make audio work in DMT (computer monitor) modes.
 #hdmi_drive=2
+
+# Set "hdmi_blanking=1" to allow the display going into standby after 10 minutes without input.
+# With default value "0", the display shows a blank screen instead, but will not go into standby.
+# NB: With "1" some applications (e.g. Kodi, OMXPlayer) cannot prevent display standby due to missing DPMS signal.
+#hdmi_blanking=1
 
 # Set to "1" if your display has a black border of unused pixels visible.
 disable_overscan=1
@@ -74,7 +79,8 @@ i2c_arm_baudrate=100000
 dtparam=spi=off
 
 #-------Serial/UART-----
-# NB: Enabled for 1st run only, if you want to keep this setting, please set CONFIG_SERIAL_CONSOLE_ENABLE=1 in /DietPi/dietpi.txt
+# NB: Enabled for 1st run only, if you want to keep this setting, please set CONFIG_SERIAL_CONSOLE_ENABLE=1 in /DietPi/dietpi.txt.
+# NB: "enable_uart=1" will forcefully set "core_freq=250" unless "force_turbo=1" is set as well.
 enable_uart=1
 
 #-------Overclock-------

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -780,9 +780,9 @@
 			)
 
 			G_WHIP_DEFAULT_ITEM=$current
-			if G_WHIP_MENU 'Please select a display resolution. Current: $current
+			if G_WHIP_MENU "Please select a display resolution. Current: $current
 \nNB: This only affects the virtual screen resolution, not the SSH session.
-	You might need to increase the maximum guest screen resolution within your VM software.'; then
+	You might need to increase the maximum guest screen resolution within your VM software."; then
 
 				if [[ $G_WHIP_RETURNED_VALUE == 'System default' ]]; then
 
@@ -2752,7 +2752,7 @@ _EOF_
 					mask+=0
 
 				fi
-				[[ $i < 3 ]] && mask+=.
+				(( $i < 3 )) && mask+=.
 
 			done
 			echo $mask

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -4002,25 +4002,25 @@ Additional benchmarks:
 		# - RPi, low power mode (PSU noise ripple reduction): https://github.com/Fourdee/DietPi/issues/757
 		if (( $G_HW_MODEL < 10 )); then
 
-			local current_cpu_governor=$(grep -m1 '^CONFIG_CPU_GOVERNOR=' /DietPi/dietpi.txt | sed 's/.*=//')
+			local current_cpu_governor=$(grep -m1 '^[[:blank:]]*CONFIG_CPU_GOVERNOR=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 			local hdmi_output=1
-			(( $(grep -ci -m1 'hdmi_blanking=1' /DietPi/config.txt | sed 's/.*=//') )) && hdmi_output=0
+			grep -qi 'hdmi_ignore_hotplug=1' /DietPi/config.txt &&
+			grep -qi 'hdmi_ignore_composite=1' /DietPi/config.txt && hdmi_output=0
 			local psu_noise_reduction_enabled=0
 			if [[ $current_cpu_governor == 'powersave' ]] && (( ! $hdmi_output )); then
 
-				G_WHIP_MENU_ARRAY+=('PSU noise reduction' ': [Enabled]')
+				G_WHIP_MENU_ARRAY+=('PSU noise reduction' ': [On]')
 				psu_noise_reduction_enabled=1
 
 			else
 
-				G_WHIP_MENU_ARRAY+=('PSU noise reduction' ': [Disabled]')
+				G_WHIP_MENU_ARRAY+=('PSU noise reduction' ': [Off]')
 
 			fi
 
 		fi
 
-		G_WHIP_MENU 'Please select an option:'
-		if (( $? == 0 )); then
+		if G_WHIP_MENU 'Please select an option:'; then
 
 			#Return to This Menu
 			TARGETMENUID=14
@@ -4031,14 +4031,14 @@ Additional benchmarks:
 
 					G_WHIP_MSG "PSU noise reduction:\n\nThis mode attempts to reduce power consumption on your SBC. In turn, this may reduce PSU inflicted noise, that may degrade audio output quality.\n\nThe following has now been set:\n - CPU gov = Powersave\n - HDMI output = Disabled"
 
-					sed -i '/CONFIG_CPU_GOVERNOR=/c\CONFIG_CPU_GOVERNOR=powersave' /DietPi/dietpi.txt
+					G_CONFIG_INJECT 'CONFIG_CPU_GOVERNOR=' 'CONFIG_CPU_GOVERNOR=powersave' /DietPi/dietpi.txt
 					/DietPi/dietpi/func/dietpi-set_cpu
 
 					/DietPi/dietpi/func/dietpi-set_hardware headless 1
 
 				else
 
-					sed -i '/CONFIG_CPU_GOVERNOR=/c\CONFIG_CPU_GOVERNOR=ondemand' /DietPi/dietpi.txt
+					G_CONFIG_INJECT 'CONFIG_CPU_GOVERNOR=' 'CONFIG_CPU_GOVERNOR=ondemand' /DietPi/dietpi.txt
 					/DietPi/dietpi/func/dietpi-set_cpu
 
 					/DietPi/dietpi/func/dietpi-set_hardware headless 0

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -80,11 +80,16 @@
 	#TARGETMENUID=0
 	Menu_Main(){
 
-		G_WHIP_MENU_ARRAY=(
+		G_WHIP_MENU_ARRAY=('1' ': Display Options')
+		# Hide Audio and Performance Options on VM
+		(( $G_HW_MODEL == 20 )) || G_WHIP_MENU_ARRAY+=(
 
-			'1' ': Display Options'
 			'2' ': Audio Options'
 			'3' ': Performance Options'
+
+		)
+		 G_WHIP_MENU_ARRAY+=(
+
 			'4' ': Advanced Options'
 			'5' ': Language/Regional Options'
 			'6' ': Security Options'
@@ -94,7 +99,6 @@
 			'10' ': Tools'
 
 		)
-
 
 		if G_WHIP_MENU "Hardware : $G_HW_MODEL_DESCRIPTION"; then
 
@@ -106,23 +110,9 @@
 
 				TARGETMENUID=14
 
-				if (( $G_HW_MODEL == 20 )); then
-
-					TARGETMENUID=0
-					Info_HW_OptionNotSupported
-
-				fi
-
 			elif (( $G_WHIP_RETURNED_VALUE == 3 )); then
 
 				TARGETMENUID=4
-
-				if (( $G_HW_MODEL == 20 )); then
-
-					TARGETMENUID=0
-					Info_HW_OptionNotSupported
-
-				fi
 
 			elif (( $G_WHIP_RETURNED_VALUE == 4 )); then
 
@@ -221,6 +211,10 @@
 
 			fi
 
+		else
+
+			Info_HW_OptionNotSupported
+
 		fi
 
 	}
@@ -262,43 +256,21 @@
 		#RPi only
 		if (( $G_HW_MODEL < 10 )); then
 
-			# - Get Current Settings
-			local overscan_enabled=$(grep -ci -m1 '^[[:blank:]]*disable_overscan=0' /DietPi/config.txt)
-			local overscan_text='[Off]'
-			(( $overscan_enabled )) && overscan_text='[On]'
-
-			local hdmi_boost_current=$(grep -m1 '[[:blank:]]*config_hdmi_boost=' /DietPi/config.txt | sed 's/^[^=]*=//')
-			local hdmi_boost_text="[$hdmi_boost_current]"
-			(( $hdmi_boost_current )) || hdmi_boost_text='[Off]'
-
-			local rpi_camera_module_enabled=$(grep -ci -m1 '^[[:blank:]]*start_x=1' /DietPi/config.txt)
-			local rpi_camera_module_text='[Off]'
-			(( $rpi_camera_module_enabled )) && rpi_camera_module_text='[On]'
-
-			local rpi_camera_led_enabled=$(grep -ci -m1 '^[[:blank:]]*disable_camera_led=0' /DietPi/config.txt)
-			local rpi_camera_led_text='[Off]'
-			(( $rpi_camera_led_enabled )) && rpi_camera_led_text='[On]'
-
+			# HDMI rotation
 			local rotation_hdmi_current=$(grep -m1 '^[[:blank:]]*display_hdmi_rotate=' /DietPi/config.txt | sed 's/^[^=]*=//')
-			local rotation_lcd_current=$(grep -m1 '^[[:blank:]]*lcd_rotate=' /DietPi/config.txt | sed 's/^[^=]*=//')
-
-			local vc1_key_current=$(grep -m1 '^[[:blank:]]*decode_WVC1=' /DietPi/config.txt | sed 's/^[^=]*=//')
-			local mpeg2_key_current=$(grep -m1 '^[[:blank:]]*decode_MPG2=' /DietPi/config.txt | sed 's/^[^=]*=//')
-
-			#JustBoom IR Remote
-			local justboom_ir_remote_text='[Off]'
-			local justboom_ir_remote_enabled=0
-			if [[ -f /etc/systemd/system/justboom-ir-mpd.service ]]; then
-
-				justboom_ir_remote_text='[On]'
-				justboom_ir_remote_enabled=1
-
-			fi
-
 			G_WHIP_MENU_ARRAY+=('4' ": Rotation (HDMI)     : [${rotation_hdmi_current:=0}]")
+
+			# LCD rotation
+			local rotation_lcd_current=$(grep -m1 '^[[:blank:]]*lcd_rotate=' /DietPi/config.txt | sed 's/^[^=]*=//')
 			G_WHIP_MENU_ARRAY+=('5' ": Rotation (LCD)      : [${rotation_lcd_current:=0}]")
+
+			# Display overscan
+			local overscan_disabled=$(grep -ci -m1 '^[[:blank:]]*disable_overscan=1' /DietPi/config.txt)
+			local overscan_text='[On]'
+			(( $overscan_disabled )) && overscan_text='[Off]'
 			G_WHIP_MENU_ARRAY+=('6' ": Overscan            : $overscan_text")
-			if (( $overscan_enabled )); then
+			#	- Overscan sizes
+			if (( ! $overscan_disabled )); then
 
 				local overscan_options=(
 
@@ -309,20 +281,48 @@
 
 				)
 
-				local overscan_left=$(grep -m1 '^[[:blank:]]*overscan_left=' /DietPi/config.txt | sed 's/^[^=]*=//')
-				local overscan_right=$(grep -m1 '^[[:blank:]]*overscan_right=' /DietPi/config.txt | sed 's/^[^=]*=//')
-				local overscan_top=$(grep -m1 '^[[:blank:]]*overscan_top=' /DietPi/config.txt | sed 's/^[^=]*=//')
-				local overscan_bottom=$(grep -m1 '^[[:blank:]]*overscan_bottom=' /DietPi/config.txt | sed 's/^[^=]*=//')
-				G_WHIP_MENU_ARRAY+=('15' ": Overscan Compensation [L:${overscan_left:=0}] [R:${overscan_right:=0}] [T:${overscan_top:=0}] [B:${overscan_bottom:=0}]")
+				local overscan_left=$(vcgencmd get_config overscan_left | sed 's/^[^=]*=//')
+				local overscan_right=$(vcgencmd get_config overscan_right | sed 's/^[^=]*=//')
+				local overscan_top=$(vcgencmd get_config overscan_top | sed 's/^[^=]*=//')
+				local overscan_bottom=$(vcgencmd get_config overscan_bottom | sed 's/^[^=]*=//')
+				G_WHIP_MENU_ARRAY+=('15' ": Overscan Compensation [L:${overscan_left:=N/A}] [R:${overscan_right:=N/A}] [T:${overscan_top:=N/A}] [B:${overscan_bottom:=N/A}]")
 
 			fi
 
-			G_WHIP_MENU_ARRAY+=('7'	": HDMI Boost          : $hdmi_boost_text")
+			# HDMI signal boost
+			local hdmi_boost_current=$(vcgencmd get_config config_hdmi_boost | sed 's/^[^=]*=//')
+			G_WHIP_MENU_ARRAY+=('7'	": HDMI Boost          : [${hdmi_boost_current:=N/A}]")
+
+			# RPi camera module
+			local rpi_camera_module_enabled=$(grep -ci -m1 '^[[:blank:]]*start_x=1' /DietPi/config.txt)
+			local rpi_camera_module_text='[Off]'
+			(( $rpi_camera_module_enabled )) && rpi_camera_module_text='[On]'
 			G_WHIP_MENU_ARRAY+=('8' ": RPi Camera          : $rpi_camera_module_text")
+
+			# RPi camera LED
+			local rpi_camera_led_disabled=$(grep -ci -m1 '^[[:blank:]]*disable_camera_led=1' /DietPi/config.txt)
+			local rpi_camera_led_text='[On]'
+			(( $rpi_camera_led_disabled )) && rpi_camera_led_text='[Off]'
 			G_WHIP_MENU_ARRAY+=('9' ": RPI Camera led      : $rpi_camera_led_text")
+
+			# JustBoom IR Remote
+			local justboom_ir_remote_text='[Off]'
+			local justboom_ir_remote_enabled=0
+			if [[ -f /etc/systemd/system/justboom-ir-mpd.service ]]; then
+
+				justboom_ir_remote_text='[On]'
+				justboom_ir_remote_enabled=1
+
+			fi
 			G_WHIP_MENU_ARRAY+=('11' ": JustBoom IR remote  : $justboom_ir_remote_text")
-			G_WHIP_MENU_ARRAY+=('12' ": VC1 Key             : [$vc1_key_current]")
-			G_WHIP_MENU_ARRAY+=('13' ": MPEG2 Key           : [$mpeg2_key_current]")
+
+			# VC1 key
+			local vc1_key_current=$(grep -m1 '^[[:blank:]]*decode_WVC1=' /DietPi/config.txt | sed 's/^[^=]*=//')
+			G_WHIP_MENU_ARRAY+=('12' ": VC1 Key             : [${vc1_key_current:=none}]")
+
+			# MPEG2 key
+			local mpeg2_key_current=$(grep -m1 '^[[:blank:]]*decode_MPG2=' /DietPi/config.txt | sed 's/^[^=]*=//')
+			G_WHIP_MENU_ARRAY+=('13' ": MPEG2 Key           : [${mpeg2_key_current:=none}]")
 
 		fi
 
@@ -342,7 +342,7 @@
 
 		fi
 
-		G_WHIP_DEFAULT_ITEM="$WHIP_SELECTION_PREVIOUS"
+		G_WHIP_DEFAULT_ITEM=$WHIP_SELECTION_PREVIOUS
 
 		if G_WHIP_MENU 'Please select an option:'; then
 
@@ -359,7 +359,7 @@
 					G_WHIP_DEFAULT_ITEM=${!i}
 					if G_WHIP_INPUTBOX "Please enter a value (pixel count) for $i\n - EG: 16"; then
 
-						sed -i "/$i=/c $i=$G_WHIP_RETURNED_VALUE" /DietPi/config.txt
+						G_CONFIG_INJECT "$i=" "$i=$G_WHIP_RETURNED_VALUE" /DietPi/config.txt
 						REBOOT_REQUIRED=1
 
 					else
@@ -395,7 +395,7 @@
 
 					fi
 
-					G_WHIP_DEFAULT_ITEM="$lcdpanel_text"
+					G_WHIP_DEFAULT_ITEM=$lcdpanel_text
 					if G_WHIP_MENU 'Please select an option:'; then
 
 						/DietPi/dietpi/func/dietpi-set_hardware lcdpanel "$G_WHIP_RETURNED_VALUE"
@@ -427,23 +427,22 @@
 				#RPI only
 				if (( $G_HW_MODEL < 10 )); then
 
-					if (( $overscan_enabled )); then
+					if (( $overscan_disabled )); then
+
+						G_CONFIG_INJECT 'disable_overscan=' 'disable_overscan=0' /DietPi/config.txt
+
+					else
 
 						G_CONFIG_INJECT 'disable_overscan=' 'disable_overscan=1' /DietPi/config.txt
 						for i in "${overscan_options[@]}"
 						do
 
-							G_CONFIG_INJECT "$i=" "$i=0" /DietPi/config.txt
+							G_CONFIG_INJECT "$i=" "#$i=0" /DietPi/config.txt
 
-						done
-						REBOOT_REQUIRED=1
-
-					else
-
-						G_CONFIG_INJECT 'disable_overscan=' 'disable_overscan=0' /DietPi/config.txt
-						REBOOT_REQUIRED=1
+						done						
 
 					fi
+					REBOOT_REQUIRED=1
 
 				else
 
@@ -493,14 +492,13 @@
 					if (( $rpi_camera_module_enabled )); then
 
 						/DietPi/dietpi/func/dietpi-set_hardware rpi-camera disable
-						REBOOT_REQUIRED=1
 
 					else
 
 						/DietPi/dietpi/func/dietpi-set_hardware rpi-camera enable
-						REBOOT_REQUIRED=1
 
 					fi
+					REBOOT_REQUIRED=1
 
 				else
 
@@ -513,19 +511,18 @@
 				#RPI only
 				if (( $G_HW_MODEL < 10 )); then
 
-					if (( $rpi_camera_led_enabled )); then
+					if (( $rpi_camera_led_disabled )); then
 
 						#disable
-						G_CONFIG_INJECT 'disable_camera_led=' 'disable_camera_led=1' /DietPi/config.txt
-						REBOOT_REQUIRED=1
+						G_CONFIG_INJECT 'disable_camera_led=' 'disable_camera_led=0' /DietPi/config.txt
 
 					else
 
 						#enable
-						G_CONFIG_INJECT 'disable_camera_led=' 'disable_camera_led=0' /DietPi/config.txt
-						REBOOT_REQUIRED=1
+						G_CONFIG_INJECT 'disable_camera_led=' 'disable_camera_led=1' /DietPi/config.txt
 
 					fi
+					REBOOT_REQUIRED=1
 
 				else
 
@@ -575,10 +572,8 @@
 
 			elif (( $G_WHIP_RETURNED_VALUE == 12 )); then
 
-				G_WHIP_DEFAULT_ITEM="$vc1_key_current"
+				G_WHIP_DEFAULT_ITEM=$vc1_key_current
 				if G_WHIP_INPUTBOX 'Please enter your key for VC1:\n - EG: 0x00000000'; then
-
-					grep -qi 'decode_WVC1=' /DietPi/config.txt || echo -e "\ndecode_WVC1=0x00000000" >> /DietPi/config.txt
 
 					G_CONFIG_INJECT 'decode_WVC1=' "decode_WVC1=$G_WHIP_RETURNED_VALUE" /DietPi/config.txt
 
@@ -592,10 +587,8 @@
 
 			elif (( $G_WHIP_RETURNED_VALUE == 13 )); then
 
-				G_WHIP_DEFAULT_ITEM="$mpeg2_key_current"
+				G_WHIP_DEFAULT_ITEM=$mpeg2_key_current
 				if G_WHIP_INPUTBOX 'Please enter your key for MPEG2:\n - EG: 0x00000000'; then
-
-					grep -qi 'decode_MPG2=' /DietPi/config.txt || echo -e "\ndecode_MPG2=0x00000000" >> /DietPi/config.txt
 
 					G_CONFIG_INJECT 'decode_MPG2=' "decode_MPG2=$G_WHIP_RETURNED_VALUE" /DietPi/config.txt
 
@@ -620,7 +613,7 @@
 
 				)
 
-				G_WHIP_DEFAULT_ITEM="$rotation_hdmi_current"
+				G_WHIP_DEFAULT_ITEM=$rotation_hdmi_current
 				if G_WHIP_MENU "Please select an option:
 \nNB: If you have the RPi touchscreen, please set this to 0 and use LCD rotation option."; then
 
@@ -651,10 +644,10 @@
 
 				)
 
-				G_WHIP_DEFAULT_ITEM="$rotation_lcd_current"
+				G_WHIP_DEFAULT_ITEM=$rotation_lcd_current
 				if G_WHIP_MENU 'Please select an option:\n\nNB: This option is for RPi touchscreen.'; then
 
-					sed -i "/lcd_rotate=/c\lcd_rotate=$G_WHIP_RETURNED_VALUE" /DietPi/config.txt
+					G_CONFIG_INJECT 'lcd_rotate=' "lcd_rotate=$G_WHIP_RETURNED_VALUE" /DietPi/config.txt
 					REBOOT_REQUIRED=1
 
 				fi
@@ -772,7 +765,7 @@
 		#VM
 		if (( $G_HW_MODEL == 20 )); then
 
-			local current="$(grep -m1 '^[[:blank:]]*GRUB_GFXMODE=' /etc/default/grub | sed 's/^[^=]*=//')"
+			local current=$(grep -m1 '^[[:blank:]]*GRUB_GFXMODE=' /etc/default/grub | sed 's/^[^=]*=//')
 			[[ $current ]] || current='System default'
 
 			G_WHIP_MENU_ARRAY=(
@@ -786,7 +779,7 @@
 
 			)
 
-			G_WHIP_DEFAULT_ITEM="$current"
+			G_WHIP_DEFAULT_ITEM=$current
 			if G_WHIP_MENU 'Please select a display resolution. Current: $current
 \nNB: This only affects the virtual screen resolution, not the SSH session.
 	You might need to increase the maximum guest screen resolution within your VM software.'; then
@@ -882,7 +875,8 @@
 				current_value="$framebuffer_x X $framebuffer_y"
 
 				# - check for headless
-				grep -qi 'hdmi_blanking=1' /DietPi/config.txt && current_value='Headless'
+				grep -qi 'hdmi_ignore_hotplug=1' /DietPi/config.txt &&
+				grep -qi 'hdmi_ignore_composite=1' /DietPi/config.txt && current_value='Headless'
 
 			fi
 
@@ -906,7 +900,7 @@
 
 			)
 
-			G_WHIP_DEFAULT_ITEM="$current_value"
+			G_WHIP_DEFAULT_ITEM=$current_value
 			if G_WHIP_MENU "Hardware: $G_HW_MODEL_DESCRIPTION\nCurrent resolution: $current_value"; then
 
 				REBOOT_REQUIRED=1
@@ -1042,7 +1036,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 			)
 
-			G_WHIP_DEFAULT_ITEM="$current_resolution"
+			G_WHIP_DEFAULT_ITEM=$current_resolution
 			if G_WHIP_MENU "Hardware : $G_HW_MODEL_DESCRIPTION\nCurrent: $current_resolution"; then
 
 				REBOOT_REQUIRED=1
@@ -1094,7 +1088,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 		elif (( $G_HW_MODEL == 11 )); then
 
 			#Get Current Values
-			local current_resolution="$(grep -m1 'setenv videoconfig \"' /DietPi/boot.ini)"
+			local current_resolution=$(grep -m1 'setenv videoconfig \"' /DietPi/boot.ini)
 			if [[ $current_resolution == *'1920x1080'* ]]; then
 
 				current_resolution='1080p'
@@ -1118,7 +1112,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 			)
 
-			G_WHIP_DEFAULT_ITEM="$current_resolution"
+			G_WHIP_DEFAULT_ITEM=$current_resolution
 			if G_WHIP_MENU "Hardware : $G_HW_MODEL_DESCRIPTION \nCurrent: $current_resolution"; then
 
 				REBOOT_REQUIRED=1
@@ -1164,7 +1158,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 			)
 
-			G_WHIP_DEFAULT_ITEM="$current_resolution"
+			G_WHIP_DEFAULT_ITEM=$current_resolution
 			if G_WHIP_MENU "Hardware : $G_HW_MODEL_DESCRIPTION \nCurrent: $current_resolution"; then
 
 				[[ $current_resolution != $G_WHIP_RETURNED_VALUE ]] && REBOOT_REQUIRED=1
@@ -1213,7 +1207,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 			)
 
-			G_WHIP_DEFAULT_ITEM="$current_resolution"
+			G_WHIP_DEFAULT_ITEM=$current_resolution
 			if G_WHIP_MENU "Hardware : $G_HW_MODEL_DESCRIPTION \nCurrent: $current_resolution"; then
 
 				if [[ $current_resolution != $G_WHIP_RETURNED_VALUE ]]; then
@@ -1245,7 +1239,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 		#Swap file
 		local swap_size=$(free -m | mawk '/Swap:/ {print $2;exit}')
-		local swap_location="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_SWAPFILE_LOCATION=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
+		local swap_location=$(grep -m1 '^[[:blank:]]*AUTO_SETUP_SWAPFILE_LOCATION=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 		local swap_size_text="$swap_size MB"
 		(( ! $swap_size )) && swap_size_text='[Off]'
 		G_WHIP_MENU_ARRAY+=('Swapfile' ": [$swap_size_text | $swap_location]")
@@ -1318,7 +1312,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 			local rpi_i2c_text='[Off]'
 			(( $rpi_i2c_enabled )) && rpi_i2c_text='[On]'
 
-			local rpi_i2cbaudrate_hz="$(grep -m1 '^[[:blank:]]*i2c_arm_baudrate=' /DietPi/config.txt | sed 's/^[^=]*=//')"
+			local rpi_i2cbaudrate_hz=$(grep -m1 '^[[:blank:]]*i2c_arm_baudrate=' /DietPi/config.txt | sed 's/^[^=]*=//')
 			# Allow commented/non-existent entry, using default value: https://github.com/raspberrypi/firmware/blob/d69aadedb7c146ba5d3b0b45a661e5669a9141c4/boot/overlays/README#L115-L116
 			rpi_i2cbaudrate_hz="$(( ${rpi_i2cbaudrate_hz:-100000} / 1000 )) kHz"
 			local usb_max_current_enabled=$(grep -ci -m1 '^[[:blank:]]*max_usb_current=1' /DietPi/config.txt)
@@ -1386,7 +1380,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 				)
 
-				G_WHIP_DEFAULT_ITEM="$ntpd_mode_current"
+				G_WHIP_DEFAULT_ITEM=$ntpd_mode_current
 				G_WHIP_MENU 'Here you can adjust the frequency of network time syncs.\n
  - Modes 1-3:\nDietPi will launch systemd-timesyncd as a program, rather than a daemon. Once the time has been updated on your system, timesyncd will exit to reduce resource usage.\n
  - Mode 4:\nsystemd-timesyncd will run as a background daemon/service. Differences in time will be gradually adjusted over time, rather than instantly.\n
@@ -1748,7 +1742,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 							# - MAX
 							if (( $index == 0 )); then
 
-								G_WHIP_DEFAULT_ITEM="$user_frequency_max_current"
+								G_WHIP_DEFAULT_ITEM=$user_frequency_max_current
 								G_WHIP_MENU "Limit the maximum frequency that your processor can reach.\nThis can be useful for lowering temperature and saving power.\n\nCurrent setting: $user_frequency_max_text"
 								if (( $? == 0 )); then
 
@@ -1759,7 +1753,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 							# - MIN
 							else
 
-								G_WHIP_DEFAULT_ITEM="$user_frequency_min_current"
+								G_WHIP_DEFAULT_ITEM=$user_frequency_min_current
 								G_WHIP_MENU "Limit the minimum frequency that your processor can reach.\nThis can be useful for some timing critical stuff (eg. 1-wire below 480 Mhz won't work).\n\nCurrent setting: $user_frequency_min_text"
 								if (( $? == 0 )); then
 
@@ -1835,7 +1829,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 						fi
 
-						G_WHIP_DEFAULT_ITEM="$current_cpu_governor"
+						G_WHIP_DEFAULT_ITEM=$current_cpu_governor
 						if G_WHIP_MENU "$Description"; then
 
 							G_CONFIG_INJECT 'CONFIG_CPU_GOVERNOR=' "CONFIG_CPU_GOVERNOR=$G_WHIP_RETURNED_VALUE" /DietPi/dietpi.txt
@@ -1902,7 +1896,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 		#Get existing Hostname
 		local hostname_existing=$(</etc/hostname)
-		G_WHIP_DEFAULT_ITEM="$hostname_existing"
+		G_WHIP_DEFAULT_ITEM=$hostname_existing
 		if G_WHIP_INPUTBOX 'Please enter a new hostname' && [[ $hostname_existing != $G_WHIP_RETURNED_VALUE ]]; then
 
 			/DietPi/dietpi/func/change_hostname "$G_WHIP_RETURNED_VALUE"
@@ -2125,7 +2119,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 		TARGETMENUID=0
 
-		local locale_current="$(grep -m1 '^[[:blank:]]*AUTO_SETUP_LOCALE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
+		local locale_current=$(grep -m1 '^[[:blank:]]*AUTO_SETUP_LOCALE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 
 		G_WHIP_MENU_ARRAY=(
 
@@ -2156,7 +2150,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 					while read line
 					do
 
-						G_WHIP_MENU_ARRAY[$index]="$line"
+						G_WHIP_MENU_ARRAY[$index]=$line
 						((index++))
 						G_WHIP_MENU_ARRAY[$index]=''
 						((index++))
@@ -2164,7 +2158,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 					done < /tmp/available_locale
 					rm /tmp/available_locale
 
-					G_WHIP_DEFAULT_ITEM="$locale_current"
+					G_WHIP_DEFAULT_ITEM=$locale_current
 					G_WHIP_MENU 'Please select a system locale. DietPi will automatically apply this as the default locale:'
 					if (( $? == 0 )); then
 
@@ -2372,10 +2366,10 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 			eth_dhcp_static_text='static'
 			eth_dns_text=''
-			ETH_IP="$ETH_IP_STATIC"
-			ETH_GATEWAY="$ETH_GATEWAY_STATIC"
-			ETH_MASK="$ETH_MASK_STATIC"
-			ETH_DNS="$ETH_DNS_STATIC"
+			ETH_IP=$ETH_IP_STATIC
+			ETH_GATEWAY=$ETH_GATEWAY_STATIC
+			ETH_MASK=$ETH_MASK_STATIC
+			ETH_DNS=$ETH_DNS_STATIC
 
 		fi
 
@@ -2389,10 +2383,10 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 			wifi_dhcp_static_text='static'
 			wifi_dns_text=''
-			WIFI_IP="$WIFI_IP_STATIC"
-			WIFI_GATEWAY="$WIFI_GATEWAY_STATIC"
-			WIFI_MASK="$WIFI_MASK_STATIC"
-			WIFI_DNS="$WIFI_DNS_STATIC"
+			WIFI_IP=$WIFI_IP_STATIC
+			WIFI_GATEWAY=$WIFI_GATEWAY_STATIC
+			WIFI_MASK=$WIFI_MASK_STATIC
+			WIFI_DNS=$WIFI_DNS_STATIC
 
 		fi
 
@@ -2463,13 +2457,13 @@ _EOF_
 		#Ethernet
 		if (( $1 == 0 )); then
 
-			G_WHIP_DEFAULT_ITEM="$ETH_IP_STATIC"
+			G_WHIP_DEFAULT_ITEM=$ETH_IP_STATIC
 			G_WHIP_INPUTBOX 'Please enter a new static IP address' && ETH_IP_STATIC=$G_WHIP_RETURNED_VALUE
 
 		#wifi
 		elif (( $1 == 1 )); then
 
-			G_WHIP_DEFAULT_ITEM="$WIFI_IP_STATIC"
+			G_WHIP_DEFAULT_ITEM=$WIFI_IP_STATIC
 			G_WHIP_INPUTBOX 'Please enter a new static IP address' && WIFI_IP_STATIC=$G_WHIP_RETURNED_VALUE
 
 		fi
@@ -2481,13 +2475,13 @@ _EOF_
 		#Ethernet
 		if (( $1 == 0 )); then
 
-			G_WHIP_DEFAULT_ITEM="$ETH_GATEWAY_STATIC"
+			G_WHIP_DEFAULT_ITEM=$ETH_GATEWAY_STATIC
 			G_WHIP_INPUTBOX 'Please enter a new static Gateway address' && ETH_GATEWAY_STATIC=$G_WHIP_RETURNED_VALUE
 
 		#wifi
 		elif (( $1 == 1 )); then
 
-			G_WHIP_DEFAULT_ITEM="$WIFI_GATEWAY_STATIC"
+			G_WHIP_DEFAULT_ITEM=$WIFI_GATEWAY_STATIC
 			G_WHIP_INPUTBOX 'Please enter a new static Gateway address' && WIFI_GATEWAY_STATIC=$G_WHIP_RETURNED_VALUE
 
 		fi
@@ -2499,13 +2493,13 @@ _EOF_
 		#Ethernet
 		if (( $1 == 0 )); then
 
-			G_WHIP_DEFAULT_ITEM="$ETH_MASK_STATIC"
+			G_WHIP_DEFAULT_ITEM=$ETH_MASK_STATIC
 			G_WHIP_INPUTBOX 'Please enter a new static Mask address' && ETH_MASK_STATIC=$G_WHIP_RETURNED_VALUE
 
 		#wifi
 		elif (( $1 == 1 )); then
 
-			G_WHIP_DEFAULT_ITEM="$WIFI_MASK_STATIC"
+			G_WHIP_DEFAULT_ITEM=$WIFI_MASK_STATIC
 			G_WHIP_INPUTBOX 'Please enter a new static Mask address' && WIFI_MASK_STATIC=$G_WHIP_RETURNED_VALUE
 
 		fi
@@ -2548,14 +2542,14 @@ _EOF_
 
 		)
 
-		G_WHIP_DEFAULT_ITEM="$current_value"
+		G_WHIP_DEFAULT_ITEM=$current_value
 		if G_WHIP_MENU 'Please select a DNS server, or choose custom for manual entry.'; then
 
 			case $G_WHIP_RETURNED_VALUE in
 
 				'Custom')
 
-					G_WHIP_DEFAULT_ITEM="$current_value"
+					G_WHIP_DEFAULT_ITEM=$current_value
 					G_WHIP_INPUTBOX 'Please enter a new DNS server address\n - 2 maximum, seperated by a space.\n - eg: 8.8.8.8 8.8.4.4'
 					(( $? )) || return_value=$G_WHIP_RETURNED_VALUE
 
@@ -2600,7 +2594,7 @@ _EOF_
 
 		)
 
-		G_WHIP_DEFAULT_ITEM="$WIFI_COUNTRYCODE"
+		G_WHIP_DEFAULT_ITEM=$WIFI_COUNTRYCODE
 		G_WHIP_MENU 'Please select a country, to enable WiFi channels and power ratings allowed in your country.'
 		if (( $? == 0 )); then
 
@@ -2608,7 +2602,7 @@ _EOF_
 
 				'Manual')
 
-					G_WHIP_DEFAULT_ITEM="$WIFI_COUNTRYCODE"
+					G_WHIP_DEFAULT_ITEM=$WIFI_COUNTRYCODE
 					G_WHIP_INPUTBOX "Please enter a 2 character country code: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2"
 					if (( $? == 0 )); then
 
@@ -3069,7 +3063,7 @@ _EOF_
 
 				'Test')
 
-					G_WHIP_DEFAULT_ITEM="$INTERNET_TEST_URL"
+					G_WHIP_DEFAULT_ITEM=$INTERNET_TEST_URL
 					G_WHIP_INPUTBOX 'Press enter a URL address to test (eg: http://google.com)'
 					if (( $? == 0 )); then
 
@@ -3150,7 +3144,7 @@ _EOF_
 
 		Net_Update_UsageStats eth$ETH_DEV_INDEX
 
-		G_WHIP_DEFAULT_ITEM="$WHIP_SELECTION_PREVIOUS"
+		G_WHIP_DEFAULT_ITEM=$WHIP_SELECTION_PREVIOUS
 		G_WHIP_MENU "Ethernet Details:\nUsage   : Sent = $NET_TX_MB | Recieved = $NET_RX_MB\nAddress : IP = $ETH_IP | Mask = $ETH_MASK | Gateway = $ETH_GATEWAY | DNS = $ETH_DNS"
 		if (( $? == 0 )); then
 
@@ -3295,7 +3289,7 @@ _EOF_
 			G_WHIP_MENU_ARRAY+=('Key' ": [$HOTSPOT_KEY]")
 			G_WHIP_MENU_ARRAY+=('802.11 N' ": [$hotspot_n_text]")
 
-			description_text+="$hotspot_status_text"
+			description_text+=$hotspot_status_text
 
 		#WiFi Menu
 		else
@@ -3369,7 +3363,7 @@ _EOF_
 		G_WHIP_MENU_ARRAY+=('' '●─ Apply ')
 		G_WHIP_MENU_ARRAY+=('Apply' ': Save all changes and restart networking')
 
-		G_WHIP_DEFAULT_ITEM="$WHIP_SELECTION_PREVIOUS"
+		G_WHIP_DEFAULT_ITEM=$WHIP_SELECTION_PREVIOUS
 		if G_WHIP_MENU "$description_text"; then
 
 			#Return to this menu
@@ -3395,7 +3389,7 @@ _EOF_
 
 				'Key')
 
-					G_WHIP_DEFAULT_ITEM="$HOTSPOT_KEY"
+					G_WHIP_DEFAULT_ITEM=$HOTSPOT_KEY
 					G_WHIP_INPUTBOX 'Please enter a key/password for the WiFi hotspot\n - NB: Minimum of 8 characters'
 					(( $? == 0 )) && HOTSPOT_KEY=$G_WHIP_RETURNED_VALUE
 
@@ -3403,7 +3397,7 @@ _EOF_
 
 				'SSID')
 
-					G_WHIP_DEFAULT_ITEM="$HOTSPOT_SSID"
+					G_WHIP_DEFAULT_ITEM=$HOTSPOT_SSID
 					G_WHIP_INPUTBOX 'Please enter a SSID for the WiFi hotspot' && HOTSPOT_SSID=$G_WHIP_RETURNED_VALUE
 
 				;;
@@ -3665,11 +3659,11 @@ Additional benchmarks:
 				'Custom Filesystem')
 
 					/DietPi/dietpi/dietpi-drive_manager 1
-					local fp_fsbench_custom_mount="$(</tmp/dietpi-drive_manager_selmnt)"
+					local fp_fsbench_custom_mount=$(</tmp/dietpi-drive_manager_selmnt)
 
 					if [[ $fp_fsbench_custom_mount ]]; then
 
-						FP_BENCHFILE="$fp_fsbench_custom_mount" /DietPi/dietpi/func/dietpi-benchmark 1
+						FP_BENCHFILE=$fp_fsbench_custom_mount /DietPi/dietpi/func/dietpi-benchmark 1
 
 					fi
 
@@ -4192,7 +4186,7 @@ Additional benchmarks:
 				# - Global usb-dac, prefer at bottom of list
 				G_WHIP_MENU_ARRAY+=('usb-dac' ': USB Audio DAC (any)')
 
-				G_WHIP_DEFAULT_ITEM="$soundcard_current"
+				G_WHIP_DEFAULT_ITEM=$soundcard_current
 				if G_WHIP_MENU "Please select a soundcard\n - Current : $soundcard_current"; then
 
 					/DietPi/dietpi/func/dietpi-set_hardware soundcard "$G_WHIP_RETURNED_VALUE"
@@ -4256,7 +4250,7 @@ Additional benchmarks:
 
 				)
 
-				G_WHIP_DEFAULT_ITEM="$STRESS_TEST_DURATION"
+				G_WHIP_DEFAULT_ITEM=$STRESS_TEST_DURATION
 				if G_WHIP_MENU 'Please select a duration for the test'; then
 
 					STRESS_TEST_DURATION=$G_WHIP_RETURNED_VALUE
@@ -4273,7 +4267,7 @@ Additional benchmarks:
 
 				)
 
-				G_WHIP_DEFAULT_ITEM="$STRESS_TEST_MODE"
+				G_WHIP_DEFAULT_ITEM=$STRESS_TEST_MODE
 				if G_WHIP_MENU 'Please select a stress test type'; then
 
 					STRESS_TEST_MODE=$G_WHIP_RETURNED_VALUE
@@ -4496,14 +4490,14 @@ Additional benchmarks:
 
 					fi
 
-					G_WHIP_DEFAULT_ITEM="$apt_mirror_current"
+					G_WHIP_DEFAULT_ITEM=$apt_mirror_current
 					if G_WHIP_MENU 'Please select an APT mirror, or choose custom for manual entry.'; then
 
 						case $G_WHIP_RETURNED_VALUE in
 
 							'Custom')
 
-								G_WHIP_DEFAULT_ITEM="$apt_mirror_current"
+								G_WHIP_DEFAULT_ITEM=$apt_mirror_current
 								if G_WHIP_INPUTBOX 'Please enter a new APT Mirror\n - eg: http://ftp.debian.org/debian'; then
 
 									return_value=$G_WHIP_RETURNED_VALUE
@@ -4543,7 +4537,7 @@ Additional benchmarks:
 
 					)
 
-					G_WHIP_DEFAULT_ITEM="$ntp_mirror_current"
+					G_WHIP_DEFAULT_ITEM=$ntp_mirror_current
 					G_WHIP_MENU 'Please select an NTP mirror:\n
 "Gateway": Try to detect and use local router for time sync. Recommended, allows fastest sync and reduces load to the *.pool.ntp.org servers.\n
 "Custom": Manually enter local or external NTP server address(es).\n
@@ -4551,7 +4545,7 @@ Additional benchmarks:
 Use "*.pool.ntp.org" mirrors, if your device is mobile or should act as local NTP server. Further information: "http://www.pool.ntp.org/zone/@"'
 					if (( $? == 0 )) && [[ $G_WHIP_RETURNED_VALUE ]]; then
 
-						local new_setting_ntp_mirror="$G_WHIP_RETURNED_VALUE"
+						local new_setting_ntp_mirror=$G_WHIP_RETURNED_VALUE
 						local previous_setting_ntp_mirror=$(grep -m1 '^[[:blank:]]*CONFIG_NTP_MIRROR=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 
 						local apply=1
@@ -4560,13 +4554,12 @@ Use "*.pool.ntp.org" mirrors, if your device is mobile or should act as local NT
 
 							'Custom')
 
-								G_WHIP_DEFAULT_ITEM="$ntp_mirror_current"
-								G_WHIP_INPUTBOX 'Please enter one or more (space-separated) NTP mirrors.\n
+								G_WHIP_DEFAULT_ITEM=$ntp_mirror_current
+								if G_WHIP_INPUTBOX 'Please enter one or more (space-separated) NTP mirrors.\n
 NB: If you need to use *.pool.ntp.org servers, enter the base domain only. The subdomains 0-3 will be added automatically.
-- Enter "uk.pool.ntp.org" to use [0-3].uk.pool.ntp.org'
-								if (( $? == 0 )); then
+- Enter "uk.pool.ntp.org" to use [0-3].uk.pool.ntp.org'; then
 
-									new_setting_ntp_mirror="$G_WHIP_RETURNED_VALUE"
+									new_setting_ntp_mirror=$G_WHIP_RETURNED_VALUE
 
 								else
 
@@ -4701,15 +4694,15 @@ NB: If you need to use *.pool.ntp.org servers, enter the base domain only. The s
 
 				'Address')
 
-					G_WHIP_DEFAULT_ITEM="$PROXY_ADDRESS"
+					G_WHIP_DEFAULT_ITEM=$PROXY_ADDRESS
 					G_WHIP_INPUTBOX 'Please enter the proxy URL or IP address\n - eg: MyProxy.com'
-					(( $? == 0 )) && PROXY_ADDRESS="$G_WHIP_RETURNED_VALUE"
+					(( $? == 0 )) && PROXY_ADDRESS=$G_WHIP_RETURNED_VALUE
 
 				;;
 
 				'Port')
 
-					G_WHIP_DEFAULT_ITEM="$PROXY_PORT"
+					G_WHIP_DEFAULT_ITEM=$PROXY_PORT
 					G_WHIP_INPUTBOX 'Please enter the proxy port number\n - eg: 1234'
 					(( $? == 0 )) && PROXY_PORT=$G_WHIP_RETURNED_VALUE
 
@@ -4717,17 +4710,17 @@ NB: If you need to use *.pool.ntp.org servers, enter the base domain only. The s
 
 				'Username')
 
-					G_WHIP_DEFAULT_ITEM="$PROXY_USERNAME"
+					G_WHIP_DEFAULT_ITEM=$PROXY_USERNAME
 					G_WHIP_INPUTBOX 'Please enter the proxy username\n - eg: JoeBloggs\n - Leave blank if not required'
-					(( $? == 0 )) && PROXY_USERNAME="$G_WHIP_RETURNED_VALUE"
+					(( $? == 0 )) && PROXY_USERNAME=$G_WHIP_RETURNED_VALUE
 
 				;;
 
 				'Password')
 
-					G_WHIP_DEFAULT_ITEM="$PROXY_PASSWORD"
+					G_WHIP_DEFAULT_ITEM=$PROXY_PASSWORD
 					G_WHIP_INPUTBOX 'Please enter the proxy password\n - eg: LetMeIn\n - Leave blank if not required'
-					(( $? == 0 )) && PROXY_PASSWORD="$G_WHIP_RETURNED_VALUE"
+					(( $? == 0 )) && PROXY_PASSWORD=$G_WHIP_RETURNED_VALUE
 
 				;;
 
@@ -4793,7 +4786,7 @@ _EOF_
 		while (( $TARGETMENUID >= 0 )); do
 
 			printf '\ec' # clear current terminal screen
-			G_WHIP_BUTTON_CANCEL_TEXT="$TEXT_MENU_BACK"
+			G_WHIP_BUTTON_CANCEL_TEXT=$TEXT_MENU_BACK
 
 			if (( $TARGETMENUID == 0 )); then
 

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -237,14 +237,14 @@ systemctl enable dietpi-rm_program_usb_boot_mode
 			#odroid C1
 			elif (( $G_HW_MODEL == 10 )); then
 
-				sed -i '/setenv hdmioutput /c\setenv hdmioutput "0"' /DietPi/boot.ini
-				sed -i '/setenv vpu /c\setenv vpu "0"' /DietPi/boot.ini
-				sed -i '/setenv m_bpp /c\setenv m_bpp "32"' /DietPi/boot.ini
+				G_CONFIG_INJECT 'setenv hdmioutput ' 'setenv hdmioutput "0"' /DietPi/boot.ini
+				G_CONFIG_INJECT 'setenv vpu ' 'setenv vpu "0"' /DietPi/boot.ini
+				G_CONFIG_INJECT 'setenv m_bpp ' 'setenv m_bpp "32"' /DietPi/boot.ini
 
 			#Odroid C2
 			elif (( $G_HW_MODEL == 12 )); then
 
-				sed -i '/setenv nographics /c\setenv nographics "1"' /DietPi/boot.ini
+				G_CONFIG_INJECT 'setenv nographics ' 'setenv nographics "1"' /DietPi/boot.ini
 
 			else
 
@@ -260,19 +260,18 @@ systemctl enable dietpi-rm_program_usb_boot_mode
 				G_CONFIG_INJECT 'hdmi_ignore_hotplug=' '#hdmi_ignore_hotplug=0' /DietPi/config.txt
 				G_CONFIG_INJECT 'hdmi_ignore_composite=' '#hdmi_ignore_composite=0' /DietPi/config.txt
 				G_CONFIG_INJECT 'hdmi_blanking=' '#hdmi_blanking=0' /DietPi/config.txt
-				G_CONFIG_INJECT 'disable_splash=' 'disable_splash=0' /DietPi/config.txt
 
 			#odroid C1
 			elif (( $G_HW_MODEL == 10 )); then
 
-				sed -i '/setenv hdmioutput /c\setenv hdmioutput "1"' /DietPi/boot.ini
-				sed -i '/setenv vpu /c\setenv vpu "1"' /DietPi/boot.ini
-				sed -i '/setenv m_bpp /c\setenv m_bpp "32"' /DietPi/boot.ini
+				G_CONFIG_INJECT 'setenv hdmioutput ' 'setenv hdmioutput "1"' /DietPi/boot.ini
+				G_CONFIG_INJECT 'setenv vpu ' 'setenv vpu "1"' /DietPi/boot.ini
+				G_CONFIG_INJECT 'setenv m_bpp ' 'setenv m_bpp "32"' /DietPi/boot.ini
 
 			#Odroid C2
 			elif (( $G_HW_MODEL == 12 )); then
 
-				sed -i '/setenv nographics /c\setenv nographics "0"' /DietPi/boot.ini
+				G_CONFIG_INJECT 'setenv nographics ' 'setenv nographics "0"' /DietPi/boot.ini
 
 			else
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1585,6 +1585,16 @@ Also have a look at "Sonarr", another alternative TV show manager, available for
 				sed -i '/disable_pvt/d' /DietPi/config.txt
 				sed -i '/avoid_pwm_pll/d' /DietPi/config.txt
 
+				# - Remove doubled AUTO_SETUP_HEADLESS entry, introduced with Beta v6.20.2
+				if (( $(grep -c '^[[:blank:]]*AUTO_SETUP_HEADLESS=' /DietPi/dietpi.txt) > 1 )); then
+
+					# - Last match is the correct one, added by "dietpi-set_hardware headless 1"
+					local current=$(grep '^[[:blank:]]*AUTO_SETUP_HEADLESS=' /DietPi/dietpi.txt | tail -1 | sed 's/^[^=]*=//')
+					sed -i '/^[[:blank:]]*AUTO_SETUP_HEADLESS=/d' /DietPi/dietpi.txt
+					echo "AUTO_SETUP_HEADLESS=$current" >> /DietPi/dietpi.txt
+
+				fi
+
 				# - Apply new headless mode method, if set
 				if grep -q '^[[:blank:]]*CONFIG_HDMI_OUTPUT=0' /DietPi/dietpi.txt; then
 
@@ -1592,8 +1602,8 @@ Also have a look at "Sonarr", another alternative TV show manager, available for
 
 				fi
 
-				#Only used in automation 1st run now, changed to 'AUTO_SETUP_HEADLESS'
-				sed -i 's/^CONFIG_HDMI_OUTPUT=/AUTO_SETUP_HEADLESS=/' /DietPi/config.txt
+				# - Renamed to: AUTO_SETUP_HEADLESS (added by verify_dietpi.txt automatically)
+				sed -i '/CONFIG_HDMI_OUTPUT/d' /DietPi/config.txt
 
 			fi
 			#-------------------------------------------------------------------------------

--- a/dietpi/preboot
+++ b/dietpi/preboot
@@ -125,8 +125,8 @@
 
 		fi
 
-		# - Apply RPi headless mode, if set in dietpi.txt
-		(( $G_HW_MODEL < 10 )) && /DietPi/dietpi/func/dietpi-set_hardware headless $(grep -ci -m1 '^[[:blank:]]*AUTO_SETUP_HEADLESS=1' /DietPi/dietpi.txt)
+		# - Apply headless mode, if set in dietpi.txt (RPi, Odroid C1/C2)
+		(( $G_HW_MODEL < 11 || $G_HW_MODEL == 12 )) && /DietPi/dietpi/func/dietpi-set_hardware headless $(grep -ci -m1 '^[[:blank:]]*AUTO_SETUP_HEADLESS=1' /DietPi/dietpi.txt)
 
 		# - Apply forced eth speed, if set in dietpi.txt
 		/DietPi/dietpi/func/dietpi-set_hardware eth-forcespeed $(grep -m1 '^[[:blank:]]*AUTO_SETUP_NET_ETH_FORCE_SPEED=' /DietPi/dietpi.txt | sed 's/^[^=]*=//' )


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Config | Hide Audio and Performance Options on VM
+ DietPi-Config | RPi: Check config.txt options for `*disable*=1` options, instead of `*disable*=0`, where default values are `0`, otherwise when setting is commented or removed by user, estimation is wrong.
+ DietPi-Config | RPi: Use vcgencmd to estimate config.txt settings, where default values depend on device and/or other settings (HDMI boost, overscan)
+ DietPi-Config | RPi: Reorder display options code to each current value estimation beside related menu entry 
+ DietPi-Config | RPi: Estimate headless mode correctly via `hdmi_ignore_hotplug=1 && hdmi_ignore_composite=1` settings
+ DietPi-Config | Minor coding
+ DietPi-Set_Hardware | Headless mode: Apply Odroid settings via `G_CONFIG_INJECT`
+ DietPi-Set_Hardware | Headless mode: When disabling headless mode on RPi, leave boot rainbow splash disabled, which was as well default before implementing new config.txt-based headless mode
+ RPi | config.txt: Add "hdmi_blanking" setting and info, since we set this with headless mode now
+ RPi | config.txt: Add info about "enable_uart=1" forcing "core_freq=250"
+ DietPi-Patch | `s/^CONFIG_HDMI_OUTPUT=/AUTO_SETUP_HEADLESS=/` lead to doubled entry, since `AUTO_SETUP_HEADLESS` was already added by `verify_dietpi.txt`. Remove old setting only and remove doubled entry from Beta v6.20.2 testers, which otherwise causes `G_CONFIG_INJECT` to fail.
+ DietPi-PreBoot | Enable first run headless mode for Odroids C1 and C2 as well