### PR TITLE
DietPi-Login | Fix and tuning

### DIFF
--- a/dietpi/dietpi-login
+++ b/dietpi/dietpi-login
@@ -9,7 +9,7 @@
 	#////////////////////////////////////
 	#
 	# Info:
-	# - filename /DietPi/dietpi/login
+	# - filename /DietPi/dietpi/dietpi-login
 	# - activates on login /etc/bashrc.d/dietpi-login.sh
 	#////////////////////////////////////
 
@@ -189,7 +189,7 @@
 				fi
 
 				# - Prompt and wait if this script runs in other session already
-				if (( $(pgrep -c 'login') >= 2 )); then
+				if (( $(pgrep -c 'dietpi-login') >= 2 )); then
 
 					# - First run setup running in other session
 					local additional_text='Please resume setup on the active screen.'

--- a/dietpi/login
+++ b/dietpi/login
@@ -159,7 +159,7 @@
 	Main(){
 
 		# Wait for full system boot
-		until systemctl status dietpi-postboot | grep -qi 'exited'
+		until sudo systemctl status dietpi-postboot | grep -qi 'exited' #Sudo required for non-root
 		do
 
 			echo -e '\e[90m[\e[0m INFO \e[90m]\e[0m Waiting for DietPi-Postboot to finish, before executing login script...'

--- a/dietpi/login
+++ b/dietpi/login
@@ -189,7 +189,7 @@
 				fi
 
 				# - Prompt and wait if this script runs in other session already
-				if (( $(pgrep 'login' 2> /dev/null | wc -l) >= 2 )); then
+				if (( $(pgrep -c 'login') >= 2 )); then
 
 					# - First run setup running in other session
 					local additional_text='Please resume setup on the active screen.'

--- a/dietpi/login
+++ b/dietpi/login
@@ -189,7 +189,7 @@
 				fi
 
 				# - Prompt and wait if this script runs in other session already
-				if pgrep 'login' &> /dev/null; then
+				if (( $(pgrep 'login' 2> /dev/null | wc -l) >= 2 )); then
 
 					# - First run setup running in other session
 					local additional_text='Please resume setup on the active screen.'

--- a/dietpi/login
+++ b/dietpi/login
@@ -33,12 +33,12 @@
 		if (( $screen_valid )); then
 
 			# - Kodi
-			if (( $AUTO_START_INDEX == 1 )); then
+			if (( $auto_start_index == 1 )); then
 
 				/DietPi/dietpi/misc/start_kodi
 
 			# - Desktop (LXDE/MATE etc)
-			elif (( $AUTO_START_INDEX == 2 )); then
+			elif (( $auto_start_index == 2 )); then
 
 				clear
 				if (( $G_HW_MODEL == 11 )); then
@@ -52,46 +52,46 @@
 				fi
 
 			# - RetroPie/Emulation station
-			elif (( $AUTO_START_INDEX == 3 )); then
+			elif (( $auto_start_index == 3 )); then
 
 				#	emulationstation - can no longer be run as root
 				/opt/retropie/supplementary/emulationstation/emulationstation.sh
 
 			# - OpenTyrian
-			elif (( $AUTO_START_INDEX == 4 )); then
+			elif (( $auto_start_index == 4 )); then
 
 				/usr/local/games/opentyrian/run
 
 			# - DietPi-Cloudshell
-			elif (( $AUTO_START_INDEX == 5 )); then
+			elif (( $auto_start_index == 5 )); then
 
 				setterm --blank 0 --powersave off --cursor off
 				systemctl start dietpi-cloudshell
 
 			# - Amiberry standard boot
-			elif (( $AUTO_START_INDEX == 8 )); then
+			elif (( $auto_start_index == 8 )); then
 
 				systemctl start amiberry
 
 			# - DXX-Rebirth
-			elif (( $AUTO_START_INDEX == 9 )); then
+			elif (( $auto_start_index == 9 )); then
 
 				$G_FP_DIETPI_USERDATA/dxx-rebirth/run.sh
 
 			# - CAVA
-			elif (( $AUTO_START_INDEX == 10 )); then
+			elif (( $auto_start_index == 10 )); then
 
 				sleep 4 # Wait for MPD fifo to start
 				setterm --blank 0 --powersave off
 				cava
 
 			# - Chromium
-			elif (( $AUTO_START_INDEX == 11 )); then
+			elif (( $auto_start_index == 11 )); then
 
 				/var/lib/dietpi/dietpi-software/installed/chromium-autostart.sh
 
 			# - LightDM
-			elif (( $AUTO_START_INDEX == 16 )); then
+			elif (( $auto_start_index == 16 )); then
 
 				/usr/sbin/lightdm
 
@@ -158,6 +158,23 @@
 
 	Main(){
 
+		# Wait for full system boot
+		until systemctl status dietpi-postboot | grep -qi 'exited'
+		do
+
+			echo -e '\e[90m[\e[0m INFO \e[90m]\e[0m Waiting for DietPi-Postboot to finish, before executing login script...'
+			sleep 1
+
+		done
+
+		# Automated first run setup?
+		if (( $(</DietPi/dietpi/.install_stage) < 2 )) && grep -qi '^[[:blank:]]*AUTO_SETUP_AUTOMATED=1' /DietPi/dietpi.txt; then
+
+			# - Set non-interactive shell, if automated installation (as .bashrc run via STDIN check is interactive)
+			export G_USER_INPUTS=0
+
+		fi
+
 		while :
 		do
 
@@ -166,23 +183,6 @@
 			G_PROGRAM_NAME='DietPi-Login'
 			#G_INIT
 			# Import DietPi-Globals --------------------------------------------------------------
-
-			# - Wait for full system boot
-			until systemctl status dietpi-postboot | grep -qi 'exited'
-			do
-
-				G_DIETPI-NOTIFY 2 'Waiting for DietPi-Postboot to finish, before executing login script.'
-				sleep 1
-
-			done
-
-			# - Automated install?
-			if (( $G_DIETPI_INSTALL_STAGE < 2 )) && grep -qi '^[[:blank:]]*AUTO_SETUP_AUTOMATED=1' /DietPi/dietpi.txt; then
-
-				#	Set non-interactive shell, if automated installation (as .bashrc run via STDIN check is interactive)
-				export G_USER_INPUTS=0
-
-			fi
 
 			/DietPi/dietpi/func/obtain_network_details
 

--- a/dietpi/login
+++ b/dietpi/login
@@ -104,24 +104,8 @@
 	# First Run Setup
 	Run_First_Update_Setup(){
 
-		# First run setup running in other session
-		Other_Session_User_Prompt(){
-
-			local additional_text='Please resume setup on the active screen.'
-			(( ! $G_USER_INPUTS )) && additional_text='Automated setup is in progress, the system will reboot automatically when completed.'
-
-			#	Force interactive whiptail
-			G_USER_INPUTS=1 G_WHIP_MSG "[WARNING] DietPi is currently running on another screen.\n\n$additional_text"
-
-			exit
-
-		}
-
 		# 1st run dietpi-update
 		if (( $G_DIETPI_INSTALL_STAGE == 0 )); then
-
-			# - Prompt and exit if DietPi-Update runs in other session already
-			pgrep 'dietpi-update' &> /dev/null && Other_Session_User_Prompt
 
 			# - Check internet
 			optional_cmd_inputs='--no-check-certificate' G_CHECK_URL "$(grep -m1 '^[[:blank:]]*deb ' /etc/apt/sources.list | mawk '{print $2}')" # Will exit on failure here then prompt user to configure network
@@ -134,9 +118,6 @@
 
 		# 1st run dietpi-software installs
 		elif (( $G_DIETPI_INSTALL_STAGE == 1 )); then
-
-			# - Prompt and exit if DietPi-Software runs in other session already
-			pgrep 'dietpi-software' &> /dev/null && Other_Session_User_Prompt
 
 			# - Start DietPi-Software
 			/DietPi/dietpi/dietpi-software 2>&1 | tee $FP_DIETPI_FIRSTRUNSETUP_LOG # Sets G_DIETPI_INSTALL_STAGE=2
@@ -166,14 +147,6 @@
 			sleep 1
 
 		done
-
-		# Automated first run setup?
-		if (( $(</DietPi/dietpi/.install_stage) < 2 )) && grep -qi '^[[:blank:]]*AUTO_SETUP_AUTOMATED=1' /DietPi/dietpi.txt; then
-
-			# - Set non-interactive shell, if automated installation (as .bashrc run via STDIN check is interactive)
-			export G_USER_INPUTS=0
-
-		fi
 
 		while :
 		do
@@ -205,19 +178,40 @@
 			elif (( $G_DIETPI_INSTALL_STAGE == 0 || $G_DIETPI_INSTALL_STAGE == 1 )); then
 
 				/DietPi/dietpi/func/dietpi-banner 0
-
 				G_CHECK_ROOT_USER
-				if (( $G_CHECK_ROOT_USER_VERIFIED )); then
 
-					Run_First_Update_Setup
+				# - Automated first run setup?
+				grep -qi '^[[:blank:]]*AUTO_SETUP_AUTOMATED=1' /DietPi/dietpi.txt; then
 
-				else
+					# - Set non-interactive shell, if automated installation (as .bashrc run via STDIN check is interactive)
+					export G_USER_INPUTS=0
+
+				fi
+
+				# - Prompt and wait if this script runs in other session already
+				if pgrep 'login' &> /dev/null; then
+
+					# - First run setup running in other session
+					local additional_text='Please resume setup on the active screen.'
+					(( ! $G_USER_INPUTS )) && additional_text='Automated setup is in progress. When completed, the system will be rebooted (if required), or, this terminal session will login.'
+
+					G_WHIP_MSG "[WARNING] DietPi first run setup: Currently running on another screen.\n\n$additional_text"
+
+					local restart_loop_delay=5
+					G_DIETPI-NOTIFY 2 "Waiting $restart_loop_delay seconds before checking again. Please wait... (Press CTRL+C to abort)"
+					sleep $restart_loop_delay
+
+				elif (( ! $G_CHECK_ROOT_USER_VERIFIED )); then
 
 					G_WHIP_MSG '[WARNING] Root login required\n
 To finish DietPi first run setup, root permissions are required.\n
 Please login again as user "root" with password "dietpi", respectively the one you chose in "dietpi.txt".'
 
 					break
+
+				else
+
+					Run_First_Update_Setup
 
 				fi
 

--- a/rootfs/etc/bashrc.d/dietpi-login.sh
+++ b/rootfs/etc/bashrc.d/dietpi-login.sh
@@ -4,4 +4,4 @@
 . /DietPi/dietpi/func/dietpi-globals
 
 # login scripts and banner
-/DietPi/dietpi/login
+/DietPi/dietpi/dietpi-login


### PR DESCRIPTION
**Status**: Testing

**Commit list/description**:
+ DietPi-Login | Fix changed AUTO_START_INDEX => auto_start_index
+ DietPi-Login | Check for PostBoot finish only once before loop: Tiny speed-up of following loops
+ DietPi-Login | Check for AUTO_SETUP_AUTOMATED only once before loop, to have "export G_USER_INPUTS=0" (on invalid install state) not being overwritten on next loop
+ Make above checks work without globals loaded