### PR TITLE
DietPi-Software | Store global password with enhanced security

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ v6.22
 (xx/03/19)
 
 Changes / Improvements / Optimisations:
+- Security | The DietPi-Software global password is now stored with enhanced security which also resolves a warning on Buster systems: https://github.com/MichaIng/DietPi/issues/2213
 - General | DietPi scripts now use the lightweight standalone "7zr" command to handle 7z archives. This allows us to lower DietPi core package dependencies from "p7zip-full" to "p7zip".
 - DietPi-NordVPN | Added sent/received usage stats for VPN tunnel.
 - DietPi-Sync | Sync will now abort if the source dir is empty. Merged dry run into real sync, as this was performed anyway to do required free space check. When "Sync" is selected, after dry run the user is presented a summary and given the option to view the detailed dry run log, cancel or continue with real sync. Some other minor fixes and enhancements have been applied as well. Many thanks to @midnightwatcher for doing this request: https://dietpi.com/phpbb/viewtopic.php?f=12&t=5588

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -156,7 +156,10 @@ _EOF_
 		# - Encrypted
 		if [[ -r '/var/lib/dietpi/dietpi-software/.GLOBAL_PW.bin' ]]; then
 
-			GLOBAL_PW=$(cat /var/lib/dietpi/dietpi-software/.GLOBAL_PW.bin | openssl enc -base64 -d -aes-256-cbc -nosalt -pass pass:'DietPiRocks!')
+			# - Use new "pbkdf2" function on Buster to resolve warning about deprecated key derivation used: https://github.com/MichaIng/DietPi/issues/2213
+			local pbkdf2=''
+			(( $G_DISTRO > 4 )) && pbkdf2='-iter 10000'
+			GLOBAL_PW=$(openssl enc -d -a -aes-256-cbc $pbkdf2 -salt -pass pass:'DietPiRocks!' -in /var/lib/dietpi/dietpi-software/.GLOBAL_PW.bin)
 
 		# - 1st run automated setup only
 		else

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -652,8 +652,12 @@ It is highly recommended to change this password, ideally, it should be differen
 			# - Nullify automated PW
 			G_CONFIG_INJECT 'AUTO_SETUP_GLOBAL_PASSWORD=' 'AUTO_SETUP_GLOBAL_PASSWORD=Password has been encrypted and secured on rootFS' /DietPi/dietpi.txt
 
-			mkdir -p /var/lib/dietpi/dietpi-software #should already exist, failsafe
-			echo -e "$pw_dietpi_software" | openssl enc -base64 -e -aes-256-cbc -nosalt -pass pass:DietPiRocks! > /var/lib/dietpi/dietpi-software/.GLOBAL_PW.bin
+			mkdir -p /var/lib/dietpi/dietpi-software # Should already exist, failsafe
+
+			# - Use new "pbkdf2" function on Buster to resolve warning about deprecated key derivation used: https://github.com/MichaIng/DietPi/issues/2213
+			local pbkdf2=''
+			(( $G_DISTRO > 4 )) && pbkdf2='-iter 10000'
+			openssl enc -e -a -aes-256-cbc $pbkdf2 -salt -pass pass:'DietPiRocks!' -out /var/lib/dietpi/dietpi-software/.GLOBAL_PW.bin <<< $pw_dietpi_software
 
 			Setpermissions_Main &> /dev/null
 
@@ -669,9 +673,6 @@ It is highly recommended to change this password, ideally, it should be differen
 			G_DIETPI-NOTIFY 2 '"root" and "dietpi" login password successfully changed'
 
 		fi
-
-		unset pw_dietpi_software
-		unset pw_root_dietpi_users
 
 	}
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -876,8 +876,12 @@ _EOF_
 
 				G_CONFIG_INJECT 'AUTO_SETUP_GLOBAL_PASSWORD=' 'AUTO_SETUP_GLOBAL_PASSWORD=Password has been encrypted and secured on rootFS' /DietPi/dietpi.txt
 
-				mkdir -p /var/lib/dietpi/dietpi-software #should already exist, failsafe
-				echo "$pw_dietpi_software" | openssl enc -base64 -e -aes-256-cbc -nosalt -pass pass:DietPiRocks! > /var/lib/dietpi/dietpi-software/.GLOBAL_PW.bin
+				mkdir -p /var/lib/dietpi/dietpi-software # Should already exist, failsafe
+
+				# - Use new "pbkdf2" function on Buster to resolve warning about deprecated key derivation used: https://github.com/MichaIng/DietPi/issues/2213
+				local pbkdf2=''
+				(( $G_DISTRO > 4 )) && pbkdf2='-iter 10000'
+				openssl enc -e -a -aes-256-cbc $pbkdf2 -salt -pass pass:'DietPiRocks!' -out /var/lib/dietpi/dietpi-software/.GLOBAL_PW.bin <<< $pw_dietpi_software
 
 				unset pw_dietpi_software
 

--- a/dietpi/pre-patch_file
+++ b/dietpi/pre-patch_file
@@ -56,11 +56,21 @@
 		if (( $G_DIETPI_VERSION_SUB < 21 )) && [[ -f /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf ]] &&
 			grep -qi 'buster' /etc/os-release; then
 
-			echo -e '\e[90m[\e[0m \e[33mWARN\e[0m \e[90m]\e[0m Pre-patch 2 | Patch /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf for MariaDB v10.3/Buster support'
+			echo -e '\e[90m[\e[0m \e[33mWARN\e[0m \e[90m]\e[0m Pre-patch 2 | Patching /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf for MariaDB v10.3/Buster support'
 			sed -i '/innodb_large_prefix/d' /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf || { EXIT_CODE=2; break; }
 			sed -i '/innodb_file_format/d' /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf || { EXIT_CODE=2; break; }
 
 		fi	
+		#-------------------------------------------------------------------------------
+		# Pre-patch 3: https://github.com/MichaIng/DietPi/issues/2213
+		if (( $G_DIETPI_VERSION_SUB < 22 )) &&
+			GLOBAL_PW=$(openssl enc -d -a -aes-256-cbc -nosalt -pass pass:'DietPiRocks!' -in /var/lib/dietpi/dietpi-software/.GLOBAL_PW.bin 2> /dev/null); then
+
+			echo -e '\e[90m[\e[0m \e[33mWARN\e[0m \e[90m]\e[0m Pre-patch 3 | Saving global DietPi-Software password in a more secured way'
+			grep -qi 'buster' /etc/os-release && pbkdf2='-iter 10000' || pbkdf2=''
+			openssl enc -e -a -aes-256-cbc $pbkdf2 -salt -pass pass:'DietPiRocks!' -out /var/lib/dietpi/dietpi-software/.GLOBAL_PW.bin <<< $GLOBAL_PW || { EXIT_CODE=3; break; }
+
+		fi
 		#-------------------------------------------------------------------------------
 		# Finished
 		echo -e '\e[90m[\e[0m  \e[32mOK\e[0m  \e[90m]\e[0m Successfully applied critical pre-patches\n'

--- a/dietpi/pre-patch_file
+++ b/dietpi/pre-patch_file
@@ -66,7 +66,7 @@
 		if (( $G_DIETPI_VERSION_SUB < 22 )) &&
 			GLOBAL_PW=$(openssl enc -d -a -aes-256-cbc -nosalt -pass pass:'DietPiRocks!' -in /var/lib/dietpi/dietpi-software/.GLOBAL_PW.bin 2> /dev/null); then
 
-			echo -e '\e[90m[\e[0m \e[33mWARN\e[0m \e[90m]\e[0m Pre-patch 3 | Saving global DietPi-Software password in a more secured way'
+			echo -e '\e[90m[\e[0m \e[33mWARN\e[0m \e[90m]\e[0m Pre-patch 3 | Storing global DietPi-Software password with enhanced security'
 			grep -qi 'buster' /etc/os-release && pbkdf2='-iter 10000' || pbkdf2=''
 			openssl enc -e -a -aes-256-cbc $pbkdf2 -salt -pass pass:'DietPiRocks!' -out /var/lib/dietpi/dietpi-software/.GLOBAL_PW.bin <<< $GLOBAL_PW || { EXIT_CODE=3; break; }
 


### PR DESCRIPTION
**Status**: Ready
- [x] DietPi-Software
- [x] DietPi-Set_software
- [x] DietPi-Patch
- [x] Changelog

**Testing**:
- [x] VM Jessie
- [x] VM Stretch
- [x] VM Buster

**Reference**: https://github.com/MichaIng/DietPi/issues/2213

**Commit list/description**:
+ DietPi-Pre-patch | Safe global DietPi-Software password with salt to enhance security; On Buster use new "pbkdf2" function with 10000 iterations to resolve a warning about deprecated key derivation used.
  - This needs to be done during pre-patches to assure DietPi-Software can decrypt with new method during DietPi-Patch reinstalls.
+ DietPi-Software | Global password is now saved with salt to enhance security; On Buster use new "pbkdf2" function is used with 10000 iterations to resolve a warning about deprecated key derivation used.
+ DietPi-Set_software | Store global DietPi-Software password with salt to enhance security; On Buster use new "pbkdf2" function with 10000 iterations to resolve warnings about deprecated key derivation used.
+ DietPi-Set_software | Minor coding: No reason to unset local variables at end of function
+ DietPi-Patch | Store global DietPi-Software password with salt to enhance security; On Buster use new "pbkdf2" function with 10000 iterations to resolve warnings about deprecated key derivation used.