### PR TITLE
DietPi-Software | Blynk Server: Fix logging issue and enable Buster support

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -32,6 +32,8 @@ Changes / Improvements / Optimisations:
 - DietPi-Software | Nextcloud Talk: We do not apply (D)TLS settings to coTURN any more. Since WebRTC is encrypted by itself there is no security benefit. More importantly Nextcloud Talk does not make use of the required TURNS protocol, so there is absolutely no point to apply these settings. The (D)TLS feature is meant to allow passing firewalls that only allow encrypted traffic. WebRTC, although encrypted, might not pass such firewalls since the encryption is not on transport layer. For those how are interested in further details and discussion: https://github.com/coturn/coturn/issues/33, https://github.com/nextcloud/spreed/issues/257
 - DietPi-Software | SABnzbd: Install latest version via GitHub master and skip adjusting existing config file. Systemd unit and dependencies have been adjusted to match minimum requirements and official documentation. The update will be applied via DietPi v6.23 patch as well. Many thanks to @19eighties for reporting the outdated version: https://github.com/MichaIng/DietPi/issues/2762
 - DietPi-Software | Jackett: On non-ARMv6 devices the new (v0.11+) standalone (non-mono) binary is installed now. This is applied on DietPi-Update as well, preserving your settings: https://github.com/MichaIng/DietPi/pull/2773
+- DietPi-Software | Blynk: Enabled support for Debian Buster by using the new Java 11 binary.
+- DietPi-Software | UrBackup: New version 2.3.8 is installed now. Many thanks to @DeathIsUnknown for informing us about the update: https://github.com/MichaIng/DietPi/issues/2783
 
 Bug Fixes:
 - System | Debian has vastly reduced support for Jessie systems from their official APT repository. The limited possible list entries are applied during DietPi-Update. Many thanks to @BerndKohl for reporting this issue: https://github.com/MichaIng/DietPi/issues/2665
@@ -56,6 +58,7 @@ Bug Fixes:
 - DietPi-Software | Node.js: Resolved an issue where install failed on ARMv6 since Node 12 does not support it any more. Many thanks to @axwax for reporting this issue: https://github.com/MichaIng/DietPi/issues/2755
 - DietPi-Software | Tor/WiFi Hotspot: Resolved an issue where WiFi Hotspot fails to start when Tor Hotspot is installed. Many thanks to @schnuckz for reporting this issue: https://github.com/MichaIng/DietPi/issues/2673#issuecomment-482605700
 - DietPi-Software | Jackett: Resolved an issue where service start fails after using the internal updater. Many thanks to @DeathIsUnknown for reporting this issue and providing a solution: https://github.com/MichaIng/DietPi/issues/2593#issuecomment-490096681
+- DietPi-Software | Blynk: Resolved an issue where logging failed and changed the default log dir to /var/log/blynk. Many thanks to @Phil1988 for reporting this issue: https://github.com/MichaIng/DietPi/issues/2777
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX/files
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4353,8 +4353,7 @@ _EOF_
 
 		fi
 
-		#mosquitto
-		software_id=123
+		software_id=123 # Mosquitto
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -4370,7 +4369,19 @@ _EOF_
 			INSTALL_URL_ADDRESS='https://api.github.com/repos/blynkkk/blynk-server/releases/latest'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
-			INSTALL_URL_ADDRESS=$(curl -s "$INSTALL_URL_ADDRESS" | grep -m1 'browser_download_url' | cut -d \" -f 4)
+			# On Buster use non-Java8 binary, else Java 8
+			local java='java8'
+			(( $G_DISTRO > 4 )) && java='[^a].' # Exclude "a" von jav[a]8 but allow "8" as this can be from version string
+			INSTALL_URL_ADDRESS=$(curl -s "$INSTALL_URL_ADDRESS" | grep -m1 "browser_download_url.*$java\.jar" | cut -d \" -f 4)
+
+			# Fallback URL
+			if [[ ! $INSTALL_URL_ADDRESS ]]; then
+
+				INSTALL_URL_ADDRESS='https://github.com/blynkkk/blynk-server/releases/download/v0.41.5/server-0.41.5-java8.jar'
+				(( $G_DISTRO > 4 )) && INSTALL_URL_ADDRESS='https://github.com/blynkkk/blynk-server/releases/download/v0.41.5/server-0.41.5-java8.jar'
+
+			fi
+
 			mkdir -p $G_FP_DIETPI_USERDATA/blynk/data
 			G_THREAD_START wget "$INSTALL_URL_ADDRESS" -O $G_FP_DIETPI_USERDATA/blynk/blynkserver.jar
 
@@ -4383,20 +4394,19 @@ _EOF_
 
 		fi
 
-		#NAA Daemon
-		software_id=124
+		software_id=124 # NAA Daemon
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
 
-			# - Skip license for NAA daemon:
+			# Skip license for NAA daemon:
 			debconf-set-selections <<< 'networkaudiod networkaudiod/license note false'
 
 			# Packages
 			local apackages=()
 
-			# - Jessie - requires stretch packages
-			if (( $G_DISTRO == 3 )); then
+			# - Jessie: Requires Stretch packages
+			if (( $G_DISTRO < 4 )); then
 
 				apackages+=('https://dietpi.com/downloads/binaries/all/gcc-6-base_6.3.0-6_armhf.deb')
 				apackages+=('https://dietpi.com/downloads/binaries/all/libstdc++6_6.3.0-6_armhf.deb')
@@ -4404,7 +4414,7 @@ _EOF_
 			fi
 
 			# - ARMv6/7
-			if (( $G_HW_ARCH <= 2 )); then
+			if (( $G_HW_ARCH < 3 )); then
 
 				apackages+=('https://www.signalyst.eu/bins/naa/linux/stretch/networkaudiod_3.5.5-39_armhf.deb')
 
@@ -4420,24 +4430,24 @@ _EOF_
 
 			fi
 
-			# - Check online
-			for ((i=0; i<${#apackages[@]}; i++))
+			# Check online
+			for i in "${apackages[@]}"
 			do
 
-				G_CHECK_URL "${apackages[$i]}"
+				G_CHECK_URL "$i"
 
 			done
 
-			# - Prereqs
+			# Pre-reqs
 			DEPS_LIST='libasound2'
 
 			# - Stretch+ additional packages
 			(( $G_DISTRO > 3 )) && DEPS_LIST+=' gcc-6-base libstdc++6'
 
-			for ((i=0; i<${#apackages[@]}; i++))
+			for i in "${apackages[@]}"
 			do
 
-				no_check_url=1 Download_Install "${apackages[$i]}"
+				no_check_url=1 Download_Install "$i"
 
 			done
 
@@ -4448,8 +4458,7 @@ _EOF_
 
 		fi
 
-		#Tomcat8
-		software_id=125
+		software_id=125 # Tomcat8
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -11395,7 +11404,7 @@ _EOF_
 
 		fi
 
-		software_id=131 # Blynk
+		software_id=131 # Blynk Server
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -11410,7 +11419,9 @@ _EOF_
 			fi
 
 			# User
-			useradd -rM blynk -G dietpi -s /usr/sbin/nologin
+			usercmd='useradd -rM'
+			getent passwd blynk &> /dev/null && usercmd='usermod'
+			$usercmd blynk -G dietpi -d $G_FP_DIETPI_USERDATA/blynk -s /usr/sbin/nologin
 
 			# Service
 			cat << _EOF_ > /etc/systemd/system/blynkserver.service
@@ -11421,7 +11432,8 @@ After=network.target
 [Service]
 User=blynk
 Group=dietpi
-ExecStart=$(command -v java) -jar $G_FP_DIETPI_USERDATA/blynk/blynkserver.jar -serverConfig $G_FP_DIETPI_USERDATA/blynk/server.properties
+WorkingDirectory=$G_FP_DIETPI_USERDATA/blynk
+ExecStart=$(command -v java) -jar $G_FP_DIETPI_USERDATA/blynk/blynkserver.jar
 
 [Install]
 WantedBy=multi-user.target
@@ -11429,8 +11441,7 @@ _EOF_
 
 		fi
 
-		#MotionEye
-		software_id=136
+		software_id=136 # MotionEye
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -12880,15 +12891,19 @@ _EOF_
 
 		fi
 
-		software_id=131
+		software_id=131 # Blynk Server
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			[[ -f /etc/systemd/system/blynkserver.service ]] && rm /etc/systemd/system/blynkserver.service
-			[[ -d $G_FP_DIETPI_USERDATA/blynk ]] && rm -R $G_FP_DIETPI_USERDATA/blynk
-			[[ -d /etc/blynkserver ]] && rm -R /etc/blynkserver #pre v6.19
+			if [[ -f '/etc/systemd/system/blynkserver.service' ]]; then
 
+				systemctl disable blynkserver
+				rm /etc/systemd/system/blynkserver.service
+
+			fi
 			userdel -rf blynk
+			[[ -d $G_FP_DIETPI_USERDATA/blynk ]] && rm -R $G_FP_DIETPI_USERDATA/blynk
+			[[ -d '/etc/blynkserver' ]] && rm -R /etc/blynkserver # Pre-v6.19
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3066,24 +3066,24 @@ Package: *php7.3*\nPin: release *\nPin-Priority: -1' > /etc/apt/preferences.d/di
 			[[ -f $target ]] && G_WHIP_MSG "[INFO] Updating file: $target"
 			G_RUN_CMD mv $file "$target"
 
-		elif [[ $type == deb ]]; then
+		elif [[ $type == 'deb' ]]; then
 
 			# - Allow error on first attempt, giving APT fix a change to resolve e.g. dependencies
 			G_USER_INPUTS=0 G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD dpkg --force-hold,confdef,confold -i $file
 			(( $G_ERROR_HANDLER_EXITCODE_RETURN )) && G_DIETPI-NOTIFY 2 'Trying automated APT fix' && G_AGF
 
-		elif [[ $type == zip ]]; then
+		elif [[ $type == 'zip' ]]; then
 
 			[[ $target ]] && target="-d $target"
 			G_RUN_CMD unzip -o $file "$target"
 
-		elif [[ $type == tar ]]; then
+		elif [[ $type == 'tar' ]]; then
 
 			#[[ $target ]] && target="--one-top-level=$target" # Option exist not on Jessie
 			[[ $target ]] && G_RUN_CMD mkdir -p "$target" && target="-C $target"
 			G_RUN_CMD tar xf $file "$target"
 
-		elif [[ $type == 7z ]]; then
+		elif [[ $type == '7z' ]]; then
 
 			[[ $target ]] && target="-o$target"
 			G_RUN_CMD 7zr x -y $file "$target"
@@ -3254,8 +3254,7 @@ Package: *php7.3*\nPin: release *\nPin-Priority: -1' > /etc/apt/preferences.d/di
 
 		fi
 
-		#vsFTPD
-		software_id=95
+		software_id=95 # vsFTPD
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -3263,8 +3262,7 @@ Package: *php7.3*\nPin: release *\nPin-Priority: -1' > /etc/apt/preferences.d/di
 
 		fi
 
-		#NFS_SERVER
-		software_id=109
+		software_id=109 # NFS Server
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -3278,8 +3276,7 @@ Package: *php7.3*\nPin: release *\nPin-Priority: -1' > /etc/apt/preferences.d/di
 
 		fi
 
-		#WEBSERVER_APACHE
-		software_id=83
+		software_id=83 # Apache Webserver
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -3290,8 +3287,7 @@ Package: *php7.3*\nPin: release *\nPin-Priority: -1' > /etc/apt/preferences.d/di
 
 		fi
 
-		#WEBSERVER_NGINX
-		software_id=85
+		software_id=85 # Nginx Webserver
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -3302,8 +3298,7 @@ Package: *php7.3*\nPin: release *\nPin-Priority: -1' > /etc/apt/preferences.d/di
 
 		fi
 
-		#WEBSERVER_LIGHTTPD
-		software_id=84
+		software_id=84 # Lighttpd Webserver
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -3312,8 +3307,7 @@ Package: *php7.3*\nPin: release *\nPin-Priority: -1' > /etc/apt/preferences.d/di
 
 		fi
 
-		#WEBSERVER_MARIADB
-		software_id=88
+		software_id=88 # MariaDB Database
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -3328,7 +3322,7 @@ Package: *php7.3*\nPin: release *\nPin-Priority: -1' > /etc/apt/preferences.d/di
 				# - Remove possible dead symlinks/files:
 				rm $G_FP_DIETPI_USERDATA/mysql &> /dev/null
 				mkdir -p $G_FP_DIETPI_USERDATA/mysql
-				if [[ -d /var/lib/mysql ]]; then
+				if [[ -d '/var/lib/mysql' ]]; then
 
 					G_DIETPI-NOTIFY 2 '/var/lib/mysql exists, will migrate containing databases'
 					G_RUN_CMD cp -a /var/lib/mysql/. $G_FP_DIETPI_USERDATA/mysql
@@ -3338,7 +3332,7 @@ Package: *php7.3*\nPin: release *\nPin-Priority: -1' > /etc/apt/preferences.d/di
 			fi
 
 			G_DIETPI-NOTIFY 2 'Removing /var/lib/mysql, if existent'
-			[[ -L /var/lib/mysql && ! $(readlink /var/lib/mysql) =~ $G_FP_DIETPI_USERDATA/mysql ]] &&
+			[[ -L '/var/lib/mysql' && ! $(readlink /var/lib/mysql) =~ $G_FP_DIETPI_USERDATA/mysql ]] &&
 				rm -R "$(readlink /var/lib/mysql)" &> /dev/null
 			rm -R /var/lib/mysql &> /dev/null
 
@@ -3363,8 +3357,7 @@ Package: *php7.3*\nPin: release *\nPin-Priority: -1' > /etc/apt/preferences.d/di
 
 		fi
 
-		#WEBSERVER_SQLITE
-		software_id=87
+		software_id=87 # SQLite Database
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -3375,8 +3368,7 @@ Package: *php7.3*\nPin: release *\nPin-Priority: -1' > /etc/apt/preferences.d/di
 
 		fi
 
-		#WEBSERVER_REDIS
-		software_id=91
+		software_id=91 # Redis Database
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -3400,8 +3392,7 @@ ExecStartPre=$(command -v chown) -R redis:redis /var/run/redis /var/lib/redis" >
 
 		fi
 
-		#WEBSERVER_PHP
-		software_id=89
+		software_id=89 # PHP
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -3484,13 +3475,12 @@ Package: openssl libssl1.1\nPin: origin packages.sury.org\nPin-Priority: -1' > /
 
 		fi
 
-		#WEBSERVER_MYADMINPHP
-		software_id=90
+		software_id=90 # phpMyAdmin
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
 
-			#MySQL must be running during install to allow debconf setup.
+			# MariaDB must be running during install to allow debconf setup.
 			G_RUN_CMD systemctl start $MARIADB_SERVICE
 
 			# Set password parameters before installing
@@ -3560,13 +3550,13 @@ We work around this error by running APT a second time. Please do not worry and 
 
 		fi
 
-		software_id=54 # Forums phpBB
+		software_id=54 # phpBB Forum
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
 
 			# Skip install, if already present
-			if [[ -d /var/www/phpBB3 ]]; then
+			if [[ -d '/var/www/phpBB3' ]]; then
 
 				G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$software_id]} install dir \"/var/www/phpBB3\" already exists. Download and install steps will be skipped.
  - If you want to update ${aSOFTWARE_WHIP_NAME[$software_id]}, please follow the instructions from WebUI ACP.
@@ -3585,42 +3575,42 @@ We work around this error by running APT a second time. Please do not worry and 
 
 			Banner_Installing
 
+			# Install Golang Go: https://golang.org/dl/
 			# - x86_64
 			if (( $G_HW_ARCH == 10 )); then
 
-				INSTALL_URL_ADDRESS='https://dl.google.com/go/go1.11.9.linux-amd64.tar.gz'
+				INSTALL_URL_ADDRESS='https://dl.google.com/go/go1.11.10.linux-amd64.tar.gz'
 
 			# - ARMv8
 			elif (( $G_HW_ARCH == 3 )); then
 
-				INSTALL_URL_ADDRESS='https://dl.google.com/go/go1.11.9.linux-arm64.tar.gz'
+				INSTALL_URL_ADDRESS='https://dl.google.com/go/go1.11.10.linux-arm64.tar.gz'
 
 			# - ARMv6/7
 			else
 
-				INSTALL_URL_ADDRESS='https://dl.google.com/go/go1.11.9.linux-armv6l.tar.gz'
+				INSTALL_URL_ADDRESS='https://dl.google.com/go/go1.11.10.linux-armv6l.tar.gz'
 
 			fi
 
 			Download_Install "$INSTALL_URL_ADDRESS" /usr/local/
 
+			# Export Go path variables
 			mkdir -p $G_FP_DIETPI_USERDATA/go
 			cat << _EOF_ > /etc/bashrc.d/go.sh
 #!/bin/bash
 export GOPATH=$G_FP_DIETPI_USERDATA/go
 export PATH=\$PATH:/usr/local/go/bin:$G_FP_DIETPI_USERDATA/go/bin
 _EOF_
-
 			. /etc/bashrc.d/go.sh
 
-			# - Install OB
+			# Install OpenBazaar
 			G_DIETPI-NOTIFY 2 "Installing ${aSOFTWARE_WHIP_NAME[$software_id]}, please wait, this will take some time (1-5 minutes)"
 			G_RUN_CMD go get github.com/OpenBazaar/openbazaar-go
 
 		fi
 
-		#YACY
-		software_id=133
+		software_id=133 # YaCy
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -3628,13 +3618,12 @@ _EOF_
 
 		fi
 
-		#Folding@Home
-		software_id=2
+		software_id=2 # Folding@Home
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
 
-			# - We must uninstall previous package for reinstall, else it will fail: https://github.com/MichaIng/DietPi/issue_comments#issuecomment-411688073
+			# We must uninstall previous package for reinstall, else it will fail: https://github.com/MichaIng/DietPi/issue_comments#issuecomment-411688073
 			if dpkg-query -s 'fahclient' &> /dev/null; then
 
 				G_DIETPI-NOTIFY 2 'Removing previous package before installing the latest version'
@@ -3651,7 +3640,7 @@ _EOF_
 
 			Download_Install 'https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v7.5/latest.deb'
 
-			killall -w FAHClient #due to https://github.com/FoldingAtHome/fah-issues/issues/1193
+			killall -w FAHClient # Due to https://github.com/FoldingAtHome/fah-issues/issues/1193
 
 		fi
 
@@ -3661,7 +3650,7 @@ _EOF_
 			Banner_Installing
 			DEPS_LIST="$PHP_NAME-intl" # https://doc.owncloud.org/server/administration_manual/installation/manual_installation.html#php-extensions
 
-			if [[ -f /var/www/owncloud/occ ]]; then
+			if [[ -f '/var/www/owncloud/occ' ]]; then
 
 				G_DIETPI-NOTIFY 2 'Existing ownCloud installation found, will NOT overwrite...'
 
@@ -3696,7 +3685,7 @@ _EOF_
 			Banner_Installing
 			DEPS_LIST="$PHP_NAME-intl" # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
 
-			if [[ -f /var/www/nextcloud/occ ]]; then
+			if [[ -f '/var/www/nextcloud/occ' ]]; then
 
 				G_DIETPI-NOTIFY 2 'Existing Nextcloud installation found, will NOT overwrite...'
 
@@ -3735,8 +3724,7 @@ _EOF_
 
 		fi
 
-		#YMPD
-		software_id=32
+		software_id=32 # ympd
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -3814,7 +3802,7 @@ _EOF_
 
 			Banner_Installing
 
-			#Sourcebuild pre-reqs
+			# Sourcebuild pre-reqs
 			DEPS_LIST='cppcheck pkg-config libssl-dev libmpdclient-dev libmpdclient2 cmake'
 
 			#Download_Install 'https://github.com/jcorporation/myMPD/archive/master.zip'
@@ -3823,6 +3811,7 @@ _EOF_
 			cd myMPD*
 			G_RUN_CMD ./mkrelease.sh
 			cd /tmp/$G_PROGRAM_NAME
+			rm -R myMPD*
 
 		fi
 
@@ -3902,7 +3891,7 @@ _EOF_
 
 			# Install our config file only, if not yet existent, to preserve manual user config.
 			# - This needs to be done prior to APT install, since this would otherwise install a default config file as well.
-			[[ -f /etc/mopidy/mopidy.conf ]] || dps_index=$software_id Download_Install 'mopidy.conf' /etc/mopidy/mopidy.conf
+			[[ -f '/etc/mopidy/mopidy.conf' ]] || dps_index=$software_id Download_Install 'mopidy.conf' /etc/mopidy/mopidy.conf
 
 			curl -sSL "$INSTALL_URL_ADDRESS" | apt-key add -
 			# No Buster list available yet, use stretch.list for testing:
@@ -3977,8 +3966,7 @@ _EOF_
 
 		fi
 
-		#MINIDLNA
-		software_id=39
+		software_id=39 # MiniDLNA
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -4029,8 +4017,7 @@ _EOF_
 
 		fi
 
-		#dxx-rebirth
-		software_id=112
+		software_id=112 # DDX-Rebirth
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -4046,17 +4033,17 @@ _EOF_
 			Banner_Installing
 
 			# ARMv7
-			INSTALL_URL_ADDRESS='https://hndl.urbackup.org/Server/2.3.7/urbackup-server_2.3.7_armhf.deb'
+			INSTALL_URL_ADDRESS='https://hndl.urbackup.org/Server/latest/urbackup-server_2.3.8_armhf.deb'
 
 			# x86_64
 			if (( $G_HW_ARCH == 10 )); then
 
-				INSTALL_URL_ADDRESS='https://hndl.urbackup.org/Server/2.3.7/urbackup-server_2.3.7_amd64.deb'
+				INSTALL_URL_ADDRESS='https://hndl.urbackup.org/Server/latest/urbackup-server_2.3.8_amd64.deb'
 
 			# ARMv8 source
 			elif (( $G_HW_ARCH == 3 )); then
 
-				INSTALL_URL_ADDRESS='https://hndl.urbackup.org/Server/2.3.7/urbackup-server-2.3.7.tar.gz'
+				INSTALL_URL_ADDRESS='https://hndl.urbackup.org/Server/latest/urbackup-server-2.3.8.tar.gz'
 
 			fi
 
@@ -4072,7 +4059,7 @@ _EOF_
 				G_RUN_CMD make -j $G_HW_CPU_CORES
 				G_RUN_CMD make install
 
-				sed -i "/ExecStart=/c ExecStart=/usr/local/bin/urbackupsrv run --config /etc/default/urbackupsrv --no-consoletime" urbackup-server.service
+				sed -i '/ExecStart=/c ExecStart=/usr/local/bin/urbackupsrv run --config /etc/default/urbackupsrv --no-consoletime' urbackup-server.service
 				cp urbackup-server.service /etc/systemd/system/urbackupsrv.service
 				cp defaults_server /etc/default/urbackupsrv
 				cp logrotate_urbackupsrv /etc/logrotate.d/urbackupsrv
@@ -4095,7 +4082,7 @@ _EOF_
 
 			Banner_Installing
 
-			if (( $G_HW_MODEL >= 10 )); then
+			if (( $G_HW_MODEL > 9 )); then
 
 				G_AGI opentyrian
 
@@ -4103,7 +4090,7 @@ _EOF_
 
 				DEPS_LIST='ibsdl1.2debian libsdl-net1.2'
 				Download_Install 'https://dietpi.com/downloads/binaries/rpi/opentyrian_armhf.zip' /
-				cp -R /usr/local/games/opentyrian /usr/games/ #cp 'just does it', mv will fail if already exists.
+				cp -R /usr/local/games/opentyrian /usr/games/ # cp 'just does it', mv will fail if already exists.
 				rm -R /usr/local/games/opentyrian
 				chmod +x /usr/games/opentyrian/opentyrian
 
@@ -4111,8 +4098,7 @@ _EOF_
 
 		fi
 
-		#RPi Cam Control
-		software_id=59
+		software_id=59 # RPi Cam Control
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -4177,7 +4163,7 @@ _EOF_
 			#Download_Install 'https://github.com/ArturSierzant/OMPD/archive/master.zip' /var/www
 			Download_Install 'https://github.com/ArturSierzant/OMPD/archive/2a2909be2d7abc8cce7dff741f529c7d876d4094.zip' /var/www
 
-			rm -R /var/www/ompd &> /dev/null #Replace/upgrade existing installs
+			rm -R /var/www/ompd &> /dev/null # Replace/upgrade existing installs
 			mv /var/www/OMPD* /var/www/ompd
 
 		fi
@@ -4280,11 +4266,10 @@ _EOF_
 
 		fi
 
-		#WEBIOPI requires RPIGPIO
+		# WebIOPi requires RPi GPIO
 		(( ${aSOFTWARE_INSTALL_STATE[71]} == 1 )) && aSOFTWARE_INSTALL_STATE[69]=1
 
-		#RPIGPIO
-		software_id=69
+		software_id=69 # RPi GPIO
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -4292,24 +4277,23 @@ _EOF_
 
 		fi
 
-		#WIRINGPI
-		software_id=70
+		software_id=70 # WebIOPi
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
 
-			# - RPi
+			# RPi
 			if (( $G_HW_MODEL < 10 )); then
 
-				#	https://git.drogon.net/?p=wiringPi;a=shortlog;h=refs/heads/master snapshot
+				# https://git.drogon.net/?p=wiringPi;a=shortlog;h=refs/heads/master snapshot
 				Download_Install 'https://dietpi.com/downloads/binaries/all/wiringPi-8d188fa.tar.gz'
 
-			# - Odroid's
+			# Odroids
 			elif (( $G_HW_MODEL < 20 )); then
 
 				Download_Install 'https://github.com/hardkernel/wiringPi/archive/master.zip'
 
-			# - BPiPro
+			# BPi Pro
 			elif (( $G_HW_MODEL == 51 )); then
 
 				Download_Install 'https://github.com/LeMaker/WiringBP/archive/bananapro.zip'
@@ -4328,8 +4312,7 @@ _EOF_
 
 		fi
 
-		#RPII2C
-		software_id=72
+		software_id=72 # RPi I2C
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -4337,8 +4320,7 @@ _EOF_
 
 		fi
 
-		#nodered
-		software_id=122
+		software_id=122 # Node-RED
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -4399,7 +4381,7 @@ _EOF_
 
 			Banner_Installing
 
-			# Skip license for NAA daemon:
+			# Skip license for NAA daemon
 			debconf-set-selections <<< 'networkaudiod networkaudiod/license note false'
 
 			# Packages
@@ -4466,8 +4448,7 @@ _EOF_
 
 		fi
 
-		#WEBIOPI
-		software_id=71
+		software_id=71 # WebIOPi
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -4490,20 +4471,18 @@ _EOF_
 
 		fi
 
-		#DIETPICLOUDSHELL
-		software_id=62
+		software_id=62 # DietPi-CloudShell
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
 
-			#LCD panels can be enabled in Dietpi-config > display options
-			#	XU4 enable cloudshell
+			# LCD panels can be enabled in Dietpi-config > display options
+			# - XU4 enable cloudshell
 			(( $G_HW_MODEL == 11 )) && /DietPi/dietpi/func/dietpi-set_hardware lcdpanel odroid-cloudshell
 
 		fi
 
-		#HAPROXY
-		software_id=98
+		software_id=98 # HAProxy
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -4551,8 +4530,7 @@ _EOF_
 
 		fi
 
-		#WORDPRESS
-		software_id=55
+		software_id=55 # Wordpress
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -4573,8 +4551,7 @@ _EOF_
 
 		fi
 
-		#TIGHTVNCSERVER
-		software_id=27
+		software_id=27 # TightVNC Server
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -4582,32 +4559,26 @@ _EOF_
 
 		fi
 
-		#VNC4SERVER
-		software_id=28
+		software_id=28 # VNC4 Server
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
 
 			local package_list='vnc4server x11vnc'
 
-			# - Stretch+
-			if (( $G_DISTRO >= 4 )); then
-
-				package_list+=' tigervnc-common'
-
-			fi
+			# Stretch+
+			(( $G_DISTRO > 3 )) && package_list+=' tigervnc-common'
 
 			G_AGI $package_list
 
 		fi
 
-		#REALVNCSERVER
-		software_id=120
+		software_id=120 # RealVNC Server
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
 
-			# - Available in Raspbian apt
+			# Available in Raspbian APT repo
 			G_AGI realvnc-vnc-server
 
 		fi
@@ -4698,8 +4669,7 @@ _EOF_
 
 		fi
 
-		#PHPSYSINFO
-		software_id=64
+		software_id=64 # phpSysInfo
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -4709,8 +4679,7 @@ _EOF_
 
 		fi
 
-		#Ubooquity
-		software_id=80
+		software_id=80 # Ubooquity
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -4723,8 +4692,7 @@ _EOF_
 
 		fi
 
-		#PHPIMAGEGALLERY
-		software_id=56
+		software_id=56 # PHP Image Gallery
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -4732,8 +4700,7 @@ _EOF_
 
 		fi
 
-		#AMPACHE
-		software_id=40
+		software_id=40 # Ampache
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -4756,8 +4723,7 @@ _EOF_
 
 		fi
 
-		#OPENVPNSERVER
-		software_id=97
+		software_id=97 # OpenVPN Server
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -4765,8 +4731,7 @@ _EOF_
 
 		fi
 
-		#PiVPN
-		software_id=117
+		software_id=117 # PiVPN
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -4776,14 +4741,14 @@ _EOF_
 
 			G_AGI lsb-release iptables-persistent dnsutils expect net-tools openvpn
 
-			# - Requires underpriv user: https://github.com/MichaIng/DietPi/issues/570#issuecomment-255588307
+			# Requires underpriv user: https://github.com/MichaIng/DietPi/issues/570#issuecomment-255588307
 			useradd pivpn
 			mkdir -p /home/pivpn
 
 			wget "$INSTALL_URL_ADDRESS" -O pivpn_install.sh
 			chmod +x pivpn_install.sh
 
-			# - Disable reboot
+			# Disable reboot
 			sed -i '/shutdown[[:space:]]/d' pivpn_install.sh
 
 			until ./pivpn_install.sh
@@ -4819,8 +4784,8 @@ _EOF_
 
 				kernel_packages='raspberrypi-bootloader raspberrypi-kernel libraspberrypi-bin libraspberrypi0 raspberrypi-kernel-headers'
 
-			#Odroid C1
-			elif (( $G_HW_MODEL == 10 && $G_DISTRO == 3 )); then #REMOVE v6.24
+			# - Odroid C1: REMOVE v6.24
+			elif (( $G_HW_MODEL == 10 && $G_DISTRO == 3 )); then
 
 				 kernel_packages='linux-image-armhf-odroid-c1 linux-headers-armhf-odroid-c1'
 
@@ -4917,7 +4882,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 			else
 
 				# - Remove/Update existing certbot installer scripts
-				[[ -d /etc/certbot_scripts ]] && rm -R /etc/certbot_scripts
+				[[ -d '/etc/certbot_scripts' ]] && rm -R /etc/certbot_scripts
 
 				Download_Install 'https://github.com/certbot/certbot/archive/master.zip' /etc
 				mv /etc/certbot* /etc/certbot_scripts
@@ -4994,8 +4959,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 		fi
 
-		#SHAIRPORTSYNC
-		software_id=37
+		software_id=37 # Shairport-Sync
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -5009,8 +4973,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 		fi
 
-		#PYDIO
-		software_id=48
+		software_id=48 # Pydio
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -5036,8 +4999,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 		fi
 
-		#SQUEEZELITE
-		software_id=36
+		software_id=36 # SqueezeLite
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -5075,8 +5037,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 		fi
 
-		#EMONHUB
-		software_id=99
+		software_id=99 # EmonHub
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -5086,14 +5047,13 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 			pip install paho-mqtt pydispatcher
 
-			# - move everything to /etc/emonhub
+			# Move everything to /etc/emonhub
 			rm -R /etc/emonhub
 			mv emonhub-* /etc/emonhub
 
 		fi
 
-		#RPIMONITOR
-		software_id=66
+		software_id=66 # RPi Monitor
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -5121,8 +5081,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 		fi
 
-		#BAIKAL
-		software_id=57
+		software_id=57 # BaiKal
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -5132,8 +5091,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 		fi
 
-		#MUMBLESERVER
-		software_id=43
+		software_id=43 # Mumble Server
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -5278,8 +5236,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 		fi
 
-		#QBITTORRENT
-		software_id=46
+		software_id=46 # qBitTorrent
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -5372,7 +5329,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 			fi
 
-			#Web interface
+			# Web interface
 			Download_Install 'https://github.com/ziahamza/webui-aria2/archive/master.zip'
 
 			cp -R webui-aria2* /var/www/aria2
@@ -5380,8 +5337,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 		fi
 
-		#Medusa
-		software_id=116
+		software_id=116 # Medusa
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -5404,13 +5360,12 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 		fi
 
-		#SYNCTHING
-		software_id=50
+		software_id=50 # Syncthing
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
 
-			if [[ -d /etc/syncthing ]]; then
+			if [[ -d '/etc/syncthing' ]]; then
 
 				G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$software_id]} install dir \"/etc/syncthing\" already exists. Download and install steps will be skipped.
  - If you want to update ${aSOFTWARE_WHIP_NAME[$software_id]}, please use the internal updater from WebUI.
@@ -5445,8 +5400,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 		fi
 
-		#TONIDO
-		software_id=134
+		software_id=134 # Tonido
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -5479,17 +5433,16 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 		fi
 
-		#CHROMIUM
-		software_id=113
+		software_id=113 # Chromium
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
 
-			#Pre-Req's
+			# Pre-reqs
 			G_AG_CHECK_INSTALL_PREREQ lsb-release
 
-			#Stretch via apt
-			if (( $G_DISTRO >= 4 )); then
+			# Stretch+ via APT
+			if (( $G_DISTRO > 3 )); then
 
 				if (( $G_HW_MODEL < 10 )); then
 
@@ -5503,19 +5456,19 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 			else
 
-				#armv6+
+				# ARMv6/7
 				if (( $G_HW_ARCH == 1 || $G_HW_ARCH == 2 )); then
 
 					INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/chromium_52.0.2743.116-1-deb8u1.1_armhf.deb'
 
-				#ARMv8
+				# ARMv8
 				elif (( $G_HW_ARCH == 3 )); then
 
 					INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/chromium_52.0.2743.116-1-deb8u1.1_arm64.deb'
 
 				fi
 
-				# - Odroid's, 'apt-get install -f' removes chromium package, rather than install required deps...
+				# Odroids, 'apt-get -f install' removes chromium package, rather than install required deps...
 				if (( $G_HW_MODEL > 9 && $G_HW_MODEL < 20 )); then
 
 					DEPS_LIST='libgnome-keyring0 libnspr4 libnss3 libnss3-1d libspeechd2 libxslt1.1 libxss1 xdg-utils libgnome-keyring-common libltdl7'
@@ -5526,27 +5479,26 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 				Download_Install 'https://dietpi.com/downloads/binaries/all/chromium-l10n_52.0.2743.116-1-deb8u1.1_all.deb'
 
-				#	armv6+
+				# ARMv6/7
 				if (( $G_HW_ARCH == 1 || $G_HW_ARCH == 2 )); then
 
 					Download_Install 'https://dietpi.com/downloads/binaries/all/chromedriver_52.0.2743.116-1-deb8u1.1_armhf.deb'
 
-				#	arm64
+				# ARMv8
 				elif (( $G_HW_ARCH == 3 )); then
 
 					Download_Install 'https://dietpi.com/downloads/binaries/all/chromedriver_52.0.2743.116-1-deb8u1.1_arm64.deb'
 
 				fi
 
-				# - Prevent Debian repo from replacing our chromium packages: https://github.com/MichaIng/DietPi/issues/658
+				# Prevent Debian repo from replacing our chromium packages: https://github.com/MichaIng/DietPi/issues/658
 				apt-mark hold chromium chromedriver
 
 			fi
 
 		fi
 
-		#MotionEye
-		software_id=136
+		software_id=136 # MotionEye
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -6962,19 +6914,19 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 			# Run uninstall of old file servers, after install loop
 			UNINSTALL_REQUIRED=1
 
-			#No File server
+			# No File server
 			if (( $INDEX_FILESERVER_TARGET == 0 )); then
 
 				(( ${aSOFTWARE_INSTALL_STATE[94]} == 2 )) && aSOFTWARE_INSTALL_STATE[94]=-1
 				(( ${aSOFTWARE_INSTALL_STATE[96]} == 2 )) && aSOFTWARE_INSTALL_STATE[96]=-1
 
-			#ProFTP
+			# ProFTP
 			elif (( $INDEX_FILESERVER_TARGET == -1 )); then
 
 				aSOFTWARE_INSTALL_STATE[94]=1
 				(( ${aSOFTWARE_INSTALL_STATE[96]} == 2 )) && aSOFTWARE_INSTALL_STATE[96]=-1
 
-			#Samba
+			# Samba
 			elif (( $INDEX_FILESERVER_TARGET == -2 )); then
 
 				aSOFTWARE_INSTALL_STATE[96]=1
@@ -6982,7 +6934,7 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 
 			fi
 
-			#Update Current SSHSERVER index
+			# Update Current SSHSERVER index
 			INDEX_FILESERVER_CURRENT=$INDEX_FILESERVER_TARGET
 
 		fi
@@ -7075,7 +7027,7 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 			G_THREAD_START wget https://raw.githubusercontent.com/MichaIng/DietPi/$G_GITBRANCH/.conf/desktop/lxde/lxde-rc.xml -O /root/.config/openbox/lxde-rc.xml
 
 			# - Remove Lxrandr Menu item (monitor configuration tool as we set res in dietpi-config)
-			[[ -f /usr/share/applications/lxrandr.desktop ]] && rm /usr/share/applications/lxrandr.desktop
+			[[ -f '/usr/share/applications/lxrandr.desktop' ]] && rm /usr/share/applications/lxrandr.desktop
 
 			# - Disable Trash
 			G_CONFIG_INJECT 'use_trash=' 'use_trash=0' /etc/xdg/libfm/libfm.conf
@@ -7146,8 +7098,7 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 
 		fi
 
-		#WEBSERVER_APACHE
-		software_id=83
+		software_id=83 # Apache Webserver
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -7208,8 +7159,7 @@ _EOF_
 
 		fi
 
-		#WEBSERVER_NGINX
-		software_id=85
+		software_id=85 # Nginx Webserver
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -7234,17 +7184,16 @@ _EOF_
 
 		fi
 
-		#WEBSERVER_LIGHTTPD
-		software_id=84
+		software_id=84 # Lighttpd Webserver
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
 
-			#www path
+			# www path
 			G_BACKUP_FP /etc/lighttpd/lighttpd.conf
 			sed -i '/^server.document-root/c\server.document-root        = "/var/www"' /etc/lighttpd/lighttpd.conf
 
-			#Configure fastcgi for PHP-FPM
+			# Configure fastcgi for PHP-FPM
 			cat << _EOF_ > /etc/lighttpd/conf-available/15-fastcgi-php.conf
 # -*- depends: fastcgi -*-
 # /usr/share/doc/lighttpd/fastcgi.txt.gz
@@ -7259,29 +7208,28 @@ fastcgi.server += ( ".php" =>
 )
 _EOF_
 
-			#enable cgi/php
+			# Enable cgi/php
 			lighttpd-enable-mod fastcgi
 			lighttpd-enable-mod fastcgi-php
 
-			#Move default page
+			# Move default page
 			mv /var/www/html/index.lighttpd.html /var/www/
 			[[ $(ls -A /var/www/html 2>&1) ]] || rm -R /var/www/html
 
 		fi
 
-		#WEBSERVER_PHP
-		software_id=89
+		software_id=89 # PHP
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
 
-			# - Apache2 has its own PHP module
+			# Apache2 has its own PHP module
 			if (( ${aSOFTWARE_INSTALL_STATE[83]} > 0 )); then
 
 				# https://github.com/MichaIng/DietPi/issues/1144
 				local php_service='/lib/systemd/system/apache2.service'
 
-			# - Nginx and Lighttpd use PHP-FPM
+			# Nginx and Lighttpd use PHP-FPM
 			elif (( ${aSOFTWARE_INSTALL_STATE[84]} > 0 || ${aSOFTWARE_INSTALL_STATE[85]} > 0 )); then
 
 				local php_service="/lib/systemd/system/${PHP_NAME}-fpm.service"
@@ -7374,8 +7322,7 @@ _EOF_
 
 		fi
 
-		#WEBSERVER_MARIADB
-		software_id=88
+		software_id=88 # MariaDB Database
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -7404,8 +7351,7 @@ _EOF_
 
 		fi
 
-		#WEBSERVER_MYADMINPHP
-		software_id=90
+		software_id=90 # phpMyAdmin
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -7426,8 +7372,7 @@ _EOF_
 
 		fi
 
-		#WEBSERVER_REDIS
-		software_id=91
+		software_id=91 # Redis Database
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -7666,7 +7611,7 @@ url.redirect += (
 				fi
 
 				# Cal/CardDAV redirects to ownCloud DAV endpoint
-				if [[ ! -f /etc/nginx/sites-dietpi/dietpi-dav_redirect.conf ]]; then
+				if [[ ! -f '/etc/nginx/sites-dietpi/dietpi-dav_redirect.conf' ]]; then
 
 					echo '# Redirect Cal/CardDAV requests to ownCloud endpoint:
 location = /.well-known/carddav {
@@ -7822,7 +7767,7 @@ _EOF_
 
 		fi
 
-		software_id=114 #N extcloud
+		software_id=114 # Nextcloud
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -7932,7 +7877,7 @@ url.redirect += (
 				fi
 
 				# Cal/CardDAV redirects to Nextcloud DAV endpoint
-				if [[ ! -f /etc/nginx/sites-dietpi/dietpi-dav_redirect.conf ]]; then
+				if [[ ! -f '/etc/nginx/sites-dietpi/dietpi-dav_redirect.conf' ]]; then
 
 					echo '# Redirect Cal/CardDAV requests to Nextcloud endpoint:
 location = /.well-known/carddav {
@@ -8130,8 +8075,8 @@ The install script will now exit. After applying one of the the above, rerun die
 			if [[ -f '/lib/systemd/system/coturn.service' ]]; then
 
 				# - Remove init.d service traces
-				[[ -f /etc/init.d/coturn ]] && rm /etc/init.d/coturn
-				[[ -f /etc/default/coturn ]] && rm /etc/default/coturn
+				[[ -f '/etc/init.d/coturn' ]] && rm /etc/init.d/coturn
+				[[ -f '/etc/default/coturn' ]] && rm /etc/default/coturn
 
 				# - Disable coturn logging by default, this can be overridden via /etc/turnserver.conf
 				mkdir -p /etc/systemd/system/coturn.service.d
@@ -8230,7 +8175,7 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 			G_RUN_CMD systemctl start $MARIADB_SERVICE
 			G_RUN_CMD systemctl start redis-server
 			G_RUN_CMD ncc maintenance:mode --off
-			[[ -d /var/www/nextcloud/apps/spreed ]] || G_RUN_CMD ncc app:install spreed
+			[[ -d '/var/www/nextcloud/apps/spreed' ]] || G_RUN_CMD ncc app:install spreed
 			ncc app:enable spreed
 
 			# Adjust Nextcloud Talk settings to use coturn
@@ -8251,9 +8196,9 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 
 			Banner_Configuration
 
-			# Remove obsolete init.d service and it's environment file
-			[[ -f /etc/init.d/transmission-daemon ]] && rm /etc/init.d/transmission-daemon
-			[[ -f /etc/default/transmission-daemon ]] && rm /etc/default/transmission-daemon
+			# Remove obsolete init.d service and its environment file
+			[[ -f '/etc/init.d/transmission-daemon' ]] && rm /etc/init.d/transmission-daemon
+			[[ -f '/etc/default/transmission-daemon' ]] && rm /etc/default/transmission-daemon
 
 			# Run service as "dietpi" group: https://github.com/MichaIng/DietPi/issues/350#issuecomment-423763518
 			mkdir -p /etc/systemd/system/transmission-daemon.service.d
@@ -8287,8 +8232,7 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 
 		fi
 
-		#PHPBB
-		software_id=54
+		software_id=54 # phpBB Forum
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -8316,12 +8260,12 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 			>> $G_FP_DIETPI_USERDATA/.mpd_cache/state
 			>> $G_FP_DIETPI_USERDATA/.mpd_cache/sticker.sql
 			# - Symlink from MPD defaults that applications may still expect/use.
-			[[ ! -e /var/lib/mpd/music || -L /var/lib/mpd/music ]] || mv -n /var/lib/mpd/music/* $G_FP_DIETPI_USERDATA/Music/ &> /dev/null
-			[[ ! -e /var/lib/mpd/playlists || -L /var/lib/mpd/playlists ]] || mv -n /var/lib/mpd/playlists/* $G_FP_DIETPI_USERDATA/Music/ &> /dev/null
-			[[ ! -e /var/lib/mpd/mpd.db || -L /var/lib/mpd/mpd.db ]] || mv -n /var/lib/mpd/mpd.db $G_FP_DIETPI_USERDATA/.mpd_cache/db_file
-			[[ ! -e /var/lib/mpd/state || -L /var/lib/mpd/state ]] || mv -n /var/lib/mpd/state $G_FP_DIETPI_USERDATA/.mpd_cache/state
-			[[ ! -e /var/lib/mpd/sticker.sql || -L /var/lib/mpd/sticker.sql ]] || mv -n /var/lib/mpd/sticker.sql $G_FP_DIETPI_USERDATA/.mpd_cache/sticker.sql
-			[[ -d /var/lib/mpd ]] && rm -R /var/lib/mpd
+			[[ ! -e '/var/lib/mpd/music' || -L '/var/lib/mpd/music' ]] || mv -n /var/lib/mpd/music/* $G_FP_DIETPI_USERDATA/Music/ &> /dev/null
+			[[ ! -e '/var/lib/mpd/playlists' || -L '/var/lib/mpd/playlists' ]] || mv -n /var/lib/mpd/playlists/* $G_FP_DIETPI_USERDATA/Music/ &> /dev/null
+			[[ ! -e '/var/lib/mpd/mpd.db' || -L '/var/lib/mpd/mpd.db' ]] || mv -n /var/lib/mpd/mpd.db $G_FP_DIETPI_USERDATA/.mpd_cache/db_file
+			[[ ! -e '/var/lib/mpd/state' || -L '/var/lib/mpd/state' ]] || mv -n /var/lib/mpd/state $G_FP_DIETPI_USERDATA/.mpd_cache/state
+			[[ ! -e '/var/lib/mpd/sticker.sql' || -L '/var/lib/mpd/sticker.sql' ]] || mv -n /var/lib/mpd/sticker.sql $G_FP_DIETPI_USERDATA/.mpd_cache/sticker.sql
+			[[ -d '/var/lib/mpd' ]] && rm -R /var/lib/mpd
 			mkdir -p /var/lib/mpd
 			ln -sf $G_FP_DIETPI_USERDATA/Music /var/lib/mpd/music
 			ln -sf $G_FP_DIETPI_USERDATA/Music /var/lib/mpd/playlists
@@ -8341,7 +8285,7 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 			fi
 
 			# MPD service/confs
-			[[ -f /etc/default/mpd ]] && rm /etc/default/mpd
+			[[ -f '/etc/default/mpd' ]] && rm /etc/default/mpd
 
 			# - Upsteam systemd unit: https://github.com/MusicPlayerDaemon/MPD/blob/master/systemd/system/mpd.service.in
 			# - Debian package systemd unit: https://deb.debian.org/debian/pool/main/m/mpd/
@@ -8417,8 +8361,7 @@ _EOF_
 
 		fi
 
-		# Proftpd
-		software_id=94
+		software_id=94 # ProFTPD
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -8430,8 +8373,7 @@ _EOF_
 
 		fi
 
-		#Samba Server
-		software_id=96
+		software_id=96 # Samba Server
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -8446,8 +8388,7 @@ _EOF_
 
 		fi
 
-		#vsFTPD
-		software_id=95
+		software_id=95 # vsFTPD
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -8462,8 +8403,7 @@ _EOF_
 
 		fi
 
-		#NFS_SERVER
-		software_id=109
+		software_id=109 # NFS Server
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -8474,8 +8414,7 @@ _EOF_
 
 		fi
 
-		#YMPD
-		software_id=32
+		software_id=32 # ympd
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -8501,8 +8440,7 @@ _EOF_
 
 		fi
 
-		#myMPD
-		software_id=148
+		software_id=148 # myMPD
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -8532,18 +8470,17 @@ _EOF_
 
 			mkdir -p /var/lib/mympd/smartpls /var/lib/mympd/tmp
 
-			#symlink music/libary folders used by mympd
+			# Symlink music/libary folders used by mympd
 			if [[ $(readlink /usr/share/mympd/htdocs/library) != $G_FP_DIETPI_USERDATA/Music ]]; then
 
-				[[ -d /usr/share/mympd/htdocs/library ]] && rm -R /usr/share/mympd/htdocs/library
+				[[ -d '/usr/share/mympd/htdocs/library' ]] && rm -R /usr/share/mympd/htdocs/library
 				ln -sf $G_FP_DIETPI_USERDATA/Music /usr/share/mympd/htdocs/library
 
 			fi
 
 		fi
 
-		#Roon Bridge
-		software_id=121
+		software_id=121 # Roon Bridge
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -8596,8 +8533,7 @@ _EOF_
 
 		fi
 
-		#Tomcat8
-		software_id=125
+		software_id=125 # Tomcat8
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -8605,8 +8541,7 @@ _EOF_
 
 		fi
 
-		#CAVA
-		software_id=119
+		software_id=119 # CAVA
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -8641,8 +8576,7 @@ _EOF_
 
 		fi
 
-		#Mopidy
-		software_id=118
+		software_id=118 # Mopidy
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -8652,7 +8586,7 @@ _EOF_
 			G_CONFIG_INJECT 'cache_dir[[:blank:]]*=' 'cache_dir = /mnt/dietpi_userdata/mopidy/cache' /etc/mopidy/mopidy.conf '\[core\]'
 
 			# - Move existing home+data to dietpi_userdata, if not yet existent
-			if [[ -d /var/lib/mopidy && ! -d $G_FP_DIETPI_USERDATA/mopidy ]]; then
+			if [[ -d '/var/lib/mopidy' && ! -d $G_FP_DIETPI_USERDATA/mopidy ]]; then
 
 				mv /var/lib/mopidy $G_FP_DIETPI_USERDATA/mopidy
 				mkdir -p $G_FP_DIETPI_USERDATA/mopidy/data
@@ -8667,7 +8601,7 @@ _EOF_
 			fi
 
 			# - Move existing cache to dietpi_userdata, if not yet existent
-			if [[ -d /var/cache/mopidy && ! -d $G_FP_DIETPI_USERDATA/mopidy/cache ]]; then
+			if [[ -d '/var/cache/mopidy' && ! -d $G_FP_DIETPI_USERDATA/mopidy/cache ]]; then
 
 				mv /var/cache/mopidy $G_FP_DIETPI_USERDATA/mopidy/cache
 
@@ -8698,7 +8632,7 @@ _EOF_
 			userdel -r kodi &> /dev/null
 
 			#Run Kodi as root
-			[[ -f /etc/default/kodi ]] && G_CONFIG_INJECT 'USER=' 'USER=root' /etc/default/kodi
+			[[ -f '/etc/default/kodi' ]] && G_CONFIG_INJECT 'USER=' 'USER=root' /etc/default/kodi
 
 			#Copy udev rules, probably not needed for root, but we'll do it anyway
 			dps_index=$software_id Download_Install '99-dietpi-kodi.rules' /etc/udev/rules.d/99-dietpi-kodi.rules
@@ -8706,14 +8640,13 @@ _EOF_
 
 			#Create .desktop SymLinks
 			mkdir -p /root/Desktop
-			[[ -f /usr/share/applications/kodi.desktop ]] && rm /usr/share/applications/kodi.desktop
+			[[ -f '/usr/share/applications/kodi.desktop' ]] && rm /usr/share/applications/kodi.desktop
 			G_RUN_CMD wget https://raw.githubusercontent.com/MichaIng/DietPi/$G_GITBRANCH/.conf/desktop/apps/kodi.desktop -O /usr/share/applications/kodi.desktop
 			ln -sf /usr/share/applications/kodi.desktop /root/Desktop/kodi.desktop
 
 		fi
 
-		#MINIDLNA
-		software_id=39
+		software_id=39 # MiniDLNA
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -8756,10 +8689,10 @@ _EOF_
 
 			Banner_Configuration
 
-			#Failsafe: Directory required for "noip2 -C" to create the config file
+			# Failsafe: Directory required for "noip2 -C" to create the config file
 			mkdir -p /usr/local/etc
 
-			#noip2 service file
+			# noip2 service file
 			cat << _EOF_ > /etc/systemd/system/noip2.service
 [Unit]
 Description=noip2 (DietPi)
@@ -8872,8 +8805,7 @@ _EOF_
 
 		fi
 
-		#dxx-rebirth
-		software_id=112
+		software_id=112 # DDX-Rebirth
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -8915,8 +8847,7 @@ _EOF_
 
 		fi
 
-		#DIETPICAM
-		software_id=59
+		software_id=59 # RPi Cam Control
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -8947,7 +8878,7 @@ WantedBy=multi-user.target
 _EOF_
 
 			# - Replace confs with /var/www to /var/www/rpicam, once
-			if (( ! $(grep -ci -m1 '/rpicam' /etc/raspimjpeg) )); then
+			if ! grep -q '/rpicam' /etc/raspimjpeg; then
 
 				sed -i 's#/var/www#/var/www/rpicam#g' /etc/raspimjpeg
 				sed -i 's#/var/www#/var/www/rpicam#g' /etc/motion/motion.conf
@@ -9013,7 +8944,7 @@ WantedBy=multi-user.target
 _EOF_
 
 			# Add web.log to logrotate config
-			if [[ -f /etc/logrotate.d/deluged ]] && ! grep -q 'web.log' /etc/logrotate.d/deluged; then
+			if [[ -f '/etc/logrotate.d/deluged' ]] && ! grep -q 'web.log' /etc/logrotate.d/deluged; then
 
 				echo -e "\n$(</etc/logrotate.d/deluged)" >> /etc/logrotate.d/deluged
 				sed -i '1,1s/daemon.log/web.log/' /etc/logrotate.d/deluged
@@ -9041,9 +8972,9 @@ _EOF_
 			fi
 
 			# Remove init.d service leftovers, installed by Debian APT package
-			[[ -f /etc/init.d/deluged ]] && rm /etc/init.d/deluged
-			[[ -f /etc/default/deluged ]] && rm /etc/default/deluged
-			[[ -d /var/lib/deluged ]] && rm -R /var/lib/deluged
+			[[ -f '/etc/init.d/deluged' ]] && rm /etc/init.d/deluged
+			[[ -f '/etc/default/deluged' ]] && rm /etc/default/deluged
+			[[ -d '/var/lib/deluged' ]] && rm -R /var/lib/deluged
 
 		fi
 
@@ -9069,8 +9000,7 @@ _EOF_
 
 		fi
 
-		#PIHOLE
-		software_id=93
+		software_id=93 # Pi-hole
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -9177,12 +9107,12 @@ _EOF_
 
 		fi
 
-		software_id=71 # WEBIOPI
+		software_id=71 # WebIOPi
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
 
-			# autostart
+			# Autostart
 			update-rc.d webiopi defaults
 
 		fi
@@ -9215,23 +9145,22 @@ _EOF_
 
 		fi
 
-		#HAPROXY
-		software_id=98
+		software_id=98 # HAProxy
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
 
-			#Create jail directory
+			# Create jail directory
 			mkdir -p /var/lib/haproxy
 
 			cat << _EOF_ > /etc/haproxy/haproxy.cfg
 global
 
-	#rsyslog is required for logging
+	# rsyslog is required for logging
 	#log /var/log    local0
 	#log /var/log    local1 notice
 	maxconn 64
-	#Jail directory
+	# Jail directory
 	chroot /var/lib/haproxy
 	stats socket /run/haproxy.sock mode 660 level admin
 	stats timeout 30s
@@ -9282,7 +9211,7 @@ backend nodes
 	server web02 127.0.0.1:9001 check
 	server web03 127.0.0.1:9002 check
 
-#Admin web page
+# Admin web page
 
 	listen stats
 	bind *:1338
@@ -9292,7 +9221,7 @@ backend nodes
 	stats auth admin:dietpi
 _EOF_
 
-			#Add html error pages
+			# Add html error pages
 			mkdir -p /etc/haproxy/errors
 			local errorcode=0
 
@@ -9347,7 +9276,7 @@ _EOF_
 
 			Banner_Configuration
 
-			#Create mysql DB
+			# Create MariaDB database
 			/DietPi/dietpi/func/create_mysql_db wordpress wordpress "$GLOBAL_PW"
 
 		fi
@@ -9403,8 +9332,7 @@ _EOF_
 
 		fi
 
-		#TIGHTVNCSERVER / VNC4SERVER / RealVNC - Shared setup
-		#software_id=27/28/120
+		#software_id=27/28/120 # TightVNC/VNC4/RealVNC Server - Shared setup
 		if (( ${aSOFTWARE_INSTALL_STATE[27]} == 1 ||
 			${aSOFTWARE_INSTALL_STATE[28]} == 1 ||
 			${aSOFTWARE_INSTALL_STATE[120]} == 1 )); then
@@ -9537,8 +9465,7 @@ _EOF_
 
 		fi
 
-		#VNC4SERVER / RealVNC
-		software_id=28
+		software_id=28 # VNC4/RealVNC Server
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} > 0 ||
 			${aSOFTWARE_INSTALL_STATE[120]} > 0 )); then
 
@@ -9591,7 +9518,7 @@ _EOF_
 
 			Banner_Configuration
 
-			# - Move DB/datadir to userdata location
+			# Move DB/datadir to userdata location
 			mv /var/lib/influxdb $G_FP_DIETPI_USERDATA/
 			ln -sf $G_FP_DIETPI_USERDATA/influxdb /var/lib/influxdb
 
@@ -9602,11 +9529,11 @@ _EOF_
 
 			Banner_Configuration
 
-			# - Move DB/plugins to userdata location, if not already existent
+			# Move DB/plugins to userdata location, if not already existent
 			if [[ -d $G_FP_DIETPI_USERDATA/grafana ]]; then
 
 				G_DIETPI-NOTIFY 2 "Existing database/plugin directory $G_FP_DIETPI_USERDATA/grafana found. Will not overwrite..."
-				[[ -e /var/lib/grafana ]] && rm -R /var/lib/grafana
+				[[ -e '/var/lib/grafana' ]] && rm -R /var/lib/grafana
 
 			else
 
@@ -9615,7 +9542,7 @@ _EOF_
 			fi
 			ln -sf $G_FP_DIETPI_USERDATA/grafana /var/lib/grafana
 
-			# - Set password, wrap into trippled double quotes in case of ; or # being contained, according to docs: http://docs.grafana.org/installation/configuration/#password
+			# Set password, wrap into trippled double quotes in case of ; or # being contained, according to docs: http://docs.grafana.org/installation/configuration/#password
 			GCI_PASSWORD=1 GCI_PRESERVE=1 G_CONFIG_INJECT 'admin_password[[:blank:]]*=' "admin_password = \"\"\"$GLOBAL_PW\"\"\"" /etc/grafana/grafana.ini
 			G_CONFIG_INJECT 'http_port = ' 'http_port = 3001' /etc/grafana/grafana.ini
 
@@ -9647,8 +9574,7 @@ _EOF_
 
 		fi
 
-		#PHPSYSINFO
-		software_id=64
+		software_id=64 # phpSysInfo
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -9658,8 +9584,7 @@ _EOF_
 
 		fi
 
-		#PHPIMAGEGALLERY
-		software_id=56
+		software_id=56 # PHP Image Gallery
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -9681,8 +9606,7 @@ _EOF_
 
 		fi
 
-		#AMPACHE
-		software_id=40
+		software_id=40 # Ampache
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -9701,15 +9625,14 @@ _EOF_
 
 		fi
 
-		#OPENVPNSERVER
-		software_id=97
+		software_id=97 # OpenVPN Server
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
 
 			local key_size=2048
 
-			#Start Cert/Key generation.
+			# Start Cert/Key generation.
 			cp -a /usr/share/easy-rsa/ /etc/openvpn
 			mkdir -p /etc/openvpn/easy-rsa/keys
 			cat << _EOF_ >> /etc/openvpn/easy-rsa/vars
@@ -9723,11 +9646,11 @@ export KEY_OU='DietPi'
 export KEY_NAME='DietPi_OpenVPN_Server'
 _EOF_
 
-			#Create Server Cert Auth
+			# Create Server Cert Auth
 			G_DIETPI-NOTIFY 2 'Generating unique OpenVPN certificates and keys. Please wait...\n'
 			openssl dhparam -out /etc/openvpn/dh${key_size}.pem $key_size
 
-			#Build Server certs/keys
+			# Build Server certs/keys
 			chmod -R +x /etc/openvpn/easy-rsa
 			cd /etc/openvpn/easy-rsa
 			# - https://github.com/MichaIng/DietPi/issues/1450#issuecomment-362608574
@@ -9738,16 +9661,16 @@ _EOF_
 			./build-ca --batch DietPi_OpenVPN_Server
 			./build-key-server --batch DietPi_OpenVPN_Server
 
-			#Copy Server cert/keys
+			# Copy Server cert/keys
 			cp -a /etc/openvpn/easy-rsa/keys/{DietPi_OpenVPN_Server.crt,DietPi_OpenVPN_Server.key,ca.crt} /etc/openvpn/
 
-			#Build client cert/keys
+			# Build client cert/keys
 			./build-key --batch DietPi_OpenVPN_Client
 
 			cd /tmp/$G_PROGRAM_NAME
-			#End Cert/Key generation.
+			# End Cert/Key generation.
 
-			#Server config
+			# Server config
 			cat << _EOF_ > /etc/openvpn/server.conf
 port 1194
 proto udp
@@ -9772,19 +9695,19 @@ persist-key
 persist-tun
 verb 3
 
-#Web Forwarding (uncomment to enable)
+# Web Forwarding (uncomment to enable)
 #push "redirect-gateway"
 #push "dhcp-option DNS 10.8.0.1"
 
 _EOF_
 
-			#Client config
+			# Client config
 			cat << _EOF_ > /etc/openvpn/easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
 client
 proto udp
 dev tun
 
-#Ip/Domain name of DietPi system, running OpenVPN server.
+# Ip/Domain name of DietPi system, running OpenVPN server.
 remote mywebsite.com 1194
 
 resolv-retry infinite
@@ -9802,7 +9725,7 @@ verb 3
 
 _EOF_
 
-			#Unified client file. Add DietPi generated certs/keys.
+			# Unified client file. Add DietPi generated certs/keys.
 			# - Add Server Cert auth
 			echo '<ca>' >> /etc/openvpn/easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
 			cat /etc/openvpn/ca.crt >> /etc/openvpn/easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
@@ -9816,16 +9739,16 @@ _EOF_
 			cat /etc/openvpn/easy-rsa/keys/DietPi_OpenVPN_Client.key >> /etc/openvpn/easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
 			echo '</key>' >> /etc/openvpn/easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
 
-			#Copy client file to userdata location
+			# Copy client file to userdata location
 			cp /etc/openvpn/easy-rsa/keys/DietPi_OpenVPN_Client.ovpn $G_FP_DIETPI_USERDATA/
 			# - and /boot partition
 			cp /etc/openvpn/easy-rsa/keys/DietPi_OpenVPN_Client.ovpn /boot/
 
-			#Enable IP forwarding
+			# Enable IP forwarding
 			echo -e 'net.ipv4.ip_forward=1\nnet.ipv6.conf.all.forwarding=1\nnet.ipv6.conf.default.forwarding=1' > /etc/sysctl.d/dietpi-openvpn.conf
 			sysctl net.ipv4.ip_forward=1 net.ipv6.conf.all.forwarding=1 net.ipv6.conf.default.forwarding=1
 
-			#Web Fowarding (Setup IPtables, must also be run during boot)
+			# Web Fowarding (Setup IPtables, must also be run during boot)
 			#iptables -t nat -A POSTROUTING -s 10.8.0.0/24 -o "$(sed -n 3p /DietPi/dietpi/.network)" -j MASQUERADE
 
 		fi
@@ -10141,13 +10064,12 @@ _EOF_
 
 		fi
 
-		#SHAIRPORTSYNC
-		software_id=37
+		software_id=37 # Shairport-Sync
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
 
-			#Enable SOXR by default:
+			# Enable SOXR by default:
 			G_BACKUP_FP /usr/local/etc/shairport-sync.conf
 			cat << _EOF_ >  /usr/local/etc/shairport-sync.conf
 general =
@@ -10175,15 +10097,14 @@ alsa =
 };
 _EOF_
 
-			#Create shairport user
+			# Create shairport user
 			useradd -rM shairport-sync -G audio -s /usr/sbin/nologin
 
 			chmod +x /usr/local/bin/shairport-sync
 
 		fi
 
-		#PYDIO
-		software_id=48
+		software_id=48 # Pydio
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -10256,8 +10177,7 @@ _EOF_
 
 		fi
 
-		#SQUEEZELITE
-		software_id=36
+		software_id=36 # SqueezeLite
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -10271,8 +10191,7 @@ _EOF_
 
 		fi
 
-		#EMONHUB
-		software_id=99
+		software_id=99 # EmonHub
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -10287,7 +10206,7 @@ _EOF_
 
 			chmod +x -R /etc/emonhub
 
-			#RPI 3 - Must disable BCM BT to recover UART 0
+			# RPI 3 - Must disable BCM BT to recover UART 0
 			if (( $G_HW_MODEL == 3 )); then
 
 				# - Add DToverlay to disable bluetooth
@@ -10317,8 +10236,7 @@ _EOF_
 
 		fi
 
-		#RPIMONITOR
-		software_id=66
+		software_id=66 # RPi Monitor
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -10409,8 +10327,7 @@ _EOF_
 
 		fi
 
-		#BAIKAL
-		software_id=57
+		software_id=57 # BaiKal
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -10465,29 +10382,27 @@ location = /.well-known/caldav {
 
 		fi
 
-		#MUMBLESERVER
-		software_id=43
+		software_id=43 # Mumble Server
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
 
-			#Cap total connections
+			# Cap total connections
 			local max_users=$(( $G_HW_CPU_CORES * 8 ))
 			sed -i "/users=/c\users=$max_users" /etc/mumble-server.ini
 
-			#Name the root channel
+			# Name the root channel
 			sed -i '/registerName=/c\registerName=DietPi Mumble Server' /etc/mumble-server.ini
 
-			#Disable DB logging
+			# Disable DB logging
 			sed -i '/logdays=/c\logdays=-1' /etc/mumble-server.ini
 
-			#Set Superuser passwd: https://dietpi.com/phpbb/viewtopic.php?f=11&t=2024#p8084
+			# Set Superuser passwd: https://dietpi.com/phpbb/viewtopic.php?f=11&t=2024#p8084
 			murmurd -ini /etc/mumble-server.ini -supw "$GLOBAL_PW"
 
 		fi
 
-		#EMBYSERVER
-		software_id=41
+		software_id=41 # Emby Server
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -10507,13 +10422,14 @@ location = /.well-known/caldav {
 
 		fi
 
-		#CUBERITE
-		software_id=52
+		software_id=52 # Cuberite
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
 
-			useradd -rM cuberite -G dietpi -s /usr/sbin/nologin
+			usercmd='useradd -rM'
+			getent passwd cuberite &> /dev/null && usercmd='usermod'
+			$usercmd cuberite -G dietpi -d $G_FP_DIETPI_USERDATA/cubrite -s $(command -v nologin)
 
 			cat << _EOF_ > /etc/systemd/system/cuberite.service
 [Unit]
@@ -10530,7 +10446,7 @@ ExecStart=$G_FP_DIETPI_USERDATA/cubrite/Cuberite --service
 WantedBy=multi-user.target
 _EOF_
 
-			#WebUI settings
+			# WebUI settings
 			cat << _EOF_ > $G_FP_DIETPI_USERDATA/cubrite/webadmin.ini
 [User:admin]
 Password=$GLOBAL_PW
@@ -10632,7 +10548,7 @@ _EOF_
 
 			useradd -rm qbittorrent -p "$GLOBAL_PW" -G dietpi -s $(command -v nologin)
 
-			# - conf.
+			# Config
 			mkdir -p /home/qbittorrent/.config/qBittorrent
 			G_BACKUP_FP /home/qbittorrent/.config/qBittorrent/qBittorrent.conf
 			cat << _EOF_ > /home/qbittorrent/.config/qBittorrent/qBittorrent.conf
@@ -10713,10 +10629,10 @@ enabled=false
 program=
 _EOF_
 
-			#Jessie WebUI\Password_ha1 breaks login with m5dsum generated pw, revert to default 'adminadmin': https://github.com/MichaIng/DietPi/issues/1499#issuecomment-364769146
+			# - Jessie WebUI\Password_ha1 breaks login with m5dsum generated pw, revert to default 'adminadmin': https://github.com/MichaIng/DietPi/issues/1499#issuecomment-364769146
 			(( $G_DISTRO == 3 )) && sed -i '/Password_ha1=/d' /root/.config/qBittorrent/qBittorrent.conf
 
-			# - service
+			# Service
 			cat << _EOF_ > /etc/systemd/system/qbittorrent.service
 [Unit]
 Description=qBittorrent (DietPi)
@@ -11074,38 +10990,37 @@ _EOF_
 
 		fi
 
-		#SYNCTHING
-		software_id=50
+		software_id=50 # Syncthing
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
 
-			# - Generate dir's
+			# Generate dirs
 			mkdir -p $G_FP_DIETPI_USERDATA/syncthing
 			mkdir -p $G_FP_DIETPI_USERDATA/syncthing_data
 
-			#	Logs/Binary
+			# - Logs/Binary
 			mkdir -p /var/log/syncthing
    			>> /var/log/syncthing/syncthing.log
    			chown -R dietpi:dietpi /var/log/syncthing
    			chown -R dietpi:dietpi /etc/syncthing
 
-			# - Run Syncthing to create cert/config and exit
+			# Run Syncthing to create cert/config and exit
 			/etc/syncthing/syncthing -generate=$G_FP_DIETPI_USERDATA/syncthing
 
-			# - Disable automatic upgrades
+			# Disable automatic upgrades
 			sed -i '/<\/autoUpgradeIntervalH>/c\        <autoUpgradeIntervalH>0<\/autoUpgradeIntervalH>' $G_FP_DIETPI_USERDATA/syncthing/config.xml
 
-			# - Allow external access (LAN).
+			# Allow external access (LAN).
 			sed -i '/:8384<\/address>/c\        <address>0.0.0.0:8384<\/address>' $G_FP_DIETPI_USERDATA/syncthing/config.xml
 
-			# - Set default folder
+			# Set default folder
 			sed -i '/label=\"Default Folder/c\    <folder id=\"0000-0000\" label=\"Syncthing Data\" path=\"'"$G_FP_DIETPI_USERDATA/syncthing_data"'\" type=\"readwrite\" rescanIntervalS=\"60\" ignorePerms=\"false\" autoNormalize=\"true\">' $G_FP_DIETPI_USERDATA/syncthing/config.xml
 
-			# - Disable browser starting
+			# Disable browser starting
 			sed -i '/<\/startBrowser>/c\        <startBrowser>false<\/startBrowser>' $G_FP_DIETPI_USERDATA/syncthing/config.xml
 
-			# - Enable filesystem watcher (previously inotify)
+			# Enable filesystem watcher (previously inotify)
 			sed -i 's/fsWatcherEnabled=\"false\"/fsWatcherEnabled=\"true\"/g' $G_FP_DIETPI_USERDATA/syncthing/config.xml
 
 			# Services
@@ -11142,8 +11057,7 @@ _EOF_
 
 		fi
 
-		#Medusa
-		software_id=116
+		software_id=116 # Medusa
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -11157,15 +11071,16 @@ _EOF_
 
 		fi
 
-		#TONIDO
-		software_id=134
+		software_id=134 # Tonido
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
 
-			useradd -rm tonido -G dietpi -s /usr/sbin/nologin
+			usercmd='useradd -rm'
+			getent passwd tonido &> /dev/null && usercmd='usermod'
+			$usercmd tonido -G dietpi -s $(command -v nologin)
 
-			#service
+			# Service
 			cat << _EOF_ > /etc/systemd/system/tonido.service
 [Unit]
 Description=Tonido (DietPi)
@@ -11174,24 +11089,24 @@ Description=Tonido (DietPi)
 User=tonido
 Group=dietpi
 WorkingDirectory=$G_FP_DIETPI_USERDATA/tonido
-ExecStart=/bin/bash -c 'export LD_LIBRARY_PATH=$G_FP_DIETPI_USERDATA/tonido; export TONIDODIR=$G_FP_DIETPI_USERDATA/tonido; ./tonidoconsole'
+ExecStart=/bin/dash -c 'export LD_LIBRARY_PATH=$G_FP_DIETPI_USERDATA/tonido; export TONIDODIR=$G_FP_DIETPI_USERDATA/tonido; ./tonidoconsole'
 
 [Install]
 WantedBy=multi-user.target
 _EOF_
 
-			# - userdirs
+			# User dirs
 			mkdir -p $G_FP_DIETPI_USERDATA/tonido/sync
 			mkdir -p $G_FP_DIETPI_USERDATA/tonido/syncdata
 
-			#	symlink
+			# - Symlink
 			cp -R /home/tonido/tonido $G_FP_DIETPI_USERDATA/ &> /dev/null
 			rm -R /home/tonido/tonido &> /dev/null
 			ln -sf $G_FP_DIETPI_USERDATA/tonido /home/tonido/tonido
 			ln -sf $G_FP_DIETPI_USERDATA/tonido/sync /home/tonido/TonidoSync
 			ln -sf $G_FP_DIETPI_USERDATA/tonido/syncdata /home/tonido/TonidoSyncData
 
-			# - armv7 switch
+			# ARMv7 switch
 			if (( $G_HW_ARCH == 2 )); then
 
 				sed -i 's/armv6l/armv7l/' $G_FP_DIETPI_USERDATA/tonido/manifest.xml
@@ -11206,7 +11121,7 @@ _EOF_
 
 			Banner_Configuration
 
-			#Allow root, start maximized and disable sandbox under root (blank screen without)
+			# Allow root, start maximized and disable sandbox under root (blank screen without)
 			local export_options="export CHROMIUM_FLAGS=\"\$CHROMIUM_FLAGS \
 --test-type \
 --no-sandbox \
@@ -11219,10 +11134,10 @@ _EOF_
 --profiler-timing=0 \
 --disable-composited-antialiasing "
 
-			#RPi
+			# RPi
 			if (( $G_HW_MODEL < 10 )); then
 
-				#	OpenGL
+				# - OpenGL
 				#if (( $G_HW_MODEL >= 2 )); then
 
 					# Hangs xinit: https://github.com/MichaIng/DietPi/issues/834
@@ -11231,12 +11146,12 @@ _EOF_
 				#fi
 				:
 
-			#OpenGL
+			# OpenGL
 			elif (( $G_HW_MODEL == 21 )); then
 
 				:
 
-			#GLES
+			# GLES
 			else
 
 				export_options+='--use-gl=egl'
@@ -11246,28 +11161,25 @@ _EOF_
 			export_options+="\""
 
 			mkdir -p /etc/chromium.d
-			cat << _EOF_ > /etc/chromium.d/custom_flags
-$export_options
-_EOF_
+			echo "$export_options" > /etc/chromium.d/custom_flags
 
-			#	Chromium 60+
+			# Chromium 60+
 			cp /etc/chromium.d/custom_flags /root/.chromium-browser.init
 
-			#Symlink to desktop
-			#	* for RPi Stretch due to chromium-browser.desktop
+			# Symlink to desktop
+			# - * for RPi Stretch due to chromium-browser.desktop
 			ln -sf /usr/share/applications/chromium*.desktop /root/Desktop/chromium.desktop &> /dev/null
 
-			# - Autostart run script for Kiosk mode, based on @AYapejian https://github.com/MichaIng/DietPi/issues/1737#issue-318697621
-
+			# Autostart run script for Kiosk mode, based on @AYapejian https://github.com/MichaIng/DietPi/issues/1737#issue-318697621
 			cat << _EOF_ > /var/lib/dietpi/dietpi-software/installed/chromium-autostart.sh
 #!/bin/bash
-#Autostart run script for Kiosk mode, based on @AYapejian https://github.com/MichaIng/DietPi/issues/1737#issue-318697621
+# Autostart run script for Kiosk mode, based on @AYapejian https://github.com/MichaIng/DietPi/issues/1737#issue-318697621
 # - Please see /root/.chromium-browser.init (and /etc/chromium.d/custom_flags) for additional egl/gl init options
 
 # Command line switches https://peter.sh/experiments/chromium-command-line-switches/
-# 	--test-type gets rid of some of the chromium warnings that you may or may not care about in kiosk on a LAN
-#   --pull-to-refresh=1
-#   --ash-host-window-bounds="400,300"
+# --test-type gets rid of some of the chromium warnings that you may or may not care about in kiosk on a LAN
+# --pull-to-refresh=1
+# --ash-host-window-bounds="400,300"
 
 # - Resolution to use for kiosk mode, should ideally match current system resolution
 RES_X=\$(grep -m1 '^[[:blank:]]*SOFTWARE_CHROMIUM_RES_X=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
@@ -11281,7 +11193,7 @@ CHROMIUM_OPTS="--kiosk --test-type --window-size=\$RES_X,\$RES_Y --start-fullscr
 URL=\$(grep -m1 '^[[:blank:]]*SOFTWARE_CHROMIUM_AUTOSTART_URL=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 CHROMIUM_OPTS+=" --homepage \$URL"
 
-#Find absolute filepath location of Chromium binary.
+# Find absolute filepath location of Chromium binary.
 FP_CHROMIUM=\$(command -v chromium)
 if [[ ! \$FP_CHROMIUM ]]; then
 
@@ -11296,8 +11208,7 @@ _EOF_
 
 		fi
 
-		#O!MPD
-		software_id=129
+		software_id=129 # O!MPD
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -11319,23 +11230,22 @@ _EOF_
 
 		fi
 
-		#IceCast + DarkIce
-		software_id=135
+		software_id=135 # IceCast + DarkIce
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
 
-			#icecast set passwords:
+			# IceCast set passwords
 			sed -i '/\<source-password\>/c\\<source-password\>'"$GLOBAL_PW"'\<\/source-password\>' /etc/icecast2/icecast.xml
 			sed -i '/\<relay-password\>/c\\<relay-password\>'"$GLOBAL_PW"'\<\/relay-password\>' /etc/icecast2/icecast.xml
 
-			#	Create random password
+			# - Create random password
 			local admin_password=$(tr -cd '[:alnum:]' < /dev/urandom | fold -w10 | head -n1)
 			sed -i "/\<admin-password\>/c\\<admin-password\>$admin_password\<\/admin-password\>" /etc/icecast2/icecast.xml
 
 			sed -i '/ENABLE=/c\ENABLE=true' /etc/default/icecast2
 
-			#Darkice
+			# DarkIce
 			local input_device_index=$(arecord -l | mawk '/card/ {print $2;exit}' | sed 's/://')
 
 			cat << _EOF_ > /etc/darkice.cfg
@@ -11366,7 +11276,7 @@ public        = no
 #localDumpFile = $G_FP_DIETPI_USERDATA/darkice_recording.ogg
 _EOF_
 
-			#Systemd service for Darkice
+			# Systemd service for DarkIce
 			rm /etc/init.d/darkice
 			cat << _EOF_ > /etc/systemd/system/darkice.service
 [Unit]
@@ -11383,8 +11293,7 @@ _EOF_
 
 		fi
 
-		#mosquitto
-		software_id=123
+		software_id=123 # Mosquitto
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -11415,6 +11324,9 @@ _EOF_
 				local config_file_url_address='https://raw.githubusercontent.com/blynkkk/blynk-server/master/server/core/src/main/resources/server.properties'
 				G_RUN_CMD wget "$config_file_url_address" -O $G_FP_DIETPI_USERDATA/blynk/server.properties
 				G_CONFIG_INJECT 'data.folder=' "data.folder=$G_FP_DIETPI_USERDATA/blynk/data" $G_FP_DIETPI_USERDATA/blynk/server.properties
+				# - Log to RAMlog
+				mkdir -p /var/log/blynk
+				G_CONFIG_INJECT 'logs.folder=' 'logs.folder=/var/log/blynk' $G_FP_DIETPI_USERDATA/blynk/server.properties
 
 			fi
 
@@ -11465,8 +11377,7 @@ _EOF_
 
 		fi
 
-		#CloudPrint
-		software_id=137
+		software_id=137 # CloudPrint
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -11578,15 +11489,14 @@ _EOF_
 
 		fi
 
-		#spotifyconnectweb
-		software_id=141
+		software_id=141 # Spotify Connect Web
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
 
 			cat << _EOF_ > /etc/systemd/system/spotify-connect-web.service
 [Unit]
-Description=spotify-connect-web (DietPi)
+Description=Spotify Connect Web (DietPi)
 After=sound.target
 
 [Service]
@@ -11599,8 +11509,7 @@ _EOF_
 
 		fi
 
-		#couchpotato
-		software_id=142
+		software_id=142 # CouchPotato
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -11617,8 +11526,7 @@ _EOF_
 
 		fi
 
-		#Koel
-		software_id=143
+		software_id=143 # Koel
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -11663,13 +11571,14 @@ _EOF_
 
 		fi
 
-		#Sonarr
-		software_id=144
+		software_id=144 # Sonarr
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
 
-			useradd -rM sonarr -G dietpi -s /usr/sbin/nologin
+			usercmd='useradd -rM'
+			getent passwd sonarr &> /dev/null && usercmd='usermod'
+			$usercmd sonarr -G dietpi -d $G_FP_DIETPI_USERDATA/sonarr -s $(command -v nologin)
 
 			mkdir -p $G_FP_DIETPI_USERDATA/sonarr
 
@@ -11697,13 +11606,14 @@ _EOF_
 
 		fi
 
-		#Radarr
-		software_id=145
+		software_id=145 # Radarr
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
 
-			useradd -rM radarr -G dietpi -s /usr/sbin/nologin
+			usercmd='useradd -rM'
+			getent passwd radarr &> /dev/null && usercmd='usermod'
+			$usercmd radarr -G dietpi -d $G_FP_DIETPI_USERDATA/radarr -s $(command -v nologin)
 
 			mkdir -p $G_FP_DIETPI_USERDATA/radarr
 
@@ -11731,13 +11641,14 @@ _EOF_
 
 		fi
 
-		#Lidarr
-		software_id=106
+		software_id=106 # Lidarr
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
 
-			useradd -rM lidarr -G dietpi -s /usr/sbin/nologin
+			usercmd='useradd -rM'
+			getent passwd lidarr &> /dev/null && usercmd='usermod'
+			$usercmd lidarr -G dietpi -d $G_FP_DIETPI_USERDATA/lidarr -s $(command -v nologin)
 
 			mkdir -p $G_FP_DIETPI_USERDATA/lidarr
 
@@ -11755,7 +11666,7 @@ ExecStart=/usr/bin/mono -O=-aot /opt/Lidarr/Lidarr.exe -nobrowser -data=$G_FP_DI
 WantedBy=multi-user.target
 _EOF_
 
-			# - logs to RAM
+			# Logs to RAM
 			rm -R $G_FP_DIETPI_USERDATA/lidarr/logs* &> /dev/null
 			mkdir -p /var/log/lidarr
 			ln -sf /var/log/lidarr $G_FP_DIETPI_USERDATA/lidarr/logs
@@ -11935,7 +11846,7 @@ _EOF_
 
 		fi
 
-		software_id=154 # RoonServer
+		software_id=154 # Roon Server
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -10,7 +10,6 @@
 	#////////////////////////////////////
 	#
 	# Usage:
-	#
 	FP_SCRIPT='/DietPi/dietpi/func/dietpi-set_software'
 	AVAIABLE_COMMANDS="
 Available commands:
@@ -23,10 +22,9 @@ $FP_SCRIPT	ntpd-mode		[0-4] configures time sync mode (eg: daily/hourly/daemon)
 $FP_SCRIPT	verify_dietpi.txt	Verifies dietpi.txt entries, adds missing entries if required
 $FP_SCRIPT	passwords		NULL=Prompt user to change DietPi related passwords | X=optional set X as global password for future dietpi-software installations and \"root\" + \"dietpi\" login passwords.
 $FP_SCRIPT	setpermissions		Applies required filesystem permissions to DietPi specific content, and, DietPi userdata directory for software installs
-"
-	#////////////////////////////////////
+"	#////////////////////////////////////
 
-	#Grab inputs
+	# Grab inputs
 	INPUT_MODE_NAME=$1
 	INPUT_MODE_VALUE=$2
 
@@ -35,13 +33,13 @@ $FP_SCRIPT	setpermissions		Applies required filesystem permissions to DietPi spe
 	INPUT_ADDITIONAL_3=$5
 	INPUT_ADDITIONAL_4=$6
 
-	#Import DietPi-Globals ---------------------------------------------------------------
+	# Import DietPi-Globals --------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
 	G_PROGRAM_NAME='DietPi-Set_software'
 	G_CHECK_ROOT_USER
 	G_CHECK_ROOTFS_RW
 	G_INIT
-	#Import DietPi-Globals ---------------------------------------------------------------
+	# Import DietPi-Globals --------------------------------------------------------------
 
 	EXIT_CODE=0
 
@@ -100,18 +98,18 @@ $FP_SCRIPT	setpermissions		Applies required filesystem permissions to DietPi spe
 	}
 
 	#/////////////////////////////////////////////////////////////////////////////////////
-	# Set Apt Mirror
+	# Set APT Mirror
 	#/////////////////////////////////////////////////////////////////////////////////////
 	AptMirror_Main(){
 
 		if [[ $INPUT_MODE_VALUE ]]; then
 
-			# - Jessie ARMv8: https://github.com/MichaIng/DietPi/issues/2665#issuecomment-477348864
+			# Jessie ARMv8: https://github.com/MichaIng/DietPi/issues/2665#issuecomment-477348864
 			if (( $G_HW_ARCH == 3 && $G_DISTRO < 4 )); then
 
 				INPUT_MODE_VALUE='http://archive.debian.org/debian/'
 
-			# - Set defaults?
+			# Set defaults?
 			elif [[ $INPUT_MODE_VALUE == 'default' ]]; then
 
 				if (( $G_HW_MODEL < 10 )); then
@@ -126,16 +124,16 @@ $FP_SCRIPT	setpermissions		Applies required filesystem permissions to DietPi spe
 
 			fi
 
-			# - Set Raspbian
+			# Set Raspbian
 			if (( $G_HW_MODEL < 10 )); then
 
 				echo "deb $INPUT_MODE_VALUE $G_DISTRO_NAME main contrib non-free rpi" > /etc/apt/sources.list
 				echo "deb https://archive.raspberrypi.org/debian/ $G_DISTRO_NAME main ui" > /etc/apt/sources.list.d/raspi.list
 
-				#	Update dietpi.txt entry
+				# - Update dietpi.txt entry
 				G_CONFIG_INJECT 'CONFIG_APT_RASPBIAN_MIRROR=' "CONFIG_APT_RASPBIAN_MIRROR=$INPUT_MODE_VALUE" /DietPi/dietpi.txt
 
-			# - Set Debian
+			# Set Debian
 			else
 
 				cat << _EOF_ > /etc/apt/sources.list
@@ -145,7 +143,7 @@ deb https://deb.debian.org/debian-security/ $G_DISTRO_NAME/updates main contrib 
 deb $INPUT_MODE_VALUE $G_DISTRO_NAME-backports main contrib non-free
 _EOF_
 
-				#	Jessie: https://github.com/MichaIng/DietPi/issues/2665#issuecomment-477348864
+				# - Jessie: https://github.com/MichaIng/DietPi/issues/2665#issuecomment-477348864
 				if (( $G_DISTRO < 4 )); then
 
 					#	- Jessie APT reports warning on httpS://deb.debian.org
@@ -155,14 +153,14 @@ _EOF_
 					#	- ARMv8 has been dropped from security repo
 					(( $G_HW_ARCH == 3 )) && sed -i '/debian-security/d' /etc/apt/sources.list
 
-				#	Buster, remove backports: https://github.com/MichaIng/DietPi/issues/1285#issuecomment-351830101
+				# - Buster, remove backports: https://github.com/MichaIng/DietPi/issues/1285#issuecomment-351830101
 				elif (( $G_DISTRO > 4 )); then
 
 					sed -i '/backports/d' /etc/apt/sources.list
 
 				fi
 
-				#	Update dietpi.txt entry
+				# - Update dietpi.txt entry
 				G_CONFIG_INJECT 'CONFIG_APT_DEBIAN_MIRROR=' "CONFIG_APT_DEBIAN_MIRROR=$INPUT_MODE_VALUE" /DietPi/dietpi.txt
 
 			fi
@@ -193,12 +191,12 @@ _EOF_
 			local ntp_mirror_entry='Servers='$ntp_mirror
 
 			# - Default, lets timesyncd use DHCP server (Stretch+ only) or fallback to debian.pool.ntp.org.
-			if [[ ${ntp_mirror,,} == default ]]; then
+			if [[ ${ntp_mirror,,} == 'default' ]]; then
 
 				ntp_mirror_entry='#Servers=0.debian.pool.ntp.org 1.debian.pool.ntp.org 2.debian.pool.ntp.org 3.debian.pool.ntp.org'
 
 			# - Gateway, auto detect local gateway(s) (router) to use as NTP server.
-			elif [[ ${ntp_mirror,,} == gateway ]]; then
+			elif [[ ${ntp_mirror,,} == 'gateway' ]]; then
 
 				# NB: Turn output output into single line string via echo
 				local gateway=$(echo $(ip r | mawk '/^default/ {print $3}'))
@@ -270,7 +268,7 @@ _EOF_
 	}
 
 	#/////////////////////////////////////////////////////////////////////////////////////
-	# allo
+	# Allo
 	#/////////////////////////////////////////////////////////////////////////////////////
 	Allo_Main(){
 
@@ -458,7 +456,7 @@ _EOF_
 		chown -R sabnzbd:dietpi $G_FP_DIETPI_USERDATA/downloads/{,in}complete
 
 		# - Blynk
-		chown -R blynk:dietpi $G_FP_DIETPI_USERDATA/blynk
+		chown -R blynk:dietpi $G_FP_DIETPI_USERDATA/blynk /var/log/blynk
 
 		# - Pi-hole
 		#	- NB: Git requies special permissions to allow "pihole -up".
@@ -481,22 +479,20 @@ _EOF_
 			mkdir -p /home
 			useradd -m -s /bin/bash "$INPUT_MODE_VALUE" -p "$(grep -m1 '^[[:blank:]]*AUTO_SETUP_GLOBAL_PASSWORD=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')"
 
-			#	Copy existing profile/bashrc
+			# Copy existing profile/bashrc
 			cp /root/.profile /home/"$INPUT_MODE_VALUE"/
 			cp /root/.bashrc /home/"$INPUT_MODE_VALUE"/
 
 			chown -R "$INPUT_MODE_VALUE":"$INPUT_MODE_VALUE" /home/"$INPUT_MODE_VALUE"
 
-			#	Allow sudo without pw
+			# Allow sudo without pw
 			if ! grep -q "^$INPUT_MODE_VALUE[[:space:]]" /etc/sudoers.d/dietpi; then
 
-				cat << _EOF_ >> /etc/sudoers.d/dietpi
-$INPUT_MODE_VALUE ALL=NOPASSWD: ALL
-_EOF_
+				echo "$INPUT_MODE_VALUE ALL=NOPASSWD: ALL" >> /etc/sudoers.d/dietpi
 
 			fi
 
-			#	Same groups as user pi
+			# Same groups as user pi
 			local group_array=()
 			group_array+=('input')
 			group_array+=('netdev')
@@ -514,13 +510,13 @@ _EOF_
 			group_array+=('dialout')
 			group_array+=('adm')
 
-			#	+ allow access to www-data
+			# Allow access to www-data
 			group_array+=('www-data')
 
-			for ((i=0; i<${#group_array[@]}; i++))
+			for i in ${group_array[@]}
 			do
 
-				usermod -a -G "${group_array[$i]}" "$INPUT_MODE_VALUE"
+				usermod -a -G $i "$INPUT_MODE_VALUE"
 
 			done
 
@@ -538,12 +534,11 @@ _EOF_
 
 		if [[ $INPUT_MODE_VALUE ]]; then
 
-			# - Delete $INPUT_MODE_VALUE
-			userdel -f "$INPUT_MODE_VALUE"
-			rm -R "/home/$INPUT_MODE_VALUE"
+			# Delete $INPUT_MODE_VALUE
+			userdel -rf "$INPUT_MODE_VALUE"
 
-			# - Remove from sudoers
-			sed -i "/^$INPUT_MODE_VALUE[[:space:]]/d" /etc/sudoers.d/dietpi
+			# Remove from sudoers
+			sed -i "/^$INPUT_MODE_VALUE[[:blank:]]/d" /etc/sudoers.d/dietpi
 
 		else
 
@@ -560,8 +555,7 @@ _EOF_
 		[[ $gitbranch ]] || gitbranch='master'
 
 		INSTALL_URL="https://raw.githubusercontent.com/MichaIng/DietPi/$gitbranch/dietpi.txt"
-		G_CHECK_URL "$INSTALL_URL"
-		if (( ! $? )); then
+		if G_CHECK_URL "$INSTALL_URL"; then
 
 			G_DIETPI-NOTIFY 0 'Patching dietpi.txt'
 			l_message='Downloading current dietpi.txt' G_RUN_CMD wget "$INSTALL_URL" -O /tmp/dietpi.txt_patch
@@ -610,16 +604,16 @@ _EOF_
 		local pw_dietpi_software=''
 		local pw_root_dietpi_users=''
 
-		#Automation/input mode, set and then apply input password to both dietpi-software and root/dietpi user passwords.
+		# Automation/input mode, set and then apply input password to both dietpi-software and root/dietpi user passwords.
 		if [[ $INPUT_MODE_VALUE ]]; then
 
 			pw_dietpi_software=$INPUT_MODE_VALUE
 			pw_root_dietpi_users=$INPUT_MODE_VALUE
 
-		#Prompt to change
+		# Prompt to change
 		else
 
-			#DietPi-Software PW
+			# DietPi-Software PW
 			G_WHIP_YESNO 'Do you want to adjust the default global password for DietPi-Software installations and new unix users? We especially recommend to change the default password "dietpi". This does not affect any existing unix user login.\n
 NB: This password will be saved and encrypted within /var/lib/dietpi/dietpi-software/.GLOBAL_PW.bin to be useable by DietPi scripts for e.g. web application and database logins. We highly recommend to adjust all passwords for web services and new unix users independently afterwards.'
 			if (( ! $? )); then
@@ -630,7 +624,7 @@ NB: This password will be saved and encrypted within /var/lib/dietpi/dietpi-soft
 
 			fi
 
-			#Root/DietPi user PW
+			# Root/DietPi user PW
 			G_WHIP_YESNO 'Change unix user passwords?\n\nDietPi has two accounts by default "root" and "dietpi". On first boot, both share the global password "dietpi", respectively the one set in dietpi.txt.\n
 It is highly recommended to change this password, ideally, it should be different than the global DietPi-Software password.\n\nWould you like to change the login passwords for "root" and "dietpi"?'
 			if (( ! $? )); then
@@ -643,7 +637,7 @@ It is highly recommended to change this password, ideally, it should be differen
 
 		fi
 
-		#Apply | dietpi-software PW
+		# Apply | dietpi-software PW
 		if [[ $pw_dietpi_software ]]; then
 
 			# - Nullify automated PW
@@ -662,7 +656,7 @@ It is highly recommended to change this password, ideally, it should be differen
 
 		fi
 
-		#Apply | Root/DietPi users PW
+		# Apply | Root/DietPi users PW
 		if [[ $pw_root_dietpi_users ]]; then
 
 			chpasswd <<< "root:$pw_root_dietpi_users"
@@ -677,8 +671,7 @@ It is highly recommended to change this password, ideally, it should be differen
 	# Main Loop
 	#/////////////////////////////////////////////////////////////////////////////////////
 	#-----------------------------------------------------------------------------------
-	#info
-
+	# Info
 	G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" "$INPUT_MODE_NAME ($INPUT_MODE_VALUE)"
 
 	#-----------------------------------------------------------------------------------

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -271,9 +271,9 @@ _EOF_
 			if (( $G_DIETPI_INSTALL_STAGE == 2 )); then
 
 				# - RPi cam pre-patch
-				[[ -d /var/www/dietpicam ]] && mv /var/www/dietpicam /var/www/rpicam
+				[[ -d '/var/www/dietpicam' ]] && mv /var/www/dietpicam /var/www/rpicam
 				[[ -d $G_FP_DIETPI_USERDATA/dietpicam ]] && mv $G_FP_DIETPI_USERDATA/dietpicam $G_FP_DIETPI_USERDATA/rpicam
-				[[ -e /var/www/rpicam/media ]] && rm /var/www/rpicam/media
+				[[ -e '/var/www/rpicam/media' ]] && rm /var/www/rpicam/media
 
 				/DietPi/dietpi/dietpi-software reinstall 59 132
 
@@ -430,7 +430,7 @@ _EOF_
 			fi
 			#-------------------------------------------------------------------------------
 			#Remove minutely running "make_nas_processes_faster" cron job, present on images with preinstalled OMV: https://github.com/MichaIng/DietPi/issues/1654
-			[[ -f /etc/cron.d/make_nas_processes_faster ]] && rm /etc/cron.d/make_nas_processes_faster
+			[[ -f '/etc/cron.d/make_nas_processes_faster' ]] && rm /etc/cron.d/make_nas_processes_faster
 			#-------------------------------------------------------------------------------
 			#Add Dropbear ecdsa and dss host keys, if missing: https://github.com/MichaIng/DietPi/issues/1670
 			if (( $G_DIETPI_INSTALL_STAGE == 2 )) && grep -q '^aSOFTWARE_INSTALL_STATE\[104\]=2' /DietPi/dietpi/.installed; then
@@ -492,12 +492,12 @@ _EOF_
 			if { (( $G_HW_MODEL < 10 )) && ! grep -q 'allo-piano-dac' /DietPi/config.txt; } ||
 				{ (( $G_HW_MODEL == 70 )) && ! grep -q 'allo-piano-dac' /etc/modules; }; then
 
-				[[ -d /lib/firmware/allo ]] && rm -R /lib/firmware/allo
+				[[ -d '/lib/firmware/allo' ]] && rm -R /lib/firmware/allo
 
 			fi
 			#-------------------------------------------------------------------------------
 			#RPi UART: https://github.com/MichaIng/DietPi/issues/1759
-			if [[ -f /DietPi/config.txt ]]; then
+			if [[ -f '/DietPi/config.txt' ]]; then
 
 				local serial_state=$(grep -m1 '^[[:blank:]]*CONFIG_SERIAL_CONSOLE_ENABLE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//')
 				G_CONFIG_INJECT 'enable_uart=' "enable_uart=$serial_state" /DietPi/config.txt
@@ -1010,7 +1010,7 @@ _EOF_
 			#-------------------------------------------------------------------------------
 			#Update IPv6 handling: https://github.com/MichaIng/DietPi/issues/2027
 			# - Advice user to re-enable IPv6 on kernel level
-			if [[ ! -d /proc/sys/net/ipv6 ]]; then
+			if [[ ! -d '/proc/sys/net/ipv6' ]]; then
 
 				G_WHIP_MENU_ARRAY=(
 
@@ -1357,7 +1357,7 @@ _EOF_
 				# - Samba: Link disk cache to RAM: https://github.com/MichaIng/DietPi/issues/2396
 				if grep -q '^aSOFTWARE_INSTALL_STATE\[96\]=2' /DietPi/dietpi/.installed; then
 
-					[[ -e /var/cache/samba ]] && rm -R /var/cache/samba
+					[[ -e '/var/cache/samba' ]] && rm -R /var/cache/samba
 					mkdir -p /var/run/samba-cache
 					ln -s /var/run/samba-cache /var/cache/samba
 					echo 'd /var/run/samba-cache - - - - -' > /etc/tmpfiles.d/dietpi-samba_cache.conf
@@ -1429,7 +1429,7 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 			#Clear install state for Medusa
 			(( $G_DIETPI_INSTALL_STAGE == 2 )) && [[ ! -d $G_FP_DIETPI_USERDATA/medusa ]] && G_CONFIG_INJECT 'aSOFTWARE_INSTALL_STATE\[116\]=' 'aSOFTWARE_INSTALL_STATE[116]=0' /DietPi/dietpi/.installed
 			# - Inform user about SickRage being replaced by Medusa
-			if [[ -d /etc/sickrage || -d $G_FP_DIETPI_USERDATA/sickrage ]]; then
+			if [[ -d '/etc/sickrage' || -d $G_FP_DIETPI_USERDATA/sickrage ]]; then
 
 				G_WHIP_MSG '[WARNING] We found an existing SickRage install on your system\n
 We already dropped SickRage from DietPi-Software install options with v6.18, now it has been fully replaced with "Medusa", an older stabilized fork.
@@ -1755,8 +1755,8 @@ NB: When accessing "deluge-console" you need to do that as user "debian-deluged"
 With v6.18 we silently added a new script that allows linking Sonarr/Radarr/Lidarr database files to RAM, increasing access performance, reducing disk I/O and avoiding constant external HDD spinning due to the very regular access to these files.\n
 This script has gone through some rework and polishing with v6.23 and can now be enabled to automatically link those databases to RAM on boot and store them back to disk on shutdown.\n
 Further info and usage: https://dietpi.com/phpbb/viewtopic.php?f=8&t=5828'
-
-				#Jessie C1 switch to Stretch | should not occur for pre-patch compatible versions and auto switch over to jessie-support for existing installs.
+				#-----------------------------------------------------------------------
+				# Jessie C1 switch to Stretch | should not occur for pre-patch compatible versions and auto switch over to jessie-support for existing installs.
 				elif (( $G_HW_MODEL == 10 )); then
 
 					G_WHIP_MSG '[INFO] Odroid C1 image has been updated to Stretch. Please upgrade to continue limited support for this device:\nhttps://github.com/MichaIng/DietPi/issues/2561#issuecomment-488685121'
@@ -1799,6 +1799,16 @@ Further info and usage: https://dietpi.com/phpbb/viewtopic.php?f=8&t=5828'
 				#-----------------------------------------------------------------------
 				# Add /etc/network/interfaces.d/ drop-in config support
 				grep -q 'interfaces\.d' /etc/network/interfaces || sed -i '1i\source interfaces.d/*' /etc/network/interfaces
+				#-----------------------------------------------------------------------
+				# Blynk: Fix logging and move to RAMlog: https://github.com/MichaIng/DietPi/pull/2779
+				if [[ -f '/etc/systemd/system/blynkserver.service' && -f $G_FP_DIETPI_USERDATA/blynk/server.properties ]]; then
+
+					G_CONFIG_INJECT 'WorkingDirectory=' "WorkingDirectory=$G_FP_DIETPI_USERDATA/blynk" /etc/systemd/system/blynkserver.service '\[Service\]'
+					mkdir -p /var/log/blynk
+					chown -R blynk:dietpi /var/log/blynk
+					G_CONFIG_INJECT 'logs.folder=' 'logs.folder=/var/log/blynk' $G_FP_DIETPI_USERDATA/blynk/server.properties
+
+				fi
 				#-----------------------------------------------------------------------
 				# PHP7.3 migration: https://github.com/MichaIng/DietPi/issues/2367
 				local reinstall_ids=''


### PR DESCRIPTION
**Status**: Ready
- [x] DietPi-Patch WorkingDirectory into existing installs
- [x] Changelog

**Reference**: https://github.com/MichaIng/DietPi/issues/2777

**Commit list/description**:
+ DietPi-Software | Blynk Server: Resolve an issue where logging does not work as the service tries to create logging directory in root
+ DietPi-Software | Blynk Server: Enable Buster support by installing the Java 11 binary. Otherwise select the Java 8 binary explicitly, which was done already since the Java 8 binary is the first match from the GitHub API page.
+ DietPi-Software | Blynk Server: Use lasted known as fallback URLs, in case the API page scheme changes
+ DietPi-Software | Blynk: Log to RAMlog (/var/log) by default
+ DietPi-Software | OpenBazaar: Install latest Golang Go v11
- DietPi-Software | UrBackup: Install new v2.3.8: https://github.com/MichaIng/DietPi/issues/2783
+ DietPi-Software | Adjust last run user creations to use "usermod" if user already exists
+ DietPi-Software | Minor coding
+ DietPi-Software | Comments alignment and consistency
+ DietPi-Software | Finish "software_id=<ID> # <NAME>" line reduction
+ DietPi-Patch | Blynk: Fix logging and move to RAMlog
+ DietPi-Patch | Minor coding
+ DietPi-Set_software | Blynk: Chown new log dir as well
+ DietPi-Set_software | Minor coding and alignment
+ CHANGELOG | Blynk: Enabled support for Debian Buster by using the new Java 11 binary
+ CHANGELOG | UrBackup: New version 2.3.8 is installed now
+ CHANGELOG | Blynk: Resolved an issue where logging failed and changed the default log dir to /var/log/blynk