### PR TITLE
DietPi-Globals | G_AG*: Remove potentially harmful force options + other enhancements

### DIFF
--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -156,7 +156,7 @@ Please check if one of the following applies:
  - You started this script from within another DietPi program, causing a loop.\n
 Please assure that the concurrent execution has finished, before retrying, otherwise cancel this instance.\n
 The following info might help:
-$(ps f -eo pid,user,tty,cmd | grep -i [d]ietpi)"; then
+$(ps f -eo pid,user,tty,cmd | grep -i '[d]ietpi')"; then
 
 						G_DIETPI-NOTIFY 1 "Canceled $G_PROGRAM_NAME due to concurrent execution"
 						exit 1
@@ -1546,7 +1546,7 @@ $print_logfile_info
 
 		local string=$@
 		local options=''
-		(( $G_DISTRO >= 4 )) && options+='--allow-change-held-packages'
+		(( $G_DISTRO >= 4 )) && options='--allow-change-held-packages'
 
 		G_ERROR_HANDLER_RETRY=1
 		while (( $G_ERROR_HANDLER_RETRY ))
@@ -1578,7 +1578,7 @@ $print_logfile_info
 
 		local string=$@
 		local options=''
-		(( $G_DISTRO >= 4 )) && options+='--allow-change-held-packages'
+		(( $G_DISTRO >= 4 )) && options='--allow-change-held-packages'
 
 		G_ERROR_HANDLER_RETRY=1
 		while (( $G_ERROR_HANDLER_RETRY ))
@@ -1751,7 +1751,7 @@ $print_logfile_info
 		G_CHECK_ROOT_USER 1
 
 		local options=''
-		(( $G_DISTRO >= 4 )) && options+='--allow-change-held-packages'
+		(( $G_DISTRO >= 4 )) && options='--allow-change-held-packages'
 
 		G_ERROR_HANDLER_RETRY=1
 		while (( $G_ERROR_HANDLER_RETRY ))

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -1545,32 +1545,22 @@ $print_logfile_info
 		G_CHECK_ROOT_USER 1
 
 		local string=$@
-		local force_options=''
-
-		if (( $G_DISTRO >= 4 )); then
-
-			force_options='--allow-downgrades --allow-remove-essential --allow-change-held-packages --allow-unauthenticated'
-
-		else
-
-			force_options='--force-yes'
-
-		fi
+		local options=''
+		(( $G_DISTRO >= 4 )) && options+='--allow-change-held-packages'
 
 		G_ERROR_HANDLER_RETRY=1
 		while (( $G_ERROR_HANDLER_RETRY ))
 		do
 
-			G_ERROR_HANDLER_COMMAND="G_AGI: $string"
+			G_ERROR_HANDLER_COMMAND="G_AGI $string"
 			G_ERROR_HANDLER_ONERROR_FPLOGFILE=$G_FP_LOG_APT
 
 			#-qq can add a slight period of appearing nothing is happening, lets inform user
-			G_DIETPI-NOTIFY 0 "APT installation for: \e[33m$string\e[0m, please wait..."
+			G_DIETPI-NOTIFY 2 "\e[0mAPT installation for: \e[33m$string\e[0m, please wait..."
 
 			echo -ne '\e[90m'
-			DEBIAN_FRONTEND=noninteractive apt-get install -y -qq $force_options $string 2>&1 | tee $G_FP_LOG_APT
+			DEBIAN_FRONTEND=noninteractive apt-get -qq $options install $string 2>&1 | tee $G_FP_LOG_APT
 			G_ERROR_HANDLER_EXITCODE=${PIPESTATUS[0]}
-			echo -e '\e[0m'
 
 			G_ERROR_HANDLER
 
@@ -1586,19 +1576,15 @@ $print_logfile_info
 
 		G_CHECK_ROOT_USER 1
 
-		local string=( "$@" )
+		local string=$@
 		local options=''
-		if (( $G_DISTRO >= 4 )); then
-
-			options+=' --allow-change-held-packages'
-
-		fi
+		(( $G_DISTRO >= 4 )) && options+='--allow-change-held-packages'
 
 		G_ERROR_HANDLER_RETRY=1
 		while (( $G_ERROR_HANDLER_RETRY ))
 		do
 
-			G_ERROR_HANDLER_COMMAND="G_AGP: ${string[@]}"
+			G_ERROR_HANDLER_COMMAND="G_AGP $string"
 			G_ERROR_HANDLER_ONERROR_FPLOGFILE=$G_FP_LOG_APT
 
 			# - Remove non-matching packages from string, which are not installed, to prevent failures.
@@ -1610,10 +1596,10 @@ $print_logfile_info
 			local packages_to_remove=''
 			dpkg --get-selections > $fp_temp
 			local i=0
-			for i in "${string[@]}"; do
+			for i in $string; do
 
 				if grep -qi "^$i[[:space:]|:]" $fp_temp ||
-					{ echo -e $i | grep -qi '*' && grep -qi "^$i" $fp_temp; }; then #wildcard check
+					{ grep -qi '*' <<< $i && grep -qi "^$i" $fp_temp; }; then #wildcard check
 
 					packages_to_remove+="$i "
 					G_DIETPI-NOTIFY 2 "Install verified: $i"
@@ -1625,17 +1611,15 @@ $print_logfile_info
 				fi
 
 			done
-
 			rm $fp_temp
 			unset string #habbit :)
 
 			if [[ $packages_to_remove ]]; then
 
-				G_DIETPI-NOTIFY 0 "APT removal for: \e[33m$packages_to_remove\e[0m, please wait..."
+				G_DIETPI-NOTIFY 2 "\e[0mAPT removal for: \e[33m$packages_to_remove\e[0m, please wait..."
 				echo -ne '\e[90m'
-				DEBIAN_FRONTEND=noninteractive apt-get purge -y $packages_to_remove $options 2>&1 | tee $G_FP_LOG_APT
+				DEBIAN_FRONTEND=noninteractive apt-get -qq $options purge $packages_to_remove 2>&1 | tee $G_FP_LOG_APT
 				G_ERROR_HANDLER_EXITCODE=${PIPESTATUS[0]}
-				echo -e '\e[0m'
 
 			else
 
@@ -1664,12 +1648,11 @@ $print_logfile_info
 			G_ERROR_HANDLER_COMMAND='G_AGA'
 			G_ERROR_HANDLER_ONERROR_FPLOGFILE=$G_FP_LOG_APT
 
-			G_DIETPI-NOTIFY 0 'APT autoremove + purge, please wait...'
+			G_DIETPI-NOTIFY 2 '\e[0mAPT autoremove + purge, please wait...'
 
 			echo -ne '\e[90m'
-			DEBIAN_FRONTEND=noninteractive apt-get autoremove --purge -y 2>&1 | tee $G_FP_LOG_APT
+			DEBIAN_FRONTEND=noninteractive apt-get -qq --purge autoremove 2>&1 | tee $G_FP_LOG_APT
 			G_ERROR_HANDLER_EXITCODE=${PIPESTATUS[0]}
-			echo -e '\e[0m'
 
 			G_ERROR_HANDLER
 
@@ -1692,12 +1675,11 @@ $print_logfile_info
 			G_ERROR_HANDLER_COMMAND='G_AGF'
 			G_ERROR_HANDLER_ONERROR_FPLOGFILE=$G_FP_LOG_APT
 
-			G_DIETPI-NOTIFY 0 'APT fix, please wait...'
+			G_DIETPI-NOTIFY 2 '\e[0mAPT fix, please wait...'
 
 			echo -ne '\e[90m'
-			DEBIAN_FRONTEND=noninteractive apt-get install -f -y 2>&1 | tee $G_FP_LOG_APT
+			DEBIAN_FRONTEND=noninteractive apt-get -qq -f install 2>&1 | tee $G_FP_LOG_APT
 			G_ERROR_HANDLER_EXITCODE=${PIPESTATUS[0]}
-			echo -e '\e[0m'
 
 			G_ERROR_HANDLER
 
@@ -1720,13 +1702,12 @@ $print_logfile_info
 			G_ERROR_HANDLER_COMMAND='G_AGUP'
 			G_ERROR_HANDLER_ONERROR_FPLOGFILE=$G_FP_LOG_APT
 
-			G_DIETPI-NOTIFY 0 'APT update, please wait...'
+			G_DIETPI-NOTIFY 2 '\e[0mAPT update, please wait...'
 
 			echo -ne '\e[90m'
 			DEBIAN_FRONTEND=noninteractive apt-get clean 2>&1 | tee $G_FP_LOG_APT
-			DEBIAN_FRONTEND=noninteractive apt-get update 2>&1 | tee -a $G_FP_LOG_APT
+			DEBIAN_FRONTEND=noninteractive apt-get -q update 2>&1 | tee -a $G_FP_LOG_APT
 			G_ERROR_HANDLER_EXITCODE=${PIPESTATUS[0]}
-			echo -e '\e[0m'
 
 			G_ERROR_HANDLER
 
@@ -1749,19 +1730,11 @@ $print_logfile_info
 			G_ERROR_HANDLER_COMMAND='G_AGUG'
 			G_ERROR_HANDLER_ONERROR_FPLOGFILE=$G_FP_LOG_APT
 
-			G_DIETPI-NOTIFY 0 'APT upgrade, please wait...'
-
-			local options=''
-			if (( $G_DISTRO >= 4 )); then
-
-				options='--allow-unauthenticated'
-
-			fi
+			G_DIETPI-NOTIFY 2 '\e[0mAPT upgrade, please wait...'
 
 			echo -ne '\e[90m'
-			DEBIAN_FRONTEND=noninteractive apt-get upgrade -y $options 2>&1 | tee $G_FP_LOG_APT
+			DEBIAN_FRONTEND=noninteractive apt-get -qq upgrade 2>&1 | tee $G_FP_LOG_APT
 			G_ERROR_HANDLER_EXITCODE=${PIPESTATUS[0]}
-			echo -e '\e[0m'
 
 			G_ERROR_HANDLER
 
@@ -1777,6 +1750,9 @@ $print_logfile_info
 
 		G_CHECK_ROOT_USER 1
 
+		local options=''
+		(( $G_DISTRO >= 4 )) && options+='--allow-change-held-packages'
+
 		G_ERROR_HANDLER_RETRY=1
 		while (( $G_ERROR_HANDLER_RETRY ))
 		do
@@ -1784,22 +1760,11 @@ $print_logfile_info
 			G_ERROR_HANDLER_COMMAND='G_AGDUG'
 			G_ERROR_HANDLER_ONERROR_FPLOGFILE=$G_FP_LOG_APT
 
-			if (( $G_DISTRO >= 4 )); then
-
-				force_options='--allow-downgrades --allow-remove-essential --allow-change-held-packages --allow-unauthenticated'
-
-			else
-
-				force_options='--force-yes'
-
-			fi
-
-			G_DIETPI-NOTIFY 0 'APT dist-upgrade, please wait...'
+			G_DIETPI-NOTIFY 2 '\e[0mAPT dist-upgrade, please wait...'
 
 			echo -ne '\e[90m'
-			DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y $force_options 2>&1 | tee $G_FP_LOG_APT
+			DEBIAN_FRONTEND=noninteractive apt-get -qq $options dist-upgrade 2>&1 | tee $G_FP_LOG_APT
 			G_ERROR_HANDLER_EXITCODE=${PIPESTATUS[0]}
-			echo -e '\e[0m'
 
 			G_ERROR_HANDLER
 
@@ -1818,39 +1783,35 @@ $print_logfile_info
 
 		local fp_temp='/tmp/.G_AG_CHECK_INSTALL_PREREQ'
 		local exit_code=0
-		local string=( "$@" )
+		local string=$@
 		local packages_to_install=''
 
-		G_DIETPI-NOTIFY 0 "Checking for pre-req APT packages: \e[33m${string[*]}"
+		G_DIETPI-NOTIFY 2 "Checking for pre-req APT packages: \e[33m$string"
 
 		dpkg --get-selections > $fp_temp
 		local i=0
-		for i in "${string[@]}"; do
+		for i in $string; do
 
 			if ! grep -qi "^$i[[:space:]]" $fp_temp; then
 
-				G_DIETPI-NOTIFY 2 "Flagged for installation: $i"
+				G_DIETPI-NOTIFY 2 "Flagged for installation: \e[33m$i"
 				packages_to_install+=" $i"
 
 			fi
 
 		done
+		rm $fp_temp
 
 		if [[ $packages_to_install ]]; then
 
-			G_DIETPI-NOTIFY -2 'Installing pre-req APT packages'
 			G_AGI $packages_to_install
 			exit_code=$?
 
 		else
 
-			G_DIETPI-NOTIFY 2 'Pre-req APT packages are installed'
+			G_DIETPI-NOTIFY 2 'Pre-req APT packages were already installed'
 
 		fi
-
-		#G_AGI now handles the error
-
-		rm $fp_temp
 
 		return $exit_code
 


### PR DESCRIPTION
**Status**: Testing

**Commit list/description**:
+ DietPi-Globals | G_AG*: Remove --allow-downgrades/remove-essential/unauthenticated, since these cases are mostly harmful
+ DietPi-Globals | G_AG*: Use "G_DIETPI-NOTIFY 2 '\e[0m" for initial info print to still force white text in contrast to apt-get output
+ DietPi-Globals | G_AG*: Do not create input string array, since "for i in $string" has exactly the same result
+ DietPi-Globals | G_AG*: "-qq" includes "-y"
+ DietPi-Globals | G_AG*: Reorder apt-get command and options to have consistent "apt-get [<options>] <command> [<pkgs>]"
+ DietPi-Globals | G_AG*: No colour reset required after apt-get output, since G_ERROR_HANDLER implies this
+ DietPi-Globals | G_AG*: Add "-q(q)" to certain commands to reduce processing output a bid

**Testing**:
- [ ] VM Jessie
- [ ] VM Stretch
- [ ] VM Buster

@Fourdee 
I know this might break automation in some cases. However I am not keen to automate such potentially harmful APT steps. I prefer to clean up/solve cases where this then fails.
- For all APT repos we add, a key should be added as well to allow verifying authenticity.
- Essential packages should be never removed of course.
- Downgrades should be never automated, if this is attempted, then something with the packages we attempt to install is wrong and we should fix.
- Only hold states we should keep overriding via G_AGI and G_AGDUG, as legacy or user hold states can break installs. We require/expect latest packages in every case.

On Jessie, no separate hold state options exist. This means that in this case hold states will break APT. But since this should without manual user action never happen and the remaining Jessie systems is less 1%, I think this is acceptable now.