### PR TITLE
DietPi-Software | MariaDB: v10.3 update on Buster requires settings patch

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Changes / Improvements / Optimisations:
 Bug Fixes:
 - DietPi-Software | WireGuard: Server installation also sets port as configured during installation to wg0-client.conf. Disabled installation for ARMv6 (no binaries). Many thanks to @WilburWalsh for reporting this issue: https://github.com/Fourdee/DietPi/issues/2474
 - DietPi-Software | VNCserver: Resolved "HOME" variable not set in service.
+- DietPi-Software | MariaDB: Resolved an issue with latest MariaDB v10.3 update on Buster due to deprecated/removed settings: https://github.com/Fourdee/DietPi/pull/2490
 - PREP | Resolved issues with failed installation, due to missing pre-req directory: https://github.com/Fourdee/DietPi/issues/2487
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/Fourdee/DietPi/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+base%3Amaster

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7765,6 +7765,15 @@ innodb_file_per_table=1
 character-set-server=utf8mb4
 collation-server=utf8mb4_general_ci
 _EOF_
+			# On Buster (MariaDB 10.3) the following settings are removed and default to our needs:
+			# - innodb_large_prefix: https://mariadb.com/kb/en/library/innodb-system-variables/#innodb_large_prefix
+			# - innodb_file_format: https://mariadb.com/kb/en/library/innodb-system-variables/#innodb_file_format
+			if (( $G_DISTRO > 4 )); then
+
+				sed -i '/innodb_large_prefix/d' $fp_mariadb_conf/99-dietpi-4byte.cnf
+				sed -i '/innodb_file_format/d' $fp_mariadb_conf/99-dietpi-4byte.cnf
+
+			fi
 			G_RUN_CMD systemctl restart $MARIADB_SERVICE
 
 			# Start redis-server, which is required for ncc command:
@@ -8019,6 +8028,15 @@ innodb_file_per_table=1
 character-set-server=utf8mb4
 collation-server=utf8mb4_general_ci
 _EOF_
+			# On Buster (MariaDB 10.3) the following settings are removed and default to our needs:
+			# - innodb_large_prefix: https://mariadb.com/kb/en/library/innodb-system-variables/#innodb_large_prefix
+			# - innodb_file_format: https://mariadb.com/kb/en/library/innodb-system-variables/#innodb_file_format
+			if (( $G_DISTRO > 4 )); then
+
+				sed -i '/innodb_large_prefix/d' $fp_mariadb_conf/99-dietpi-4byte.cnf
+				sed -i '/innodb_file_format/d' $fp_mariadb_conf/99-dietpi-4byte.cnf
+
+			fi
 			G_RUN_CMD systemctl restart $MARIADB_SERVICE
 
 			# Start redis-server, which is required for ncc command:

--- a/dietpi/pre-patch_file
+++ b/dietpi/pre-patch_file
@@ -20,17 +20,18 @@
 
 	EXIT_CODE=0
 
-	G_PROGRAM_NAME='DietPi-Pre-patch'
+	echo -e '\n \e[38;5;154mDietPi-Pre-patch\e[0m
+\e[90m─────────────────────────────────────────────────────
+ Mode: \e[0mApplying critical pre-patches\n'
 
 	# Grab input, being failsafe when applying to $G_DIETPI_VERSION_SUB
-	INPUT=$1
-	if [[ $INPUT =~ ^-?[0-9]+$ ]]; then
+	if [[ $1 =~ ^-?[0-9]+$ ]]; then
 
-		G_DIETPI_VERSION_SUB=$INPUT
+		G_DIETPI_VERSION_SUB=$1
 
 	else
 
-		echo 'No valid input used'
+		echo -e "\e[90m[\e[0m\e[31mFAILED\e[0m\e[90m]\e[0m No valid input used: $1"
 		EXIT_CODE=1
 
 	fi
@@ -42,25 +43,27 @@
 	while (( $EXIT_CODE == 0 ))
 	do
 
-		echo -e "\n \e[1m$G_PROGRAM_NAME\e[0m
-\e[90m─────────────────────────────────────────────────────\e[0m
-[ \e[1mINFO\e[0m ] Applying critical pre-patches\n"
-
 		#-------------------------------------------------------------------------------
 		# Pre-patch 1: RAMlog 0 free space check due to issues with failing DietPi cron jobs in v6.11
 		if (( $G_DIETPI_VERSION_SUB < 12 && $(df -B1M --output=avail /var/log | sed -n 2p) < 2 )); then
 
-			echo -e '[ \e[33mWARN\e[0m ] Pre-patch 1 | Clearing /var/log files to free up RAMlog space (<2MB) before update will continue'
-			/DietPi/dietpi/func/dietpi-logclear 1 || EXIT_CODE=1; break
+			echo -e '\e[90m[\e[0m \e[33mWARN\e[0m \e[90m]\e[0m Pre-patch 1 | Clearing /var/log files to free up RAMlog space (<2MB) before update will continue'
+			/DietPi/dietpi/func/dietpi-logclear 1 || { EXIT_CODE=1; break; }
 
 		fi
+		#-------------------------------------------------------------------------------
+		# Pre-patch 2: https://github.com/Fourdee/DietPi/pull/2490
+		if (( $G_DIETPI_VERSION_SUB < 21 )) && [[ -f /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf ]] &&
+			grep -qi 'buster' /etc/os-release; then
 
+			echo -e '\e[90m[\e[0m \e[33mWARN\e[0m \e[90m]\e[0m Pre-patch 2 | Patch /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf for MariaDB v10.3/Buster support'
+			sed -i '/innodb_large_prefix/d' /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf || { EXIT_CODE=2; break; }
+			sed -i '/innodb_file_format/d' /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf || { EXIT_CODE=2; break; }
+
+		fi	
 		#-------------------------------------------------------------------------------
 		# Finished
-		echo -e " \e[1m$G_PROGRAM_NAME\e[0m
-\e[90m─────────────────────────────────────────────────────\e[0m
-[ \e[1mINFO\e[0m ] Completed pre-patches with exit code: \e[33m$EXIT_CODE\e[0m\n"
-
+		echo -e '\e[90m[\e[0m  \e[32mOK\e[0m  \e[90m]\e[0m Successfully applied critical pre-patches\n'
 		break
 		#-------------------------------------------------------------------------------
 


### PR DESCRIPTION
**Status**: Ready
- [x] Patch on update
  - Pre-patch required, since APT update (dpkg --configure) fails with related settings in place
- [x] Changelog

**Commit list/description**:
+ DietPi-Software | MariaDB: innodb_large_prefix + innodb_file_format were deprecated with v10.2 and removed with v10.3, thus break ownCloud/Nextcloud install after latest Buster repo update + break APT update, if ownCloud/Nextcloud already installed
+ DietPi-Pre-patch | Add MariaDB v10.3 patch for Buster support
+ DietPi-Pre-patch | Minor reorder and visual alignment with G_DIETPI-NOTIFY
+ CHANGELOG | MariaDB: Resolved an issue with latest MariaDB v10.3 update on Buster due to deprecated/removed settings