### PR TITLE
DietPi-Software | Aria2: Config tweak/fix

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11107,12 +11107,12 @@ _EOF_
 			G_BACKUP_FP /var/lib/dietpi/dietpi-software/installed/aria2.conf
 			cat << _EOF_ > /var/lib/dietpi/dietpi-software/installed/aria2.conf
 # host is where aria2c is running on
-host=localhost
+# host=localhost
 dir=$G_FP_DIETPI_USERDATA/$FOLDER_DOWNLOADS
 
 # cleanup_policy
-cleanup-policy=clean_got
-cleanup-percent=90%
+# cleanup-policy=clean_got
+# cleanup-percent=90%
 
 # The fallowing options are aria2c options as usual aria2.conf file
 # https://aria2.github.io/manual/en/html/aria2c.html
@@ -11122,6 +11122,7 @@ enable-rpc=true
 rpc-listen-all=true
 rpc-listen-port=6800
 rpc-secret=$GLOBAL_PW
+rpc-allow-origin-all=true
 pause=false
 
 # General Options
@@ -11148,18 +11149,18 @@ max-download-limit=0
 seed-ratio=0.1
 seed-time=0
 
-metalink-servers=$(Optimize_BitTorrent 2)
+# metalink-servers=$(Optimize_BitTorrent 2)
 allow-overwrite=false
 always-resume=true
 auto-file-renaming=false
 file-allocation=none
 
-[limit-options]
+# [limit-options]
 max-concurrent-downloads=$(Optimize_BitTorrent 1)
 max-overall-download-limit=1000K
 max-overall-upload-limit=100K
 
-[unlimit-options]
+# [unlimit-options]
 max-concurrent-downloads=$(Optimize_BitTorrent 1)
 max-overall-download-limit=0
 max-overall-upload-limit=0

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11106,16 +11106,11 @@ _EOF_
 
 			G_BACKUP_FP /var/lib/dietpi/dietpi-software/installed/aria2.conf
 			cat << _EOF_ > /var/lib/dietpi/dietpi-software/installed/aria2.conf
-# host is where aria2c is running on
-# host=localhost
-dir=$G_FP_DIETPI_USERDATA/$FOLDER_DOWNLOADS
-
-# cleanup_policy
-# cleanup-policy=clean_got
-# cleanup-percent=90%
-
 # The fallowing options are aria2c options as usual aria2.conf file
 # https://aria2.github.io/manual/en/html/aria2c.html
+
+# Download directory
+dir=$G_FP_DIETPI_USERDATA/$FOLDER_DOWNLOADS
 
 # RPC Options
 enable-rpc=true
@@ -11134,6 +11129,9 @@ continue=true
 check-integrity=true
 max-concurrent-downloads=$(Optimize_BitTorrent 1)
 max-connection-per-server=$(Optimize_BitTorrent 1)
+# Bandwidth limits: https://aria2.github.io/manual/en/html/aria2c.html#cmdoption-max-overall-upload-limit
+max-overall-download-limit=0
+max-overall-upload-limit=0
 max-file-not-found=3
 max-tries=5
 retry-wait=60
@@ -11149,21 +11147,10 @@ max-download-limit=0
 seed-ratio=0.1
 seed-time=0
 
-# metalink-servers=$(Optimize_BitTorrent 2)
 allow-overwrite=false
 always-resume=true
 auto-file-renaming=false
 file-allocation=none
-
-# [limit-options]
-max-concurrent-downloads=$(Optimize_BitTorrent 1)
-max-overall-download-limit=1000K
-max-overall-upload-limit=100K
-
-# [unlimit-options]
-max-concurrent-downloads=$(Optimize_BitTorrent 1)
-max-overall-download-limit=0
-max-overall-upload-limit=0
 _EOF_
 
 			cat << _EOF_ > /etc/systemd/system/aria2.service


### PR DESCRIPTION
to fix using 3rd party plugin;
and comment unknown option;


unknown option (`systemctl status aria2.service`):
```
   Loaded: loaded (/etc/systemd/system/aria2.service; disabled; vendor preset: enabled)
   Active: active (running) since Tue 2019-02-12 02:12:35 HKT; 5s ago
 Main PID: 3572 (aria2c)
   CGroup: /system.slice/aria2.service
           └─3572 /usr/bin/aria2c --conf-path=/var/lib/dietpi/dietpi-software/installed/aria2.conf

Feb 12 02:12:35 zerow systemd[1]: Started Aria2 (DietPi).
Feb 12 02:12:35 zerow aria2c[3572]: 02/12 02:12:35 [WARN] Unknown option: host=localhost
Feb 12 02:12:35 zerow aria2c[3572]: 02/12 02:12:35 [WARN] Unknown option: cleanup-policy="clean_got"
Feb 12 02:12:35 zerow aria2c[3572]: 02/12 02:12:35 [WARN] Unknown option: cleanup-percent=90%
Feb 12 02:12:35 zerow aria2c[3572]: 02/12 02:12:35 [WARN] Unknown option: metalink-servers=7
Feb 12 02:12:35 zerow aria2c[3572]: 02/12 02:12:35 [WARN] Unknown option: [limit-options]
Feb 12 02:12:35 zerow aria2c[3572]: 02/12 02:12:35 [WARN] Unknown option: [unlimit-options]
Feb 12 02:12:35 zerow aria2c[3572]: 02/12 02:12:35 [NOTICE] IPv4 RPC: listening on TCP port 6800
Feb 12 02:12:35 zerow aria2c[3572]: 02/12 02:12:35 [NOTICE] IPv6 RPC: listening on TCP port 6800
```

offical ref:
https://aria2.github.io/manual/en/html/aria2c.html#cmdoption-rpc-allow-origin-all

3rd plugin:
https://github.com/acgotaku/BaiduExporter