### PR TITLE
General | Remove dependency on p7zip-full, use lightweight p7zip/7zr instead

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ v6.22
 (xx/02/19)
 
 Changes / Improvements / Optimisations:
+- General | DietPi scripts now use the lightweight standalone "7zr" command to handle 7z archives. This allows us to lower DietPi core dependencies from "p7zip-full" to "p7zip".
 - DietPi-NordVPN | Added sent/recieved usage stats for VPN tunnel.
 - DietPi-Software | WireGuard: Switched from 10.8.0.0 to 10.9.0.0 IP addresses on fresh installs, to avoid IP double use with OpenVPN. Thanks to @XRay437 for pointing this out: https://github.com/Fourdee/DietPi/issues/2491#issuecomment-461366739
 - DietPi-Software | WireGuard: Changed the way users are adviced to add multiple clients, to enhance concurrent connections. Thanks to @curiosity-seeker for reporting and testing this issue: https://github.com/Fourdee/DietPi/issues/2491#issuecomment-462419860

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -638,7 +638,7 @@ _EOF_
 			'kmod'			# "modprobe", "lsmod", used by several DietPi scripts
 			'locales'		# Support locales, necessary for DietPi scripts, as we use en_GB.UTF8 as default language
 			'nano'			# Simple text editor
-			'p7zip-full'		# .7z wrapper
+			'p7zip'			# .7z wrapper
 			'parted'		# Drive partitioning, required by DietPi-Boot + DietPi-Drive_Manager
 			'procps'		# "kill", "ps", "pgrep", "sysctl", used by several DietPi scripts
 			'psmisc'		# "killall", used by several DietPi scripts

--- a/dietpi/dietpi-bugreport
+++ b/dietpi/dietpi-bugreport
@@ -27,13 +27,13 @@
 	#Import DietPi-Globals ---------------------------------------------------------------
 
 	INPUT=0
-	disable_error=1 G_CHECK_VALIDINT $1 && INPUT=$1
+	disable_error=1 G_CHECK_VALIDINT "$1" && INPUT=$1
 
 	UNIQUE_ID=$(sed -n 5p /DietPi/dietpi/.hw_model)
 	UPLOAD_FILENAME="$UNIQUE_ID.7z"
 
 	# - byte
-	UPLOAD_FILESIZE_LIMIT=10000000
+	UPLOAD_FILESIZE_LIMIT=20000000
 	UPLOAD_FILESIZE=0
 
 	SFTP_ADDR='ssh.dietpi.com'
@@ -43,28 +43,27 @@
 	# List of commands we want to run and redirect to upload archive
 	aCOMMAND_LIST=(
 
-		'ls -lha /var/log'
 		'dpkg -l'
+		'ip l'
 		'ip a'
 		'ip r'
-		'ip l'
 		'lsusb'
 		'cat /proc/cpuinfo'
 		'ps aux'
 		'blkid'
 		'mount'
 		'df -h'
-		"ls /etc/rc*.d/"
+		'ls /etc/rc*.d/'
 		'cut -d: -f1 /etc/passwd'
 		'locale'
-		'ls -lha /mnt' #dietpi userdata location
+		'ls -lAh /mnt' # dietpi_userdata location
 		'dmesg'
 		'uname -a'
 		'lsmod'
 		'aplay -l'
 		'aplay -L'
-		"systemctl status *.service -l"
-		"systemctl status *.mount -l"
+		'systemctl status *.service -l'
+		'systemctl status *.mount -l'
 		'/DietPi/dietpi/dietpi-services status'
 
 	)
@@ -72,38 +71,43 @@
 	# List of files and folders we want to add to upload archive
 	aFILE_LIST=(
 
-		# - command output file
+		# - aCOMMAND_LIST output file
 		'CMD_OUT.txt'
 
-		# - Git Error file
+		# - Git error file
 		'G_ERROR_HANDLER_GITREPORT'
 
-		# - logs
-		"/var/log/*"
+		# - Logs
+		'/var/log'
 
-		# - DietPi scripts / logs
-		"/DietPi/*"
-		'/boot/dietpi.txt'
+		# - Boot/kernel configs
 		'/boot/config.txt'
-		"/boot/dietpi/*"
-		"/tmp/.G*"
-		"/var/tmp/dietpi/logs/*"
+		'/boot/cmdline.txt'
+		'/boot/boot.ini'
+		'/boot/uEnv.ini'
+		'/boot/armbianEnv.ini'
 
-		# - /var/lib/dietpi
-		"/var/lib/dietpi/*"
+		# - DietPi files
+		'/DietPi'
+		'/boot/dietpi.txt'
+		'/boot/dietpi'
+		'/tmp/.G*'
+		'/var/lib/dietpi'
+		'/var/tmp/dietpi'
 
-		# - confs
+		# - Login scripts
 		#	- bash shell
 		'/etc/bash.bashrc'
-		"/etc/bashrc.d/*"
+		'/etc/bashrc.d'
 		'/root/.bashrc'
-		"/home/*/.bashrc"
+		'/home/*/.bashrc'
 		#	- login shell
 		'/etc/profile'
-		"/etc/profile.d/*"
+		'/etc/profile.d'
 		'/root/.profile'
-		"/home/*/.profile"
+		'/home/*/.profile'
 
+		# - System
 		'/etc/rc.local'
 		'/etc/X11/xorg.conf'
 		'/etc/asound.conf'
@@ -111,16 +115,16 @@
 		'/etc/wpa_supplicant/wpa_supplicant.conf'
 		'/etc/fstab'
 		'/etc/sysctl.conf'
-		"/etc/sysctl.d/*"
+		'/etc/sysctl.d'
 
 		# - Services
-		"/etc/init.d/*"
-		"/etc/systemd/system/*"
-		"/lib/systemd/system/*"
+		'/etc/init.d'
+		'/etc/systemd/system'
+		'/lib/systemd/system'
 
 		# - APT
 		'/etc/apt/sources.list'
-		"/etc/apt/sources.list.d/*"
+		'/etc/apt/sources.list.d'
 
 	)
 
@@ -131,34 +135,33 @@
 		do
 
 			echo -e "\n----------\n${aCOMMAND_LIST[$i]}:\n----------" >> CMD_OUT.txt
-			${aCOMMAND_LIST[$i]} >> CMD_OUT.txt
+			${aCOMMAND_LIST[$i]} &>> CMD_OUT.txt
 
 		done
 		unset aCOMMAND_LIST
 
 		# - Have the git error in 1st directory.
-		cp /tmp/.G_ERROR_HANDLER_GITREPORT ./G_ERROR_HANDLER_GITREPORT &> /dev/null
+		[[ -f /tmp/.G_ERROR_HANDLER_GITREPORT ]] && cp /tmp/.G_ERROR_HANDLER_GITREPORT ./G_ERROR_HANDLER_GITREPORT
 
 		G_DIETPI-NOTIFY 2 'Packing upload archive, please wait...'
-		7z a -t7z -spf "$UPLOAD_FILENAME" ${aFILE_LIST[@]} &> /tmp/dietpi-bugreport_compress.log
+		7zr a -spf "$UPLOAD_FILENAME" ${aFILE_LIST[@]} &> dietpi-bugreport_compress.log
 
 	}
 
 	Upload_Bug_Report(){
 
 		# Check upload location is online
-		G_CHECK_URL "$SFTP_ADDR"
-		if (( ! $? )); then
+		if G_CHECK_URL "$SFTP_ADDR"; then
 
 			if [[ ! -f $UPLOAD_FILENAME ]]; then
 
 				G_WHIP_MSG "Failed to create compressed upload file: $UPLOAD_FILENAME\n\nOn the next screen you will be prompted to view the log. If problems persist, please contact DietPi for support."
-				log=1 G_WHIP_VIEWFILE /tmp/dietpi-bugreport_compress.log
+				log=1 G_WHIP_VIEWFILE dietpi-bugreport_compress.log
 				exit 1
 
 			fi
 
-			rm /tmp/dietpi-bugreport_compress.log &> /dev/null
+			[[ -f dietpi-bugreport_compress.log ]] && rm dietpi-bugreport_compress.log
 
 			# Limit filesize
 			UPLOAD_FILESIZE=$(stat -c%s "$UPLOAD_FILENAME")
@@ -167,8 +170,7 @@
 			if (( $UPLOAD_FILESIZE <= $UPLOAD_FILESIZE_LIMIT )); then
 
 				G_DIETPI-NOTIFY -2 'Running cURL'
-				curl --connect-timeout 4 --retry 1 --retry-delay 4 -sT "$UPLOAD_FILENAME" sftp://"$SFTP_USER":"$SFTP_PASS"@"$SFTP_ADDR"/bugreport/
-				if (( ! $? )); then
+				if curl --connect-timeout 4 --retry 1 --retry-delay 4 -sT "$UPLOAD_FILENAME" sftp://"$SFTP_USER":"$SFTP_PASS"@"$SFTP_ADDR"/bugreport/; then
 
 					# Bug report removal via empty file upload
 					if (( $UPLOAD_FILESIZE == 0 )); then
@@ -208,57 +210,50 @@
 	# Main Loop
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Interactive menu
-	if (( $INPUT == 0 )); then
+	while (( $INPUT == 0 ))
+	do
 
-		while true
-		do
+		G_WHIP_MENU_ARRAY=(
 
-			G_WHIP_MENU_ARRAY=(
+			'1' ': Send bug report archive to help the developers investigate an issue.'
+			'2' ': Remove my previous uploaded bug report.'
+			'3' ': Show me what is included with the upload archive.'
 
-				'1' ': Send bug report archive to help the developers investigate an issue.'
-				'2' ': Remove my previous uploaded bug report.'
-				'3' ': Show me what is included with the upload archive.'
+		)
 
-			)
-
-			G_WHIP_MENU "By sending a bug report file, you can help the developers to investigate your issue, in relation to your report on GitHub or the DietPi forum.
+		if G_WHIP_MENU "By sending a bug report file, you can help the developers to investigate your issue, in relation to your report on GitHub or the DietPi forum.
 The file is sent via secured connection to our SFTP server and is stored there unreadable to the public upload user.
 The file will be removed after your issue is solved and you can remove it by yourself as well by running \"dietpi-bugreport -1\" or via this menu.
 
-Would you like to send a bug report archive or remove an already uploaded one?"
-			if (( ! $? )); then
+Would you like to send a bug report archive or remove an already uploaded one?"; then
 
-				if (( $G_WHIP_RETURNED_VALUE == 1 )); then
+			if (( $G_WHIP_RETURNED_VALUE == 1 )); then
 
-					INPUT=1
-					break
+				INPUT=1
 
-				elif (( $G_WHIP_RETURNED_VALUE == 2 )); then
+			elif (( $G_WHIP_RETURNED_VALUE == 2 )); then
 
-					INPUT=-1
-					break
+				INPUT=-1
 
-				elif (( $G_WHIP_RETURNED_VALUE == 3 )); then
+			elif (( $G_WHIP_RETURNED_VALUE == 3 )); then
 
-					G_WHIP_SCROLLBOX "The upload will contain the following command outputs:
+				G_WHIP_SCROLLBOX "The upload will contain the following command outputs:
 
 $(printf "\t- %s\n" "${aCOMMAND_LIST[@]}")
 
-It will contain as well the following file locations:
+It will contain as well the following files and directories:
 
 $(printf "\t- %s\n" "${aFILE_LIST[@]}")"
 
-				fi
-
-			else
-
-				break
-
 			fi
 
-		done
+		else
 
-	fi
+			break
+
+		fi
+
+	done
 
 	if (( $INPUT == 1 || $INPUT == -1 )); then
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3147,7 +3147,7 @@ _EOF_
 		elif [[ $type == 7z ]]; then
 
 			[[ $target ]] && target="-o$target"
-			l_message='Extracting 7zip archive' G_RUN_CMD 7za x -y $file $target
+			l_message='Extracting 7zip archive' G_RUN_CMD 7zr x -y $file $target
 
 		else
 

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -2006,7 +2006,7 @@ Once rebooted, please rerun dietpi-config > Audio Options. Re-select the sound c
 					install_url_address='https://dietpi.com/downloads/sourcebuild/I-Sabre-K2M.7z'
 					G_CHECK_URL "$install_url_address"
 					wget "$install_url_address" -O package.7z
-					7z x -y package.7z
+					7zr x -y package.7z
 					rm package.7z
 
 					G_RUN_CMD make

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1660,6 +1660,10 @@ Also have a look at "Sonarr", another alternative TV show manager, available for
 			#Remove obsolete workaround for archive.raspberrypi.org repo on Buster: https://github.com/Fourdee/DietPi/issues/1286#issuecomment-463856159
 			(( $G_DISTRO == 5 && $G_HW_MODEL < 10 )) && sed -i 's/stretch/buster/g' /etc/apt/sources.list.d/raspi.list
 			#-------------------------------------------------------------------------------
+			#Removed dependency on "p7zip-full", use "7zr" (p7zip) instead: https://github.com/Fourdee/DietPi/pull/2559
+			dpkg-query -s p7zip-full &> /dev/null && apt-mark auto p7zip-full
+			G_AGI p7zip
+			#-------------------------------------------------------------------------------
 
 		fi
 


### PR DESCRIPTION
**Status**: Testing
- [x] Check other scripts
- [x] DietPi-Patch | `G_AGI p7zip; apt-mark auto p7zip-full`
- [x] Changelog

**Testing**:
- [x] VM Stretch (update, bug report, `grep '7z' /DietPi/dietpi/* /DietPi/dietpi/*/*`)

**Commit list/description**:
+ DietPi-Bugreport | Increase max upload size to 20M, our server can effort it
+ DietPi-Bugreport | Use "ls" with option "-A" instead of "-a" not not list "." and ".." current and parent dirs
+ DietPi-Bugreport | No double quotes required when declaring commands/file paths with wildcard/asterisk, since they are expanded later when reading back array entries
+ DietPi-Bugreport | Add all known boot/kernel config files to upload archive
+ DietPi-Bugreport | Add whole directories instead of their contained files via "/*". This includes hidden files as well and allows simpler syntax without expansion.
+ DietPi-Bugreport | Write command errors to command out file as well, to derive e.g. missing commands/packages
+ DietPi-Bugreport | Use "7zr" lightweight standalone 7z archiver to lower dependency from "p7zip-full" to "p7zip"
+ DietPi-Bugreport | Minor coding, e.g. include INPUT check into menu loop to auto break
+ DietPi-Patch | Remove dependency on "p7zip-full", assure "p7zip" install instead
+ DietPi-Set_Hardware | Use standalone lightweight "7zr" to handle 7z archives
+ DietPi-PREP | Reduced "p7zip-full" dependency to "p7zip"
+ DietPi-Software | Use lightweight standalone "7zr" to handle 7z archives