### PR TITLE
DietPi-Software | rTorrent: Fix for config file not being in use + now runs as user "rtorrent"

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,7 @@ Changes / Improvements / Optimisations:
 - DietPi-Software | AmiBerry: Updated to latest version (2.25), thanks @midwan: https://github.com/MichaIng/DietPi/issues/2599
 - DietPi-Software | Netdata: On Debian Stretch/Buster and Raspbian Buster an up-to-date APT package is available, which will now be installed instead of our custom build. Many thanks to @74cmonty for this information: https://github.com/MichaIng/DietPi/issues/2446
 - DietPi-Software | DietPi-RAMlog: When installing/enabling RAMlog, the /var/log mountpoint will be now cleaned before mounting the tmpfs on it, while preserving the existing logs metadata. This resolves a warning on early boot stage and frees the disk space consumed by the disk log before.
+- DietPi-Software | rTorrent: Runs now as user "rtorrent" and creates files as group "dietpi" with 775/664 permissions. Enabled Buster support and enhanced config file handling on reinstall: https://github.com/MichaIng/DietPi/pull/2633
 
 Bug Fixes:
 - System | Resolved an issue where /etc/bashrc.d entries could be run multiple times. Many thanks to @jonare77 for reporting this issue: https://github.com/MichaIng/DietPi/issues/2529
@@ -40,7 +41,7 @@ Bug Fixes:
 - DietPi-Software | MPD: Resolved an issue with failed playback due to permissions. Permissions are now set via systemd service to ensure the MPD user can use both dietpi and audio groups: https://github.com/MichaIng/DietPi/issues/2462
 - DietPi-Software | Airsonic: Resolved an issue where during install the FFmpeg transcoder symlink could be placed wrong, leading to a failing Airsonic start. Many thanks to @pecan_pie for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?f=11&t=5637
 - DietPi-Software | DietPi-RAMlog: Fixed an issue where logging mode could be set wrong when uninstalling and reinstalling RAMlog. Many thanks to @abecvar for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?f=9&t=5666 
-- DietPi-Software | rTorrent: Resolved an issue where ruTorrent could not connect to rTorrent because the config file was not in use. The solution includes that rTorrent runs now as its own user "rtorrent". Many thanks to @Chester007 for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?f=11&t=5656
+- DietPi-Software | rTorrent: Resolved an issue where the ruTorrent web UI could not connect to the rTorrent daemon. Many thanks to @Chester007 for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?f=11&t=5656
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pulls?q=is%3Aclosed+base%3Amaster
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -40,6 +40,7 @@ Bug Fixes:
 - DietPi-Software | MPD: Resolved an issue with failed playback due to permissions. Permissions are now set via systemd service to ensure the MPD user can use both dietpi and audio groups: https://github.com/MichaIng/DietPi/issues/2462
 - DietPi-Software | Airsonic: Resolved an issue where during install the FFmpeg transcoder symlink could be placed wrong, leading to a failing Airsonic start. Many thanks to @pecan_pie for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?f=11&t=5637
 - DietPi-Software | DietPi-RAMlog: Fixed an issue where logging mode could be set wrong when uninstalling and reinstalling RAMlog. Many thanks to @abecvar for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?f=9&t=5666 
+- DietPi-Software | rTorrent: Resolved an issue where ruTorrent could not connect to rTorrent because the config file was not in use. The solution includes that rTorrent runs now as its own user "rtorrent". Many thanks to @Chester007 for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?f=11&t=5656
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pulls?q=is%3Aclosed+base%3Amaster
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10943,6 +10943,7 @@ _EOF_
 
 				# - Install SCGI module
 				G_AGI libapache2-mod-scgi
+				a2enmod rewrite scgi
 
 				# - Enable password protection
 				htpasswd -cb /etc/.rutorrent-htaccess root "$GLOBAL_PW"
@@ -10969,10 +10970,7 @@ SCGIMount /RPC2 127.0.0.1:5000
 </location>
 _EOF_
 				a2ensite dietpi-rutorrent
-
-				# - Enable rewrites
-				a2enmod rewrite
-
+				
 			# - Lighttpd
 			elif (( ${aSOFTWARE_INSTALL_STATE[84]} >= 1 )); then
 
@@ -11039,7 +11037,9 @@ _EOF_
 			mkdir -p $G_FP_DIETPI_USERDATA/downloads/.session
 
 			# Create rTorrent run user
-			useradd -rm -s $(command -v nologin) -G dietpi -d $G_FP_DIETPI_USERDATA/rtorrent rtorrent
+			local usercmd='useradd -rM'
+			getent passwd rtorrent &> /dev/null && usercmd='usermod'
+			$usercmd rtorrent -G dietpi -d $G_FP_DIETPI_USERDATA/rtorrent -s $(command -v nologin)
 
 			# - Service using screen | '/usr/bin/rtorrent &> /var/log/rtorrent.log &' doesnt work, hangs program after 5 seconds
 			cat << _EOF_ > /etc/systemd/system/rtorrent.service
@@ -11050,9 +11050,10 @@ After=network.target
 [Service]
 Type=forking
 User=rtorrent
+Group=dietpi
 KillMode=none
-ExecStart=/usr/bin/screen -fa -dmS rtorrent /usr/bin/rtorrent
-ExecStop=/usr/bin/screen -S rtorrent -X quit
+ExecStart=$(command -v screen) -fa -dmS rtorrent $(command -v rtorrent)
+ExecStop=$(command -v screen) -S rtorrent -X quit
 
 [Install]
 WantedBy=multi-user.target
@@ -11060,6 +11061,7 @@ _EOF_
 			systemctl daemon-reload
 
 			# - Default conf, do not overwrite if existent
+			mkdir -p $G_FP_DIETPI_USERDATA/rtorrent
 			[[ -f $G_FP_DIETPI_USERDATA/rtorrent/.rtorrent.rc ]] || cat << _EOF_ > $G_FP_DIETPI_USERDATA/rtorrent/.rtorrent.rc
 #Attempt to reduce disk throttling/abuse | 0.9.2 command does not exist
 #max_open_files = 50
@@ -11094,6 +11096,9 @@ directory = $G_FP_DIETPI_USERDATA/downloads
 # of rtorrent using the same session directory. Perhaps using a
 # relative path?
 session = $G_FP_DIETPI_USERDATA/downloads/.session
+
+# UMask
+system.umask.set = 002
 
 # Close torrents when diskspace is low.
 schedule = low_diskspace,5,60,close_low_diskspace=1000M

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11130,10 +11130,10 @@ ratio.max.set=125
 ratio.upload.set=1M
 
 # When seeding ratio is reached close the torrent
-system.method.set = group.seeding.ratio.command, d.close=
+method.set = group.seeding.ratio.command,d.close=
 
 # Move files to ./unsorted when download completes
-system.method.set_key = event.download.finished,move_complete,"execute=mv,-n,$d.get_base_path=,./unsorted/;d.set_directory=./unsorted/"
+method.set_key = event.download.finished,move_complete,"execute=mv,-n,$d.get_base_path=,./unsorted/;d.set_directory=./unsorted/"
 
 # Port range to use for listening.
 network.port_range.set = 33101-33199

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5411,8 +5411,8 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 				# - Backup known config files
 				G_BACKUP_FP /var/www/rutorrent/conf/config.php
-				G_BACKUP_FP /var/www/rutorrent/conf/access.php
-				G_BACKUP_FP /var/www/rutorrent/conf/plugins.php
+				G_BACKUP_FP /var/www/rutorrent/conf/access.ini
+				G_BACKUP_FP /var/www/rutorrent/conf/plugins.ini
 
 				# - Merge new install into old to preserve e.g. 3rd party plugins
 				cp -a ruTorrent-*/. /var/www/rutorrent/

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -778,7 +778,7 @@ _EOF_
 				 aSOFTWARE_WHIP_DESC[$software_id]='web interface audio streamer'
 			aSOFTWARE_CATEGORY_INDEX[$software_id]=2
 					  aSOFTWARE_TYPE[$software_id]=0
-			 aSOFTWARE_ONLINEDOC_URL[$software_id]='f=8&t=5&p=7305#p7305'
+			 aSOFTWARE_ONLINEDOC_URL[$software_id]='p=7305#p7305'
 		aSOFTWARE_REQUIRES_PHP[$software_id]=1
  			aSOFTWARE_REQUIRES_MYSQL[$software_id]=1
 		   aSOFTWARE_REQUIRES_NODEJS[$software_id]=1
@@ -921,7 +921,7 @@ _EOF_
 					  aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_REQUIRES_WEBSERVER[$software_id]=1
 			  aSOFTWARE_REQUIRES_PHP[$software_id]=1
-			 aSOFTWARE_ONLINEDOC_URL[$software_id]='f=8&t=5&p=2603#p2603'
+			 aSOFTWARE_ONLINEDOC_URL[$software_id]='p=2603#p2603'
 
 		#------------------
 		software_id=116
@@ -951,7 +951,7 @@ _EOF_
 				 aSOFTWARE_WHIP_DESC[$software_id]='nzb download manager'
 			aSOFTWARE_CATEGORY_INDEX[$software_id]=3
 					  aSOFTWARE_TYPE[$software_id]=0
-			 aSOFTWARE_ONLINEDOC_URL[$software_id]='f=8&t=5&p=6747#p6747'
+			 aSOFTWARE_ONLINEDOC_URL[$software_id]='p=6747#p6747'
    aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
 
 		#------------------
@@ -5389,8 +5389,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 		fi
 
-		#RTORRENT
-		software_id=107
+		software_id=107 # rTorrent
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -5399,16 +5398,32 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 			# On Jessie, nginx-full is needed for SCGI module: https://github.com/MichaIng/DietPi/issues/1240
 			(( $G_DISTRO < 4 && ${aSOFTWARE_INSTALL_STATE[85]} > 0 )) && DEPS_LIST+=' nginx-full'
 
-			# Get current version string
+			# Install ruTorrent: Web UI for rTorrent
+			# - Get current version string
 			INSTALL_URL_ADDRESS='https://api.github.com/repos/Novik/ruTorrent/releases/latest'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 			local version_string=$(curl -s "$INSTALL_URL_ADDRESS" | grep -m1 '^[[:blank:]]*"tag_name":' | cut -d \" -f 4)
 
 			Download_Install "https://github.com/Novik/ruTorrent/archive/$version_string.tar.gz"
 
-			mkdir -p /var/www/rutorrent
-			mv ruTorrent-*/* /var/www/rutorrent/
-			rm -R ruTorrent-*
+			# - Reinstall
+			if [[ -d /var/www/rutorrent ]]; then
+
+				# - Backup known config files
+				G_BACKUP_FP /var/www/rutorrent/conf/config.php
+				G_BACKUP_FP /var/www/rutorrent/conf/access.php
+				G_BACKUP_FP /var/www/rutorrent/conf/plugins.php
+
+				# - Merge new install into old to preserve e.g. 3rd party plugins
+				cp -a ruTorrent-*/. /var/www/rutorrent/
+				rm -R ruTorrent-*
+
+			# - Fresh install
+			else
+
+				mv ruTorrent-* /var/www/rutorrent
+
+			fi
 
 		fi
 
@@ -10917,25 +10932,19 @@ _EOF_
 
 		fi
 
-		#RTORRENT
-		software_id=107
+		software_id=107 # rTorrent
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
 
-			#Create username/password for rutorrent based on webserver type.
+			# Create username/password for rutorrent based on webserver type.
 			# - Apache2
 			if (( ${aSOFTWARE_INSTALL_STATE[83]} >= 1 )); then
 
-				# - Allow overrides redirects and .htaccess
-				sed -i "/AllowOverride /c\    AllowOverride All" /etc/apache2/sites-enabled/000-default*
-				sed -i "/AllowOverride /c\    AllowOverride All" /etc/apache2/apache2.conf
-
-				a2enmod rewrite
-
-				#install scgi module
+				# - Install SCGI module
 				G_AGI libapache2-mod-scgi
 
+				# - Enable password protection
 				htpasswd -cb /etc/.rutorrent-htaccess root "$GLOBAL_PW"
 				cat << _EOF_ > /var/www/rutorrent/.htaccess
 AuthUserFile /etc/.rutorrent-htaccess
@@ -10944,24 +10953,32 @@ AuthType Basic
 require user root
 _EOF_
 
+				# - Allow overrides/.htaccess and enable SCGI + authentication
 				cat << _EOF_ > /etc/apache2/sites-available/dietpi-rutorrent.conf
+<Directory /var/www/rutorrent/>
+	AllowOverride All
+</Directory>
+
 SCGIMount /RPC2 127.0.0.1:5000
 <location /RPC2>
-AuthName "rTorrent secure access"
-AuthType Basic
-AuthBasicProvider file
-AuthUserFile /etc/.rutorrent-htaccess
-Require user root
+	AuthName "rTorrent secure access"
+	AuthType Basic
+	AuthBasicProvider file
+	AuthUserFile /etc/.rutorrent-htaccess
+	Require user root
 </location>
 _EOF_
 				a2ensite dietpi-rutorrent
+
+				# - Enable rewrites
+				a2enmod rewrite
 
 			# - Lighttpd
 			elif (( ${aSOFTWARE_INSTALL_STATE[84]} >= 1 )); then
 
 				echo "root:rtorrent:$(echo -n 'root:rtorrent:dietpi' | md5sum | cut -b -32)" > /etc/.rutorrent-htaccess
 
-				# - add to /etc/lighttpd/lighttpd.conf
+				# - Add to /etc/lighttpd/lighttpd.conf
 				if ! grep -qi '^#RUTORRENT_DIETPI' /etc/lighttpd/lighttpd.conf; then
 
 					cat << _EOF_ >> /etc/lighttpd/lighttpd.conf
@@ -11012,14 +11029,17 @@ _EOF_
 
 			fi
 
-			# - Define curl location in config.php (for lighttpd and nginx)
-			sed -i '/"curl"[[:space:]]/c\        "curl" => "/usr/bin/curl",' /var/www/rutorrent/conf/config.php
+			# - Define curl location in config.php (for Lighttpd and Nginx)
+			G_CONFIG_INJECT '"curl"[[:blank:]]' '		"curl"	=> "/usr/bin/curl",' /var/www/rutorrent/conf/config.php
 
 			chown www-data:www-data /etc/.rutorrent-htaccess
 			chmod 400 /etc/.rutorrent-htaccess
 
 			# - Session folder
 			mkdir -p $G_FP_DIETPI_USERDATA/downloads/.session
+
+			# Create rTorrent run user
+			useradd -rm -s $(which nologin) -G dietpi -d $G_FP_DIETPI_USERDATA/rtorrent rtorrent
 
 			# - Service using screen | '/usr/bin/rtorrent &> /var/log/rtorrent.log &' doesnt work, hangs program after 5 seconds
 			cat << _EOF_ > /etc/systemd/system/rtorrent.service
@@ -11029,18 +11049,18 @@ After=network.target
 
 [Service]
 Type=forking
+User=rtorrent
 KillMode=none
-ExecStart=/usr/bin/screen -d -m -fa -S rtorrent /usr/bin/rtorrent
-ExecStop=/usr/bin/killall -w -s 2 /usr/bin/rtorrent
-WorkingDirectory=%h
+ExecStart=/usr/bin/screen -fa -dmS rtorrent /usr/bin/rtorrent
+ExecStop=/usr/bin/screen -S rtorrent -X quit
 
 [Install]
 WantedBy=multi-user.target
 _EOF_
 			systemctl daemon-reload
 
-			#Default conf
-			cat << _EOF_ > $HOME/.rtorrent.rc
+			# - Default conf, do not overwrite if existent
+			[[ -f $G_FP_DIETPI_USERDATA/rtorrent/.rtorrent.rc ]] || cat << _EOF_ > $G_FP_DIETPI_USERDATA/rtorrent/.rtorrent.rc
 #Attempt to reduce disk throttling/abuse | 0.9.2 command does not exist
 #max_open_files = 50
 
@@ -11158,7 +11178,7 @@ peer_exchange = yes
 scgi_port = localhost:5000
 
 _EOF_
-
+			chown -R rtorrent:rtorrent $G_FP_DIETPI_USERDATA/rtorrent
 
 		fi
 
@@ -14062,28 +14082,28 @@ _EOF_
 
 		fi
 
-		software_id=107
+		software_id=107 # rTorrent
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
 			G_AGP rtorrent
-			rm -R /var/www/rutorrent
-			rm $HOME/.rtorrent.rc
-			rm /etc/systemd/system/rtorrent.service
+			[[ -d /var/www/rutorrent ]] && rm -R /var/www/rutorrent
+			[[ -d $G_FP_DIETPI_USERDATA/rtorrent ]] && rm -R $G_FP_DIETPI_USERDATA/rtorrent
+			[[ -f /etc/systemd/system/rtorrent.service ]] && rm /etc/systemd/system/rtorrent.service
 
-			# - webserver rutorrent user/pw settings
-			rm /etc/.rutorrent-htaccess
+			# - Webserver rutorrent user/pw settings
+			[[ -f /etc/.rutorrent-htaccess ]] && rm /etc/.rutorrent-htaccess
 
-			#	lighttpd
+			#	Lighttpd
 			#Remove from
 			#RUTORRENT_DIETPI to #RUTORRENT_DIETPI in /etc/lighttpd/lighttpd.conf
 
-			#	nginx
-			rm /etc/nginx/sites-dietpi/dietpi-rutorrent.conf
+			#	Nginx
+			[[ -f /etc/nginx/sites-dietpi/dietpi-rutorrent.conf ]] && rm /etc/nginx/sites-dietpi/dietpi-rutorrent.conf
 
-			#	apache2
+			#	Apache2
 			command -v a2dissite &> /dev/null && a2dissite dietpi-rutorrent
-			rm /etc/apache2/sites-available/dietpi-rutorrent.conf
+			[[ -f /etc/apache2/sites-available/dietpi-rutorrent.conf ]] && rm /etc/apache2/sites-available/dietpi-rutorrent.conf
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11039,7 +11039,7 @@ _EOF_
 			mkdir -p $G_FP_DIETPI_USERDATA/downloads/.session
 
 			# Create rTorrent run user
-			useradd -rm -s $(which nologin) -G dietpi -d $G_FP_DIETPI_USERDATA/rtorrent rtorrent
+			useradd -rm -s $(command -v nologin) -G dietpi -d $G_FP_DIETPI_USERDATA/rtorrent rtorrent
 
 			# - Service using screen | '/usr/bin/rtorrent &> /var/log/rtorrent.log &' doesnt work, hangs program after 5 seconds
 			cat << _EOF_ > /etc/systemd/system/rtorrent.service

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5394,7 +5394,9 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 			Banner_Installing
 
-			DEPS_LIST='rtorrent screen' #mediainfo
+			DEPS_LIST='rtorrent' #mediainfo
+			# On Buster no "screen" is required to run rTorrent as daemon
+			(( $G_DISTRO < 5 )) && DEPS_LIST+=' screen'
 			# On Jessie, nginx-full is needed for SCGI module: https://github.com/MichaIng/DietPi/issues/1240
 			(( $G_DISTRO < 4 && ${aSOFTWARE_INSTALL_STATE[85]} > 0 )) && DEPS_LIST+=' nginx-full'
 
@@ -11058,53 +11060,64 @@ ExecStop=$(command -v screen) -S rtorrent -X quit
 [Install]
 WantedBy=multi-user.target
 _EOF_
+			# - On Buster we use new daemon mode
+			if (( $G_DISTRO > 4 )); then
+
+				sed -Ei '/^(KillMode|ExecStop)=/d' /etc/systemd/system/rtorrent.service
+				G_CONFIG_INJECT 'ExecStart=' "ExecStart=$(command -v rtorrent)" /etc/systemd/system/rtorrent.service
+
+			fi
 			systemctl daemon-reload
 
 			# - Default conf, do not overwrite if existent
+			#	Example: https://github.com/rakshasa/rtorrent/blob/master/doc/rtorrent.rc
+			#	Deprecated commands:
+			#		- https://github.com/rakshasa/rtorrent/wiki/rTorrent-0.9-Comprehensive-Command-list-(WIP)
+			#		- https://github.com/rakshasa/rtorrent/blob/master/doc/scripts/update_commands_0.9.sed
 			mkdir -p $G_FP_DIETPI_USERDATA/rtorrent
 			[[ -f $G_FP_DIETPI_USERDATA/rtorrent/.rtorrent.rc ]] || cat << _EOF_ > $G_FP_DIETPI_USERDATA/rtorrent/.rtorrent.rc
-#Attempt to reduce disk throttling/abuse | 0.9.2 command does not exist
-#max_open_files = 50
+# Attempt to reduce disk throttling/abuse
+network.max_open_files.set = 50
 
-#Max queue
+# Max queue
 scheduler.max_active.set = 3
 
-#byte value
-max_memory_usage = $(( $(Optimize_BitTorrent 0) * 1024 * 1024 ))
+# byte value
+pieces.memory.max.set = $(( $(Optimize_BitTorrent 0) * 1024 * 1024 ))
 
 # Maximum and minimum number of peers to connect to per torrent.
-min_peers = 1
-max_peers = $(( $(Optimize_BitTorrent 2) / 2 + 1 ))
+throttle.min_peers.normal.set = 1
+throttle.max_peers.normal.set = $(( $(Optimize_BitTorrent 2) / 2 + 1 ))
 
 # Same as above but for seeding completed torrents (-1 = same as downloading)
-min_peers_seed = -1
-max_peers_seed = -1
+throttle.min_peers.seed.set = -1
+throttle.max_peers.seed.set = -1
 
 # Maximum number of simultaneous downloads
-max_downloads_global = $(Optimize_BitTorrent 2)
+throttle.max_downloads.set = $(Optimize_BitTorrent 2)
 # Maximum number of simultaneous uploads
-max_uploads_global = $(Optimize_BitTorrent 3)
+throttle.max_uploads.set = $(Optimize_BitTorrent 3)
 
 # Global upload and download rate in KiB. "0" for unlimited.
-download_rate = 0
-upload_rate = 0
+throttle.global_down.max_rate.set_kb = 0
+throttle.global_up.max_rate.set_kb = 0
 
 # Default directory to save the downloaded torrents.
-directory = $G_FP_DIETPI_USERDATA/downloads
+directory.default.set = $G_FP_DIETPI_USERDATA/downloads
 
 # Default session directory. Make sure you don't run multiple instance
 # of rtorrent using the same session directory. Perhaps using a
 # relative path?
-session = $G_FP_DIETPI_USERDATA/downloads/.session
+session.path.set = $G_FP_DIETPI_USERDATA/downloads/.session
 
 # UMask
 system.umask.set = 002
 
 # Close torrents when diskspace is low.
-schedule = low_diskspace,5,60,close_low_diskspace=1000M
+schedule2 = low_diskspace,5,60,close_low_diskspace=1000M
 
 # Periodically save session data
-schedule = session_save,240,300,session_save=
+schedule2 = session_save,240,300,session_save=
 
 # Enable the default ratio group.
 ratio.enable=yes
@@ -11123,10 +11136,10 @@ system.method.set = group.seeding.ratio.command, d.close=
 system.method.set_key = event.download.finished,move_complete,"execute=mv,-n,$d.get_base_path=,./unsorted/;d.set_directory=./unsorted/"
 
 # Port range to use for listening.
-port_range = 33101-33199
+network.port_range.set = 33101-33199
 
 # Start opening ports at a random position within the port range.
-port_random = yes
+network.port_random.set = yes
 
 # Encryption options, set to none (default) or any combination of the following:
 # allow_incoming, try_outgoing, require, require_RC4, enable_retry, prefer_plaintext
@@ -11135,7 +11148,7 @@ port_random = yes
 # outgoing connections but retries with encryption if they fail, preferring
 # plaintext to RC4 encryption after the encrypted handshake
 #
-encryption = require
+protocol.encryption.set = require
 
 # Sort the main view by ratio
 view.sort_current = main,greater=d.get_ratio=
@@ -11159,30 +11172,37 @@ view.sort_new = leeching,less=d.get_name=
 view.filter = active,d.get_peers_connected=
 view.sort = active
 
-schedule = sort_main,11,5,view.sort=main
-schedule = sort_seeding,12,5,view.sort=seeding
-schedule = sort_leeching,13,5,view.sort=leeching
-schedule = sort_active,14,5,view.sort=active
+schedule2 = sort_main,11,5,view.sort=main
+schedule2 = sort_seeding,12,5,view.sort=seeding
+schedule2 = sort_leeching,13,5,view.sort=leeching
+schedule2 = sort_active,14,5,view.sort=active
 
 # Enable DHT support for trackerless torrents or when all trackers are down.
 # May be set to "disable" (completely disable DHT), "off" (do not start DHT),
 # "auto" (start and stop DHT as needed), or "on" (start DHT immediately).
 # The default is "off". For DHT to work, a session directory must be defined.
 #
-dht = auto
+dht.mode.set = auto
 
 # UDP port to use for DHT.
 #
-#dht_port = 6881
+#dht.port.set = 6881
 
 # Enable peer exchange (for torrents not marked private)
 #
-peer_exchange = yes
+protocol.pex.set = yes
 
-#Enable remote access (eg: webui)
-scgi_port = localhost:5000
-
+# SCGI Connectivity (for alternative rtorrent interfaces, XMLRPC)
+#
+# Use a IP socket with scgi_port, or a Unix socket with scgi_local.
+# schedule can be used to set permissions on the unix socket.
+#
+scgi_port = 127.0.0.1:5000
+#scgi_local = /home/user/rtorrent/rpc.socket
+#schedule2 = scgi_permission,0,0,"execute.nothrow=chmod,\"g+w,o=\",/home/user/rtorrent/rpc.socket"
 _EOF_
+			# On Buster use new daemon mode
+			(( $G_DISTRO > 4 )) && G_CONFIG_INJECT 'system.daemon.set[[:blank:]=]' 'system.daemon.set = true' $G_FP_DIETPI_USERDATA/rtorrent/.rtorrent.rc
 			chown -R rtorrent:rtorrent $G_FP_DIETPI_USERDATA/rtorrent
 
 		fi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5395,9 +5395,9 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 			Banner_Installing
 
 			DEPS_LIST='rtorrent' #mediainfo
-			# On Buster no "screen" is required to run rTorrent as daemon
+			# On Buster, no "screen" is required to run rTorrent as daemon: https://github.com/rakshasa/rtorrent/wiki/Daemon_Mode
 			(( $G_DISTRO < 5 )) && DEPS_LIST+=' screen'
-			# On Jessie, nginx-full is needed for SCGI module: https://github.com/MichaIng/DietPi/issues/1240
+			# On Jessie, nginx-full is required for SCGI module: https://github.com/MichaIng/DietPi/issues/1240
 			(( $G_DISTRO < 4 && ${aSOFTWARE_INSTALL_STATE[85]} > 0 )) && DEPS_LIST+=' nginx-full'
 
 			# Install ruTorrent: Web UI for rTorrent
@@ -5429,8 +5429,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 		fi
 
-		#Aria2
-		software_id=132
+		software_id=132 # Aria2
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -10941,7 +10940,7 @@ _EOF_
 
 			# Create username/password for rutorrent based on webserver type.
 			# - Apache2
-			if (( ${aSOFTWARE_INSTALL_STATE[83]} >= 1 )); then
+			if (( ${aSOFTWARE_INSTALL_STATE[83]} > 0 )); then
 
 				# - Install SCGI module
 				G_AGI libapache2-mod-scgi
@@ -10974,7 +10973,7 @@ _EOF_
 				a2ensite dietpi-rutorrent
 				
 			# - Lighttpd
-			elif (( ${aSOFTWARE_INSTALL_STATE[84]} >= 1 )); then
+			elif (( ${aSOFTWARE_INSTALL_STATE[84]} > 0 )); then
 
 				echo "root:rtorrent:$(echo -n 'root:rtorrent:dietpi' | md5sum | cut -b -32)" > /etc/.rutorrent-htaccess
 
@@ -11011,7 +11010,7 @@ _EOF_
 				fi
 
 			# - Nginx
-			elif (( ${aSOFTWARE_INSTALL_STATE[85]} >= 1 )); then
+			elif (( ${aSOFTWARE_INSTALL_STATE[85]} > 0 )); then
 
 				echo "root:$(openssl passwd -crypt dietpi)" > /etc/.rutorrent-htaccess
 
@@ -11047,7 +11046,8 @@ _EOF_
 			cat << _EOF_ > /etc/systemd/system/rtorrent.service
 [Unit]
 Description=rTorrent (DietPi)
-After=network.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 Type=forking
@@ -11063,7 +11063,7 @@ _EOF_
 			# - On Buster we use new daemon mode
 			if (( $G_DISTRO > 4 )); then
 
-				sed -Ei '/^(KillMode|ExecStop)=/d' /etc/systemd/system/rtorrent.service
+				sed -Ei '/^(Type|KillMode|ExecStop)=/d' /etc/systemd/system/rtorrent.service
 				G_CONFIG_INJECT 'ExecStart=' "ExecStart=$(command -v rtorrent)" /etc/systemd/system/rtorrent.service
 
 			fi
@@ -11207,8 +11207,7 @@ _EOF_
 
 		fi
 
-		#Aria2
-		software_id=132
+		software_id=132 # Aria2
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -299,7 +299,7 @@ _EOF_
 
 		# - DietPi-Software secure global_pw encrypted
 		chown root:root /var/lib/dietpi/dietpi-software/.GLOBAL_PW.bin
-		chmod 700 /var/lib/dietpi/dietpi-software/.GLOBAL_PW.bin
+		chmod 600 /var/lib/dietpi/dietpi-software/.GLOBAL_PW.bin
 
 		# - /var/www / www-data
 		chown -R www-data:www-data /var/www
@@ -308,12 +308,9 @@ _EOF_
 		#Apply non-root permissions for files and folders in G_FP_DIETPI_USERDATA
 
 		# - dietpi user
-		chown -R dietpi:dietpi /home/dietpi
-		chown -R dietpi:dietpi $G_FP_DIETPI_USERDATA
-		chmod -R 775 $G_FP_DIETPI_USERDATA
-		#	+ for symlinked locations
-		chown -R dietpi:dietpi $G_FP_DIETPI_USERDATA/*
-		chmod -R 775 $G_FP_DIETPI_USERDATA/*
+		#	Include symlinked locations via $G_FP_DIETPI_USERDATA/*
+		chown -R dietpi:dietpi /home/dietpi $G_FP_DIETPI_USERDATA $G_FP_DIETPI_USERDATA/*
+		chmod -R 775 $G_FP_DIETPI_USERDATA $G_FP_DIETPI_USERDATA/*
 
 		# - Apply program specific permissions
 		#	NB: Following should be ordered ascending by index to prevent dupes.
@@ -322,7 +319,7 @@ _EOF_
 		chown -R 775 /var/lib/dietpi/dietpi-software/installed/desktop
 		#	Set execute to prevent "untrusted" prompt in Mate, and possibily other desktops.
 		chmod +x /usr/share/applications/*
-		chmod +x $HOME/Desktop/*
+		chmod +x /root/Desktop/*
 
 		# - O!MPD, requires write permissions
 		chmod -R 777 /var/www/ompd/tmp #(required for database update)
@@ -385,17 +382,13 @@ _EOF_
 		chown -R influxdb:influxdb $G_FP_DIETPI_USERDATA/influxdb
 
 		# - gogs
-		chown -R gogs:gogs /etc/gogs
-		chown -R gogs:gogs $G_FP_DIETPI_USERDATA/gogs-repo
-		chown -R gogs:gogs /var/log/gogs
+		chown -R gogs:gogs /etc/gogs $G_FP_DIETPI_USERDATA/gogs-repo /var/log/gogs
 
 		# - ubooquity
 		chown -R ubooquity:dietpi $G_FP_DIETPI_USERDATA/ubooquity
 
 		# - Mineos
-		chown -R mineos:dietpi $G_FP_DIETPI_USERDATA/mineos
-		chown -R mineos:dietpi /var/games/minecraft
-		chown mineos:dietpi /etc/ssl/certs/mineos*
+		chown -R mineos:dietpi $G_FP_DIETPI_USERDATA/mineos /var/games/minecraft /etc/ssl/certs/mineos*
 
 		# - cubrite
 		chown -R cuberite:dietpi $G_FP_DIETPI_USERDATA/cubrite
@@ -408,23 +401,16 @@ _EOF_
 		chown -R medusa:dietpi $G_FP_DIETPI_USERDATA/medusa
 
 		# - Sonarr
-		chown -R sonarr:dietpi $G_FP_DIETPI_USERDATA/sonarr
-		chown -R sonarr:dietpi /opt/NzbDrone
-		chown -R sonarr:dietpi /var/log/sonarr
+		chown -R sonarr:dietpi $G_FP_DIETPI_USERDATA/sonarr /opt/NzbDrone /var/log/sonarr
 
 		# - Radarr
-		chown -R radarr:dietpi $G_FP_DIETPI_USERDATA/radarr
-		chown -R radarr:dietpi /opt/Radarr
-		chown -R radarr:dietpi /var/log/radarr
+		chown -R radarr:dietpi $G_FP_DIETPI_USERDATA/radarr /opt/Radarr /var/log/radarr
 
 		# - Lidarr
-		chown -R lidarr:dietpi $G_FP_DIETPI_USERDATA/lidarr
-		chown -R lidarr:dietpi /opt/Lidarr
-		chown -R lidarr:dietpi /var/log/lidarr
+		chown -R lidarr:dietpi $G_FP_DIETPI_USERDATA/lidarr /opt/Lidarr /var/log/lidarr
 
 		# - Tonido
-		chown -R tonido:dietpi $G_FP_DIETPI_USERDATA/tonido
-		chown -R tonido:dietpi /home/tonido
+		chown -R tonido:dietpi $G_FP_DIETPI_USERDATA/tonido /home/tonido
 
 		# - NZBget
 		chown -R nzbget:dietpi $G_FP_DIETPI_USERDATA/nzbget
@@ -452,13 +438,17 @@ _EOF_
 		# - qBitTorrent
 		chown -R qbittorrent:dietpi /home/qbittorrent
 
+		# - rTorrent
+		chown -R rtorrent:rtorrent $G_FP_DIETPI_USERDATA/rtorrent $G_FP_DIETPI_USERDATA/downloads/.session
+		#	ruTorrent web access
+		chown www-data:www-data /etc/.rutorrent-htaccess
+		chmod 400 /etc/.rutorrent-htaccess
+
 		# - FAHClient (Folding@Home)
-		chown -R fahclient:dietpi $G_FP_DIETPI_USERDATA/fahclient
-		chown fahclient:dietpi /var/log/fahclient.log
+		chown -R fahclient:dietpi $G_FP_DIETPI_USERDATA/fahclient /var/log/fahclient.log
 
 		# - Sabnzbd
-		chown -R sabnzbd:dietpi /etc/sabnzbd
-		chown -R sabnzbd:dietpi /var/log/sabnzbd
+		chown -R sabnzbd:dietpi /etc/sabnzbd /var/log/sabnzbd
 
 		# - Blynk
 		chown -R blynk:dietpi $G_FP_DIETPI_USERDATA/blynk

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1688,6 +1688,7 @@ _EOF_
 					[[ -f /root/.rtorrent.rc ]]; then
 
 					reinstall_indices+=' 107'
+					G_CONFIG_INJECT 'system.umask.set[[:blank:]=]' 'system.umask.set = 002' /root/.rtorrent.rc
 					mkdir -p $G_FP_DIETPI_USERDATA/rtorrent
 					mv /root/.rtorrent.rc $G_FP_DIETPI_USERDATA/rtorrent/
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1679,9 +1679,19 @@ _EOF_
 			#Reinstalls
 			#	Amiberry 2.25: https://github.com/MichaIng/DietPi/issues/2599
 			#	Deluge: Patch according to installer rework: https://github.com/MichaIng/DietPi/pull/2594
+			#	rTorrent: https://github.com/MichaIng/DietPi/issues/2629
 			if (( $G_DIETPI_INSTALL_STAGE == 2 )); then
 
 				local reinstall_indices='108'
+
+				if grep -q '^aSOFTWARE_INSTALL_STATE\[107\]=2' /DietPi/dietpi/.installed &&
+					[[ -f /root/.rtorrent.rc ]]; then
+
+					reinstall_indices+=' 107'
+					mkdir -p $G_FP_DIETPI_USERDATA/rtorrent
+					mv /root/.rtorrent.rc $G_FP_DIETPI_USERDATA/rtorrent/
+
+				fi
 
 				if grep -q '^aSOFTWARE_INSTALL_STATE\[45\]=2' /DietPi/dietpi/.installed &&
 					getent passwd deluge &> /dev/null; then # Only do this once, regardless of re-patches
@@ -1713,7 +1723,6 @@ NB: When accessing "deluge-console" you need to do that as user "debian-deluged"
 
 			fi
 			#-------------------------------------------------------------------------------
-
 
 		fi
 


### PR DESCRIPTION
**Status**: Ready
- [x] Patch
- [x] Changelog

**Testing**:
- [x] Stretch VM fresh install + reinstall + uninstall
- [x] Jessie pre-v6.22 install + patch
- [x] Buster pre-v6.22 install + patch

**Reference**: https://github.com/MichaIng/DietPi/issues/2629

**Commit list/description**:
+ DietPi-Software | rTorrent: Enhance ruTorrent reinstall, backup main config files and merge new files into install dir to preserve e.g. 3rd party plugins
+ DietPi-Software | rTorrent: On Apache do not set "AllowOverride All" globally, instead merge it into dietpi-rutorrent.conf to be applied only for rutorrent subdir
+ DietPi-Software | rTorrent: Run as as user "rtorrent" with home and config file dir $G_FP_DIETPI_USERDATA/rtorrent
+ DietPi-Software | rTorrent: Stop service by quitting the screen window to have no trace left on service stop
+ DietPi-Software | rTorrent: Do not overwrite existing .rtorrent.rc
+ DietPi-Patch | rTorrent: Reinstall to apply new run user and fix non-used config file
+ CHANGELOG | rTorrent: Resolved an issue where ruTorrent could not connect to rTorrent
+ DietPi-Software | rTorrent: Run as group "dietpi" with umask "002" to allow other software with dietpi group permissions full access to downloads
+ DietPi-Software | rTorrent: Minor enhancements
+ DietPi-Set_software | setpermissions: Add rTorrent and minor coding
+ DietPi-Software | rTorrent: Use new daemon mode setting on Buster instead of "screen"
+ DietPi-Software | rTorrent: Update commands/config entries to new syntax, which were deprecated already since v0.7.x but removed with v0.9.7 (Buster)