### PR TITLE
DietPi-Pre-patch | Apply hardened Sid repo handling already with pre-patches to block Sid distro upgrades before the update itself runs any APT command

### DIFF
--- a/dietpi/pre-patch_file
+++ b/dietpi/pre-patch_file
@@ -63,12 +63,23 @@
 		fi	
 		#-------------------------------------------------------------------------------
 		# Pre-patch 3: https://github.com/MichaIng/DietPi/issues/2213
-		if (( $G_DIETPI_VERSION_SUB < 22 )) &&
-			GLOBAL_PW=$(openssl enc -d -a -aes-256-cbc -nosalt -pass pass:'DietPiRocks!' -in /var/lib/dietpi/dietpi-software/.GLOBAL_PW.bin 2> /dev/null); then
+		# Pre-patch 4: https://github.com/MichaIng/DietPi/issues/2656
+		if (( $G_DIETPI_VERSION_SUB < 22 )); then
 
-			echo -e '\e[90m[\e[0m \e[33mWARN\e[0m \e[90m]\e[0m Pre-patch 3 | Storing global DietPi-Software password with enhanced security'
-			grep -qi 'buster' /etc/os-release && pbkdf2='-iter 10000' || pbkdf2=''
-			openssl enc -e -a -md sha256 -aes-256-cbc $pbkdf2 -salt -pass pass:'DietPiRocks!' -out /var/lib/dietpi/dietpi-software/.GLOBAL_PW.bin <<< $GLOBAL_PW || { EXIT_CODE=3; break; }
+			if GLOBAL_PW=$(openssl enc -d -a -aes-256-cbc -nosalt -pass pass:'DietPiRocks!' -in /var/lib/dietpi/dietpi-software/.GLOBAL_PW.bin 2> /dev/null); then
+
+				echo -e '\e[90m[\e[0m \e[33mWARN\e[0m \e[90m]\e[0m Pre-patch 3 | Storing global DietPi-Software password with enhanced security'
+				grep -qi 'buster' /etc/os-release && pbkdf2='-iter 10000' || pbkdf2=''
+				openssl enc -e -a -md sha256 -aes-256-cbc $pbkdf2 -salt -pass pass:'DietPiRocks!' -out /var/lib/dietpi/dietpi-software/.GLOBAL_PW.bin <<< $GLOBAL_PW || { EXIT_CODE=3; break; }
+
+			fi
+			if [[ -f /etc/apt/preferences.d/dietpi-wireguard ]]; then
+
+				echo -e '\e[90m[\e[0m \e[33mWARN\e[0m \e[90m]\e[0m Pre-patch 4 | Hardening Debian Sid repo usage to prevent accidental distro upgrades'
+				echo -e 'Package: *\nPin: release n=sid\nPin-Priority: -1\n
+Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Priority: 99' > /etc/apt/preferences.d/dietpi-wireguard || { EXIT_CODE=4; break; }
+
+			fi
 
 		fi
 		#-------------------------------------------------------------------------------


### PR DESCRIPTION
**Reference**: https://github.com/MichaIng/DietPi/issues/2656

**Commit list/description**:
+ DietPi-Pre-patch | Apply hardened Sid repo handling already with pre-patches to block Sid distro upgrades before the update itself runs any APT command.
