### PR TITLE
DietPi-Software | Java: On Jessie, download our self-hosted packages

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -47,6 +47,7 @@ Bug Fixes:
 - DietPi-Software | Nextcloud: Resolved an issue on Lighttpd with HTTPS enabled where OPcache settings were not applied as desired, leading to a warning on Nextcloud admin panel. Many thanks to @Borotes for reporting this issue: https://github.com/MichaIng/DietPi/issues/2489
 - DietPi-Software | Nextcloud Talk: Resolved an issue where coTURN prints two warnings about deprecated settings on Buster systems, due to some changes with latest versions.
 - DietPi-Software | Kodi: Resolved an issue on RPi where Kodi (v18) fails to start when a custom screen resolution was chosen. Many thanks to @johnnypea for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?p=17550#p17550
+- DietPi-Software | Java: Resolved an issue where install fails on Jessie systems since the used jessie-backports APT repo does not exist any more: https://github.com/MichaIng/DietPi/issues/2752
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX/files
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6775,28 +6775,28 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 
 			Banner_Installing
 
-			local packages='ca-certificates-java openjdk-8-jre-headless openjdk-8-jdk-headless'
+			# On Jessie we need to our self-hosted packages:
+			if (( $G_DISTRO < 4 )); then
 
-			# On Jessie use backports repo:
-			if (( $G_DISTRO == 3 )); then
+				Download_Install "https://dietpi.com/downloads/binaries/jessie/openjdk-8-jre_$G_HW_ARCH_DESCRIPTION.7z"
+				Download_Install "https://dietpi.com/downloads/binaries/jessie/openjdk-8-jdk_$G_HW_ARCH_DESCRIPTION.7z"
+				dpkg --force-hold,confdef,confold -i ca-certificates-java.deb openjdk-8-jre-headless.deb openjdk-8-jdk-headless.deb
+				G_AGF
+				rm ca-certificates-java.deb openjdk-8-jre-headless.deb openjdk-8-jdk-headless.deb
+				
 
-				cat << _EOF_ > /etc/apt/preferences.d/99-dietpi-openjdk-8-jdk
-Package: ca-certificates-java java-common openjdk-8-*
-Pin: release a=jessie-backports
-Pin-Priority: 990
-_EOF_
+			else
 
-				packages+=' -t jessie-backports'
+				local packages='ca-certificates-java openjdk-8-jre-headless openjdk-8-jdk-headless'
+				# Workaround for ARM install issue: https://github.com/MichaIng/DietPi/issues/2524
+				apt-get install -y -qq $packages
+				G_AGI $packages
 
 			fi
 
-			# Workaround for ARM install issue: https://github.com/MichaIng/DietPi/issues/2524
-			apt-get install -y -qq $packages
-			G_AGI $packages
-
 		fi
 
-		software_id=9
+		software_id=9 # Node.js
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -6812,7 +6812,7 @@ _EOF_
 
 		fi
 
-		software_id=130
+		software_id=130 # Python pip
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -6831,48 +6831,40 @@ _EOF_
 
 		fi
 
-		#SDL2
-		software_id=140
+		software_id=140 # SDL2
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
 
-			#X86_64
+			# X86_64
 			if (( $G_HW_ARCH == 10 )); then
 
 				# G_AGI libsdl2-2.0-0 libsdl2-image-2.0-0 libsdl2-ttf-2.0-0 libsdl2-net-2.0-0 libsdl2-mixer-2.0-0
 				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/sdl2-x86_64_stretch.7z'
 
-			#ARMv6
+			# ARMv6
 			elif (( $G_HW_ARCH == 1 )); then
 
 				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/sdl2-armv6_stretch.7z'
 
-			#ARMv7 FKMS:
+			# ARMv7 FKMS:
 			#	./configure --disable-video-rpi --enable-video-kmsdrm
 			elif (( $G_HW_ARCH == 2 )); then
 
 				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/sdl2-armv7_stretch.7z'
 
 				# - RPi 2/3 Enable fkms OpenGL
-				if (( $G_HW_MODEL < 10 )); then
-
-					/DietPi/dietpi/func/dietpi-set_hardware rpi-opengl vc4-fkms-v3d
-
-				fi
+				(( $G_HW_MODEL < 10 )) && /DietPi/dietpi/func/dietpi-set_hardware rpi-opengl vc4-fkms-v3d
 
 			fi
 
 			Download_Install "$INSTALL_URL_ADDRESS" sdl2
-
 			dpkg -i sdl2/*.deb
-
 			rm -R sdl2
 
 		fi
 
-		#Mono repo
-		software_id=150
+		software_id=150 # Mono runtime
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -14528,9 +14528,7 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-
 			apt-mark auto $(dpkg --get-selections default-jre* default-jdk* openjdk-* | mawk '{print $1}') ca-certificates-java
-			[[ -f /etc/apt/preferences.d/99-dietpi-openjdk-8-jdk ]] && rm /etc/apt/preferences.d/99-dietpi-openjdk-8-jdk
 
 		fi
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1742,6 +1742,9 @@ NB: When accessing "deluge-console" you need to do that as user "debian-deluged"
 			# dietpi-set_dphys-swapfile renamed to: "dietpi-set_swapfile": https://github.com/MichaIng/DietPi/pull/2720
 			rm -f /{DietPi,boot}/dietpi/func/dietpi-set_dphys-swapfile
 			#-------------------------------------------------------------------------------
+			# Remove obsolete OpenJDK APT preferences on Jessie: https://github.com/MichaIng/DietPi/pull/2753
+			[[ -f '/etc/apt/preferences.d/99-dietpi-openjdk-8-jdk' ]] && rm /etc/apt/preferences.d/99-dietpi-openjdk-8-jdk
+			#-------------------------------------------------------------------------------
 			if (( $G_DIETPI_INSTALL_STAGE == 2 )); then
 
 				# Infom Sonarr/Radarr/Lidarr users about DietPi-Arr_to_RAM: https://github.com/MichaIng/DietPi/pull/2698


### PR DESCRIPTION
**Status**: Ready
- [x] Patch: Remove obsolete APT preferences
- [x] Changelog

**Reference**: https://github.com/MichaIng/DietPi/issues/2752

**Commit list/description**:
+ DietPi-Software | Java: On Jessie, download our self-hosted packages, since jessie-backports branch has been removed from Debian repo which was the source for OpenJDK 8