### PR TITLE
DietPi-Software | Fail2Ban: Rework and fix wrong loglevel value on Stretch

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4726,7 +4726,17 @@ port = ssh
 port = ssh
 _EOF_
 
-			G_AGI python3-systemd fail2ban
+			if (( $G_DISTRO > 3 )); then
+
+				G_AGI python3-systemd fail2ban
+
+			# On Jessie, the systemd backend is not yet supported, so we install the Stretch package manually
+			else
+
+				DEPS_LIST='python3-systemd'
+				Download_Install 'https://dietpi.com/downloads/binaries/all/fail2ban.deb'
+
+			fi
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1765,11 +1765,11 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		#--------------------------------------------------------------------------------
 		software_id=73
 
-				 aSOFTWARE_WHIP_NAME[$software_id]='Fail2Ban'
-				 aSOFTWARE_WHIP_DESC[$software_id]='prevents brute-force attacks with ip ban'
-			aSOFTWARE_CATEGORY_INDEX[$software_id]=12
-					  aSOFTWARE_TYPE[$software_id]=0
-			 aSOFTWARE_ONLINEDOC_URL[$software_id]='p=452#p452'
+		aSOFTWARE_WHIP_NAME[$software_id]='Fail2Ban'
+		aSOFTWARE_WHIP_DESC[$software_id]='prevents brute-force attacks with ip ban'
+		aSOFTWARE_CATEGORY_INDEX[$software_id]=12
+		aSOFTWARE_TYPE[$software_id]=0
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=452#p452'
 		#------------------
 
 		#Webserver stacks
@@ -4697,13 +4697,33 @@ _EOF_
 
 		fi
 
-		#FAIL2BAN
-		software_id=73
+		software_id=73 # Fail2Ban
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
 
-			>> /var/log/auth.log #: https://github.com/MichaIng/DietPi/issues/475#issuecomment-310873879
+			# Create jail.conf (backend = systemd) first, to prevent APT failure due to missing /var/log/auth.log: https://github.com/MichaIng/DietPi/issues/475#issuecomment-310873879
+			[[ -f '/etc/fail2ban/jail.conf' ]] || cat << _EOF_ > /etc/fail2ban/jail.conf
+[DEFAULT]
+ignoreip = 127.0.0.1/8
+ignorecommand =
+bantime  = 600
+findtime  = 600
+maxretry = 3
+backend = systemd
+enabled = true
+filter = %(__name__)s
+port = 0:65535
+banaction = route
+action_ = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s"]
+action = %(action_)s
+
+[sshd]
+port = ssh
+
+[dropbear]
+port = ssh
+_EOF_
 
 			G_AGI python3-systemd fail2ban
 
@@ -9716,57 +9736,7 @@ _EOF_
 
 		fi
 
-		#FAIL2BAN
-		software_id=73
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Configuration
-
-			G_BACKUP_FP /etc/fail2ban/fail2ban.conf /etc/fail2ban/jail.conf
-			cat << _EOF_ > /etc/fail2ban/fail2ban.conf
-[Definition]
-# loglevel #1=error #2=warn #3=info
-loglevel = 3
-logtarget = /var/log/fail2ban.log
-socket = /var/run/fail2ban/fail2ban.sock
-pidfile = /var/run/fail2ban/fail2ban.pid
-_EOF_
-
-			cat << _EOF_ > /etc/fail2ban/jail.conf
-[DEFAULT]
-
-enabled = true
-ignoreip = 127.0.0.1/8
-ignorecommand =
-backend = systemd
-bantime = 600
-findtime = 600
-maxretry = 3
-banaction = route
-action_ = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s"]
-action = %(action_)s
-
-[sshd]
-
-enabled  = true
-port     = ssh
-filter   = sshd
-logpath  = /var/log/auth.log
-maxretry = 3
-
-[dropbear]
-
-enabled  = true
-port     = ssh
-filter   = dropbear
-logpath  = /var/log/auth.log
-maxretry = 3
-_EOF_
-
-		fi
-
-		#InfluxDB
-		software_id=74
+		software_id=74 # InfluxDB
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -13708,11 +13678,13 @@ _EOF_
 
 		fi
 
-		software_id=73
+		software_id=73 # Fail2Ban
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
 			G_AGP fail2ban
+			apt-mark auto python3-systemd
+			[[ -d '/etc/fail2ban' ]] && rm -R /etc/fail2ban
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4703,6 +4703,7 @@ _EOF_
 			Banner_Installing
 
 			# Create jail.conf (backend = systemd) first, to prevent APT failure due to missing /var/log/auth.log: https://github.com/MichaIng/DietPi/issues/475#issuecomment-310873879
+			mkdir -p /etc/fail2ban
 			[[ -f '/etc/fail2ban/jail.conf' ]] || cat << _EOF_ > /etc/fail2ban/jail.conf
 [DEFAULT]
 ignoreip = 127.0.0.1/8

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3129,23 +3129,23 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		elif [[ $type == deb ]]; then
 
 			# - Allow error on first attempt, giving APT fix a change to resolve e.g. dependencies
-			l_message='Installing deb package' G_USER_INPUTS=0 G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD dpkg -i $file
+			G_USER_INPUTS=0 G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD dpkg --force-hold,confdef,confold -i $file
 			(( $G_ERROR_HANDLER_EXITCODE_RETURN )) && G_DIETPI-NOTIFY 2 'Trying automated APT fix' && G_AGF
 
 		elif [[ $type == zip ]]; then
 
 			[[ $target ]] && target="-d $target"
-			l_message='Unzipping archive' G_RUN_CMD unzip -o $file "$target"
+			G_RUN_CMD unzip -o $file "$target"
 
 		elif [[ $type == tar ]]; then
 
 			[[ $target ]] && target="--one-top-level=$target"
-			l_message='Unpacking tarball' G_RUN_CMD tar xf $file "$target"
+			G_RUN_CMD tar xf $file "$target"
 
 		elif [[ $type == 7z ]]; then
 
 			[[ $target ]] && target="-o$target"
-			l_message='Extracting 7zip archive' G_RUN_CMD 7zr x -y $file "$target"
+			G_RUN_CMD 7zr x -y $file "$target"
 
 		else
 
@@ -3153,7 +3153,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 
 		fi
 
-		[[ -f $file ]] && l_message='Cleaning download directory' G_RUN_CMD rm $file
+		[[ -f $file ]] && G_RUN_CMD rm $file
 		unset fallback_url dps_index no_check_url
 
 	}


### PR DESCRIPTION
**Status**: Ready
- [x] Changelog

**Reference**: https://github.com/MichaIng/DietPi/issues/90#issuecomment-485140236

**Commit list/description**:
+ DietPi-Software | Fail2Ban: Fix changed loglevel options on Stretch
+ DietPi-Software | Fail2Ban: Skip overwriting fail2ban.conf since our values match the APT defaults
+ DietPi-Software | Fail2Ban: Create jail.conf (with backend = systemd) before installing fail2ban APT package, so we can skip the /var/log/auth.log creation which is only required for log file based banning. This is never required on DietPi systems since systemd/journald is present as default syslog daemon and used Dropbear and OpenSSH. The whole configuration step can be skipped then.
+ DietPi-Software | Fail2Ban: Create [DEFAULT]s for all required variables (all ports, filter based on jail name) and define SSH port (22) in separate jails only.
+ DietPi-Software | Fail2Ban: Never overwrite existing config files. They are usually (should be) customized based on own needs.