### PR TITLE
DietPi-Software | Koel/MineOS: Fix install on ARMv8 systems

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ Changes / Improvements / Optimisations:
 
 Bug Fixes:
 - General | Resolved an issue where /etc/bashrc.d entries could be run multiple times. Many thanks to @jonare77 for reporting this: https://github.com/Fourdee/DietPi/issues/2529
+- DietPi-Software | MineOS/Koel: Resolved an issue where install on ARMv8 devices failed. Many thanks to @DeathIsUnknown for reporting this issue and solution: https://github.com/Fourdee/DietPi/issues/1880#issuecomment-464097174
 - DietPi-Software | Emby Server: We disabled the option to install it on Jessie ARM systems. This was never possible, since Debian Jessie does not provide the minimum required libc6 version. Thanks to @mbone for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?f=11&t=5502
 - DietPi-Software | Mopidy: Resolved issue with failed audio playback. Many thanks to @arkhub for reporting this issue! https://github.com/Fourdee/DietPi/issues/2536
 - DietPi-Software | WireGuard: Resolved an issue with wrong client DNS entry, if on server 127.0.0.1/localhost loopback DNS entry is used. Thanks to @swrobel for reporting this issue: https://github.com/Fourdee/DietPi/issues/2482

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5313,11 +5313,11 @@ _EOF_
 
 			Banner_Installing
 
-			#check folder is online
+			# Check folder is online
 			INSTALL_URL_ADDRESS='https://github.com/hexparrot/mineos-node.git'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
-			#prereqs
+			# Pre-reqs
 			G_AGI python python3 supervisor rdiff-backup screen rsync
 
 			mkdir -p $G_FP_DIETPI_USERDATA/mineos
@@ -5328,9 +5328,12 @@ _EOF_
 			git config core.filemode false
 			chmod +x service.js mineos_console.js generate-sslcert.sh webui.js
 
-			#Install Node 8, as MineOS is currently not compatible with Node 10
+			# Install Node 8, as MineOS is currently not compatible with Node 10: https://github.com/Fourdee/DietPi/issues/1880
 			npm i -g --unsafe-perm n
-			n 8
+			# - On ARMv8 explicitly add arch info, since it is not recognized by "n": https://github.com/Fourdee/DietPi/issues/1880#issuecomment-464097174
+			local arch=''
+			(( $G_HW_ARCH == 3 )) && arch='-a arm64'
+			n $arch 8
 
 			npm i --unsafe-perm
 
@@ -5758,7 +5761,10 @@ _EOF_
 
 			# Install pre-req yarn and "n" to downgrade to Node 8, as Node 10 is not (yet) compatible with Koel build.
 			npm i -g --unsafe-perm yarn n
-			n 8
+			# - On ARMv8 explicitly add arch info, since it is not recognized by "n": https://github.com/Fourdee/DietPi/issues/1880#issuecomment-464097174
+			local arch=''
+			(( $G_HW_ARCH == 3 )) && arch='-a arm64'
+			n $arch 8
 
 			# Download and install Composer:
 			php -r "readfile('https://getcomposer.org/installer');" > composer-setup.php


### PR DESCRIPTION
**Status**: Ready
- [x] Changelog

**Reference**:
- https://github.com/Fourdee/DietPi/issues/1880#issuecomment-464097174
- Open PR on "n" repo to fix/add ARMv8 detection natively: https://github.com/tj/n/pull/448

**Commit list/description**:
+ DietPi-Software | Koel/MineOS: Fix install on ARMv8 systems, where "n" command explicitly requires "-a arm64"
+ CHANGELOG | MineOS/Koel: Resolved an issue where install on ARMv8 devices failed