### PR TITLE
DietPi-Software | Gitea 1.4 -> 1.7

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6096,7 +6096,7 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://dl.gitea.io/gitea/1.4/gitea-1.4-'
+			INSTALL_URL_ADDRESS='https://dl.gitea.io/gitea/1.7/gitea-1.7-'
 
 			#armv6
 			if (( $G_HW_ARCH == 1 )); then


### PR DESCRIPTION
This PR updates the download link for Gitea to 1.7 in `dietpi-software`. Installation has been verified to work on a fresh DietPi install, and the service runs normally without the need to change anything else.

---

**Status**: Ready

- [x] Change Gitea binary download from 1.4 to 1.7

**Reference**:

No different from the approach in #1723! 😛

**Commit list/description**:

- Software | Change Gitea binary download from 1.4 to 1.7

---

![api/terminal](https://user-images.githubusercontent.com/10241434/51793100-120ca200-21f6-11e9-820c-34579cc0866e.png)

---

| Home                                                                                                          | Repository                                                                                                          |
| ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
| ![home](https://user-images.githubusercontent.com/10241434/51793080-dd98e600-21f5-11e9-99db-7b3ca5c5446d.png) | ![repository](https://user-images.githubusercontent.com/10241434/51793084-eab5d500-21f5-11e9-8685-664adc755f70.png) |