### PR TITLE
DietPi-Software | Pi-hole: Fix "pihole -up"

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,7 @@ Bug Fixes:
 - DietPi-Software | WireGuard: Resolved an issue where on uninstall the Debian Sid repo was not removed. Thanks to @XRay437 for reporting this issue: https://github.com/Fourdee/DietPi/issues/2545
 - DietPi-Software | Java: Resolved an issue where install failed on ARM. Thanks to @WTFMaster for reporting this issue: https://github.com/Fourdee/DietPi/issues/2524
 - DietPi-Software | Remot3.it: Resolved an issue where install failed due to Git repo changes. Additionally Remot3.it is now available on x86_64 and ARMv8 systems as well. Thanks to @techano for reporting this issue: https://github.com/Fourdee/DietPi/issues/2551
+- DietPi-Software | Pi-hole: Resolved an issue where "pihole -up" fails because of wrong file permissions. Thanks to @jonare77 for resporting this issue: https://github.com/Fourdee/DietPi/issues/2516
 - DietPi-Software | MPD: Resolved an issue with failed playback due to permissions. Permissions are now set via systemd service, to ensure the MPD user can use both dietpi and audio groups: https://github.com/Fourdee/DietPi/issues/2462
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/Fourdee/DietPi/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+base%3Amaster

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -467,6 +467,15 @@ _EOF_
 		# - Blynk
 		chown -R blynk:dietpi $G_FP_DIETPI_USERDATA/blynk
 
+		# - Pi-hole
+		#	- NB: Git requies special permissions to allow "pihole -up".
+		if [[ -d /var/www/html/pihole ]]; then
+
+			cd /var/www/html/admin && git reset --hard HEAD
+			cd /tmp/$G_PROGRAM_NAME
+
+		fi
+
 	}
 
 	#/////////////////////////////////////////////////////////////////////////////////////

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1668,6 +1668,14 @@ Also have a look at "Sonarr", another alternative TV show manager, available for
 			#	MPD: https://github.com/Fourdee/DietPi/issues/2462
 			(( $G_DIETPI_INSTALL_STAGE == 2 )) && /DietPi/dietpi/dietpi-software reinstall 128
 			#-------------------------------------------------------------------------------
+			#Fix Pi-hole permissions to allow "pihole -up"
+			if [[ -d /var/www/html/pihole ]]; then
+
+				cd /var/www/html/admin && git reset --hard HEAD
+				cd /tmp/$G_PROGRAM_NAME
+
+			fi
+			#-------------------------------------------------------------------------------
 
 		fi
 


### PR DESCRIPTION
**Status**: Ready
- [x] Patch
- [x] Changelog

**Reference**: https://github.com/Fourdee/DietPi/issues/2516

**Commit list/description**:
+ DietPi-Set_Software | setpermissions: Add Pi-hole Git based permissions reset to allow "pihole -up"
+ DietPi-Patch | Fix Pi-hole permissions to allow "pihole -up"
+ CHANGELOG | Pi-hole: Resolved an issue where "pihole -up" fails because of wrong file permissions