### PR TITLE
DietPi-Software | Java: Reapply workaround to fix ARM install issue

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Changes / Improvements / Optimisations:
 Bug Fixes:
 - General | Resolved an issue where /etc/bashrc.d entries could be run multiple times. Many thanks to @jonare77 for reporting this: https://github.com/Fourdee/DietPi/issues/2529
 - DietPi-Software | Mopidy: Resolved issue with failed audio playback. Many thanks to @arkhub for reporting this issue! https://github.com/Fourdee/DietPi/issues/2536
+- DietPi-Software | Java: Resolved an issue where install failed on ARM. Thanks to @WTFMaster for reporting this issue: https://github.com/Fourdee/DietPi/issues/2524
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/Fourdee/DietPi/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+base%3Amaster
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6743,7 +6743,7 @@ _EOF_
 
 			# Workaround for ARM install issue: https://github.com/Fourdee/DietPi/issues/2524
 			apt-get install -y -qq $packages
-			G_AGI $package
+			G_AGI $packages
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6726,6 +6726,8 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 
 			Banner_Installing
 
+			local packages='ca-certificates-java openjdk-8-jre-headless openjdk-8-jdk-headless'
+
 			# On Jessie use backports repo:
 			if (( $G_DISTRO == 3 )); then
 
@@ -6735,13 +6737,13 @@ Pin: release a=jessie-backports
 Pin-Priority: 990
 _EOF_
 
-				G_AGI openjdk-8-jre-headless openjdk-8-jdk-headless -t jessie-backports
-
-			else
-
-				G_AGI openjdk-8-jre-headless openjdk-8-jdk-headless
+				packages+=' -t jessie-backports'
 
 			fi
+
+			# Workaround for ARM install issue: https://github.com/Fourdee/DietPi/issues/2524
+			apt-get install -y -qq $packages
+			G_AGI $package
 
 		fi
 


### PR DESCRIPTION
**Status**: Ready
- [x] Changelog

**Reference**: https://github.com/Fourdee/DietPi/issues/2524

**Commit list/description**:
+ DietPi-Software | Java: Reapply workaround to fix ARM install issue
+ CHANGELOG | Java: Resolved an issue where install failed on ARM