### PR TITLE
DietPi-Software | Transmission: Add password with escaped double quotes to prevent service startup failures in case

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Bug Fixes:
 - DietPi-Update | Resolved an issue where on older images first run update didn't finalise as intended, leading to several first run setup issues, depending on the image age. The fix has been applied outside of the releases since only the online part of the updater is affected: https://github.com/MichaIng/DietPi/pull/2684
 - DietPi-Login | Resolved an issue where login as non-root user could result in a "sudo" password prompt or endless failure loop due to missing sudo permissions. Many thanks to @xsak for reporting this issue: https://github.com/MichaIng/DietPi/issues/2667
 - DietPi-Software | Emby Server: Resolved an issue where download failed if the latest release does not contain a Debian package. Many thanks to @niblettr for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?f=11&t=5755
+- DietPi-Software | Transmission: Resolved an issue where double quotes in global software password caused a service startup failure. Many thanks to @Drew80 for reporting this issue: https://github.com/MichaIng/DietPi/issues/2484#issuecomment-480675168
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX/files
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8363,7 +8363,6 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 			G_CONFIG_INJECT '"cache-size-mb"' '    "cache-size-mb": '$(Optimize_BitTorrent 0)',' /etc/transmission-daemon/settings.json '^\{$'
 			G_CONFIG_INJECT '"download-queue-size"' '    "download-queue-size": '$(Optimize_BitTorrent 1)',' /etc/transmission-daemon/settings.json '^\{$'
 			G_CONFIG_INJECT '"peer-limit-global"' '    "peer-limit-global": '$(Optimize_BitTorrent 2)',' /etc/transmission-daemon/settings.json '^\{$'
-			G_CONFIG_INJECT '"max-peers-global"' '    "max-peers-global": '$(Optimize_BitTorrent 2)',' /etc/transmission-daemon/settings.json '^\{$'
 			G_CONFIG_INJECT '"upload-slots-per-torrent"' '    "upload-slots-per-torrent": '$(Optimize_BitTorrent 3)',' /etc/transmission-daemon/settings.json '^\{$'
 
 			G_CONFIG_INJECT '"port-forwarding-enabled"' '    "port-forwarding-enabled": true,' /etc/transmission-daemon/settings.json '^\{$'
@@ -8376,7 +8375,9 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 			G_CONFIG_INJECT '"trash-original-torrent-files"' '    "trash-original-torrent-files": true,' /etc/transmission-daemon/settings.json '^\{$'
 
 			G_CONFIG_INJECT '"download-dir"' '    "download-dir": "'$G_FP_DIETPI_USERDATA'/downloads",' /etc/transmission-daemon/settings.json '^\{$'
-			G_CONFIG_INJECT '"rpc-password"' '    "rpc-password": "'"$GLOBAL_PW"'",' /etc/transmission-daemon/settings.json '^\{$'
+			# - Double quotes need to be escaped in .json files: https://github.com/MichaIng/DietPi/issues/2484#issuecomment-481374924
+			# - ToDo: Hash password directly. Which hash method is used?
+			G_CONFIG_INJECT '"rpc-password"' '    "rpc-password": "'"${GLOBAL_PW//\"/\\\"}"'",' /etc/transmission-daemon/settings.json '^\{$'
 			G_CONFIG_INJECT '"rpc-username"' '    "rpc-username": "root",' /etc/transmission-daemon/settings.json '^\{$'
 			G_CONFIG_INJECT '"rpc-whitelist-enabled"' '    "rpc-whitelist-enabled": false,' /etc/transmission-daemon/settings.json '^\{$'
 			G_CONFIG_INJECT '"message-level"' '    "message-level": 0,' /etc/transmission-daemon/settings.json '^\{$'


### PR DESCRIPTION
**Status**: ready
- [x] Changelog

**Testing**:
- 🈯️ Passed test with `"` inside password.

**Reference**: https://github.com/MichaIng/DietPi/issues/2484#issuecomment-481374924

**Commit list/description**:
+ DietPi-Software | Transmission: Add password with escaped double quotes to prevent service startup failures in case. As well skip adding legacy "max-peers-global" setting which is replaced by "peer-limit-global" for a long time which we add/adjust as well.
  - https://github.com/transmission/transmission/wiki/Editing-Configuration-Files