### PR TITLE
General | Move Jessie systems to "jessie-support" branch

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,12 @@
 v6.23
 (XX/04/19)
 
+Jessie support:
+- The support for Debian Jessie is fading constantly by software titles and Debian itself, increasing the effort for us to work around the raising issues: https://github.com/MichaIng/DietPi/issues/2332
+- As a result we move Jessie systems to a dedicated "jessie-support" branch. Next DietPi v6.24 will still be merged into this branch as well, but for following updates it depends on how much additional related issues we face.
+- We highly recommend to migrate to Stretch as fast as possible.
+- For Ordoid C1 there is no Stretch image available since its kernel and firmware are not maintained to match minimum requirements. There are reports about successful "apt-get dist-upgrade" migrations and an ARMbian Stretch image is available that can be used as a basis for DietPi-PREP. But these systems face major limitations, especially no GPU (Xserver, Kodi, desktops) support is available. Read more about it or contribute to solutions for Odroid C1 users here: https://github.com/MichaIng/DietPi/issues/2561
+
 Changes / Improvements / Optimisations:
 - DietPi-Banner | Added support for DietPi message of the day (MOTD). This is enabled by default, however, can be disabled. Checks for latest MOTD once a day.
 - DietPi-Banner | Always prints the local IP during boot mode display: https://github.com/MichaIng/DietPi/issues/2681

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -76,18 +76,9 @@
 
 	# Move Jessie systems to "jessie-support" branch: https://github.com/MichaIng/DietPi/issues/2332
 	# - We check/apply this already via pre-patches but do as well here since older DietPi version do not yet run pre-patches.
-	if (( $G_DISTRO < 4 )) && [[ $(grep -m1 '^[[:blank:]]*DEV_GITBRANCH=' /DietPi/dietpi.txt | sed 's/^[^=]*=//') != 'jessie-support' ]]; then
+	if (( $G_DISTRO < 4 )) && ! grep -q '^[[:blank:]]*DEV_GITBRANCH=jessie-support' DietPi/dietpi.txt; then
 
-		if grep -q '^[[:blank:]]*DEV_GITBRANCH=' /DietPi/dietpi.txt; then
-
-			sed -i '/^[[:blank:]]*DEV_GITBRANCH=/c\DEV_GITBRANCH=jessie-support' /DietPi/dietpi.txt
-
-		else
-
-			echo 'DEV_GITBRANCH=jessie-support' >> /DietPi/dietpi.txt
-
-		fi
-
+		G_CONFIG_INJECT 'DEV_GITBRANCH=' 'DEV_GITBRANCH=jessie-support' /DietPi/dietpi.txt
 		Restart_DietPi_Update
 
 	fi

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -74,6 +74,24 @@
 
 	}
 
+	# Move Jessie systems to "jessie-support" branch: https://github.com/MichaIng/DietPi/issues/2332
+	# - We check/apply this already via pre-patches but do as well here since older DietPi version do not yet run pre-patches.
+	if (( $G_DISTRO < 4 )) && [[ $(grep -m1 '^[[:blank:]]*DEV_GITBRANCH=' /DietPi/dietpi.txt | sed 's/^[^=]*=//') != 'jessie-support' ]]; then
+
+		if grep -q '^[[:blank:]]*DEV_GITBRANCH=' /DietPi/dietpi.txt; then
+
+			sed -i '/^[[:blank:]]*DEV_GITBRANCH=/c\DEV_GITBRANCH=jessie-support' /DietPi/dietpi.txt
+
+		else
+
+			echo 'DEV_GITBRANCH=jessie-support' >> /DietPi/dietpi.txt
+
+		fi
+
+		Restart_DietPi_Update
+
+	fi
+
 	# Pre-v6.17: New ".version" system
 	# - As loaded pre-v6.17 dietpi-update will overwrite ".version" to previous 2 line system, we need to rerun dietpi-update.
 	# Pre-v6.20: New $G_DIETPI_INSTALL_STAGE system

--- a/dietpi/pre-patch_file
+++ b/dietpi/pre-patch_file
@@ -104,6 +104,31 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 			fi
 
 		fi
+		# Pre-patch 7: Move Jessie systems to "jessie-support" branch: https://github.com/MichaIng/DietPi/issues/2332
+		if grep -qi 'jessie' /etc/os-release && [[ $(grep -m1 '^[[:blank:]]*DEV_GITBRANCH=' /DietPi/dietpi.txt | sed 's/^[^=]*=//') != 'jessie-support' ]]; then
+
+			if grep -q '^[[:blank:]]*DEV_GITBRANCH=' /DietPi/dietpi.txt; then
+
+				sed -i '/^[[:blank:]]*DEV_GITBRANCH=/c\DEV_GITBRANCH=jessie-support' /DietPi/dietpi.txt
+
+			else
+
+				echo 'DEV_GITBRANCH=jessie-support' >> /DietPi/dietpi.txt
+
+			fi
+
+			# Remove DietPi-Update working directory to allow concurrent execution.
+			cd /tmp
+			[[ -d '/tmp/DietPi-Update' ]] && rm -R /tmp/DietPi-Update
+
+			# Apply update forcefully, since user has already chosen to do so.
+			dietpi-update 1
+
+			# Kill parental dietpi-update instance and exit this script to avoid deprecated update finish.
+			kill $PPID
+			exit
+
+		fi
 		#-------------------------------------------------------------------------------
 		# Finished
 		echo -e '\e[90m[\e[0m  \e[32mOK\e[0m  \e[90m]\e[0m Successfully applied pre-patches\n'

--- a/dietpi/pre-patch_file
+++ b/dietpi/pre-patch_file
@@ -74,7 +74,6 @@
 		#-------------------------------------------------------------------------------
 		# Pre-patch 4: https://github.com/MichaIng/DietPi/issues/2656
 		# Pre-patch 5: Add new G_CHECK_URL dietpi.txt settings
-		# Pre-patch 6: https://github.com/MichaIng/DietPi/pull/2728
 		if (( $G_DIETPI_VERSION_SUB < 23 )); then
 
 			if [[ -f '/etc/apt/preferences.d/dietpi-wireguard' ]]; then
@@ -88,45 +87,52 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 			grep -q 'CONFIG_G_CHECK_URL_TIMEOUT' /DietPi/dietpi.txt || echo 'CONFIG_G_CHECK_URL_TIMEOUT=5' >> /DietPi/dietpi.txt || { EXIT_CODE=5; break; }
 			grep -q 'CONFIG_G_CHECK_URL_ATTEMPTS' /DietPi/dietpi.txt || echo 'CONFIG_G_CHECK_URL_ATTEMPTS=3' >> /DietPi/dietpi.txt || { EXIT_CODE=5; break; }
 
-			if (( $(sed -n 1p /DietPi/dietpi/.hw_model) > 9 )) && grep -qi 'jessie' /etc/os-release; then
+		fi
+		#-------------------------------------------------------------------------------
+		# Pre-patch 6: Move Jessie systems to "jessie-support" branch: https://github.com/MichaIng/DietPi/issues/2332
+		# Pre-patch 7: https://github.com/MichaIng/DietPi/pull/2728
+		if grep -qi 'jessie' /etc/os-release; then
 
-				echo -e '\e[90m[\e[0m INFO \e[90m]\e[0m Pre-patch 6 | Applying changes to APT sources.list since Debian dropped support for Jessie systems'
-				if [[ $(uname -m) == 'aarch64' ]]; then
+			if ! grep -q '^[[:blank:]]*DEV_GITBRANCH=jessie-support' /DietPi/dietpi.txt; then
 
-					echo 'deb http://archive.debian.org/debian/ main contrib non-free' > /etc/apt/sources.list || { EXIT_CODE=6; break; }
+				echo -e '\e[90m[\e[0m INFO \e[90m]\e[0m Pre-patch 7 | Migrating Jessie systems to "jessie-support" update branch'
+				if grep -q '^[[:blank:]]*DEV_GITBRANCH=' /DietPi/dietpi.txt; then
+
+					sed -i '/^[[:blank:]]*DEV_GITBRANCH=/c\DEV_GITBRANCH=jessie-support' /DietPi/dietpi.txt
 
 				else
 
-					sed -Ei '/jessie-(backports|updates)/d' /etc/apt/sources.list || { EXIT_CODE=6; break; }
+					echo 'DEV_GITBRANCH=jessie-support' >> /DietPi/dietpi.txt
+
+				fi
+
+				# Remove DietPi-Update working directory to allow concurrent execution.
+				cd /tmp
+				[[ -d '/tmp/DietPi-Update' ]] && rm -R /tmp/DietPi-Update
+
+				# Apply update forcefully, since user has already chosen to do so.
+				dietpi-update 1
+
+				# Kill parental dietpi-update instance and exit this script to avoid deprecated update finish.
+				kill $PPID
+				exit
+
+			fi
+
+			if (( $G_DIETPI_VERSION_SUB < 23 && $(sed -n 1p /DietPi/dietpi/.hw_model) > 9 )); then
+
+				echo -e '\e[90m[\e[0m INFO \e[90m]\e[0m Pre-patch 7 | Applying changes to APT sources.list since Debian dropped support for Jessie systems'
+				if [[ $(uname -m) == 'aarch64' ]]; then
+
+					echo 'deb http://archive.debian.org/debian/ main contrib non-free' > /etc/apt/sources.list || { EXIT_CODE=7; break; }
+
+				else
+
+					sed -Ei '/jessie-(backports|updates)/d' /etc/apt/sources.list || { EXIT_CODE=7; break; }
 
 				fi
 
 			fi
-
-		fi
-		# Pre-patch 7: Move Jessie systems to "jessie-support" branch: https://github.com/MichaIng/DietPi/issues/2332
-		if grep -qi 'jessie' /etc/os-release && [[ $(grep -m1 '^[[:blank:]]*DEV_GITBRANCH=' /DietPi/dietpi.txt | sed 's/^[^=]*=//') != 'jessie-support' ]]; then
-
-			if grep -q '^[[:blank:]]*DEV_GITBRANCH=' /DietPi/dietpi.txt; then
-
-				sed -i '/^[[:blank:]]*DEV_GITBRANCH=/c\DEV_GITBRANCH=jessie-support' /DietPi/dietpi.txt
-
-			else
-
-				echo 'DEV_GITBRANCH=jessie-support' >> /DietPi/dietpi.txt
-
-			fi
-
-			# Remove DietPi-Update working directory to allow concurrent execution.
-			cd /tmp
-			[[ -d '/tmp/DietPi-Update' ]] && rm -R /tmp/DietPi-Update
-
-			# Apply update forcefully, since user has already chosen to do so.
-			dietpi-update 1
-
-			# Kill parental dietpi-update instance and exit this script to avoid deprecated update finish.
-			kill $PPID
-			exit
 
 		fi
 		#-------------------------------------------------------------------------------


### PR DESCRIPTION
**Status**: Review
- [x] DietPi-Patch | Apply the same there to migrate as well older DietPi systems without pre-patch support.
- [x] Changelog

**Reference**: https://github.com/MichaIng/DietPi/issues/2332

**Commit list/description**:
- Apply the branch migration via pre-patches and regular patch.
- Older systems do not yet run pre-patches, so we need to apply with `patch_file` as well to catch all.
- Newer systems will be migrated via pre-patches which is preferred to prevent download and load of possibly incompatible code with `patch_file`.