### PR TITLE
System | Debian Jessie: Apply APT list changes according to dropped support by Debian

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,7 @@ Changes / Improvements / Optimisations:
 - DietPi-Software | Tor/WiFi Hotspot: Resolved an issue where WiFi Hotspot fails to start when Tor Hotspot is installed. Many thanks to @schnuckz for reporting this issue: https://github.com/MichaIng/DietPi/issues/2673#issuecomment-482605700
 
 Bug Fixes:
+- System | Debian has vastly reduced support for Jessie systems from their official APT repository. The limited possible list entries are applied during DietPi-Update. Many thanks to @BerndKohl for reporting this issue: https://github.com/MichaIng/DietPi/issues/2665
 - DietPi-Set_swapfile | Resolved an issue where on first boot (and when calling the script manually) the swapfile creation is attempted on target file systems that do not support it (BTRFS). Many thanks to @mzramna for reporting this issue: https://github.com/MichaIng/DietPi/issues/719#issuecomment-484205696
 - DietPi-Config | Resolved an issue where proxy settings would not be correct after a reboot. Many thanks to @stephantual for reporting this!: https://github.com/MichaIng/DietPi/issues/2704
 - DietPi-Update | Resolved an issue where on older images first run update didn't finalise as intended, leading to several first run setup issues, depending on the image age. The fix has been applied outside of the releases since only the online part of the updater is affected: https://github.com/MichaIng/DietPi/pull/2684

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -60,6 +60,21 @@
 	# - OMV: https://dietpi.com/phpbb/viewtopic.php?f=11&t=2772&p=10646#p10594
 	[[ -f /etc/apt/sources.list.d/openmediavault.list ]] && rm /etc/apt/sources.list.d/openmediavault.list
 
+	# Fixing sources.list due to Debian dropped Jessie support: https://github.com/MichaIng/DietPi/issues/2665
+	if grep -qi 'jessie' /etc/os-release && ! grep -qi 'raspbian' /etc/os-release; then
+
+		if [[ $(uname -m) == 'aarch64' ]]; then
+
+			echo 'deb http://archive.debian.org/debian/ main contrib non-free' > /etc/apt/sources.list
+
+		else
+
+			sed -Ei '/jessie(\/updates|-backports|-updates)/d' /etc/apt/sources.list
+
+		fi
+
+	fi
+
 	apt-get clean
 	apt-get update
 	for i in "${a_MIN_APT_PREREQS[@]}"

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -4411,7 +4411,7 @@ Additional benchmarks:
 				'APT Mirror')
 
 					# Jessie ARMv8: https://github.com/MichaIng/DietPi/issues/2665#issuecomment-477348864
-					if (( $G_HW_ARCH == 3 && G_DISTRO < 4 )); then
+					if (( $G_HW_ARCH == 3 && $G_DISTRO < 4 )); then
 
 						G_WHIP_MSG '[INFO] Debian has dropped the Jessie ARMv8 branch from the official APT repository.\n
 Related packages are now available only from the archive: http://archive.debian.org/debian/\n

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -4410,6 +4410,17 @@ Additional benchmarks:
 
 				'APT Mirror')
 
+					# Jessie ARMv8: https://github.com/MichaIng/DietPi/issues/2665#issuecomment-477348864
+					if (( $G_HW_ARCH == 3 && G_DISTRO < 4 )); then
+
+						G_WHIP_MSG '[INFO] Debian has dropped the Jessie ARMv8 branch from the official APT repository.\n
+Related packages are now available only from the archive: http://archive.debian.org/debian/\n
+This has been applied to your APT sources.list during DietPi update to v6.23 and it cannot be changed.\n
+Aborting...'
+						return
+
+					fi
+
 					# Create Menu List for Whiptail
 					G_WHIP_MENU_ARRAY=('Custom' ': Manually enter APT mirror')
 

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -106,8 +106,13 @@ $FP_SCRIPT	setpermissions		Applies required filesystem permissions to DietPi spe
 
 		if [[ $INPUT_MODE_VALUE ]]; then
 
+			# - Jessie ARMv8: https://github.com/MichaIng/DietPi/issues/2665#issuecomment-477348864
+			if (( $G_HW_ARCH == 3 && G_DISTRO < 4 )); then
+
+				INPUT_MODE_VALUE='http://archive.debian.org/debian/'
+
 			# - Set defaults?
-			if [[ $INPUT_MODE_VALUE == 'default' ]]; then
+			elif [[ $INPUT_MODE_VALUE == 'default' ]]; then
 
 				if (( $G_HW_MODEL < 10 )); then
 
@@ -121,17 +126,16 @@ $FP_SCRIPT	setpermissions		Applies required filesystem permissions to DietPi spe
 
 			fi
 
-			# - Set raspbian
+			# - Set Raspbian
 			if (( $G_HW_MODEL < 10 )); then
 
 				echo "deb $INPUT_MODE_VALUE $G_DISTRO_NAME main contrib non-free rpi" > /etc/apt/sources.list
-
 				echo "deb https://archive.raspberrypi.org/debian/ $G_DISTRO_NAME main ui" > /etc/apt/sources.list.d/raspi.list
 
 				#	Update dietpi.txt entry
 				G_CONFIG_INJECT 'CONFIG_APT_RASPBIAN_MIRROR=' "CONFIG_APT_RASPBIAN_MIRROR=$INPUT_MODE_VALUE" /DietPi/dietpi.txt
 
-			# - Set debian
+			# - Set Debian
 			else
 
 				cat << _EOF_ > /etc/apt/sources.list
@@ -141,13 +145,10 @@ deb https://deb.debian.org/debian-security/ $G_DISTRO_NAME/updates main contrib 
 deb $INPUT_MODE_VALUE $G_DISTRO_NAME-backports main contrib non-free
 _EOF_
 
-				#	Jessie, switch deb.debian.org to http: https://github.com/MichaIng/DietPi/issues/1285#issuecomment-351830101
+				#	Jessie: https://github.com/MichaIng/DietPi/issues/2665#issuecomment-477348864
 				if (( $G_DISTRO < 4 )); then
 
-					sed -i 's/https:/http:/g' /etc/apt/sources.list
-
-					# - ARM64 packages no longer available: https://github.com/MichaIng/DietPi/issues/1915
-					(( $G_HW_ARCH == 3 )) && sed -i '/debian-security/d' /etc/apt/sources.list
+					echo "deb $INPUT_MODE_VALUE $G_DISTRO_NAME main contrib non-free" > /etc/apt/sources.list
 
 				#	Buster, remove backports: https://github.com/MichaIng/DietPi/issues/1285#issuecomment-351830101
 				elif (( $G_DISTRO > 4 )); then

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -107,7 +107,7 @@ $FP_SCRIPT	setpermissions		Applies required filesystem permissions to DietPi spe
 		if [[ $INPUT_MODE_VALUE ]]; then
 
 			# - Jessie ARMv8: https://github.com/MichaIng/DietPi/issues/2665#issuecomment-477348864
-			if (( $G_HW_ARCH == 3 && G_DISTRO < 4 )); then
+			if (( $G_HW_ARCH == 3 && $G_DISTRO < 4 )); then
 
 				INPUT_MODE_VALUE='http://archive.debian.org/debian/'
 

--- a/dietpi/pre-patch_file
+++ b/dietpi/pre-patch_file
@@ -74,6 +74,7 @@
 		#-------------------------------------------------------------------------------
 		# Pre-patch 4: https://github.com/MichaIng/DietPi/issues/2656
 		# Pre-patch 5: Add new G_CHECK_URL dietpi.txt settings
+		# Pre-patch 6: https://github.com/MichaIng/DietPi/pull/2728
 		if (( $G_DIETPI_VERSION_SUB < 23 )); then
 
 			if [[ -f '/etc/apt/preferences.d/dietpi-wireguard' ]]; then
@@ -86,6 +87,21 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 			grep -q 'CONFIG_G_CHECK_URL_TIMEOUT' /DietPi/dietpi.txt || echo 'CONFIG_G_CHECK_URL_TIMEOUT=5' >> /DietPi/dietpi.txt || { EXIT_CODE=5; break; }
 			grep -q 'CONFIG_G_CHECK_URL_ATTEMPTS' /DietPi/dietpi.txt || echo 'CONFIG_G_CHECK_URL_ATTEMPTS=3' >> /DietPi/dietpi.txt || { EXIT_CODE=5; break; }
+
+			if (( $(sed -n 1p /DietPi/dietpi/.hw_model) > 9 )) && grep -qi 'jessie' /etc/os-release; then
+
+				echo -e '\e[90m[\e[0m INFO \e[90m]\e[0m Pre-patch 6 | Applying changes to APT sources.list since Debian dropped support for Jessie systems'
+				if [[ $(uname -m) == 'aarch64' ]]; then
+
+					echo 'deb http://archive.debian.org/debian/ main contrib non-free' > /etc/apt/sources.list || { EXIT_CODE=6; break; }
+
+				else
+
+					sed -Ei '/(debian-security|jessie-backports|jessie-updates)/d' /etc/apt/sources.list || { EXIT_CODE=6; break; }
+
+				fi
+
+			fi
 
 		fi
 		#-------------------------------------------------------------------------------


### PR DESCRIPTION
**Status**: Ready
- [x] DietPi-Config | Remove APT mirror choice for Jessie + ARMv8
- [x] DietPi-Pre-patch | Patch changes
- [x] Changelog

**Reference**: https://github.com/MichaIng/DietPi/issues/2665

**Commit list/description**:
+ DietPi-Set_software | APT mirror: Debian dropped jessie-updates and jessie-backports branch and debian-security Jessie branch is about to reach validity timeout. Finally only the main branch remains.
+ DietPi-Set_software | APT mirror: Debian Jessie ARMv8 branch has been removed completely from repo. It is only available from archive: http://archive.debian.org/debian/