### PR TITLE
DietPi-Software | GMediaRender: Service starts with obtained IP

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,8 @@ Bug Fixes:
 - General | Resolved an issue where /etc/bashrc.d entries could be run multiple times. Many thanks to @jonare77 for reporting this: https://github.com/Fourdee/DietPi/issues/2529
 - RPi | Resolved an issue where I-Sabre-K2M sound card selection failed. Thanks to @klasLiesen for reporting this issue: https://github.com/Fourdee/DietPi/issues/2547
 - DietPi-Software | MineOS/Koel: Resolved an issue where install on ARMv8 devices failed. Many thanks to @DeathIsUnknown for reporting this issue and solution: https://github.com/Fourdee/DietPi/issues/1880#issuecomment-464097174
+- DietPi-Software | GMediaRender: Resolved an issue where the daemon can attach to a wrong IP if multiple network devices are present. As well resolved a failing service start on fresh install if/as the log file does not exist yet. Many thanks to @WilburWalsh for reporting these issues and providing a fix: https://github.com/Fourdee/DietPi/issues/2576
+- DietPi-Software | OpenSSH Client: Resolved an issue where uninstalling the OpenSSH Client will in case also remove the OpenSSH Server.
 - DietPi-Software | Emby Server: We disabled the option to install it on Jessie ARM systems. This was never possible, since Debian Jessie does not provide the minimum required libc6 version. Thanks to @mbone for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?f=11&t=5502
 - DietPi-Software | Mopidy: Resolved issue with failed audio playback. Many thanks to @arkhub for reporting this issue! https://github.com/Fourdee/DietPi/issues/2536
 - DietPi-Software | WireGuard: Resolved an issue with wrong client DNS entry, if on server 127.0.0.1/localhost loopback DNS entry is used. Thanks to @swrobel for reporting this issue: https://github.com/Fourdee/DietPi/issues/2482

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12342,13 +12342,15 @@ _EOF_
 			cat << _EOF_ > /etc/systemd/system/gmrender.service
 [Unit]
 Description=GMrender (DietPi)
-After=network.target
+After=network.target dietpi-boot.service
 
 [Service]
 Type=simple
 User=gmrender
 Group=dietpi
-ExecStart=$(command -v gmediarender) -u "$(sed -n 5p /DietPi/dietpi/.hw_model)" -f "$(cat /etc/hostname)" --gstout-audiodevice=sysdefault --gstout-initial-volume-db=-1 --logfile=/var/log/gmrender.log
+ExecStartPre=+/usr/bin/touch /var/log/gmrender.log
+ExecStartPre=+/bin/chown gmrender /var/log/gmrender.log
+ExecStart=/bin/bash -c '$(command -v gmediarender) -u "$(sed -n 5p /DietPi/dietpi/.hw_model)" -f "$(cat /etc/hostname)" --gstout-audiodevice=sysdefault --gstout-initial-volume-db=-1 --logfile=/var/log/gmrender.log -I "\$(/bin/sed -n 4p /DietPi/dietpi/.network)"'
 
 [Install]
 WantedBy=multi-user.target

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -801,7 +801,7 @@ _EOF_
 				 aSOFTWARE_WHIP_DESC[$software_id]='Roon capable audio player and core'
 			aSOFTWARE_CATEGORY_INDEX[$software_id]=2
 					  aSOFTWARE_TYPE[$software_id]=0
-			 aSOFTWARE_ONLINEDOC_URL[$software_id]='f=8&t=5&p=7966#p7966'
+			 aSOFTWARE_ONLINEDOC_URL[$software_id]='p=7966#p7966'
 			 aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		   aSOFTWARE_REQUIRES_FFMPEG[$software_id]=1
 
@@ -839,12 +839,12 @@ _EOF_
 		#------------------
 		software_id=163
 
-				 aSOFTWARE_WHIP_NAME[$software_id]='Gmediarender'
+				 aSOFTWARE_WHIP_NAME[$software_id]='GMediaRender'
 				 aSOFTWARE_WHIP_DESC[$software_id]='DLNA audio render/endpoint'
 			aSOFTWARE_CATEGORY_INDEX[$software_id]=2
 					  aSOFTWARE_TYPE[$software_id]=0
 			 aSOFTWARE_REQUIRES_ALSA[$software_id]=1
-			 aSOFTWARE_ONLINEDOC_URL[$software_id]='f=8&t=5&p=9012#p9012'
+			 aSOFTWARE_ONLINEDOC_URL[$software_id]='p=9012#p9012'
 
 		#------------------
 		software_id=167
@@ -854,7 +854,7 @@ _EOF_
 			aSOFTWARE_CATEGORY_INDEX[$software_id]=2
 					  aSOFTWARE_TYPE[$software_id]=0
 			 aSOFTWARE_REQUIRES_ALSA[$software_id]=1
-			 aSOFTWARE_ONLINEDOC_URL[$software_id]='f=8&t=5&p=9368#p9368'
+			 aSOFTWARE_ONLINEDOC_URL[$software_id]='p=9368#p9368'
 
 		# Disable for ARMv8 + x86_64:
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,3]=0
@@ -868,7 +868,7 @@ _EOF_
 			aSOFTWARE_CATEGORY_INDEX[$software_id]=2
 					  aSOFTWARE_TYPE[$software_id]=0
 	 aSOFTWARE_REQUIRES_JAVA_JRE_JDK[$software_id]=1
-			 aSOFTWARE_ONLINEDOC_URL[$software_id]='f=8&t=5&p=12969#p12969'
+			 aSOFTWARE_ONLINEDOC_URL[$software_id]='p=12969#p12969'
 
 		#------------------
 		software_id=86
@@ -879,7 +879,7 @@ _EOF_
 					  aSOFTWARE_TYPE[$software_id]=0
 			  aSOFTWARE_REQUIRES_GIT[$software_id]=1
 		   aSOFTWARE_REQUIRES_NODEJS[$software_id]=1
-			 aSOFTWARE_ONLINEDOC_URL[$software_id]='f=8&t=5&p=13160#p13160'
+			 aSOFTWARE_ONLINEDOC_URL[$software_id]='p=13160#p13160'
 
 		#BitTorrent
 		#--------------------------------------------------------------------------------
@@ -6134,8 +6134,7 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 
 		fi
 
-		#Allo Web Interface
-		software_id=159 #160 for quick reinstall
+		software_id=159 # Allo Web Interface (160 for quick reinstall)
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 ||
 			${aSOFTWARE_INSTALL_STATE[160]} == 1 )); then
 
@@ -6144,8 +6143,7 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 
 		fi
 
-		#Gmediarender
-		software_id=163
+		software_id=163 # GMediaRender
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -6174,8 +6172,7 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 
 		fi
 
-		#AudioPhonics Pi-SPC
-		software_id=166
+		software_id=166 # AudioPhonics Pi-SPC
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -6186,8 +6183,7 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 
 		fi
 
-		#Raspotify
-		software_id=167
+		software_id=167 # Raspotify
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -12331,26 +12327,32 @@ _EOF_
 
 		fi
 
-		#Gmediarender
-		software_id=163
+		software_id=163 # GMediaRender
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
 
-			useradd -rm gmrender -G dietpi,audio -s /usr/sbin/nologin
+			# Create/Edit user
+			local usercmd='useradd -rm'
+			getent passwd gmrender &> /dev/null && usercmd='usermod'
+			$usercmd gmrender -G dietpi,audio -s /usr/sbin/nologin
 
+			# Pre-create log file
+			>> /var/log/gmrender.log
+			chown gmrender:gmrender /var/log/gmrender.log
+
+			# Create systemd unit
 			cat << _EOF_ > /etc/systemd/system/gmrender.service
 [Unit]
-Description=GMrender (DietPi)
+Description=GMediaRender (DietPi)
 After=network.target dietpi-boot.service
 
 [Service]
-Type=simple
 User=gmrender
 Group=dietpi
-ExecStartPre=+/usr/bin/touch /var/log/gmrender.log
-ExecStartPre=+/bin/chown gmrender /var/log/gmrender.log
-ExecStart=/bin/bash -c '$(command -v gmediarender) -u "$(sed -n 5p /DietPi/dietpi/.hw_model)" -f "$(cat /etc/hostname)" --gstout-audiodevice=sysdefault --gstout-initial-volume-db=-1 --logfile=/var/log/gmrender.log -I "\$(/bin/sed -n 4p /DietPi/dietpi/.network)"'
+ExecStartPre=!$(command -v touch) /var/log/gmrender.log
+ExecStartPre=!$(command -v chown) gmrender:gmrender /var/log/gmrender.log
+ExecStart=$(command -v gmediarender) -u '$(sed -n 5p /DietPi/dietpi/.hw_model)' -f '$(</etc/hostname)' --gstout-audiodevice=sysdefault --gstout-initial-volume-db=-1 --logfile=/var/log/gmrender.log -I "\$($(command -v sed) -n 4p /DietPi/dietpi/.network)"
 
 [Install]
 WantedBy=multi-user.target
@@ -12358,8 +12360,7 @@ _EOF_
 
 		fi
 
-		#AudioPhonics Pi-SPC
-		software_id=166
+		software_id=166 # AudioPhonics Pi-SPC
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -14250,10 +14251,10 @@ _EOF_
 
 			Banner_Uninstalling
 			# Remove Service file
-			rm /etc/systemd/system/nukkit.service
+			[[ -f /etc/systemd/system/nukkit.service ]] && rm /etc/systemd/system/nukkit.service
 
-			# remove nukkit java file/folder
-			rm -r /usr/local/bin/nukkit
+			# Remove nukkit java file/folder
+			[[ -e /usr/local/bin/nukkit ]] && rm -R /usr/local/bin/nukkit
 
 		fi
 
@@ -14263,9 +14264,9 @@ _EOF_
 			Banner_Uninstalling
 			#apt-mark auto libupnp6 gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-alsa &> /dev/null
 			G_AGP gmrender
-			rm /etc/systemd/system/gmrender.service
+			[[ -f /etc/systemd/system/gmrender.service ]] && rm /etc/systemd/system/gmrender.service
 
-			userdel -rf gmrender
+			getent passwd gmrender &> /dev/null && userdel -rf gmrender
 
 		fi
 
@@ -14450,11 +14451,7 @@ _EOF_
 
 			Banner_Uninstalling
 			# This also removes OpenSSH server. So lets check OpenSSH server isn't installed before hand.
-			if dpkg --get-selections | grep -qi 'openssh-server'; then
-
-				G_AGP openssh-client
-
-			fi
+			dpkg-query -s 'openssh-server' &> /dev/null || G_AGP openssh-client
 
 		fi
 


### PR DESCRIPTION
- Gmediarender service waits for Dietpi Boot Service to finish, then uses obtained IP address
- Fixed bug with missing write access for log file

**Status**: Ready 
- Tested on Pi1/Stretch with Wifi, infinite wait for valid network connection

**Reference**: #2576

**Commit list/description**:
- DietPi-Software | Gmediarender: Service started with IP obtained after dietpi-boot has finished, see #2576. Additional bug with missing permissions for logfile fixed.
+ DietPi-Software | GMediaRender: Enhance reinstall by using "usermod", if user already exists
+ DietPi-Software | GMediaRender: Pre-create log file; Failsafe
+ DietPi-Software | GMediaRender: Generally use $(command -v cmd) when adding commands to systemd units; Failsafe
+ DietPi-Software | GMediaRender: Generally do not use bash subshell for systemd unit Exec if not required for redirects
+ DietPi-Software | OpenSSH Client: Do NOT purge "openssh-client" if server is installed, since due to dependencies OpenSSH Server would be removed as well.
+ DietPi-Software | Minor coding and ordering
+ CHANGELOG | GMediaRender: Resolved an issue where the daemon can attach to a wrong IP and a failing service start due to missing log file
+ CHANGELOG | OpenSSH Client: Resolved an issue where uninstalling the OpenSSH Client will in case also remove the OpenSSH Server