### PR TITLE
DietPi-Start_kodi | Do not load DietPi-Globals, since G_HW_MODEL is required only

### DIFF
--- a/dietpi/misc/start_kodi
+++ b/dietpi/misc/start_kodi
@@ -17,8 +17,8 @@
 	# - /DietPi/dietpi/misc/start_kodi
 	#////////////////////////////////////
 	#Import DietPi-Globals ---------------------------------------------------------------
-	. /DietPi/dietpi/func/dietpi-globals
-	G_PROGRAM_NAME='DietPi-Start_kodi'
+	# G_HW_MODEL required only
+	G_HW_MODEL=$(sed -n 1p /DietPi/dietpi/.hw_model)
 	##Import DietPi-Globals ---------------------------------------------------------------
 
 	#/////////////////////////////////////////////////////////////////////////////////////
@@ -35,7 +35,7 @@
 	else
 
 		#From Desktop
-		if [ "$DISPLAY" ]; then
+		if [[ $DISPLAY ]]; then
 
 			#C2 fix for stuttering and laggy audio: https://github.com/Fourdee/DietPi/issues/399#issuecomment-229413994
 			if (( $G_HW_MODEL == 12 )); then
@@ -57,7 +57,6 @@
 	fi
 
 	#-----------------------------------------------------------------------------------
-	#exit
 	exit
 	#-----------------------------------------------------------------------------------
 }


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Start_kodi | Do not load DietPi-Globals, since G_HW_MODEL is required only

@Fourdee 
Or did I oversee something?