### PR TITLE
DietPi-Obtain_network_details | Skip loading DietPi-Globals

### DIFF
--- a/dietpi/func/obtain_network_details
+++ b/dietpi/func/obtain_network_details
@@ -24,11 +24,14 @@
 	# - IP address
 	#////////////////////////////////////
 
-	#Import DietPi-Globals ---------------------------------------------------------------
-	. /DietPi/dietpi/func/dietpi-globals
-	G_PROGRAM_NAME='DietPi-Obtain_network_details'
-	G_INIT
-	#Import DietPi-Globals ---------------------------------------------------------------
+	# Import DietPi-Globals --------------------------------------------------------------
+	#. /DietPi/dietpi/func/dietpi-globals
+	#G_PROGRAM_NAME='DietPi-Obtain_network_details'
+	#G_INIT
+	# Import DietPi-Globals --------------------------------------------------------------
+
+	# Exit, if already running
+	pgrep 'obtain_network_details' &> /dev/null && exit
 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Global
@@ -47,7 +50,7 @@
 	DEV_MAX=9
 	Scrape_IP(){
 
-		#ETH
+		# ETH
 		for (( i=0; i<=$DEV_MAX; i++ ))
 		do
 
@@ -68,7 +71,7 @@
 
 		done
 
-		#WLAN
+		# WLAN
 		for (( i=0; i<=$DEV_MAX; i++ ))
 		do
 
@@ -101,7 +104,7 @@
 	#/////////////////////////////////////////////////////////////////////////////////////
 	Scrape_IP
 	#-----------------------------------------------------------------------------------
-	#Output to file
+	# Output to file
 	cat << _EOF_ > $FP_NETFILE
 $ETH_INDEX
 $WLAN_INDEX
@@ -111,7 +114,7 @@ ETH_IP=$ETH_IP
 WLAN_IP=$WLAN_IP
 _EOF_
 
-	#Assure that non-root user can read file:
+	# Assure that non-root user can read file:
 	(( $UID )) || chmod 666 $FP_NETFILE
 
 	#-----------------------------------------------------------------------------------


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Obtain_network_details | Skip loading DietPi-Globals, since we don't use them at all. Add exit path in case of concurrent execution instead.

@Fourdee 
Another case where we can skip loading DietPi-Globals. Just the concurrency included with G_INIT should stay, just exiting silently here.