### PR TITLE
v6.22

### DIFF
--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -1011,7 +1011,8 @@ _EOF_
 		rm -f /etc/profile.d/99-dietpi*
 
 		# - Enable /etc/bashrc.d/ support for custom interactive non-login shell scripts:
-		G_CONFIG_INJECT '.*/etc/bashrc\.d/.*' 'for i in /etc/bashrc.d/*.sh; do [ -r "$i" ] && . $i; done' /etc/bash.bashrc
+		sed -i '\#for i in /etc/bashrc\.d#d' /etc/bash.bashrc
+		G_CONFIG_INJECT '.*/etc/bashrc\.d/.*' 'for i in /etc/bashrc.d/*.sh /etc/bashrc.d/*.bash; do [ -r "$i" ] && . $i; done' /etc/bash.bashrc
 
 		# - Enable bash-completion for non-login shells:
 		#	- NB: It is called twice on login shells then, but breaks directly if called already once.


### PR DESCRIPTION
+ DietPi-PREP | Add /etc/bashrc.d/*.bash support, backport of: https://github.com/MichaIng/DietPi/commit/c51a554976c1bf02762b580ec01e3fdbe7c21ca7