### PR TITLE
RPi | Remove "framebuffer_depth" handling completely which defaults to 16 which works in every known case

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ Changes / Improvements / Optimisations:
 - Security | The DietPi-Software global password is now stored with enhanced security which also resolves a warning on Buster systems: https://github.com/MichaIng/DietPi/issues/2213
 - General | DietPi scripts now use the lightweight standalone "7zr" command to handle 7z archives. This allows us to lower DietPi core package dependencies from "p7zip-full" to "p7zip".
 - General | CPU temps (if available on the device) now displayed in the login banners. Many thanks to esturniolo for the suggestion: https://twitter.com/esturniolo/status/1104912062298423297
+- RPi | DietPi does not set or change "framebuffer_depth" in config.txt anymore which defaults to 16 which works in every known case. It will be re-added as fast as we find a case where another value is required.
 - DietPi-NordVPN | Added sent/received usage stats for VPN tunnel.
 - DietPi-Sync | Sync will now abort if the source dir is empty. Merged dry run into real sync, as this was performed anyway to do required free space check. When "Sync" is selected, after dry run the user is presented a summary and given the option to view the detailed dry run log, cancel or continue with real sync. Some other minor fixes and enhancements have been applied as well. Many thanks to @midnightwatcher for doing this request: https://dietpi.com/phpbb/viewtopic.php?f=12&t=5588
 - DietPi-Software | Emby Server: Now installs the latest version automatically (currently 4.0.2) which as well offers a native ARMv8 package: https://github.com/MichaIng/DietPi/pull/2525

--- a/config.txt
+++ b/config.txt
@@ -22,7 +22,6 @@
 # Uncomment to force a console size. By default it will be display's size minus overscan.
 #framebuffer_width=1280
 #framebuffer_height=720
-#framebuffer_depth=16
 
 # SDTV_MODES
 #sdtv_mode=0

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -223,8 +223,6 @@ systemctl enable dietpi-rm_program_usb_boot_mode
 				G_CONFIG_INJECT 'framebuffer_height=' '#framebuffer_height=0' /DietPi/config.txt
 				G_CONFIG_INJECT 'max_framebuffer_width=' '#max_framebuffer_width=0' /DietPi/config.txt
 				G_CONFIG_INJECT 'max_framebuffer_height=' '#max_framebuffer_height=0' /DietPi/config.txt
-				# - framebuffer_depth defaults to a set value of 16, even with HDMI disabled, so we manually reduce it to min 8
-				G_CONFIG_INJECT 'framebuffer_depth=' 'framebuffer_depth=8' /DietPi/config.txt
 				# - Splash cannot be seen anyway, without video output
 				G_CONFIG_INJECT 'disable_splash=' 'disable_splash=1' /DietPi/config.txt
 				# - hdmi_blanking should not play a role, however mode 1 should be generally preferred, which on idle disables HDMI output completely instead of just blanking the screen
@@ -256,7 +254,6 @@ systemctl enable dietpi-rm_program_usb_boot_mode
 
 			if (( $G_HW_MODEL < 10 )); then
 
-				G_CONFIG_INJECT 'framebuffer_depth=' '#framebuffer_depth=16' /DietPi/config.txt
 				G_CONFIG_INJECT 'hdmi_ignore_hotplug=' '#hdmi_ignore_hotplug=0' /DietPi/config.txt
 				G_CONFIG_INJECT 'hdmi_ignore_composite=' '#hdmi_ignore_composite=0' /DietPi/config.txt
 				G_CONFIG_INJECT 'hdmi_blanking=' '#hdmi_blanking=0' /DietPi/config.txt

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -499,13 +499,6 @@ _EOF_
 
 			fi
 			#-------------------------------------------------------------------------------
-			#RPi add FB depth 16: https://github.com/MichaIng/DietPi/issues/1716
-			if (( $G_HW_MODEL < 10 )) && ! grep -q 'framebuffer_depth=' /DietPi/config.txt; then
-
-				echo -e "\n#framebuffer_depth=16" >> /DietPi/config.txt
-
-			fi
-			#-------------------------------------------------------------------------------
 			#RPi UART: https://github.com/MichaIng/DietPi/issues/1759
 			if [[ -f /DietPi/config.txt ]]; then
 
@@ -1675,6 +1668,9 @@ _EOF_
 				echo $survey_opted_in > /DietPi/dietpi/.dietpi-survey
 
 			fi
+			#-------------------------------------------------------------------------------
+			#RPi | Remove "framebuffer_depth" handling: https://github.com/MichaIng/DietPi/pull/2635
+			(( $G_HW_MODEL < 10 )) && sed -i '/framebuffer_depth/d' /DietPi/config.txt
 			#-------------------------------------------------------------------------------
 			#Reinstalls
 			#	Amiberry 2.25: https://github.com/MichaIng/DietPi/issues/2599


### PR DESCRIPTION
**Status**: WIP
- [x] Set_Hardware
- [x] Patch
- [x] Changelog

**Commit list/description**:
+ RPi | Remove "framebuffer_depth" handling completely which defaults to 16 which works in every known case