### PR TITLE
DietPi-Login | Failsafe hardening and resolving possible first run loops

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -16172,6 +16172,8 @@ NB: You can use dietpi-software at a later date, to install optimized software f
 					#exit menu system
 					TARGETMENUID=-1
 
+					DISABLE_REBOOT=1
+
 					#Enable installation start flag
 					GOSTARTINSTALL=1
 

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -410,7 +410,6 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 
 	}
 
-
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Main Loop
 	#/////////////////////////////////////////////////////////////////////////////////////
@@ -527,21 +526,7 @@ Please download the latest DietPi image:\n - https://dietpi.com/#download\n\n - 
 			G_DIETPI-NOTIFY 2 "$INFO_SERVER_VERSION"
 
 			# - 1st run setup
-			if (( $G_DIETPI_INSTALL_STAGE < 2 )); then
-
-				Apply_1st_Run_Update_Sucess
-
-				G_WHIP_MSG 'DietPi has been updated to the latest version.\n\nThe system will now reboot. Once completed, simply login to resume DietPi Setup.\n\nPress Enter to Continue.'
-				DO_REBOOT=1
-
-			# - Reboot prompt, if system is already installed
-			else
-
-				G_WHIP_YESNO "[  OK  ] Update applied\n
-Current version: $INFO_CURRENT_VERSION\n
-A system reboot is required to finalise the update. Would you like to reboot the system now?" && DO_REBOOT=1
-
-			fi
+			Apply_1st_Run_Update_Sucess
 
 			# Failsafe: Restart RAMdisk + sync to disk
 			# - https://github.com/Fourdee/DietPi/issues/2473#issuecomment-458874222
@@ -549,9 +534,7 @@ A system reboot is required to finalise the update. Would you like to reboot the
 			G_RUN_CMD systemctl restart dietpi-ramdisk
 			sync
 
-			(( $DO_REBOOT )) && reboot
-
-			/DietPi/dietpi/dietpi-services restart
+			(( $G_DIETPI_INSTALL_STAGE == 2 )) && /DietPi/dietpi/dietpi-services restart
 
 		fi
 

--- a/dietpi/login
+++ b/dietpi/login
@@ -181,7 +181,7 @@
 				pgrep 'dietpi-software' &> /dev/null && Other_Session_User_Prompt
 
 				# - Start DietPi-Software
-				/DietPi/dietpi/dietpi-software | tee $FP_DIETPI_FIRSTRUNSETUP_LOG # Sets G_DIETPI_INSTALL_STAGE=2
+				/DietPi/dietpi/dietpi-software 2>&1 | tee $FP_DIETPI_FIRSTRUNSETUP_LOG # Sets G_DIETPI_INSTALL_STAGE=2
 
 				# - Update install state, to exit loop, if user skipped immediate reboot
 				export G_DIETPI_INSTALL_STAGE=$(</DietPi/dietpi/.install_stage)
@@ -189,6 +189,7 @@
 			fi
 
 			# Check for second loop and in case inform user, since this indicates an error
+			# NB: Check via "! (( $G_DIETPI_INSTALL_STAGE == 2 ))" to prompt error as well in case of empty or non-integer $G_DIETPI_INSTALL_STAGE
 			if ! (( $G_DIETPI_INSTALL_STAGE == 2 )); then
 
 				# - Force interactive mode to show G_WHIP error prompts

--- a/dietpi/login
+++ b/dietpi/login
@@ -13,15 +13,6 @@
 	# - activates on login /etc/bashrc.d/dietpi-login.sh
 	#////////////////////////////////////
 
-	# Precaution: Wait for DietPi RAMdisk to finish
-	until [[ -f /DietPi/.ramdisk ]]
-	do
-
-		G_DIETPI-NOTIFY 2 'Waiting for DietPi-RAMDISK to finish mounting DietPi to RAM...'
-		sleep 1
-
-	done
-
 	# Import DietPi-Globals --------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
 	G_PROGRAM_NAME='DietPi-Login'
@@ -32,12 +23,6 @@
 	# Globals
 	#/////////////////////////////////////////////////////////////////////////////////////
 	FP_DIETPI_FIRSTRUNSETUP_LOG='/var/tmp/dietpi/logs/dietpi-firstrun-setup.log'
-
-	#/////////////////////////////////////////////////////////////////////////////////////
-	# DietPi-Autostart
-	#/////////////////////////////////////////////////////////////////////////////////////
-	AUTO_START_INDEX=0
-	[[ -f /DietPi/dietpi/.dietpi-autostart_index ]] && AUTO_START_INDEX=$(</DietPi/dietpi/.dietpi-autostart_index)
 
 	# Autoboot
 	Run_AutoStart(){
@@ -131,6 +116,7 @@
 
 	}
 
+	# First Run Setup
 	Run_First_Update_Setup(){
 
 		local automated_setup=0
@@ -242,8 +228,9 @@ If this repeatedly fails, please collect all terminal output and the content of 
 		fi
 
 		/DietPi/dietpi/func/dietpi-banner 1
-
-		(( $AUTO_START_INDEX > 0 )) && Run_AutoStart
+		local auto_start_index=0
+		[[ -f /DietPi/dietpi/.dietpi-autostart_index ]] && auto_start_index=$(</DietPi/dietpi/.dietpi-autostart_index)
+		(( $auto_start_index > 0 )) && Run_AutoStart
 
 	#----------------------------------------------------------------
 	# Run DietPi-Update/DietPi-Software (1st run setup) (G_DIETPI_INSTALL_STAGE=0/1)

--- a/dietpi/login
+++ b/dietpi/login
@@ -32,7 +32,6 @@
 	# Globals
 	#/////////////////////////////////////////////////////////////////////////////////////
 	FP_DIETPI_FIRSTRUNSETUP_LOG='/var/tmp/dietpi/logs/dietpi-firstrun-setup.log'
-	FP_TMP_DIETPI_FIRSTRUNSETUP_LOG='/tmp/dietpi-firstrun-setup.log'
 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# DietPi-Autostart
@@ -196,8 +195,7 @@
 				pgrep 'dietpi-software' &> /dev/null && Other_Session_User_Prompt
 
 				# - Start DietPi-Software
-				/DietPi/dietpi/dietpi-software | tee $FP_TMP_DIETPI_FIRSTRUNSETUP_LOG # Sets G_DIETPI_INSTALL_STAGE=2
-				mv $FP_TMP_DIETPI_FIRSTRUNSETUP_LOG $FP_DIETPI_FIRSTRUNSETUP_LOG
+				/DietPi/dietpi/dietpi-software | tee $FP_DIETPI_FIRSTRUNSETUP_LOG # Sets G_DIETPI_INSTALL_STAGE=2
 
 				# - Update install state, to exit loop, if user skipped immediate reboot
 				export G_DIETPI_INSTALL_STAGE=$(</DietPi/dietpi/.install_stage)
@@ -205,7 +203,7 @@
 			fi
 
 			# Check for second loop and in case inform user, since this indicates an error
-			if ! (( $G_DIETPI_INSTALL_STAGE == 2 )); then
+			if (( $G_DIETPI_INSTALL_STAGE != 2 )); then
 
 				# - Force interactive mode to show G_WHIP error prompts
 				export G_USER_INPUTS=1

--- a/dietpi/login
+++ b/dietpi/login
@@ -189,7 +189,7 @@
 			fi
 
 			# Check for second loop and in case inform user, since this indicates an error
-			if (( $G_DIETPI_INSTALL_STAGE != 2 )); then
+			if ! (( $G_DIETPI_INSTALL_STAGE == 2 )); then
 
 				# - Force interactive mode to show G_WHIP error prompts
 				export G_USER_INPUTS=1
@@ -273,5 +273,6 @@ In case report this issue to: https://github.com/Fourdee/DietPi/issues'
 
 	#-----------------------------------------------------------------------------------
 	exit
+	#Run loop, update globals after updates, no reboots required?
 	#-----------------------------------------------------------------------------------
 }

--- a/dietpi/login
+++ b/dietpi/login
@@ -13,7 +13,7 @@
 	# - activates on login /etc/bashrc.d/dietpi-login.sh
 	#////////////////////////////////////
 
-	#Precaution: Wait for DietPi Ramdisk to finish
+	# Precaution: Wait for DietPi RAMdisk to finish
 	until [[ -f /DietPi/.ramdisk ]]
 	do
 
@@ -22,35 +22,35 @@
 
 	done
 
-	#Import DietPi-Globals ---------------------------------------------------------------
+	# Import DietPi-Globals --------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
 	G_PROGRAM_NAME='DietPi-Login'
 	#G_INIT
-	##Import DietPi-Globals ---------------------------------------------------------------
+	# Import DietPi-Globals --------------------------------------------------------------
 
 	#/////////////////////////////////////////////////////////////////////////////////////
-	#Globals
+	# Globals
 	#/////////////////////////////////////////////////////////////////////////////////////
 	FP_DIETPI_FIRSTRUNSETUP_LOG='/var/tmp/dietpi/logs/dietpi-firstrun-setup.log'
 	FP_TMP_DIETPI_FIRSTRUNSETUP_LOG='/tmp/dietpi-firstrun-setup.log'
 
 	#/////////////////////////////////////////////////////////////////////////////////////
-	#DietPi-Autostart
+	# DietPi-Autostart
 	#/////////////////////////////////////////////////////////////////////////////////////
 	AUTO_START_INDEX=0
 	[[ -f /DietPi/dietpi/.dietpi-autostart_index ]] && AUTO_START_INDEX=$(</DietPi/dietpi/.dietpi-autostart_index)
 
-	#Autoboot
+	# Autoboot
 	Run_AutoStart(){
 
-		#Do we have a valid screen for autoboot?
+		# - Do we have a valid screen for autoboot?
 		local screen_valid=0
 		[[ ! $DISPLAY && $(tty) == '/dev/tty1' ]] && screen_valid=1
 
-		#Boot to specific Program
+		# - Boot to specific program
 		if (( $screen_valid )); then
 
-			#Wait for postboot
+			# - Wait for DietPi-PostBoot
 			local max_seconds=15
 			local current_seconds=1
 			until systemctl status dietpi-postboot | grep -qi 'exited'
@@ -59,18 +59,16 @@
 				G_DIETPI-NOTIFY 2 "Waiting for DietPi-Postboot to finish ($current_seconds/$max_seconds)"
 				sleep 1
 				((current_seconds++))
-
-				#max loop limit
 				(( $current_seconds >= $max_seconds )) && break
 
 			done
 
-			#Kodi
+			# - Kodi
 			if (( $AUTO_START_INDEX == 1 )); then
 
 				/DietPi/dietpi/misc/start_kodi
 
-			#Desktop (LXDE/MATE etc)
+			# - Desktop (LXDE/MATE etc)
 			elif (( $AUTO_START_INDEX == 2 )); then
 
 				clear
@@ -84,49 +82,46 @@
 
 				fi
 
-			#RetroPie/Emulation station
+			# - RetroPie/Emulation station
 			elif (( $AUTO_START_INDEX == 3 )); then
 
-				#emulationstation - can no longer be run as root
+				#	emulationstation - can no longer be run as root
 				/opt/retropie/supplementary/emulationstation/emulationstation.sh
 
-			#OpenTyrian
+			# - OpenTyrian
 			elif (( $AUTO_START_INDEX == 4 )); then
 
 				/usr/local/games/opentyrian/run
 
-			#DietPi-Cloudshell
+			# - DietPi-Cloudshell
 			elif (( $AUTO_START_INDEX == 5 )); then
 
-				#Launch DietPi-Cloudshell
 				setterm --blank 0 --powersave off --cursor off
 				systemctl start dietpi-cloudshell
 
-			#Amiberry standard boot
+			# - Amiberry standard boot
 			elif (( $AUTO_START_INDEX == 8 )); then
 
 				systemctl start amiberry
 
-			#DXX-Rebirth
+			# - DXX-Rebirth
 			elif (( $AUTO_START_INDEX == 9 )); then
 
 				$G_FP_DIETPI_USERDATA/dxx-rebirth/run.sh
 
-			#CAVA
+			# - CAVA
 			elif (( $AUTO_START_INDEX == 10 )); then
 
-				# wait for MPD fifo to start
-				sleep 4
-
+				sleep 4 # Wait for MPD fifo to start
 				setterm --blank 0 --powersave off
 				cava
 
-			#Chromium
+			# - Chromium
 			elif (( $AUTO_START_INDEX == 11 )); then
 
 				/var/lib/dietpi/dietpi-software/installed/chromium-autostart.sh
 
-			#LightDM
+			# - LightDM
 			elif (( $AUTO_START_INDEX == 16 )); then
 
 				/usr/sbin/lightdm
@@ -139,88 +134,91 @@
 
 	Run_First_Update_Setup(){
 
-		/DietPi/dietpi/func/dietpi-banner 0
 		local automated_setup=0
+
+		# First run setup running in other session
+		Other_Session_User_Prompt(){
+
+			local additional_text='Please resume setup on the active screen.'
+			(( $automated_setup )) && additional_text='Automated setup is in progress, the system will reboot automatically when completed.'
+
+			#	Force interactive whiptail
+			G_USER_INPUTS=1 G_WHIP_MSG "[WARNING] DietPi is currently running on another screen.\n\n$additional_text"
+
+			exit
+
+		}
+
+		# Automated?
+		if grep -qi '^[[:blank:]]*AUTO_SETUP_AUTOMATED=1' /DietPi/dietpi.txt; then
+
+			automated_setup=1
+			#	Set non-interactive shell, if automated installation (as .bashrc run via STDIN check is interactive)
+			export G_USER_INPUTS=0
+
+		fi
+
+		# Show GPL license
+		if [[ -f /var/lib/dietpi/license.txt ]] && (( ! $automated_setup )); then
+
+			G_WHIP_VIEWFILE /var/lib/dietpi/license.txt
+			rm /var/lib/dietpi/license.txt
+
+		fi
 
 		until (( $G_DIETPI_INSTALL_STAGE == 2 ))
 		do
 
-			# - Automated?
-			if grep -qi '^[[:blank:]]*AUTO_SETUP_AUTOMATED=1' /DietPi/dietpi.txt; then
-
-				automated_setup=1
-				#	Set non-interactive shell, if automated installation (as .bashrc run via STDIN check is interactive)
-				export G_USER_INPUTS=0
-
-			fi
-
-			# - 1st run dietpi-update
+			# 1st run dietpi-update
 			if (( $G_DIETPI_INSTALL_STAGE == 0 )); then
 
-				if pgrep 'dietpi-update' &> /dev/null; then
+				# - Prompt and exit if DietPi-Update runs in other session already
+				pgrep 'dietpi-update' &> /dev/null && Other_Session_User_Prompt
 
-					local additional_text='Please resume setup on the active screen.'
-					grep -q '^[[:blank:]]*AUTO_SETUP_AUTOMATED=1' /DietPi/dietpi.txt && additional_text='Automated installation update is in progress, the system will reboot automatically when completed.'
+				# - Check internet
+				optional_cmd_inputs='--no-check-certificate' G_CHECK_URL "$(grep -m1 '^[[:blank:]]*deb ' /etc/apt/sources.list | mawk '{print $2}')" # Will exit on failure here then prompt user to configure network
 
-					G_WHIP_MSG "DietPi is currently running on another screen.\n\n$additional_text"
+				# - Check NTP synced
+				/DietPi/dietpi/func/run_ntpd
 
-				else
+				# - Start DietPi-Update
+				/DietPi/dietpi/dietpi-update 1 # Sets G_DIETPI_INSTALL_STAGE=1
 
-					#	Check internet
-					optional_cmd_inputs='--no-check-certificate' G_CHECK_URL "$(grep -m1 '^[[:blank:]]*deb ' /etc/apt/sources.list | awk '{print $2}')" # Will exit on failure here then prompt user to configure network
-
-					#	Check NTP synced
-					/DietPi/dietpi/func/run_ntpd
-
-					#	Show GPL license
-					if [[ -f /var/lib/dietpi/license.txt ]]; then
-
-						G_WHIP_VIEWFILE /var/lib/dietpi/license.txt
-						rm /var/lib/dietpi/license.txt
-
-					fi
-
-					/DietPi/dietpi/dietpi-update 1 #Sets G_DIETPI_INSTALL_STAGE=1
-
-				fi
-
-			# - 1st run dietpi-software installs
-			elif (( $G_DIETPI_INSTALL_STAGE == 1 )); then
-
-				#	Wait for DietPi-Software if already running, else run it
-				local run_dietpi_software=1
-				while pgrep 'dietpi-software' &> /dev/null
-				do
-
-					run_dietpi_software=0
-
-					# - Automated
-					if (( $automated_setup )); then
-
-						G_DIETPI-NOTIFY 2 'DietPi is currently installing and configuring your system. Please wait for this to complete, check back later.'
-
-					else
-
-						G_DIETPI-NOTIFY 2 'DietPi-Software is already running on another terminal/screen. Please complete or exit, before continuing.'
-
-					fi
-
-					sleep 2
-
-				done
-
-				#	Start DietPi-Software
-				if (( $run_dietpi_software )); then
-
-					/DietPi/dietpi/dietpi-software | tee $FP_TMP_DIETPI_FIRSTRUNSETUP_LOG #Sets G_DIETPI_INSTALL_STAGE=2
-					mv $FP_TMP_DIETPI_FIRSTRUNSETUP_LOG $FP_DIETPI_FIRSTRUNSETUP_LOG
-
-				fi
+				# - Update install state, to allow DietPi-Software in same loop, if no update was required
+				export G_DIETPI_INSTALL_STAGE=$(</DietPi/dietpi/.install_stage)
 
 			fi
 
-			# - reset to auto detection
-			unset G_USER_INPUTS
+			# 1st run dietpi-software installs
+			if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
+
+				# - Prompt and exit if DietPi-Software runs in other session already
+				pgrep 'dietpi-software' &> /dev/null && Other_Session_User_Prompt
+
+				# - Start DietPi-Software
+				/DietPi/dietpi/dietpi-software | tee $FP_TMP_DIETPI_FIRSTRUNSETUP_LOG # Sets G_DIETPI_INSTALL_STAGE=2
+				mv $FP_TMP_DIETPI_FIRSTRUNSETUP_LOG $FP_DIETPI_FIRSTRUNSETUP_LOG
+
+				# - Update install state, to exit loop, if user skipped immediate reboot
+				export G_DIETPI_INSTALL_STAGE=$(</DietPi/dietpi/.install_stage)
+
+			fi
+
+			# Check for second loop and in case inform user, since this indicates an error
+			if ! (( $G_DIETPI_INSTALL_STAGE == 2 )); then
+
+				# - Force interactive mode to show G_WHIP error prompts
+				export G_USER_INPUTS=1
+
+				# - In case of broken install state, reset to 0 to force update and fix code
+				(( $G_DIETPI_INSTALL_STAGE == 0 || $G_DIETPI_INSTALL_STAGE == 1 )) || { export G_DIETPI_INSTALL_STAGE=0; echo 0 > /DietPi/dietpi/.install_stage; }
+
+				G_WHIP_MSG "[FAILED] First run setup failed\n
+An error has occured either during first run update or installs.\n
+First run setup will now try to re-apply the last step.
+If this repeatedly fails, please collect all terminal output and the content of $FP_DIETPI_FIRSTRUNSETUP_LOG if available and report this issue to: https://github.com/Fourdee/DietPi/issues"
+
+			fi
 
 		done
 
@@ -234,32 +232,57 @@
 	/DietPi/dietpi/func/obtain_network_details
 
 	#----------------------------------------------------------------
-	#Normal Login
+	# Normal Login
 	if (( $G_DIETPI_INSTALL_STAGE == 2 )); then
+
+		# - Show GPL license on first normal login, if setup was automated
+		if [[ -f /var/lib/dietpi/license.txt ]]; then
+
+			G_WHIP_VIEWFILE /var/lib/dietpi/license.txt
+			rm /var/lib/dietpi/license.txt
+
+		fi
 
 		/DietPi/dietpi/func/dietpi-banner 1
 
 		(( $AUTO_START_INDEX > 0 )) && Run_AutoStart
 
 	#----------------------------------------------------------------
-	#Run DietPi-Update/DietPi-Software (1st run setup) (G_DIETPI_INSTALL_STAGE=0/1)
-	elif (( $G_DIETPI_INSTALL_STAGE >= 0 )); then
+	# Run DietPi-Update/DietPi-Software (1st run setup) (G_DIETPI_INSTALL_STAGE=0/1)
+	elif (( $G_DIETPI_INSTALL_STAGE == 0 || $G_DIETPI_INSTALL_STAGE == 1 )); then
 
-		Run_First_Update_Setup
+		/DietPi/dietpi/func/dietpi-banner 0
+
+		if (( $UID )); then
+
+			G_WHIP_MSG '[WARNING] Root login required\n
+To finish DietPi first run setup, root permissions are required.\n
+Please login again as user "root" with password "dietpi", respectively the one you chose in "dietpi.txt".'
+
+		else
+
+			Run_First_Update_Setup
+
+		fi
 
 	#----------------------------------------------------------------
-	#DietPi finishing up bootloader.
+	# DietPi-Boot first run setup not finished
 	elif (( $G_DIETPI_INSTALL_STAGE == -1 )); then
 
 		/DietPi/dietpi/func/dietpi-banner 0
-		echo -e ' >> DietPi System prep is nearly completed: \n Please run /DietPi/dietpi/login after a few seconds.'
+		G_WHIP_MSG '[WARNING] Boot scripts still running\n
+DietPi boot scripts have not yet finished system preparations.\n
+Please run "/DietPi/dietpi/login" after a few seconds, to start first run setup.'
 
 	#----------------------------------------------------------------
-	#DietPi running filesystem prep
+	# Unknown install state
 	else
 
 		/DietPi/dietpi/func/dietpi-banner 0
-		echo -e ' >> Filesystem prep has not yet completed: \n Please wait for the system to reboot.'
+		G_WHIP_MSG '[WARNING] Unknown install state\n
+DietPi could not determine a valid install state. Please check if DietPi boot scripts have successfully finished:\n
+    systemctl status dietpi-*\n
+In case report this issue to: https://github.com/Fourdee/DietPi/issues'
 
 	fi
 

--- a/dietpi/login
+++ b/dietpi/login
@@ -14,9 +14,7 @@
 	#////////////////////////////////////
 
 	# Import DietPi-Globals --------------------------------------------------------------
-	. /DietPi/dietpi/func/dietpi-globals
-	G_PROGRAM_NAME='DietPi-Login'
-	#G_INIT
+	# In main loop
 	# Import DietPi-Globals --------------------------------------------------------------
 
 	#/////////////////////////////////////////////////////////////////////////////////////
@@ -33,19 +31,6 @@
 
 		# - Boot to specific program
 		if (( $screen_valid )); then
-
-			# - Wait for DietPi-PostBoot
-			local max_seconds=15
-			local current_seconds=1
-			until systemctl status dietpi-postboot | grep -qi 'exited'
-			do
-
-				G_DIETPI-NOTIFY 2 "Waiting for DietPi-Postboot to finish ($current_seconds/$max_seconds)"
-				sleep 1
-				((current_seconds++))
-				(( $current_seconds >= $max_seconds )) && break
-
-			done
 
 			# - Kodi
 			if (( $AUTO_START_INDEX == 1 )); then
@@ -119,13 +104,11 @@
 	# First Run Setup
 	Run_First_Update_Setup(){
 
-		local automated_setup=0
-
 		# First run setup running in other session
 		Other_Session_User_Prompt(){
 
 			local additional_text='Please resume setup on the active screen.'
-			(( $automated_setup )) && additional_text='Automated setup is in progress, the system will reboot automatically when completed.'
+			(( ! $G_USER_INPUTS )) && additional_text='Automated setup is in progress, the system will reboot automatically when completed.'
 
 			#	Force interactive whiptail
 			G_USER_INPUTS=1 G_WHIP_MSG "[WARNING] DietPi is currently running on another screen.\n\n$additional_text"
@@ -134,73 +117,136 @@
 
 		}
 
-		# Automated?
-		if grep -qi '^[[:blank:]]*AUTO_SETUP_AUTOMATED=1' /DietPi/dietpi.txt; then
+		# 1st run dietpi-update
+		if (( $G_DIETPI_INSTALL_STAGE == 0 )); then
 
-			automated_setup=1
-			#	Set non-interactive shell, if automated installation (as .bashrc run via STDIN check is interactive)
-			export G_USER_INPUTS=0
+			# - Prompt and exit if DietPi-Update runs in other session already
+			pgrep 'dietpi-update' &> /dev/null && Other_Session_User_Prompt
+
+			# - Check internet
+			optional_cmd_inputs='--no-check-certificate' G_CHECK_URL "$(grep -m1 '^[[:blank:]]*deb ' /etc/apt/sources.list | mawk '{print $2}')" # Will exit on failure here then prompt user to configure network
+
+			# - Check NTP synced
+			/DietPi/dietpi/func/run_ntpd
+
+			# - Start DietPi-Update
+			/DietPi/dietpi/dietpi-update 1 # Sets G_DIETPI_INSTALL_STAGE=1
+
+			# - Update install state, to allow DietPi-Software in same loop
+			export G_DIETPI_INSTALL_STAGE=$(</DietPi/dietpi/.install_stage)
+
+		# 1st run dietpi-software installs
+		elif (( $G_DIETPI_INSTALL_STAGE == 1 )); then
+
+			# - Prompt and exit if DietPi-Software runs in other session already
+			pgrep 'dietpi-software' &> /dev/null && Other_Session_User_Prompt
+
+			# - Start DietPi-Software
+			/DietPi/dietpi/dietpi-software | tee $FP_DIETPI_FIRSTRUNSETUP_LOG # Sets G_DIETPI_INSTALL_STAGE=2
+
+			# - Update install state, to exit loop, if user skipped immediate reboot
+			export G_DIETPI_INSTALL_STAGE=$(</DietPi/dietpi/.install_stage)
 
 		fi
 
-		# Show GPL license
-		if [[ -f /var/lib/dietpi/license.txt ]] && (( ! $automated_setup )); then
+	}
+
+	Show_License(){
+
+		if [[ -f /var/lib/dietpi/license.txt ]] && (( $G_USER_INPUTS )); then
 
 			G_WHIP_VIEWFILE /var/lib/dietpi/license.txt
 			rm /var/lib/dietpi/license.txt
 
 		fi
 
-		until (( $G_DIETPI_INSTALL_STAGE == 2 ))
+	}
+
+	Main(){
+
+		while :
 		do
 
-			# 1st run dietpi-update
-			if (( $G_DIETPI_INSTALL_STAGE == 0 )); then
+			# Import DietPi-Globals --------------------------------------------------------------
+			. /DietPi/dietpi/func/dietpi-globals
+			G_PROGRAM_NAME='DietPi-Login'
+			#G_INIT
+			# Import DietPi-Globals --------------------------------------------------------------
 
-				# - Prompt and exit if DietPi-Update runs in other session already
-				pgrep 'dietpi-update' &> /dev/null && Other_Session_User_Prompt
+			# - Wait for full system boot
+			until systemctl status dietpi-postboot | grep -qi 'exited'
+			do
 
-				# - Check internet
-				optional_cmd_inputs='--no-check-certificate' G_CHECK_URL "$(grep -m1 '^[[:blank:]]*deb ' /etc/apt/sources.list | mawk '{print $2}')" # Will exit on failure here then prompt user to configure network
+				G_DIETPI-NOTIFY 2 'Waiting for DietPi-Postboot to finish, before executing login script.'
+				sleep 1
 
-				# - Check NTP synced
-				/DietPi/dietpi/func/run_ntpd
+			done
 
-				# - Start DietPi-Update
-				/DietPi/dietpi/dietpi-update 1 # Sets G_DIETPI_INSTALL_STAGE=1
+			# - Automated install?
+			if (( $G_DIETPI_INSTALL_STAGE < 2 )) && grep -qi '^[[:blank:]]*AUTO_SETUP_AUTOMATED=1' /DietPi/dietpi.txt; then
 
-				# - Update install state, to allow DietPi-Software in same loop, if no update was required
-				export G_DIETPI_INSTALL_STAGE=$(</DietPi/dietpi/.install_stage)
-
-			fi
-
-			# 1st run dietpi-software installs
-			if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
-
-				# - Prompt and exit if DietPi-Software runs in other session already
-				pgrep 'dietpi-software' &> /dev/null && Other_Session_User_Prompt
-
-				# - Start DietPi-Software
-				/DietPi/dietpi/dietpi-software | tee $FP_DIETPI_FIRSTRUNSETUP_LOG # Sets G_DIETPI_INSTALL_STAGE=2
-
-				# - Update install state, to exit loop, if user skipped immediate reboot
-				export G_DIETPI_INSTALL_STAGE=$(</DietPi/dietpi/.install_stage)
+				#	Set non-interactive shell, if automated installation (as .bashrc run via STDIN check is interactive)
+				export G_USER_INPUTS=0
 
 			fi
 
-			# Check for second loop and in case inform user, since this indicates an error
-			if ! (( $G_DIETPI_INSTALL_STAGE == 2 )); then
+			/DietPi/dietpi/func/obtain_network_details
+
+			Show_License
+
+			#----------------------------------------------------------------
+			# Normal Login
+			if (( $G_DIETPI_INSTALL_STAGE == 2 )); then
+
+				/DietPi/dietpi/func/dietpi-banner 1
+
+				local auto_start_index=0
+				[[ -f /DietPi/dietpi/.dietpi-autostart_index ]] && auto_start_index=$(</DietPi/dietpi/.dietpi-autostart_index)
+				(( $auto_start_index > 0 )) && Run_AutoStart
+
+				break
+
+			#----------------------------------------------------------------
+			# Run DietPi-Update/DietPi-Software (1st run setup) (G_DIETPI_INSTALL_STAGE=0/1)
+			elif (( $G_DIETPI_INSTALL_STAGE == 0 || $G_DIETPI_INSTALL_STAGE == 1 )); then
+
+				/DietPi/dietpi/func/dietpi-banner 0
+				if (( $G_CHECK_ROOT_USER_VERIFIED )); then
+
+					Run_First_Update_Setup
+
+				else
+
+					G_WHIP_MSG '[WARNING] Root login required\n
+To finish DietPi first run setup, root permissions are required.\n
+Please login again as user "root" with password "dietpi", respectively the one you chose in "dietpi.txt".'
+
+					break
+
+				fi
+
+			#----------------------------------------------------------------
+			# Unknown install state
+			else
+
+				/DietPi/dietpi/func/dietpi-banner 0
 
 				# - Force interactive mode to show G_WHIP error prompts
 				export G_USER_INPUTS=1
 
-				# - In case of broken install state, reset to 0 to force update and fix code
-				(( $G_DIETPI_INSTALL_STAGE == 0 || $G_DIETPI_INSTALL_STAGE == 1 )) || { export G_DIETPI_INSTALL_STAGE=0; echo 0 > /DietPi/dietpi/.install_stage; }
-
-				G_WHIP_MSG "[FAILED] First run setup failed\n
+				if G_WHIP_YESNO "[FAILED] Unknown install state/First run setup failed\n
 An error has occured either during first run update or installs.\n
-First run setup will now try to re-apply the last step.
-If this repeatedly fails, please collect all terminal output and the content of $FP_DIETPI_FIRSTRUNSETUP_LOG if available and report this issue to: https://github.com/Fourdee/DietPi/issues"
+First run setup will now attempt to re-apply the last step.
+If this repeatedly fails, please collect all terminal output and the content of $FP_DIETPI_FIRSTRUNSETUP_LOG if available and report this issue to: https://github.com/Fourdee/DietPi/issues\n\nWould you like to restart the first run setup and installation?"; then
+
+					# - reset to 0 to force update and fix code
+					echo 0 > /DietPi/dietpi/.install_stage
+
+				else
+
+					break
+
+				fi
 
 			fi
 
@@ -211,68 +257,9 @@ If this repeatedly fails, please collect all terminal output and the content of 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Main Loop
 	#/////////////////////////////////////////////////////////////////////////////////////
-
-	#Update network details for banner IP address.
-	/DietPi/dietpi/func/obtain_network_details
-
-	#----------------------------------------------------------------
-	# Normal Login
-	if (( $G_DIETPI_INSTALL_STAGE == 2 )); then
-
-		# - Show GPL license on first normal login, if setup was automated
-		if [[ -f /var/lib/dietpi/license.txt ]]; then
-
-			G_WHIP_VIEWFILE /var/lib/dietpi/license.txt
-			rm /var/lib/dietpi/license.txt
-
-		fi
-
-		/DietPi/dietpi/func/dietpi-banner 1
-		local auto_start_index=0
-		[[ -f /DietPi/dietpi/.dietpi-autostart_index ]] && auto_start_index=$(</DietPi/dietpi/.dietpi-autostart_index)
-		(( $auto_start_index > 0 )) && Run_AutoStart
-
-	#----------------------------------------------------------------
-	# Run DietPi-Update/DietPi-Software (1st run setup) (G_DIETPI_INSTALL_STAGE=0/1)
-	elif (( $G_DIETPI_INSTALL_STAGE == 0 || $G_DIETPI_INSTALL_STAGE == 1 )); then
-
-		/DietPi/dietpi/func/dietpi-banner 0
-
-		if (( $UID )); then
-
-			G_WHIP_MSG '[WARNING] Root login required\n
-To finish DietPi first run setup, root permissions are required.\n
-Please login again as user "root" with password "dietpi", respectively the one you chose in "dietpi.txt".'
-
-		else
-
-			Run_First_Update_Setup
-
-		fi
-
-	#----------------------------------------------------------------
-	# DietPi-Boot first run setup not finished
-	elif (( $G_DIETPI_INSTALL_STAGE == -1 )); then
-
-		/DietPi/dietpi/func/dietpi-banner 0
-		G_WHIP_MSG '[WARNING] Boot scripts still running\n
-DietPi boot scripts have not yet finished system preparations.\n
-Please run "/DietPi/dietpi/login" after a few seconds, to start first run setup.'
-
-	#----------------------------------------------------------------
-	# Unknown install state
-	else
-
-		/DietPi/dietpi/func/dietpi-banner 0
-		G_WHIP_MSG '[WARNING] Unknown install state\n
-DietPi could not determine a valid install state. Please check if DietPi boot scripts have successfully finished:\n
-    systemctl status dietpi-*\n
-In case report this issue to: https://github.com/Fourdee/DietPi/issues'
-
-	fi
+	Main
 
 	#-----------------------------------------------------------------------------------
 	exit
-	#Run loop, update globals after updates, no reboots required?
 	#-----------------------------------------------------------------------------------
 }

--- a/dietpi/login
+++ b/dietpi/login
@@ -14,7 +14,9 @@
 	#////////////////////////////////////
 
 	# Import DietPi-Globals --------------------------------------------------------------
-	# In main loop
+	. /DietPi/dietpi/func/dietpi-globals
+	G_PROGRAM_NAME='DietPi-Login'
+	#G_INIT
 	# Import DietPi-Globals --------------------------------------------------------------
 
 	#/////////////////////////////////////////////////////////////////////////////////////
@@ -31,6 +33,19 @@
 
 		# - Boot to specific program
 		if (( $screen_valid )); then
+
+			# - Wait for DietPi-PostBoot
+			local max_seconds=15
+			local current_seconds=1
+			until systemctl status dietpi-postboot | grep -qi 'exited'
+			do
+
+				G_DIETPI-NOTIFY 2 "Waiting for DietPi-Postboot to finish ($current_seconds/$max_seconds)"
+				sleep 1
+				((current_seconds++))
+				(( $current_seconds >= $max_seconds )) && break
+
+			done
 
 			# - Kodi
 			if (( $AUTO_START_INDEX == 1 )); then
@@ -104,11 +119,13 @@
 	# First Run Setup
 	Run_First_Update_Setup(){
 
+		local automated_setup=0
+
 		# First run setup running in other session
 		Other_Session_User_Prompt(){
 
 			local additional_text='Please resume setup on the active screen.'
-			(( ! $G_USER_INPUTS )) && additional_text='Automated setup is in progress, the system will reboot automatically when completed.'
+			(( $automated_setup )) && additional_text='Automated setup is in progress, the system will reboot automatically when completed.'
 
 			#	Force interactive whiptail
 			G_USER_INPUTS=1 G_WHIP_MSG "[WARNING] DietPi is currently running on another screen.\n\n$additional_text"
@@ -117,136 +134,73 @@
 
 		}
 
-		# 1st run dietpi-update
-		if (( $G_DIETPI_INSTALL_STAGE == 0 )); then
+		# Automated?
+		if grep -qi '^[[:blank:]]*AUTO_SETUP_AUTOMATED=1' /DietPi/dietpi.txt; then
 
-			# - Prompt and exit if DietPi-Update runs in other session already
-			pgrep 'dietpi-update' &> /dev/null && Other_Session_User_Prompt
-
-			# - Check internet
-			optional_cmd_inputs='--no-check-certificate' G_CHECK_URL "$(grep -m1 '^[[:blank:]]*deb ' /etc/apt/sources.list | mawk '{print $2}')" # Will exit on failure here then prompt user to configure network
-
-			# - Check NTP synced
-			/DietPi/dietpi/func/run_ntpd
-
-			# - Start DietPi-Update
-			/DietPi/dietpi/dietpi-update 1 # Sets G_DIETPI_INSTALL_STAGE=1
-
-			# - Update install state, to allow DietPi-Software in same loop
-			export G_DIETPI_INSTALL_STAGE=$(</DietPi/dietpi/.install_stage)
-
-		# 1st run dietpi-software installs
-		elif (( $G_DIETPI_INSTALL_STAGE == 1 )); then
-
-			# - Prompt and exit if DietPi-Software runs in other session already
-			pgrep 'dietpi-software' &> /dev/null && Other_Session_User_Prompt
-
-			# - Start DietPi-Software
-			/DietPi/dietpi/dietpi-software | tee $FP_DIETPI_FIRSTRUNSETUP_LOG # Sets G_DIETPI_INSTALL_STAGE=2
-
-			# - Update install state, to exit loop, if user skipped immediate reboot
-			export G_DIETPI_INSTALL_STAGE=$(</DietPi/dietpi/.install_stage)
+			automated_setup=1
+			#	Set non-interactive shell, if automated installation (as .bashrc run via STDIN check is interactive)
+			export G_USER_INPUTS=0
 
 		fi
 
-	}
-
-	Show_License(){
-
-		if [[ -f /var/lib/dietpi/license.txt ]] && (( $G_USER_INPUTS )); then
+		# Show GPL license
+		if [[ -f /var/lib/dietpi/license.txt ]] && (( ! $automated_setup )); then
 
 			G_WHIP_VIEWFILE /var/lib/dietpi/license.txt
 			rm /var/lib/dietpi/license.txt
 
 		fi
 
-	}
-
-	Main(){
-
-		while :
+		until (( $G_DIETPI_INSTALL_STAGE == 2 ))
 		do
 
-			# Import DietPi-Globals --------------------------------------------------------------
-			. /DietPi/dietpi/func/dietpi-globals
-			G_PROGRAM_NAME='DietPi-Login'
-			#G_INIT
-			# Import DietPi-Globals --------------------------------------------------------------
+			# 1st run dietpi-update
+			if (( $G_DIETPI_INSTALL_STAGE == 0 )); then
 
-			# - Wait for full system boot
-			until systemctl status dietpi-postboot | grep -qi 'exited'
-			do
+				# - Prompt and exit if DietPi-Update runs in other session already
+				pgrep 'dietpi-update' &> /dev/null && Other_Session_User_Prompt
 
-				G_DIETPI-NOTIFY 2 'Waiting for DietPi-Postboot to finish, before executing login script.'
-				sleep 1
+				# - Check internet
+				optional_cmd_inputs='--no-check-certificate' G_CHECK_URL "$(grep -m1 '^[[:blank:]]*deb ' /etc/apt/sources.list | mawk '{print $2}')" # Will exit on failure here then prompt user to configure network
 
-			done
+				# - Check NTP synced
+				/DietPi/dietpi/func/run_ntpd
 
-			# - Automated install?
-			if (( $G_DIETPI_INSTALL_STAGE < 2 )) && grep -qi '^[[:blank:]]*AUTO_SETUP_AUTOMATED=1' /DietPi/dietpi.txt; then
+				# - Start DietPi-Update
+				/DietPi/dietpi/dietpi-update 1 # Sets G_DIETPI_INSTALL_STAGE=1
 
-				#	Set non-interactive shell, if automated installation (as .bashrc run via STDIN check is interactive)
-				export G_USER_INPUTS=0
+				# - Update install state, to allow DietPi-Software in same loop, if no update was required
+				export G_DIETPI_INSTALL_STAGE=$(</DietPi/dietpi/.install_stage)
 
 			fi
 
-			/DietPi/dietpi/func/obtain_network_details
+			# 1st run dietpi-software installs
+			if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
 
-			Show_License
+				# - Prompt and exit if DietPi-Software runs in other session already
+				pgrep 'dietpi-software' &> /dev/null && Other_Session_User_Prompt
 
-			#----------------------------------------------------------------
-			# Normal Login
-			if (( $G_DIETPI_INSTALL_STAGE == 2 )); then
+				# - Start DietPi-Software
+				/DietPi/dietpi/dietpi-software | tee $FP_DIETPI_FIRSTRUNSETUP_LOG # Sets G_DIETPI_INSTALL_STAGE=2
 
-				/DietPi/dietpi/func/dietpi-banner 1
+				# - Update install state, to exit loop, if user skipped immediate reboot
+				export G_DIETPI_INSTALL_STAGE=$(</DietPi/dietpi/.install_stage)
 
-				local auto_start_index=0
-				[[ -f /DietPi/dietpi/.dietpi-autostart_index ]] && auto_start_index=$(</DietPi/dietpi/.dietpi-autostart_index)
-				(( $auto_start_index > 0 )) && Run_AutoStart
+			fi
 
-				break
-
-			#----------------------------------------------------------------
-			# Run DietPi-Update/DietPi-Software (1st run setup) (G_DIETPI_INSTALL_STAGE=0/1)
-			elif (( $G_DIETPI_INSTALL_STAGE == 0 || $G_DIETPI_INSTALL_STAGE == 1 )); then
-
-				/DietPi/dietpi/func/dietpi-banner 0
-				if (( $G_CHECK_ROOT_USER_VERIFIED )); then
-
-					Run_First_Update_Setup
-
-				else
-
-					G_WHIP_MSG '[WARNING] Root login required\n
-To finish DietPi first run setup, root permissions are required.\n
-Please login again as user "root" with password "dietpi", respectively the one you chose in "dietpi.txt".'
-
-					break
-
-				fi
-
-			#----------------------------------------------------------------
-			# Unknown install state
-			else
-
-				/DietPi/dietpi/func/dietpi-banner 0
+			# Check for second loop and in case inform user, since this indicates an error
+			if ! (( $G_DIETPI_INSTALL_STAGE == 2 )); then
 
 				# - Force interactive mode to show G_WHIP error prompts
 				export G_USER_INPUTS=1
 
-				if G_WHIP_YESNO "[FAILED] Unknown install state/First run setup failed\n
+				# - In case of broken install state, reset to 0 to force update and fix code
+				(( $G_DIETPI_INSTALL_STAGE == 0 || $G_DIETPI_INSTALL_STAGE == 1 )) || { export G_DIETPI_INSTALL_STAGE=0; echo 0 > /DietPi/dietpi/.install_stage; }
+
+				G_WHIP_MSG "[FAILED] First run setup failed\n
 An error has occured either during first run update or installs.\n
-First run setup will now attempt to re-apply the last step.
-If this repeatedly fails, please collect all terminal output and the content of $FP_DIETPI_FIRSTRUNSETUP_LOG if available and report this issue to: https://github.com/Fourdee/DietPi/issues\n\nWould you like to restart the first run setup and installation?"; then
-
-					# - reset to 0 to force update and fix code
-					echo 0 > /DietPi/dietpi/.install_stage
-
-				else
-
-					break
-
-				fi
+First run setup will now try to re-apply the last step.
+If this repeatedly fails, please collect all terminal output and the content of $FP_DIETPI_FIRSTRUNSETUP_LOG if available and report this issue to: https://github.com/Fourdee/DietPi/issues"
 
 			fi
 
@@ -257,9 +211,68 @@ If this repeatedly fails, please collect all terminal output and the content of 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Main Loop
 	#/////////////////////////////////////////////////////////////////////////////////////
-	Main
+
+	#Update network details for banner IP address.
+	/DietPi/dietpi/func/obtain_network_details
+
+	#----------------------------------------------------------------
+	# Normal Login
+	if (( $G_DIETPI_INSTALL_STAGE == 2 )); then
+
+		# - Show GPL license on first normal login, if setup was automated
+		if [[ -f /var/lib/dietpi/license.txt ]]; then
+
+			G_WHIP_VIEWFILE /var/lib/dietpi/license.txt
+			rm /var/lib/dietpi/license.txt
+
+		fi
+
+		/DietPi/dietpi/func/dietpi-banner 1
+		local auto_start_index=0
+		[[ -f /DietPi/dietpi/.dietpi-autostart_index ]] && auto_start_index=$(</DietPi/dietpi/.dietpi-autostart_index)
+		(( $auto_start_index > 0 )) && Run_AutoStart
+
+	#----------------------------------------------------------------
+	# Run DietPi-Update/DietPi-Software (1st run setup) (G_DIETPI_INSTALL_STAGE=0/1)
+	elif (( $G_DIETPI_INSTALL_STAGE == 0 || $G_DIETPI_INSTALL_STAGE == 1 )); then
+
+		/DietPi/dietpi/func/dietpi-banner 0
+
+		if (( $UID )); then
+
+			G_WHIP_MSG '[WARNING] Root login required\n
+To finish DietPi first run setup, root permissions are required.\n
+Please login again as user "root" with password "dietpi", respectively the one you chose in "dietpi.txt".'
+
+		else
+
+			Run_First_Update_Setup
+
+		fi
+
+	#----------------------------------------------------------------
+	# DietPi-Boot first run setup not finished
+	elif (( $G_DIETPI_INSTALL_STAGE == -1 )); then
+
+		/DietPi/dietpi/func/dietpi-banner 0
+		G_WHIP_MSG '[WARNING] Boot scripts still running\n
+DietPi boot scripts have not yet finished system preparations.\n
+Please run "/DietPi/dietpi/login" after a few seconds, to start first run setup.'
+
+	#----------------------------------------------------------------
+	# Unknown install state
+	else
+
+		/DietPi/dietpi/func/dietpi-banner 0
+		G_WHIP_MSG '[WARNING] Unknown install state\n
+DietPi could not determine a valid install state. Please check if DietPi boot scripts have successfully finished:\n
+    systemctl status dietpi-*\n
+In case report this issue to: https://github.com/Fourdee/DietPi/issues'
+
+	fi
 
 	#-----------------------------------------------------------------------------------
 	exit
+	#Run loop, update globals after updates, no reboots required?
 	#-----------------------------------------------------------------------------------
 }

--- a/rootfs/etc/systemd/system/dietpi-boot.service
+++ b/rootfs/etc/systemd/system/dietpi-boot.service
@@ -3,7 +3,7 @@ Description=DietPi-Boot
 # Order 3
 Requires=dietpi-preboot.service
 After=dietpi-preboot.service network.target networking.service
-Before=getty@tty1.service getty.target
+Before=getty-pre.target getty@tty1.service getty.target ssh.service dropbear.service
 
 [Service]
 Type=oneshot

--- a/rootfs/etc/systemd/system/dietpi-postboot.service
+++ b/rootfs/etc/systemd/system/dietpi-postboot.service
@@ -2,7 +2,7 @@
 Description=DietPi-PostBoot
 # Order 4
 Requires=dietpi-boot.service
-After=dietpi-boot.service
+After=dietpi-boot.service multi-user.target
 
 [Service]
 Type=idle

--- a/rootfs/etc/systemd/system/dietpi-postboot.service
+++ b/rootfs/etc/systemd/system/dietpi-postboot.service
@@ -2,7 +2,7 @@
 Description=DietPi-PostBoot
 # Order 4
 Requires=dietpi-boot.service
-After=dietpi-boot.service multi-user.target
+After=dietpi-boot.service
 
 [Service]
 Type=idle


### PR DESCRIPTION
**Status**: Testing

**Reference**: https://github.com/Fourdee/DietPi/issues/2478

**Commit list/description**:
+ DietPi-Login | Remove "Filesystem prep" install state info, as this does not exist anymore, instead warn user about unknown install state, ask for check and report issue
+ DietPi-Login | Prompt G_WHIP_MSG, if install state is "-1" to make this more prominent
+ DietPi-Login | Check for root user before starting first run setup, otherwise ask user to login as root
+ DietPi-Login | Assure that user accepts license interactively one time: Skip on automated install to have it shown on first normal login instead
+ DietPi-Login | If on first run setup dietpi-update or dietpi-software is running in other session, show same G_WHIP once and exit script to prevent user from being kept in loop that can never be resolved in this session.
+ DietPi-Login | Re-read install state after first run update and dietpi-software run, to exit loop if immediate reboot was skipped. Allow update and installs in a single loop, e.g. if already on latest version, so second loop is an error indicator. Inform user in case. Apply install state 0, if not valid before second loop to prevent unlimited repeats.
+ DietPi-Boot | Assure it has finished before OpenSSH and Dropbear to prevent too early login
+ DietPi-Boot | Add "Before=getty-pre.target" which is reached on Buster before any getty starts. This is actually what we want, does not exist on Stretch yet but does not harm to add. On Buster we should add it to Wants= as well, as it is not pulled in automatically. But on Stretch this would produce an error, as it does not exist: https://www.freedesktop.org/software/systemd/man/systemd.special.html#getty-pre.target