### PR TITLE
DietPi-Software | Nextcloud: Add OCM/OCS provider redirects as this is checked and printed as warning on admin panel

### DIFF
--- a/.conf/dps_114/apache.nextcloud.conf
+++ b/.conf/dps_114/apache.nextcloud.conf
@@ -1,5 +1,9 @@
 # Based on: https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#apache-web-server-configuration
 
+# Redirect OCM/OCS provider requests to Nextcloud endpoint:
+Redirect permanent /ocm-provider /nextcloud/ocm-provider
+Redirect permanent /ocs-provider /nextcloud/ocs-provider
+
 <Directory /var/www/nextcloud/>
         Options +FollowSymlinks
         AllowOverride All

--- a/.conf/dps_114/lighttpd.nextcloud.conf
+++ b/.conf/dps_114/lighttpd.nextcloud.conf
@@ -2,6 +2,12 @@
 # - Apache: https://github.com/nextcloud/server/blob/master/.htaccess
 # - Nginx:  https://docs.nextcloud.com/server/stable/admin_manual/installation/nginx.html
 
+# Redirect OCM/OCS provider requests to Nextcloud endpoint:
+url.redirect = (
+	"^/ocm-provider"  => "/nextcloud/ocm-provider",
+	"^/ocs-provider" => "/nextcloud/ocs-provider"
+)
+
 $HTTP["url"] =~ "^/nextcloud($|/)" {
 
 	# Hardening

--- a/.conf/dps_114/lighttpd.nextcloud.conf
+++ b/.conf/dps_114/lighttpd.nextcloud.conf
@@ -3,7 +3,7 @@
 # - Nginx:  https://docs.nextcloud.com/server/stable/admin_manual/installation/nginx.html
 
 # Redirect OCM/OCS provider requests to Nextcloud endpoint:
-url.redirect = (
+url.redirect += (
 	"^/ocm-provider"  => "/nextcloud/ocm-provider",
 	"^/ocs-provider" => "/nextcloud/ocs-provider"
 )

--- a/.conf/dps_114/lighttpd.nextcloud.conf
+++ b/.conf/dps_114/lighttpd.nextcloud.conf
@@ -4,7 +4,7 @@
 
 # Redirect OCM/OCS provider requests to Nextcloud endpoint:
 url.redirect += (
-	"^/ocm-provider"  => "/nextcloud/ocm-provider",
+	"^/ocm-provider" => "/nextcloud/ocm-provider",
 	"^/ocs-provider" => "/nextcloud/ocs-provider"
 )
 

--- a/.conf/dps_114/nginx.nextcloud.conf
+++ b/.conf/dps_114/nginx.nextcloud.conf
@@ -1,5 +1,10 @@
 # Based on: https://docs.nextcloud.com/server/stable/admin_manual/installation/nginx.html
 
+# Redirect OCM/OCS provider requests to Nextcloud endpoint:
+location ~ ^\/(?:ocm-provider|ocs-provider).* {
+	rewrite ^ /nextcloud$request_uri;
+}
+
 location ^~ /nextcloud {
 
 	# Add headers to serve security related headers

--- a/.conf/dps_114/nginx.nextcloud.conf
+++ b/.conf/dps_114/nginx.nextcloud.conf
@@ -1,4 +1,4 @@
-# Based on: https://docs.nextcloud.com/server/stable/admin_manual/installation/nginx.html
+# Based on: https://docs.nextcloud.com/server/stable/admin_manual/installation/nginx.html#nextcloud-in-a-subdir-of-nginx
 
 # Redirect OCM/OCS provider requests to Nextcloud endpoint:
 location ~ ^\/(?:ocm-provider|ocs-provider).* {
@@ -39,15 +39,15 @@ location ^~ /nextcloud {
 		rewrite ^ /nextcloud/index.php$request_uri;
 	}
 
-	location ~ ^/nextcloud/(?:build|tests|config|lib|3rdparty|templates|data)/ {
+	location ~ ^\/nextcloud\/(?:build|tests|config|lib|3rdparty|templates|data)\/ {
 		deny all;
 	}
-	location ~ ^/nextcloud/(?:\.|autotest|occ|issue|indie|db_|console) {
+	location ~ ^\/nextcloud\/(?:\.|autotest|occ|issue|indie|db_|console) {
 		deny all;
 	}
 
-	location ~ ^/nextcloud/(?:index|remote|public|cron|core/ajax/update|status|ocs/v[12]|updater/.+|ocs-provider/.+)\.php(?:$|/) {
-		fastcgi_split_path_info ^(.+?\.php)(/.*)$;
+	location ~ ^\/nextcloud\/(?:index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|ocs-provider\/.+|ocm-provider\/.+)\.php(?:$|\/) {
+		fastcgi_split_path_info ^(.+?\.php)(\/.*|)$;
 		include fastcgi_params;
 		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 		fastcgi_param PATH_INFO $fastcgi_path_info;
@@ -64,14 +64,14 @@ location ^~ /nextcloud {
 		fastcgi_param PHP_ADMIN_VALUE "opcache.memory_consumption=128";
         }
 
-	location ~ ^/nextcloud/(?:updater|ocs-provider)(?:$|/) {
+	location ~ ^\/nextcloud\/(?:updater|ocs-provider|ocm-provider)(?:$|\/) {
 		try_files $uri/ =404;
 		index index.php;
 	}
 
 	# Adding the cache control header for js and css files
 	# Make sure it is BELOW the PHP block
-	location ~ \.(?:css|js|woff|svg|gif)$ {
+	location ~ ^\/nextcloud\/.+[^\/]\.(?:css|js|woff2?|svg|gif)$ {
 		try_files $uri /nextcloud/index.php$request_uri;
 		add_header Cache-Control "public, max-age=15778463";
 		# Add headers to serve security related headers  (It is intended
@@ -88,7 +88,7 @@ location ^~ /nextcloud {
 		access_log off;
 	}
 
-	location ~ \.(?:png|html|ttf|ico|jpg|jpeg)$ {
+	location ~ ^\/nextcloud\/.+[^\/]\.(?:png|html|ttf|ico|jpg|jpeg)$ {
 		try_files $uri /nextcloud/index.php$request_uri;
 		# Optional: Don't log access to other assets
 		access_log off;

--- a/.conf/dps_85/nginx.default
+++ b/.conf/dps_85/nginx.default
@@ -14,12 +14,6 @@ server {
 		try_files $uri $uri/ =404;
 	}
 
-	error_page 404 /404.html;
-	error_page 500 502 503 504 /50x.html;
-	location = /50x.html {
-		root /var/www;
-	}
-
 	location ~ \.php(?:$|/) {
 		fastcgi_split_path_info ^(.+\.php)(/.+)$;
 		fastcgi_param PATH_INFO $fastcgi_path_info;

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -23,6 +23,7 @@ Changes / Improvements / Optimisations:
 - DietPi-Software | DietPi-RAMlog: When installing/enabling RAMlog, the /var/log mountpoint will be now cleaned before mounting the tmpfs on it, while preserving the existing logs metadata. This resolves a warning on early boot stage and frees the disk space consumed by the disk log before.
 - DietPi-Software | rTorrent: Runs now as user "rtorrent" and creates files as group "dietpi" with 775/664 permissions. Enabled Buster support and enhanced config file handling on reinstall: https://github.com/MichaIng/DietPi/pull/2633
 - DietPi-Software | Plex Media Server: Now installs the latest version automatically (currently 1.15) which as well includes official ARM binaries. Many thanks to @WolfganP for informing us about this new release: https://github.com/MichaIng/DietPi/issues/2553
+- DietPi-Software | Nextcloud: Resolved an admin panel warning about missing ocm/ocs-provider redirects. Many thanks to @minnux for reporting this issue: https://github.com/MichaIng/DietPi/issues/2638
 
 Bug Fixes:
 - System | Resolved an issue where /etc/bashrc.d entries could be run multiple times. Many thanks to @jonare77 for reporting this issue: https://github.com/MichaIng/DietPi/issues/2529

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12836,6 +12836,7 @@ _EOF_
 			[[ -f /etc/turnserver.conf ]] && rm /etc/turnserver.conf
 			[[ -d /etc/systemd/system/coturn.service.d ]] && rm -R /etc/systemd/system/coturn.service.d
 			systemctl start $MARIADB_SERVICE
+			systemctl start redis-server
 			ncc maintenance:mode --off
 			ncc app:disable spreed
 			G_DIETPI-NOTIFY 2 'Disabled Nextcloud Talk app, but you need to remove it manually from Nextcloud web UI, if desired.'

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7747,7 +7747,7 @@ Redirect permanent /.well-known/caldav /owncloud/remote.php/dav' > /etc/apache2/
 				if [[ ! -f /etc/lighttpd/conf-enabled/99-dietpi-dav_redirect.conf ]]; then
 
 					echo '# Redirect Cal/CardDAV requests to ownCloud endpoint:
-url.redirect = (
+url.redirect += (
 	"^/.well-known/caldav"  => "/owncloud/remote.php/dav",
 	"^/.well-known/carddav" => "/owncloud/remote.php/dav"
 )' > /etc/lighttpd/conf-available/99-dietpi-dav_redirect.conf
@@ -8009,7 +8009,7 @@ Redirect permanent /.well-known/caldav /nextcloud/remote.php/dav' > /etc/apache2
 				if [[ ! -f /etc/lighttpd/conf-enabled/99-dietpi-dav_redirect.conf ]]; then
 
 					echo '# Redirect Cal/CardDAV requests to Nextcloud endpoint:
-url.redirect = (
+url.redirect += (
 	"^/.well-known/caldav"  => "/nextcloud/remote.php/dav",
 	"^/.well-known/carddav" => "/nextcloud/remote.php/dav"
 )' > /etc/lighttpd/conf-available/99-dietpi-dav_redirect.conf
@@ -10611,7 +10611,7 @@ Redirect permanent /.well-known/caldav /baikal/html/dav.php' > /etc/apache2/conf
 			elif (( ${aSOFTWARE_INSTALL_STATE[84]} > 0 )); then
 
 				echo '# Redirect Cal/CardDAV requests to Baikal endpoint:
-url.redirect = (
+url.redirect += (
 	"^/.well-known/caldav"  => "/baikal/html/dav.php",
 	"^/.well-known/carddav" => "/baikal/html/dav.php"
 )' > /etc/lighttpd/conf-available/99-dietpi-dav_redirect.conf

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7915,7 +7915,18 @@ _EOF_
 			# - Enable Redis socket and grant www-data access to it:
 			#	- NB: To allow wildcard expansion, do not use quotes around $redis_conf!
 			GCI_PRESERVE=1 G_CONFIG_INJECT 'unixsocket[[:blank:]]' 'unixsocket /var/run/redis/redis-server.sock' $redis_conf
-			G_CONFIG_INJECT 'unixsocketperm[[:blank:]]' 'unixsocketperm 770' $redis_conf
+			#	- Current Buster PHP7.3 Redis module cannot access Redis socket even with group + 770 permissions.
+			#	- Obviously group of spawned processes is overridden by only www-data while redis membership is lost.
+			#	- Requires secure solution, however for now we workaround with 777 socket permissions.
+			if (( $G_DISTRO > 4 )); then
+
+				G_CONFIG_INJECT 'unixsocketperm[[:blank:]]' 'unixsocketperm 777' $redis_conf
+
+			else
+
+				G_CONFIG_INJECT 'unixsocketperm[[:blank:]]' 'unixsocketperm 770' $redis_conf
+
+			fi
 			local redis_sock=$(grep -m1 '^[[:blank:]]*unixsocket[[:blank:]]' $redis_conf | mawk '{print $2}')
 			usermod -a -G redis www-data
 			G_RUN_CMD systemctl restart redis-server
@@ -8205,7 +8216,18 @@ The install script will now exit. After applying one of the the above, rerun die
 			# - Enable Redis socket and grant www-data access to it:
 			#	- NB: To allow wildcard expansion, do not use quotes around $redis_conf!
 			GCI_PRESERVE=1 G_CONFIG_INJECT 'unixsocket[[:blank:]]' 'unixsocket /var/run/redis/redis-server.sock' $redis_conf
-			G_CONFIG_INJECT 'unixsocketperm[[:blank:]]' 'unixsocketperm 770' $redis_conf
+			#	- Current Buster PHP7.3 Redis module cannot access Redis socket even with group + 770 permissions.
+			#	- Obviously group of spawned processes is overridden by only www-data while redis membership is lost.
+			#	- Requires secure solution, however for now we workaround with 777 socket permissions.
+			if (( $G_DISTRO > 4 )); then
+
+				G_CONFIG_INJECT 'unixsocketperm[[:blank:]]' 'unixsocketperm 777' $redis_conf
+
+			else
+
+				G_CONFIG_INJECT 'unixsocketperm[[:blank:]]' 'unixsocketperm 770' $redis_conf
+
+			fi
 			local redis_sock=$(grep -m1 '^[[:blank:]]*unixsocket[[:blank:]]' $redis_conf | mawk '{print $2}')
 			usermod -a -G redis www-data
 			G_RUN_CMD systemctl restart redis-server
@@ -8231,12 +8253,28 @@ The install script will now exit. After applying one of the the above, rerun die
 			Banner_Configuration
 
 			G_DIETPI-NOTIFY 2 'Configuring TURN server:'
-			# - Enable init.d service
-			G_CONFIG_INJECT 'TURNSERVER_ENABLED=' 'TURNSERVER_ENABLED=1' /etc/default/coturn
-			# - Disable coturn logging by default, this can be overridden via /etc/turnserver.conf
-			G_CONFIG_INJECT 'DAEMON_ARGS=' "DAEMON_ARGS='-c /etc/turnserver.conf -o -l stdout --no-stdout-log --simple-log'" /etc/default/coturn
+			# Buster (systemd unit)
+			if (( $G_DISTRO > 4 )); then
 
-			# - Ask user for server domain and desired TURN server port
+				# - Remove init.d service traces
+				[[ -f /etc/init.d/coturn ]] && rm /etc/init.d/coturn
+				[[ -f /etc/default/coturn ]] && rm /etc/default/coturn
+
+				# - Disable coturn logging by default, this can be overridden via /etc/turnserver.conf
+				mkdir -p /etc/systemd/system/coturn.service.d
+				echo -e "[Service]\nExecStart=\n$(grep -m1 "^[[:blank:]]*ExecStart=" /lib/systemd/system/coturn.service) -l stdout --no-stdout-log --simple-log" > /etc/systemd/system/coturn.service.d/dietpi-logging.conf
+
+			# Stretch/Jessie (init.d service)
+			else
+
+				# - Enable init.d service
+				G_CONFIG_INJECT 'TURNSERVER_ENABLED=' 'TURNSERVER_ENABLED=1' /etc/default/coturn
+				# - Disable coturn logging by default, this can be overridden via /etc/turnserver.conf
+				G_CONFIG_INJECT 'DAEMON_ARGS=' "DAEMON_ARGS='-c /etc/turnserver.conf -o -l stdout --no-stdout-log --simple-log'" /etc/default/coturn
+
+			fi
+
+			# Ask user for server domain and desired TURN server port
 			local invalid_text=''
 			local domain=$(hostname)
 			while :
@@ -8277,7 +8315,14 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 
 			done
 
-			# - Adjust coturn settings
+			# Adjust coturn settings
+			# - On Buster by default /etc/turnserver.conf is not created. Use example or create empty file:
+			if [[ ! -f /etc/turnserver.conf ]]; then
+
+				> /etc/turnserver.conf
+				[[ -f /usr/share/doc/coturn/examples/etc/turnserver.conf.gz ]] && gzip -cd /usr/share/doc/coturn/examples/etc/turnserver.conf.gz > /etc/turnserver.conf
+
+			fi
 			G_CONFIG_INJECT 'fingerprint' 'fingerprint' /etc/turnserver.conf
 			G_CONFIG_INJECT 'use-auth-secret' 'use-auth-secret' /etc/turnserver.conf
 			G_CONFIG_INJECT 'realm=' "realm=$domain" /etc/turnserver.conf
@@ -8287,7 +8332,7 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 			G_CONFIG_INJECT 'no-loopback-peers' 'no-loopback-peers' /etc/turnserver.conf
 			G_CONFIG_INJECT 'no-multicast-peers' 'no-multicast-peers' /etc/turnserver.conf
 
-			# - Add TLS settings, if LetsEncrypt certificates are available:
+			# Add TLS settings, if LetsEncrypt certificates are available:
 			if [[ -f /DietPi/dietpi/.dietpi-letsencrypt &&
 				-f /etc/letsencrypt/live/$(sed -n 1p /DietPi/dietpi/.dietpi-letsencrypt)/cert.pem ]]; then
 
@@ -8307,19 +8352,19 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 
 			fi
 
-			# - Install Nextcloud Talk app
+			# Install Nextcloud Talk app
 			G_RUN_CMD systemctl start $MARIADB_SERVICE
 			G_RUN_CMD systemctl start redis-server
 			G_RUN_CMD ncc maintenance:mode --off
 			G_RUN_CMD ncc app:install spreed
 			ncc app:enable spreed
 
-			# - Adjust Nextcloud Talk settings to use coturn
+			# Adjust Nextcloud Talk settings to use coturn
 			ncc config:app:set spreed stun_servers --value="[\"$domain:$port\"]"
-			#	Generate random secret to secure TURN server access
+			# - Generate random secret to secure TURN server access
 			local secret=$(openssl rand -hex 32)
 			GCI_PRESERVE=1 G_CONFIG_INJECT 'static-auth-secret=' "static-auth-secret=$secret" /etc/turnserver.conf
-			#	Scrape existing secret, in case user manually chose/edited it
+			# - Scrape existing secret, in case user manually chose/edited it
 			secret=$(grep -m1 '^[[:blank:]]*static-auth-secret=' /etc/turnserver.conf)
 			secret=${secret#*static-auth-secret=}
 			ncc config:app:set spreed turn_servers --value="[{\"server\":\"$domain:$port\",\"secret\":\"$secret\",\"protocols\":\"udp,tcp\"}]"
@@ -12739,8 +12784,7 @@ _EOF_
 
 		fi
 
-		#ownCloud
-		software_id=47
+		software_id=47 # ownCloud
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
@@ -12784,12 +12828,13 @@ _EOF_
 
 		fi
 
-		#Nextcloud Talk + TURN server "coturn"
-		software_id=168
+		software_id=168 # Nextcloud Talk + TURN server "coturn"
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
 			G_AGP coturn
+			[[ -f /etc/turnserver.conf ]] && rm /etc/turnserver.conf
+			[[ -d /etc/systemd/system/coturn.service.d ]] && rm -R /etc/systemd/system/coturn.service.d
 			systemctl start $MARIADB_SERVICE
 			ncc maintenance:mode --off
 			ncc app:disable spreed
@@ -12797,8 +12842,7 @@ _EOF_
 
 		fi
 
-		#Nextcloud
-		software_id=114
+		software_id=114 # Nextcloud
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8356,7 +8356,7 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 			G_RUN_CMD systemctl start $MARIADB_SERVICE
 			G_RUN_CMD systemctl start redis-server
 			G_RUN_CMD ncc maintenance:mode --off
-			G_RUN_CMD ncc app:install spreed
+			[[ -d /var/www/nextcloud/apps/spreed ]] || G_RUN_CMD ncc app:install spreed
 			ncc app:enable spreed
 
 			# Adjust Nextcloud Talk settings to use coturn

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1684,13 +1684,15 @@ _EOF_
 			fi
 			#-------------------------------------------------------------------------------
 			#Nextcloud: Add OCM/OCS provider redirects as this is checked and printed as warning on admin panel: https://github.com/MichaIng/DietPi/issues/2638
-			if [[ -f /etc/apache2/sites-available/dietpi-nextcloud.conf ]]; then
+			if [[ -f /etc/apache2/sites-available/dietpi-nextcloud.conf ]] &&
+				! grep -qE '(ocm|ocs)-provider' /etc/apache2/sites-available/dietpi-nextcloud.conf; then
 
 				echo 'Redirect permanent /ocm-provider /nextcloud/ocm-provider
 Redirect permanent /ocs-provider /nextcloud/ocs-provider' >> /etc/apache2/sites-available/dietpi-nextcloud.conf
 
 			fi
-			if [[ -f /etc/lighttpd/conf-available/99-dietpi-nextcloud.conf ]]; then
+			if [[ -f /etc/lighttpd/conf-available/99-dietpi-nextcloud.conf ]] &&
+				! grep -qE '(ocm|ocs)-provider' /etc/lighttpd/conf-available/99-dietpi-nextcloud.conf; then
 
 				echo 'url.redirect = (
 	"^/ocm-provider"  => "/nextcloud/ocm-provider",
@@ -1698,7 +1700,8 @@ Redirect permanent /ocs-provider /nextcloud/ocs-provider' >> /etc/apache2/sites-
 )' >> /etc/lighttpd/conf-available/99-dietpi-nextcloud.conf
 
 			fi
-			if [[ -f /etc/nginx/sites-dietpi/dietpi-nextcloud.conf ]]; then
+			if [[ -f /etc/nginx/sites-dietpi/dietpi-nextcloud.conf ]] &&
+				! grep -qE '(ocm|ocs)-provider' /etc/nginx/sites-dietpi/dietpi-nextcloud.conf; then
 
 				echo 'location ~ ^\/(?:ocm-provider|ocs-provider).* {
 	rewrite ^ /nextcloud$request_uri;

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1694,7 +1694,7 @@ Redirect permanent /ocs-provider /nextcloud/ocs-provider' >> /etc/apache2/sites-
 			if [[ -f /etc/lighttpd/conf-available/99-dietpi-nextcloud.conf ]] &&
 				! grep -qE '(ocm|ocs)-provider' /etc/lighttpd/conf-available/99-dietpi-nextcloud.conf; then
 
-				echo 'url.redirect = (
+				echo 'url.redirect += (
 	"^/ocm-provider"  => "/nextcloud/ocm-provider",
 	"^/ocs-provider" => "/nextcloud/ocs-provider"
 )' >> /etc/lighttpd/conf-available/99-dietpi-nextcloud.conf

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1683,6 +1683,29 @@ _EOF_
 
 			fi
 			#-------------------------------------------------------------------------------
+			#Nextcloud: Add OCM/OCS provider redirects as this is checked and printed as warning on admin panel: https://github.com/MichaIng/DietPi/issues/2638
+			if [[ -f /etc/apache2/sites-available/dietpi-nextcloud.conf ]]; then
+
+				echo 'Redirect permanent /ocm-provider /nextcloud/ocm-provider
+Redirect permanent /ocs-provider /nextcloud/ocs-provider' >> /etc/apache2/sites-available/dietpi-nextcloud.conf
+
+			fi
+			if [[ -f /etc/lighttpd/conf-available/99-dietpi-nextcloud.conf ]]; then
+
+				echo 'url.redirect = (
+	"^/ocm-provider"  => "/nextcloud/ocm-provider",
+	"^/ocs-provider" => "/nextcloud/ocs-provider"
+)' >> /etc/lighttpd/conf-available/99-dietpi-nextcloud.conf
+
+			fi
+			if [[ -f /etc/nginx/sites-dietpi/dietpi-nextcloud.conf ]]; then
+
+				echo 'location ~ ^\/(?:ocm-provider|ocs-provider).* {
+	rewrite ^ /nextcloud$request_uri;
+}' >> /etc/nginx/sites-dietpi/dietpi-nextcloud.conf
+
+			fi
+			#-------------------------------------------------------------------------------
 			#Reinstalls
 			#	Amiberry 2.25: https://github.com/MichaIng/DietPi/issues/2599
 			#	Deluge: Patch according to installer rework: https://github.com/MichaIng/DietPi/pull/2594


### PR DESCRIPTION
**Status**: Testing
- [x] Lighttpd
- [x] Nginx
- [x] Apache
- [x] Patch
- [x] Changelog

**Testing**:
- [x] VM Jessie
- [x] VM Stretch
- [x] VM Buster

**Reference**: https://github.com/MichaIng/DietPi/issues/2638

**Commit list/description**:
+ DietPi-Software | Nextcloud: Add OCM/OCS provider redirects to Lighttpd config as this is checked and printed as warning on admin panel
+ DietPi-Software | Nextcloud: Add OCM/OCS provider redirects to Apache config as this is checked and printed as warning on admin panel
+ DietPi-Software | Nextcloud: Add OCM/OCS provider redirects to Nginx config as this is checked and printed as warning on admin panel
+ DietPi-Patch | Nextcloud: Patch in OCM/OCS provider redirects
+ DietPi-Patch | Nextcloud: Only add OCM/OCS provider once, regardless of re-patch of if already added by user manually
+ CHANGELOG | Nextcloud: Resolved an admin panel warning about missing ocm/ocs-provider redirects
+ DietPi-Software | Nextcloud: Further update Nginx config according to latest changes in official docs
+ DietPi-Software | ownCloud/Nextcloud: Workaround Redis socket permission issue on Buster. Requires more secure solution until official Buster release/support
+ DietPi-Software | Nextcloud Talk: Handle new coTURN systemd unit and missing config file on Buster
+ DietPi-Software | Nginx: Do not add non-existent 40x/50x pages, revert to default