### PR TITLE
DietPi | Fix wrong shown connection state if IP+route is active but link "DOWN"

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ Changes / Improvements / Optimisations:
 
 Bug Fixes:
 - General | Resolved an issue where /etc/bashrc.d entries could be run multiple times. Many thanks to @jonare77 for reporting this: https://github.com/Fourdee/DietPi/issues/2529
+- General | Resolved an issue where DietPi-Config and banner shows wrong adapter state if it is not connected but has an IP assigned. Thanks to @msongz for reporting this issue: https://github.com/Fourdee/DietPi/issues/2573
 - RPi | Resolved an issue where I-Sabre-K2M sound card selection failed. Thanks to @klasLiesen for reporting this issue: https://github.com/Fourdee/DietPi/issues/2547
 - DietPi-Software | MineOS/Koel: Resolved an issue where install on ARMv8 devices failed. Many thanks to @DeathIsUnknown for reporting this issue and solution: https://github.com/Fourdee/DietPi/issues/1880#issuecomment-464097174
 - DietPi-Software | GMediaRender: Resolved an issue where the daemon can attach to a wrong IP if multiple network devices are present. As well resolved a failing service start on fresh install if/as the log file does not exist yet. Many thanks to @WilburWalsh for reporting these issues and providing a fix: https://github.com/Fourdee/DietPi/issues/2576

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -2765,7 +2765,7 @@ _EOF_
 			ETH_MODE_TARGET=$ETH_MODE
 
 			#Connected and Valid IP?
-			ETH_CONNECTED=$(ip r | grep -ci -m1 "eth$ETH_DEV_INDEX")
+			ETH_CONNECTED=$(ip -o r l dev eth$ETH_DEV_INDEX | grep -vcim1 '[[:blank:]]linkdown')
 
 			#Enabled and Connected
 			if (( $ETH_DISABLED == 0 && $ETH_CONNECTED == 1 )); then
@@ -2789,7 +2789,7 @@ _EOF_
 			WIFI_MODE_TARGET=$WIFI_MODE
 
 			#Connected and Valid IP?
-			WIFI_CONNECTED=$(ip r | grep -ci -m1 "wlan$WIFI_DEV_INDEX")
+			WIFI_CONNECTED=$(ip -o r l dev wlan$ETH_DEV_INDEX | grep -vcim1 '[[:blank:]]linkdown')
 
 			#Enabled and Connected
 			if (( $WIFI_DISABLED == 0 && $WIFI_CONNECTED == 1 )); then

--- a/dietpi/func/obtain_network_details
+++ b/dietpi/func/obtain_network_details
@@ -10,25 +10,18 @@
 	#////////////////////////////////////
 	#
 	# Info:
+	# - Location: /{DietPi,boot}/dietpi/func/obtain_network_details
 	# - Attempts to find the 1st available index numbers for eth[0-9] and wlan[0-9] devices
 	# - Obtains the active network adapter (eth, then wlan).
-	# - Saves the above data to $FP_NETFILE for use systemwide
+	# - Saves the above data to $FP_NETFILE for use system-wide
 	#
-	# $FP_NETFILE line1
-	# - eth index
-	# $FP_NETFILE line2
-	# - wlan index
-	# $FP_NETFILE line3
-	# - Active adapter name (eg: eth0)
-	# $FP_NETFILE line4
-	# - IP address
+	# line1: eth index
+	# line2: wlan index
+	# line3: Active adapter name (eg: eth0)
+	# line4: Active IP address
+	# line5: ETH_IP=<eth ip>
+	# line6: WLAN_IP=<wlan ip>
 	#////////////////////////////////////
-
-	# Import DietPi-Globals --------------------------------------------------------------
-	#. /DietPi/dietpi/func/dietpi-globals
-	#G_PROGRAM_NAME='DietPi-Obtain_network_details'
-	#G_INIT
-	# Import DietPi-Globals --------------------------------------------------------------
 
 	# Exit, if already running
 	pgrep 'obtain_network_details' &> /dev/null && exit
@@ -39,61 +32,74 @@
 
 	FP_NETFILE='/DietPi/dietpi/.network'
 
-	ETH_INDEX=0
-	WLAN_INDEX=0
-
-	ACTIVE_DEVICE='NONE'
+	ETH_INDEX=''
+	WLAN_INDEX=''
+	ACTIVE_DEVICE=''
+	ACTIVE_IP=''
 	ETH_IP=''
 	WLAN_IP=''
-	IP_ADDRESS='Use dietpi-config to setup a connection'
 
-	DEV_MAX=9
-	Scrape_IP(){
+	Scan(){
 
 		# ETH
-		for (( i=0; i<=$DEV_MAX; i++ ))
+		local eth_dev='' eth_index='' eth_out='' eth_ip=''
+		for i in /sys/class/net/eth*
 		do
 
-			if ETH_IP=$(ip -o a s eth$i 2>/dev/null); then
+			# Check if any eth dev exists
+			[[ -e $i ]] || break
 
-				ETH_INDEX=$i
-				ETH_IP=${ETH_IP#*inet* }
-				ETH_IP=${ETH_IP%%/*}
-				if [[ $ETH_IP ]]; then
+			# Get dev name and index, assign not yet if lower index found
+			eth_dev=${i#*net/}
+			eth_index=${eth_dev#eth}
+			[[ $ETH_INDEX ]] || ETH_INDEX=$eth_index
 
-					ACTIVE_DEVICE="eth$ETH_INDEX"
-					IP_ADDRESS=$ETH_IP
-					break
+			# Get and check IP, assign not yet if lower index IP found
+			eth_out=$(ip a s $eth_dev 2>/dev/null) || continue
+			eth_ip=${eth_out#*inet* }
+			eth_ip=${eth_ip%%/*}
+			[[ $eth_ip ]] || continue
+			[[ $ETH_IP ]] || { ETH_IP=$eth_ip; ETH_INDEX=$eth_index; }
 
-				fi
+			# Check connection state
+			[[ $eth_out =~ [[:blank:]]UP[[:blank:]] ]] || continue
 
-			fi
+			# Assign active dev info
+			ETH_INDEX=$eth_index
+			ETH_IP=$eth_ip
+			ACTIVE_DEVICE=$eth_dev
+			ACTIVE_IP=$ETH_IP
+			break
 
 		done
 
 		# WLAN
-		for (( i=0; i<=$DEV_MAX; i++ ))
+		local wlan_dev='' wlan_index='' wlan_out='' wlan_ip=''
+		for i in /sys/class/net/wlan*
 		do
 
-			if WLAN_IP=$(ip -o a s wlan$i 2>/dev/null); then
+			[[ -e $i ]] || break
 
-				WLAN_INDEX=$i
-				WLAN_IP=${WLAN_IP#*inet* }
-				WLAN_IP=${WLAN_IP%%/*}
-				if [[ $WLAN_IP ]]; then
+			# Get dev name and index, assign not yet if lower index found
+			wlan_dev=${i#*net/}
+			wlan_index=${wlan_dev#wlan}
+			[[ $WLAN_INDEX ]] || WLAN_INDEX=$wlan_index
 
-					if [[ ! $ETH_IP ]]; then
+			# Get and check IP, assign not yet if lower index IP found
+			wlan_out=$(ip a s $wlan_dev 2>/dev/null) || continue
+			wlan_ip=${wlan_out#*inet* }
+			wlan_ip=${wlan_ip%%/*}
+			[[ $wlan_ip ]] || continue
+			[[ $WLAN_IP ]] || { WLAN_IP=$wlan_ip; WLAN_INDEX=$wlan_index; }
 
-						ACTIVE_DEVICE="wlan$WLAN_INDEX"
-						IP_ADDRESS=$WLAN_IP
+			# Check connection state
+			[[ $wlan_out =~ [[:blank:]]UP[[:blank:]] ]] || continue
 
-					fi
-
-					break
-
-				fi
-
-			fi
+			# Assign active dev info if none (eth) assigned yet
+			WLAN_INDEX=$wlan_index
+			WLAN_IP=$wlan_ip
+			[[ $ACTIVE_DEVICE ]] || { ACTIVE_DEVICE=$wlan_dev; ACTIVE_IP=$WLAN_IP; }
+			break
 
 		done
 
@@ -102,19 +108,19 @@
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Main Loop
 	#/////////////////////////////////////////////////////////////////////////////////////
-	Scrape_IP
+	Scan
 	#-----------------------------------------------------------------------------------
-	# Output to file
+	# Write to file
 	cat << _EOF_ > $FP_NETFILE
-$ETH_INDEX
-$WLAN_INDEX
-$ACTIVE_DEVICE
-$IP_ADDRESS
+${ETH_INDEX:-0}
+${WLAN_INDEX:-0}
+${ACTIVE_DEVICE:-NONE}
+${ACTIVE_IP:-Use dietpi-config to setup a connection}
 ETH_IP=$ETH_IP
 WLAN_IP=$WLAN_IP
 _EOF_
 
-	# Assure that non-root user can read file:
+	# Assure that non-root user can write file
 	(( $UID )) || chmod 666 $FP_NETFILE
 
 	#-----------------------------------------------------------------------------------


### PR DESCRIPTION
**Status**: Ready
- [x] DietPi-Obtain_network_details
- [x] Changelog

**Reference**: https://github.com/Fourdee/DietPi/issues/2573

**Testing**:

Old script:
```
root@VM-Stretch:~# time for i in {1..10}; do /DietPi/dietpi/func/obtain_network_details; done

real    0m1.645s
user    0m0.144s
sys     0m0.204s
root@VM-Stretch:~# time for i in {1..10}; do /DietPi/dietpi/func/obtain_network_details; done

real    0m1.632s
user    0m0.140s
sys     0m0.204s
root@VM-Stretch:~# time for i in {1..10}; do /DietPi/dietpi/func/obtain_network_details; done

real    0m1.611s
user    0m0.132s
sys     0m0.196s
root@VM-Stretch:~# time for i in {1..10}; do /DietPi/dietpi/func/obtain_network_details; done

real    0m1.611s
user    0m0.136s
sys     0m0.216s
```
New script:
```
root@VM-Stretch:~# time for i in {1..10}; do /DietPi/dietpi/func/obtain_network_details_new; done

real    0m0.641s
user    0m0.368s
sys     0m0.160s
root@VM-Stretch:~# time for i in {1..10}; do /DietPi/dietpi/func/obtain_network_details_new; done

real    0m0.651s
user    0m0.392s
sys     0m0.132s
root@VM-Stretch:~# time for i in {1..10}; do /DietPi/dietpi/func/obtain_network_details_new; done

real    0m0.648s
user    0m0.360s
sys     0m0.168s
root@VM-Stretch:~# time for i in {1..10}; do /DietPi/dietpi/func/obtain_network_details_new; done

real    0m0.646s
user    0m0.336s
sys     0m0.192s
root@VM-Stretch:~# cat /DietPi/dietpi/.network
0
0
eth0
192.168.178.29
ETH_IP=192.168.178.29
WLAN_IP=
```
- 🈯️ 🚀 Performance increase > 100%

**Commit list/description**:
+ DietPi-Config | Fix wrong shown connection state where in some cases a route is shown but suffixed with "linkdown"
+ DietPi-Obtain_network_details | Rewrite: Scan more targeted via /sys/class/net entries: Performance!
+ DietPi-Obtain_network_details | Verify that device with assigned IP is actually connected, via "ip a" =~ "UP" flag