### PR TITLE
DietPi-Software | Remot3.it: Fix install due to changed GitHub repo

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@ Bug Fixes:
 - DietPi-Software | WireGuard: Resolved an issue with wrong client DNS entry, if on server 127.0.0.1/localhost loopback DNS entry is used. Thanks to @swrobel for reporting this issue: https://github.com/Fourdee/DietPi/issues/2482
 - DietPi-Software | WireGuard: Resolved an issue where on uninstall the Debian Sid repo was not removed. Thanks to @XRay437 for reporting this issue: https://github.com/Fourdee/DietPi/issues/2545
 - DietPi-Software | Java: Resolved an issue where install failed on ARM. Thanks to @WTFMaster for reporting this issue: https://github.com/Fourdee/DietPi/issues/2524
+- DietPi-Software | Remot3.it: Resolved an issue where install failed due to Git repo changes. Additionally Remot3.it is now available on x86_64 and ARMv8 systems as well. Thanks to @techano for reporting this issue: https://github.com/Fourdee/DietPi/issues/2551
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/Fourdee/DietPi/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+base%3Amaster
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1527,11 +1527,7 @@ _EOF_
 				 aSOFTWARE_WHIP_DESC[$software_id]='(Weaved) access your device over the internet'
 			aSOFTWARE_CATEGORY_INDEX[$software_id]=10
 					  aSOFTWARE_TYPE[$software_id]=0
-			 aSOFTWARE_ONLINEDOC_URL[$software_id]='f=8&t=5&start=20#p188'
-
-		# - Currently ARMv6/7 only
-		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,3]=0
-		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,10]=0
+			 aSOFTWARE_ONLINEDOC_URL[$software_id]='p=188#p188'
 
 		#------------------
 		software_id=138
@@ -4336,12 +4332,30 @@ _EOF_
 
 		fi
 
-		#WEAVED
-		software_id=68
+		software_id=68 # Remot3.it (previously Weaved)
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-			Download_Install 'https://github.com/weaved/installer/raw/master/Raspbian%20deb/1.3-07/weavedconnectd_1.3-07z1_armhf.deb'
+			INSTALL_URL_ADDRESS='https://api.github.com/repos/remoteit/installer/releases/latest'
+			G_CHECK_URL "$INSTALL_URL_ADDRESS"
+
+			# ARMv6/7
+			local arch='armhf'
+
+			# ARMv8
+			if (( $G_HW_ARCH == 3 )); then
+
+				arch='arm64'
+
+			# x86_64
+			elif (( $G_HW_ARCH == 10 )); then
+
+				arch='amd64'
+
+			fi
+
+			INSTALL_URL_ADDRESS=$(curl -s "$INSTALL_URL_ADDRESS" | grep -m1 "browser_download_url.*connectd_.*_$arch\.deb" | cut -d \" -f 4)
+			Download_Install "$INSTALL_URL_ADDRESS"
 
 		fi
 
@@ -13489,13 +13503,7 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			# <= v150 (weaved)
-			rm -R /etc/weaved
-			rm -R $HOME/weaved_software
-			rm $HOME/weaved_setup.bin
-
-			# Remot3.it
-			G_AGP weavedconnectd
+			G_AGP connectd weavedconnectd # pre-v6.22
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4355,7 +4355,7 @@ _EOF_
 			fi
 
 			INSTALL_URL_ADDRESS=$(curl -s "$INSTALL_URL_ADDRESS" | grep -m1 "browser_download_url.*connectd_.*_$arch\.deb" | cut -d \" -f 4)
-			Download_Install "$INSTALL_URL_ADDRESS"
+			no_check_url=1 Download_Install "$INSTALL_URL_ADDRESS"
 
 		fi
 


### PR DESCRIPTION
**Status**: Testing
- [x] Changelog
- [x] Online docs. Installer command updated to `connectd_installer`: https://dietpi.com/phpbb/viewtopic.php?p=188#p188

**Reference**: https://github.com/Fourdee/DietPi/issues/2551

**Testing**:
- [x] Stretch VM
- [x] Buster VM
- [x] Jessie VM

**Commit list/description**:
+ DietPi-Software | Remot3.it: Fix install due to changed GitHub repo. Install latest available version via: api.github.com
+ DietPi-Software | Remot3.it: Removed <=v150 uninstall code due to v160 update freeze
+ CHANGELOG | Remot3.it: Resolved an issue where install failed due to Git repo changes