### PR TITLE
DietPi-Survey | Cleanup: Remove survey version and sent count from upload file

### DIFF
--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -121,8 +121,6 @@
 	SURVEY_COUNT_TOTAL=0
 	SURVEY_COUNT_EMPTY=0
 
-	aSURVEY_VERSION=()
-	aSURVEY_SENTCOUNT=()
 	declare -A aDIETPI_VERSION
 	declare -A aDEVICE_NAME
 	declare -A aCPU_ARCH
@@ -138,13 +136,6 @@
 	declare -A aNETWORK_INTERFACE
 	# v6.17 addition
 	declare -A aGIT_BRANCH
-
-	# Pre v6.10: Convert cpu arch index to name array
-	#aCPU_NAME=()
-	#aCPU_NAME[1]='armv6l'
-	#aCPU_NAME[2]='armv7l'
-	#aCPU_NAME[3]='aarch64'
-	#aCPU_NAME[10]='x86_64'
 
 	# Convert autostart index to name array
 	aAUTOSTART_NAME=()
@@ -168,7 +159,7 @@
 	aSOFTWARE_NAME=()
 	aSOFTWARE_NAME[0]='OpenSSH Client'
 	aSOFTWARE_NAME[1]='Samba Client'
-	aSOFTWARE_NAME[2]='Curlftpfs'
+	aSOFTWARE_NAME[2]='Folding@Home'
 	aSOFTWARE_NAME[3]='MC'
 	aSOFTWARE_NAME[4]='ViFM'
 	aSOFTWARE_NAME[5]='ALSA'
@@ -204,7 +195,7 @@
 	aSOFTWARE_NAME[35]='SqueezeBox'
 	aSOFTWARE_NAME[36]='SqueezeLite'
 	aSOFTWARE_NAME[37]='Shairport Sync'
-	aSOFTWARE_NAME[38]='BruteFIR'
+	aSOFTWARE_NAME[38]='FreshRSS'
 	aSOFTWARE_NAME[39]='ReadyMedia'
 	aSOFTWARE_NAME[40]='Ampache'
 	aSOFTWARE_NAME[41]='Emby Server'
@@ -246,13 +237,13 @@
 	aSOFTWARE_NAME[77]='Grafana'
 	aSOFTWARE_NAME[78]='LESP'
 	aSOFTWARE_NAME[79]='LEMP'
-	aSOFTWARE_NAME[80]='80'
+	aSOFTWARE_NAME[80]='Ubooquity'
 	aSOFTWARE_NAME[81]='LLSP'
 	aSOFTWARE_NAME[82]='LLMP'
 	aSOFTWARE_NAME[83]='Apache2'
 	aSOFTWARE_NAME[84]='Lighttpd'
 	aSOFTWARE_NAME[85]='Nginx'
-	aSOFTWARE_NAME[86]='86'
+	aSOFTWARE_NAME[86]='Roon Extension Manager'
 	aSOFTWARE_NAME[87]='SQlite'
 	aSOFTWARE_NAME[88]='MariaDB'
 	aSOFTWARE_NAME[89]='PHP'
@@ -272,7 +263,7 @@
 	aSOFTWARE_NAME[103]='DietPi-RAMlog'
 	aSOFTWARE_NAME[104]='Dropbear'
 	aSOFTWARE_NAME[105]='OpenSSH Server'
-	aSOFTWARE_NAME[106]='NTP'
+	aSOFTWARE_NAME[106]='Lidarr'
 	aSOFTWARE_NAME[107]='rTorrent'
 	aSOFTWARE_NAME[108]='AmiBerry'
 	aSOFTWARE_NAME[109]='NFS'
@@ -314,7 +305,7 @@
 	aSOFTWARE_NAME[145]='Radarr'
 	aSOFTWARE_NAME[146]='Tautulli'
 	aSOFTWARE_NAME[147]='Jackett'
-	aSOFTWARE_NAME[148]='JRiver MC'
+	aSOFTWARE_NAME[148]='148'
 	aSOFTWARE_NAME[149]='NZBget'
 	aSOFTWARE_NAME[150]='Mono'
 	aSOFTWARE_NAME[151]='Nvidia'
@@ -334,66 +325,17 @@
 	aSOFTWARE_NAME[165]='Gitea'
 	aSOFTWARE_NAME[166]='PI-SPC'
 	aSOFTWARE_NAME[167]='Raspotify'
-	aSOFTWARE_NAME[168]='moOde'
+	aSOFTWARE_NAME[168]='168'
 	aSOFTWARE_NAME[169]='Google AIY'
 
-	# - v6.9 software fixes: https://github.com/MichaIng/DietPi/issues/1927#issuecomment-426453144
-	aSOFTWARE_NAME6_9=()
-	# - v6.10 software index changes
-	aSOFTWARE_NAME6_10=()
+	# - v6.14 (earliest version that can upload to ssh.dietpi.com)
+	aSOFTWARE_NAME6_14=()
 	for i in ${!aSOFTWARE_NAME[@]}
 	do
 
-		aSOFTWARE_NAME6_9[$i]=${aSOFTWARE_NAME[$i]}
-		aSOFTWARE_NAME6_10[$i]=${aSOFTWARE_NAME[$i]}
+		aSOFTWARE_NAME6_14[$i]=${aSOFTWARE_NAME[$i]}
 
 	done
-	#aSOFTWARE_NAME6_10[2]='2' # CurlTMPFS Removed but not marked as removed => v6.12
-	aSOFTWARE_NAME6_10[80]='Ubooquity'
-	aSOFTWARE_NAME6_10[86]='Roon Extension Manager'
-	aSOFTWARE_NAME6_10[106]='106' # NTP
-	aSOFTWARE_NAME6_10[168]='168' # Moode
-
-	# - v6.11 hotfix
-	aSOFTWARE_NAME6_11=()
-	for i in ${!aSOFTWARE_NAME6_10[@]}
-	do
-
-		aSOFTWARE_NAME6_11[$i]=${aSOFTWARE_NAME6_10[$i]}
-
-	done
-
-	# - v6.12
-	aSOFTWARE_NAME6_12=()
-	for i in ${!aSOFTWARE_NAME6_11[@]}
-	do
-
-		aSOFTWARE_NAME6_12[$i]=${aSOFTWARE_NAME6_11[$i]}
-
-	done
-	aSOFTWARE_NAME6_12[2]='2' # CurlTMPFS
-	aSOFTWARE_NAME6_12[148]='148' # JRiver
-
-	# - v6.13
-	aSOFTWARE_NAME6_13=()
-	for i in ${!aSOFTWARE_NAME6_12[@]}
-	do
-
-		aSOFTWARE_NAME6_13[$i]=${aSOFTWARE_NAME6_12[$i]}
-
-	done
-	aSOFTWARE_NAME6_13[2]='Folding@Home'
-	aSOFTWARE_NAME6_13[106]='Lidarr'
-
-	# - v6.14
-	aSOFTWARE_NAME6_14=()
-	for i in ${!aSOFTWARE_NAME6_13[@]}
-	do
-
-		aSOFTWARE_NAME6_14[$i]=${aSOFTWARE_NAME6_13[$i]}
-
-	done
-	aSOFTWARE_NAME6_14[38]='FreshRSS'
 
 	# - v6.15
 	aSOFTWARE_NAME6_15=()
@@ -536,71 +478,6 @@
 
 			fi
 
-			# pre v6.10: Files need to be scraped:
-
-			# Reset variables
-			#survey_version=0
-			#survey_sendcount=0
-			#dietpi_version='0.0'
-			#device_name='NULL'
-			#cpu_arch=0
-			#cpu_count=0
-			#distro_version='NULL'
-			#autostart_option=-1
-			#software_list=''
-			#software=''
-
-			# Survey versions
-			#survey_version=$(grep -m1 '^DietPi-Survey v' $file)
-			#((aSURVEY_VERSION[${survey_version##* v}]++))
-			# - Can only be v5 on pre v6.10
-			#((aSURVEY_VERSION[5]++))
-
-			# Upload count numbers
-			#survey_sendcount=$(grep -m1 '^Upload Count' $file)
-			#((aSURVEY_SENTCOUNT[${survey_sendcount##* : }]++))
-
-			# DietPi versions
-			#dietpi_version=$(grep -m1 '^DietPi Version' $file)
-			# As survey runs on v6.9 currently within patch file, the version string is still at v6.8. Currently manual edit is needed, on v6.10 survey will run on dietpi-update after version string increase.
-			#dietpi_version=${dietpi_version/6.8/6.9}
-			#((aDIETPI_VERSION[${dietpi_version##* : }]++))
-			# - Can only be v6.9
-			#((aDIETPI_VERSION[6.9]++))
-
-			# Device name
-			#device_name=$(grep -m1 '^Hardware Name' $file)
-			#((aDEVICE_NAME[${device_name##* : }]++))
-
-			# CPU architecture
-			#cpu_arch=$(grep -m1 '^CPU Arch Index' $file)
-			#cpu_arch=${cpu_arch##* : }
-			#((aCPU_ARCH[${aCPU_NAME[$cpu_arch]:=$cpu_arch}]++))
-
-			# CPU core count
-			#cpu_count=$(grep -m1 '^CPU Count' $file)
-			#((aCPU_COUNT[${cpu_count##* : }]++))
-
-			# Distro version
-			#distro_version=$(grep -m1 '^Distro Name' $file)
-			#((aDISTRO_VERSION[${distro_version##* : }]++))
-
-			# Autostart option
-			#autostart_option=$(grep -m1 '^Autoboot Index' $file)
-			#autostart_option=${autostart_option##* : }
-			#((aAUTOSTART_OPTION[${aAUTOSTART_NAME[$autostart_option]:=$autostart_option}]++))
-
-			# Installed software
-			#software_list=$(grep '^aSOFTWARE_INSTALL_STATE\[' $file)
-			#while read software
-			#do
-
-			#	software=${software##*[}
-			#	software=${software%%]*}
-			#	((aSOFTWARE[${aSOFTWARE_NAME[$software]:=$software}]++))
-
-			#done <<< "$software_list"
-
 		done
 
 		# Navigate to parent /tmp
@@ -608,15 +485,6 @@
 
 		# Clean up reports dir
 		rm -R /tmp/dietpi-survey_report
-
-		# Calculate overall opt-in upload counts
-		SURVEY_SENTCOUNT_TOTAL=0
-		for i in ${!aSURVEY_SENTCOUNT[@]}
-		do
-
-			(( SURVEY_SENTCOUNT_TOTAL += $i * ${aSURVEY_SENTCOUNT[$i]} ))
-
-		done
 
 		#Bench Results, HW_MODEL array:
 		local default_min_value=100000
@@ -885,26 +753,14 @@
 		</style>
 	</head>
 	<body>
-		<h2>DietPi-Survey report page:</h2>
-                <b>Uploads since: 01.01.2019 00:00:00 UTC</b><br>
+		<h2>DietPi-Survey report page</h2>
+                <i>Uploads since: 01.01.2019 00:00:00 UTC</i><br>
                 <i>Last update: $(TZ=UTC date "+%Y-%m-%d %T UTC")</i><br>
 		<br>
 		<table>
-			<tr><td>Total user count</td><td align="right">$SURVEY_COUNT_TOTAL</td></tr>
-			<tr><td>Users opted in</td><td align="right">$(( $SURVEY_COUNT_TOTAL - $SURVEY_COUNT_EMPTY ))</td></tr>
-			<tr><td>Users opted out</td><td align="right">$SURVEY_COUNT_EMPTY</td></tr>
-		</table>
-
-		<h4>DietPi-Survey versions:</h4>
-		<table>
-			$(for i in ${!aSURVEY_VERSION[@]}; do echo "<tr><td>DietPi-Survey v$i</td><td align=\"right\">	${aSURVEY_VERSION[$i]}</td></tr>"; done | sort -nrk 1.24 -t '	')
-		</table>
-
-		<h4>DietPi-Survey opt-in upload counts:</h4>
-		<table>
-			<tr><td>Overall upload count</td><td align="right">$SURVEY_SENTCOUNT_TOTAL</td></tr>
-			<tr><th>Upload count</th><th>by user count</th></tr>
-			$(for i in ${!aSURVEY_SENTCOUNT[@]}; do echo "<tr><td>$i</td><td align=\"right\">	${aSURVEY_SENTCOUNT[$i]}</td></tr>"; done | sort -nrk 1.9 -t '	')
+			<tr><td>Total install count</td><td align="right">$SURVEY_COUNT_TOTAL</td></tr>
+			<tr><td>Opted in installs</td><td align="right">$(( $SURVEY_COUNT_TOTAL - $SURVEY_COUNT_EMPTY ))</td></tr>
+			<tr><td>Opted out installs</td><td align="right">$SURVEY_COUNT_EMPTY</td></tr>
 		</table>
 
 		<h4>DietPi versions:</h4>

--- a/dietpi/dietpi-survey
+++ b/dietpi/dietpi-survey
@@ -23,23 +23,20 @@
 	# $(sed -n 5p /DietPi/dietpi/.hw_model).txt
 	#////////////////////////////////////
 
-	#Import DietPi-Globals ---------------------------------------------------------------
+	# Import DietPi-Globals --------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
 	G_PROGRAM_NAME='DietPi-Survey'
 	G_CHECK_ROOT_USER
 	G_INIT
-	#Import DietPi-Globals ---------------------------------------------------------------
+	# Import DietPi-Globals --------------------------------------------------------------
 
 	EXIT_CODE=1 # 1=failed to send survey, 0=survey sent, 2=opted out and sent
 
-	#Grab Input (valid interger)
-	INPUT=0
-	disable_error=1 G_CHECK_VALIDINT "$1" && INPUT=$1
+	# Grab Input (valid interger)
+	disable_error=1 G_CHECK_VALIDINT "$1" && INPUT=$1 || INPUT=0
 
-	#Force opted in, for automated installations by default
-	OPTED_IN=1 #1=yes | 0=no and purge data
-	SURVEY_SENTCOUNT=0
-	SURVEY_VERSION=6
+	# Force opted in for automated installations by default
+	OPTED_IN=1 # 1=yes | 0=no and purge data
 
 	DIETPI_VERSION="$G_DIETPI_VERSION_CORE.$G_DIETPI_VERSION_SUB"
 	UNIQUE_ID=$(sed -n 5p /DietPi/dietpi/.hw_model)
@@ -50,21 +47,12 @@
 	SFTP_PASS='upload2dietpi'
 
 	FP_SETTINGS='/DietPi/dietpi/.dietpi-survey'
-	Write_Settings(){
-
-		cat << _EOF_ > $FP_SETTINGS
-$OPTED_IN
-$SURVEY_SENTCOUNT
-_EOF_
-
-	}
-
+	Write_Settings(){ echo $OPTED_IN > $FP_SETTINGS; }
 	Read_Settings(){
 
-		OPTED_IN=$(sed -n 1p $FP_SETTINGS)
-		# Force interactive mode, if invalid opt value is found:
-		(( OPTED_IN < 0 || OPTED_IN > 1 )) && INPUT=0
-		SURVEY_SENTCOUNT=$(sed -n 2p $FP_SETTINGS)
+		OPTED_IN=$(<$FP_SETTINGS)
+		# Force interactive mode if invalid opt value is found
+		[[ $OPTED_IN == [01] ]] || INPUT=0
 
 	}
 
@@ -84,10 +72,8 @@ _EOF_
 		cat << _EOF_ > $UPLOAD_FILENAME
 #!/bin/bash
 # -------------------------
-((aSURVEY_VERSION[$SURVEY_VERSION]++))
-# -------------------------
-((aSURVEY_SENTCOUNT[$((SURVEY_SENTCOUNT+1))]++))
 ((aDIETPI_VERSION[$DIETPI_VERSION]++))
+# -------------------------
 ((aGIT_BRANCH[$gitbranch]++))
 ((aDEVICE_NAME[$G_HW_MODEL_DESCRIPTION]++))
 ((aCPU_ARCH[$G_HW_ARCH_DESCRIPTION]++))
@@ -137,7 +123,7 @@ _EOF_
 
 		local info_failure_msg='Failed to connect to SFTP server. Please try again later. If problems persist, please report this issue to the DietPi dev team (forum or GitHub repo).'
 
-		#Check if we have a working internet connection beforehand
+		# Check if we have a working internet connection beforehand
 		G_USER_INPUTS=0 G_ERROR_HANDLER_INFO_ONLY=1 G_CHECK_URL "$SFTP_ADDR"
 		if (( $G_ERROR_HANDLER_EXITCODE_RETURN == 0 )); then
 
@@ -152,7 +138,7 @@ _EOF_
 
 			fi
 
-			#Upload to server
+			# Upload to server
 			curl --connect-timeout 8 --retry 1 --retry-delay 4 -sT "$UPLOAD_FILENAME" sftp://"$SFTP_USER":"$SFTP_PASS"@"$SFTP_ADDR"/survey/
 			if (( $? )); then
 
@@ -164,8 +150,6 @@ _EOF_
 
 				EXIT_CODE=0
 				G_DIETPI-NOTIFY 0 'Successfully sent survey data'
-				# Increase sent count
-				((SURVEY_SENTCOUNT++))
 
 			# Successful upload + opted out + interactive
 			elif (( ! $INPUT )); then
@@ -190,19 +174,19 @@ _EOF_
 	# Main Loop
 	#/////////////////////////////////////////////////////////////////////////////////////
 
-	#Read data from .dietpi-survey file
+	# Read data from .dietpi-survey file
 	if [[ -f $FP_SETTINGS ]]; then
 
 		Read_Settings
 
-	#Force interactive user choice, if no settings file found = no choice made yet
+	# Force interactive user choice, if no settings file found = no choice made yet
 	elif (( $G_USER_INPUTS )); then
 
 		INPUT=0
 
 	fi
 
-	#Input mode: Send survey if opted in or empty file if opted out
+	# Input mode: Send survey if opted in or empty file if opted out
 	if (( $INPUT == 1 )); then
 
 		Generate_File
@@ -221,7 +205,7 @@ _EOF_
 
 		)
 
-		G_WHIP_MENU "DietPi-Survey would like to collect anonymous statistics about your hardware, DietPi software and settings. \
+		if G_WHIP_MENU "DietPi-Survey would like to collect anonymous statistics about your hardware, DietPi software and settings. \
 This allows us to focus development based on popularity. NO private data will be collected and NO ONE can identify you based on the data. \
 The data is sent via secured connection to our SFTP server and is stored there unreadable to the public upload user. \
 If you agree, your uploaded data will be automatically updated on every DietPi-Update and DietPi-Software usage. \
@@ -230,8 +214,7 @@ The current survey statistics can be reviewed at: https://dietpi.com/survey
 Your personal upload file would look like this:
 $(<$UPLOAD_FILENAME)
 
-Would you like to join DietPi-Survey?"
-		if (( ! $? )); then
+Would you like to join DietPi-Survey?"; then
 
 			OPTED_IN=$G_WHIP_RETURNED_VALUE
 			Send_File

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1668,6 +1668,14 @@ _EOF_
 
 			fi
 			#-------------------------------------------------------------------------------
+			#DietPi-Survey: Remove survey sent count from settings file: https://github.com/MichaIng/DietPi/pull/2626
+			if [[ -f /DietPi/dietpi/.dietpi-survey ]]; then
+
+				local survey_opted_in=$(sed -n 1p /DietPi/dietpi/.dietpi-survey)
+				echo $survey_opted_in > /DietPi/dietpi/.dietpi-survey
+
+			fi
+			#-------------------------------------------------------------------------------
 			#Reinstalls
 			#	Amiberry 2.25: https://github.com/MichaIng/DietPi/issues/2599
 			#	Deluge: Patch according to installer rework: https://github.com/MichaIng/DietPi/pull/2594


### PR DESCRIPTION
**Status**: Ready
- [x] DietPi-Patch
- [x] DietPi-Survey_report

**Commit list/description**:
+ DietPi-Survey | Cleanup: Remove survey version and sent count from upload file. We handle added/removed entries via array sourcing automatically, otherwise can derive this from DietPi version. Sent count is of minor interest and simply overloads the report page, especially when we want to introduce optional regular (weekly or monthly) uploads in future versions.
+ DietPi-Survey | Minor coding