### PR TITLE
DietPi-Software | GMediaRender: Enable Buster support by using the up-to-date APT repo package

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Changes / Improvements / Optimisations:
 - DietPi-Software | Emby Server: Now installs the latest version automatically (currently 4.0.1), which as well offers a native ARMv8 package: https://github.com/Fourdee/DietPi/pull/2525
 - DietPi-Software | WireGuard: Switched from 10.8.0.0 to 10.9.0.0 IP addresses on fresh installs, to avoid IP double use with OpenVPN. Thanks to @XRay437 for pointing this out: https://github.com/Fourdee/DietPi/issues/2491#issuecomment-461366739
 - DietPi-Software | WireGuard: Changed the way users are adviced to add multiple clients, to enhance concurrent connections. Thanks to @curiosity-seeker for reporting and testing this issue: https://github.com/Fourdee/DietPi/issues/2491#issuecomment-462419860
+- DietPi-Software | GMediaRender: Enabled support for Debian/Raspbian Buster by using the up-to-date APT repo package.
 - DietPi-Software | Aria2: Tweaked settings to enhance 3rd party plugin support and removed deprecated/doubled entries. Many thanks to @msongz for the commit: https://github.com/Fourdee/DietPi/pull/2538
 - DietPi-Software | UrBackup: Updated installed version to 2.3.7. Thanks to @DeathIsUnknown for the information: https://github.com/Fourdee/DietPi/issues/2577
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3591,7 +3591,7 @@ We work around this error by running APT a second time. Please do not worry and 
 				if (( $G_HW_ARCH == 3 )); then
 
 					# libupnp6 for net discov with upnp/avahi
-					DEPS_LIST='libupnp6 libwrap0 libmpdclient2 libao-common libao4 libasound2 libasound2-data libasyncns0 libaudiofile1 libavahi-client3 libavahi-common-data libavahi-common3 libavcodec56 libavformat56 libavresample2 libavutil54 libbinio1ldbl libcaca0 libcdio-cdda1 libcdio-paranoia1 libcdio13 libcups2 libcurl3-gnutls libdirectfb-1.2-9 libdnet libfaad2 libflac8 libfluidsynth1 libgme0 libgomp1 libgsm1 libice6 libid3tag0 libiso9660-8 libjack-jackd2-0 libjson-c2 libldb1 libmad0 libmikmod3 libmms0 libmodplug1 libmp3lame0 libmpcdec6 libmpg123-0 libnfs4 libntdb1 libogg0 libopenal-data libopenal1 libopenjpeg5 libopus0 liborc-0.4-0 libpulse0 libresid-builder0c2a libroar2 libsamplerate0 libschroedinger-1.0-0 libsdl1.2debian libshout3 libsidplay2 libsidutils0 libslp1 libsm6 libsmbclient libsndfile1 libsoxr0 libspeex1 libspeexdsp1 libsqlite3-0 libtalloc2 libtdb1 libtevent0 libtheora0 libupnp6 libva1 libvorbis0a libvorbisenc2 libvorbisfile3 libvpx1 libwavpack1 libwbclient0 libwildmidi-config libwildmidi1 libx11-6 libx11-data libx11-xcb1 libx264-142 libxau6 libxcb1 libxdmcp6 libxext6 libxi6 libxtst6 libxvidcore4 libyajl2 libzzip-0-13 mime-support python python-talloc python2.7 samba-libs x11-common file'
+					DEPS_LIST='libupnp6 libwrap0 libmpdclient2 libao-common libao4 libasound2 libasound2-data libasyncns0 libaudiofile1 libavahi-client3 libavahi-common-data libavahi-common3 libavcodec56 libavformat56 libavresample2 libavutil54 libbinio1ldbl libcaca0 libcdio-cdda1 libcdio-paranoia1 libcdio13 libcups2 libcurl3-gnutls libdirectfb-1.2-9 libdnet libfaad2 libflac8 libfluidsynth1 libgme0 libgomp1 libgsm1 libice6 libid3tag0 libiso9660-8 libjack-jackd2-0 libjson-c2 libldb1 libmad0 libmikmod3 libmms0 libmodplug1 libmp3lame0 libmpcdec6 libmpg123-0 libnfs4 libntdb1 libogg0 libopenal-data libopenal1 libopenjpeg5 libopus0 liborc-0.4-0 libpulse0 libresid-builder0c2a libroar2 libsamplerate0 libschroedinger-1.0-0 libsdl1.2debian libshout3 libsidplay2 libsidutils0 libslp1 libsm6 libsmbclient libsndfile1 libsoxr0 libspeex1 libspeexdsp1 libsqlite3-0 libtalloc2 libtdb1 libtevent0 libtheora0 libva1 libvorbis0a libvorbisenc2 libvorbisfile3 libvpx1 libwavpack1 libwbclient0 libwildmidi-config libwildmidi1 libx11-6 libx11-data libx11-xcb1 libx264-142 libxau6 libxcb1 libxdmcp6 libxext6 libxi6 libxtst6 libxvidcore4 libyajl2 libzzip-0-13 mime-support python python-talloc python2.7 samba-libs x11-common file'
 					Download_Install 'https://dietpi.com/downloads/binaries/all/mpd_0.20.18-1_armv8.deb'
 
 				else
@@ -3611,8 +3611,8 @@ We work around this error by running APT a second time. Please do not worry and 
 			#Buster+
 			else
 
-				# libcdio-paranoia1 and libiso9660-8 not available, but ibcdio-paranoia2 and libiso9660-11 instead
-				# Buster repo version >= 0.20.23, thus stay with APT for now:
+				# libcdio-paranoia1, libiso9660-8 and libupnp6 not available, but ibcdio-paranoia2, libiso9660-11 and libupnp13 instead
+				# Buster repo version >= 0.21.4, thus stay with APT for now:
 				G_AGI mpd
 
 			fi
@@ -6147,27 +6147,39 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/gmrender_1_'
-			if (( $G_HW_ARCH == 10 )); then
+			# Stretch + Jessie: Use our updated package
+			if (( $G_DISTRO < 5 )); then
 
-				INSTALL_URL_ADDRESS+='amd64.deb'
+				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/gmrender_1_'
+				if (( $G_HW_ARCH == 10 )); then
 
-			elif (( $G_HW_ARCH == 3 )); then
+					INSTALL_URL_ADDRESS+='amd64.deb'
 
-				INSTALL_URL_ADDRESS+='arm64.deb'
+				elif (( $G_HW_ARCH == 3 )); then
 
-			elif (( $G_HW_ARCH == 2 )); then
+					INSTALL_URL_ADDRESS+='arm64.deb'
 
-				INSTALL_URL_ADDRESS+='armv7.deb'
+				elif (( $G_HW_ARCH == 2 )); then
 
-			elif (( $G_HW_ARCH == 1 )); then
+					INSTALL_URL_ADDRESS+='armv7.deb'
 
-				INSTALL_URL_ADDRESS+='armv6.deb'
+				elif (( $G_HW_ARCH == 1 )); then
+
+					INSTALL_URL_ADDRESS+='armv6.deb'
+
+				fi
+
+				DEPS_LIST='libupnp6 gstreamer1.0-alsa gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly'
+				Download_Install "$INSTALL_URL_ADDRESS"
+
+			# Buster: Use the up-to-date APT repo package
+			else
+
+				G_AGI gmediarender gstreamer1.0-alsa gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly
+				# - Disable init.d service, use our systemd unit instead
+				systemctl disable gmediarender
 
 			fi
-
-			DEPS_LIST='libupnp6 gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-alsa'
-			Download_Install "$INSTALL_URL_ADDRESS"
 
 		fi
 
@@ -12912,7 +12924,7 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			#apt-mark auto libavformat57 libupnp6 libao-common libao4 libasound2 libasound2-data libasyncns0 libaudiofile1 libavahi-client3 libavahi-common-data libavahi-common3 libavcodec56 libavformat56 libavresample2 libavutil54 libbinio1ldbl libcaca0 libcdio-cdda1 libcdio-paranoia1 libcdio13 libcups2 libcurl3-gnutls libdirectfb-1.2-9 libdnet libfaad2 libflac8 libfluidsynth1 libgme0 libgomp1 libgsm1 libice6 libid3tag0 libiso9660-8 libjack-jackd2-0 libjson-c2 libldb1 libmad0 libmikmod3 libmms0 libmodplug1 libmp3lame0 libmpcdec6 libmpg123-0 libnfs4 libntdb1 libogg0 libopenal-data libopenal1 libopenjpeg5 libopus0 liborc-0.4-0 libpulse0 libresid-builder0c2a libroar2 libsamplerate0 libschroedinger-1.0-0 libsdl1.2debian libshout3 libsidplay2 libsidutils0 libslp1 libsm6 libsmbclient libsndfile1 libsoxr0 libspeex1 libspeexdsp1 libsqlite3-0 libtalloc2 libtdb1 libtevent0 libtheora0 libupnp6 libva1 libvorbis0a libvorbisenc2 libvorbisfile3 libvpx1 libwavpack1 libwbclient0 libwildmidi-config libwildmidi1 libx11-6 libx11-data libx11-xcb1 libx264-142 libxau6 libxcb1 libxdmcp6 libxext6 libxi6 libxtst6 libxvidcore4 libyajl2 libzzip-0-13 mime-support python python-talloc python2.7 samba-libs x11-common file &> /dev/null
+			#apt-mark auto libavformat57 libupnp6 libao-common libao4 libasound2 libasound2-data libasyncns0 libaudiofile1 libavahi-client3 libavahi-common-data libavahi-common3 libavcodec56 libavformat56 libavresample2 libavutil54 libbinio1ldbl libcaca0 libcdio-cdda1 libcdio-paranoia1 libcdio13 libcups2 libcurl3-gnutls libdirectfb-1.2-9 libdnet libfaad2 libflac8 libfluidsynth1 libgme0 libgomp1 libgsm1 libice6 libid3tag0 libiso9660-8 libjack-jackd2-0 libjson-c2 libldb1 libmad0 libmikmod3 libmms0 libmodplug1 libmp3lame0 libmpcdec6 libmpg123-0 libnfs4 libntdb1 libogg0 libopenal-data libopenal1 libopenjpeg5 libopus0 liborc-0.4-0 libpulse0 libresid-builder0c2a libroar2 libsamplerate0 libschroedinger-1.0-0 libsdl1.2debian libshout3 libsidplay2 libsidutils0 libslp1 libsm6 libsmbclient libsndfile1 libsoxr0 libspeex1 libspeexdsp1 libsqlite3-0 libtalloc2 libtdb1 libtevent0 libtheora0 libva1 libvorbis0a libvorbisenc2 libvorbisfile3 libvpx1 libwavpack1 libwbclient0 libwildmidi-config libwildmidi1 libx11-6 libx11-data libx11-xcb1 libx264-142 libxau6 libxcb1 libxdmcp6 libxext6 libxi6 libxtst6 libxvidcore4 libyajl2 libzzip-0-13 mime-support python python-talloc python2.7 samba-libs x11-common file &> /dev/null
 			apt-mark unhold mpd 1> /dev/null
 			G_AGP mpd libmpdclient2
 			getent passwd mpd &> /dev/null && userdel -rf mpd
@@ -14261,7 +14273,7 @@ _EOF_
 
 			Banner_Uninstalling
 			#apt-mark auto libupnp6 gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-alsa &> /dev/null
-			G_AGP gmrender
+			G_AGP gmrender gmediarender
 			[[ -f /etc/systemd/system/gmrender.service ]] && rm /etc/systemd/system/gmrender.service
 
 			getent passwd gmrender &> /dev/null && userdel -rf gmrender


### PR DESCRIPTION
**Status**: Ready
- [x] Changelog

**Commit list/description**:
+ DietPi-Software | GMediaRender: Enable Buster support by using the up-to-date APT repo package