### PR TITLE
DietPi-Software | Tor Hotspot: Mark WiFi Hotspot during regular pre-req check

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,7 @@ Changes / Improvements / Optimisations:
 - DietPi-Software | LXQt, GIMP, XFCE4 Power manager: Now available for installations.
 - DietPi-Software | Plex Media Server: All systems are migrated to the new official APT repository. This allows easy and consistent upgrades via APT. On ARM systems the until now used 3rd party dev2day repo receives no further updates and will be shut down soon, which makes the migration mandatory. Many thanks to @WolfganP for keeping us informed with news about Plex v1.15 and the new APT repo: https://github.com/MichaIng/DietPi/issues/2655
 - DietPi-Software | Logitech Media Server: Now installs the latest nightly version, since no public "releases" are done. As well the systemd service has gone through some update and now runs as limited user to align with other media servers, enhance security and follow the defaults of the DPKG package. The update/change is applied to existing installs via DietPi-Update as well. Your settings/date are preserved.
+- DietPi-Software | Tor/WiFi Hotspot: Resolved an issue where WiFi Hotspot fails to start when Tor Hotspot is installed. Many thanks to @schnuckz for reporting this issue: https://github.com/MichaIng/DietPi/issues/2673#issuecomment-482605700
 
 Bug Fixes:
 - DietPi-Set_swapfile | Resolved an issue where on first boot (and when calling the script manually) the swapfile creation is attempted on target file systems that do not support it (BTRFS). Many thanks to @mzramna for reporting this issue: https://github.com/MichaIng/DietPi/issues/719#issuecomment-484205696

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1452,11 +1452,11 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		#--------------------------------------------------------------------------------
 		software_id=60
 
-				 aSOFTWARE_WHIP_NAME[$software_id]='WiFi Hotspot'
-				 aSOFTWARE_WHIP_DESC[$software_id]='turn your device into a wifi hotspot'
-			aSOFTWARE_CATEGORY_INDEX[$software_id]=8
-					  aSOFTWARE_TYPE[$software_id]=0
-			 aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1207#p1207'
+		aSOFTWARE_WHIP_NAME[$software_id]='WiFi Hotspot'
+		aSOFTWARE_WHIP_DESC[$software_id]='turn your device into a wifi hotspot'
+		aSOFTWARE_CATEGORY_INDEX[$software_id]=8
+		aSOFTWARE_TYPE[$software_id]=0
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1207#p1207'
 
 		# - VM
 		aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,20]=0
@@ -1464,11 +1464,11 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		#------------------
 		software_id=61
 
-				 aSOFTWARE_WHIP_NAME[$software_id]='Tor Hotspot'
-				 aSOFTWARE_WHIP_DESC[$software_id]='optional: route hotspot traffic through tor'
-			aSOFTWARE_CATEGORY_INDEX[$software_id]=8
-					  aSOFTWARE_TYPE[$software_id]=0
-			 aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1529#p1529'
+		aSOFTWARE_WHIP_NAME[$software_id]='Tor Hotspot'
+		aSOFTWARE_WHIP_DESC[$software_id]='optional: route hotspot traffic through tor'
+		aSOFTWARE_CATEGORY_INDEX[$software_id]=8
+		aSOFTWARE_TYPE[$software_id]=0
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1529#p1529'
 
 		# - VM
 		aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,20]=0
@@ -2488,6 +2488,15 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		software_id=114
 		if (( ${aSOFTWARE_INSTALL_STATE[168]} == 1 &&
 			${aSOFTWARE_INSTALL_STATE[$software_id]} < 1 )); then
+
+			aSOFTWARE_INSTALL_STATE[$software_id]=1
+			G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$software_id]} will be installed"
+
+		fi
+
+		#Tor Hotspot requires WiFi Hotspot
+		software_id=60
+		if (( ${aSOFTWARE_INSTALL_STATE[61]} == 1 )); then
 
 			aSOFTWARE_INSTALL_STATE[$software_id]=1
 			G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$software_id]} will be installed"
@@ -4976,11 +4985,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 		fi
 
-		#TORHOTSPOT requires WIFIHOTSPOT:
-		(( ${aSOFTWARE_INSTALL_STATE[61]} == 1 )) && aSOFTWARE_INSTALL_STATE[60]=1
-
-		#WIFIHOTSPOT
-		software_id=60
+		software_id=60 # WiFi Hotspot
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -4995,7 +5000,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 			fi
 
-			#Which binary to install
+			# Which binary to install
 			local filename_hostapd=''
 			local filename_hostapd_cli=''
 
@@ -5030,19 +5035,16 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 			rm hostapd-*
 
-			#Enable wifi modules
+			# Enable wifi modules
 			/DietPi/dietpi/func/dietpi-set_hardware wifimodules enable
 
 		fi
 
 
-		#TORHOTSPOT
-		software_id=61
+		software_id=61 # Tor Hotspot
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-
-			# - Prereqs
 			G_AGI tor
 
 		fi


### PR DESCRIPTION
**Status**: Ready
- [x] Changelog

**Reference**: https://github.com/MichaIng/DietPi/issues/2673

**Commit list/description**:
+ DietPi-Software | Tor Hotspot: Mark WiFi Hotspot during regular pre-req check, otherwise WiFi Hotspot pre-reqs will not be marked: libssl1.0.0