### PR TITLE
DietPi-Software | Plex Media Server: Install from/migrate to new official APT repo

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ Changes / Improvements / Optimisations:
 - DietPi-Software | Subsonic: Runs now as limited user "subsonic". This change is as well applied to existing installs via patch during DietPi-Update: https://github.com/MichaIng/DietPi/pull/2705
 - DietPi-Software | WireGuard APT packages are now upgraded when running "apt-get upgrade". Many thanks to @swrobel for reporting this issue: https://github.com/MichaIng/DietPi/issues/2671
 - DietPi-Software | LXQt, GIMP, XFCE4 Power manager: Now available for installations.
+- DietPi-Software | Plex Media Server: All systems are migrated to the new official APT repository. This allows easy and consistent upgrades via APT. On ARM systems the until now used 3rd party dev2day repo receives no further updates and will be shut down soon, which makes the migration mandatory. Many thanks to @WolfganP for keeping us informed with news about Plex v1.15 and the new APT repo: https://github.com/MichaIng/DietPi/issues/2655
 
 Bug Fixes:
 - DietPi-Set_swapfile | Resolved an issue where on first boot (and when calling the script manually) the swapfile creation is attempted on target file systems that do not support it (BTRFS). Many thanks to @mzramna for reporting this issue: https://github.com/MichaIng/DietPi/issues/719#issuecomment-484205696

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -699,11 +699,11 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		#------------------
 		software_id=42
 
-				 aSOFTWARE_WHIP_NAME[$software_id]='Plex Media Server'
-				 aSOFTWARE_WHIP_DESC[$software_id]='web interface media streaming server'
-			aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-					  aSOFTWARE_TYPE[$software_id]=0
-			 aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1949#p1949'
+		aSOFTWARE_WHIP_NAME[$software_id]='Plex Media Server'
+		aSOFTWARE_WHIP_DESC[$software_id]='web interface media streaming server'
+		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
+		aSOFTWARE_TYPE[$software_id]=0
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1949#p1949'
 
 		# - Disable for ARMv6: https://github.com/MichaIng/DietPi/issues/648
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
@@ -3983,7 +3983,7 @@ _EOF_
 			# - This needs to be done prior to APT install, since this would otherwise install a default config file as well.
 			[[ -f /etc/mopidy/mopidy.conf ]] || dps_index=$software_id Download_Install 'mopidy.conf' /etc/mopidy/mopidy.conf
 
-			wget -q -O - "$INSTALL_URL_ADDRESS" | apt-key add -
+			curl -sSL "$INSTALL_URL_ADDRESS" | apt-key add -
 			# No Buster list available yet, use stretch.list for testing:
 			if (( $G_DISTRO > 3 )); then
 
@@ -4717,8 +4717,7 @@ _EOF_
 
 		fi
 
-		#InfluxDB
-		software_id=74
+		software_id=74 # InfluxDB
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -4726,7 +4725,7 @@ _EOF_
 			INSTALL_URL_ADDRESS='https://repos.influxdata.com/influxdb.key'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
-			curl -sL "$INSTALL_URL_ADDRESS" | apt-key add -
+			curl -sSL "$INSTALL_URL_ADDRESS" | apt-key add -
 			echo "deb https://repos.influxdata.com/debian $G_DISTRO_NAME stable" > /etc/apt/sources.list.d/influxdb.list
 			G_AGUP
 
@@ -4734,8 +4733,7 @@ _EOF_
 
 		fi
 
-		#Grafana
-		software_id=77
+		software_id=77 # Grafana
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -4751,7 +4749,7 @@ _EOF_
 			fi
 
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-			curl -sL "$INSTALL_URL_ADDRESS" | apt-key add -
+			curl -sSL "$INSTALL_URL_ADDRESS" | apt-key add -
 
 			# APT repo source & update
 			echo "$deb_address" > /etc/apt/sources.list.d/grafana.list
@@ -5251,27 +5249,19 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 			Banner_Installing
 
-			# Derive latest version from: https://plex.tv/pms/downloads/5
-			INSTALL_URL_ADDRESS='https://plex.tv/pms/downloads/5'
+			# Apply APT key
+			INSTALL_URL_ADDRESS='https://downloads.plex.tv/plex-keys/PlexSign.key'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
+			curl -sSL "$INSTALL_URL_ADDRESS" | apt-key add -
 
-			# ARMv7
-			local arch='armhf'
+			# Apply APT repo
+			echo 'deb https://downloads.plex.tv/repo/deb public main' > /etc/apt/sources.list.d/plexmediaserver.list
 
-			# ARMv8
-			if (( $G_HW_ARCH == 3 )); then
+			# Update APT lists
+			G_AGUP
 
-				arch='arm64'
-
-			# x86_64
-			elif (( $G_HW_ARCH == 10 )); then
-
-				arch='amd64'
-
-			fi
-
-			# Derive URL from arch
-			no_check_url=1 Download_Install "$(curl -s "$INSTALL_URL_ADDRESS" | grep -m1 "distro=\"debian\".*$arch\.deb" | cut -d \" -f 8)"
+			# Install PMS
+			G_AGI plexmediaserver
 
 		fi
 
@@ -5649,19 +5639,20 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 			Banner_Installing
 
-			if (( $G_DISTRO == 3 )); then #https://github.com/MichaIng/DietPi/issues/855#issuecomment-292712002
+			if (( $G_DISTRO == 3 )); then # https://github.com/MichaIng/DietPi/issues/855#issuecomment-292712002
 
-				INSTALL_URL_ADDRESS='http://davesteele.github.io/cloudprint-service'
-
-				# url/redirect fails wget spider test...
+				# Apply APT key
+				INSTALL_URL_ADDRESS='https://davesteele.github.io/key-366150CE.pub.txt'
 				G_CHECK_URL "$INSTALL_URL_ADDRESS"
+				curl -sSL "$INSTALL_URL_ADDRESS" | apt-key add -
 
-				INSTALL_URL_ADDRESS+='/repo'
+				# Apply APT repo
+				echo 'deb https://davesteele.github.io/cloudprint-service/repo cloudprint-jessie main' > /etc/apt/sources.list.d/cloudprint.list
 
-				echo -e "deb $INSTALL_URL_ADDRESS cloudprint-jessie main" > /etc/apt/sources.list.d/cloudprint.list
-				wget -q -O - https://davesteele.github.io/key-366150CE.pub.txt | apt-key add -
+				# Update APT lists
 				G_AGUP
 
+				# Install CloudPrint
 				G_AGI cloudprint-service
 
 			else
@@ -6202,7 +6193,7 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 			INSTALL_URL_ADDRESS='https://dtcooper.github.io/raspotify/key.asc'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
-			wget -O - "$INSTALL_URL_ADDRESS" | apt-key add -
+			curl -sSL "$INSTALL_URL_ADDRESS" | apt-key add -
 			echo 'deb https://dtcooper.github.io/raspotify jessie main' > /etc/apt/sources.list.d/raspotify.list
 			G_AGUP
 
@@ -14039,14 +14030,13 @@ _EOF_
 
 		fi
 
-		software_id=58
+		software_id=58 # OpenBazaar
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-
-			rm /etc/systemd/system/openbazaar.service
-			rm -R $G_FP_DIETPI_USERDATA/go/src/github.com/OpenBazaar
-			rm -R /etc/openbazaar-server &> /dev/null # Pre v6.15 OB1.0
+			[[ -f '/etc/systemd/system/openbazaar.service' ]] && rm /etc/systemd/system/openbazaar.service
+			[[ -d $G_FP_DIETPI_USERDATA/go/src/github.com/OpenBazaar ]] && rm -R $G_FP_DIETPI_USERDATA/go/src/github.com/OpenBazaar
+			[[ -d '/etc/openbazaar-server' ]] && rm -R /etc/openbazaar-server # Pre v6.15 OB1.0
 
 		fi
 
@@ -14054,10 +14044,9 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			G_AGP $(dpkg --get-selections plexmediaserver* | mawk '{print $1}')
-			[[ -d /etc/systemd/system/plexmediaserver.service.d ]] && rm -R /etc/systemd/system/plexmediaserver.service.d # post v6.17
-			[[ -d /var/lib/plexmediaserver ]] && rm -R /var/lib/plexmediaserver # pre v6.22 Plex v1.15
-			[[ -f etc/apt/sources.list.d/plex.list ]] && rm /etc/apt/sources.list.d/plex.list && G_AGUP # pre v6.22
+			G_AGP plexmediaserver
+			[[ -d '/var/lib/plexmediaserver' ]] && rm -R /var/lib/plexmediaserver # Left over from purging package, still...
+			[[ -d '/etc/systemd/system/plexmediaserver.service.d' ]] && rm -R /etc/systemd/system/plexmediaserver.service.d
 
 		fi
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1756,10 +1756,15 @@ Further info and usage: https://dietpi.com/phpbb/viewtopic.php?f=8&t=5828'
 					sed -i '/^ListenPort/a\PostDown = ip6tables -D FORWARD -i %i -j ACCEPT; ip6tables -t nat -D POSTROUTING -o $(sed -n 3p /DietPi/dietpi/.network) -j MASQUERADE' /etc/wireguard/wg0.conf
 
 				fi
-				#Reinstalls
+				#-----------------------------------------------------------------------
+				# Reinstalls
 				#	Subsonic: https://github.com/MichaIng/DietPi/pull/2705
 				[[ -L '/var/subsonic/transcode' ]] && rm /var/subsonic/transcode
-				/DietPi/dietpi/dietpi-software reinstall 34
+				#	Plex Media Server: https://github.com/MichaIng/DietPi/pull/2722
+				dpkg-query -s plexmediaserver-installer &> /dev/null && dpkg -r plexmediaserver-installer
+				[[ -f '/etc/apt/sources.list.d/plex.list' ]] && rm /etc/apt/sources.list.d/plex.list
+
+				/DietPi/dietpi/dietpi-software reinstall 34 42
 
 			fi
 			#-------------------------------------------------------------------------------


### PR DESCRIPTION
**Status**: Ready
- [x] Patch
- [x] DietPi-Software list (Wiki)
- [x] Changelog

**Reference**:
- https://github.com/MichaIng/DietPi/issues/2655
- https://github.com/MichaIng/DietPi/issues/2553

**Commit list/description**:
+ DietPi-Software | Plex Media Server: Install via new official APT repo
+ DietPi-Software | Plex Media Server: Consistent method to apply APT keys, via "curl" (+silent+errors+redirects) which is slightly faster then "wget"