### PR TITLE
DietPi-Update | Fix v6.20 update issues

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ Changes / Improvements / Optimisations:
 - DietPi-Software | GPU memory split: You will now be prompted to increase GPU memory if DietPi detects a higher value is required for installed software: https://github.com/Fourdee/DietPi/issues/2483
 
 Bug Fixes:
+- General | Resolved an issue when updating to v6.20, where DietPi-RAMdisk failed to sync changes to disk, causing several issues after reboot: https://github.com/Fourdee/DietPi/issues/2471#issuecomment-460104856
 - General | G_RUN_CMD: Resolved issue with incorrect exit code return: https://github.com/Fourdee/DietPi/issues/2508
 - DietPi-Software | WireGuard: Server installation also sets port as configured during installation to wg0-client.conf. Disabled installation for ARMv6 (no binaries). Many thanks to @WilburWalsh for reporting this issue: https://github.com/Fourdee/DietPi/issues/2474
 - DietPi-Software | VNCserver: Resolved "HOME" variable not set in service.

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -389,12 +389,6 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 			# - Save current version and Git owner/branch info
 			G_VERSIONDB_SAVE
 
-			# Failsafe: Restart RAMdisk + sync to disk
-			# - https://github.com/Fourdee/DietPi/issues/2473#issuecomment-458874222
-			# - https://dietpi.com/phpbb/viewtopic.php?f=9&t=2591
-			G_RUN_CMD systemctl restart dietpi-ramdisk
-			sync
-
 			# - Update info strings
 			INFO_VERSIONS_UPDATE
 
@@ -411,12 +405,7 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 	Apply_1st_Run_Update_Sucess(){
 
 		# - 1st run setup
-		if (( $G_DIETPI_INSTALL_STAGE == 0 )); then
-
-			export G_DIETPI_INSTALL_STAGE=1
-			echo $G_DIETPI_INSTALL_STAGE > /DietPi/dietpi/.install_stage
-
-		fi
+		(( $G_DIETPI_INSTALL_STAGE < 2 )) && echo 1 > /DietPi/dietpi/.install_stage
 
 	}
 
@@ -536,30 +525,34 @@ Please download the latest DietPi image:\n - https://dietpi.com/#download\n\n - 
 			G_DIETPI-NOTIFY 2 "$INFO_CURRENT_VERSION"
 			G_DIETPI-NOTIFY 2 "$INFO_SERVER_VERSION"
 
+			local do_reboot=0
+
 			# - 1st run setup
-			if (( $G_DIETPI_INSTALL_STAGE == 0 )); then
+			if (( $G_DIETPI_INSTALL_STAGE < 2 )); then
 
 				Apply_1st_Run_Update_Sucess
 
-				G_WHIP_MSG 'DietPi has been updated to the latest version.\n\nThe system will now reboot. Once completed, simply login to resume DietPi Setup. \n\nPress Enter to Continue.'
-				reboot
+				G_WHIP_MSG 'DietPi has been updated to the latest version.\n\nThe system will now reboot. Once completed, simply login to resume DietPi Setup.\n\nPress Enter to Continue.'
+				do_reboot=1
 
 			# - Reboot prompt, if system is already installed
-			elif (( $G_DIETPI_INSTALL_STAGE == 2 )); then
+			else
 
-				if G_WHIP_YESNO "[  OK  ] Update applied\n
- Current version: $INFO_CURRENT_VERSION\n
- A system reboot is required to finalise the update. Would you like to reboot the system now?"; then
-
-					reboot
-
-				else
-
-					/DietPi/dietpi/dietpi-services restart
-
-				fi
+				G_WHIP_YESNO "[  OK  ] Update applied\n
+Current version: $INFO_CURRENT_VERSION\n
+A system reboot is required to finalise the update. Would you like to reboot the system now?" && do_reboot=1
 
 			fi
+
+			# Failsafe: Restart RAMdisk + sync to disk
+			# - https://github.com/Fourdee/DietPi/issues/2473#issuecomment-458874222
+			# - https://dietpi.com/phpbb/viewtopic.php?f=9&t=2591
+			G_RUN_CMD systemctl restart dietpi-ramdisk
+			sync
+
+			(( $do_reboot )) && reboot
+
+			/DietPi/dietpi/dietpi-services restart
 
 		fi
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -33,14 +33,18 @@
 	#Patches that require a restart of DietPi-Update and patch system.
 	Restart_DietPi_Update(){
 
-		#Save current version, to re-run patch on next launch
+		#Save current version, to rerun patch on next launch
 		G_VERSIONDB_SAVE
 
-		#Remove DietPi-Update and DietPi-Patchfile working directories do allow concurrent execution
+		#Remove DietPi-Update and DietPi-Patchfile working directories to allow concurrent execution
 		cd /tmp
 		rm -R /tmp/DietPi-Update /tmp/DietPi-Patchfile
 
-		G_DIETPI-NOTIFY 0 'Re-running DietPi-Update, to apply this new system'
+		G_DIETPI-NOTIFY 0 'Re-running DietPi-Update, to apply this new system...'
+
+		#Sync changes to disk to avoid async issues
+		sync
+		sleep 3
 
 		#Apply update forcefully, since user has already chosen to do so
 		/DietPi/dietpi/dietpi-update 1
@@ -51,8 +55,8 @@
 
 	}
 
-	#Pre-v6.17: Switch to new branch and versioning system
-	#	As loaded pre-v6.17 dietpi-update will overwrite .version to previous 2 line system, we need to rerun dietpi-update.
+	#Pre-v6.17: Apply to new branch and versioning system
+	#	As loaded pre-v6.17 dietpi-update will overwrite ".version" to previous 2 line system, we need to rerun dietpi-update.
 	if (( $G_DIETPI_VERSION_SUB < 17 )) && [[ ! $(sed -n 6p /DietPi/dietpi/.version) ]]; then
 
 		#Switch from obsolete testing to new dev branch
@@ -72,34 +76,34 @@
 
 	fi
 
-	#Update G_DIETPI_INSTALL_STAGE to new versioning system.
+	#Pre-v6.20: Update to new G_DIETPI_INSTALL_STAGE system
+	#	As loaded pre-v6.20 dietpi-update will recreate ".update_stage", we need to rerun dietpi-update.
 	if [[ -f /DietPi/dietpi/.update_stage ]]; then
 
-		rm -f /DietPi/dietpi/.update_stage /boot/dietpi/.update_stage
-
-		# Failsafe: Assure removal is synced to disk
-		sync
+		rm -f /{DietPi,boot}/dietpi/.update_stage
 
 		echo ''
 		G_DIETPI-NOTIFY 0 'DietPi has applied a new G_DIETPI_INSTALL_STAGE system to the device.'
 
-		#System already installed, re-run patch
-		if (( $(</DietPi/dietpi/.install_stage) == 1 )); then
+		#System already installed, rerun patch
+		if (( $(</DietPi/dietpi/.install_stage) > 0 )); then
 
 			echo 2 > /DietPi/dietpi/.install_stage
 			Restart_DietPi_Update
 
 		#System updating for the 1st time. We need to reboot the system, to kill dietpi-software old code and reload the new one.
-		elif (( $(</DietPi/dietpi/.install_stage) < 1 )); then
+		else
 
 			echo 0 > /DietPi/dietpi/.install_stage
-			G_WHIP_MSG 'A system reboot is required to update G_DIETPI_INSTALL_STAGE system. Once the system reboots, please login to continue setup.'
+			G_RUN_CMD systemctl restart dietpi-ramdisk
+			sync
+			G_WHIP_MSG 'A system reboot is required to apply the new G_DIETPI_INSTALL_STAGE system. Once the system has rebooted, please login to continue setup.'
+			sleep 3 # Sleep to assure sync has finished in case of G_USER_INPUTS=0
 			reboot
 
 		fi
 
 	fi
-
 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	#Incremental patch system:


### PR DESCRIPTION
**Status**: Testing
- [x] DietPi-Update
- [x] Changelog

**Reference**:
- https://github.com/Fourdee/DietPi/issues/2471
- https://github.com/Fourdee/DietPi/issues/2495

**Commit list/description**:
+ DietPi-Patch | Assure RAMdisk sync and disk sync has finished before doing a reboot
+ DietPi-Update | Force DietPi-RAMdisk restart (sync RAMdisk to disk) + "sync" disk changes after every update at the very end. This assures that nothing (not even install state changes) is lost in case of DietPi-RAMdisk failure on shutdown.