### PR TITLE
DietPi-Set_Hardware | I-Sabre-K2M: Fix module source build, add informational comments

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ Changes / Improvements / Optimisations:
 
 Bug Fixes:
 - General | Resolved an issue where /etc/bashrc.d entries could be run multiple times. Many thanks to @jonare77 for reporting this: https://github.com/Fourdee/DietPi/issues/2529
+- RPi | Resolved an issue where I-Sabre-K2M sound card selection failed. Thanks to @klasLiesen for reporting this issue: https://github.com/Fourdee/DietPi/issues/2547
 - DietPi-Software | Mopidy: Resolved issue with failed audio playback. Many thanks to @arkhub for reporting this issue! https://github.com/Fourdee/DietPi/issues/2536
 - DietPi-Software | WireGuard: Resolved an issue with wrong client DNS entry, if on server 127.0.0.1/localhost loopback DNS entry is used. Thanks to @swrobel for reporting this issue: https://github.com/Fourdee/DietPi/issues/2482
 - DietPi-Software | WireGuard: Resolved an issue where on uninstall the Debian Sid repo was not removed. Thanks to @XRay437 for reporting this issue: https://github.com/Fourdee/DietPi/issues/2545

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -1988,7 +1988,9 @@ _EOF_
 					local old_firmware=$(ls /lib/modules/)
 					local rpi_firmware='raspberrypi-bootloader raspberrypi-kernel libraspberrypi-bin libraspberrypi0'
 					G_AGUP
-					G_AGI $rpi_firmware raspberrypi-kernel-headers make
+					# - gcc version needs to match "cat /proc/version", currently 4.9.3 on raspberrypi.org Stretch repo
+					# - This makes the build process currently incompatible with Raspbian Buster: g++-4.9 => g++/gcc v4.9.4
+					G_AGI $rpi_firmware raspberrypi-kernel-headers make g++-4.9
 					apt-mark unhold $rpi_firmware # Should be not required, since we did that on v6.20 patch, but better be failsafe
 
 					if [[ $old_firmware != $(ls /lib/modules/) ]]; then
@@ -2000,10 +2002,14 @@ Once rebooted, please rerun dietpi-config > Audio Options. Re-select the sound c
 
 					fi
 
+					# - /lib/modules/$(uname -r)/source expected, but only .../build included in headers package currently
+					# - A symlink does the job: https://github.com/notro/rpi-source/blob/master/rpi-source#L340-L341
+					[[ -e /lib/modules/$(uname -r)/source ]] || ln -s /lib/modules/$(uname -r)/build /lib/modules/$(uname -r)/source
+
 					# - Build dtoverlay
 					mkdir -p i-sabre-k2m_build
 					cd i-sabre-k2m_build
-					install_url_address='https://dietpi.com/downloads/sourcebuild/I-Sabre-K2M.7z'
+					install_url_address='https://dietpi.com/downloads/sourcebuild/I-Sabre-K2M.7z' # https://github.com/SatoruKawase/I-Sabre-K2M
 					G_CHECK_URL "$install_url_address"
 					wget "$install_url_address" -O package.7z
 					7z x -y package.7z

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -1990,7 +1990,7 @@ _EOF_
 					G_AGUP
 					# - gcc version needs to match "cat /proc/version", currently 4.9.3 on raspberrypi.org Stretch repo
 					# - This makes the build process currently incompatible with Raspbian Buster: g++-4.9 => g++/gcc v4.9.4
-					G_AGI $rpi_firmware raspberrypi-kernel-headers make g++-4.9
+					G_AGI $rpi_firmware raspberrypi-kernel-headers make gcc-4.9
 					apt-mark unhold $rpi_firmware # Should be not required, since we did that on v6.20 patch, but better be failsafe
 
 					if [[ $old_firmware != $(ls /lib/modules/) ]]; then
@@ -2015,10 +2015,10 @@ Once rebooted, please rerun dietpi-config > Audio Options. Re-select the sound c
 					7z x -y package.7z
 					rm package.7z
 
-					G_RUN_CMD make
-					G_RUN_CMD make modules_install
-					G_RUN_CMD make dtbs
-					G_RUN_CMD make install_dtbo
+					G_RUN_CMD make CC=gcc-4.9
+					G_RUN_CMD make CC=gcc-4.9 modules_install
+					G_RUN_CMD make CC=gcc-4.9 dtbs
+					G_RUN_CMD make CC=gcc-4.9 install_dtbo
 
 					cd /tmp/$G_PROGRAM_NAME
 					rm -R i-sabre-k2m_build

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -1989,7 +1989,7 @@ _EOF_
 					local rpi_firmware='raspberrypi-bootloader raspberrypi-kernel libraspberrypi-bin libraspberrypi0'
 					G_AGUP
 					# - gcc version needs to match "cat /proc/version", currently 4.9.3 on raspberrypi.org Stretch repo
-					# - This makes the build process currently incompatible with Raspbian Buster: g++-4.9 => g++/gcc v4.9.4
+					# - This makes the build process currently incompatible with Raspbian Buster: gcc-4.9 => v4.9.4
 					G_AGI $rpi_firmware raspberrypi-kernel-headers make gcc-4.9
 					apt-mark unhold $rpi_firmware # Should be not required, since we did that on v6.20 patch, but better be failsafe
 


### PR DESCRIPTION
**Status**: Testing
- [x] Changelog
- [x] `ln -s /usr/bin/gcc-4.9 /usr/bin/gcc` and `ln -s /usr/bin/g++-4.9 /usr/bin/g++`
  - The 4.9 packages do not place that symlink.
  - But those would override/fail if other gcc/g++ versions are installed, e.g. simply gcc/g++ packages from repo (via build-essential)...
  - At best we find a way to tell  `make` to use the /usr/bin/gcc-4.9/g++-4.9 binaries
**EDIT: `make CC=gcc-4.9 CXX=g++-4.9`, but needs check if this is handed over to the sub `make` calls as well.**
- [x] Is `g++` actually required? User reported success without `g++` binary linked.
  - For my personal understanding: https://stackoverflow.com/questions/172587/what-is-the-difference-between-g-and-gcc#172592

**Reference**: https://github.com/Fourdee/DietPi/issues/2547

**Commit list/description**:
+ DietPi-Set_Hardware | I-Sabre-K2M: Fix module source build, add informational comments
+ DietPi-Set_Hardware | I-Sabre-K2M: "gcc-4.9" should be sufficient for build
+ DietPi-Set_Hardware | I-Sabre-K2M: Add correct gcc binary to make commands