### PR TITLE
DietPi-Config | Serial/UART rework: Allow to toggle login console on single serial devices

### DIFF
--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -1200,10 +1200,11 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 		G_WHIP_MENU_ARRAY=('' '●─ Toggle console ')
 		for i in /dev/tty{S,AMA,SAC}[0-9]
 		do
-		
+
 			[[ -e $i ]] || continue
+			i=${i#/dev/}
 			aSTATE[$i]='[Off]'
-			systemctl -q is-active serial-console@$i && aSTATE[$i]='[On]'
+			systemctl -q is-active serial-getty@$i && aSTATE[$i]='[On]'
 			G_WHIP_MENU_ARRAY+=("$i" ": ${aSTATE[$i]}")
 
 		done
@@ -1245,7 +1246,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 		fi
 
-		(( ${#G_WHIP_MENU_ARRAY[@]} == 2 )) || { G_WHIP_MSG 'No serial/UART devices have been found on your system.'; return; }
+		(( ${#G_WHIP_MENU_ARRAY[@]} > 2 )) || { G_WHIP_MSG 'No serial/UART devices have been found on your system.'; TARGETMENUID=3; return; }
 
 		G_WHIP_BUTTON_CANCEL_TEXT='Back'
 		if G_WHIP_MENU "Select an available serial/UART device to toggle a login console on it.$rpi_text"; then
@@ -1261,7 +1262,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 				G_CONFIG_INJECT 'enable_uart=' 'enable_uart=0' /DietPi/config.txt
 				REBOOT_REQUIRED=1
 
-			else
+			elif [[ $G_WHIP_RETURNED_VALUE ]]; then
 
 				local toggle='enable'
 				[[ ${aSTATE[$G_WHIP_RETURNED_VALUE]} == '[On]' ]] && toggle='disable'
@@ -1328,13 +1329,12 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 		G_WHIP_MENU_ARRAY+=('Update firmware' '')
 
-		# No Bluetooth and serial/UART devices for VM
+		# Serial/UART devices
+		G_WHIP_MENU_ARRAY+=('Serial/UART' ': Manage available devices')
+
+		# Bluetooth: Not for VM
 		if (( $G_HW_MODEL != 20 )); then
 
-			# Serial/UART devices
-			G_WHIP_MENU_ARRAY+=('Serial/UART' ': Manage available devices')
-
-			# Bluetooth
 			local bluetooth_state_text='[On]'
 			local bluetooth_state=1
 			if [[ -f /etc/modprobe.d/disable_bt.conf ]]; then

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -339,8 +339,7 @@
 
 		if G_WHIP_MENU 'Please select an option:'; then
 
-			#Return to this menu
-			TARGETMENUID=1
+			TARGETMENUID=1 # Return to this menu
 
 			WHIP_SELECTION_PREVIOUS=$G_WHIP_RETURNED_VALUE
 
@@ -752,10 +751,9 @@
 	#TARGETMENUID=2
 	Menu_DisplayOptions_Driver_Resolution(){
 
-		#Return to Display Options Menu
-		TARGETMENUID=1
+		TARGETMENUID=1 # Return to Display Options menu
 
-		#VM
+		# VM
 		if (( $G_HW_MODEL == 20 )); then
 
 			local current=$(grep -m1 '^[[:blank:]]*GRUB_GFXMODE=' /etc/default/grub | sed 's/^[^=]*=//')
@@ -793,7 +791,7 @@
 
 			fi
 
-		#Native PC
+		# Native PC
 		elif (( $G_HW_MODEL == 21 )); then
 
 			local nvidia_installed=0
@@ -856,7 +854,7 @@
 
 			fi
 
-		#RPI
+		# RPi
 		elif (( $G_HW_MODEL < 10 )); then
 
 			local framebuffer_x=$(grep -m1 '^[[:blank:]]*framebuffer_width=' /DietPi/config.txt || vcgencmd get_config framebuffer_width)
@@ -900,8 +898,7 @@
 
 				REBOOT_REQUIRED=1
 
-				#Return to This Menu
-				TARGETMENUID=2
+				TARGETMENUID=2 # Return to this menu
 
 				if [[ $G_WHIP_RETURNED_VALUE == 'Headless' ]]; then
 
@@ -1015,7 +1012,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 			fi
 
-		#Odroid C1
+		# Odroid C1
 		elif (( $G_HW_MODEL == 10 )); then
 
 			#Get Current Values
@@ -1036,8 +1033,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 				REBOOT_REQUIRED=1
 
-				#Return to This Menu
-				TARGETMENUID=2
+				TARGETMENUID=2 # Return to this menu
 
 				# - Always reset to HDMI
 				sed -i '/setenv vout_mode /c\setenv vout_mode "hdmi"' /DietPi/boot.ini
@@ -1079,7 +1075,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 			fi
 
-		#Odroid xu3/4
+		# Odroid XU3/4
 		elif (( $G_HW_MODEL == 11 )); then
 
 			#Get Current Values
@@ -1112,8 +1108,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 				REBOOT_REQUIRED=1
 
-				#Return to This Menu
-				TARGETMENUID=2
+				TARGETMENUID=2 # Return to this menu
 
 				# - Always reset to hdmi
 				sed -i '/setenv vout /c\setenv vout "hdmi"' /DietPi/boot.ini
@@ -1127,7 +1122,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 			fi
 
-		#Odroid C2
+		# Odroid C2
 		elif (( $G_HW_MODEL == 12 )); then
 
 			#Get Current Values
@@ -1170,17 +1165,16 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 				fi
 
-				#Remove the space from option
-				local temp_string=$(echo "$G_WHIP_RETURNED_VALUE" | tr -d '[:blank:]')
+				# Remove the space from option
+				local temp_string=${G_WHIP_RETURNED_VALUE//[[:blank:]]/}
 
 				sed -i "/setenv m /c\setenv m \"$temp_string\"" /DietPi/boot.ini
 
-				#Return to This Menu
-				TARGETMENUID=2
+				TARGETMENUID=2 # Return to this menu
 
 			fi
 
-		#Pine a64
+		# Pine A64
 		elif (( $G_HW_MODEL == 40 )); then
 
 			#Get Current Values
@@ -1212,8 +1206,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 				fi
 
-				#Return to This Menu
-				TARGETMENUID=2
+				TARGETMENUID=2 # Return to this menu
 
 			fi
 
@@ -1232,14 +1225,14 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 		G_WHIP_MENU_ARRAY=()
 
-		#Swap file
+		# Swap file
 		local swap_size=$(free -m | mawk '/Swap:/ {print $2;exit}')
 		local swap_location=$(grep -m1 '^[[:blank:]]*AUTO_SETUP_SWAPFILE_LOCATION=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 		local swap_size_text="$swap_size MB"
 		(( ! $swap_size )) && swap_size_text='[Off]'
 		G_WHIP_MENU_ARRAY+=('Swapfile' ": [$swap_size_text | $swap_location]")
 
-		#Time sync
+		# Time sync
 		local ntpd_mode_current=$(grep -m1 '^[[:blank:]]*CONFIG_NTP_MODE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 		local ntpd_mode_text=''
 		if (( $ntpd_mode_current == 0 )); then
@@ -1265,29 +1258,26 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 		fi
 		G_WHIP_MENU_ARRAY+=('Time sync mode' ": [$ntpd_mode_text]")
 
-		local rtc_enabled=0
-		local rtc_text='Emulated'
-		if ! command -v fake-hwclock &> /dev/null; then
+		# RTC clock
+		local rtc_enabled=1
+		local rtc_text='Hardware'
+		if command -v fake-hwclock &> /dev/null; then
 
-			rtc_enabled=1
-			rtc_text='Hardware'
+			rtc_enabled=0
+			rtc_text='Emulated'
 
 		fi
-
 		G_WHIP_MENU_ARRAY+=('RTC mode' ": [$rtc_text]")
 
 		G_WHIP_MENU_ARRAY+=('Update firmware' '')
 
-		#No bluetooth and serial console for VM
+		# No Bluetooth and serial/UART devices for VM
 		if (( $G_HW_MODEL != 20 )); then
 
-			#Serial console
-			local serialconsole_state=$(grep -m1 '^[[:blank:]]*CONFIG_SERIAL_CONSOLE_ENABLE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
-			local serialconsole_text='[Off]'
-			(( $serialconsole_state )) && serialconsole_text='[On]'
-			G_WHIP_MENU_ARRAY+=('Serial console' ": $serialconsole_text")
+			# Serial/UART devices
+			G_WHIP_MENU_ARRAY+=('Serial/UART' ': Manage available devices')
 
-			#Bluetooth
+			# Bluetooth
 			local bluetooth_state_text='[On]'
 			local bluetooth_state=1
 			if [[ -f /etc/modprobe.d/disable_bt.conf ]]; then
@@ -1300,40 +1290,42 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 		fi
 
-		#RPi Specific
+		# RPi specific
 		if (( $G_HW_MODEL < 10 )); then
 
+			# I2C state
 			local rpi_i2c_enabled=$(grep -ci -m1 '^[[:blank:]]*dtparam=i2c_arm=on' /DietPi/config.txt)
 			local rpi_i2c_text='[Off]'
 			(( $rpi_i2c_enabled )) && rpi_i2c_text='[On]'
+			G_WHIP_MENU_ARRAY+=('I2C state' ": $rpi_i2c_text")
 
+			# I2C baudrate
 			local rpi_i2cbaudrate_hz=$(grep -m1 '^[[:blank:]]*i2c_arm_baudrate=' /DietPi/config.txt | sed 's/^[^=]*=//')
-			# Allow commented/non-existent entry, using default value: https://github.com/raspberrypi/firmware/blob/d69aadedb7c146ba5d3b0b45a661e5669a9141c4/boot/overlays/README#L115-L116
+			# - Allow commented/non-existent entry, using default value: https://github.com/raspberrypi/firmware/blob/d69aadedb7c146ba5d3b0b45a661e5669a9141c4/boot/overlays/README#L115-L116
 			rpi_i2cbaudrate_hz="$(( ${rpi_i2cbaudrate_hz:-100000} / 1000 )) kHz"
+			G_WHIP_MENU_ARRAY+=('I2C frequency' ": [$rpi_i2cbaudrate_hz]")
+
+			# USB max current
 			local usb_max_current_enabled=$(grep -ci -m1 '^[[:blank:]]*max_usb_current=1' /DietPi/config.txt)
 			local rpi_usbmaxcurrent_text='[Off]'
 			(( $usb_max_current_enabled )) && rpi_usbmaxcurrent_text='[On]'
+			G_WHIP_MENU_ARRAY+=('Max USB current' ": $rpi_usbmaxcurrent_text")
 
-			if (( $G_HW_MODEL == 3 )); then
+			# USB boot option: RPi3 only and not required for RPi3+: https://www.raspberrypi.org/documentation/hardware/raspberrypi/bootmodes/msd.md
+			if (( $G_HW_MODEL == 3 )) && [[ $G_HW_MODEL_DESCRIPTION == *'3 Model '[AB]'+' ]]; then
 
 				local rpi3_usb_boot_bit_enabled=$(vcgencmd otp_dump | grep -m1 '17:' | grep -ci -m1 '3020000a')
 				local rpi3_usb_boot_bit_enabled_text='[Off]'
 				(( $rpi3_usb_boot_bit_enabled )) && rpi3_usb_boot_bit_enabled_text='[On]'
-
 				G_WHIP_MENU_ARRAY+=('USB boot support' ": $rpi3_usb_boot_bit_enabled_text")
 
 			fi
-
-			G_WHIP_MENU_ARRAY+=('Max USB current' ": $rpi_usbmaxcurrent_text")
-			G_WHIP_MENU_ARRAY+=('I2c state' ": $rpi_i2c_text")
-			G_WHIP_MENU_ARRAY+=('I2c frequency' ": [$rpi_i2cbaudrate_hz]")
 
 		fi
 
 		if G_WHIP_MENU 'Please select an option:'; then
 
-			#Return to This Menu
-			TARGETMENUID=3
+			TARGETMENUID=3 # Return to this menu
 
 			if [[ $G_WHIP_RETURNED_VALUE == 'Swapfile' ]]; then
 
@@ -1356,7 +1348,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 					systemctl stop fake-hwclock
 
-					# - allow times in the past
+					# - Allow times in the past
 					G_CONFIG_INJECT 'FORCE=' 'FORCE=force' /etc/default/fake-hwclock
 
 					systemctl restart fake-hwclock
@@ -1391,8 +1383,8 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 				local old_firmware=$(ls /lib/modules/)
 
-				#PineA64
-				if (( $G_HW_MODEL == 40 )); then
+				# Pine A64: Non-ARMbian only
+				if (( $G_HW_MODEL == 40 && -f /usr/local/sbin/pine64_update_uboot.sh && -f /usr/local/sbin/pine64_update_kernel.sh )); then
 
 					if G_WHIP_YESNO "Would you like to update the firmware/kernel for $G_HW_MODEL_DESCRIPTION?
  - This will run longsleep's update scripts to update the U-Boot and kernel."; then
@@ -1402,7 +1394,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 					fi
 
-				#G_AGDUG based (not all devices support this)
+				# G_AGDUG based (not all devices support this)
 				elif G_WHIP_YESNO "Would you like to update the firmware/kernel for $G_HW_MODEL_DESCRIPTION?
  - This will run G_AGDUG, a wrapper for 'apt-get dist-upgrade'\n - Most (but not all) devices allow APT based firmware updates
  \nNB: If requested to overwrite the current kernel, press TAB and then ENTER (to confirm)."; then
@@ -1412,12 +1404,12 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 				fi
 
-				#Reboot required only, if firmware got actually updated
+				# Reboot required only, if firmware got actually updated
 				[[ $old_firmware != $(ls /lib/modules/) ]] && REBOOT_REQUIRED=1
 
 			elif [[ $G_WHIP_RETURNED_VALUE == 'Max USB current' ]]; then
 
-				#Enabled
+				# Enabled
 				if (( $usb_max_current_enabled == 1 )); then
 
 					if G_WHIP_YESNO "Current setting: $rpi_usbmaxcurrent_text (1.2AMP)\nWould you like to disable this setting?
@@ -1428,7 +1420,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 					fi
 
-				#Disabled
+				# Disabled
 				elif (( $usb_max_current_enabled == 0 )); then
 
 					if G_WHIP_YESNO "Current setting: $rpi_usbmaxcurrent_text (0.6AMP)\nWould you like to enable this setting?
@@ -1441,7 +1433,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 				fi
 
-			elif [[ $G_WHIP_RETURNED_VALUE == 'I2c state' ]]; then
+			elif [[ $G_WHIP_RETURNED_VALUE == 'I2C state' ]]; then
 
 				if (( $rpi_i2c_enabled )); then
 
@@ -1454,13 +1446,13 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 				fi
 				REBOOT_REQUIRED=1
 
-			elif [[ $G_WHIP_RETURNED_VALUE == 'I2c frequency' ]]; then
+			elif [[ $G_WHIP_RETURNED_VALUE == 'I2C frequency' ]]; then
 
-				#remove kHz from current
-				G_WHIP_DEFAULT_ITEM=$(echo -e "$rpi_i2cbaudrate_hz" | tr -d ' kHz')
-				if G_WHIP_INPUTBOX 'Please enter the required i2c baudrate frequency (kHz).'; then
+				# Remove kHz from current
+				G_WHIP_DEFAULT_ITEM=${rpi_i2cbaudrate_hz% kHz}
+				if G_WHIP_INPUTBOX 'Please enter the required I2C baudrate frequency (kHz).'; then
 
-					#check valid int
+					# Check valid int
 					if G_CHECK_VALIDINT $G_WHIP_RETURNED_VALUE; then
 
 						/DietPi/dietpi/func/dietpi-set_hardware i2c "$G_WHIP_RETURNED_VALUE"
@@ -1470,18 +1462,82 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 				fi
 
-			elif [[ $G_WHIP_RETURNED_VALUE == 'Serial console' ]]; then
+			elif [[ $G_WHIP_RETURNED_VALUE == 'Serial/UART' ]]; then
 
-				if (( $serialconsole_state )); then
+				declare -A aSTATE=()
+				G_WHIP_MENU_ARRAY=('' '●─ Toggle console ')
+				for i in /dev/tty{S,AMA,SAC}[0-9]
+				do
+		
+					[[ -e $i ]] || continue
+					aSTATE[$i]='[Off]'
+					systemctl -q is-active serial-console@$i && aSTATE[$i]='[On]'
+					G_WHIP_MENU_ARRAY+=("$i" ": ${aSTATE[$i]}")
 
-					/DietPi/dietpi/func/dietpi-set_hardware serialconsole disable
+				done
 
-				else
+				# RPi special
+				local rpi_text=''
+				if (( $G_HW_MODEL < 10 )); then
 
-					/DietPi/dietpi/func/dietpi-set_hardware serialconsole enable
+					local rpi_text='\n\nOn Raspberry Pi you can additionally enable or disable the primary UART device completely (requires reboot).'
+					G_WHIP_MENU_ARRAY+=('' '●─ Toggle device ')
+
+					# Onboard WiFi/BT: "enable_uart" toggles ttyS0 (mini UART), disabled by default
+					if (( $(sed -n 9p /DietPi/dietpi/.hw_model) )); then
+
+						if grep -q '^[[:blank:]]*enable_uart=1' /DietPi/config.txt; then
+
+							G_WHIP_MENU_ARRAY+=('Disable ttyS0' ': [On] mini UART ttyS0')
+
+						else
+
+							G_WHIP_MENU_ARRAY+=('Enable ttyS0' ': [Off] mini UART ttyS0')
+
+						fi
+
+					# Nonboard WiFi/BT: "enable_uart" toggles ttyAMA0 (full UART). enabled by default
+					else
+
+						if grep -q '^[[:blank:]]*enable_uart=0' /DietPi/config.txt; then
+
+							G_WHIP_MENU_ARRAY+=('Enable ttyAMA0' ': [Off] full UART ttyAMA0')
+
+						else
+
+							G_WHIP_MENU_ARRAY+=('Disable ttyAMA0' ': [On] full UART ttyAMA0')
+
+						fi
+
+					fi
 
 				fi
-				REBOOT_REQUIRED=1
+
+				(( ${#G_WHIP_MENU_ARRAY[@]} == 2 )) || { G_WHIP_MSG 'No serial/UART devices have been found on your system.'; return; }
+
+				G_WHIP_BUTTON_CANCEL_TEXT='Back'
+				if G_WHIP_MENU "Select an available serial/UART device to toggle a login console on it.$rpi_text"; then
+
+					if [[ $G_WHIP_RETURNED_VALUE == 'Enable'* ]]; then
+
+						G_CONFIG_INJECT 'enable_uart=' 'enable_uart=1' /DietPi/config.txt
+						REBOOT_REQUIRED=1
+
+					elif [[ $G_WHIP_RETURNED_VALUE == 'Disable'* ]]; then
+
+						/DietPi/dietpi/func/dietpi-set_hardware serialconsole disable ${G_WHIP_RETURNED_VALUE##* }
+						G_CONFIG_INJECT 'enable_uart=' 'enable_uart=0' /DietPi/config.txt
+						REBOOT_REQUIRED=1
+
+					else
+
+						local toggle='enable'
+						[[ ${aSTATE[$G_WHIP_RETURNED_VALUE]} == '[On]' ]] && toggle='disable'
+						/DietPi/dietpi/func/dietpi-set_hardware serialconsole $toggle $G_WHIP_RETURNED_VALUE
+
+					fi
+
+				fi
 
 			elif [[ $G_WHIP_RETURNED_VALUE == 'Bluetooth' ]]; then
 
@@ -1525,30 +1581,22 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 		TARGETMENUID=0
 
-		#All devices
+		# All devices
 		local current_cpu_governor=$(grep -m1 '^[[:blank:]]*CONFIG_CPU_GOVERNOR=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 
 		local frequency_min_cpu_governor=1
 		local fp_frequency_min_cpu_governor='/sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq'
-		if [[ -f $fp_frequency_min_cpu_governor ]]; then
-
-			frequency_min_cpu_governor=$(( $(<$fp_frequency_min_cpu_governor) / 1000 ))
-
-		fi
+		[[ -f $fp_frequency_min_cpu_governor ]] && frequency_min_cpu_governor=$(( $(<$fp_frequency_min_cpu_governor) / 1000 ))
 
 		local frequency_max_cpu_governor=2
 		local fp_frequency_max_cpu_governor='/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq'
-		if [[ -f $fp_frequency_max_cpu_governor ]]; then
-
-			frequency_max_cpu_governor=$(( $(<$fp_frequency_max_cpu_governor) / 1000 ))
-
-		fi
+		[[ -f $fp_frequency_max_cpu_governor ]] && frequency_max_cpu_governor=$(( $(<$fp_frequency_max_cpu_governor) / 1000 ))
 
 		local cpu_temp=$(G_OBTAIN_CPU_TEMP)
 		local cpu_temp_f='Unknown'
 		if disable_error=1 G_CHECK_VALIDINT "$cpu_temp"; then
 
-			cpu_temp_f="$(( ( $cpu_temp * 9 / 5 ) + 32 ))'f"
+			cpu_temp_f="$(( $cpu_temp * 9/5 + 32 ))'f"
 			cpu_temp+="'c"
 
 		fi
@@ -1557,17 +1605,17 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 		local memory_free=$(( $(mawk '/MemFree:/ {print $2;exit}' /proc/meminfo) / 1000 ))
 		local memory_usage=$(( $memory_total - $memory_free ))
 
-		#Create Menu List for Whiptail
+		# Create Menu List for Whiptail
 		# - this will list the menu options available for each device.
 		G_WHIP_MENU_ARRAY=()
 
-		#RPi: Overclocking
+		# RPi: Overclocking
 		(( $G_HW_MODEL < 10 )) && G_WHIP_MENU_ARRAY+=('Overclocking' ': Set Profile')
 
-		#CPU GOV
+		# CPU GOV
 		G_WHIP_MENU_ARRAY+=('CPU Governor' ": [$current_cpu_governor]")
 
-		#Ondemand/Interactive Throttle up menu
+		# Ondemand/Interactive Throttle up menu
 		if [[ $current_cpu_governor == 'ondemand' ||
 			$current_cpu_governor == 'conservative' ||
 			$current_cpu_governor == 'interactive' ]]; then
@@ -1577,7 +1625,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 		fi
 
-		#Ondemand extras
+		# Ondemand extras
 		if [[ $current_cpu_governor == 'ondemand' ]]; then
 
 			local current_cpu_sample_rate=$(( $(grep -m1 '^[[:blank:]]*CONFIG_CPU_ONDEMAND_SAMPLE_RATE=' /DietPi/dietpi.txt | sed 's/[^=]*=//') / 1000 )) #convert to ms
@@ -1589,7 +1637,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 		fi
 
-		#Define CPU scaling frequency or percent
+		# Define CPU scaling frequency or percent
 		local type_cpu_freq_info='MHz'
 		# - Intel
 		[[ -f /sys/devices/system/cpu/intel_pstate/max_perf_pct ]] && type_cpu_freq_info='%'
@@ -1606,7 +1654,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 		G_WHIP_MENU_ARRAY+=('CPU Frequency Limits' ": Max = [$user_frequency_max_text] | Min = [$user_frequency_min_text]")
 
-		#RPi extras
+		# RPi extras
 		if (( $G_HW_MODEL < 10 )); then
 
 			local current_cpu_temp_limit=$(grep -m1 'temp_limit' /DietPi/config.txt | sed 's/^[^=]*=//')
@@ -1622,8 +1670,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 		G_WHIP_MENU "Hardware : $G_HW_MODEL_DESCRIPTION \nCPU Temp: $cpu_temp : $cpu_temp_f\nRAM: $memory_total MB | Used: $memory_usage MB | Free: $memory_free MB"
 		if (( $? == 0 )); then
 
-			#Return to this menu
-			TARGETMENUID=4
+			TARGETMENUID=4 # Return to this menu
 
 			case "$G_WHIP_RETURNED_VALUE" in
 
@@ -1637,7 +1684,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 						if G_CHECK_VALIDINT $G_WHIP_RETURNED_VALUE $MIN_VALUE $MAX_VALUE; then
 
-							sed -i "/CONFIG_CPU_ONDEMAND_SAMPLE_DOWNFACTOR=/c\CONFIG_CPU_ONDEMAND_SAMPLE_DOWNFACTOR=$G_WHIP_RETURNED_VALUE" /DietPi/dietpi.txt
+							G_CONFIG_INJECT 'CONFIG_CPU_ONDEMAND_SAMPLE_DOWNFACTOR=' "CONFIG_CPU_ONDEMAND_SAMPLE_DOWNFACTOR=$G_WHIP_RETURNED_VALUE" /DietPi/dietpi.txt
 							/DietPi/dietpi/func/dietpi-set_cpu
 
 						fi
@@ -1648,8 +1695,8 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 				'Ondemand Sample Rate'*)
 
-					local index=-1
-					local input_fp=(
+					local file=''
+					local afile=(
 
 						'/sys/devices/system/cpu/cpufreq/ondemand/sampling_rate_min'
 						'/sys/devices/system/cpu/cpufreq/ondemand/min_sampling_rate'
@@ -1658,45 +1705,37 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 					)
 
-					for ((i=0; i<${#input_fp[@]}; i++))
+					for i in ${afile[@]}
 					do
 
-						if [[ -f ${input_fp[$i]} ]]; then
-
-							index=$i
-							break
-
-						fi
+						[[ -f $i ]] && file=$i && break
 
 					done
 
+					if [[ $file ]]; then
+
+						MIN_VALUE=$(( $(<$file) / 1000 ))
+
 					# - Unable to find min value, hard set it
-					if (( $index <= -1 )); then
-
-						MIN_VALUE=20 # RPi is min 20ms, however, no way to currently detect min available values...
-
 					else
 
-						MIN_VALUE=$(( $(<${input_fp[$index]}) / 1000 ))
+						MIN_VALUE=20 # RPi is min 20ms, however, no way to currently detect min available values...
 
 					fi
 
 					MAX_VALUE=300
 					G_WHIP_DEFAULT_ITEM=$current_cpu_sample_rate
-					G_WHIP_INPUTBOX "Please enter a sample rate in miliseconds, for Ondemand to check if it needs to increase CPU clocks.\nA lower value will make the system more responsive.\n - valid range: $MIN_VALUE - $MAX_VALUE"
+					G_WHIP_INPUTBOX "Please enter a sample rate in milliseconds, for Ondemand to check if it needs to increase CPU clocks.\nA lower value will make the system more responsive.\n - valid range: $MIN_VALUE - $MAX_VALUE"
 					if (( $? == 0 )); then
 
 						if G_CHECK_VALIDINT $G_WHIP_RETURNED_VALUE $MIN_VALUE $MAX_VALUE; then
 
-							sed -i "/CONFIG_CPU_ONDEMAND_SAMPLE_RATE=/c\CONFIG_CPU_ONDEMAND_SAMPLE_RATE=$(( $G_WHIP_RETURNED_VALUE * 1000 ))" /DietPi/dietpi.txt
-							#Apply changes
+							G_CONFIG_INJECT 'CONFIG_CPU_ONDEMAND_SAMPLE_RATE=' "CONFIG_CPU_ONDEMAND_SAMPLE_RATE=$(( $G_WHIP_RETURNED_VALUE * 1000 ))" /DietPi/dietpi.txt
 							/DietPi/dietpi/func/dietpi-set_cpu
 
 						fi
 
 					fi
-
-					unset input_fp
 
 				;;
 
@@ -1714,13 +1753,9 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 						readarray available_frequency_array < /tmp/dietpi-available_cpu_freqs
 						local division_factor=1000 #display MHz for user menu
 						# - Intel (disable conversion)
-						if [[ -f /sys/devices/system/cpu/intel_pstate/max_perf_pct ]]; then
+						[[ -f /sys/devices/system/cpu/intel_pstate/max_perf_pct ]] && division_factor=1
 
-							division_factor=1
-
-						fi
-
-						local index=0 #0=max | 1=min
+						local index=0 # 0=max | 1=min
 						while (( $index < 2 ))
 						do
 
@@ -1847,7 +1882,6 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 						if G_CHECK_VALIDINT $G_WHIP_RETURNED_VALUE $MIN_VALUE $MAX_VALUE; then
 
 							G_CONFIG_INJECT 'CONFIG_CPU_USAGE_THROTTLE_UP=' "CONFIG_CPU_USAGE_THROTTLE_UP=$G_WHIP_RETURNED_VALUE" /DietPi/dietpi.txt
-							#Apply changes
 							/DietPi/dietpi/func/dietpi-set_cpu
 
 						fi
@@ -1889,7 +1923,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 	Change_Hostname(){
 
-		#Get existing Hostname
+		# Get existing Hostname
 		local hostname_existing=$(</etc/hostname)
 		G_WHIP_DEFAULT_ITEM=$hostname_existing
 		if G_WHIP_INPUTBOX 'Please enter a new hostname' && [[ $hostname_existing != $G_WHIP_RETURNED_VALUE ]]; then
@@ -1900,7 +1934,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 			G_WHIP_YESNO "The Hostname has been changed: \n - From $hostname_existing \n - To $G_WHIP_RETURNED_VALUE\n\nA reboot now is highly recommended for hostname change, and, before continuing with any further changes.\n\nWould you like to reboot now?"
 			(( $? )) || reboot
 
-		#Aborted
+		# Aborted
 		else
 
 			G_WHIP_MSG 'Hostname change has been aborted. No changes have been applied.'
@@ -1923,8 +1957,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 		if G_WHIP_MENU 'Lock down your DietPi Install'; then
 
-			#Return to this menu
-			TARGETMENUID=5
+			TARGETMENUID=5 # Return to this menu
 
 			if (( $G_WHIP_RETURNED_VALUE == 1 )); then
 
@@ -1945,7 +1978,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 		TARGETMENUID=1
 
-		#Get Current and/or total (depends on board) mem split settings
+		# Get Current and/or total (depends on board) mem split settings
 		local gpu_mem_current=0
 		local ram_mem_current=$(free -m | mawk '/Mem:/ {print $2;exit}')
 		local ram_mem_total=$(grep -m1 'HW_MEMORY_SIZE=' /DietPi/dietpi/.hw_model | sed 's/^[^=]*=//')
@@ -1965,10 +1998,10 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 		fi
 
-		#RPi's
+		# RPi
 		if (( $G_HW_MODEL < 10 )); then
 
-			#Create array for storing menu selectable options.
+			# Create array for storing menu selectable options.
 			G_WHIP_MENU_ARRAY=(
 
 				16 ': Server'
@@ -1996,22 +2029,19 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 			G_WHIP_MENU "Hardware : $G_HW_MODEL_DESCRIPTION\nCurrent: $gpu_mem_current MB GPU | $ram_mem_current MB RAM"
 			if (( $? == 0 )); then
 
-				# Apply
 				/DietPi/dietpi/func/dietpi-set_hardware gpumemsplit $G_WHIP_RETURNED_VALUE
-
 				REBOOT_REQUIRED=1
 
-				#Return to this menu
-				TARGETMENUID=6
+				TARGETMENUID=6 # Return to this menu
 
 			fi
 
-		#Odroid C1
+		# Odroid C1
 		elif (( $G_HW_MODEL == 10 )); then
 
-			#Odroid HDMI/headless extra data
-			local display_output_enabled=$(cat /DietPi/boot.ini | grep -ci -m1 '^setenv hdmioutput "1"')
-			local display_vpu_enabled=$(cat /DietPi/boot.ini | grep -ci -m1 '^setenv vpu "1"')
+			# Odroid HDMI/headless extra data
+			local display_output_enabled=$(grep -ci -m1 '^setenv hdmioutput "1"' /DietPi/boot.ini)
+			local display_vpu_enabled=$(grep -ci -m1 '^setenv vpu "1"' /DietPi/boot.ini)
 			local display_output_text='[On]'
 			local display_vpu_text='[On]'
 
@@ -2031,8 +2061,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 				REBOOT_REQUIRED=1
 
-				#Return to this menu
-				TARGETMENUID=6
+				TARGETMENUID=6 # Return to this menu
 
 				case "$G_WHIP_RETURNED_VALUE" in
 
@@ -2045,7 +2074,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 					'Server')
 
 						/DietPi/dietpi/func/dietpi-set_hardware headless 0
-						sed -i '/setenv vpu /c\setenv vpu "0"' /DietPi/boot.ini
+						G_CONFIG_INJECT 'setenv vpu ' 'setenv vpu "0"' /DietPi/boot.ini
 
 					;;
 
@@ -2059,10 +2088,10 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 			fi
 
-		#C2
+		# Odroid C2
 		elif (( $G_HW_MODEL == 12 )); then
 
-			#Odroid HDMI/headless extra data
+			# Odroid HDMI/headless extra data
 			local display_output_enabled=$(grep -ci -m1 '^setenv nographics "0"' /DietPi/boot.ini)
 			local display_output_text='[On]'
 
@@ -2080,8 +2109,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 				REBOOT_REQUIRED=1
 
-				#Return to this menu
-				TARGETMENUID=6
+				TARGETMENUID=6 # Return to this menu
 
 				case "$G_WHIP_RETURNED_VALUE" in
 
@@ -2127,8 +2155,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 		G_WHIP_MENU 'Please select an option:'
 		if (( $? == 0 )); then
 
-			#Return to this menu
-			TARGETMENUID=7
+			TARGETMENUID=7 # Return to this menu
 
 			case "$G_WHIP_RETURNED_VALUE" in
 
@@ -2138,10 +2165,10 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 					G_FILE_EXISTS /usr/share/i18n/SUPPORTED
 
-					cat /usr/share/i18n/SUPPORTED | sed 's/#//g' | mawk '{print $1}' | grep 'UTF-8' > /tmp/available_locale
+					mawk '/UTF-8/ {print $1}' /usr/share/i18n/SUPPORTED | sed 's/#//g' > /tmp/available_locale
 					G_WHIP_MENU_ARRAY=()
 					local index=0
-					#	convert for whiptail 0-1=1st option 2-3=2nd
+					# convert for whiptail 0-1=1st option 2-3=2nd
 					while read line
 					do
 
@@ -2154,8 +2181,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 					rm /tmp/available_locale
 
 					G_WHIP_DEFAULT_ITEM=$locale_current
-					G_WHIP_MENU 'Please select a system locale. DietPi will automatically apply this as the default locale:'
-					if (( $? == 0 )); then
+					if G_WHIP_MENU 'Please select a system locale. DietPi will automatically apply this as the default locale:'; then
 
 						/DietPi/dietpi/func/dietpi-set_software locale "$G_WHIP_RETURNED_VALUE"
 
@@ -2206,14 +2232,14 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 			NET_RX_BYTE=$(</sys/class/net/$input/statistics/rx_bytes)
 			NET_TX_BYTE=$(</sys/class/net/$input/statistics/tx_bytes)
 			NET_RX_MB='Unknown'
-			if disable_error=1 G_CHECK_VALIDINT $NET_RX_BYTE && (( $NET_RX_BYTE > 0 )); then
+			if disable_error=1 G_CHECK_VALIDINT $NET_RX_BYTE 1; then
 
 				NET_RX_MB="$(( $NET_RX_BYTE / 1024 / 1024 ))MB"
 
 			fi
 
 			NET_TX_MB='Unknown'
-			if disable_error=1 G_CHECK_VALIDINT $NET_TX_BYTE && (( $NET_TX_BYTE > 0 )); then
+			if disable_error=1 G_CHECK_VALIDINT $NET_TX_BYTE 1; then
 
 				NET_TX_MB="$(( $NET_TX_BYTE / 1024 / 1024 ))MB"
 
@@ -2293,10 +2319,10 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 	Network_Restart(){
 
-		#Stop all services (required for hotspot)
+		# Stop all services (required for hotspot)
 		/DietPi/dietpi/dietpi-services stop
 
-		# Enable/Disable wifi modules
+		# Enable/Disable WiFi modules
 		if (( $WIFI_DISABLED )); then
 
 			/DietPi/dietpi/func/dietpi-set_hardware wifimodules disable
@@ -2307,34 +2333,34 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 		fi
 
-		#Drop Connections
+		# Drop Connections
 		G_DIETPI-NOTIFY 0 'Dropping connections, please wait...'
 		ifdown eth$ETH_DEV_INDEX --force &> /dev/null
 		ifdown wlan$WIFI_DEV_INDEX --force &> /dev/null
 
-		#Kill dhclient
+		# Kill dhclient
 		killall dhclient &> /dev/null
 
-		#Flush, not viable to handle this if change of IP, requires a detect of SSH loss/ip change, then exit script.
-		# ip addr flush dev eth$ETH_DEV_INDEX &> /dev/null
-		# ip addr flush dev wlan$WIFI_DEV_INDEX &> /dev/null
+		# Flush, not viable to handle this if change of IP, requires a detect of SSH loss/ip change, then exit script.
+		# - ip addr flush dev eth$ETH_DEV_INDEX &> /dev/null
+		# - ip addr flush dev wlan$WIFI_DEV_INDEX &> /dev/null
 
-		#Restart Networking
+		# Restart Networking
 		G_DIETPI-NOTIFY 2 'Restarting network, please wait...'
 		systemctl daemon-reload
 
-		#Manually bring up adapters
+		# Manually bring up adapters
 		(( $ETH_DISABLED == 0 )) && ifup eth$ETH_DEV_INDEX --force
 		(( $WIFI_DISABLED == 0 )) && ifup wlan$WIFI_DEV_INDEX --force
 
-		#Restart all services (required for hotspot)
+		# Restart all services (required for hotspot)
 		/DietPi/dietpi/dietpi-services start
 
 		# - Add a little delay to ensure all network device data are updated (eg: SSID current takes a little longer)
 		G_DIETPI-NOTIFY 2 'Reloading networking data, please wait...'
 		sleep 2
 
-		#Update network data
+		# Update network data
 		Network_GetData
 
 		G_DIETPI-NOTIFY 0 'Network restarted'
@@ -2351,7 +2377,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 	Network_ApplyChanges(){
 
-		#Eth
+		# Eth
 		local eth_enabled_text=''
 		(( $ETH_DISABLED )) && eth_enabled_text='#'
 
@@ -2368,7 +2394,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 		fi
 
-		#Wlan
+		# WiFi
 		local wifi_enabled_text=''
 		(( $WIFI_DISABLED )) && wifi_enabled_text='#'
 
@@ -2401,7 +2427,7 @@ netmask $ETH_MASK
 gateway $ETH_GATEWAY
 ${eth_dns_text}dns-nameservers $ETH_DNS
 
-# Wifi
+# WiFi
 ${wifi_enabled_text}allow-hotplug wlan$WIFI_DEV_INDEX
 iface wlan$WIFI_DEV_INDEX inet $wifi_dhcp_static_text
 address $WIFI_IP
@@ -2438,24 +2464,24 @@ _EOF_
 		# - Update WiFi db/wpa_supplicant
 		/DietPi/dietpi/func/dietpi-wifidb 1
 
-		#Update Current Mode for network restart
+		# Update Current Mode for network restart
 		ETH_MODE=$ETH_MODE_TARGET
 		WIFI_MODE=$WIFI_MODE_TARGET
 
-		#restart net
+		# Restart net
 		Network_Restart
 
 	}
 
 	Change_StaticIp(){
 
-		#Ethernet
+		# Ethernet
 		if (( $1 == 0 )); then
 
 			G_WHIP_DEFAULT_ITEM=$ETH_IP_STATIC
 			G_WHIP_INPUTBOX 'Please enter a new static IP address' && ETH_IP_STATIC=$G_WHIP_RETURNED_VALUE
 
-		#wifi
+		# WiFi
 		elif (( $1 == 1 )); then
 
 			G_WHIP_DEFAULT_ITEM=$WIFI_IP_STATIC
@@ -2467,13 +2493,13 @@ _EOF_
 
 	Change_StaticGateway(){
 
-		#Ethernet
+		# Ethernet
 		if (( $1 == 0 )); then
 
 			G_WHIP_DEFAULT_ITEM=$ETH_GATEWAY_STATIC
 			G_WHIP_INPUTBOX 'Please enter a new static Gateway address' && ETH_GATEWAY_STATIC=$G_WHIP_RETURNED_VALUE
 
-		#wifi
+		# WiFi
 		elif (( $1 == 1 )); then
 
 			G_WHIP_DEFAULT_ITEM=$WIFI_GATEWAY_STATIC
@@ -2485,13 +2511,13 @@ _EOF_
 
 	Change_StaticMask(){
 
-		#Ethernet
+		# Ethernet
 		if (( $1 == 0 )); then
 
 			G_WHIP_DEFAULT_ITEM=$ETH_MASK_STATIC
 			G_WHIP_INPUTBOX 'Please enter a new static Mask address' && ETH_MASK_STATIC=$G_WHIP_RETURNED_VALUE
 
-		#wifi
+		# WiFi
 		elif (( $1 == 1 )); then
 
 			G_WHIP_DEFAULT_ITEM=$WIFI_MASK_STATIC
@@ -2505,7 +2531,7 @@ _EOF_
 
 		#$1 = Adapater type | 0=Eth, 1=WiFi
 
-		#Store current into var
+		# Store current into var
 		local current_value=0
 
 		# - Ethernet
@@ -2522,7 +2548,7 @@ _EOF_
 
 		local return_value=$current_value
 
-		#Create Menu List for Whiptail
+		# Create Menu List for Whiptail
 		G_WHIP_MENU_ARRAY=(
 
 			'Custom' 'Manually enter your DNS server'
@@ -2560,7 +2586,7 @@ _EOF_
 
 		fi
 
-		#Apply new value
+		# Apply new value
 		# - Ethernet
 		if (( $1 == 0 )); then
 
@@ -2615,7 +2641,6 @@ _EOF_
 
 			esac
 
-			#Apply
 			/DietPi/dietpi/func/dietpi-set_hardware wificountrycode "$wifi_country_code_target"
 
 			# - Restart networking
@@ -2640,23 +2665,16 @@ _EOF_
 	Wifi_Reconnect(){
 
 		G_WHIP_YESNO "WiFi will connect to the strongest configured SSID that is secure, with an open SSID being the last priority.\n\nSave all changes and restart networking?\n\nNB: All WiFi connections will be dropped!"
-		if (( $? == 0 )); then
-
-			#Apply Changes
-			Network_ApplyChanges
-
-		fi
+		(( $? == 0 )) && Network_ApplyChanges
 
 	}
 
 	Ethernet_Reconnect(){
 
-		G_WHIP_YESNO 'Do you wish to apply settings and reconnect network now? \n\n(NOTICE) All Ethernet connections will be dropped!'
-		if (( $? == 0 )); then
+		if G_WHIP_YESNO 'Do you wish to apply settings and reconnect network now? \n\n(NOTICE) All Ethernet connections will be dropped!'; then
 
-			#Apply Changes
 			printf '\ec' # clear current terminal screen
-			echo -e 'Reconnecting Ethernet , please wait'
+			echo 'Reconnecting Ethernet , please wait...'
 			Network_ApplyChanges
 
 		fi
@@ -2668,13 +2686,13 @@ _EOF_
 
 	Network_GetData(){
 
-		#Update DietPi system network details
+		# Update DietPi system network details
 		/DietPi/dietpi/func/obtain_network_details
 
-		#Copy /etc/network/interfaces to /tmp (tmpfs) and pull data from it.
+		# Copy /etc/network/interfaces to /tmp (tmpfs) and pull data from it.
 		cp /etc/network/interfaces /tmp/net_interfaces
 
-		#Reset
+		# Reset
 		ETH_IP_STATIC=$(mawk '/address / {print $2;exit}' /tmp/net_interfaces)
 		ETH_GATEWAY_STATIC=$(mawk '/gateway / {print $2;exit}' /tmp/net_interfaces)
 		ETH_MASK_STATIC=$(mawk '/netmask / {print $2;exit}' /tmp/net_interfaces)
@@ -2714,7 +2732,7 @@ _EOF_
 		[[ ! $WIFI_SSID_CURRENT ]] && WIFI_SSID_CURRENT='Disconnected / No SSID'
 		WIFI_CRED_INDEX=0 # Which index of SSID/KEY etc we are editing
 
-		#Get extra wifi stats
+		# Get extra WiFi stats
 		WIFI_BITRATE=0
 		WIFI_SIGNALSTRENGTH=0
 		# - Hotspot enabled?
@@ -2754,20 +2772,20 @@ _EOF_
 
 		}
 
-		#eth
+		# Eth
 		if [[ -d /sys/class/net/eth$ETH_DEV_INDEX ]]; then
 
-			#Hardware
+			# Hardware
 			ETH_HARDWARE=1
 
-			#Static or DHCP?
+			# Static or DHCP?
 			ETH_MODE=$(grep -ci -m1 "iface eth$ETH_DEV_INDEX inet dhcp" /tmp/net_interfaces)
 			ETH_MODE_TARGET=$ETH_MODE
 
-			#Connected and Valid IP?
+			# Connected and Valid IP?
 			ETH_CONNECTED=$(ip -o r l dev eth$ETH_DEV_INDEX | grep -vcim1 '[[:blank:]]linkdown')
 
-			#Enabled and Connected
+			# Enabled and Connected
 			if (( $ETH_DISABLED == 0 && $ETH_CONNECTED == 1 )); then
 
 				ETH_IP=$(ip a s eth$ETH_DEV_INDEX | grep -m1 '^[[:blank:]]*inet ' | mawk '{print $2}' | sed 's|/.*$||')
@@ -2779,19 +2797,20 @@ _EOF_
 
 		fi
 
+		# WiFi
 		if [[ -d /sys/class/net/wlan$WIFI_DEV_INDEX ]]; then
 
-			#Hardware
+			# Hardware
 			WIFI_HARDWARE=1
 
-			#Static or DHCP?
+			# Static or DHCP?
 			WIFI_MODE=$(grep -ci -m1 "iface wlan$WIFI_DEV_INDEX inet dhcp" /tmp/net_interfaces)
 			WIFI_MODE_TARGET=$WIFI_MODE
 
-			#Connected and Valid IP?
+			# Connected and Valid IP?
 			WIFI_CONNECTED=$(ip -o r l dev wlan$ETH_DEV_INDEX | grep -vcim1 '[[:blank:]]linkdown')
 
-			#Enabled and Connected
+			# Enabled and Connected
 			if (( $WIFI_DISABLED == 0 && $WIFI_CONNECTED == 1 )); then
 
 				WIFI_IP=$(ip a s wlan$WIFI_DEV_INDEX | grep -m1 '^[[:blank:]]*inet ' | mawk '{print $2}' | sed 's|/.*$||')
@@ -2799,7 +2818,7 @@ _EOF_
 				WIFI_MASK=$(cidr2mask $(ip a s wlan$WIFI_DEV_INDEX | grep -m1 '^[[:blank:]]*inet ' | mawk '{print $2}' | sed 's|^.*/||'))
 				WIFI_DNS=$(mawk '/nameserver/ {print $2;exit}' /etc/resolv.conf)
 
-				#Get extra wifi stats
+				# Get extra WiFi stats
 				WIFI_BITRATE=$(iwconfig wlan$WIFI_DEV_INDEX | mawk '/Bit Rate/ {print $2;exit}' | sed 's/Rate[:=]//g')
 				WIFI_SIGNALSTRENGTH=$(iwconfig wlan$WIFI_DEV_INDEX | mawk '/Signal level=/ {print $4;exit}' | sed 's/level=//g' | cut -f1 -d "/")
 
@@ -2818,7 +2837,7 @@ _EOF_
 
 		fi
 
-		#cleanup tmp
+		# Cleanup tmp
 		[[ -f /tmp/net_interfaces ]] && rm /tmp/net_interfaces
 
 	}
@@ -2828,26 +2847,26 @@ _EOF_
 
 		TARGETMENUID=0
 
-		#Check Network
+		# Check Network
 		Network_GetData
 
 		G_WHIP_MENU_ARRAY=()
 
-		#Obtain enabled/disabled status
+		# Obtain enabled/disabled status
 		local eth_disabled_text='[On]'
 		(( $ETH_DISABLED )) && eth_disabled_text='[Off]'
 
 		local wlan_disabled_text='[On]'
 		(( $WIFI_DISABLED )) && wlan_disabled_text='[Off]'
 
-		#Obtain Hardware Status
+		# Obtain Hardware Status
 		local eth_hardware_text='Available'
 		(( ! $ETH_HARDWARE )) && eth_hardware_text='Not Found'
 
 		local wlan_hardware_text='Available'
 		(( ! $WIFI_HARDWARE )) && wlan_hardware_text='Not Found'
 
-		#Obtain Connected/Carrier Status
+		# Obtain Connected/Carrier Status
 		local eth_connected_text='Disconnected'
 		(( $ETH_CONNECTED )) && eth_connected_text='Connected'
 
@@ -2859,7 +2878,7 @@ _EOF_
 
 		fi
 
-		#Internet Connection Status
+		# Internet Connection Status
 		local Internet_connected_text='Please run Internet Test'
 		if (( $INTERNET_TEST_STATE == 2 )); then
 
@@ -2871,7 +2890,7 @@ _EOF_
 
 		fi
 
-		#Proxy settings (global vars, force an int to obtain current values stored in dietpi.txt)
+		# Proxy settings (global vars, force an int to obtain current values stored in dietpi.txt)
 		Load_Proxy_Vars
 
 		local proxy_state_text='[Off]'
@@ -2904,7 +2923,7 @@ _EOF_
 
 		G_WHIP_MENU_ARRAY+=('' '●─ Additional Options ')
 
-		#IPv6
+		# IPv6
 		local ipv6_status_text='[WARNING] Not supported or disabled on kernel level!'
 		if [[ -d /proc/sys/net/ipv6 ]]; then
 
@@ -2942,8 +2961,7 @@ _EOF_
 		G_WHIP_MENU "Ethernet     : $eth_hardware_text | $eth_disabled_text | $eth_connected_text \nWifi         : $wlan_hardware_text | $wlan_disabled_text | $wlan_connected_text\nIPv6         : $ipv6_status_text$ipv4_status_long\nInternet     : $Internet_connected_text\nProxy        : $proxy_state_text"
 		if (( $? == 0 )); then
 
-			#Return to this Menu
-			TARGETMENUID=8
+			TARGETMENUID=8 # Return to this menu
 
 			case "$G_WHIP_RETURNED_VALUE" in
 
@@ -2959,20 +2977,18 @@ _EOF_
 
 					fi
 
-					REBOOT_REQUIRED=1
-
 					G_WHIP_MSG 'Onboard WiFi modules setting applied\n\nNB: A reboot is required for the changes to take effect.'
 
 				;;
 
 				'IPv6')
 
-					#Disable
+					# Disable
 					if (( $ipv6_enabled )); then
 
 						/DietPi/dietpi/func/dietpi-set_hardware enableipv6 0
 
-					#Enable
+					# Enable
 					else
 
 						/DietPi/dietpi/func/dietpi-set_hardware enableipv6 1
@@ -2983,12 +2999,12 @@ _EOF_
 
 				'Prefer IPv4')
 
-					#Don't prefer
+					# Don't prefer
 					if (( $ipv4_preferred )); then
 
 						/DietPi/dietpi/func/dietpi-set_hardware preferipv4 0
 
-					#Prefer
+					# Prefer
 					else
 
 						/DietPi/dietpi/func/dietpi-set_hardware preferipv4 1
@@ -2999,12 +3015,12 @@ _EOF_
 
 				'Ethernet')
 
-					#No hardware found
+					# No hardware found
 					if (( ! $ETH_HARDWARE )); then
 
 						G_WHIP_MSG 'No Ethernet Hardware was found. You are most likely running a Pi Model A.'
 
-					#Disabled
+					# Disabled
 					elif (( $ETH_DISABLED )); then
 
 						G_WHIP_YESNO 'Ethernet must be enabled before settings can be changed.\n\nWould you like to enable Ethernet now?\n - (NOTICE) Connections may drop!'
@@ -3026,7 +3042,7 @@ _EOF_
 
 				'WiFi')
 
-					#Disabled | Offer chance to enable (also enables wifi modules)
+					# Disabled | Offer chance to enable (also enables wifi modules)
 					if (( $WIFI_DISABLED )); then
 
 						G_WHIP_YESNO 'WiFi must be enabled before settings can be changed.\n\nWould you like to enable WiFi now? \n - (NOTICE) Connections may drop!'
@@ -3037,7 +3053,7 @@ _EOF_
 
 						fi
 
-					# - No hardware found
+					# No hardware found
 					elif (( ! $WIFI_HARDWARE )); then
 
 						G_WHIP_YESNO 'No supported Wifi Hardware was found.\n\nWould you like to disable WiFi? \n - (NOTICE) Connections may drop!'
@@ -3059,20 +3075,19 @@ _EOF_
 				'Test')
 
 					G_WHIP_DEFAULT_ITEM=$INTERNET_TEST_URL
-					G_WHIP_INPUTBOX 'Press enter a URL address to test (eg: http://google.com)'
-					if (( $? == 0 )); then
+					if G_WHIP_INPUTBOX 'Press enter a URL address to test (eg: http://google.com)'; then
 
 						INTERNET_TEST_URL=$G_WHIP_RETURNED_VALUE
 
-						INTERNET_TEST_STATE=0 #Not tested
+						INTERNET_TEST_STATE=0 # Not tested
 						G_ERROR_HANDLER_INFO_ONLY=1 retry_max=2 G_CHECK_URL "$INTERNET_TEST_URL"
 						if (( $G_ERROR_HANDLER_EXITCODE_RETURN == 0 )); then
 
-							INTERNET_TEST_STATE=2 #Online
+							INTERNET_TEST_STATE=2 # Online
 
 						else
 
-							INTERNET_TEST_STATE=1 #Failed
+							INTERNET_TEST_STATE=1 # Failed
 
 						fi
 
@@ -3088,14 +3103,13 @@ _EOF_
 
 			esac
 
-		#Cancel
+		# Cancel
 		else
 
-			#Exit DietPi-Config on back to previous menu?
+			# Exit DietPi-Config on back to previous menu?
 			if (( $EXITONBACK == 1 )); then
 
-				#Return to this menu
-				TARGETMENUID=8
+				TARGETMENUID=8 # Return to this menu
 				Menu_Exit
 
 			fi
@@ -3143,8 +3157,7 @@ _EOF_
 		G_WHIP_MENU "Ethernet Details:\nUsage   : Sent = $NET_TX_MB | Recieved = $NET_RX_MB\nAddress : IP = $ETH_IP | Mask = $ETH_MASK | Gateway = $ETH_GATEWAY | DNS = $ETH_DNS"
 		if (( $? == 0 )); then
 
-			#Return to this menu
-			TARGETMENUID=9
+			TARGETMENUID=9 # Return to this menu
 
 			WHIP_SELECTION_PREVIOUS=$G_WHIP_RETURNED_VALUE
 
@@ -3242,7 +3255,7 @@ _EOF_
 
 		G_WHIP_MENU_ARRAY=('' '●─ Basic Options ')
 
-		#WiFi Hotspot Menu
+		# WiFi Hotspot Menu
 		if (( $WIFI_HOTSPOT )); then
 
 			# - Load current details into global vars, once.
@@ -3286,7 +3299,7 @@ _EOF_
 
 			description_text+=$hotspot_status_text
 
-		#WiFi Menu
+		# WiFi Menu
 		else
 
 			# - Get current Mode details
@@ -3361,8 +3374,7 @@ _EOF_
 		G_WHIP_DEFAULT_ITEM=$WHIP_SELECTION_PREVIOUS
 		if G_WHIP_MENU "$description_text"; then
 
-			#Return to this menu
-			TARGETMENUID=10
+			TARGETMENUID=10 # Return to this menu
 
 			WHIP_SELECTION_PREVIOUS=$G_WHIP_RETURNED_VALUE
 
@@ -3614,8 +3626,7 @@ Additional benchmarks:
  - Network LAN       : Transfer rate = $BENCH_NET_LAN_SPEED MB/s"
 		if (( $? == 0 )); then
 
-			#Return to this menu
-			TARGETMENUID=12
+			TARGETMENUID=12 # Return to this menu
 
 			case "$G_WHIP_RETURNED_VALUE" in
 
@@ -3702,7 +3713,7 @@ Additional benchmarks:
 			sed -i '/core_freq=/c\#core_freq=250' /DietPi/config.txt
 			sed -i '/sdram_freq=/c\#sdram_freq=400' /DietPi/config.txt
 
-			#Zero , via name id
+			# Zero , via name id
 			if grep -qi 'rpi zero' /DietPi/dietpi/.hw_model; then
 
 				sed -i '/arm_freq=/c\#arm_freq=1000' /DietPi/config.txt
@@ -3728,27 +3739,22 @@ Additional benchmarks:
 
 		TARGETMENUID=4
 
-		#Get Current Overclocking Settings
+		# Get Current Overclocking Settings
 		local over_voltage_value=$(grep -m1 'over_voltage=' /DietPi/config.txt | tr -d '#over_voltage=')
 		local arm_freq_value=$(grep -m1 'arm_freq=' /DietPi/config.txt | tr -d '#arm_freq=')
 		local core_freq_value=$(grep -m1 'core_freq=' /DietPi/config.txt | tr -d '#core_freq=')
 		local sdram_freq_value=$(grep -m1 'sdram_freq=' /DietPi/config.txt | tr -d '#sdram_freq=')
 
-		#Overclocking Pi1
+		# Overclocking RPi1
 		# - Zero
 		if grep -qi 'rpi zero' /DietPi/dietpi/.hw_model; then
 
-			G_WHIP_MENU_ARRAY=(
-
-				'none' ': 1000 MHz ARM | 400 MHz core | 450 MHz SDRAM | 0 overvolt'
-
-			)
+			G_WHIP_MENU_ARRAY=('none' ': 1000 MHz ARM | 400 MHz core | 450 MHz SDRAM | 0 overvolt')
 
 			G_WHIP_MENU "Hardware : $G_HW_MODEL_DESCRIPTION\nCurrent: $arm_freq_value MHz ARM | $core_freq_value MHz core | $sdram_freq_value MHz SDRAM | $over_voltage_value overvolt"
 			if (( $? == 0 )); then
 
-				#Return to this menu
-				TARGETMENUID=13
+				TARGETMENUID=13 # Return to this menu
 
 				case "$G_WHIP_RETURNED_VALUE" in
 
@@ -3776,8 +3782,7 @@ Additional benchmarks:
 			G_WHIP_MENU "Hardware : $G_HW_MODEL_DESCRIPTION\nCurrent: $arm_freq_value MHz ARM | $core_freq_value MHz core | $sdram_freq_value MHz SDRAM | $over_voltage_value overvolt"
 			if (( $? == 0 )); then
 
-				#Return to this menu
-				TARGETMENUID=13
+				TARGETMENUID=13 # Return to this menu
 
 				case "$G_WHIP_RETURNED_VALUE" in
 					'none')
@@ -3824,7 +3829,7 @@ Additional benchmarks:
 
 			fi
 
-		#Overclocking Pi2
+		# Overclocking Pi2
 		elif (( $G_HW_MODEL == 2 )); then
 
 			G_WHIP_MENU_ARRAY=(
@@ -3839,8 +3844,7 @@ Additional benchmarks:
 			G_WHIP_MENU "Hardware : $G_HW_MODEL_DESCRIPTION\nCurrent: $arm_freq_value MHz ARM | $core_freq_value MHz core | $sdram_freq_value MHz SDRAM | $over_voltage_value overvolt"
 			if (( $? == 0 )); then
 
-				#Return to this menu
-				TARGETMENUID=13
+				TARGETMENUID=13 # Return to this menu
 
 				case "$G_WHIP_RETURNED_VALUE" in
 
@@ -3892,16 +3896,12 @@ Additional benchmarks:
 
 			fi
 
-		#Overclocking Pi3
+		# Overclocking Pi3
 		elif (( $G_HW_MODEL == 3 )); then
 
 			if grep -qi 'RPi 3 Model B+' /DietPi/dietpi/.hw_model; then
 
-				G_WHIP_MENU_ARRAY=(
-
-					'none' ': 1400 MHz ARM | 400 MHz core | 500 MHz SDRAM | 0 overvolt'
-
-				)
+				G_WHIP_MENU_ARRAY=('none' ': 1400 MHz ARM | 400 MHz core | 500 MHz SDRAM | 0 overvolt')
 
 			else
 
@@ -3919,8 +3919,7 @@ Additional benchmarks:
 			G_WHIP_MENU "Hardware : $G_HW_MODEL_DESCRIPTION \nCurrent: $arm_freq_value MHz ARM | $core_freq_value MHz core | $sdram_freq_value MHz SDRAM | $over_voltage_value overvolt"
 			if (( $? == 0 )); then
 
-				#Return to this menu
-				TARGETMENUID=13
+				TARGETMENUID=13 # Return to this menu
 
 				case "$G_WHIP_RETURNED_VALUE" in
 
@@ -4017,8 +4016,7 @@ Additional benchmarks:
 
 		if G_WHIP_MENU 'Please select an option:'; then
 
-			#Return to This Menu
-			TARGETMENUID=14
+			TARGETMENUID=14 # Return to this menu
 
 			if [[ $G_WHIP_RETURNED_VALUE == 'PSU noise reduction' ]]; then
 
@@ -4047,7 +4045,7 @@ Additional benchmarks:
 				G_WHIP_MENU_ARRAY=()
 
 				# - Global:
-				#	RPI, none disables HDMI aswell.
+				#	RPi, none disables HDMI as well.
 				if (( $G_HW_MODEL < 10 )); then
 
 					G_WHIP_MENU_ARRAY+=('none' ': Disables HDMI + 3.5mm Analogue')
@@ -4065,11 +4063,7 @@ Additional benchmarks:
 					G_WHIP_MENU_ARRAY+=('default' ': HW:0,0')
 
 					#	Install prereqs to allow for detection
-					if dpkg-query -s alsa-utils &> /dev/null; then
-
-						/DietPi/dietpi/func/dietpi-set_hardware soundcard default
-
-					fi
+					dpkg-query -s alsa-utils &> /dev/null || /DietPi/dietpi/func/dietpi-set_hardware soundcard default
 
 					for i in {0..9}
 					do
@@ -4155,9 +4149,9 @@ Additional benchmarks:
 					G_WHIP_MENU_ARRAY+=('H3-analogue' ': 3.5mm analogue')
 
 				# - H5
-				# elif (( $G_HW_CPUID == 2 )); then
+				#elif (( $G_HW_CPUID == 2 )); then
 
-					# G_WHIP_MENU_ARRAY+=('H5-analogue' '3.5mm analogue')
+					#G_WHIP_MENU_ARRAY+=('H5-analogue' '3.5mm analogue')
 
 				# - Sparky
 				elif (( $G_HW_MODEL == 70 )); then
@@ -4197,7 +4191,7 @@ Additional benchmarks:
 	}
 
 	#TARGETMENUID=15
-	STRESS_TEST_MODE=0 #0=CPU only | 1=CPU/RAM 2=CPU/RAM/IO
+	STRESS_TEST_MODE=0 # 0=CPU only | 1=CPU/RAM 2=CPU/RAM/IO
 	STRESS_TEST_DURATION=60
 	STRESS_TEST_RESULTS_TEMP_MIN=0
 	STRESS_TEST_RESULTS_TEMP_MAX=0
@@ -4227,8 +4221,7 @@ Additional benchmarks:
 
 		if G_WHIP_MENU 'Please select an option:'; then
 
-			#Return to this menu
-			TARGETMENUID=15
+			TARGETMENUID=15 # Return to this menu
 
 			if [[ $G_WHIP_RETURNED_VALUE == 'Duration' ]]; then
 
@@ -4243,11 +4236,7 @@ Additional benchmarks:
 				)
 
 				G_WHIP_DEFAULT_ITEM=$STRESS_TEST_DURATION
-				if G_WHIP_MENU 'Please select a duration for the test'; then
-
-					STRESS_TEST_DURATION=$G_WHIP_RETURNED_VALUE
-
-				fi
+				G_WHIP_MENU 'Please select a duration for the test' && STRESS_TEST_DURATION=$G_WHIP_RETURNED_VALUE
 
 			elif [[ $G_WHIP_RETURNED_VALUE == 'Mode' ]]; then
 
@@ -4260,11 +4249,7 @@ Additional benchmarks:
 				)
 
 				G_WHIP_DEFAULT_ITEM=$STRESS_TEST_MODE
-				if G_WHIP_MENU 'Please select a stress test type'; then
-
-					STRESS_TEST_MODE=$G_WHIP_RETURNED_VALUE
-
-				fi
+				G_WHIP_MENU 'Please select a stress test type' && STRESS_TEST_MODE=$G_WHIP_RETURNED_VALUE
 
 			elif [[ $G_WHIP_RETURNED_VALUE == 'Start' ]]; then
 
@@ -4361,10 +4346,10 @@ Additional benchmarks:
 
 		TARGETMENUID=0
 
-		#Update installed software
+		# Update installed software
 		Load_Installed_Software
 
-		#No-IP Client
+		# No-IP Client
 		local noip_installed=0
 		local noip_status='Not Installed'
 		local noip_menutext='Install No-IP now'
@@ -4374,7 +4359,7 @@ Additional benchmarks:
 			noip_status='Offline - Please enter No-IP details'
 			noip_menutext='Enter/Setup No-IP details'
 
-			#Check if No-IP is running (indicates login details are valid)
+			# Check if No-IP is running (indicates login details are valid)
 			if pgrep '/usr/local/bin/noip2' &> /dev/null; then
 
 				noip_status='Online / Active'
@@ -4384,15 +4369,15 @@ Additional benchmarks:
 
 		fi
 
-		#APT mirror
+		# APT mirror
 		local apt_mirror_current=$(grep -m1 '^[[:blank:]]*deb[[:blank:]]' /etc/apt/sources.list | mawk '{print $2}')
 		[[ $apt_mirror_current ]] || apt_mirror_current='Unknown, no string from scrape'
 
-		#NTP mirror
+		# NTP mirror
 		local ntp_mirror_current=$(grep -m1 '^[[:blank:]]*CONFIG_NTP_MIRROR=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 		[[ $ntp_mirror_current ]] || ntp_mirror_current='Unknown, no string from scrape'
 
-		#Network boot wait
+		# Network boot wait
 		local boot_wait_for_network=$(grep -m1 '^[[:blank:]]*CONFIG_BOOT_WAIT_FOR_NETWORK=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 		local boot_wait_for_network_text=''
 		if (( $boot_wait_for_network == 0 )); then
@@ -4423,8 +4408,7 @@ Additional benchmarks:
 
 		if G_WHIP_MENU ''; then
 
-			#Return to this Menu
-			TARGETMENUID=16
+			TARGETMENUID=16 # Return to this menu
 
 			case "$G_WHIP_RETURNED_VALUE" in
 
@@ -4453,12 +4437,8 @@ Additional benchmarks:
 
 				'APT Mirror')
 
-					#Create Menu List for Whiptail
-					G_WHIP_MENU_ARRAY=(
-
-						'Custom' ': Manually enter APT mirror'
-
-					)
+					# Create Menu List for Whiptail
+					G_WHIP_MENU_ARRAY=('Custom' ': Manually enter APT mirror')
 
 					# - Raspbian
 					if (( $G_HW_MODEL < 10 )); then
@@ -4510,7 +4490,7 @@ Additional benchmarks:
 
 				'NTP Mirror')
 
-					#Create Menu List for Whiptail
+					# Create Menu List for Whiptail
 					G_WHIP_MENU_ARRAY=(
 
 						'Gateway' ': Use local router as NTP server (Recommended)'
@@ -4584,7 +4564,7 @@ NB: If you need to use *.pool.ntp.org servers, enter the base domain only. The s
 
 				'No-IP')
 
-					#Installed?
+					# Installed?
 					if (( ! $noip_installed )); then
 
 						G_WHIP_YESNO 'No-IP Client is not installed, would you like to install it now?\n
@@ -4595,7 +4575,7 @@ NB: If you need to use *.pool.ntp.org servers, enter the base domain only. The s
 
 						printf '\ec' # clear current terminal screen
 						G_RUN_CMD systemctl stop noip2
-						#Failsafe: Directory required for "noip2 -C" to create the config file there
+						# Failsafe: Directory required for "noip2 -C" to create the config file there
 						mkdir -p /usr/local/etc
 						noip2 -C
 						read -p 'Press any key to continue...'
@@ -4607,14 +4587,13 @@ NB: If you need to use *.pool.ntp.org servers, enter the base domain only. The s
 
 			esac
 
-		#Cancel
+		# Cancel
 		else
 
-			#Exit DietPi-Config on back to previous menu?
+			# Exit DietPi-Config on back to previous menu?
 			if (( $EXITONBACK == 1 )); then
 
-				#Return to this menu
-				TARGETMENUID=16
+				TARGETMENUID=16 # Return to this menu
 				Menu_Exit
 
 			fi
@@ -4629,7 +4608,7 @@ NB: If you need to use *.pool.ntp.org servers, enter the base domain only. The s
 	PROXY_USERNAME=''
 	PROXY_PASSWORD=''
 
-	#So we can call this in other menus (eg: submenu of this)
+	# So we can call this in other menus (eg: submenu of this)
 	Load_Proxy_Vars(){
 
 		PROXY_ENABLED=$(grep -m1 '^[[:blank:]]*CONFIG_PROXY_ENABLED=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
@@ -4645,7 +4624,7 @@ NB: If you need to use *.pool.ntp.org servers, enter the base domain only. The s
 
 		TARGETMENUID=8
 
-		#Get current details on first menu init (PROXY_ENABLED=-1)
+		# Get current details on first menu init (PROXY_ENABLED=-1)
 		if (( $PROXY_ENABLED == -1 )); then
 
 			Load_Proxy_Vars
@@ -4672,8 +4651,7 @@ NB: If you need to use *.pool.ntp.org servers, enter the base domain only. The s
 		G_WHIP_MENU "Current Details:\n - Status: $proxy_state_text\n - Address: $PROXY_ADDRESS\n - Port: $PROXY_PORT\n - Username: $PROXY_USERNAME\n - Password: $PROXY_PASSWORD"
 		if (( $? == 0 )); then
 
-			#Return to this menu
-			TARGETMENUID=17
+			TARGETMENUID=17 # Return to this menu
 
 			case "$G_WHIP_RETURNED_VALUE" in
 
@@ -4774,7 +4752,7 @@ _EOF_
 	#/////////////////////////////////////////////////////////////////////////////////////
 	if (( $G_DIETPI_INSTALL_STAGE >= 0 )); then
 
-		#Start DietPi-Config
+		# Start DietPi-Config
 		while (( $TARGETMENUID >= 0 )); do
 
 			printf '\ec' # clear current terminal screen
@@ -4866,7 +4844,7 @@ Please report it to: https://github.com/MichaIng/DietPi/issues"
 
 	else
 
-		echo -e ' >> Filesystem prep has not yet completed:\n Please wait for the system to reboot'
+		G_WHIP_MSG '[INFO] First run setup has not reached sufficient state.\n\nPlease reboot before using DietPi-Config. If the issue persists, please report this as bug.'
 
 	fi
 

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -17,15 +17,15 @@
 	# - iEXITONBACK - 1=Exit DietPi-Config when going back to previous menu (applied to TARGETMENUINDEX 8 only!!)
 	#////////////////////////////////////
 
-	#Import DietPi-Globals ---------------------------------------------------------------
+	# Import DietPi-Globals --------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
 	G_PROGRAM_NAME='DietPi-Config'
 	G_CHECK_ROOT_USER
 	G_CHECK_ROOTFS_RW
 	G_INIT
-	#Import DietPi-Globals ---------------------------------------------------------------
+	# Import DietPi-Globals --------------------------------------------------------------
 
-	#Grab Inputs
+	# Grab Inputs
 	# - target MENU INDEX (valid interger)
 	disable_error=1 G_CHECK_VALIDINT "$1" && TARGETMENUID=$1
 
@@ -38,29 +38,20 @@
 	fi
 
 	#/////////////////////////////////////////////////////////////////////////////////////
-	#Obtain Hardware Details
+	# Obtain Hardware Details
 	#/////////////////////////////////////////////////////////////////////////////////////
 	HW_ONBOARD_WIFI=$(sed -n 10p /DietPi/dietpi/.hw_model)
 	FP_CPU_SCALING_GOV='/sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors'
 
 	#/////////////////////////////////////////////////////////////////////////////////////
-	#Obtain Installed software
+	# Obtain Installed software
 	#/////////////////////////////////////////////////////////////////////////////////////
-	Load_Installed_Software(){
-
-		[[ -f /DietPi/dietpi/.installed ]] && . /DietPi/dietpi/.installed
-
-	}
+	Load_Installed_Software(){ [[ -f /DietPi/dietpi/.installed ]] && . /DietPi/dietpi/.installed; }
 
 	#/////////////////////////////////////////////////////////////////////////////////////
-	#Whiltail Info
+	# Whiltail Info
 	#/////////////////////////////////////////////////////////////////////////////////////
-	HW_MSG_NOTSUPPORTED='Not Supported'
-	Info_HW_OptionNotSupported(){
-
-		G_WHIP_MSG "This option is not available for $G_HW_MODEL_DESCRIPTION"
-
-	}
+	Info_HW_OptionNotSupported(){ G_WHIP_MSG "This option is not available for $G_HW_MODEL_DESCRIPTION"; }
 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# MENUS
@@ -73,11 +64,11 @@
 
 	REBOOT_REQUIRED=0
 
-	#Interger min/max value holders
+	# Interger min/max value holders
 	MIN_VALUE=0
 	MAX_VALUE=0
 
-	#TARGETMENUID=0
+	# TARGETMENUID=0
 	Menu_Main(){
 
 		G_WHIP_MENU_ARRAY=('1' ': Display Options')
@@ -159,7 +150,7 @@
 
 	Menu_Exit(){
 
-		# TARGETMENUID = -1 , if we are to exit the menu
+		# TARGETMENUID=-1, if we are to exit DietPi-Config
 		G_WHIP_SIZE_X_MAX=50
 		if G_WHIP_YESNO "Exit $G_PROGRAM_NAME?"; then
 
@@ -212,7 +203,7 @@
 
 	}
 
-	#TARGETMENUID=1
+	# TARGETMENUID=1
 	Menu_DisplayOptions(){
 
 		TARGETMENUID=0
@@ -238,7 +229,7 @@
 
 		fi
 
-		#Display brightness
+		# Display brightness
 		G_WHIP_MENU_ARRAY+=('16' ': Display Brightness')
 
 		local xorg_dpi_current=$(grep -m1 '^[[:blank:]]*SOFTWARE_XORG_DPI=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
@@ -246,7 +237,7 @@
 
 		(( $G_HW_MODEL != 20 )) && G_WHIP_MENU_ARRAY+=('14' ': LED Control')
 
-		#RPi only
+		# RPi only
 		if (( $G_HW_MODEL < 10 )); then
 
 			# HDMI rotation
@@ -262,7 +253,7 @@
 			local overscan_text='[On]'
 			(( $overscan_disabled )) && overscan_text='[Off]'
 			G_WHIP_MENU_ARRAY+=('6' ": Overscan            : $overscan_text")
-			#	- Overscan sizes
+			# - Overscan sizes
 			if (( ! $overscan_disabled )); then
 
 				local overscan_options=(
@@ -319,7 +310,7 @@
 
 		fi
 
-		#Odroid Remote
+		# Odroid Remote
 		if (( $G_HW_MODEL >= 10 && $G_HW_MODEL <= 12 )); then
 
 			local odroid_remote_text='[Off]'
@@ -371,9 +362,7 @@
 				# RPi and Odroids only
 				if (( $G_HW_MODEL < 20 )); then
 
-					G_WHIP_MENU_ARRAY=()
-
-					G_WHIP_MENU_ARRAY+=('none' ': Uninstall all panels')
+					G_WHIP_MENU_ARRAY=('none' ': Uninstall all panels')
 					G_WHIP_MENU_ARRAY+=('waveshare32' ': 320x240 panel with touch input')
 
 					if (( $G_HW_MODEL < 10 )); then
@@ -405,7 +394,7 @@
 
 				if (( $G_HW_MODEL < 10 || $G_HW_MODEL == 10 || $G_HW_MODEL == 12 )); then
 
-					G_WHIP_MSG 'GPU/RAM Memory splits are pre-configured and applied during DietPi-Software setup. \n \nThe split value is optimized based on your software installs, however, feel free to tweak them.'
+					G_WHIP_MSG 'GPU/RAM Memory splits are pre-configured and applied during DietPi-Software setup.\n\nThe split value is optimized based on your software installs, however, feel free to tweak them.'
 					TARGETMENUID=6
 
 				else
@@ -416,7 +405,7 @@
 
 			elif (( $G_WHIP_RETURNED_VALUE == 6 )); then
 
-				#RPI only
+				# RPi only
 				if (( $G_HW_MODEL < 10 )); then
 
 					if (( $overscan_disabled )); then
@@ -444,7 +433,7 @@
 
 			elif (( $G_WHIP_RETURNED_VALUE == 7 )); then
 
-				#RPI only
+				# RPi only
 				if (( $G_HW_MODEL < 10 )); then
 
 					G_WHIP_MENU_ARRAY=(
@@ -478,7 +467,7 @@
 
 			elif (( $G_WHIP_RETURNED_VALUE == 8 )); then
 
-				#RPI only
+				# RPi only
 				if (( $G_HW_MODEL < 10 )); then
 
 					if (( $rpi_camera_module_enabled )); then
@@ -500,17 +489,15 @@
 
 			elif (( $G_WHIP_RETURNED_VALUE == 9 )); then
 
-				#RPI only
+				# RPi only
 				if (( $G_HW_MODEL < 10 )); then
 
 					if (( $rpi_camera_led_disabled )); then
 
-						#disable
 						G_CONFIG_INJECT 'disable_camera_led=' 'disable_camera_led=0' /DietPi/config.txt
 
 					else
 
-						#enable
 						G_CONFIG_INJECT 'disable_camera_led=' 'disable_camera_led=1' /DietPi/config.txt
 
 					fi
@@ -524,7 +511,6 @@
 
 			elif (( $G_WHIP_RETURNED_VALUE == 10 )); then
 
-				# - Enable
 				if (( $odroid_remote_enabled )); then
 
 					/DietPi/dietpi/func/dietpi-set_hardware remoteir none
@@ -539,12 +525,10 @@
 					fi
 
 				fi
-
 				REBOOT_REQUIRED=1
 
 			elif (( $G_WHIP_RETURNED_VALUE == 11 )); then
 
-				# - Enable
 				if (( $justboom_ir_remote_enabled )); then
 
 					/DietPi/dietpi/func/dietpi-set_hardware remoteir none
@@ -559,7 +543,6 @@
 					fi
 
 				fi
-
 				REBOOT_REQUIRED=1
 
 			elif (( $G_WHIP_RETURNED_VALUE == 12 )); then
@@ -569,7 +552,7 @@
 
 					G_CONFIG_INJECT 'decode_WVC1=' "decode_WVC1=$G_WHIP_RETURNED_VALUE" /DietPi/config.txt
 
-					#https://github.com/MichaIng/DietPi/issues/1487
+					# https://github.com/MichaIng/DietPi/issues/1487
 					local current_gpu_mem=$(grep -m1 '^[[:blank:]]*gpu_mem_1024' /DietPi/config.txt | sed 's/^[^=]*=//g')
 					(( $current_gpu_mem < 128 )) && /DietPi/dietpi/func/dietpi-set_hardware gpumemsplit 128
 
@@ -584,7 +567,7 @@
 
 					G_CONFIG_INJECT 'decode_MPG2=' "decode_MPG2=$G_WHIP_RETURNED_VALUE" /DietPi/config.txt
 
-					#https://github.com/MichaIng/DietPi/issues/1487
+					# https://github.com/MichaIng/DietPi/issues/1487
 					local current_gpu_mem=$(grep -m1 '^[[:blank:]]*gpu_mem_1024' /DietPi/config.txt | sed 's/^[^=]*=//g')
 					(( $current_gpu_mem < 128 )) && /DietPi/dietpi/func/dietpi-set_hardware gpumemsplit 128
 
@@ -611,18 +594,17 @@
 
 					G_CONFIG_INJECT 'display_hdmi_rotate=' "display_hdmi_rotate=$G_WHIP_RETURNED_VALUE" /DietPi/config.txt
 
-					#	rotation 90/270 | invert x/y on FB (Y > X)
+					# rotation 90/270 | invert x/y on FB (Y > X)
 					if [[ $G_WHIP_RETURNED_VALUE == '1' || $G_WHIP_RETURNED_VALUE == '3' ]]; then
 
 						Display_Rotation_Calc_XY_Invert 1
 
-					#	X > Y
+					# X > Y
 					else
 
 						Display_Rotation_Calc_XY_Invert 0
 
 					fi
-
 					REBOOT_REQUIRED=1
 
 				fi
@@ -682,14 +664,10 @@
 
 					G_WHIP_DEFAULT_ITEM=$current_brightness
 					G_WHIP_INPUTBOX "Please enter a brightness value:\n - Min = $MIN_VALUE | Max = $MAX_VALUE"
-					if (( $? == 0 )) && [[ $G_WHIP_RETURNED_VALUE ]]; then
+					if (( $? == 0 )) && G_CHECK_VALIDINT $G_WHIP_RETURNED_VALUE $MIN_VALUE $MAX_VALUE; then
 
-						if G_CHECK_VALIDINT $G_WHIP_RETURNED_VALUE $MIN_VALUE $MAX_VALUE; then
-
-							# - apply
-							echo $G_WHIP_RETURNED_VALUE > $fp_brightness/brightness
-
-						fi
+						# - apply
+						echo $G_WHIP_RETURNED_VALUE > $fp_brightness/brightness
 
 					fi
 
@@ -698,8 +676,6 @@
 					Info_HW_OptionNotSupported
 
 				fi
-
-				unset afp_current_set_brightness
 
 			elif (( $G_WHIP_RETURNED_VALUE == 17 )); then
 
@@ -730,8 +706,6 @@
 
 		fi
 
-		unset overscan_options
-
 	}
 
 	Xorg_Configure(){
@@ -742,13 +716,13 @@
 \nWould you like to continue?"; then
 
 			G_RUN_CMD Xorg -configure
-			mv $HOME/xorg.conf.new /etc/X11/xorg.conf
+			mv /root/xorg.conf.new /etc/X11/xorg.conf
 
 		fi
 
 	}
 
-	#TARGETMENUID=2
+	# TARGETMENUID=2
 	Menu_DisplayOptions_Driver_Resolution(){
 
 		TARGETMENUID=1 # Return to Display Options menu
@@ -834,7 +808,6 @@
 						/DietPi/dietpi/dietpi-software install 151
 
 					fi
-
 					REBOOT_REQUIRED=1
 
 				elif [[ $G_WHIP_RETURNED_VALUE == 'Intel' ]]; then
@@ -1015,7 +988,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 		# Odroid C1
 		elif (( $G_HW_MODEL == 10 )); then
 
-			#Get Current Values
+			# Get Current Values
 			local current_resolution=$(mawk -F '"' '/setenv m "/ {print $2;exit}' /DietPi/boot.ini)
 
 			G_WHIP_MENU_ARRAY=(
@@ -1078,7 +1051,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 		# Odroid XU3/4
 		elif (( $G_HW_MODEL == 11 )); then
 
-			#Get Current Values
+			# Get Current Values
 			local current_resolution=$(grep -m1 'setenv videoconfig \"' /DietPi/boot.ini)
 			if [[ $current_resolution == *'1920x1080'* ]]; then
 
@@ -1125,7 +1098,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 		# Odroid C2
 		elif (( $G_HW_MODEL == 12 )); then
 
-			#Get Current Values
+			# Get Current Values
 			local current_resolution=$(mawk -F '"' '/setenv m "/ {print $2;exit}' /DietPi/boot.ini | sed 's/p/p /')
 			# - NB: also added space after xxxp, so its easier to read, and selects default item.
 
@@ -1153,11 +1126,11 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 				[[ $current_resolution != $G_WHIP_RETURNED_VALUE ]] && REBOOT_REQUIRED=1
 
-				# - Always reset vga/dvi options
+				# Always reset vga/dvi options
 				sed -i '/setenv vout "dvi"/c\# setenv vout "dvi"' /DietPi/boot.ini
 				sed -i '/setenv vout "vga"/c\# setenv vout "vga"' /DietPi/boot.ini
 
-				#DVI / VU7+
+				# DVI / VU7+
 				if [[ $G_WHIP_RETURNED_VALUE == '1024x600p 60hz' ]]; then
 
 					# + DVI mode
@@ -1177,7 +1150,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 		# Pine A64
 		elif (( $G_HW_MODEL == 40 )); then
 
-			#Get Current Values
+			# Get Current Values
 			local current_resolution=$(grep -m1 '^[[:blank:]]*hdmi_mode=' /DietPi/uEnv.txt | sed 's/^[^=]*=//')
 			[[ $current_resolution ]] || current_resolution='Not set'
 
@@ -1218,19 +1191,103 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 	}
 
-	#TARGETMENUID=3
+	# TARGETMENUID=18
+	Menu_AdvancedOptions_Serial_UART(){
+
+		TARGETMENUID=18 # Return to this menu
+
+		declare -A aSTATE=()
+		G_WHIP_MENU_ARRAY=('' '●─ Toggle console ')
+		for i in /dev/tty{S,AMA,SAC}[0-9]
+		do
+		
+			[[ -e $i ]] || continue
+			aSTATE[$i]='[Off]'
+			systemctl -q is-active serial-console@$i && aSTATE[$i]='[On]'
+			G_WHIP_MENU_ARRAY+=("$i" ": ${aSTATE[$i]}")
+
+		done
+
+		# RPi special
+		local rpi_text=''
+		if (( $G_HW_MODEL < 10 )); then
+
+			local rpi_text='\n\nOn Raspberry Pi you can additionally enable or disable the primary UART device completely (requires reboot).'
+			G_WHIP_MENU_ARRAY+=('' '●─ Toggle device ')
+
+			# Onboard WiFi/BT: "enable_uart" toggles ttyS0 (mini UART), disabled by default
+			if (( $(sed -n 9p /DietPi/dietpi/.hw_model) )); then
+
+				if grep -q '^[[:blank:]]*enable_uart=1' /DietPi/config.txt; then
+
+					G_WHIP_MENU_ARRAY+=('Disable ttyS0' ': [On] mini UART ttyS0')
+
+				else
+
+					G_WHIP_MENU_ARRAY+=('Enable ttyS0' ': [Off] mini UART ttyS0')
+
+				fi
+
+			# Nonboard WiFi/BT: "enable_uart" toggles ttyAMA0 (full UART). enabled by default
+			else
+
+				if grep -q '^[[:blank:]]*enable_uart=0' /DietPi/config.txt; then
+
+					G_WHIP_MENU_ARRAY+=('Enable ttyAMA0' ': [Off] full UART ttyAMA0')
+
+				else
+
+					G_WHIP_MENU_ARRAY+=('Disable ttyAMA0' ': [On] full UART ttyAMA0')
+
+				fi
+
+			fi
+
+		fi
+
+		(( ${#G_WHIP_MENU_ARRAY[@]} == 2 )) || { G_WHIP_MSG 'No serial/UART devices have been found on your system.'; return; }
+
+		G_WHIP_BUTTON_CANCEL_TEXT='Back'
+		if G_WHIP_MENU "Select an available serial/UART device to toggle a login console on it.$rpi_text"; then
+
+			if [[ $G_WHIP_RETURNED_VALUE == 'Enable'* ]]; then
+
+				G_CONFIG_INJECT 'enable_uart=' 'enable_uart=1' /DietPi/config.txt
+				REBOOT_REQUIRED=1
+
+			elif [[ $G_WHIP_RETURNED_VALUE == 'Disable'* ]]; then
+
+				/DietPi/dietpi/func/dietpi-set_hardware serialconsole disable ${G_WHIP_RETURNED_VALUE##* }
+				G_CONFIG_INJECT 'enable_uart=' 'enable_uart=0' /DietPi/config.txt
+				REBOOT_REQUIRED=1
+
+			else
+
+				local toggle='enable'
+				[[ ${aSTATE[$G_WHIP_RETURNED_VALUE]} == '[On]' ]] && toggle='disable'
+				/DietPi/dietpi/func/dietpi-set_hardware serialconsole $toggle $G_WHIP_RETURNED_VALUE
+
+			fi
+
+		else
+
+			TARGETMENUID=3 # Return to Advanced Options
+
+		fi
+
+	}
+
+	# TARGETMENUID=3
 	Menu_AdvancedOptions(){
 
 		TARGETMENUID=0
-
-		G_WHIP_MENU_ARRAY=()
 
 		# Swap file
 		local swap_size=$(free -m | mawk '/Swap:/ {print $2;exit}')
 		local swap_location=$(grep -m1 '^[[:blank:]]*AUTO_SETUP_SWAPFILE_LOCATION=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 		local swap_size_text="$swap_size MB"
-		(( ! $swap_size )) && swap_size_text='[Off]'
-		G_WHIP_MENU_ARRAY+=('Swapfile' ": [$swap_size_text | $swap_location]")
+		(( $swap_size )) || swap_size_text='[Off]'
+		G_WHIP_MENU_ARRAY=('Swapfile' ": [$swap_size_text | $swap_location]")
 
 		# Time sync
 		local ntpd_mode_current=$(grep -m1 '^[[:blank:]]*CONFIG_NTP_MODE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
@@ -1464,80 +1521,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 			elif [[ $G_WHIP_RETURNED_VALUE == 'Serial/UART' ]]; then
 
-				declare -A aSTATE=()
-				G_WHIP_MENU_ARRAY=('' '●─ Toggle console ')
-				for i in /dev/tty{S,AMA,SAC}[0-9]
-				do
-		
-					[[ -e $i ]] || continue
-					aSTATE[$i]='[Off]'
-					systemctl -q is-active serial-console@$i && aSTATE[$i]='[On]'
-					G_WHIP_MENU_ARRAY+=("$i" ": ${aSTATE[$i]}")
-
-				done
-
-				# RPi special
-				local rpi_text=''
-				if (( $G_HW_MODEL < 10 )); then
-
-					local rpi_text='\n\nOn Raspberry Pi you can additionally enable or disable the primary UART device completely (requires reboot).'
-					G_WHIP_MENU_ARRAY+=('' '●─ Toggle device ')
-
-					# Onboard WiFi/BT: "enable_uart" toggles ttyS0 (mini UART), disabled by default
-					if (( $(sed -n 9p /DietPi/dietpi/.hw_model) )); then
-
-						if grep -q '^[[:blank:]]*enable_uart=1' /DietPi/config.txt; then
-
-							G_WHIP_MENU_ARRAY+=('Disable ttyS0' ': [On] mini UART ttyS0')
-
-						else
-
-							G_WHIP_MENU_ARRAY+=('Enable ttyS0' ': [Off] mini UART ttyS0')
-
-						fi
-
-					# Nonboard WiFi/BT: "enable_uart" toggles ttyAMA0 (full UART). enabled by default
-					else
-
-						if grep -q '^[[:blank:]]*enable_uart=0' /DietPi/config.txt; then
-
-							G_WHIP_MENU_ARRAY+=('Enable ttyAMA0' ': [Off] full UART ttyAMA0')
-
-						else
-
-							G_WHIP_MENU_ARRAY+=('Disable ttyAMA0' ': [On] full UART ttyAMA0')
-
-						fi
-
-					fi
-
-				fi
-
-				(( ${#G_WHIP_MENU_ARRAY[@]} == 2 )) || { G_WHIP_MSG 'No serial/UART devices have been found on your system.'; return; }
-
-				G_WHIP_BUTTON_CANCEL_TEXT='Back'
-				if G_WHIP_MENU "Select an available serial/UART device to toggle a login console on it.$rpi_text"; then
-
-					if [[ $G_WHIP_RETURNED_VALUE == 'Enable'* ]]; then
-
-						G_CONFIG_INJECT 'enable_uart=' 'enable_uart=1' /DietPi/config.txt
-						REBOOT_REQUIRED=1
-
-					elif [[ $G_WHIP_RETURNED_VALUE == 'Disable'* ]]; then
-
-						/DietPi/dietpi/func/dietpi-set_hardware serialconsole disable ${G_WHIP_RETURNED_VALUE##* }
-						G_CONFIG_INJECT 'enable_uart=' 'enable_uart=0' /DietPi/config.txt
-						REBOOT_REQUIRED=1
-
-					else
-
-						local toggle='enable'
-						[[ ${aSTATE[$G_WHIP_RETURNED_VALUE]} == '[On]' ]] && toggle='disable'
-						/DietPi/dietpi/func/dietpi-set_hardware serialconsole $toggle $G_WHIP_RETURNED_VALUE
-
-					fi
-
-				fi
+				TARGETMENUID=18
 
 			elif [[ $G_WHIP_RETURNED_VALUE == 'Bluetooth' ]]; then
 
@@ -1576,7 +1560,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 	}
 
-	#TARGETMENUID=4
+	# TARGETMENUID=4
 	Menu_PerformanceOptions(){
 
 		TARGETMENUID=0
@@ -1943,7 +1927,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 	}
 
-	#TARGETMENUID=5
+	# TARGETMENUID=5
 	Menu_SecurityOptions(){
 
 		TARGETMENUID=0
@@ -1973,7 +1957,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 	}
 
-	#TARGETMENUID=6
+	# TARGETMENUID=6
 	Menu_GpumemoryOptions(){
 
 		TARGETMENUID=1
@@ -1981,11 +1965,11 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 		# Get Current and/or total (depends on board) mem split settings
 		local gpu_mem_current=0
 		local ram_mem_current=$(free -m | mawk '/Mem:/ {print $2;exit}')
-		local ram_mem_total=$(grep -m1 'HW_MEMORY_SIZE=' /DietPi/dietpi/.hw_model | sed 's/^[^=]*=//')
+		local ram_mem_total=$(grep -m1 '^HW_MEMORY_SIZE=' /DietPi/dietpi/.hw_model | sed 's/^[^=]*=//')
 
 		if (( $G_HW_MODEL < 10 )); then
 
-			gpu_mem_current=$(grep -m1 'gpu_mem_1024=' /DietPi/config.txt  | sed 's/^.*=//')
+			gpu_mem_current=$(grep -m1 '^[[:blank:]]*gpu_mem_1024=' /DietPi/config.txt  | sed 's/^[^=]*=//')
 			ram_mem_current=$((ram_mem_total-gpu_mem_current))
 
 		elif (( $G_HW_MODEL == 10 )); then
@@ -2026,8 +2010,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 			fi
 
 			G_WHIP_DEFAULT_ITEM=$gpu_mem_current
-			G_WHIP_MENU "Hardware : $G_HW_MODEL_DESCRIPTION\nCurrent: $gpu_mem_current MB GPU | $ram_mem_current MB RAM"
-			if (( $? == 0 )); then
+			if G_WHIP_MENU "Hardware : $G_HW_MODEL_DESCRIPTION\nCurrent: $gpu_mem_current MB GPU | $ram_mem_current MB RAM"; then
 
 				/DietPi/dietpi/func/dietpi-set_hardware gpumemsplit $G_WHIP_RETURNED_VALUE
 				REBOOT_REQUIRED=1
@@ -2137,7 +2120,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 	}
 
-	#TARGETMENUID=7
+	# TARGETMENUID=7
 	Menu_LanguageOptions(){
 
 		TARGETMENUID=0
@@ -2152,8 +2135,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 
 		)
 
-		G_WHIP_MENU 'Please select an option:'
-		if (( $? == 0 )); then
+		if G_WHIP_MENU 'Please select an option:'; then
 
 			TARGETMENUID=7 # Return to this menu
 
@@ -2217,7 +2199,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 	NET_RX_MB='Unknown'
 	NET_TX_MB='Unknown'
 
-	#$1 = device+index
+	# $1 = device+index
 	Net_Update_UsageStats(){
 
 		local input=$1
@@ -2412,8 +2394,8 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 		fi
 
 		cat << _EOF_ > /etc/network/interfaces
-#/etc/network/interfaces
-#Please use DietPi-Config to modify network settings.
+# /etc/network/interfaces
+# Please use DietPi-Config to modify network settings.
 
 # Local
 auto lo
@@ -2842,7 +2824,7 @@ _EOF_
 
 	}
 
-	#TARGETMENUID=8
+	# TARGETMENUID=8
 	Menu_NetworkAdapters(){
 
 		TARGETMENUID=0
@@ -2861,10 +2843,10 @@ _EOF_
 
 		# Obtain Hardware Status
 		local eth_hardware_text='Available'
-		(( ! $ETH_HARDWARE )) && eth_hardware_text='Not Found'
+		(( $ETH_HARDWARE )) || eth_hardware_text='Not Found'
 
 		local wlan_hardware_text='Available'
-		(( ! $WIFI_HARDWARE )) && wlan_hardware_text='Not Found'
+		(( $WIFI_HARDWARE )) || wlan_hardware_text='Not Found'
 
 		# Obtain Connected/Carrier Status
 		local eth_connected_text='Disconnected'
@@ -3118,7 +3100,7 @@ _EOF_
 
 	}
 
-	#TARGETMENUID=9
+	# TARGETMENUID=9
 	Menu_NetworkAdapters_Ethernet(){
 
 		TARGETMENUID=8
@@ -3243,7 +3225,7 @@ _EOF_
 
 	}
 
-	#TARGETMENUID=10
+	# TARGETMENUID=10
 	Menu_NetworkAdapters_Wifi(){
 
 		TARGETMENUID=8
@@ -3267,7 +3249,7 @@ _EOF_
 
 			fi
 
-			#	N enabled?
+			# - N enabled?
 			local hotspot_n_enabled=0
 			local hotspot_n_text='Disabled'
 			if grep -q '^ieee80211n=1' /etc/hostapd/hostapd.conf; then
@@ -3277,18 +3259,14 @@ _EOF_
 
 			fi
 
-			#	toggle
+			# - Toggle
 			local hotspot_active_state=$(systemctl is-active hostapd | grep -ci -m1 '^active' )
-			local hotspot_status_text='Status  : '
-			local hotspot_active_state_text='[Enabled] | Select to turn off hotspot'
-			if (( ! $hotspot_active_state )); then
+			local hotspot_status_text='Status  : Offline'
+			local hotspot_active_state_text='[Disabled] | Select to turn on hotspot'
+			if (( $hotspot_active_state )); then
 
-				hotspot_active_state_text='[Disabled] | Select to turn on hotspot'
-				hotspot_status_text+='Offline'
-
-			else
-
-				 hotspot_status_text+='Online'
+				hotspot_status_text+='Status  : Online'
+				hotspot_active_state_text='[Enabled] | Select to turn off hotspot'
 
 			fi
 
@@ -3304,11 +3282,11 @@ _EOF_
 
 			# - Get current Mode details
 			local mode_current='DHCP'
-			(( $WIFI_MODE == 0 )) && mode_current='STATIC'
+			(( $WIFI_MODE )) || mode_current='STATIC'
 
 			# - Target Details
 			local mode_target='DHCP'
-			(( $WIFI_MODE_TARGET == 0 )) && mode_target='STATIC'
+			(( $WIFI_MODE_TARGET )) || mode_target='STATIC'
 
 			G_WHIP_MENU_ARRAY+=('Scan' ': Scan and configure SSID')
 
@@ -3557,7 +3535,7 @@ _EOF_
 
 	}
 
-	#TARGETMENUID=11
+	# TARGETMENUID=11
 	Menu_Tools(){
 
 		TARGETMENUID=0
@@ -3591,7 +3569,7 @@ _EOF_
 
 	}
 
-	#TARGETMENUID=12
+	# TARGETMENUID=12
 	Menu_FilesystemBenchmark(){
 
 		TARGETMENUID=11
@@ -3734,7 +3712,7 @@ Additional benchmarks:
 
 	}
 
-	#TARGETMENUID=13
+	# TARGETMENUID=13
 	Menu_Overclock(){
 
 		TARGETMENUID=4
@@ -3976,7 +3954,7 @@ Additional benchmarks:
 
 	}
 
-	#TARGETMENUID=14
+	# TARGETMENUID=14
 	Menu_AudioOptions(){
 
 		TARGETMENUID=0
@@ -4190,7 +4168,7 @@ Additional benchmarks:
 
 	}
 
-	#TARGETMENUID=15
+	# TARGETMENUID=15
 	STRESS_TEST_MODE=0 # 0=CPU only | 1=CPU/RAM 2=CPU/RAM/IO
 	STRESS_TEST_DURATION=60
 	STRESS_TEST_RESULTS_TEMP_MIN=0
@@ -4261,7 +4239,7 @@ Additional benchmarks:
 				local start_time=$(date)
 				local start_time_epoch=$(date +%s)
 				local memory_per_thread=$(( $(free -m | mawk '/^Mem:/ {print $2;exit}') / ( $G_HW_CPU_CORES * 2 ) ))
-				local fp_log="$HOME/dietpi-config_stress.log"
+				local fp_log='/root/dietpi-config_stress.log'
 				rm $fp_log &> /dev/null
 
 				if (( $STRESS_TEST_MODE == 0 )); then
@@ -4341,7 +4319,7 @@ Additional benchmarks:
 
 	}
 
-	#TARGETMENUID=16
+	# TARGETMENUID=16
 	Menu_Network_Nas_Misc(){
 
 		TARGETMENUID=0
@@ -4619,7 +4597,7 @@ NB: If you need to use *.pool.ntp.org servers, enter the base domain only. The s
 
 	}
 
-	#TARGETMENUID=17
+	# TARGETMENUID=17
 	Menu_NetworkAdapters_Proxy(){
 
 		TARGETMENUID=8
@@ -4738,7 +4716,7 @@ _EOF_
 
 			esac
 
-		#Reset init flag to force a reload of setings next time this menu is run.
+		# Reset init flag to force a reload of setings next time this menu is run.
 		else
 
 			PROXY_ENABLED=-1
@@ -4830,6 +4808,10 @@ _EOF_
 			elif (( $TARGETMENUID == 17 )); then
 
 				Menu_NetworkAdapters_Proxy
+
+			elif (( $TARGETMENUID == 18 )); then
+
+				Menu_AdvancedOptions_Serial_UART
 
 			else
 

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -1197,7 +1197,9 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 		TARGETMENUID=18 # Return to this menu
 
 		declare -A aSTATE=()
-		G_WHIP_MENU_ARRAY=('' '●─ Toggle console ')
+		G_WHIP_MENU_ARRAY=()
+
+		(( $G_HW_MODEL < 10 )) && G_WHIP_MENU_ARRAY+=('' '●─ Toggle console ')
 		for i in /dev/tty{S,AMA,SAC}[0-9]
 		do
 
@@ -1205,7 +1207,7 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 			i=${i#/dev/}
 			aSTATE[$i]='[Off]'
 			systemctl -q is-active serial-getty@$i && aSTATE[$i]='[On]'
-			G_WHIP_MENU_ARRAY+=("$i" ": ${aSTATE[$i]}")
+			G_WHIP_MENU_ARRAY+=("$i console" ": ${aSTATE[$i]}")
 
 		done
 
@@ -1219,30 +1221,19 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 			# Onboard WiFi/BT: "enable_uart" toggles ttyS0 (mini UART), disabled by default
 			if (( $(sed -n 9p /DietPi/dietpi/.hw_model) )); then
 
-				if grep -q '^[[:blank:]]*enable_uart=1' /DietPi/config.txt; then
-
-					G_WHIP_MENU_ARRAY+=('Disable ttyS0' ': [On] mini UART ttyS0')
-
-				else
-
-					G_WHIP_MENU_ARRAY+=('Enable ttyS0' ': [Off] mini UART ttyS0')
-
-				fi
+				local rpi_uart='ttyS0 (mini UART)'
+				local rpi_uart_state='[Off]'
+				grep -q '^[[:blank:]]*enable_uart=1' /DietPi/config.txt && rpi_uart_state='[On]'
 
 			# Nonboard WiFi/BT: "enable_uart" toggles ttyAMA0 (full UART). enabled by default
 			else
 
-				if grep -q '^[[:blank:]]*enable_uart=0' /DietPi/config.txt; then
-
-					G_WHIP_MENU_ARRAY+=('Enable ttyAMA0' ': [Off] full UART ttyAMA0')
-
-				else
-
-					G_WHIP_MENU_ARRAY+=('Disable ttyAMA0' ': [On] full UART ttyAMA0')
-
-				fi
+				local rpi_uart='ttyAMA0 (full UART)'
+				local rpi_uart_state='[On]'
+				grep -q '^[[:blank:]]*enable_uart=0' /DietPi/config.txt && rpi_uart_state='[Off]'
 
 			fi
+			G_WHIP_MENU_ARRAY+=("$rpi_uart device" ': $rpi_uart_state')
 
 		fi
 
@@ -1251,22 +1242,18 @@ More info here: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p10500
 		G_WHIP_BUTTON_CANCEL_TEXT='Back'
 		if G_WHIP_MENU "Select an available serial/UART device to toggle a login console on it.$rpi_text"; then
 
-			if [[ $G_WHIP_RETURNED_VALUE == 'Enable'* ]]; then
+			if [[ $G_WHIP_RETURNED_VALUE == *'device' ]]; then
 
-				G_CONFIG_INJECT 'enable_uart=' 'enable_uart=1' /DietPi/config.txt
+				local toggle=1
+				[[ $rpi_uart_state == '[On]' ]] && toggle=0 && /DietPi/dietpi/func/dietpi-set_hardware serialconsole disable ${G_WHIP_RETURNED_VALUE%% *}
+				G_CONFIG_INJECT 'enable_uart=' "enable_uart=$toggle" /DietPi/config.txt
 				REBOOT_REQUIRED=1
 
-			elif [[ $G_WHIP_RETURNED_VALUE == 'Disable'* ]]; then
-
-				/DietPi/dietpi/func/dietpi-set_hardware serialconsole disable ${G_WHIP_RETURNED_VALUE##* }
-				G_CONFIG_INJECT 'enable_uart=' 'enable_uart=0' /DietPi/config.txt
-				REBOOT_REQUIRED=1
-
-			elif [[ $G_WHIP_RETURNED_VALUE ]]; then
+			elif [[ $G_WHIP_RETURNED_VALUE == *'console' ]]; then
 
 				local toggle='enable'
-				[[ ${aSTATE[$G_WHIP_RETURNED_VALUE]} == '[On]' ]] && toggle='disable'
-				/DietPi/dietpi/func/dietpi-set_hardware serialconsole $toggle $G_WHIP_RETURNED_VALUE
+				[[ ${aSTATE[${G_WHIP_RETURNED_VALUE%% *}]} == '[On]' ]] && toggle='disable'
+				/DietPi/dietpi/func/dietpi-set_hardware serialconsole $toggle ${G_WHIP_RETURNED_VALUE%% *}
 
 			fi
 

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -19,7 +19,7 @@ $FP_SCRIPT	eth-forcespeed		10/100/1000/disable
 $FP_SCRIPT	wifimodules		enable/disable/onboard_enable/onboard_disable
 $FP_SCRIPT	wificountrycode		GB/US/DE/...
 $FP_SCRIPT	bluetooth		enable/disable
-$FP_SCRIPT	serialconsole		enable/disable
+$FP_SCRIPT	serialconsole		enable/disable		[tty(S|AMA|SAC)[0-9]] (optional Serial/UART device)
 $FP_SCRIPT	i2c			enable/disable/khz
 $FP_SCRIPT	soundcard		target_card (non-matching name for reset to default). Add '-eq' to target_card string to enable ALSA equalizer on card. HW:x,x (specify target card and device index eg: HW:9,1)
 $FP_SCRIPT	remoteir		odroid_remote/justboom_ir_remote # Odroid/RPi only
@@ -45,6 +45,7 @@ $FP_SCRIPT	rpi3_usb_boot		enable
 		INPUT_DEVICE_VALUE='disable'
 
 	fi
+	INPUT_ADDITIONAL=$3
 
 	# Import DietPi-Globals --------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
@@ -1150,8 +1151,22 @@ _EOF_
 			# Pre-Reqs
 			if (( $G_HW_MODEL < 10 )); then
 
-				# - Serial console must be disabled: https://github.com/MichaIng/DietPi/issues/2607#issuecomment-470523194
-				INPUT_DEVICE_VALUE='disable' Serial_Main
+				# - Login console on ttyAMA0 must be disabled: https://github.com/MichaIng/DietPi/issues/2607#issuecomment-470523194
+				if systemctl -q is-active serial-getty@ttyAMA0; then
+
+					if G_WHIP_YESNO '[WARNING] A serial login console is currently active on ttyAMA0\n
+Do you want to continue and disable the serial login console?'; then
+
+						INPUT_DEVICE_VALUE='disable' INPUT_ADDITIONAL='ttyAMA0' Serial_Main
+
+					else
+
+						exit 0
+
+					fi
+
+				fi
+
 				G_AG_CHECK_INSTALL_PREREQ pi-bluetooth
 
 			else
@@ -1449,130 +1464,139 @@ _EOF_
 	# serialconsole
 	#/////////////////////////////////////////////////////////////////////////////////////
 
-	MAX_SERIAL_CONSOLES=2
-
 	Serial_Main(){
 
 		#-------------------------------------------------------------------------------------
 		# Enable
 		if [[ $INPUT_DEVICE_VALUE == 'enable' ]]; then
 
-			G_DIETPI-NOTIFY 2 'Enabling known serial-getty services, please wait...'
-			systemctl unmask serial-getty@tty 2> /dev/null
-			systemctl enable serial-getty@tty 2> /dev/null
-			for ((i=0; i<=$MAX_SERIAL_CONSOLES; i++))
-			do
+			# Enable for specific Serial/UART device
+			if [[ $INPUT_ADDITIONAL ]]; then
 
-				# - unmask v6.3+
-				systemctl unmask serial-getty@ttyAMA$i 2> /dev/null
-				systemctl unmask serial-getty@ttySAC$i 2> /dev/null
-				systemctl unmask serial-getty@ttyS$i 2> /dev/null
-				#systemctl unmask serial-getty@ttyFIQ$i 2> /dev/null #:https://github.com/MichaIng/DietPi/issues/1829#issuecomment-398302497
+				# - RPi: Warn if ttyAMA0 is about to be enabled while Bluetooth is up
+				if (( $G_HW_MODEL < 10 )) && systemctl -q is-active hciuart; then
 
+					if G_WHIP_YESNO '[WARNING] ttyAMA0 is currently used by Bluetooth\n
+Do you want to continue and DISABLE Bluetooth now?'; then
 
-				# - Enable v6.2-
-				systemctl enable serial-getty@ttyAMA$i 2> /dev/null
-				systemctl enable serial-getty@ttySAC$i 2> /dev/null
-				systemctl enable serial-getty@ttyS$i 2> /dev/null
-				#systemctl enable serial-getty@ttyFIQ$i 2> /dev/null #:https://github.com/MichaIng/DietPi/issues/1829#issuecomment-398302497
+						INPUT_DEVICE_VALUE='disable' Bluetooth_Main
 
-				# - Allow root login for known TTY's not in /etc/securetty by default
-				#	NanoPC-T4
-				G_CONFIG_INJECT "ttyFIQ$i" "ttyFIQ$i" /etc/securetty
+					else
 
-			done
+						exit 0
 
-			# Device Specific:
-			# - RPi
-			if (( $G_HW_MODEL < 10 )); then
-
-				G_CONFIG_INJECT 'enable_uart=' 'enable_uart=1' /DietPi/config.txt
-
-			# - Odroid C1
-			elif (( $G_HW_MODEL == 10 )); then
-
-				sed -i '/^setenv condev/c\setenv condev "console=tty0 console=ttyS0,115200n8"' /DietPi/boot.ini
-
-			# - Odroid XU4
-			elif (( $G_HW_MODEL == 11 )); then
-
-				if ! grep -qi 'console=ttySAC2,115200n8 ' /DietPi/boot.ini; then
-
-					sed -i 's/console=tty1 /console=tty1 console=ttySAC2,115200n8 /' /DietPi/boot.ini
+					fi
 
 				fi
 
-			# - Odroid C2
-			elif (( $G_HW_MODEL == 12 )); then
+				G_DIETPI-NOTIFY 2 "Enabling serial-getty on: /dev/$INPUT_ADDITIONAL"
+				G_RUN_CMD systemctl unmask serial-getty@$INPUT_ADDITIONAL
+				G_RUN_CMD systemctl enable serial-getty@$INPUT_ADDITIONAL
+				# - Start now if device (already) exists
+				[[ -e /dev/$INPUT_ADDITIONAL ]] && G_RUN_CMD systemctl start serial-getty@$INPUT_ADDITIONAL
 
-				sed -i '/^setenv condev/c\setenv condev "console=tty0 console=ttyS0,115200n8"' /DietPi/boot.ini
+				# Allow root login on selected TTY if not enabled by default
+				G_CONFIG_INJECT "$INPUT_ADDITIONAL" "$INPUT_ADDITIONAL" /etc/securetty
 
-			# - Pine A64 (on ARMbian ttyS0 boot output is forced)
-			elif (( $G_HW_MODEL == 40 && ! $ARMBIAN )); then
+				# Enable boot messages depending on device
+				# - RPi
+				if (( $G_HW_MODEL < 10 )); then
 
-				if ! grep -qi 'console=ttyS0,115200n8 ' $FP_UENV; then
+					grep -q "console=$INPUT_ADDITIONAL" /boot/cmdline.txt || sed -i "/root=/s/$/ console=$INPUT_ADDITIONAL,115200/" /boot/cmdline.txt
 
-					sed -i 's/console=tty0 /console=tty0 console=ttyS0,115200n8 /' $FP_UENV
+				# - Odroid C1/C2
+				elif (( $G_HW_MODEL == 10 || $G_HW_MODEL == 12 )); then
+
+					G_CONFIG_INJECT 'setenv condev[[:blank:]]' "setenv condev \"console=tty0 console=$INPUT_ADDITIONAL,115200n8\"" /DietPi/boot.ini
+
+				# - Odroid XU4
+				elif (( $G_HW_MODEL == 11 )); then
+
+					grep -q "console=$INPUT_ADDITIONAL" /DietPi/boot.ini || sed -i "s/console=tty1/console=tty1 console=$INPUT_ADDITIONAL,115200n8/" /DietPi/boot.ini
+
+				
+				# - Pine A64: On ARMbian ttyS0 boot output is forced and custom console is not possible via armbianEnv.txt
+				elif (( $G_HW_MODEL == 40 && ! $ARMBIAN )); then
+
+					grep -q "console=$INPUT_ADDITIONAL" $FP_UENV || sed -i "s/console=tty0/console=tty0 console=$INPUT_ADDITIONAL,115200n8/" $FP_UENV
 
 				fi
+
+			# Enable for all detected Serial/UART devices
+			else
+
+				# ttyFIQ[0-9]: https://github.com/MichaIng/DietPi/issues/1829#issuecomment-398302497
+				for i in /dev/tty{S,AMA,SAC}[0-9]
+				do
+		
+					[[ -e $i ]] || continue
+					INPUT_ADDITIONAL=${i/\/dev\/} Serial_Main
+
+				done
+
+				# On RPi enable primary UART device
+				(( $G_HW_MODEL < 10 )) && G_CONFIG_INJECT 'enable_uart=' 'enable_uart=1' $FP_RPI_CONFIG
+
+				# Update dietpi.txt global var
+				G_CONFIG_INJECT 'CONFIG_SERIAL_CONSOLE_ENABLE=' 'CONFIG_SERIAL_CONSOLE_ENABLE=1' /DietPi/dietpi.txt
 
 			fi
-
-			# - Update dietpi.txt global var
-			G_CONFIG_INJECT 'CONFIG_SERIAL_CONSOLE_ENABLE=' 'CONFIG_SERIAL_CONSOLE_ENABLE=1' /DietPi/dietpi.txt
-
 
 		#-------------------------------------------------------------------------------------
 		# Disable
 		elif [[ $INPUT_DEVICE_VALUE == 'disable' ]]; then
 
-			#Disable services. Although, this seems to have no effect on the cmdline.txt boot.ini etc serial console entries. They run regardless. But lets do it for consistency.
-			G_DIETPI-NOTIFY 2 'Disabling known serial-getty services, please wait...'
-			systemctl disable serial-getty@tty 2> /dev/null
-			systemctl mask serial-getty@tty 2> /dev/null
-			for ((i=0; i<=$MAX_SERIAL_CONSOLES; i++))
-			do
+			# Disable for specific Serial/UART device
+			if [[ $INPUT_ADDITIONAL ]]; then
 
-				# Disable first, to remove symlink from /etc/systemd/system/getty.target.wants/
-				systemctl disable serial-getty@ttyAMA$i 2> /dev/null
-				systemctl disable serial-getty@ttySAC$i 2> /dev/null
-				systemctl disable serial-getty@ttyS$i 2> /dev/null
-				#systemctl disable serial-getty@ttyFIQ$i 2> /dev/null #:https://github.com/MichaIng/DietPi/issues/1829#issuecomment-398302497
+				G_DIETPI-NOTIFY 2 "Disabling serial-getty on: /dev/$INPUT_ADDITIONAL"
+				systemctl stop serial-getty@$INPUT_ADDITIONAL
+				systemctl disable serial-getty@$INPUT_ADDITIONAL
+				systemctl mask serial-getty@$INPUT_ADDITIONAL
 
-				systemctl mask serial-getty@ttyAMA$i 2> /dev/null
-				systemctl mask serial-getty@ttySAC$i 2> /dev/null
-				systemctl mask serial-getty@ttyS$i 2> /dev/null
-				#systemctl mask serial-getty@ttyFIQ$i 2> /dev/null #:https://github.com/MichaIng/DietPi/issues/1829#issuecomment-398302497
+				# Disable boot messages depending on device
+				# - RPi
+				if (( $G_HW_MODEL < 10 )); then
 
-			done
+					sed -i "s/[[:blank:]]console=$INPUT_ADDITIONAL,115200//" /boot/cmdline.txt
 
-			# Device Specific:
-			# - RPi
-			if (( $G_HW_MODEL < 10 )); then
+				# - Odroid C1/C2
+				elif (( $G_HW_MODEL == 10 || $G_HW_MODEL == 12 )); then
 
-				sed -i 's/console=ttyAMA0,115200 //' /boot/cmdline.txt # Replaced by enable_uart=
+					G_CONFIG_INJECT 'setenv condev[[:blank:]]' 'setenv condev "console=tty0"' /DietPi/boot.ini
 
-				G_CONFIG_INJECT 'enable_uart=' 'enable_uart=0' /DietPi/config.txt
+				# - Odroid XU4
+				elif (( $G_HW_MODEL == 11 )); then
 
-			# - Odroid C1/C2
-			elif (( $G_HW_MODEL == 10 || $G_HW_MODEL == 12 )); then
+					sed -i "s/[[:blank:]]console=$INPUT_ADDITIONAL,115200n8//" /DietPi/boot.ini
 
-				G_CONFIG_INJECT 'setenv condev' 'setenv condev "console=tty0"' /DietPi/boot.ini
+				
+				# - Pine A64: On ARMbian ttyS0 boot output is forced and custom console is not possible via armbianEnv.txt
+				elif (( $G_HW_MODEL == 40 && ! $ARMBIAN )); then
 
-			# - Odroid XU4
-			elif (( $G_HW_MODEL == 11 )); then
+					sed -i "s/[[:blank:]]console=$INPUT_ADDITIONAL,115200n8//" $FP_UENV
 
-				sed -i 's/console=ttySAC2,115200n8 //' /DietPi/boot.ini
+				fi
 
-			# - Pine A64 (on ARMbian ttyS0 boot output is forced)
-			elif (( $G_HW_MODEL == 40 && ! $ARMBIAN )); then
+			# Disable for all detected Serial/UART devices
+			else
 
-				sed -i 's/console=ttyS0,115200n8 //' $FP_UENV
+				# ttyFIQ[0-9]: https://github.com/MichaIng/DietPi/issues/1829#issuecomment-398302497
+				for i in /dev/tty{S,AMA,SAC}[0-9]
+				do
+		
+					[[ -e $i ]] || continue
+					INPUT_ADDITIONAL=${i/\/dev\/} Serial_Main
+
+				done
+
+				# On RPi disable primary UART device
+				(( $G_HW_MODEL < 10 )) && G_CONFIG_INJECT 'enable_uart=' 'enable_uart=0' $FP_RPI_CONFIG
+
+				# Update dietpi.txt global var
+				G_CONFIG_INJECT 'CONFIG_SERIAL_CONSOLE_ENABLE=' 'CONFIG_SERIAL_CONSOLE_ENABLE=0' /DietPi/dietpi.txt
 
 			fi
-
-			# - Update dietpi.txt global var
-			G_CONFIG_INJECT 'CONFIG_SERIAL_CONSOLE_ENABLE=' 'CONFIG_SERIAL_CONSOLE_ENABLE=0' /DietPi/dietpi.txt
 
 		else
 
@@ -2351,7 +2375,6 @@ _EOF_
 	else
 
 		Unknown_Input_Name
-		EXIT_CODE=1
 
 	fi
 

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -899,7 +899,7 @@ _EOF_
 		sed -i '/^[[:blank:]]*spi_s3c64xx/d' /etc/modules
 		sed -i '/^[[:blank:]]*fbtft_device/d' /etc/modules
 
-		##Cant run it on the fly, locks up device.
+		# Cant run it on the fly, locks up device.
 		#root@DietPi-XU4:~# modprobe -rf spi_s3c64xx
 		#root@DietPi-XU4:~# modprobe -rf fbtft_device
 		#Segmentation fault
@@ -1473,8 +1473,8 @@ Do you want to continue and disable the serial login console?'; then
 			# Enable for specific Serial/UART device
 			if [[ $INPUT_ADDITIONAL ]]; then
 
-				# - RPi: Warn if ttyAMA0 is about to be enabled while Bluetooth is up
-				if (( $G_HW_MODEL < 10 )) && systemctl -q is-active hciuart; then
+				# - RPi: Warn if on RPi ttyAMA0 is about to be enabled while Bluetooth is up
+				if [[ $G_HW_MODEL == [0-9] && $INPUT_ADDITIONAL == 'ttyAMA0' ]] && systemctl -q is-active hciuart; then
 
 					if G_WHIP_YESNO '[WARNING] ttyAMA0 is currently used by Bluetooth\n
 Do you want to continue and DISABLE Bluetooth now?'; then
@@ -1507,18 +1507,44 @@ Do you want to continue and DISABLE Bluetooth now?'; then
 				# - Odroid C1/C2
 				elif (( $G_HW_MODEL == 10 || $G_HW_MODEL == 12 )); then
 
-					G_CONFIG_INJECT 'setenv condev[[:blank:]]' "setenv condev \"console=tty0 console=$INPUT_ADDITIONAL,115200n8\"" /DietPi/boot.ini
+					local old=''
+					[[ -f /DietPi/boot.ini ]] && old=$(grep -m1 '^setenv condev "' /DietPi/boot.ini) || return
+					[[ $old =~ console=$INPUT_ADDITIONAL ]] && return
+					old=$(cut -d \" -f 2 <<< "$old")
+					G_CONFIG_INJECT 'setenv condev "' "setenv condev \"$old console=$INPUT_ADDITIONAL,115200n8\"" /DietPi/boot.ini
 
 				# - Odroid XU4
 				elif (( $G_HW_MODEL == 11 )); then
 
-					grep -q "console=$INPUT_ADDITIONAL" /DietPi/boot.ini || sed -i "s/console=tty1/console=tty1 console=$INPUT_ADDITIONAL,115200n8/" /DietPi/boot.ini
+					local old=''
+					[[ -f /DietPi/boot.ini ]] && old=$(grep -m1 '^setenv bootrootfs "' /DietPi/boot.ini) || return
+					[[ $old =~ console=$INPUT_ADDITIONAL ]] && return
+					old=$(cut -d \" -f 2 <<< "$old")
+					G_CONFIG_INJECT 'setenv bootrootfs "' "setenv bootrootfs \"$old console=$INPUT_ADDITIONAL,115200n8\"" /DietPi/boot.ini
 
-				
+				# - ARMbian: armbianEnv.txt only allows to toggle a fixed serial console depending on device
+				elif (( $ARMBIAN )); then
+
+					grep -q "console=$INPUT_ADDITIONAL" /boot/boot.cmd || return
+					if grep -qE 'console=(display|both)' $FP_UENV; then
+
+						G_CONFIG_INJECT 'console=' 'console=both' $FP_UENV
+
+					else
+
+						G_CONFIG_INJECT 'console=' 'console=serial' $FP_UENV
+
+					fi
+
 				# - Pine A64: On ARMbian ttyS0 boot output is forced and custom console is not possible via armbianEnv.txt
-				elif (( $G_HW_MODEL == 40 && ! $ARMBIAN )); then
+				elif (( $G_HW_MODEL == 40 )); then
 
-					grep -q "console=$INPUT_ADDITIONAL" $FP_UENV || sed -i "s/console=tty0/console=tty0 console=$INPUT_ADDITIONAL,115200n8/" $FP_UENV
+					[[ ! -f $FP_UENV ]] || grep -q "console=$INPUT_ADDITIONAL" $FP_UENV && return
+					echo "console=$INPUT_ADDITIONAL,115200n8" >> $FP_UENV
+
+				#elif (( $G_HW_MODEL == 70 )); then
+
+				#	grep -q "console=$INPUT_ADDITIONAL" $FP_UENV || sed -i "/bootargs=/s/$/ console=$INPUT_ADDITIONAL,115200n8/" $FP_UENV
 
 				fi
 
@@ -1528,7 +1554,7 @@ Do you want to continue and DISABLE Bluetooth now?'; then
 				# ttyFIQ[0-9]: https://github.com/MichaIng/DietPi/issues/1829#issuecomment-398302497
 				for i in /dev/tty{S,AMA,SAC}[0-9]
 				do
-		
+
 					[[ -e $i ]] || continue
 					INPUT_ADDITIONAL=${i/\/dev\/} Serial_Main
 
@@ -1552,29 +1578,42 @@ Do you want to continue and DISABLE Bluetooth now?'; then
 				G_DIETPI-NOTIFY 2 "Disabling serial-getty on: /dev/$INPUT_ADDITIONAL"
 				systemctl stop serial-getty@$INPUT_ADDITIONAL
 				systemctl disable serial-getty@$INPUT_ADDITIONAL
-				systemctl mask serial-getty@$INPUT_ADDITIONAL
+				# - Place a mask only if device exists
+				[[ -e /dev/$INPUT_ADDITIONAL ]] && systemctl mask serial-getty@$INPUT_ADDITIONAL
 
 				# Disable boot messages depending on device
 				# - RPi
 				if (( $G_HW_MODEL < 10 )); then
 
-					sed -i "s/[[:blank:]]console=$INPUT_ADDITIONAL,115200//" /boot/cmdline.txt
+					sed -i "s/[[:blank:]]*console=$INPUT_ADDITIONAL[^\"[:blank:]]*//" /boot/cmdline.txt
 
-				# - Odroid C1/C2
-				elif (( $G_HW_MODEL == 10 || $G_HW_MODEL == 12 )); then
+				# - Odroid C1/C2/XU4
+				elif (( $G_HW_MODEL < 12 )); then
 
-					G_CONFIG_INJECT 'setenv condev[[:blank:]]' 'setenv condev "console=tty0"' /DietPi/boot.ini
+					sed -i "s/[[:blank:]]*console=$INPUT_ADDITIONAL[^\"[:blank:]]*//" /DietPi/boot.ini
 
-				# - Odroid XU4
-				elif (( $G_HW_MODEL == 11 )); then
+				elif (( $ARMBIAN )); then
 
-					sed -i "s/[[:blank:]]console=$INPUT_ADDITIONAL,115200n8//" /DietPi/boot.ini
+					grep -q "console=$INPUT_ADDITIONAL" /boot/boot.cmd || return
+					if grep -qE 'console=(display|both)' $FP_UENV; then
 
-				
+						G_CONFIG_INJECT 'console=' 'console=display' $FP_UENV
+
+					else
+
+						G_CONFIG_INJECT 'console=' 'console=none' $FP_UENV
+
+					fi
+
 				# - Pine A64: On ARMbian ttyS0 boot output is forced and custom console is not possible via armbianEnv.txt
-				elif (( $G_HW_MODEL == 40 && ! $ARMBIAN )); then
+				elif (( $G_HW_MODEL == 40 )); then
 
-					sed -i "s/[[:blank:]]console=$INPUT_ADDITIONAL,115200n8//" $FP_UENV
+					sed -i "/^[[:blank:]]*console=$INPUT_ADDITIONAL[^\"[:blank:]]*$/d" $FP_UENV # New style: One variable each line
+					sed -i "s/[[:blank:]]*console=$INPUT_ADDITIONAL[^\"[:blank:]]*//" $FP_UENV # Old style: Multiple variables possible each line
+
+				#elif (( $G_HW_MODEL == 70 )); then
+
+				#	sed -i "s/[[:blank:]]*console=$INPUT_ADDITIONAL[^\"[:blank:]]*//" $FP_UENV
 
 				fi
 
@@ -1584,7 +1623,7 @@ Do you want to continue and DISABLE Bluetooth now?'; then
 				# ttyFIQ[0-9]: https://github.com/MichaIng/DietPi/issues/1829#issuecomment-398302497
 				for i in /dev/tty{S,AMA,SAC}[0-9]
 				do
-		
+
 					[[ -e $i ]] || continue
 					INPUT_ADDITIONAL=${i/\/dev\/} Serial_Main
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1707,6 +1707,32 @@ NB: When accessing "deluge-console" you need to do that as user "debian-deluged"
 			fi
 			#-------------------------------------------------------------------------------
 
+		elif (( $G_DIETPI_VERSION_SUB == 22 )); then
+
+			#-------------------------------------------------------------------------------
+			# Apply Serial/UART rework: https://github.com/MichaIng/DietPi/pull/2678
+			# - Cleanup: Remove serial-getty masks for all non-existent serial devices
+			for i in /etc/systemd/system/serial-getty@tty{S,AMA,SAC}[0-9].service
+			do
+
+				[[ -L $i && $(readlink $i) == '/dev/null' ]] || continue
+				local tty=${i##*serial-getty@}
+				tty=${tty%.service}
+				[[ -e /dev/$tty ]] || systemctl unmask serial-getty@$tty
+
+			done
+			# - Fix: Disable serial-getty instances for all non-existent serial devices
+			for i in /etc/systemd/system/getty.target.wants/serial-getty@tty{S,AMA,SAC}[0-9].service
+			do
+
+				[[ -L $i ]] || continue
+				local tty=${i##*serial-getty@}
+				tty=${tty%.service}
+				[[ -e /dev/$tty ]] || systemctl disable serial-getty@$tty
+
+			done
+			#-------------------------------------------------------------------------------
+
 		fi
 
 		#-------------------------------------------------------------------------------


### PR DESCRIPTION
**Status**: ready
- [x] Patch:
  - Remove all masks, disable all serial-getty instances
  - Re-enable only currently active serial-getty instances
- [x] Changelog: **Whoopsie, added changelog to "dev" accidentally**
- [x] DietPi-PREP: Assure best compatible default is set, so that login consoles are enabled on all existing serial devices on first boot. The existing first run setup prompt allows to keep or disable them.
- [x] Add ARMbian image handling: Detect used serial device within boot.cmd. If it matches the one that is to be enabled, set console=both in `armbianEnv.ini`. Skip direct boot.cmd adjustments since those can break expacted behaviour of armbianEnv.ini etc.
- [x] Allow adding individual console entries to boot.ini on Odroids

**Reference**: https://github.com/MichaIng/DietPi/issues/2607

**Commit list/description**:
+ DietPi-Set_hardware | Serial/UART rework: Allow to toggle login console (+boot messages) on single serial devices. Without input (backwards compatibility) toggle for active devices only based on /dev/tty* existence to prevent e.g. boot error logs because systemd attempts to start serial-getty on unavailable serial devices.
+ DietPi-Set_hardware | Serial/UART rework: On RPi warn when attempting to enable login console on ttyAMA0 while Bluetooth is active and the other way round since onboard Bluetooth uses ttyAMA0.
+ DietPi-Config | Serial/UART rework: Allow to toggle login console on single serial devices
+ DietPi-Config | Adjust Pine A64 options based on ARMbian vs Ayufan/Longsleep image
+ DietPi-Config | Fix: Reset soundcard defaults and with this install alsa-utils if missing when entering Audio Options. Installing alsa-utils was skipped if it was NOT installed.
+ DietPi-Config | Minor coding and wording
+ DietPi-Patch | Cleanup and fix masked/enabled serial-getty instances for non-existent serial devices
+ DietPi-Config | Move Serial/UART options into own menu function so we will not return to parent menu after every selection
+ DietPi-Config | Further minor coding and reorder
+ DietPi-Set_hardware | serialconsole: Add ARMbian image handling: Detect used serial device within boot.cmd. If it matches the one that is to be enabled, set console=display|serial|both|none in armbianEnv.ini.
+ DietPi-Set_hardware | serialconsole: Allow adding individual console entries to boot.ini on Odroids
+ DietPi-Set_hardware | serialconsole: On RPi, only prompt Bluetooth warning if ttyAMA0 is about to be enabled
+ DietPi-Set_hardware | serialconsole: Minor fine tuning
+ DietPi-Config | Serial/UART: Several fixes
+ DietPi-Config | Serial/UART: Enable VM support since VirtualBox and VMware allow to enable virtual serial ports and attach devices from host.