### PR TITLE
DietPi-Software | Grafana: Switch to official APT repo with all archs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -35,6 +35,7 @@ Changes / Improvements / Optimisations:
 - DietPi-Software | You will now receive a whiptail prompt, if config files are overwritten during software installations: https://github.com/Fourdee/DietPi/issues/2325
 - DietPi-Software | NoMachine: Enabled ARMv8 support and will now install current version 6.4.6: https://github.com/Fourdee/DietPi/pull/2408
 - DietPi-Software | Shairport Sync: Updated to 3.2.2 (previously 3.1.7): https://github.com/Fourdee/DietPi/issues/2439
+- DietPi-Software | Grafana: Now the new official APT repo is used for all architectures, which allows updates to the current upstream version (currently v5.4.3) as well. This change will be applied to existing installs on dietpi-update to v6.20. Thanks to @jvteleco for informing us: https://github.com/Fourdee/DietPi/issues/2449
 - DietPi-Update | Added optional ability to automatically update DietPi, when updates are available. Please note, this is disabled by default.
 - DietPi-Sync | Removed the compression option, which has no effect on local sync, since files are not stored compressed, but only transferred compressed through remote sync protocols, which are currently not offered by DietPi-Sync.
 - DietPi-RAMlog/Logclear | The internally rotated LetsEncrypt (CertBot) log files are now removed, hourly with DietPi-RAMlog enabled, or when executing DietPi-Logclear manually.

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -14298,7 +14298,7 @@ _EOF_
 			Banner_Uninstalling
 
 			G_AGP grafana
-			rm /etc/apt/sources.list.d/grafana*.list &> /dev/null && G_AGUP
+			[[ -f /etc/apt/sources.list.d/grafana.list ]] && rm /etc/apt/sources.list.d/grafana.list
 
 			[[ -e /var/lib/grafana ]] && rm -R /var/lib/grafana
 			[[ -d $G_FP_DIETPI_USERDATA/grafana ]] && rm -R $G_FP_DIETPI_USERDATA/grafana

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1718,7 +1718,7 @@ _EOF_
 				 aSOFTWARE_WHIP_DESC[$software_id]='platform for analytics and monitoring'
 			aSOFTWARE_CATEGORY_INDEX[$software_id]=11
 					  aSOFTWARE_TYPE[$software_id]=0
-			 aSOFTWARE_ONLINEDOC_URL[$software_id]='f=8&t=5&p=12524#p12524'
+			 aSOFTWARE_ONLINEDOC_URL[$software_id]='p=12524#p12524'
 
 
 		#System security
@@ -4726,44 +4726,16 @@ _EOF_
 
 			Banner_Installing
 
-			if (( $G_HW_ARCH == 10 )); then
+			# APT repo GPG key
+			INSTALL_URL_ADDRESS='https://packages.grafana.com/gpg.key'
+			G_CHECK_URL "$INSTALL_URL_ADDRESS"
+			curl -sL "$INSTALL_URL_ADDRESS" | apt-key add -
 
-				INSTALL_URL_ADDRESS='https://packagecloud.io/install/repositories/grafana/stable/script.deb.sh'
-				G_CHECK_URL "$INSTALL_URL_ADDRESS"
+			# APT repo source & update
+			echo 'deb https://packages.grafana.com/oss/deb stable main' > /etc/apt/sources.list.d/grafana.list
+			G_AGUP
 
-				wget "$INSTALL_URL_ADDRESS" -O $software_id.sh
-				chmod +x $software_id.sh
-				./$software_id.sh
-
-				rm $software_id.sh
-
-			else
-
-				INSTALL_URL_ADDRESS='https://bintray.com/user/downloadSubjectPublicKey?username=bintray'
-				G_CHECK_URL "$INSTALL_URL_ADDRESS"
-
-				curl -sL "$INSTALL_URL_ADDRESS" | apt-key add -
-
-				local deb_address=''
-				if (( $G_HW_ARCH == 3 )); then
-
-					deb_address='https://bintray.com/fg2it/deb-arm64/grafana-on-raspberry/'
-
-				elif (( $G_HW_ARCH == 1 )); then
-
-					deb_address='https://dl.bintray.com/fg2it/deb-rpi-1b'
-
-				else
-
-					deb_address='https://dl.bintray.com/fg2it/deb'
-
-				fi
-
-				echo "deb $deb_address $G_DISTRO_NAME main" > /etc/apt/sources.list.d/grafana.list
-				G_AGUP
-
-			fi
-
+			# APT package
 			G_AGI grafana
 
 		fi
@@ -9728,7 +9700,7 @@ _EOF_
 
 		fi
 
-		#grafana
+		#Grafana
 		software_id=77
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
@@ -14320,7 +14292,7 @@ _EOF_
 
 		fi
 
-		software_id=77
+		software_id=77 # Grafana
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
@@ -14328,8 +14300,8 @@ _EOF_
 			G_AGP grafana
 			rm /etc/apt/sources.list.d/grafana*.list &> /dev/null && G_AGUP
 
-			rm -R /var/lib/grafana
-			rm -R $G_FP_DIETPI_USERDATA/grafana
+			[[ -e /var/lib/grafana ]] && rm -R /var/lib/grafana
+			[[ -d $G_FP_DIETPI_USERDATA/grafana ]] && rm -R $G_FP_DIETPI_USERDATA/grafana
 
 		fi
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1475,6 +1475,9 @@ _EOF_
 
 			fi
 			#-------------------------------------------------------------------------------
+			#Grafana: Remove obsolete x86_64 APT source, reinstall below to apply official repo: https://github.com/Fourdee/DietPi/issues/2449
+			rm -f /etc/apt/sources.list.d/grafana*.list
+			#-------------------------------------------------------------------------------
 			# - Reinstalls
 			#	Blynk: Apply new run user, update binary (jar)
 			#	Deluge: https://github.com/Fourdee/DietPi/issues/2339
@@ -1484,9 +1487,10 @@ _EOF_
 			#	Samba: https://github.com/Fourdee/DietPi/issues/2396#issuecomment-451701569
 			#	Amiberry 2.24
 			#	Shairport Sync: https://github.com/Fourdee/DietPi/issues/2439
+			#	Grafana: https://github.com/Fourdee/DietPi/issues/2449
 			if (( $G_DIETPI_INSTALL_STAGE == 2 )); then
 
-				/DietPi/dietpi/dietpi-software reinstall 37 45 65 108 124 128 131
+				/DietPi/dietpi/dietpi-software reinstall 37 45 65 77 108 124 128 131
 
 				# - Samba: Link disk cache to RAM: https://github.com/Fourdee/DietPi/issues/2396
 				if grep -q '^aSOFTWARE_INSTALL_STATE\[96\]=2' /DietPi/dietpi/.installed; then


### PR DESCRIPTION
**Status**: Testing
- [x] Patch x86_64 APT source
- [x] Changelog entry

**Testing**:
- [x] x86_64 `dietpi-update` on existing install
- [x] x86_64 fresh install
  - Buster support enabled, since the official repo does not have distro version branches, but stable/beta instead each, working with all distro versions.
- [x] ARMv6
- [x] ARMv7
- [x] ARMv8

**Reference**: https://github.com/Fourdee/DietPi/issues/2449

**Commit list/description**:
+ DietPi-Software | Grafana: Switch to official APT repo witch all archs
+ DietPi-Patch | Grafana: Remove obsolete x86_64 APT source, reinstall to switch all systems to the new official repo
+ CHANGELOG | Grafana: Now the new official APT repo is used for all architectures