### PR TITLE
DietPi-Software | WireGuard: Harden "sid" repo handling on RPi

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Changes / Improvements / Optimisations:
 - DietPi-Software | Emby Server: Now installs the latest version automatically (currently 4.0.1), which as well offers a native ARMv8 package: https://github.com/Fourdee/DietPi/pull/2525
 - DietPi-Software | WireGuard: Switched from 10.8.0.0 to 10.9.0.0 IP addresses on fresh installs, to avoid IP double use with OpenVPN. Thanks to @XRay437 for pointing this out: https://github.com/Fourdee/DietPi/issues/2491#issuecomment-461366739
 - DietPi-Software | WireGuard: Changed the way users are adviced to add multiple clients, to enhance concurrent connections. Thanks to @curiosity-seeker for reporting and testing this issue: https://github.com/Fourdee/DietPi/issues/2491#issuecomment-462419860
+- DietPi-Software | WireGuard: Hardened "sid" repo handling on RPi, to prevent accidental non-WireGuard package installs. Thanks to @rucknapucknavitz for reporting this issue: https://github.com/Fourdee/DietPi/issues/2568#issuecomment-465725312
 - DietPi-Software | Aria2: Tweaked settings to enhance 3rd party plugin support and removed deprecated/doubled entries. Many thanks to @msongz for the commit: https://github.com/Fourdee/DietPi/pull/2538
 
 Bug Fixes:

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4919,13 +4919,19 @@ _EOF_
 			# Odroids need to purge before we install, else, does not update to latest version...
 			(( $G_HW_MODEL >= 10 && $G_HW_MODEL < 20 )) && G_AGP $kernel_packages
 
-			# Since G_AGUG does not upgrade packages with changed dependencies, in case of kernel image meta packages, those need to be installed via G_AGI.
+			# Since G_AGUG does not upgrade packages with changed dependencies, in case of kernel image meta packages, those need to be installed+upgraded via G_AGI.
 			G_AGI $kernel_packages # apt-get install overrides hold state
 
-			# Add Debian "sid" repo, which contains the wireguard packages
+			# Add Debian "sid" repo, which contains the WireGuard packages
 			echo 'deb https://deb.debian.org/debian/ sid main' > /etc/apt/sources.list.d/dietpi-wireguard.list
-			# - Set "sid" priority low enough to only install packages that are not available in main repo(s)
-			echo -e 'Package: *\nPin: release n=sid\nPin-Priority: 99' > /etc/apt/preferences.d/dietpi-wireguard
+			# - Disable sid repo via priority "-1", to prevent any accidental package upgrades: https://github.com/Fourdee/DietPi/issues/2568
+			# - Enable but set sid WireGuard package priorities low enough to install only if not available in main repo(s)
+			echo -e 'Package: *\nPin: release n=sid\nPin-Priority: -1\n
+Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Priority: 99' > /etc/apt/preferences.d/dietpi-wireguard
+
+			# RPi: Install debian-archive-keyring, currently version 2018.1 from sid branch: https://packages.debian.org/de/sid/debian-archive-keyring
+			(( $G_HW_MODEL < 10 )) && Download_Install 'https://dietpi.com/downloads/binaries/rpi/debian-archive-keyring.deb'
+
 			G_AGUP
 
 			# Check for existing WireGuard install


### PR DESCRIPTION
**Status**: Ready
- [x] Changelog

**Reference**: https://github.com/Fourdee/DietPi/issues/2568

**Commit list/description**:
+ DietPi-Software | WireGuard: Disable sid repo by default, only enable WireGuard packages, to prevent any accidental package upgrades
+ DietPi-Software | WireGuard: On RPi, install Debian repo keyring