### PR TITLE
Update to get correct CPU temp

### DIFF
--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -1922,11 +1922,11 @@ $print_logfile_info
 				fi
 
 				# - Boards that provide 2 digit output
-				#	Pine
+				#	Pine (when using sunxi64 kernel thermal_zone gives 1000*temp_value)
 				#	NanoPi M2
 				#	H3 3.x
 				#	H2+ 3.x
-				if (( $G_HW_MODEL == 40 ||
+				if (( ($G_HW_MODEL == 40 && $(uname -r | awk -F '-' '{ print $2 }') != 'sunxi64') ||
 					$G_HW_MODEL == 61 ||
 					( $G_HW_CPUID == 1 && $(uname -r | grep -ci -m1 '^3.') ) ||
 					( $G_HW_MODEL == 32 && $(uname -r | grep -ci -m1 '^3.') ) )); then


### PR DESCRIPTION
Update to get correct CPU temperature reading on Pine64 with sunxi64 based kernel. As it gives temperature multiplied by 1000 and this value is integer instead of float. Just a minor change.

**Commit list/description**:
- DietPi-CPUInfo | Minor change of func/dietpi-globals file to correct behaviour on Pine platform.