### PR TITLE
DietPi-Autostart | Enable systemd-logind with AmiBerry fastboot

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,6 +24,7 @@ Bug Fixes:
 - DietPi-Software | Transmission: Resolved an issue where double quotes in global software password caused a service startup failure. Many thanks to @Drew80 for reporting this issue: https://github.com/MichaIng/DietPi/issues/2484#issuecomment-480675168
 - DietPi-Software | WireGuard: Resolved an issue where IPv6 connections did not work with enabled IPv6 forwarding. Many thats to @schnuckz for reporting this issue: https://github.com/MichaIng/DietPi/issues/2691
 - DietPi-Software | Subsonic: Resolved an issue where FFmpeg transcoder might not have been applied correctly. Many thanks to @spectrumcomputing for reporting this issue: https://github.com/MichaIng/DietPi/issues/2697
+- DietPi-Software | AmiBerry: Resolved an issue where no login prompt was present when exiting AmiBerry from fastboot mode. Many thanks to @Trigger58 for reporting this issue: https://github.com/MichaIng/DietPi/issues/2703#issuecomment-482471440
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX/files
 

--- a/dietpi/dietpi-autostart
+++ b/dietpi/dietpi-autostart
@@ -80,6 +80,7 @@ Type=idle
 RemainAfterExit=yes
 StandardOutput=tty
 ExecStartPre=$(command -v chmod) +x /var/lib/dietpi/dietpi-autostart/custom.sh
+ExecStartPre=$(command -v echo) 'Starting DietPi-Autostart (Custom) script...'
 ExecStart=/var/lib/dietpi/dietpi-autostart/custom.sh
 
 [Install]

--- a/dietpi/dietpi-autostart
+++ b/dietpi/dietpi-autostart
@@ -80,7 +80,7 @@ Type=idle
 RemainAfterExit=yes
 StandardOutput=tty
 ExecStartPre=$(command -v chmod) +x /var/lib/dietpi/dietpi-autostart/custom.sh
-ExecStartPre=$(command -v echo) 'Starting DietPi-Autostart (Custom) script...'
+ExecStartPre=$(which echo) 'Starting DietPi-Autostart (Custom) script...'
 ExecStart=/var/lib/dietpi/dietpi-autostart/custom.sh
 
 [Install]

--- a/dietpi/dietpi-autostart
+++ b/dietpi/dietpi-autostart
@@ -16,16 +16,15 @@
 	# - dietpi-autostart int (set value only)
 	#////////////////////////////////////
 
-	#Import DietPi-Globals ---------------------------------------------------------------
+	# Import DietPi-Globals --------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
 	G_PROGRAM_NAME='DietPi-Autostart'
 	G_CHECK_ROOT_USER
 	G_INIT
-	#Import DietPi-Globals ---------------------------------------------------------------
+	# Import DietPi-Globals --------------------------------------------------------------
 
-	#Grab Input (valid integer)
-	INPUT=-1
-	disable_error=1 G_CHECK_VALIDINT "$1" && INPUT=$1
+	# Grab Input (valid integer)
+	disable_error=1 G_CHECK_VALIDINT "$1" && INPUT=$1 || INPUT=-1
 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# MENUS
@@ -36,12 +35,12 @@
 
 	Apply_Boot_Index(){
 
-		# - Always disable LightDM
+		# Disable all autostart options first
+		# - LightDM
 		systemctl disable lightdm &> /dev/null
 
-		# - Amiberry | always disable services, service launched by DietPi/login if non fastboot mode
+		# - Amiberry
 		systemctl disable amiberry &> /dev/null
-
 		if (( $G_HW_MODEL < 10 )); then
 
 			sed -i '/^[[:blank:]]*boot_delay=0/d' /DietPi/config.txt
@@ -51,49 +50,53 @@
 
 		fi
 
-		# - Disable custom launch service
+		# - Custom script
+		systemctl disable dietpi-autostart_custom &> /dev/null
 		[[ -f /etc/systemd/system/dietpi-autostart_custom.service ]] && rm /etc/systemd/system/dietpi-autostart_custom.service
 
-		# - Disable auto login
+		# - Auto login
 		local fp_svc='/etc/systemd/system/getty@tty1.service.d'
 		if [[ -d $fp_svc ]]; then
 
 			[[ -f $fp_svc/dietpi-autologin.conf ]] && rm $fp_svc/dietpi-autologin.conf
-			[[ $(ls -A $fp_svc) ]] || rmdir $fp_svc
+			rmdir --ignore-fail-on-non-empty $fp_svc
 
 		fi
 
 		#----------------------------------------------------------------------
-		#Enable autoboot options
-		#	Custom script, service without auto login: https://github.com/MichaIng/DietPi/issues/1024
+		# Enable selected autostart option
+		# - Custom script, service without auto login: https://github.com/MichaIng/DietPi/issues/1024
 		if (( $AUTO_START_INDEX == 14 )); then
 
 			cat << _EOF_ > /etc/systemd/system/dietpi-autostart_custom.service
 [Unit]
 Description=DietPi-Autostart (Custom /var/lib/dietpi/dietpi-autostart/custom.sh)
-After=dietpi-boot.service dietpi-ramdisk.service dietpi-ramlog.service dietpi-postboot.service rc-local.service
-Requires=dietpi-boot.service dietpi-ramdisk.service
+Requisite=dietpi-boot.service
+After=dietpi-boot.service dietpi-postboot.service rc-local.service
+ConditionPathExists=/var/lib/dietpi/dietpi-autostart/custom.sh
 
 [Service]
 Type=idle
-ExecStartPre=$(command -v echo) 'Starting DietPi-Autostart (Custom) script'
+RemainAfterExit=yes
+StandardOutput=tty
 ExecStartPre=$(command -v chmod) +x /var/lib/dietpi/dietpi-autostart/custom.sh
 ExecStart=/var/lib/dietpi/dietpi-autostart/custom.sh
-StandardOutput=tty
-RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target
 _EOF_
-
 			systemctl enable dietpi-autostart_custom
 
-		#	Uae4arm special | fast boot via enabled service
+		# - Uae4arm special | fast boot via enabled service
 		elif (( $AUTO_START_INDEX == 6 )); then
 
 			systemctl enable amiberry
 
-			# - apply tweaks
+			# - Enable systemd-logind to have a login console ready after exiting AmiBerry from fastboot
+			systemctl unmask systemd-logind
+			systemctl enable systemd-logind &> /dev/null
+
+			# - Apply tweaks
 			if (( $G_HW_MODEL < 10 )); then
 
 				G_CONFIG_INJECT 'boot_delay=' 'boot_delay=0' /DietPi/config.txt
@@ -103,7 +106,7 @@ _EOF_
 
 			fi
 
-		#	Enable auto login
+		# - Enable auto login
 		elif (( $AUTO_START_INDEX > 0 )); then
 
 			mkdir -p /etc/systemd/system/getty@tty1.service.d
@@ -120,17 +123,17 @@ _EOF_
 
 		fi
 
-		#Save boot index, if not default 0
+		# Save boot index, if not default 0
 		(( $AUTO_START_INDEX )) && echo $AUTO_START_INDEX > /DietPi/dietpi/.dietpi-autostart_index
 
 		systemctl daemon-reload
 
 	}
 
-	#TARGETMENUID=0
+	# TARGETMENUID=0
 	Menu_Main(){
 
-		#existing boot flag
+		# Existing boot flag
 		[[ -f /DietPi/dietpi/.dietpi-autostart_index ]] && AUTO_START_INDEX=$(</DietPi/dietpi/.dietpi-autostart_index)
 
 		G_WHIP_MENU_ARRAY=(
@@ -165,22 +168,22 @@ _EOF_
 
 			local choice=$G_WHIP_RETURNED_VALUE
 
-			#AmiBerry fast boot info
+			# AmiBerry fast boot info
 			if (( $choice == 6 )); then
 
 				G_WHIP_MSG 'AmiBerry: (Fast boot):\nA highly optimized and tweaked boot mode.\nThis mode allows for a < 2.5 second boot on a RPi 3, into AmiBerry.\n\nIf you experience boot issues with this mode, please try (Standard Boot)'
 
-			#Chromium prompt for URL
+			# Chromium prompt for URL
 			elif (( $choice == 11 )); then
 
-				G_WHIP_DEFAULT_ITEM="$(grep -m1 '^[[:blank:]]*SOFTWARE_CHROMIUM_AUTOSTART_URL=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
-				G_WHIP_INPUTBOX "Please enter a homepage URL to start with Chromium:\n - eg: https://google.com"
+				G_WHIP_DEFAULT_ITEM=$(grep -m1 '^[[:blank:]]*SOFTWARE_CHROMIUM_AUTOSTART_URL=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
+				G_WHIP_INPUTBOX 'Please enter a homepage URL to start with Chromium:\n - eg: https://dietpi.com'
 				(( $? == 0 )) && G_CONFIG_INJECT 'SOFTWARE_CHROMIUM_AUTOSTART_URL=' "SOFTWARE_CHROMIUM_AUTOSTART_URL=$G_WHIP_RETURNED_VALUE" /DietPi/dietpi.txt
 
-			#Custom info
+			# Custom info
 			elif (( $choice == 14 )); then
 
-				#	create template
+				# - Create template
 				if [[ ! -f '/var/lib/dietpi/dietpi-autostart/custom.sh' ]]; then
 
 					mkdir -p /var/lib/dietpi/dietpi-autostart
@@ -200,26 +203,24 @@ _EOF_
 #---Put your code below this line---
 
 _EOF_
-
 					G_WHIP_MSG 'A template script has been created:\n - /var/lib/dietpi/dietpi-autostart/custom.sh\n\nPlease edit this file and enter the required commands you wish to launch. DietPi will then execute this script during boot.'
 
 				fi
 
-			#LightDM pre-req check
+			# LightDM pre-req check
 			elif (( $choice == 16 )); then
 
 				G_AG_CHECK_INSTALL_PREREQ lightdm
 
 			fi
 
-			#Apply Selected boot option
+			# Apply selected boot option
 			AUTO_START_INDEX=$choice
-
 			Apply_Boot_Index
 
 		else
 
-			#Exit
+			# Exit
 			TARGETMENUID=-1
 
 		fi
@@ -229,7 +230,7 @@ _EOF_
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Main Loop
 	#/////////////////////////////////////////////////////////////////////////////////////
-	#Start Menu
+	# Start Menu
 	if (( $INPUT == -1 )); then
 
 		while (( $TARGETMENUID > -1 )); do
@@ -240,7 +241,7 @@ _EOF_
 
 		done
 
-	#Apply boot index
+	# Apply boot index
 	elif (( $INPUT >= 0 )); then
 
 		AUTO_START_INDEX=$INPUT


### PR DESCRIPTION
**Status**: Ready
- [x] Changelog

**Reference**: https://github.com/MichaIng/DietPi/issues/2703#issuecomment-482471440

**Commit list/description**:
+ DietPi-Autostart | Enable systemd-logind with AmiBerry fastboot to have a login console ready when exiting
+ DietPi-Autostart | Minor coding and custom boot script simplification