### PR TITLE
DietPi-Patch | Restart_DietPi_Update() needs to finish BEFORE any reboot can be done

### DIFF
--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -18,95 +18,81 @@
 
 	INPUT=$1
 
-	#Import DietPi-Globals ---------------------------------------------------------------
+	# Import DietPi-Globals --------------------------------------------------------------
 	/DietPi/dietpi/func/dietpi-obtain_hw_model # Always update
 	. /DietPi/dietpi/func/dietpi-globals
 	G_PROGRAM_NAME='DietPi-Patchfile'
-	export G_PROMPT_BACKUP_DISABLED=1 # prevent backup user request prompts during patching
+	export G_PROMPT_BACKUP_DISABLED=1 # Prevent backup user request prompts during patching
 	G_INIT
-	#Import DietPi-Globals ---------------------------------------------------------------
+	# Import DietPi-Globals --------------------------------------------------------------
 
-	#Grab + export input (export is pre v6.14 required)
+	# Grab + export input (export is pre-v6.14 required)
 	export G_DIETPI_VERSION_SUB=$INPUT
 
 	#/////////////////////////////////////////////////////////////////////////////////////
-	#Patches that require a restart of DietPi-Update and patch system.
+	# Patches that require a restart of DietPi-Update
+	# - $1='reboot' forces a reboot afterwards instead of just exiting the script.
 	Restart_DietPi_Update(){
 
-		#Save current version, to rerun patch on next launch
+		local reboot=0
+		[[ $1 == 'reboot' ]] && reboot=1
+
+		# Save current version to rerun patch on next launch.
 		G_VERSIONDB_SAVE
 
-		#Remove DietPi-Update and DietPi-Patchfile working directories to allow concurrent execution
+		# Remove DietPi-Update and DietPi-Patchfile working directories to allow concurrent execution.
 		cd /tmp
 		rm -R /tmp/DietPi-Update /tmp/DietPi-Patchfile
 
-		G_DIETPI-NOTIFY 0 'Re-running DietPi-Update, to apply this new system...'
+		G_DIETPI-NOTIFY 0 'Restarting DietPi-Update with new code...'
 
-		#Sync changes to disk to avoid async issues
+		# Sync changes to disk to avoid async-related issues.
 		sync
 		sleep 3
 
-		#Apply update forcefully, since user has already chosen to do so
+		# Apply update forcefully, since user has already chosen to do so.
 		/DietPi/dietpi/dietpi-update 1
 
-		#Kill parental dietpi-update instance and exit this script to avoid obsolete update finish
-		kill $PPID
-		exit
+		if (( $reboot )); then
 
-	}
+			G_WHIP_MSG 'The system will now reboot to finish this update.'
+			reboot
 
-	#Pre-v6.17: Apply to new branch and versioning system
-	#	As loaded pre-v6.17 dietpi-update will overwrite ".version" to previous 2 line system, we need to rerun dietpi-update.
-	if (( $G_DIETPI_VERSION_SUB < 17 )) && [[ ! $(sed -n 6p /DietPi/dietpi/.version) ]]; then
+		else
 
-		#Switch from obsolete testing to new dev branch
-		BRANCH_INFO=''
-		if grep -q '^[[:blank:]]*DEV_GITBRANCH=testing$' /DietPi/dietpi.txt; then
-
-			G_CONFIG_INJECT 'DEV_GITBRANCH=' 'DEV_GITBRANCH=dev' /DietPi/dietpi.txt
-			BRANCH_INFO=' branch and'
+			# Kill parental dietpi-update instance and exit this script to avoid deprecated update finish.
+			kill $PPID
+			exit
 
 		fi
 
-		#Inform user to avoid confusion
-		echo ''
-		G_DIETPI-NOTIFY 0 "DietPi has applied a new$BRANCH_INFO versioning system to the device."
+	}
 
-		[[ -f /DietPi/dietpi/.update_stage ]] && G_VERSIONDB_SAVE || Restart_DietPi_Update
-
-	fi
-
-	#Pre-v6.20: Update to new G_DIETPI_INSTALL_STAGE system
-	#	As loaded pre-v6.20 dietpi-update will recreate ".update_stage", we need to rerun dietpi-update.
-	if [[ -f /DietPi/dietpi/.update_stage ]]; then
+	# Pre-v6.17: New ".version" system
+	# - As loaded pre-v6.17 dietpi-update will overwrite ".version" to previous 2 line system, we need to rerun dietpi-update.
+	# Pre-v6.20: New $G_DIETPI_INSTALL_STAGE system
+	# - As loaded pre-v6.20 dietpi-update will recreate ".update_stage", we need to rerun dietpi-update.
+	if [[ ! $(sed -n 6p /DietPi/dietpi/.version) || -f /DietPi/dietpi/.update_stage ]]; then
 
 		rm -f /{DietPi,boot}/dietpi/.update_stage
 
-		echo ''
-		G_DIETPI-NOTIFY 0 'DietPi has applied a new G_DIETPI_INSTALL_STAGE system to the device.'
-
-		#System already installed, rerun patch
 		if (( $(</DietPi/dietpi/.install_stage) > 0 )); then
 
 			echo 2 > /DietPi/dietpi/.install_stage
 			Restart_DietPi_Update
 
-		#System updating for the 1st time. We need to reboot the system, to kill dietpi-software old code and reload the new one.
+		# - As first run dietpi-update is executed from old dietpi-software, we need to reboot to load new first run setup scripts.
 		else
 
 			echo 0 > /DietPi/dietpi/.install_stage
-			l_message='Syncing new DietPi scripts to disk' G_RUN_CMD /DietPi/dietpi/func/dietpi-ramdisk 1
-			> /DietPi/.ramdisk
-			G_WHIP_MSG 'A system reboot is required to apply the new G_DIETPI_INSTALL_STAGE system. Once the system has rebooted, please login to continue setup.'
-			sleep 3 # Sleep to assure sync has finished in case of G_USER_INPUTS=0
-			reboot
+			Restart_DietPi_Update reboot
 
 		fi
 
 	fi
 
 	#/////////////////////////////////////////////////////////////////////////////////////
-	#Incremental patch system:
+	# Incremental patch system
 	Incremental_Patch_System(){
 
 		if (( $G_DIETPI_VERSION_SUB == -1 )); then

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -16,17 +16,20 @@
 	# - /DietPi/dietpi/patch_file $G_DIETPI_VERSION_SUB
 	#////////////////////////////////////
 
+	# Grab input
 	INPUT=$1
 
 	# Import DietPi-Globals --------------------------------------------------------------
 	/DietPi/dietpi/func/dietpi-obtain_hw_model # Always update
 	. /DietPi/dietpi/func/dietpi-globals
 	G_PROGRAM_NAME='DietPi-Patchfile'
-	export G_PROMPT_BACKUP_DISABLED=1 # Prevent backup user request prompts during patching
 	G_INIT
 	# Import DietPi-Globals --------------------------------------------------------------
 
-	# Grab + export input (export is pre-v6.14 required)
+	# Prevent backup prompts during patching e.g. from DietPi-Software reinstalls
+	export G_PROMPT_BACKUP_DISABLED=1
+
+	# Export subversion, required for pre-v6.14
 	export G_DIETPI_VERSION_SUB=$INPUT
 
 	#/////////////////////////////////////////////////////////////////////////////////////
@@ -42,7 +45,7 @@
 
 		# Remove DietPi-Update and DietPi-Patchfile working directories to allow concurrent execution.
 		cd /tmp
-		rm -R /tmp/DietPi-Update /tmp/DietPi-Patchfile
+		rm -Rf /tmp/DietPi-{Update,Patchfile}
 
 		G_DIETPI-NOTIFY 0 'Restarting DietPi-Update with new code...'
 
@@ -99,8 +102,7 @@
 
 			#-------------------------------------------------------------------------------
 			#Asus TB G_HW_MODEL change
-			if [[ -r /etc/.dietpi_hw_model_identifier ]] &&
-				(( $(sed -n 1p /etc/.dietpi_hw_model_identifier) == 100 )); then
+			if [[ -f /etc/.dietpi_hw_model_identifier && $(sed -n 1p /etc/.dietpi_hw_model_identifier) == 100 ]]; then
 
 				G_HW_MODEL=52
 				echo $G_HW_MODEL > /etc/.dietpi_hw_model_identifier
@@ -113,13 +115,12 @@
 			sed -i '/#Apply system locale/Q' /etc/bash.bashrc
 			sed -i '/#DietPi Additions/Q' /etc/bash.bashrc
 			#-------------------------------------------------------------------------------
-			#Fix doubled and renamed config files:
-			#https://github.com/MichaIng/DietPi/commit/68148cec6b49afc787deca638456e1c4689e1cab#diff-8370b86e635383d521462994afe04a2d
+			#Fix doubled and renamed config files: https://github.com/MichaIng/DietPi/commit/68148cec6b49afc787deca638456e1c4689e1cab#diff-8370b86e635383d521462994afe04a2d
 			[[ -f /etc/apt/apt.conf.d/99force-ipv ]] && rm /etc/apt/apt.conf.d/99force-ipv
 			[[ -f /etc/sysctl.d/97-dietpi.conf ]] && rm /etc/sysctl.d/97-dietpi.conf
 			#-------------------------------------------------------------------------------
 			#Core_ENV update: https://github.com/MichaIng/DietPi/pull/1419
-			#	consoleblank disable x86_64
+			# - consoleblank disable x86_64
 			if [[ -f /etc/default/grub ]]; then
 
 				G_CONFIG_INJECT 'GRUB_CMDLINE_LINUX_DEFAULT=' 'GRUB_CMDLINE_LINUX_DEFAULT="consoleblank=0 quiet"' /etc/default/grub
@@ -155,10 +156,8 @@
 			G_WHIP_MSG 'Notice (locale):\n\nTo resolve broken locales, they have been reset to "en_GB.UTF-8".\n\nIf you had a different locale configured on this system, please use "dietpi-config" at a later date to re-configure.\n\nIn relation to that, DietPi does not use "/etc/environment" anymore, thus it is cleaned. In case you manually edited it, a backup was created: /mnt/dietpi_userdata/environment.bak'
 			#------------------------------------------------------------------------------
 			#Removed control from DietPi-Services: https://github.com/MichaIng/DietPi/issues/1501
-			systemctl enable dnsmasq &> /dev/null
-			systemctl enable openvpn &> /dev/null
-			systemctl start dnsmasq &> /dev/null
-			systemctl start openvpn &> /dev/null
+			systemctl enable dnsmasq &> /dev/null; systemctl start dnsmasq &> /dev/null
+			systemctl enable openvpn &> /dev/null; systemctl start openvpn &> /dev/null
 			#-------------------------------------------------------------------------------
 			#https://dietpi.com/phpbb/viewtopic.php?f=11&t=2772&p=10646#p10646
 			[[ -f /etc/apt/sources.list.d/openmediavault.list ]] && rm /etc/apt/sources.list.d/openmediavault.list
@@ -166,12 +165,12 @@
 			#DietPi-Software removals: https://github.com/MichaIng/DietPi/issues/1491
 			if [[ -f /DietPi/dietpi/.installed ]]; then
 
-				sed -i '/^aSOFTWARE_INSTALL_STATE\[100\]=/c\aSOFTWARE_INSTALL_STATE\[100\]=0' /DietPi/dietpi/.installed #grashopper (now pijuice)
-				sed -i '/^aSOFTWARE_INSTALL_STATE\[106\]=/c\aSOFTWARE_INSTALL_STATE\[106\]=0' /DietPi/dietpi/.installed #raspcontrol (now ntp)
+				sed -i '/^aSOFTWARE_INSTALL_STATE\[100\]=/c\aSOFTWARE_INSTALL_STATE\[100\]=0' /DietPi/dietpi/.installed # Grashopper (now pijuice)
+				sed -i '/^aSOFTWARE_INSTALL_STATE\[106\]=/c\aSOFTWARE_INSTALL_STATE\[106\]=0' /DietPi/dietpi/.installed # raspcontrol (now ntp)
 				if grep -qi '^aSOFTWARE_INSTALL_STATE\[170\]=2' /DietPi/dietpi/.installed; then
 
-					sed -i '/^aSOFTWARE_INSTALL_STATE\[106\]=/c\aSOFTWARE_INSTALL_STATE\[106\]=2' /DietPi/dietpi/.installed #ntp (replaces raspcontrol)
-					sed -i '/^aSOFTWARE_INSTALL_STATE\[170\]=/c\aSOFTWARE_INSTALL_STATE\[170\]=0' /DietPi/dietpi/.installed #ntp (now 106)
+					sed -i '/^aSOFTWARE_INSTALL_STATE\[106\]=/c\aSOFTWARE_INSTALL_STATE\[106\]=2' /DietPi/dietpi/.installed # NTP (replaces raspcontrol)
+					sed -i '/^aSOFTWARE_INSTALL_STATE\[170\]=/c\aSOFTWARE_INSTALL_STATE\[170\]=0' /DietPi/dietpi/.installed # NTP (now 106)
 
 				fi
 


### PR DESCRIPTION
**Status**: Ready

**Reference**: https://dietpi.com/phpbb/viewtopic.php?f=11&t=5752

**Commit list/description**:
+ DietPi-Patch | Restart_DietPi_Update() needs to finish BEFORE any reboot can be done, otherwise possible new DietPi services (PreBoot, PostBoot) and login scripts (/etc/bashrc.d) are not yet enabled, leading to boot/login issues, missing update finalise etc...
+ DietPi-Patch | Cleanup and merge pre-v6.17 and pre-v6.20 update restarts. Applying testing => dev branch is obsolete since with obsolete testing branch the update fails now at earlier stage (but/and we have no users on testing branch). Running the new update code first allows to skip sync tasks before reboot.