### PR TITLE
META | DietPi-Image: Create from disk or shrink an image file

### DIFF
--- a/.meta/dietpi-image
+++ b/.meta/dietpi-image
@@ -26,6 +26,15 @@
 	ROOT=$3
 	[[ $4 == GPT ]] && GPT=1 || GPT=0
 
+	# Check root
+	(( $UID )) && { echo 'ERROR: This script must run with root permissions. Please retry with "sudo".'; exit 1; }
+
+	# Force locale
+	export LC_ALL='en_GB.UTF-8'
+
+	# Move to /tmp for temp file creation
+	cd /tmp
+
 	# Check source
 	SOURCE_IS_FILE=1
 	if [[ $SOURCE == /dev/* ]]; then
@@ -39,6 +48,7 @@
 
 	fi
 
+	# Install required packages
 	apt-get -y install gparted gdisk gpart dosfstools zerofree p7zip
 
 	# GPT images (RockPro64) after reading the image AND again after shrinking
@@ -73,25 +83,35 @@
 	# Fsck
 	e2fsck -f $ROOT_DEV
 
-	# Run the shrinking multiple times as the size can be reduced every time a bid more
-	for i in {0..2}
+	# Shrink file system
+	# - Run multiple times until no change is done any more
+	out=''
+	FS_SIZE=0
+	while :
 	do
 
-		# Shrink root file system to minimum size
-		resize2fs -M $ROOT_DEV
-		read -p 'The minimum file system size above is as well the minimum for gparted, besides gparted shows a larger minimum already.
-Press CTRL+C to exit, else gparted will now start to allow partition resizing'
+		resize2fs -M $ROOT_DEV | tee resize2fs_out
+		if out=$(grep -m1 'Nothing to do!' resize2fs_out); then
 
-		# gparted to resize boot partition to minimum
-		gparted $SOURCE
-		read -p 'If failed press CTRL+C to exit and prevent further action, else, press any key to continue...'
+			FS_SIZE=$(mawk '{print $5 * 4096}' <<< $out)
+			echo "[  OK  ] Shrunken file system to $FS_SIZE bytes"
+			break
 
-		sync
-
-		# Override free space with zeros to purge removed data and allow further image/archive size reduction
-		zerofree -v $ROOT_DEV
+		fi
 
 	done
+
+	read -p 'The minimum file system size above is as well the minimum for gparted, besides gparted shows a larger minimum already.
+Press CTRL+C to exit, else gparted will now start to allow partition resizing'
+
+	# gparted to resize boot partition to minimum
+	gparted $SOURCE
+	read -p 'If failed press CTRL+C to exit and prevent further action, else, press any key to continue...'
+
+	sync
+
+	# Override free space with zeros to purge removed data and allow further image/archive size reduction
+	zerofree -v $ROOT_DEV
 
 	# GPT images (RockPro64) after reading the image AND again after shrinking
 	# To fix:

--- a/.meta/dietpi-image
+++ b/.meta/dietpi-image
@@ -95,6 +95,7 @@
 
 			FS_SIZE=$(mawk '{print $5 * 8}' <<< $out) # 4k blocks => 512 byte sectors
 			echo "[  OK  ] Shrunken root file system to $(( $FS_SIZE / 2048 + 1 )) MiB"
+			rm resize2fs_out
 			break
 
 		fi
@@ -106,10 +107,14 @@
 	PART_END=$(( $PART_START + $FS_SIZE ))
 
 	# Resize partition to minimum
-	parted -s $SOURCE unit s resizepart 2 $PART_END
+	echo '[ INFO ] Shrinking partition. Please press "y" when asked.'
+	parted $SOURCE unit s resizepart 2 $PART_END	
 
 	# Sync changes to disk now
 	sync
+
+	# Re-read partition layout
+	partprobe $SOURCE
 
 	# Override free space with zeros to purge removed data and allow further image/archive size reduction
 	zerofree -v $ROOT_DEV
@@ -160,7 +165,7 @@ SHA256:	$(sha256sum $NAME.img | mawk '{print $1}')
 _EOF_
 
 	# Download current README
-	wget https://raw.githubusercontent.com/MichaIng/DietPi/master/README.md
+	wget https://raw.githubusercontent.com/MichaIng/DietPi/master/README.md -O README.md
 
 	# Generate 7z archive
 	# NB: LZMA2 ultra compression method requires 2G RAM

--- a/.meta/dietpi-image
+++ b/.meta/dietpi-image
@@ -10,20 +10,20 @@
 	#////////////////////////////////////
 	#
 	# Usage:
-	# - ./dietpi-image <source> <name> <root_partition> [GPT]
+	# - ./dietpi-image <source> <root_partition> <name> [GPT]
 	#	source: /dev/* | *.img
+	#	root_partition: 0 | 1 | 2 | ... ("0" means no partition table)
 	#	name: DietPi_<device>-<arch>-<distro>
 	#		device: RPi | OdroidXU4 | NativePC-BIOS | ...
 	#		arch: ARMv6 | ARMv7 | ARMv8 | x86_64
 	#		distro: Stretch | Buster
-	#	root_partition: 0 | 1 | 2 | ... ("0" means no partition table)
 	#	"GPT": Required to correctly handle GPT partition tables
 	#////////////////////////////////////
 
 	# Grab input
 	SOURCE=$1
-	NAME=$2
-	ROOT=$3
+	ROOT=$2
+	NAME=$3
 	[[ $4 == GPT ]] && GPT=1 || GPT=0
 
 	# Check root
@@ -49,7 +49,7 @@
 	fi
 
 	# Install required packages
-	apt-get -y install gdist dosfstools parted zerofree p7zip
+	apt-get -qq install gdisk dosfstools parted zerofree p7zip
 
 	# GPT images (RockPro64) after reading the image AND again after shrinking
 	# To fix:
@@ -90,7 +90,7 @@
 	while :
 	do
 
-		resize2fs -M $ROOT_DEV | tee resize2fs_out
+		resize2fs -M $ROOT_DEV 2>&1 | tee resize2fs_out
 		if out=$(grep -m1 'Nothing to do!' resize2fs_out); then
 
 			FS_SIZE=$(mawk '{print $5 * 8}' <<< $out) # 4k blocks => 512 byte sectors
@@ -106,7 +106,7 @@
 	PART_END=$(( $PART_START + $FS_SIZE ))
 
 	# Resize partition to minimum
-	parted $SOURCE unit s resizepart 2 $PART_END
+	parted -s $SOURCE unit s resizepart 2 $PART_END
 
 	# Sync changes to disk now
 	sync
@@ -148,7 +148,7 @@
 	else
 
 		dd if=$SOURCE of=$NAME.img bs=1M status=progress count=$(( $IMAGE_SIZE / 1024 / 1024 + 1 ))
-		read -p "Image file created: /root/$NAME.img"
+		echo "Image file created: /root/$NAME.img"
 
 	fi
 

--- a/.meta/dietpi-image
+++ b/.meta/dietpi-image
@@ -93,9 +93,12 @@
 		resize2fs -M $ROOT_DEV 2>&1 | tee resize2fs_out
 		if out=$(grep -m1 'Nothing to do!' resize2fs_out); then
 
-			FS_SIZE=$(mawk '{print $5 * 8}' <<< $out) # 4k blocks => 512 byte sectors
-			echo "[  OK  ] Shrunken root file system to $(( $FS_SIZE / 2048 + 1 )) MiB"
+			# Re-add 4M to be failsafe, was required on Raspbian Buster for successful boot
+			FS_SIZE=$(mawk '{print $5 + 1024}' <<< $out) # 4k blocks
 			rm resize2fs_out
+			resize2fs $ROOT_DEV $FS_SIZE
+			echo "[  OK  ] Shrunken root file system to $(( $FS_SIZE / 256 + 1 )) MiB"
+			FS_SIZE=$(( $FS_SIZE * 8 )) # 4k blocks => 512 byte sectors
 			break
 
 		fi
@@ -132,14 +135,14 @@
 	# - Without partition table, the whole raw disk space needs to be cloned
 	if [[ $ROOT == 0 ]]; then
 
-		PART_SIZE=$(lsblk -o SIZE --bytes $SOURCE)
+		PART_SIZE=$(lsblk -o SIZE --bytes $SOURCE) # Byte
 
 	else
 
-		PART_SIZE=$(( ( $(fdisk -l -o End $SOURCE | tail -1) + 1 ) * 512 ))
+		PART_SIZE=$(( ( $(fdisk -l -o End $SOURCE | tail -1) + 1 ) * 512 )) # 512 byte sectors => Byte 
 
 	fi
-	IMAGE_SIZE=$(( $PART_SIZE + 512*256 )) # 64 bytes for secondary GPT + safety net
+	IMAGE_SIZE=$(( $PART_SIZE + 512*256 )) # 64 byte for secondary GPT + safety net
 
 	# Create final image in /root
 	cd /root
@@ -152,6 +155,7 @@
 	# else create .img file from block device source via dd, stopping at block count that matches used size
 	else
 
+		[[ -f $NAME.img ]] && rm $NAME.img
 		dd if=$SOURCE of=$NAME.img bs=1M status=progress count=$(( $IMAGE_SIZE / 1024 / 1024 + 1 ))
 		echo "Image file created: /root/$NAME.img"
 
@@ -169,6 +173,7 @@ _EOF_
 
 	# Generate 7z archive
 	# NB: LZMA2 ultra compression method requires 2G RAM
+	[[ -f $NAME.7z ]] && rm $NAME.7z
 	7zr a -m0=lzma2 -mx=9 $NAME.7z $NAME.img hash.txt README.md
 
 	#-----------------------------------------------------------------------------------

--- a/.meta/dietpi-image
+++ b/.meta/dietpi-image
@@ -1,0 +1,137 @@
+#!/bin/bash
+{
+	#////////////////////////////////////
+	# DietPi Image creation/finalise Script
+	#
+	#////////////////////////////////////
+	# Created by Daniel Knight / daniel.knight@dietpi.com / dietpi.com
+	# Updated by MichaIng / micha@dietpi.com / dietpi.com
+	#
+	#////////////////////////////////////
+	#
+	# Usage:
+	# - ./dietpi-image <source> <name> <root_partition> [GPT]
+	#	source: /dev/* | *.img
+	#	name: DietPi_<device>-<arch>-<distro>
+	#		device: RPi | OdroidXU4 | NativePC-BIOS | ...
+	#		arch: ARMv6 | ARMv7 | ARMv8 | x86_64
+	#		distro: Stretch | Buster
+	#	root_partition: 0 | 1 | 2 | ... ("0" means no partition table)
+	#	"GPT": Required to correctly handle GPT partition tables
+	#////////////////////////////////////
+
+	# Grab input
+	SOURCE=$1
+	NAME=$2
+	ROOT=$3
+	[[ $4 == GPT ]] && GPT=1 || GPT=0
+
+	# Check source
+	SOURCE_IS_FILE=1
+	if [[ $SOURCE == /dev/* ]]; then
+
+		SOURCE_IS_FILE=0
+		[[ -b $SOURCE ]] || { echo "ERROR: Source block device ($SOURCE) does not exist"; exit 1; }
+
+	else
+
+		[[ -f $SOURCE ]] || { echo "ERROR: Source image file ($SOURCE) does not exist"; exit 1; }
+
+	fi
+
+	apt-get -y install gparted gdisk gpart dosfstools zerofree p7zip
+
+	# GPT images (RockPro64) after reading the image AND again after shrinking
+	# To fix:
+	# - GPT PMBR size mismatch (4458495 != 15523839) will be corrected by w(rite).
+	# - 15523806
+	# RUN
+	# - gdisk "$IMAGE_FP/$IMAGE_NAME"
+	#	w | y
+	(( $GPT )) && gdisk $SOURCE
+
+	# Attach .img file to loop device
+	if (( $SOURCE_IS_FILE )); then
+
+		modprobe loop
+		SOURCE_FILE=$SOURCE
+		SOURCE=$(losetup -f)
+		losetup $SOURCE "$SOURCE_FILE"
+		partprobe $SOURCE
+
+	fi
+
+	# Estimate root partition dev
+	ROOT_DEV=$SOURCE
+	if [[ $ROOT != 0 ]]; then
+
+		[[ $SOURCE =~ /mmcblk || $SOURCE =~ /nvme || $SOURCE =~ /loop ]] && ROOT_DEV="${SOURCE}p${ROOT}"
+		[[ $SOURCE =~ /[sh]d[a-z] ]] && ROOT_DEV="${SOURCE}${ROOT}"
+
+	fi
+
+	# Fsck
+	e2fsck -f $ROOT_DEV
+
+	# Run the shrinking multiple times as the size can be reduced every time a bid more
+	for i in {0..2}
+	do
+
+		# Shrink root file system to minimum size
+		resize2fs -M $ROOT_DEV
+		read -p 'The minimum file system size above is as well the minimum for gparted, besides gparted shows a larger minimum already.
+Press CTRL+C to exit, else gparted will now start to allow partition resizing'
+
+		# gparted to resize boot partition to minimum
+		gparted $SOURCE
+		read -p 'If failed press CTRL+C to exit and prevent further action, else, press any key to continue...'
+
+		sync
+
+		# Override free space with zeros to purge removed data and allow further image/archive size reduction
+		zerofree -v $ROOT_DEV
+
+	done
+
+	# GPT images (RockPro64) after reading the image AND again after shrinking
+	# To fix:
+	# - GPT PMBR size mismatch (4458495 != 15523839) will be corrected by w(rite).
+	# - 15523806
+	# RUN
+	# - gdisk "$IMAGE_FP/$IMAGE_NAME"
+	#	w | y
+	(( $GPT )) && gdisk $SOURCE
+
+	# Estimate used size
+	# - Without partition table, the whole raw disk space needs to be cloned
+	if [[ $ROOT == 0 ]]; then
+
+		SIZE=$(lsblk -o SIZE --bytes $SOURCE)
+
+	else
+
+		# 64 bytes for secondary GPT + safety net
+		SIZE=$(( ( $(fdisk -l -o End $SOURCE | tail -1) + 1 ) * 512 ))
+
+	fi
+	SIZE=$(( $SIZE + 512*256 )) 
+
+	# If source is an image file, truncate to used size
+	if (( $SOURCE_IS_FILE )); then
+
+		umount $SOURCE
+		truncate --size=$SIZE "$SOURCE_FILE"
+
+	# else create .img file from block device source via dd, stopping at block count that matches used size
+	else
+
+		dd if=$SOURCE of=/root/$NAME.img bs=1M status=progress count=$(( $SIZE / 1024 / 1024 + 1 ))
+		read -p "Image file created: /root/$NAME.img"
+		umount $SOURCE
+
+	fi
+
+	#-----------------------------------------------------------------------------------
+	exit
+	#-----------------------------------------------------------------------------------
+}

--- a/.meta/dietpi-image
+++ b/.meta/dietpi-image
@@ -49,7 +49,7 @@
 	fi
 
 	# Install required packages
-	apt-get -y install gparted gdisk gpart dosfstools zerofree p7zip
+	apt-get -y install gdist dosfstools parted zerofree p7zip
 
 	# GPT images (RockPro64) after reading the image AND again after shrinking
 	# To fix:
@@ -83,7 +83,7 @@
 	# Fsck
 	e2fsck -f $ROOT_DEV
 
-	# Shrink file system
+	# Shrink file system to minimum
 	# - Run multiple times until no change is done any more
 	out=''
 	FS_SIZE=0
@@ -93,21 +93,22 @@
 		resize2fs -M $ROOT_DEV | tee resize2fs_out
 		if out=$(grep -m1 'Nothing to do!' resize2fs_out); then
 
-			FS_SIZE=$(mawk '{print $5 * 4096}' <<< $out)
-			echo "[  OK  ] Shrunken file system to $FS_SIZE bytes"
+			FS_SIZE=$(mawk '{print $5 * 8}' <<< $out) # 4k blocks => 512 byte sectors
+			echo "[  OK  ] Shrunken root file system to $(( $FS_SIZE / 2048 + 1 )) MiB"
 			break
 
 		fi
 
 	done
 
-	read -p 'The minimum file system size above is as well the minimum for gparted, besides gparted shows a larger minimum already.
-Press CTRL+C to exit, else gparted will now start to allow partition resizing'
+	# Estimate minimum end sector
+	PART_START=$(fdisk -l -o Start $SOURCE | tail -1) # 512 byte sectors
+	PART_END=$(( $PART_START + $FS_SIZE ))
 
-	# gparted to resize boot partition to minimum
-	gparted $SOURCE
-	read -p 'If failed press CTRL+C to exit and prevent further action, else, press any key to continue...'
+	# Resize partition to minimum
+	parted $SOURCE unit s resizepart 2 $PART_END
 
+	# Sync changes to disk now
 	sync
 
 	# Override free space with zeros to purge removed data and allow further image/archive size reduction
@@ -126,30 +127,44 @@ Press CTRL+C to exit, else gparted will now start to allow partition resizing'
 	# - Without partition table, the whole raw disk space needs to be cloned
 	if [[ $ROOT == 0 ]]; then
 
-		SIZE=$(lsblk -o SIZE --bytes $SOURCE)
+		PART_SIZE=$(lsblk -o SIZE --bytes $SOURCE)
 
 	else
 
-		# 64 bytes for secondary GPT + safety net
-		SIZE=$(( ( $(fdisk -l -o End $SOURCE | tail -1) + 1 ) * 512 ))
+		PART_SIZE=$(( ( $(fdisk -l -o End $SOURCE | tail -1) + 1 ) * 512 ))
 
 	fi
-	SIZE=$(( $SIZE + 512*256 )) 
+	IMAGE_SIZE=$(( $PART_SIZE + 512*256 )) # 64 bytes for secondary GPT + safety net
+
+	# Create final image in /root
+	cd /root
 
 	# If source is an image file, truncate to used size
 	if (( $SOURCE_IS_FILE )); then
 
-		umount $SOURCE
-		truncate --size=$SIZE "$SOURCE_FILE"
+		truncate --size=$IMAGE_SIZE "$SOURCE_FILE"
 
 	# else create .img file from block device source via dd, stopping at block count that matches used size
 	else
 
-		dd if=$SOURCE of=/root/$NAME.img bs=1M status=progress count=$(( $SIZE / 1024 / 1024 + 1 ))
+		dd if=$SOURCE of=$NAME.img bs=1M status=progress count=$(( $IMAGE_SIZE / 1024 / 1024 + 1 ))
 		read -p "Image file created: /root/$NAME.img"
-		umount $SOURCE
 
 	fi
+
+	# Generate hashes: MD5, SHA1, SHA256
+	cat << _EOF_ > hash.txt
+MD5:	$(md5sum $NAME.img | mawk '{print $1}')
+SHA1:	$(sha1sum $NAME.img | mawk '{print $1}')
+SHA256:	$(sha256sum $NAME.img | mawk '{print $1}')
+_EOF_
+
+	# Download current README
+	wget https://raw.githubusercontent.com/MichaIng/DietPi/master/README.md
+
+	# Generate 7z archive
+	# NB: LZMA2 ultra compression method requires 2G RAM
+	7zr a -m0=lzma2 -mx=9 $NAME.7z $NAME.img hash.txt README.md
 
 	#-----------------------------------------------------------------------------------
 	exit


### PR DESCRIPTION
**Status**: WIP

**ToDo**:
- ~[ ] Clean tmpfs mount directories. In most cases there are obsolete files inside. Although this can be done as well during DietPi-PREP (mount root dev to tmp mount point, clean, umount).~
**=> DietPi-PREP task**
- [x] Check whether shrink loop can be replaced with only resize2fs loop. During some test running resize2fs 3 times resulted on a bid smaller file system. The 4th loop didn't change something anymore.
- [ ] @Fourdee: Which device actually requires `RK_SINGLE_IMG` (your script) so that the file system is written directly to the drive without partition table?
- [x] @Fourdee: Do I get is right that GPT partitions require `gdisk` to run (initially and after shrink has finished), then without any actual change press `w` (write) and `y` (confirm)? So then this could be automated as well.
- [x] Retest script with another image and see if in some circumstances the UUID of the resulting image file changes. In my case it did after many back and forth creation steps. But possibly I simply mounted the actual drive and image drive in parallel with identical UUIDs and the system automatically corrected this. Otherwise: `tune2fs -U <UUID_of_initial_root_partition> $ROOT_DEV`
- [x] Automatic hash creation and 7z compression?
- [ ] Root partition as ALWAYS the last partition, right? Then we could automate root partition number estimation as well, skipping the input.

**Reference**: https://github.com/MichaIng/DietPi/issues/2026#issuecomment-458219235

**Commit list/description**:
+ DietPi-Image | Create from disk or shrink an image file