### PR TITLE
DietPi-Services 2.0 | Fine tuning part 2

### DIFF
--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -7,8 +7,9 @@
 	# Created by Daniel Knight / daniel.knight@dietpi.com / dietpi.com
 	#
 	# Info:
-	# - Allows service control for all listed programs used in dietpi-software
-	# - Disable removes the autostart from init.d and systemd. This allows DietPi to control program services below.
+	# - Allows service control for all listed programs available through dietpi-software
+	# - By default known services are "disabled", thus not started by systemd, but
+	#   started by this script at later boot stage from: /DietPi/dietpi/postboot
 	#
 	USAGE='
 Usage: dietpi-services <command> [<service>]
@@ -23,9 +24,9 @@ Available commands:
   enable/unmask		Enable service to allow its startup
   disable/mask		Disable service to prevent its startup
 Available services:
-  <service_name>	Add any systemd or sysvinit service available and enabled on your system.
+  <service_name>	Add any systemd or sysvinit service available on your system.
   <empty>		Apply command to all services known to DietPi
-  			NB: Some services, required for network or shell session, will be skipped.
+  			NB: Services required for network or shell session will be skipped.
 			NB: You can include/exclude services by editing the following file:
 			    - /DietPi/dietpi/.dietpi-services_include_exclude
 '	#////////////////////////////////////
@@ -36,7 +37,7 @@ Available services:
 	# - pre-v6.25 compatibility
 	[[ $INPUT_SERVICE == 'all' ]] && unset INPUT_SERVICE
 
-	# - Optional input variables to prevent service handling
+	# - Optional env vars to prevent service handling
 	[[ $G_DIETPI_SERVICES_DISABLE == 1 ]] && exit 0
 	[[ $DISABLE_SERVICES_START == 1 ]] && [[ $INPUT_CMD == 'start' || $INPUT_CMD == 'restart' ]] && exit 0
 
@@ -47,7 +48,11 @@ Available services:
 	G_INIT
 	# Import DietPi-Globals --------------------------------------------------------------
 
-	Init_Array(){
+
+	#/////////////////////////////////////////////////////////////////////////////////////
+	# Service Control
+	#/////////////////////////////////////////////////////////////////////////////////////
+	Load_All_Services_Array(){
 
 		aSERVICE_NAME=(
 
@@ -197,8 +202,7 @@ Available services:
 		# Additional services: https://github.com/MichaIng/DietPi/issues/1869#issuecomment-401017251
 		[[ -f '/etc/rsyncd.conf' ]] && aSERVICE_NAME+=('rsync')
 
-		# Hidden/not-controlled services
-		# - Status mode, enable service status
+		# Non-controlled services: Only show in menu and/or status mode!
 		if [[ ! $INPUT_CMD || $INPUT_CMD == 'status' ]]; then
 
 			# - SSH
@@ -237,11 +241,11 @@ Available services:
 	}
 
 
-	# User: read custom services file
-	FP_INCLUDE_CUSTOM_SERVICES='/DietPi/dietpi/.dietpi-services_include_exclude'
+	# Apply custom include/exclude choices
+	FP_INCLUDE_EXCLUDE='/DietPi/dietpi/.dietpi-services_include_exclude'
 	Process_Includes_Excludes(){
 
-		[[ -f $FP_INCLUDE_CUSTOM_SERVICES ]] || cat << _EOF_ > $FP_INCLUDE_CUSTOM_SERVICES
+		[[ -f $FP_INCLUDE_EXCLUDE ]] || cat << _EOF_ > $FP_INCLUDE_EXCLUDE
 # DietPi-Services Include/Exclude configuration
 
 # Include custom service (Use '+ servicename' without the comments to enable DietPi control of that service)
@@ -256,6 +260,7 @@ Available services:
 #- transmission-daemon
 
 _EOF_
+		local scrape i
 
 		while read line
 		do
@@ -263,8 +268,7 @@ _EOF_
 			# - Skip empty and comment lines
 			[[ ! $line || $line == '#'* ]] && continue
 
-			local scrape=${line: +2}
-			local i=''
+			scrape=${line: +2}
 
 			# - Include
 			if [[ $line == '+ '* ]]; then
@@ -307,131 +311,19 @@ _EOF_
 
 			fi
 
-		done < $FP_INCLUDE_CUSTOM_SERVICES
+		done < $FP_INCLUDE_EXCLUDE
 
 	}
 
-	# $1=index
-	FP_DIETPI_PROCESS_TOOL_SYSTEMD_CONF='dietpi-process_tool.conf'
-	Save_Process_Tool(){
+	# Load array of available/chosen services
+	Load_Service_Array(){
 
-		local index=$1
+		[[ $G_DEBUG == 1 ]] && G_DIETPI-NOTIFY 2 'Generating service list, please wait...'
 
-		# Backwards cap for init.d, create systemd wrapper
-		if [[ ${aFP_SERVICE[$index]} == '/etc/init.d/'* ]]; then
+		# Load all services array, skip in case of single service input
+		[[ $INPUT_SERVICE ]] && aSERVICE_NAME=("$INPUT_SERVICE") || Load_All_Services_Array
 
-			aFP_SERVICE[$index]="/etc/systemd/system/${aSERVICE_NAME[$index]}.service"
-			cat << _EOF_ > "${aFP_SERVICE[$index]}"
-[Unit]
-Description=${aSERVICE_NAME[$index]} sysvinit wrapper (DietPi)
-
-[Service]
-Type=forking
-ExecStart=/etc/init.d/${aSERVICE_NAME[$index]} start
-ExecStop=/etc/init.d/${aSERVICE_NAME[$index]} stop
-
-[Install]
-WantedBy=multi-user.target
-_EOF_
-			G_WHIP_MSG "[ INFO ] DietPi has created a systemd service wrapper for /etc/init.d/${aSERVICE_NAME[$index]}. This is required to allow support for applying process tool options.\n
-If you experience any issues with the wrapper, simply remove the file:\n - rm /etc/systemd/system/${aSERVICE_NAME[$index]}.service\n - Then restart the service."
-
-		fi
-
-		# Always create drop-in configs in: /etc/systemd/system/
-		mkdir -p "/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d"
-		cat << _EOF_ > "/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d/$FP_DIETPI_PROCESS_TOOL_SYSTEMD_CONF"
-[Service]
-Nice=${aCPU_NICE[$index]}
-CPUAffinity=${aCPU_AFFINITY[$index]}
-CPUSchedulingPolicy=${aCPU_SCHEDULE_POLICY[$index]}
-CPUSchedulingPriority=${aCPU_SCHEDULE_PRIORITY[$index]}
-IOSchedulingClass=${aIO_SCHEDULE_POLICY[$index]}
-IOSchedulingPriority=${aIO_PRIORITY[$index]}
-_EOF_
-		G_RUN_CMD systemctl daemon-reload
-		aSERVICE_RESTART_REQUIRED[$index]=1
-
-	}
-
-	# $1=index
-	Load_Process_Tool(){
-
-		local index=$1
-
-		# Defaults
-		aCPU_NICE[$index]=0
-		aCPU_AFFINITY[$index]="0-$(( $G_HW_CPU_CORES - 1 ))"
-		aCPU_SCHEDULE_POLICY[$index]='other'
-		aCPU_SCHEDULE_PRIORITY[$index]=0
-		aIO_SCHEDULE_POLICY[$index]='best-effort'
-		aIO_PRIORITY[$index]='3'
-
-		local fp="/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d/$FP_DIETPI_PROCESS_TOOL_SYSTEMD_CONF"
-		[[ -f $fp ]] || return
-
-		aCPU_NICE[$index]=$(grep -m1 '^[[:blank:]]*Nice=' $fp | sed 's/^[^=]*=//g')
-		aCPU_AFFINITY[$index]=$(grep -m1 '^[[:blank:]]*CPUAffinity=' $fp | sed 's/^[^=]*=//g')
-		aCPU_SCHEDULE_POLICY[$index]=$(grep -m1 '^[[:blank:]]*CPUSchedulingPolicy=' $fp | sed 's/^[^=]*=//g')
-		aCPU_SCHEDULE_PRIORITY[$index]=$(grep -m1 '^[[:blank:]]*CPUSchedulingPriority=' $fp | sed 's/^[^=]*=//g')
-		aIO_SCHEDULE_POLICY[$index]=$(grep -m1 '^[[:blank:]]*IOSchedulingClass=' $fp | sed 's/^[^=]*=//g')
-		aIO_PRIORITY[$index]=$(grep -m1 '^[[:blank:]]*IOSchedulingPriority=' $fp | sed 's/^[^=]*=//g')
-
-	}
-
-	# $1=index
-	Reset_Service_Defaults(){
-
-		local index=$1
-
-		local fp="/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d/$FP_DIETPI_PROCESS_TOOL_SYSTEMD_CONF"
-		[[ -f $fp ]] || return
-
-		G_RUN_CMD rm "$fp"
-		G_RUN_CMD rmdir --ignore-fail-on-non-empty "/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d"
-		G_RUN_CMD systemctl unmask "${aSERVICE_NAME[$index]}"
-		G_RUN_CMD systemctl daemon-reload
-		Load_Process_Tool $index
-		aSERVICE_RESTART_REQUIRED[$index]=1
-
-	}
-
-	Load_Process_Tool_Arrays(){
-
-		aSERVICE_MODE=() 		# Enabled/disabled/masked/unmasked
-		aSERVICE_RESTART_REQUIRED=() 	# eg, made changes, prompt to restart this service.
-
-		aCPU_NICE=()
-		aCPU_AFFINITY=()
-		aCPU_SCHEDULE_POLICY=()
-		aCPU_SCHEDULE_PRIORITY=()
-		aIO_SCHEDULE_POLICY=()
-		aIO_PRIORITY=()
-
-		aCPU_SCHEDULE_POLICY_TYPE=('other' 'fifo' 'rr' 'batch' 'idle')
-		aCPU_SCHEDULE_POLICY_DESC=('Normal (Default)' 'First In, First Out (Real-time, time-critical)' 'Round Robin (Real-time, time-critical)' 'Batch style execution' 'Background Jobs (Very low priority)')
-
-		aIO_SCHEDULE_POLICY_TYPE=('best-effort' 'realtime' 'idle')
-		aIO_SCHEDULE_POLICY_DESC=('Normal (Default)' 'Time-critical (Highest priority)' 'Background Jobs (Very low priority)')
-
-		for i in ${!aSERVICE_NAME[@]}
-		do
-
-			aSERVICE_MODE[$i]=$(systemctl is-enabled "${aSERVICE_NAME[$i]}" 2> /dev/null)
-			Load_Process_Tool $i	
-
-		done
-
-	}
-
-	# Check if service name is available on system.
-	Populate_Available_Array(){
-
-		[[ $G_DEBUG == 1 ]] && G_DIETPI-NOTIFY 2 'Generating service and process tool list, please wait...'
-
-		# Create service array, skip in case of single service input
-		[[ $INPUT_SERVICE ]] && aSERVICE_NAME=("$INPUT_SERVICE") || Init_Array
-
+		# Check service availability
 		aFP_SERVICE=()
 		local i j
 		for i in ${!aSERVICE_NAME[@]}
@@ -451,7 +343,7 @@ _EOF_
 
 			done
 
-			# Remove non-available services from array, print info in case of single service input
+			# - Remove non-available services from array
 			[[ ${aFP_SERVICE[$i]} ]] || unset aSERVICE_NAME[$i]
 
 		done
@@ -461,22 +353,7 @@ _EOF_
 	# $1 = command
 	# $2 = service
 	# $3 = exit code
-	Print_Status(){
-
-		# Ok
-		# - NB: systemctl exit code 5 = not loaded/active, so don't trigger a failed result.
-		if [[ $3 == [05] ]]; then
-
-			G_DIETPI-NOTIFY 0 "$1 : $2"
-
-		# Failed
-		else
-
-			G_DIETPI-NOTIFY 1 "$1 : $2"
-
-		fi
-
-	}
+	Print_Status(){ G_DIETPI-NOTIFY ${3/[^0]*/1} "$1 : $2"; }
 
 	# $1 = command (start/stop/restart)
 	# $2 = index (optional)
@@ -525,7 +402,7 @@ _EOF_
 			systemctl $command "${aSERVICE_NAME[$i]}" &> /dev/null
 			Print_Status $command "${aSERVICE_NAME[$i]}" $?
 
-		fi
+		done
 
 		# Disable ownCloud and Nextcloud maintenance mode after all services being started or restarted
 		if [[ $command == 'start' || $command == 'restart' && ! $index ]]; then
@@ -539,7 +416,7 @@ _EOF_
 
 	# $1 = command
 	# $2 = index (optional)
-	Apply_Service_States(){
+	Apply_Service_State(){
 
 		local command=$1
 		local index=$2
@@ -583,22 +460,22 @@ _EOF_
 		# dietpi_controlled/systemd_controlled/mask/unmask/enable/disable
 		else
 
-			local systemd_cmd=''
+			local systemctl_cmd
 			if [[ $command == 'dietpi_controlled' ]]; then
 
-				systemd_cmd='disable'
+				systemctl_cmd='disable'
 
 			elif [[ $command == 'systemd_controlled' ]]; then
 
-				systemd_cmd='enable'
+				systemctl_cmd='enable'
 
 			elif [[ $command == 'enable' || $command == 'unmask' ]]; then
 
-				systemd_cmd='unmask'
+				systemctl_cmd='unmask'
 
 			elif [[ $command == 'disable' || $command == 'mask' ]]; then
 
-				systemd_cmd='mask'
+				systemctl_cmd='mask'
 				# - Stop services before masking them
 				Set_Running_State stop $index
 
@@ -613,7 +490,7 @@ _EOF_
 			for i in $services
 			do
 
-				systemctl $systemd_cmd "${aSERVICE_NAME[$i]}" &> /dev/null
+				systemctl $systemctl_cmd "${aSERVICE_NAME[$i]}" &> /dev/null
 				Print_Status $command "${aSERVICE_NAME[$i]}" $?
 
 			done
@@ -622,23 +499,144 @@ _EOF_
 
 	}
 
+	#/////////////////////////////////////////////////////////////////////////////////////
+	# Process Tool
+	#/////////////////////////////////////////////////////////////////////////////////////
+	# $1=index
+	FP_PROCESS_TOOL_CONF='dietpi-process_tool.conf'
+	Save_Process_Tool(){
+
+		local index=$1
+
+		# Backwards cap for init.d, create systemd wrapper
+		if [[ ${aFP_SERVICE[$index]} == '/etc/init.d/'* ]]; then
+
+			aFP_SERVICE[$index]="/etc/systemd/system/${aSERVICE_NAME[$index]}.service"
+			cat << _EOF_ > "${aFP_SERVICE[$index]}"
+[Unit]
+Description=${aSERVICE_NAME[$index]} sysvinit wrapper (DietPi)
+
+[Service]
+Type=forking
+ExecStart=/etc/init.d/${aSERVICE_NAME[$index]} start
+ExecStop=/etc/init.d/${aSERVICE_NAME[$index]} stop
+
+[Install]
+WantedBy=multi-user.target
+_EOF_
+			G_WHIP_MSG "[ INFO ] DietPi has created a systemd service wrapper for /etc/init.d/${aSERVICE_NAME[$index]}. This is required to allow support for applying process tool options.\n
+If you experience any issues with the wrapper, simply remove the file:\n - rm /etc/systemd/system/${aSERVICE_NAME[$index]}.service\n - Then restart the service."
+
+		fi
+
+		# Always create drop-in configs in: /etc/systemd/system/
+		mkdir -p "/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d"
+		cat << _EOF_ > "/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d/$FP_PROCESS_TOOL_CONF"
+# WARNING: Do not manually edit this file, use "dietpi-services" to adjust values!
+[Service]
+Nice=${aCPU_NICE[$index]}
+CPUAffinity=${aCPU_AFFINITY[$index]}
+CPUSchedulingPolicy=${aCPU_SCHEDULE_POLICY[$index]}
+CPUSchedulingPriority=${aCPU_SCHEDULE_PRIORITY[$index]}
+IOSchedulingClass=${aIO_SCHEDULE_POLICY[$index]}
+IOSchedulingPriority=${aIO_PRIORITY[$index]}
+_EOF_
+		G_RUN_CMD systemctl daemon-reload
+		aSERVICE_RESTART_REQUIRED[$index]=1
+
+	}
+
+	# $1=index
+	Load_Process_Tool(){
+
+		local index=$1
+
+		# Defaults
+		aCPU_NICE[$index]=0
+		aCPU_AFFINITY[$index]="0-$(( $G_HW_CPU_CORES - 1 ))"
+		aCPU_SCHEDULE_POLICY[$index]='other'
+		aCPU_SCHEDULE_PRIORITY[$index]=0
+		aIO_SCHEDULE_POLICY[$index]='best-effort'
+		aIO_PRIORITY[$index]='3'
+
+		local fp="/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d/$FP_PROCESS_TOOL_CONF"
+		[[ -f $fp ]] || return
+
+		# Source values from config file
+		# - [Service] line throws an effectless error that we can simply hide.
+		# - All values are single word strings, so bash assigns them correctly.
+		local Nice CPUAffinity CPUSchedulingPolicy CPUSchedulingPriority IOSchedulingClass IOSchedulingPriority
+		. $fp &> /dev/null
+
+		[[ $Nice ]] && aCPU_NICE[$index]=$Nice
+		[[ $CPUAffinity ]] && aCPU_AFFINITY[$index]=$CPUAffinity
+		[[ $CPUSchedulingPolicy ]] && aCPU_SCHEDULE_POLICY[$index]=$CPUSchedulingPolicy
+		[[ $CPUSchedulingPriority ]] && aCPU_SCHEDULE_PRIORITY[$index]=$CPUSchedulingPriority
+		[[ $IOSchedulingClass ]] && aIO_SCHEDULE_POLICY[$index]=$IOSchedulingClass
+		[[ $IOSchedulingPriority ]] && aIO_PRIORITY[$index]=$IOSchedulingPriority
+
+	}
+
+	# $1=index
+	Reset_Process_Tool(){
+
+		local index=$1
+
+		local fp="/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d/$FP_PROCESS_TOOL_CONF"
+		[[ -f $fp ]] || return
+
+		G_RUN_CMD rm "$fp"
+		G_RUN_CMD rmdir --ignore-fail-on-non-empty "/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d"
+		G_RUN_CMD systemctl unmask "${aSERVICE_NAME[$index]}"
+		G_RUN_CMD systemctl daemon-reload
+		Load_Process_Tool $index
+		aSERVICE_RESTART_REQUIRED[$index]=1
+
+	}
+
+	Load_Process_Tool_Arrays(){
+
+		aSERVICE_MODE=() 		# Enabled/disabled/masked/unmasked
+		aSERVICE_RESTART_REQUIRED=() 	# eg, made changes, prompt to restart this service.
+
+		aCPU_NICE=()
+		aCPU_AFFINITY=()
+		aCPU_SCHEDULE_POLICY=()
+		aCPU_SCHEDULE_PRIORITY=()
+		aIO_SCHEDULE_POLICY=()
+		aIO_PRIORITY=()
+
+		aCPU_SCHEDULE_POLICY_TYPE=('other' 'fifo' 'rr' 'batch' 'idle')
+		aCPU_SCHEDULE_POLICY_DESC=('Normal (Default)' 'First In, First Out (Real-time, time-critical)' 'Round Robin (Real-time, time-critical)' 'Batch style execution' 'Background Jobs (Very low priority)')
+
+		aIO_SCHEDULE_POLICY_TYPE=('best-effort' 'realtime' 'idle')
+		aIO_SCHEDULE_POLICY_DESC=('Normal (Default)' 'Time-critical (Highest priority)' 'Background Jobs (Very low priority)')
+
+		for i in ${!aSERVICE_NAME[@]}
+		do
+
+			aSERVICE_MODE[$i]=$(systemctl is-enabled "${aSERVICE_NAME[$i]}" 2> /dev/null)
+			Load_Process_Tool $i	
+
+		done
+
+	}
 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Menu System
 	#/////////////////////////////////////////////////////////////////////////////////////
 	MENU_TARGETID=0
-	MENU_SELECTED_SERVICE_INDEX=0
-	MENU_LAST_SELECTED_MAIN=0 # Main menu
-	MENU_LAST_SELECTED_SUB_0=0 # Sub menus, level 0
+	MENU_SELECTED_SERVICE_INDEX=-1
+	MENU_LAST_SELECTED_MAIN='' # Main menu
+	MENU_LAST_SELECTED_SUB_0='' # Sub menus, level 0
 
 	Menu_Exit(){
 
 		G_WHIP_SIZE_X_MAX=50
 		if G_WHIP_YESNO "Exit $G_PROGRAM_NAME?"; then
 
-			# - Prompt to restart changed services.
-			local service_restart_list_menu=''
-			local service_restart_list_systemd=''
+			# Prompt to restart changed services
+			local service_restart_list_menu service_restart_list_systemd
 			for i in ${!aSERVICE_RESTART_REQUIRED[$i]}
 			do
 
@@ -773,10 +771,10 @@ _EOF_
 
 				'Status')
 
-					systemctl -l --no-pager status "${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"> /tmp/.dietpi-services_systemctl.log
+					systemctl -l --no-pager status "${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}" &> systemctl.log
 
-					log=0 G_WHIP_VIEWFILE /tmp/.dietpi-services_systemctl.log
-					rm /tmp/.dietpi-services_systemctl.log
+					log=0 G_WHIP_VIEWFILE systemctl.log
+					rm systemctl.log
 
 				;;
 
@@ -830,7 +828,7 @@ _EOF_
 
 				'Reset')
 
-					Reset_Service_Defaults $MENU_SELECTED_SERVICE_INDEX
+					Reset_Process_Tool $MENU_SELECTED_SERVICE_INDEX
 
 				;;
 
@@ -848,7 +846,7 @@ _EOF_
 					if G_WHIP_MENU "Please select the desired Service Mode for :\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"; then
 
 						local cmd_out=$G_WHIP_RETURNED_VALUE
-						unmask_required=0
+						local unmask_required=0
 						if [[ $cmd_out == 'DietPi controlled' ]]; then
 
 							cmd_out='disable'
@@ -891,10 +889,12 @@ _EOF_
 
 				'IO Scheduling Priority')
 
+					local desc
 					G_WHIP_MENU_ARRAY=()
+
 					for i in {7..0}
 					do
-						local desc=''
+						desc=''
 						if (( $i == 0 )); then
 
 							desc='(Highest priority)'
@@ -943,12 +943,12 @@ _EOF_
 					# Get existing nice level
 					# - note: Whiptail will not work with negative numbers. The string cannot start with "-" as it throws subscript error.
 					local nice_current="Nice : ${aCPU_NICE[$MENU_SELECTED_SERVICE_INDEX]}"
-
+					local desc
 					G_WHIP_MENU_ARRAY=()
 
 					for i in {-20..19}
 					do
-						local desc=''
+						desc=''
 						if (( $i == -20 )); then
 
 							desc='(Highest priority)'
@@ -1013,7 +1013,6 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 
 						local new_affinity=''
 						local loop_count=0
-
 						for i in ${G_WHIP_RETURNED_VALUE[@]}
 						do
 
@@ -1035,7 +1034,6 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 
 						# Update affinity array with new value, if at least 1 item was selected.
 						[[ $new_affinity ]] && aCPU_AFFINITY[$MENU_SELECTED_SERVICE_INDEX]=$new_affinity
-
 						Save_Process_Tool $MENU_SELECTED_SERVICE_INDEX
 
 					fi
@@ -1074,41 +1072,42 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 					local scale_value_medium=$(( $scale_value_highest / 6 * 3 ))
 					local scale_value_high=$(( $scale_value_highest / 6 * 4 ))
 					local scale_value_higher=$(( $scale_value_highest / 6 * 5 ))
+					local desc
 					for ((i=0; i<=$scale_value_highest; i++))
 					do
 
-						local description=''
+						desc=''
 						if (( $i == $scale_value_lowest )); then
 
-							description='(Lowest priority)'
+							desc='(Lowest priority)'
 
 						elif (( $i == $scale_value_lower )); then
 
-							description='(Lower priority)'
+							desc='(Lower priority)'
 
 						elif (( $i == $scale_value_low )); then
 
-							description='(Low priority)'
+							desc='(Low priority)'
 
 						elif (( $i == $scale_value_medium )); then
 
-							description='(Medium priority)'
+							desc='(Medium priority)'
 
 						elif (( $i == $scale_value_high )); then
 
-							description='(High priority)'
+							desc='(High priority)'
 
 						elif (( $i == $scale_value_higher )); then
 
-							description='(Higher priority)'
+							desc='(Higher priority)'
 
 						elif (( $i == $scale_value_highest )); then
 
-							description='(Highest priority)'
+							desc='(Highest priority)'
 
 						fi
 
-						G_WHIP_MENU_ARRAY+=($i ": $description")
+						G_WHIP_MENU_ARRAY+=($i ": $desc")
 
 					done
 
@@ -1136,17 +1135,17 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Main
 	#/////////////////////////////////////////////////////////////////////////////////////
-	# Load array of available services
-	Populate_Available_Array
+	# Load array of available/chosen services
+	Load_Service_Array
 	#-----------------------------------------------------------------------------------
-	# Direct service control mode
+	# Direct service control
 	if [[ $INPUT_CMD ]]; then
 
 		# - Exit if input service could not be found
 		[[ $INPUT_SERVICE && ! ${aSERVICE_NAME[@]} ]] && { G_DIETPI-NOTIFY 1 "Service ($INPUT_SERVICE) could not be found."; exit 1; }
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" "$INPUT_CMD $INPUT_SERVICE"
-		Apply_Service_States $INPUT_CMD $INPUT_SERVICE
+		Apply_Service_State $INPUT_CMD $INPUT_SERVICE
 
 	#-----------------------------------------------------------------------------------
 	# Men You!

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -931,12 +931,12 @@ _EOF_
 					local target_mode='restart'
 					[[ ${service_state,,} == 'active' ]] && target_mode='stop'
 
-					G_DIETPI-NOTIFY -2 "${aSERVICE_NAME[$i]}"
-					systemctl $target_state "${aSERVICE_NAME[$i]}" &> /dev/null
-					Print_Status $target_state "${aSERVICE_NAME[$i]}" $?
+					G_DIETPI-NOTIFY -2 "${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"
+					systemctl $target_mode "${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}" &> /dev/null
+					Print_Status $target_mode "${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}" $?
 					sleep 0.5
 
-					aSERVICE_RESTART_REQUIRED[$i]=0
+					aSERVICE_RESTART_REQUIRED[$MENU_SELECTED_SERVICE_INDEX]=0
 
 				;;
 
@@ -1138,15 +1138,13 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Main
 	#/////////////////////////////////////////////////////////////////////////////////////
-	# Info
-	G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" "$INPUT_MODE $INPUT_SERVICE"
-	#-----------------------------------------------------------------------------------
 	# Load array of available services
 	Populate_Available_Array
 	#-----------------------------------------------------------------------------------
 	# Direct service control mode
 	if [[ $INPUT_MODE ]]; then
 
+		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" "$INPUT_MODE $INPUT_SERVICE"
 		Apply_Service_States $INPUT_MODE
 
 	#-----------------------------------------------------------------------------------

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -13,14 +13,15 @@
 	# Usage:
 	# - /DietPi/dietpi/dietpi-services $AVAILABLE_OPTIONS
 	AVAILABLE_OPTIONS='
- - [No Input]				(Run Menu)
- - start/stop/restart/status		(all services, known to DietPi)
- - start/stop/restart <servicename>	(single service, systemd)
- - systemd_controlled/dietpi_controlled	(all services, known to DietPi)
- - enable/disable all			(all services, known to DietPi)
- - enable/disable <servicename>		(single service, systemd)
- - mask/unmask all			(all services, known to DietPi)
- - mask/unmask <servicename>		(single service, systemd)
+ - [No Input]						(Run Menu)
+ - start/stop/restart/status				(all services, known to DietPi)
+ - start/stop/restart/status <servicename>		(single service, systemd)
+ - systemd_controlled/dietpi_controlled			(all services, known to DietPi)
+ - systemd_controlled/dietpi_controlled <servicename>	(single service, systemd)
+ - enable/disable					(all services, known to DietPi)
+ - enable/disable <servicename>				(single service, systemd)
+ - mask/unmask						(all services, known to DietPi)
+ - mask/unmask <servicename>				(single service, systemd)
 
  - You can include/exclude custom services by editing the following file: /DietPi/dietpi/.dietpi-services_include_exclude'
 	#////////////////////////////////////
@@ -28,6 +29,8 @@
 	# Grab Inputs
 	INPUT_MODE=$1
 	INPUT_SERVICE=$2
+	# - pre-v6.25 compatibility
+	[[ $INPUT_SERVICE == 'all' ]] && unset INPUT_SERVICE
 
 	# - Optional input variables to prevent service handling
 	[[ $G_DIETPI_SERVICES_DISABLE == 1 ]] && exit 0
@@ -53,6 +56,9 @@
 		aIO_SCHEDULE_POLICY=()
 		aIO_PRIORITY=()
 
+		# Single service input, skip adding any further services to array
+		[[ $INPUT_SERVICE ]] && { aSERVICE_NAME=("$INPUT_SERVICE"); return; }
+
 		aCPU_SCHEDULE_POLICY_TYPE=('other' 'fifo' 'rr' 'batch' 'idle')
 		aCPU_SCHEDULE_POLICY_DESC=('Normal (Default)' 'First In, First Out (Real-time, time-critical)' 'Round Robin (Real-time, time-critical)' 'Batch style execution' 'Background Jobs (Very low priority)')
 
@@ -71,15 +77,15 @@
 			# - File servers
 			'proftpd'
 			'vsftpd'
-			'nmbd'
-				'smbd'
+			'nmbd' 'smbd'
 			'nfs-kernel-server'
 			# Core -----------------------------------------------------------------
 
 			# Backends -------------------------------------------------------------
 			# - Databases
 			'redis-server'
-			'mariadb' # 'mysql' applied on Jessie systems during availablility check: https://github.com/MichaIng/DietPi/issues/1000#issuecomment-30776051
+			'mariadb'
+			#'mysql' # Applied on Jessie systems during availablility check: https://github.com/MichaIng/DietPi/issues/1000#issuecomment-30776051
 
 			# - PHP
 			'php5-fpm'
@@ -107,8 +113,7 @@
 			'roonbridge'
 			'roonserver'
 			'roon-extension-manager'
-			'icecast2'
-				'darkice'
+			'icecast2' 'darkice'
 			'voice-recognizer'
 
 			# - Download/BitTorrent
@@ -134,10 +139,8 @@
 			'emby-server'
 			'spotify-connect-web'
 			'ubooquity'
-			#'moode-worker'
 
 			# - Download/BitTorrent
-			'sickrage' # pre-v6.20 compatibility
 			'medusa'
 			'aria2'
 			'sabnzbd'
@@ -152,8 +155,7 @@
 			# - Cloud/Backups
 			'bdd'
 			'minio'
-			'syncthing'
-				'syncthing-inotify'
+			'syncthing' 'syncthing-inotify'
 			'urbackupsrv'
 			'tonido'
 			'gogs'
@@ -169,8 +171,7 @@
 			'raspimjpeg'
 
 			# - Printing
-			'cups'
-				'cloudprintd'
+			'cups' 'cloudprintd'
 			'octoprint'
 
 			# - Social/Search
@@ -194,7 +195,6 @@
 			# - Network
 			'noip2'
 			'virtualhere'
-			#'pihole-FTL' # https://github.com/MichaIng/DietPi/issues/1696
 			'hostapd'
 
 			# - System stats / Management
@@ -203,7 +203,6 @@
 			'webmin'
 
 			# - Misc
-			#'openmediavault-engined'
 			'docker'
 			'cron'
 			'fahclient'
@@ -230,7 +229,7 @@
 			aSERVICE_NAME+=('vncserver') 			# DietPi vnc server service/script
 			aSERVICE_NAME+=('nxserver') 			# NoMachine
 			aSERVICE_NAME+=('xrdp') 			# XRDP Server
-			aSERVICE_NAME+=('amiberry') 			# DietPi AmiBerry run service
+			aSERVICE_NAME+=('amiberry') 			# DietPi Amiberry run service
 			#aSERVICE_NAME+=('wg-quick@wg0') 		# WireGuard: Currently instantiated services are not supported 
 
 			# - DietPi
@@ -249,6 +248,8 @@
 
 		fi
 
+		Process_Includes_Excludes
+
 	}
 
 
@@ -256,60 +257,72 @@
 	FP_INCLUDE_CUSTOM_SERVICES='/DietPi/dietpi/.dietpi-services_include_exclude'
 	Process_Includes_Excludes(){
 
-		if [[ -f $FP_INCLUDE_CUSTOM_SERVICES ]]; then
+		[[ -f $FP_INCLUDE_CUSTOM_SERVICES ]] || cat << _EOF_ > $FP_INCLUDE_CUSTOM_SERVICES
+# DietPi-Services Include/Exclude configuration
 
-			while read line
-			do
+# Include custom service (Use '+ servicename' without the comments to enable DietPi control of that service)
+#	Once completed, for DietPi to control the service, please run the following command, without quotes (')
+#	'dietpi-services dietpi_controlled'
+#+ myservice1
+#+ myservice2
 
-				[[ $line == '#'* ]] && continue
+# Exclude DietPi from controlling known services (Use '- servicename' without the comments to disable DietPi control for that service)
+#	The service will be in disabled form, and, you can start and stop it manually
+#- cron
+#- transmission-daemon
 
-				local scrape=${line: +2}
-				local i=''
+_EOF_
 
-				# - Include
-				if [[ $line == '+ '* ]]; then
+		while read line
+		do
 
-					local service_known_already_to_dietpi=0
-					for i in "${aSERVICE_NAME[@]}"
-					do
+			[[ ! $line || $line == '#'* ]] && continue
 
-						if [[ $scrape == "$i" ]]; then
+			local scrape=${line: +2}
+			local i=''
 
-							service_known_already_to_dietpi=1
-							break
+			# - Include
+			if [[ $line == '+ '* ]]; then
 
-						fi
+				local service_known_already_to_dietpi=0
+				for i in "${aSERVICE_NAME[@]}"
+				do
 
-					done
+					if [[ $scrape == "$i" ]]; then
 
-					if (( ! $service_known_already_to_dietpi )); then
-
-						[[ $G_DEBUG == 1 ]] && G_DIETPI-NOTIFY 2 "Including custom service: $scrape"
-						aSERVICE_NAME+=("$scrape")
+						service_known_already_to_dietpi=1
+						break
 
 					fi
 
-				# - Exclude
-				elif [[ $line == '- '* ]]; then
+				done
 
-					for i in ${!aSERVICE_NAME[@]}
-					do
+				if (( ! $service_known_already_to_dietpi )); then
 
-						if [[ $scrape == "${aSERVICE_NAME[$i]}" ]]; then
-
-							[[ $G_DEBUG == 1 ]] && G_DIETPI-NOTIFY 2 "Excluding service: $scrape"
-							unset aSERVICE_NAME[$i]
-							break
-
-						fi
-
-					done
+					[[ $G_DEBUG == 1 ]] && G_DIETPI-NOTIFY 2 "Including custom service: $scrape"
+					aSERVICE_NAME+=("$scrape")
 
 				fi
 
-			done < $FP_INCLUDE_CUSTOM_SERVICES
+			# - Exclude
+			elif [[ $line == '- '* ]]; then
 
-		fi
+				for i in ${!aSERVICE_NAME[@]}
+				do
+
+					if [[ $scrape == "${aSERVICE_NAME[$i]}" ]]; then
+
+						[[ $G_DEBUG == 1 ]] && G_DIETPI-NOTIFY 2 "Excluding service: $scrape"
+						unset aSERVICE_NAME[$i]
+						break
+
+					fi
+
+				done
+
+			fi
+
+		done < $FP_INCLUDE_CUSTOM_SERVICES
 
 	}
 
@@ -411,8 +424,6 @@ _EOF_
 
 		Init_Arrays
 
-		Process_Includes_Excludes
-
 		local i=0
 		for i in ${!aSERVICE_NAME[@]}
 		do
@@ -437,8 +448,13 @@ _EOF_
 
 			done
 
-			# Remove non-available services from array
-			[[ ${aCPU_NICE[$i]} ]] || unset aSERVICE_NAME[$i]
+			# Remove non-available services from array, print info in case of single service input mode
+			if [[ ! ${aCPU_NICE[$i]} ]]; then
+
+				unset aSERVICE_NAME[$i]
+				[[ $INPUT_SERVICE ]] && G_DIETPI-NOTIFY 1 "Service ($INPUT_SERVICE) could not be found."
+
+			fi
 
 		done
 
@@ -450,9 +466,8 @@ _EOF_
 		# $2 = name
 		# $3 = exit code
 
-		# - NB: systemd exit code 5 = not loaded/active, so don't trigger a failed result.
-
 		# Ok
+		# - NB: systemd exit code 5 = not loaded/active, so don't trigger a failed result.
 		if [[ $3 == [05] ]]; then
 
 			G_DIETPI-NOTIFY 0 "$1 : $2"
@@ -472,8 +487,8 @@ _EOF_
 		local target_state=$1
 		local i=''
 
-		# Enable ownCloud and Nextcloud maintenance mode
-		if [[ $target_state == 'stop' || $target_state == 'restart' ]]; then
+		# Enable ownCloud and Nextcloud maintenance mode before all services being stopped or restarted
+		if [[ $target_state == 'stop' || $target_state == 'restart' && ! $INPUT_SERVICE ]]; then
 
 			[[ -f '/var/www/owncloud/config/config.php' ]] && grep -q "'maintenance' => false," /var/www/owncloud/config/config.php && G_USER_INPUTS=0 G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD occ maintenance:mode --on
 			[[ -f '/var/www/nextcloud/config/config.php' ]] && grep -q "'maintenance' => false," /var/www/nextcloud/config/config.php && G_USER_INPUTS=0 G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD ncc maintenance:mode --on
@@ -494,29 +509,30 @@ _EOF_
 			for i in $reverse
 			do
 
-				G_DIETPI-NOTIFY -2 ${aSERVICE_NAME[$i]}
-				systemctl $target_state ${aSERVICE_NAME[$i]} &> /dev/null
-				Print_Status $target_state ${aSERVICE_NAME[$i]} $?
+				G_DIETPI-NOTIFY -2 "${aSERVICE_NAME[$i]}"
+				systemctl $target_state "${aSERVICE_NAME[$i]}" &> /dev/null
+				Print_Status $target_state "${aSERVICE_NAME[$i]}" $?
 
 				aSERVICE_RESTART_REQUIRED[$i]=0
 
 			done
 
-		# EG: START/RESTART: Standard service order
+		# START/RESTART: Standard service order
 		else
 
 			for i in ${!aSERVICE_NAME[@]}
 			do
 
-				G_DIETPI-NOTIFY -2 ${aSERVICE_NAME[$i]}
-				systemctl $target_state ${aSERVICE_NAME[$i]} &> /dev/null
-				Print_Status $target_state ${aSERVICE_NAME[$i]} $?
+				G_DIETPI-NOTIFY -2 "${aSERVICE_NAME[$i]}"
+				systemctl $target_state "${aSERVICE_NAME[$i]}" &> /dev/null
+				Print_Status $target_state "${aSERVICE_NAME[$i]}" $?
 
 				aSERVICE_RESTART_REQUIRED[$i]=0
 
 			done
 
-			# - Disable ownCloud and Nextcloud maintenance mode
+			# - Disable ownCloud and Nextcloud maintenance mode before all services being started or restarted
+			[[ $INPUT_SERVICE ]] && return
 			[[ -f '/var/www/owncloud/config/config.php' ]] && grep -q "'maintenance' => true," /var/www/owncloud/config/config.php && G_USER_INPUTS=0 G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD occ maintenance:mode --off
 			[[ -f '/var/www/nextcloud/config/config.php' ]] && grep -q "'maintenance' => true," /var/www/nextcloud/config/config.php && G_USER_INPUTS=0 G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD ncc maintenance:mode --off
 
@@ -528,7 +544,6 @@ _EOF_
 	Apply_Service_States(){
 
 		local mode=$1
-		local service=$2
 		local systemd_cmd='disable'
 
 		# dietpi_controlled/systemd_controlled
@@ -539,44 +554,29 @@ _EOF_
 			for i in "${aSERVICE_NAME[@]}"
 			do
 
-				G_DIETPI-NOTIFY -2 "$i"
 				systemctl $systemd_cmd "$i" &> /dev/null
 				Print_Status $mode "$i" $?
 
 			done
 
-			systemctl daemon-reload &> /dev/null
-
 		# mask/unmask/enable/disable
 		elif [[ $mode == 'enable' || $mode == 'disable' || $mode == 'unmask' || $mode == 'mask' ]]; then
 
-			# - Switch to mask, as DietPi_Controlled uses disable to take over from systemd
+			# - Switch to mask, as DietPi_controlled uses disable to take over from systemd
 			[[ $mode == 'enable' || $mode == 'unmask' ]] && systemd_cmd='unmask' || systemd_cmd='mask'
 
-			# - Process ALL known services
-			if [[ $service == 'all' ]]; then
+			# - Stop services before disable or mask them
+			[[ $mode == 'disable' || $mode == 'mask' ]] && Set_Running_State stop
 
-				[[ $mode == 'disable' || $mode == 'mask' ]] && Set_Running_State stop
-
-				for i in "${aSERVICE_NAME[@]}"
-				do
-
-					G_DIETPI-NOTIFY 0 "$mode $service: $i"
-					systemctl $systemd_cmd "$i"
-
-				done
-
-
-			# - Process user defined single entry via cmd input
-			else
-
-				[[ $mode == 'disable' || $mode == 'mask' ]] && systemctl stop $service
+			for i in "${aSERVICE_NAME[@]}"
+			do
 
 				local notify_index=0
 				systemctl $systemd_cmd "$service" || notify_index=1
-				G_DIETPI-NOTIFY $notify_index "$mode $service"
+				G_DIETPI-NOTIFY $notify_index "$mode $i"
 
-			fi
+			done
+
 
 		# status
 		elif [[ $mode == 'status' ]]; then
@@ -584,7 +584,6 @@ _EOF_
 			for i in "${aSERVICE_NAME[@]}"
 			do
 
-				# Apply
 				local status="$i\t$(systemctl status "$i" | grep -m1 'Active' | cut -c12-)"
 				if [[ $status =~ 'failed' ]]; then
 
@@ -606,25 +605,7 @@ _EOF_
 		# start/stop/restart
 		elif [[ $mode == 'start' || $mode == 'stop' || $mode == 'restart' ]]; then
 
-			# Single use case, basically a alias for systemd
-			if [[ $service ]]; then
-
-				if systemctl $mode "$service" &> /dev/null; then
-
-					G_DIETPI-NOTIFY 0 "$mode $service"
-
-				else
-
-					G_DIETPI-NOTIFY 1 "$mode $service"
-
-				fi
-
-			# All services controlled
-			else
-
-				Set_Running_State $mode
-
-			fi
+			Set_Running_State $mode
 
 		else
 
@@ -708,10 +689,10 @@ _EOF_
 
 			if [[ $G_WHIP_RETURNED_VALUE == 'Restart' || $G_WHIP_RETURNED_VALUE == 'Stop' ]]; then
 
-				Apply_Service_States ${G_WHIP_RETURNED_VALUE,,}
+				Set_Running_State ${G_WHIP_RETURNED_VALUE,,}
 				sleep 0.5
 
-			else
+			elif [[ $G_WHIP_RETURNED_VALUE ]]; then
 
 				# Find selected program index
 				MENU_SELECTED_SERVICE_INDEX=-1
@@ -901,7 +882,6 @@ _EOF_
 					if G_WHIP_MENU "Please select the desired IO Scheduling Class for :\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"; then
 
 						aIO_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]=$G_WHIP_RETURNED_VALUE
-
 						Save_Process_Tool $MENU_SELECTED_SERVICE_INDEX
 
 					fi
@@ -951,8 +931,12 @@ _EOF_
 					local target_mode='restart'
 					[[ ${service_state,,} == 'active' ]] && target_mode='stop'
 
-					Apply_Service_States $target_mode "${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"
+					G_DIETPI-NOTIFY -2 "${aSERVICE_NAME[$i]}"
+					systemctl $target_state "${aSERVICE_NAME[$i]}" &> /dev/null
+					Print_Status $target_state "${aSERVICE_NAME[$i]}" $?
 					sleep 0.5
+
+					aSERVICE_RESTART_REQUIRED[$i]=0
 
 				;;
 
@@ -1074,7 +1058,6 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 					if G_WHIP_MENU "Please select the desired CPU Scheduling Policy for :\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"; then
 
 						aCPU_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]=$G_WHIP_RETURNED_VALUE
-
 						Save_Process_Tool $MENU_SELECTED_SERVICE_INDEX
 
 					fi
@@ -1093,7 +1076,7 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 					local scale_value_medium=$(( $scale_value_highest / 6 * 3 ))
 					local scale_value_high=$(( $scale_value_highest / 6 * 4 ))
 					local scale_value_higher=$(( $scale_value_highest / 6 * 5 ))
-					for ((i=0; i<$(( $scale_value_highest + 1 )); i++))
+					for ((i=0; i<=$scale_value_highest; i++))
 					do
 
 						local description=''
@@ -1136,7 +1119,6 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 - Lower values are low priority\n - Higher values are high priority"; then
 
 						aCPU_SCHEDULE_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]=$G_WHIP_RETURNED_VALUE
-
 						Save_Process_Tool $MENU_SELECTED_SERVICE_INDEX
 
 					fi
@@ -1157,24 +1139,7 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 	# Main
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Info
-	G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" "$INPUT_MODE"
-
-	[[ -f $FP_INCLUDE_CUSTOM_SERVICES ]] || cat << _EOF_ > $FP_INCLUDE_CUSTOM_SERVICES
-# DietPi-Services Include/Exclude configuration
-
-# Include custom service (Use '+ servicename' without the comments to enable DietPi control of that service)
-#	Once completed, for DietPi to control the service, please run the following command, without quotes (')
-#	'dietpi-services dietpi_controlled'
-#+ myservice1
-#+ myservice2
-
-# Exclude DietPi from controlling known services (Use '- servicename' without the comments to disable DietPi control for that service)
-#	The service will be in disabled form, and, you can start and stop it manually
-#- cron
-#- transmission-daemon
-
-_EOF_
-
+	G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" "$INPUT_MODE $INPUT_SERVICE"
 	#-----------------------------------------------------------------------------------
 	# Load array of available services
 	Populate_Available_Array
@@ -1182,7 +1147,7 @@ _EOF_
 	# Direct service control mode
 	if [[ $INPUT_MODE ]]; then
 
-		Apply_Service_States $INPUT_MODE $INPUT_SERVICE
+		Apply_Service_States $INPUT_MODE
 
 	#-----------------------------------------------------------------------------------
 	# Men You!

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -606,9 +606,11 @@ _EOF_
 		aIO_SCHEDULE_POLICY=()
 		aIO_PRIORITY=()
 
+		# https://manpages.debian.org/stretch/manpages/sched.7.en.html
 		aCPU_SCHEDULE_POLICY_TYPE=('other' 'fifo' 'rr' 'batch' 'idle')
 		aCPU_SCHEDULE_POLICY_DESC=('Normal (Default)' 'First In, First Out (Real-time, time-critical)' 'Round Robin (Real-time, time-critical)' 'Batch style execution' 'Background Jobs (Very low priority)')
 
+		# https://manpages.debian.org/stretch/util-linux/ionice.1.en.html
 		aIO_SCHEDULE_POLICY_TYPE=('best-effort' 'realtime' 'idle')
 		aIO_SCHEDULE_POLICY_DESC=('Normal (Default)' 'Time-critical (Highest priority)' 'Background Jobs (Very low priority)')
 
@@ -636,8 +638,8 @@ _EOF_
 		if G_WHIP_YESNO "Exit $G_PROGRAM_NAME?"; then
 
 			# Prompt to restart changed services
-			local service_restart_list_menu service_restart_list_systemd
-			for i in ${!aSERVICE_RESTART_REQUIRED[$i]}
+			local service_restart_list_menu service_restart_list_systemd i
+			for i in ${!aSERVICE_RESTART_REQUIRED[@]}
 			do
 
 				service_restart_list_menu+="\n - ${aSERVICE_NAME[$i]}: Nice=${aCPU_NICE[$i]} | Affinity=${aCPU_AFFINITY[$i]} | CPU Scheduling Policy=${aCPU_SCHEDULE_POLICY[$i]} | CPU Scheduling Priority=${aCPU_SCHEDULE_PRIORITY[$i]} | IO Scheduling Policy=${aIO_SCHEDULE_POLICY[$i]} | IO Scheduling Priority=${aIO_PRIORITY[$i]}"
@@ -740,7 +742,7 @@ _EOF_
 
 			'' '●─ Service Control '
 			'State' ": [$service_state]"
-			'Status' ': Display Systemd status log'
+			'Status' ': Display systemd status log'
 			'Edit' ": [${aFP_SERVICE[$MENU_SELECTED_SERVICE_INDEX]}]"
 			'Mode' ": [$service_mode_print]"
 			'' '●─ Process Tool '
@@ -878,7 +880,7 @@ _EOF_
 					done
 
 					G_WHIP_DEFAULT_ITEM=${aIO_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]}
-					if G_WHIP_MENU "Please select the desired IO Scheduling Class for :\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"; then
+					if G_WHIP_MENU "Please select the desired IO Scheduling Class for:\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"; then
 
 						aIO_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]=$G_WHIP_RETURNED_VALUE
 						Save_Process_Tool $MENU_SELECTED_SERVICE_INDEX
@@ -941,7 +943,7 @@ _EOF_
 				'CPU Nice')
 
 					# Get existing nice level
-					# - note: Whiptail will not work with negative numbers. The string cannot start with "-" as it throws subscript error.
+					# - Note: Whiptail will not work with negative numbers. The string cannot start with "-" as it throws subscript error.
 					local nice_current="Nice : ${aCPU_NICE[$MENU_SELECTED_SERVICE_INDEX]}"
 					local desc
 					G_WHIP_MENU_ARRAY=()
@@ -1009,7 +1011,7 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 					done
 
 					if G_WHIP_CHECKLIST "Please select the desired CPU Affinity for:\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}\n
-- Use the spacebar to enable/disable access to specific cores, for this program.\n- The default value is to enable all items."; then
+ - Use the spacebar to enable/disable access to specific cores, for this program.\n - The default value is to enable all items."; then
 
 						local new_affinity=''
 						local loop_count=0
@@ -1051,7 +1053,7 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 					done
 
 					G_WHIP_DEFAULT_ITEM=${aCPU_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]}
-					if G_WHIP_MENU "Please select the desired CPU Scheduling Policy for :\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"; then
+					if G_WHIP_MENU "Please select the desired CPU Scheduling Policy for:\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"; then
 
 						aCPU_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]=$G_WHIP_RETURNED_VALUE
 						Save_Process_Tool $MENU_SELECTED_SERVICE_INDEX
@@ -1112,8 +1114,8 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 					done
 
 					G_WHIP_DEFAULT_ITEM=${aCPU_SCHEDULE_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]}
-					if G_WHIP_MENU "Please select the desired CPU Scheduling Priority level for :\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}\n
-- Lower values are low priority\n - Higher values are high priority"; then
+					if G_WHIP_MENU "Please select the desired CPU Scheduling Priority level for:\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}\n
+ - Lower values are low priority\n - Higher values are high priority"; then
 
 						aCPU_SCHEDULE_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]=$G_WHIP_RETURNED_VALUE
 						Save_Process_Tool $MENU_SELECTED_SERVICE_INDEX

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -439,7 +439,7 @@ _EOF_
 				status_full=$(systemctl -l --no-pager status "${aSERVICE_NAME[$i]}")
 				# - Align status output
 				space='\t'
-				(( ${#i} < 13 )) && space+='\t'
+				(( ${#aSERVICE_NAME[$i]} < 13 )) && space+='\t'; (( ${#i} < 5 )) && space+='\t'
 				status="${aSERVICE_NAME[$i]}${space}$(mawk '/Active/ {print substr($0,12);exit}' <<< "$status_full")"
 				if [[ $status =~ 'failed' ]]; then
 

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -557,7 +557,7 @@ _EOF_
 		aCPU_SCHEDULE_POLICY[$index]='other'
 		aCPU_SCHEDULE_PRIORITY[$index]=0
 		aIO_SCHEDULE_POLICY[$index]='best-effort'
-		aIO_PRIORITY[$index]='3'
+		aIO_PRIORITY[$index]='4' # best-effort default == (cpu_nice + 20) / 5: https://manpages.debian.org/stretch/util-linux/ionice.1.en.html
 
 		local fp="/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d/$FP_PROCESS_TOOL_CONF"
 		[[ -f $fp ]] || return

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -481,7 +481,7 @@ _EOF_
 
 			else
 
-				G_DIETPI-NOTIFY 2 "Invalid input command ($command). Aborting...\n$USAGE"
+				G_DIETPI-NOTIFY 1 "Invalid input command ($command). Aborting...\n$USAGE"
 				exit 1
 
 			fi

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -439,7 +439,7 @@ _EOF_
 				status_full=$(systemctl -l --no-pager status "${aSERVICE_NAME[$i]}")
 				# - Align status output
 				space='\t'
-				(( ${#aSERVICE_NAME[$i]} < 13 )) && space+='\t'; (( ${#i} < 5 )) && space+='\t'
+				(( ${#aSERVICE_NAME[$i]} < 13 )) && space+='\t'; (( ${#aSERVICE_NAME[$i]} < 5 )) && space+='\t'
 				status="${aSERVICE_NAME[$i]}${space}$(mawk '/Active/ {print substr($0,12);exit}' <<< "$status_full")"
 				if [[ $status =~ 'failed' ]]; then
 

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -40,12 +40,11 @@
 	G_INIT
 	# Import DietPi-Globals --------------------------------------------------------------
 
-	FP_TEMP='dietpi-services_installed'
-
-	# INIT_ALL_ARRAYS=1 | init all arrays (loading)
-	# INIT_ALL_ARRAYS=0 | init/reset non-static arrays
-	INIT_ALL_ARRAYS=1
 	Init_Arrays(){
+
+		aFP_SERVICE=()
+		aSERVICE_MODE=() 		# Enabled/disabled/masked/unmasked
+		aSERVICE_RESTART_REQUIRED=() 	# eg, made changes, prompt to restart this service.
 
 		aCPU_NICE=()
 		aCPU_AFFINITY=()
@@ -54,209 +53,199 @@
 		aIO_SCHEDULE_POLICY=()
 		aIO_PRIORITY=()
 
-		aFP_SERVICE=()
-		aSERVICE_MODE=() 		# Enabled/disabled/masked/unmasked
-		aSERVICE_AVAILABLE=()
-		aSERVICE_RESTART_REQUIRED=() 	# eg, made changes, prompt to restart this service.
-		if (( $INIT_ALL_ARRAYS )); then
+		aCPU_SCHEDULE_POLICY_TYPE=('other' 'fifo' 'rr' 'batch' 'idle')
+		aCPU_SCHEDULE_POLICY_DESC=('Normal (Default)' 'First In, First Out (Real-time, time-critical)' 'Round Robin (Real-time, time-critical)' 'Batch style execution' 'Background Jobs (Very low priority)')
 
-			aCPU_SCHEDULE_POLICY_TYPE=( 'other' 'fifo' 'rr' 'batch' 'idle' )
-			aCPU_SCHEDULE_POLICY_DESC=( 'Normal (Default)' 'First In, First Out (Real-time, time-critical)' 'Round Robin (Real-time, time-critical)' 'Batch style execution' 'Background Jobs (Very low priority)' )
+		aIO_SCHEDULE_POLICY_TYPE=('best-effort' 'realtime' 'idle')
+		aIO_SCHEDULE_POLICY_DESC=('Normal (Default)' 'Time-critical (Highest priority)' 'Background Jobs (Very low priority)')
 
-			aIO_SCHEDULE_POLICY_TYPE=('best-effort' 'realtime' 'idle')
-			aIO_SCHEDULE_POLICY_DESC=('Normal (Default)' 'Time-critical (Highest priority)' 'Background Jobs (Very low priority)')
+		aSERVICE_NAME=(
 
-			aSERVICE_NAME=(
+			# Core -----------------------------------------------------------------
+			# - Network
+			'fail2ban'
+			'avahi-daemon'
+			'isc-dhcp-server'
+			'haproxy'
 
-				# Core -----------------------------------------------------------------
-				# - Network
-				'fail2ban'
-				'avahi-daemon'
-				'isc-dhcp-server'
-				'haproxy'
+			# - File servers
+			'proftpd'
+			'vsftpd'
+			'nmbd'
+				'smbd'
+			'nfs-kernel-server'
+			# Core -----------------------------------------------------------------
 
-				# - File servers
-				'proftpd'
-				'vsftpd'
-				'nmbd'
-					'smbd'
-				'nfs-kernel-server'
-				# Core -----------------------------------------------------------------
+			# Backends -------------------------------------------------------------
+			# - Databases
+			'redis-server'
+			'mariadb' # 'mysql' applied on Jessie systems during availablility check: https://github.com/MichaIng/DietPi/issues/1000#issuecomment-30776051
 
-				# Backends -------------------------------------------------------------
-				# - Databases
-				'redis-server'
-				'mariadb' # 'mysql' applied on Jessie systems during availablility check: https://github.com/MichaIng/DietPi/issues/1000#issuecomment-30776051
+			# - PHP
+			'php5-fpm'
+			'php7.0-fpm'
+			'php7.1-fpm'
+			'php7.2-fpm'
+			'php7.3-fpm'
 
-				# - PHP
-				'php5-fpm'
-				'php7.0-fpm'
-				'php7.1-fpm'
-				'php7.2-fpm'
-				'php7.3-fpm'
+			# - Webservers
+			'apache2'
+			'nginx'
+			'lighttpd'
+			'tomcat8'
 
-				# - Webservers
-				'apache2'
-				'nginx'
-				'lighttpd'
-				'tomcat8'
+			# - Media
+			'alsa-init'
+			'coturn'
+			'mpd'
+			'minidlna'
+			'shairport-sync'
+			'squeezelite'
+			'gmrender'
+			'mumble-server'
+			'networkaudiod'
+			'roonbridge'
+			'roonserver'
+			'roon-extension-manager'
+			'icecast2'
+				'darkice'
+			'voice-recognizer'
 
-				# - Media
-				'alsa-init'
-				'coturn'
-				'mpd'
-				'minidlna'
-				'shairport-sync'
-				'squeezelite'
-				'gmrender'
-				'mumble-server'
-				'networkaudiod'
-				'roonbridge'
-				'roonserver'
-				'roon-extension-manager'
-				'icecast2'
-					'darkice'
-				'voice-recognizer'
+			# - Download/BitTorrent
+			'transmission-daemon'
+			'qbittorrent'
+			'rtorrent'
+			'nzbget'
+			'deluged'
+			# Backends -------------------------------------------------------------
 
-				# - Download/BitTorrent
-				'transmission-daemon'
-				'qbittorrent'
-				'rtorrent'
-				'nzbget'
-				'deluged'
-				# Backends -------------------------------------------------------------
+			# Frontends / Misc -----------------------------------------------------
+			# - Media
+			'ympd'
+			'mympd'
+			'logitechmediaserver'
+			'subsonic'
+			'airsonic'
+			'mopidy'
+			'koel'
+			'raspotify'
+			'plexpy'
+			'plexmediaserver'
+			'emby-server'
+			'spotify-connect-web'
+			'ubooquity'
+			#'moode-worker'
 
-				# Frontends / Misc -----------------------------------------------------
-				# - Media
-				'ympd'
-				'mympd'
-				'logitechmediaserver'
-				'subsonic'
-				'airsonic'
-				'mopidy'
-				'koel'
-				'raspotify'
-				'plexpy'
-				'plexmediaserver'
-				'emby-server'
-				'spotify-connect-web'
-				'ubooquity'
-				#'moode-worker'
+			# - Download/BitTorrent
+			'sickrage' # pre-v6.20 compatibility
+			'medusa'
+			'aria2'
+			'sabnzbd'
+			'couchpotato'
+			'jackett'
+			'sonarr'
+			'radarr'
+			'lidarr'
+			'htpc-manager'
+			'deluge-web'
 
-				# - Download/BitTorrent
-				'sickrage' # pre-v6.20 compatibility
-				'medusa'
-				'aria2'
-				'sabnzbd'
-				'couchpotato'
-				'jackett'
-				'sonarr'
-				'radarr'
-				'lidarr'
-				'htpc-manager'
-				'deluge-web'
+			# - Cloud/Backups
+			'bdd'
+			'minio'
+			'syncthing'
+				'syncthing-inotify'
+			'urbackupsrv'
+			'tonido'
+			'gogs'
+			'gitea'
 
-				# - Cloud/Backups
-				'bdd'
-				'minio'
-				'syncthing'
-					'syncthing-inotify'
-				'urbackupsrv'
-				'tonido'
-				'gogs'
-				'gitea'
+			# - Emulation/Gaming
+			'supervisor'
+			'nukkit'
+			'cuberite'
 
-				# - Emulation/Gaming
-				'supervisor'
-				'nukkit'
-				'cuberite'
+			# - Camera/Surveillance
+			'motioneye'
+			'raspimjpeg'
 
-				# - Camera/Surveillance
-				'motioneye'
-				'raspimjpeg'
+			# - Printing
+			'cups'
+				'cloudprintd'
+			'octoprint'
 
-				# - Printing
-				'cups'
-					'cloudprintd'
-				'octoprint'
+			# - Social/Search
+			'yacy'
+			'openbazaar'
 
-				# - Social/Search
-				'yacy'
-				'openbazaar'
+			# - Hardware Projects
+			'pi-spc'
+			'pijuice'
+			'mosquitto'
+			'node-red'
+			'blynkserver'
+			'webiopi'
+			'emonhub'
+			'influxdb'
+			'grafana-server'
 
-				# - Hardware Projects
-				'pi-spc'
-				'pijuice'
-				'mosquitto'
-				'node-red'
-				'blynkserver'
-				'webiopi'
-				'emonhub'
-				'influxdb'
-				'grafana-server'
+			# - Home Automation
+			'home-assistant'
 
-				# - Home Automation
-				'home-assistant'
+			# - Network
+			'noip2'
+			'virtualhere'
+			#'pihole-FTL' # https://github.com/MichaIng/DietPi/issues/1696
+			'hostapd'
 
-				# - Network
-				'noip2'
-				'virtualhere'
-				#'pihole-FTL' # https://github.com/MichaIng/DietPi/issues/1696
-				'hostapd'
+			# - System stats / Management
+			'netdata'
+			'rpimonitor'
+			'webmin'
 
-				# - System stats / Management
-				'netdata'
-				'rpimonitor'
-				'webmin'
+			# - Misc
+			#'openmediavault-engined'
+			'docker'
+			'cron'
+			'fahclient'
+			# Frontends / Misc -----------------------------------------------------
 
-				# - Misc
-				#'openmediavault-engined'
-				'docker'
-				'cron'
-				'fahclient'
-				# Frontends / Misc -----------------------------------------------------
+		)
 
-			)
+		# Additional services: https://github.com/MichaIng/DietPi/issues/1869#issuecomment-401017251
+		[[ -f '/etc/rsyncd.conf' ]] && aSERVICE_NAME+=('rsync')
 
-			# Additional services: https://github.com/MichaIng/DietPi/issues/1869#issuecomment-401017251
-			[[ -f '/etc/rsyncd.conf' ]] && aSERVICE_NAME+=('rsync')
+		# Hidden/not-controlled services
+		# - Status mode, enable service status
+		if [[ ! $INPUT_MODE || $INPUT_MODE == 'status' ]]; then
 
-			# Hidden/not-controlled services
-			# - Status mode, enable service status
-			if [[ ! $INPUT_MODE || $INPUT_MODE == 'status' ]]; then
+			# - SSH
+			aSERVICE_NAME+=('dropbear')
+			aSERVICE_NAME+=('ssh') 				# OpenSSH Server
 
-				# - SSH
-				aSERVICE_NAME+=('dropbear')
-				aSERVICE_NAME+=('ssh') 				# OpenSSH Server
+			# - Misc
+			#aSERVICE_NAME+=('systemd-timesyncd') 		# Timesync. DietPi stops this by default after success, may confuse user/prompt questions.
+			aSERVICE_NAME+=('dnsmasq') 			# https://github.com/MichaIng/DietPi/issues/1501
+			aSERVICE_NAME+=('pihole-FTL')			# https://github.com/MichaIng/DietPi/issues/1696
+			aSERVICE_NAME+=('openvpn') 			# https://github.com/MichaIng/DietPi/issues/1501
+			aSERVICE_NAME+=('vncserver') 			# DietPi vnc server service/script
+			aSERVICE_NAME+=('nxserver') 			# NoMachine
+			aSERVICE_NAME+=('xrdp') 			# XRDP Server
+			aSERVICE_NAME+=('amiberry') 			# DietPi AmiBerry run service
+			#aSERVICE_NAME+=('wg-quick@wg0') 		# WireGuard: Currently instantiated services are not supported 
 
-				# - Misc
-				#aSERVICE_NAME+=('systemd-timesyncd') 		# Timesync. DietPi stops this by default after success, may confuse user/prompt questions.
-				aSERVICE_NAME+=('dnsmasq') 			# https://github.com/MichaIng/DietPi/issues/1501
-				aSERVICE_NAME+=('pihole-FTL')			# https://github.com/MichaIng/DietPi/issues/1696
-				aSERVICE_NAME+=('openvpn') 			# https://github.com/MichaIng/DietPi/issues/1501
-				aSERVICE_NAME+=('vncserver') 			# DietPi vnc server service/script
-				aSERVICE_NAME+=('nxserver') 			# NoMachine
-				aSERVICE_NAME+=('xrdp') 			# XRDP Server
-				aSERVICE_NAME+=('amiberry') 			# DietPi AmiBerry run service
+			# - DietPi
+			aSERVICE_NAME+=('dietpi-nordvpn') 		# NordVPN install + client
+			if [[ $INPUT_MODE == 'status' ]]; then
 
-				# - DietPi
-				aSERVICE_NAME+=('dietpi-nordvpn') 		# NordVPN install + client
-				if [[ $INPUT_MODE == 'status' ]]; then
-
-					aSERVICE_NAME+=('dietpi-ramdisk')
-					aSERVICE_NAME+=('dietpi-ramlog')
-					aSERVICE_NAME+=('dietpi-preboot')
-					aSERVICE_NAME+=('dietpi-boot')
-					aSERVICE_NAME+=('dietpi-postboot')
-					aSERVICE_NAME+=('dietpi-wifi-monitor') 	# https://github.com/MichaIng/DietPi/issues/1288#issuecomment-350653480
-					aSERVICE_NAME+=('dietpi-arr_to_RAM')	# Sonarr/Radarr/Lidarr database to RAM link service
-
-				fi
-				#aSERVICE_NAME+=('wg-quick@wg0') 		# WireGuard
+				aSERVICE_NAME+=('dietpi-ramdisk')
+				aSERVICE_NAME+=('dietpi-ramlog')
+				aSERVICE_NAME+=('dietpi-preboot')
+				aSERVICE_NAME+=('dietpi-boot')
+				aSERVICE_NAME+=('dietpi-postboot')
+				aSERVICE_NAME+=('dietpi-wifi-monitor') 	# https://github.com/MichaIng/DietPi/issues/1288#issuecomment-350653480
+				aSERVICE_NAME+=('dietpi-arr_to_RAM')	# Sonarr/Radarr/Lidarr database to RAM link service
 
 			fi
-
-			INIT_ALL_ARRAYS=0
 
 		fi
 
@@ -295,8 +284,8 @@
 
 					if (( ! $service_known_already_to_dietpi )); then
 
+						[[ $G_DEBUG == 1 ]] && G_DIETPI-NOTIFY 2 "Including custom service: $scrape"
 						aSERVICE_NAME+=("$scrape")
-						G_DIETPI-NOTIFY 2 "Including custom service: $scrape"
 
 					fi
 
@@ -308,8 +297,8 @@
 
 						if [[ $scrape == "${aSERVICE_NAME[$i]}" ]]; then
 
-							G_DIETPI-NOTIFY 2 "Excluding service: $scrape"
-							aSERVICE_NAME[$i]=''
+							[[ $G_DEBUG == 1 ]] && G_DIETPI-NOTIFY 2 "Excluding service: $scrape"
+							unset aSERVICE_NAME[$i]
 							break
 
 						fi
@@ -331,11 +320,9 @@
 		local index=$1
 
 		# Backwards cap for init.d, create systemd wrapper
-		echo ${aFP_SERVICE[$index]}
-		sleep 1
 		if [[ ${aFP_SERVICE[$index]} == '/etc/init.d/'* ]]; then
 
-			aFP_SERVICE[$index]="/lib/systemd/system/${aSERVICE_NAME[$index]}.service"
+			aFP_SERVICE[$index]="/etc/systemd/system/${aSERVICE_NAME[$index]}.service"
 			cat << _EOF_ > "${aFP_SERVICE[$index]}"
 [Unit]
 Description=${aSERVICE_NAME[$index]} sysvinit wrapper (DietPi)
@@ -349,12 +336,13 @@ ExecStop=/etc/init.d/${aSERVICE_NAME[$index]} stop
 WantedBy=multi-user.target
 _EOF_
 			G_WHIP_MSG "[ INFO ] DietPi has created a systemd service wrapper for /etc/init.d/${aSERVICE_NAME[$index]}. This is required to allow support for applying process tool options.\n
-If you experience any issues with the wrapper, simply remove the file:\n - rm /lib/systemd/system/${aSERVICE_NAME[$index]}.service\n - Then restart the service."
+If you experience any issues with the wrapper, simply remove the file:\n - rm /etc/systemd/system/${aSERVICE_NAME[$index]}.service\n - Then restart the service."
 
 		fi
 
-		mkdir -p "${aFP_SERVICE[$index]}.d"
-		cat << _EOF_ > "${aFP_SERVICE[$index]}.d/$FP_DIETPI_PROCESS_TOOL_SYSTEMD_CONF"
+		# Always create drop-in configs in: /etc/systemd/system/
+		mkdir -p "/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d"
+		cat << _EOF_ > "/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d/$FP_DIETPI_PROCESS_TOOL_SYSTEMD_CONF"
 [Service]
 Nice=${aCPU_NICE[$index]}
 CPUAffinity=${aCPU_AFFINITY[$index]}
@@ -372,13 +360,28 @@ _EOF_
 	Load_Process_Tool(){
 
 		local index=$1
+		local fp_conf="/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d/$FP_DIETPI_PROCESS_TOOL_SYSTEMD_CONF"
 
-		aCPU_NICE[$index]=$(grep -m1 '^[[:blank:]]*Nice=' ${aFP_SERVICE[$index]}.d/$FP_DIETPI_PROCESS_TOOL_SYSTEMD_CONF | sed 's/^[^=]*=//g')
-		aCPU_AFFINITY[$index]=$(grep -m1 '^[[:blank:]]*CPUAffinity=' ${aFP_SERVICE[$index]}.d/$FP_DIETPI_PROCESS_TOOL_SYSTEMD_CONF | sed 's/^[^=]*=//g')
-		aCPU_SCHEDULE_POLICY[$index]=$(grep -m1 '^[[:blank:]]*CPUSchedulingPolicy=' ${aFP_SERVICE[$index]}.d/$FP_DIETPI_PROCESS_TOOL_SYSTEMD_CONF | sed 's/^[^=]*=//g')
-		aCPU_SCHEDULE_PRIORITY[$index]=$(grep -m1 '^[[:blank:]]*CPUSchedulingPriority=' ${aFP_SERVICE[$index]}.d/$FP_DIETPI_PROCESS_TOOL_SYSTEMD_CONF | sed 's/^[^=]*=//g')
-		aIO_SCHEDULE_POLICY[$index]=$(grep -m1 '^[[:blank:]]*IOSchedulingClass=' ${aFP_SERVICE[$index]}.d/$FP_DIETPI_PROCESS_TOOL_SYSTEMD_CONF | sed 's/^[^=]*=//g')
-		aIO_PRIORITY[$index]=$(grep -m1 '^[[:blank:]]*IOSchedulingPriority=' ${aFP_SERVICE[$index]}.d/$FP_DIETPI_PROCESS_TOOL_SYSTEMD_CONF | sed 's/^[^=]*=//g')
+		aCPU_NICE[$index]=$(grep -m1 '^[[:blank:]]*Nice=' $fp_conf | sed 's/^[^=]*=//g')
+		aCPU_AFFINITY[$index]=$(grep -m1 '^[[:blank:]]*CPUAffinity=' $fp_conf | sed 's/^[^=]*=//g')
+		aCPU_SCHEDULE_POLICY[$index]=$(grep -m1 '^[[:blank:]]*CPUSchedulingPolicy=' $fp_conf | sed 's/^[^=]*=//g')
+		aCPU_SCHEDULE_PRIORITY[$index]=$(grep -m1 '^[[:blank:]]*CPUSchedulingPriority=' $fp_conf | sed 's/^[^=]*=//g')
+		aIO_SCHEDULE_POLICY[$index]=$(grep -m1 '^[[:blank:]]*IOSchedulingClass=' $fp_conf | sed 's/^[^=]*=//g')
+		aIO_PRIORITY[$index]=$(grep -m1 '^[[:blank:]]*IOSchedulingPriority=' $fp_conf | sed 's/^[^=]*=//g')
+
+	}
+
+	# $1=index
+	Load_Process_Tool_Defaults(){
+
+		local index=$1
+
+		aCPU_NICE[$index]=0
+		aCPU_AFFINITY[$index]="0-$(( $G_HW_CPU_CORES - 1 ))"
+		aCPU_SCHEDULE_POLICY[$index]='other'
+		aCPU_SCHEDULE_PRIORITY[$index]=0
+		aIO_SCHEDULE_POLICY[$index]='best-effort'
+		aIO_PRIORITY[$index]='3'
 
 	}
 
@@ -387,13 +390,14 @@ _EOF_
 
 		local index=$1
 
-		local fp="${aFP_SERVICE[$index]}.d/$FP_DIETPI_PROCESS_TOOL_SYSTEMD_CONF"
+		local fp="/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d/$FP_DIETPI_PROCESS_TOOL_SYSTEMD_CONF"
 		if [[ -f $fp ]]; then
 
 			G_RUN_CMD rm "$fp"
-			G_RUN_CMD rmdir --ignore-fail-on-non-empty "${aFP_SERVICE[$index]}.d"
+			G_RUN_CMD rmdir --ignore-fail-on-non-empty "/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d"
 			G_RUN_CMD systemctl unmask "${aSERVICE_NAME[$index]}"
 			G_RUN_CMD systemctl daemon-reload
+			Load_Process_Tool_Defaults $index
 			aSERVICE_RESTART_REQUIRED[$index]=1
 
 		fi
@@ -403,48 +407,38 @@ _EOF_
 	# Check if service name is available on system.
 	Populate_Available_Array(){
 
-		G_DIETPI-NOTIFY 2 'Generating service and process tool list, please wait...'
+		[[ $G_DEBUG == 1 ]] && G_DIETPI-NOTIFY 2 'Generating service and process tool list, please wait...'
 
 		Init_Arrays
 
 		Process_Includes_Excludes
 
-		local default_cpu_affinity="0-$(( $G_HW_CPU_CORES - 1 ))"
+		local i=0
 		for i in ${!aSERVICE_NAME[@]}
 		do
 
-			[[ ${aSERVICE_NAME[$i]} ]] || continue # Skip excluded services
+			[[ ${aSERVICE_NAME[$i]} ]] || { unset aSERVICE_NAME[$i]; continue; } # Failsafe
 
-			aSERVICE_AVAILABLE[$i]=0
-			aFP_SERVICE[$i]=''
-			[[ ${aSERVICE_RESTART_REQUIRED[$i]} == [01] ]] || aSERVICE_RESTART_REQUIRED[$i]=0 # Static init for menu use
-
-			local fp_service=( "/etc/systemd/system/${aSERVICE_NAME[$i]}.service" "/lib/systemd/system/${aSERVICE_NAME[$i]}.service" "/usr/lib/systemd/system/${aSERVICE_NAME[$i]}.service" "/etc/init.d/${aSERVICE_NAME[$i]}" )
-			for j in "${fp_service[@]}"
+			for j in /{etc,lib}/systemd/system/"${aSERVICE_NAME[$i]}.service" /etc/init.d/"${aSERVICE_NAME[$i]}"
 			do
 
 				if [[ -f $j ]]; then
 
-					aSERVICE_AVAILABLE[$i]=1
 					aFP_SERVICE[$i]=$j
-
 					aSERVICE_MODE[$i]=$(systemctl is-enabled "${aSERVICE_NAME[$i]}" 2> /dev/null)
+					aSERVICE_RESTART_REQUIRED[$i]=0 # Static init for menu use
 
-					aCPU_NICE[$i]=0
-					aCPU_AFFINITY[$i]=$default_cpu_affinity
-
-					aCPU_SCHEDULE_POLICY[$i]='other'
-					aCPU_SCHEDULE_PRIORITY[$i]=0
-					aIO_SCHEDULE_POLICY[$i]='best-effort'
-					aIO_PRIORITY[$i]='3'
-					[[ -f $j.d/$FP_DIETPI_PROCESS_TOOL_SYSTEMD_CONF ]] && Load_Process_Tool $i
+					Load_Process_Tool_Defaults $i
+					[[ -f /etc/systemd/system/${aSERVICE_NAME[$i]}.d/$FP_DIETPI_PROCESS_TOOL_SYSTEMD_CONF ]] && Load_Process_Tool $i
 
 					break
 
 				fi
 
 			done
-			unset fp_service
+
+			# Remove non-available services from array
+			[[ ${aCPU_NICE[$i]} ]] || unset aSERVICE_NAME[$i]
 
 		done
 
@@ -476,6 +470,7 @@ _EOF_
 	Set_Running_State(){
 
 		local target_state=$1
+		local i=''
 
 		# Enable ownCloud and Nextcloud maintenance mode
 		if [[ $target_state == 'stop' || $target_state == 'restart' ]]; then
@@ -488,18 +483,22 @@ _EOF_
 		# STOP: Reverse service order
 		if [[ $target_state == 'stop' ]]; then
 
-			for ((i=$(( ${#aSERVICE_NAME[@]} - 1 )); i>=0; i--))
+			local reverse=''
+			for i in ${!aSERVICE_NAME[@]}
 			do
 
-				if (( ${aSERVICE_AVAILABLE[$i]} )); then
+				reverse="$i $reverse"
 
-					G_DIETPI-NOTIFY -2 ${aSERVICE_NAME[$i]}
-					systemctl $target_state ${aSERVICE_NAME[$i]} &> /dev/null
-					Print_Status $target_state ${aSERVICE_NAME[$i]} $?
+			done
 
-					aSERVICE_RESTART_REQUIRED[$i]=0
+			for i in $reverse
+			do
 
-				fi
+				G_DIETPI-NOTIFY -2 ${aSERVICE_NAME[$i]}
+				systemctl $target_state ${aSERVICE_NAME[$i]} &> /dev/null
+				Print_Status $target_state ${aSERVICE_NAME[$i]} $?
+
+				aSERVICE_RESTART_REQUIRED[$i]=0
 
 			done
 
@@ -509,15 +508,11 @@ _EOF_
 			for i in ${!aSERVICE_NAME[@]}
 			do
 
-				if (( ${aSERVICE_AVAILABLE[$i]} )); then
+				G_DIETPI-NOTIFY -2 ${aSERVICE_NAME[$i]}
+				systemctl $target_state ${aSERVICE_NAME[$i]} &> /dev/null
+				Print_Status $target_state ${aSERVICE_NAME[$i]} $?
 
-					G_DIETPI-NOTIFY -2 ${aSERVICE_NAME[$i]}
-					systemctl $target_state ${aSERVICE_NAME[$i]} &> /dev/null
-					Print_Status $target_state ${aSERVICE_NAME[$i]} $?
-
-					aSERVICE_RESTART_REQUIRED[$i]=0
-
-				fi
+				aSERVICE_RESTART_REQUIRED[$i]=0
 
 			done
 
@@ -541,17 +536,12 @@ _EOF_
 
 			[[ $mode == 'systemd_controlled' ]] && systemd_cmd='enable'
 
-			for i in ${!aSERVICE_NAME[@]}
+			for i in "${aSERVICE_NAME[@]}"
 			do
 
-				# Apply
-				if (( ${aSERVICE_AVAILABLE[$i]} )); then
-
-					G_DIETPI-NOTIFY -2 ${aSERVICE_NAME[$i]}
-					systemctl $systemd_cmd ${aSERVICE_NAME[$i]} &> /dev/null
-					Print_Status $mode ${aSERVICE_NAME[$i]} $?
-
-				fi
+				G_DIETPI-NOTIFY -2 "$i"
+				systemctl $systemd_cmd "$i" &> /dev/null
+				Print_Status $mode "$i" $?
 
 			done
 
@@ -568,15 +558,11 @@ _EOF_
 
 				[[ $mode == 'disable' || $mode == 'mask' ]] && Set_Running_State stop
 
-				for i in ${!aSERVICE_NAME[@]}
+				for i in "${aSERVICE_NAME[@]}"
 				do
 
-					if (( ${aSERVICE_AVAILABLE[$i]} )); then
-
-						G_DIETPI-NOTIFY 0 "$mode $service: ${aSERVICE_NAME[$i]}"
-						systemctl $systemd_cmd ${aSERVICE_NAME[$i]}
-
-					fi
+					G_DIETPI-NOTIFY 0 "$mode $service: $i"
+					systemctl $systemd_cmd "$i"
 
 				done
 
@@ -587,7 +573,7 @@ _EOF_
 				[[ $mode == 'disable' || $mode == 'mask' ]] && systemctl stop $service
 
 				local notify_index=0
-				systemctl $systemd_cmd $service || notify_index=1
+				systemctl $systemd_cmd "$service" || notify_index=1
 				G_DIETPI-NOTIFY $notify_index "$mode $service"
 
 			fi
@@ -595,27 +581,23 @@ _EOF_
 		# status
 		elif [[ $mode == 'status' ]]; then
 
-			for i in ${!aSERVICE_NAME[@]}
+			for i in "${aSERVICE_NAME[@]}"
 			do
 
 				# Apply
-				if (( ${aSERVICE_AVAILABLE[$i]} )); then
+				local status="$i\t$(systemctl status "$i" | grep -m1 'Active' | cut -c12-)"
+				if [[ $status =~ 'failed' ]]; then
 
-					local status="${aSERVICE_NAME[$i]}\t$(systemctl status ${aSERVICE_NAME[$i]} | grep -m1 'Active' | cut -c12-)"
-					if [[ $status =~ 'failed' ]]; then
+					G_DIETPI-NOTIFY 1 "$status"
+					systemctl -l --no-pager status "$i"
 
-						G_DIETPI-NOTIFY 1 "$status"
-						systemctl -l --no-pager status ${aSERVICE_NAME[$i]}
+				elif [[ $status =~ 'inactive' ]]; then
 
-					elif [[ $status =~ 'inactive' ]]; then
+					G_DIETPI-NOTIFY 2 "$status"
 
-						G_DIETPI-NOTIFY 2 "$status"
+				else
 
-					else
-
-						G_DIETPI-NOTIFY 0 "$status"
-
-					fi
+					G_DIETPI-NOTIFY 0 "$status"
 
 				fi
 
@@ -627,7 +609,7 @@ _EOF_
 			# Single use case, basically a alias for systemd
 			if [[ $service ]]; then
 
-				if systemctl $mode $service &> /dev/null; then
+				if systemctl $mode "$service" &> /dev/null; then
 
 					G_DIETPI-NOTIFY 0 "$mode $service"
 
@@ -710,11 +692,7 @@ _EOF_
 		for i in ${!aSERVICE_NAME[@]}
 		do
 
-			if (( ${aSERVICE_AVAILABLE[$i]} )); then
-
-				G_WHIP_MENU_ARRAY+=("${aSERVICE_NAME[$i]}" ": $(systemctl is-active ${aSERVICE_NAME[$i]}) | Nice ${aCPU_NICE[$i]} | Affinity ${aCPU_AFFINITY[$i]}")
-
-			fi
+			G_WHIP_MENU_ARRAY+=("${aSERVICE_NAME[$i]}" ": $(systemctl is-active "${aSERVICE_NAME[$i]}") | Nice ${aCPU_NICE[$i]} | Affinity ${aCPU_AFFINITY[$i]}")
 
 		done
 
@@ -728,7 +706,7 @@ _EOF_
 
 			MENU_LAST_SELECTED_MAIN=$G_WHIP_RETURNED_VALUE
 
-			if [[ ${G_WHIP_RETURNED_VALUE,,} == 'restart' || ${G_WHIP_RETURNED_VALUE,,} == 'stop' ]]; then
+			if [[ $G_WHIP_RETURNED_VALUE == 'Restart' || $G_WHIP_RETURNED_VALUE == 'Stop' ]]; then
 
 				Apply_Service_States ${G_WHIP_RETURNED_VALUE,,}
 				sleep 0.5
@@ -764,7 +742,7 @@ _EOF_
 
 		MENU_TARGETID=1
 
-		local service_state=$(systemctl is-active ${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]})
+		local service_state=$(systemctl is-active "${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}" 2> /dev/null)
 		local service_mode_print=${aSERVICE_MODE[$MENU_SELECTED_SERVICE_INDEX]}
 		if [[ $service_mode_print == 'disabled' ]]; then
 
@@ -813,7 +791,7 @@ _EOF_
 
 				'Status')
 
-					systemctl status ${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]} -l > /tmp/.dietpi-services_systemctl.log
+					systemctl status "${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}" -l > /tmp/.dietpi-services_systemctl.log
 
 					log=0 G_WHIP_VIEWFILE /tmp/.dietpi-services_systemctl.log
 					rm /tmp/.dietpi-services_systemctl.log
@@ -839,7 +817,7 @@ _EOF_
 					aCPU_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]='idle'
 					aCPU_SCHEDULE_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]=0
 					aIO_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]='idle'
-					aIO_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]=3 #Has no effect in idle
+					aIO_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]=3 # Has no effect in idle
 					Save_Process_Tool $MENU_SELECTED_SERVICE_INDEX
 
 				;;
@@ -871,7 +849,6 @@ _EOF_
 				'Reset')
 
 					Reset_Service_Defaults $MENU_SELECTED_SERVICE_INDEX
-					Populate_Available_Array
 
 				;;
 
@@ -885,17 +862,17 @@ _EOF_
 						'unmask' ': Un-hide service from system and allow use'
 
 					)
-					G_WHIP_DEFAULT_ITEM='DietPi Controlled'
+					G_WHIP_DEFAULT_ITEM='DietPi controlled'
 					if G_WHIP_MENU "Please select the desired Service Mode for :\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"; then
 
-						local cmd_out="$G_WHIP_RETURNED_VALUE"
+						local cmd_out=$G_WHIP_RETURNED_VALUE
 						unmask_required=0
-						if [[ ${cmd_out,,} == 'dietpi controlled' ]]; then
+						if [[ $cmd_out == 'DietPi controlled' ]]; then
 
 							cmd_out='disable'
 							unmask_required=1
 
-						elif [[ ${cmd_out,,} == 'systemd controlled' ]]; then
+						elif [[ $cmd_out == 'Systemd controlled' ]]; then
 
 							cmd_out='enable'
 							unmask_required=1
@@ -904,7 +881,7 @@ _EOF_
 
 						(( $unmask_required )) && systemctl unmask ${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]} &> /dev/null
 						G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD systemctl $cmd_out ${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}
-						Populate_Available_Array
+						aSERVICE_MODE[$MENU_SELECTED_SERVICE_INDEX]=$(systemctl is-enabled "${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}" 2> /dev/null)
 
 					fi
 
@@ -952,8 +929,7 @@ _EOF_
 					done
 
 					G_WHIP_DEFAULT_ITEM=${aIO_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]}
-					G_WHIP_MENU "Please select the desired IO Scheduling Priority level for:\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}."
-					if (( ! $? )); then
+					if G_WHIP_MENU "Please select the desired IO Scheduling Priority level for:\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}."; then
 
 						# Convert back to int
 						aIO_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]=${G_WHIP_RETURNED_VALUE##*: }
@@ -975,7 +951,7 @@ _EOF_
 					local target_mode='restart'
 					[[ ${service_state,,} == 'active' ]] && target_mode='stop'
 
-					Apply_Service_States $target_mode ${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}
+					Apply_Service_States $target_mode "${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"
 					sleep 0.5
 
 				;;
@@ -1075,7 +1051,7 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 
 						done
 
-						#Update affinity array with new value, if at least 1 item was selected.
+						# Update affinity array with new value, if at least 1 item was selected.
 						[[ $new_affinity ]] && aCPU_AFFINITY[$MENU_SELECTED_SERVICE_INDEX]=$new_affinity
 
 						Save_Process_Tool $MENU_SELECTED_SERVICE_INDEX
@@ -1200,10 +1176,12 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 _EOF_
 
 	#-----------------------------------------------------------------------------------
+	# Load array of available services
+	Populate_Available_Array
+	#-----------------------------------------------------------------------------------
 	# Direct service control mode
 	if [[ $INPUT_MODE ]]; then
 
-		Populate_Available_Array
 		Apply_Service_States $INPUT_MODE $INPUT_SERVICE
 
 	#-----------------------------------------------------------------------------------
@@ -1215,7 +1193,6 @@ _EOF_
 
 			if (( $MENU_TARGETID == 0 )); then
 
-				Populate_Available_Array
 				Menu_Main
 
 			elif (( $MENU_TARGETID == 1 )); then

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -10,31 +10,35 @@
 	# - Allows service control for all listed programs used in dietpi-software
 	# - Disable removes the autostart from init.d and systemd. This allows DietPi to control program services below.
 	#
-	# Usage:
-	# - /DietPi/dietpi/dietpi-services $AVAILABLE_OPTIONS
-	AVAILABLE_OPTIONS='
- - [No Input]						(Run Menu)
- - start/stop/restart/status				(all services, known to DietPi)
- - start/stop/restart/status <servicename>		(single service, systemd)
- - systemd_controlled/dietpi_controlled			(all services, known to DietPi)
- - systemd_controlled/dietpi_controlled <servicename>	(single service, systemd)
- - enable/disable					(all services, known to DietPi)
- - enable/disable <servicename>				(single service, systemd)
- - mask/unmask						(all services, known to DietPi)
- - mask/unmask <servicename>				(single service, systemd)
-
- - You can include/exclude custom services by editing the following file: /DietPi/dietpi/.dietpi-services_include_exclude'
-	#////////////////////////////////////
+	USAGE='
+Usage: dietpi-services <command> [<service>]
+Available commands:
+  <empty>		Interactive menu to apply service modes and settings
+  status		Print service status info
+  start			Start service
+  stop			Stop service
+  restart		Restart service
+  dietpi_controlled	Let service be started by DietPi on boot
+  systemd_controlled	Let service be started by systemd on boot
+  enable/unmask		Enable service to allow its startup
+  disable/mask		Disable service to prevent its startup
+Available services:
+  <service_name>	Add any systemd or sysvinit service available and enabled on your system.
+  <empty>		Apply command to all services known to DietPi
+  			NB: Some services, required for network or shell session, will be skipped.
+			NB: You can include/exclude services by editing the following file:
+			    - /DietPi/dietpi/.dietpi-services_include_exclude
+'	#////////////////////////////////////
 
 	# Grab Inputs
-	INPUT_MODE=$1
+	INPUT_CMD=$1
 	INPUT_SERVICE=$2
 	# - pre-v6.25 compatibility
 	[[ $INPUT_SERVICE == 'all' ]] && unset INPUT_SERVICE
 
 	# - Optional input variables to prevent service handling
 	[[ $G_DIETPI_SERVICES_DISABLE == 1 ]] && exit 0
-	[[ $DISABLE_SERVICES_START == 1 ]] && [[ $INPUT_MODE == 'start' || $INPUT_MODE == 'restart' ]] && exit 0
+	[[ $DISABLE_SERVICES_START == 1 ]] && [[ $INPUT_CMD == 'start' || $INPUT_CMD == 'restart' ]] && exit 0
 
 	# Import DietPi-Globals --------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
@@ -43,27 +47,7 @@
 	G_INIT
 	# Import DietPi-Globals --------------------------------------------------------------
 
-	Init_Arrays(){
-
-		aFP_SERVICE=()
-		aSERVICE_MODE=() 		# Enabled/disabled/masked/unmasked
-		aSERVICE_RESTART_REQUIRED=() 	# eg, made changes, prompt to restart this service.
-
-		aCPU_NICE=()
-		aCPU_AFFINITY=()
-		aCPU_SCHEDULE_POLICY=()
-		aCPU_SCHEDULE_PRIORITY=()
-		aIO_SCHEDULE_POLICY=()
-		aIO_PRIORITY=()
-
-		# Single service input, skip adding any further services to array
-		[[ $INPUT_SERVICE ]] && { aSERVICE_NAME=("$INPUT_SERVICE"); return; }
-
-		aCPU_SCHEDULE_POLICY_TYPE=('other' 'fifo' 'rr' 'batch' 'idle')
-		aCPU_SCHEDULE_POLICY_DESC=('Normal (Default)' 'First In, First Out (Real-time, time-critical)' 'Round Robin (Real-time, time-critical)' 'Batch style execution' 'Background Jobs (Very low priority)')
-
-		aIO_SCHEDULE_POLICY_TYPE=('best-effort' 'realtime' 'idle')
-		aIO_SCHEDULE_POLICY_DESC=('Normal (Default)' 'Time-critical (Highest priority)' 'Background Jobs (Very low priority)')
+	Init_Array(){
 
 		aSERVICE_NAME=(
 
@@ -215,7 +199,7 @@
 
 		# Hidden/not-controlled services
 		# - Status mode, enable service status
-		if [[ ! $INPUT_MODE || $INPUT_MODE == 'status' ]]; then
+		if [[ ! $INPUT_CMD || $INPUT_CMD == 'status' ]]; then
 
 			# - SSH
 			aSERVICE_NAME+=('dropbear')
@@ -234,7 +218,7 @@
 
 			# - DietPi
 			aSERVICE_NAME+=('dietpi-nordvpn') 		# NordVPN install + client
-			if [[ $INPUT_MODE == 'status' ]]; then
+			if [[ $INPUT_CMD == 'status' ]]; then
 
 				aSERVICE_NAME+=('dietpi-ramdisk')
 				aSERVICE_NAME+=('dietpi-ramlog')
@@ -253,7 +237,7 @@
 	}
 
 
-	# - User: read custom services file
+	# User: read custom services file
 	FP_INCLUDE_CUSTOM_SERVICES='/DietPi/dietpi/.dietpi-services_include_exclude'
 	Process_Includes_Excludes(){
 
@@ -276,6 +260,7 @@ _EOF_
 		while read line
 		do
 
+			# - Skip empty and comment lines
 			[[ ! $line || $line == '#'* ]] && continue
 
 			local scrape=${line: +2}
@@ -373,28 +358,24 @@ _EOF_
 	Load_Process_Tool(){
 
 		local index=$1
-		local fp_conf="/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d/$FP_DIETPI_PROCESS_TOOL_SYSTEMD_CONF"
 
-		aCPU_NICE[$index]=$(grep -m1 '^[[:blank:]]*Nice=' $fp_conf | sed 's/^[^=]*=//g')
-		aCPU_AFFINITY[$index]=$(grep -m1 '^[[:blank:]]*CPUAffinity=' $fp_conf | sed 's/^[^=]*=//g')
-		aCPU_SCHEDULE_POLICY[$index]=$(grep -m1 '^[[:blank:]]*CPUSchedulingPolicy=' $fp_conf | sed 's/^[^=]*=//g')
-		aCPU_SCHEDULE_PRIORITY[$index]=$(grep -m1 '^[[:blank:]]*CPUSchedulingPriority=' $fp_conf | sed 's/^[^=]*=//g')
-		aIO_SCHEDULE_POLICY[$index]=$(grep -m1 '^[[:blank:]]*IOSchedulingClass=' $fp_conf | sed 's/^[^=]*=//g')
-		aIO_PRIORITY[$index]=$(grep -m1 '^[[:blank:]]*IOSchedulingPriority=' $fp_conf | sed 's/^[^=]*=//g')
-
-	}
-
-	# $1=index
-	Load_Process_Tool_Defaults(){
-
-		local index=$1
-
+		# Defaults
 		aCPU_NICE[$index]=0
 		aCPU_AFFINITY[$index]="0-$(( $G_HW_CPU_CORES - 1 ))"
 		aCPU_SCHEDULE_POLICY[$index]='other'
 		aCPU_SCHEDULE_PRIORITY[$index]=0
 		aIO_SCHEDULE_POLICY[$index]='best-effort'
 		aIO_PRIORITY[$index]='3'
+
+		local fp="/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d/$FP_DIETPI_PROCESS_TOOL_SYSTEMD_CONF"
+		[[ -f $fp ]] || return
+
+		aCPU_NICE[$index]=$(grep -m1 '^[[:blank:]]*Nice=' $fp | sed 's/^[^=]*=//g')
+		aCPU_AFFINITY[$index]=$(grep -m1 '^[[:blank:]]*CPUAffinity=' $fp | sed 's/^[^=]*=//g')
+		aCPU_SCHEDULE_POLICY[$index]=$(grep -m1 '^[[:blank:]]*CPUSchedulingPolicy=' $fp | sed 's/^[^=]*=//g')
+		aCPU_SCHEDULE_PRIORITY[$index]=$(grep -m1 '^[[:blank:]]*CPUSchedulingPriority=' $fp | sed 's/^[^=]*=//g')
+		aIO_SCHEDULE_POLICY[$index]=$(grep -m1 '^[[:blank:]]*IOSchedulingClass=' $fp | sed 's/^[^=]*=//g')
+		aIO_PRIORITY[$index]=$(grep -m1 '^[[:blank:]]*IOSchedulingPriority=' $fp | sed 's/^[^=]*=//g')
 
 	}
 
@@ -404,16 +385,42 @@ _EOF_
 		local index=$1
 
 		local fp="/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d/$FP_DIETPI_PROCESS_TOOL_SYSTEMD_CONF"
-		if [[ -f $fp ]]; then
+		[[ -f $fp ]] || return
 
-			G_RUN_CMD rm "$fp"
-			G_RUN_CMD rmdir --ignore-fail-on-non-empty "/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d"
-			G_RUN_CMD systemctl unmask "${aSERVICE_NAME[$index]}"
-			G_RUN_CMD systemctl daemon-reload
-			Load_Process_Tool_Defaults $index
-			aSERVICE_RESTART_REQUIRED[$index]=1
+		G_RUN_CMD rm "$fp"
+		G_RUN_CMD rmdir --ignore-fail-on-non-empty "/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d"
+		G_RUN_CMD systemctl unmask "${aSERVICE_NAME[$index]}"
+		G_RUN_CMD systemctl daemon-reload
+		Load_Process_Tool $index
+		aSERVICE_RESTART_REQUIRED[$index]=1
 
-		fi
+	}
+
+	Load_Process_Tool_Arrays(){
+
+		aSERVICE_MODE=() 		# Enabled/disabled/masked/unmasked
+		aSERVICE_RESTART_REQUIRED=() 	# eg, made changes, prompt to restart this service.
+
+		aCPU_NICE=()
+		aCPU_AFFINITY=()
+		aCPU_SCHEDULE_POLICY=()
+		aCPU_SCHEDULE_PRIORITY=()
+		aIO_SCHEDULE_POLICY=()
+		aIO_PRIORITY=()
+
+		aCPU_SCHEDULE_POLICY_TYPE=('other' 'fifo' 'rr' 'batch' 'idle')
+		aCPU_SCHEDULE_POLICY_DESC=('Normal (Default)' 'First In, First Out (Real-time, time-critical)' 'Round Robin (Real-time, time-critical)' 'Batch style execution' 'Background Jobs (Very low priority)')
+
+		aIO_SCHEDULE_POLICY_TYPE=('best-effort' 'realtime' 'idle')
+		aIO_SCHEDULE_POLICY_DESC=('Normal (Default)' 'Time-critical (Highest priority)' 'Background Jobs (Very low priority)')
+
+		for i in ${!aSERVICE_NAME[@]}
+		do
+
+			aSERVICE_MODE[$i]=$(systemctl is-enabled "${aSERVICE_NAME[$i]}" 2> /dev/null)
+			Load_Process_Tool $i	
+
+		done
 
 	}
 
@@ -422,9 +429,11 @@ _EOF_
 
 		[[ $G_DEBUG == 1 ]] && G_DIETPI-NOTIFY 2 'Generating service and process tool list, please wait...'
 
-		Init_Arrays
+		# Create service array, skip in case of single service input
+		[[ $INPUT_SERVICE ]] && aSERVICE_NAME=("$INPUT_SERVICE") || Init_Array
 
-		local i=0
+		aFP_SERVICE=()
+		local i j
 		for i in ${!aSERVICE_NAME[@]}
 		do
 
@@ -436,38 +445,26 @@ _EOF_
 				if [[ -f $j ]]; then
 
 					aFP_SERVICE[$i]=$j
-					aSERVICE_MODE[$i]=$(systemctl is-enabled "${aSERVICE_NAME[$i]}" 2> /dev/null)
-					aSERVICE_RESTART_REQUIRED[$i]=0 # Static init for menu use
-
-					Load_Process_Tool_Defaults $i
-					[[ -f /etc/systemd/system/${aSERVICE_NAME[$i]}.d/$FP_DIETPI_PROCESS_TOOL_SYSTEMD_CONF ]] && Load_Process_Tool $i
-
 					break
 
 				fi
 
 			done
 
-			# Remove non-available services from array, print info in case of single service input mode
-			if [[ ! ${aCPU_NICE[$i]} ]]; then
-
-				unset aSERVICE_NAME[$i]
-				[[ $INPUT_SERVICE ]] && G_DIETPI-NOTIFY 1 "Service ($INPUT_SERVICE) could not be found."
-
-			fi
+			# Remove non-available services from array, print info in case of single service input
+			[[ ${aFP_SERVICE[$i]} ]] || unset aSERVICE_NAME[$i]
 
 		done
 
 	}
 
+	# $1 = command
+	# $2 = service
+	# $3 = exit code
 	Print_Status(){
 
-		# $1 = Method
-		# $2 = name
-		# $3 = exit code
-
 		# Ok
-		# - NB: systemd exit code 5 = not loaded/active, so don't trigger a failed result.
+		# - NB: systemctl exit code 5 = not loaded/active, so don't trigger a failed result.
 		if [[ $3 == [05] ]]; then
 
 			G_DIETPI-NOTIFY 0 "$1 : $2"
@@ -481,58 +478,58 @@ _EOF_
 
 	}
 
-	# $1 = mode (start/stop/restart)
+	# $1 = command (start/stop/restart)
+	# $2 = index (optional)
 	Set_Running_State(){
 
-		local target_state=$1
-		local i=''
+		local command=$1
+		local index=$2
+		local services i
+
+		# Add and order services to be handled
+		# - Single service input
+		if [[ $index ]]; then
+
+			services=$index
+
+		# - stop: Reverse service order
+		elif [[ $command == 'stop' ]]; then
+
+			for i in ${!aSERVICE_NAME[@]}
+			do
+
+				services="$i $services"
+
+			done
+
+		# - start/restart: Standard service order
+		else
+
+			services=${!aSERVICE_NAME[@]}
+
+		fi
 
 		# Enable ownCloud and Nextcloud maintenance mode before all services being stopped or restarted
-		if [[ $target_state == 'stop' || $target_state == 'restart' && ! $INPUT_SERVICE ]]; then
+		if [[ $command == 'stop' || $command == 'restart' && ! $index ]]; then
 
 			[[ -f '/var/www/owncloud/config/config.php' ]] && grep -q "'maintenance' => false," /var/www/owncloud/config/config.php && G_USER_INPUTS=0 G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD occ maintenance:mode --on
 			[[ -f '/var/www/nextcloud/config/config.php' ]] && grep -q "'maintenance' => false," /var/www/nextcloud/config/config.php && G_USER_INPUTS=0 G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD ncc maintenance:mode --on
 
 		fi
 
-		# STOP: Reverse service order
-		if [[ $target_state == 'stop' ]]; then
+		# Apply command
+		for i in $services
+		do
 
-			local reverse=''
-			for i in ${!aSERVICE_NAME[@]}
-			do
+			G_DIETPI-NOTIFY -2 "${aSERVICE_NAME[$i]}"
+			systemctl $command "${aSERVICE_NAME[$i]}" &> /dev/null
+			Print_Status $command "${aSERVICE_NAME[$i]}" $?
 
-				reverse="$i $reverse"
+		fi
 
-			done
+		# Disable ownCloud and Nextcloud maintenance mode after all services being started or restarted
+		if [[ $command == 'start' || $command == 'restart' && ! $index ]]; then
 
-			for i in $reverse
-			do
-
-				G_DIETPI-NOTIFY -2 "${aSERVICE_NAME[$i]}"
-				systemctl $target_state "${aSERVICE_NAME[$i]}" &> /dev/null
-				Print_Status $target_state "${aSERVICE_NAME[$i]}" $?
-
-				aSERVICE_RESTART_REQUIRED[$i]=0
-
-			done
-
-		# START/RESTART: Standard service order
-		else
-
-			for i in ${!aSERVICE_NAME[@]}
-			do
-
-				G_DIETPI-NOTIFY -2 "${aSERVICE_NAME[$i]}"
-				systemctl $target_state "${aSERVICE_NAME[$i]}" &> /dev/null
-				Print_Status $target_state "${aSERVICE_NAME[$i]}" $?
-
-				aSERVICE_RESTART_REQUIRED[$i]=0
-
-			done
-
-			# - Disable ownCloud and Nextcloud maintenance mode before all services being started or restarted
-			[[ $INPUT_SERVICE ]] && return
 			[[ -f '/var/www/owncloud/config/config.php' ]] && grep -q "'maintenance' => true," /var/www/owncloud/config/config.php && G_USER_INPUTS=0 G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD occ maintenance:mode --off
 			[[ -f '/var/www/nextcloud/config/config.php' ]] && grep -q "'maintenance' => true," /var/www/nextcloud/config/config.php && G_USER_INPUTS=0 G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD ncc maintenance:mode --off
 
@@ -540,55 +537,36 @@ _EOF_
 
 	}
 
-	# $1=mode
+	# $1 = command
+	# $2 = index (optional)
 	Apply_Service_States(){
 
-		local mode=$1
-		local systemd_cmd='disable'
+		local command=$1
+		local index=$2
+		local services i
 
-		# dietpi_controlled/systemd_controlled
-		if [[ $mode == 'dietpi_controlled' || $mode == 'systemd_controlled' ]]; then
+		[[ $index ]] && services=$index || services=${!aSERVICE_NAME[@]}
 
-			[[ $mode == 'systemd_controlled' ]] && systemd_cmd='enable'
+		# start/stop/restart
+		if [[ $command == 'start' || $command == 'stop' || $command == 'restart' ]]; then
 
-			for i in "${aSERVICE_NAME[@]}"
-			do
-
-				systemctl $systemd_cmd "$i" &> /dev/null
-				Print_Status $mode "$i" $?
-
-			done
-
-		# mask/unmask/enable/disable
-		elif [[ $mode == 'enable' || $mode == 'disable' || $mode == 'unmask' || $mode == 'mask' ]]; then
-
-			# - Switch to mask, as DietPi_controlled uses disable to take over from systemd
-			[[ $mode == 'enable' || $mode == 'unmask' ]] && systemd_cmd='unmask' || systemd_cmd='mask'
-
-			# - Stop services before disable or mask them
-			[[ $mode == 'disable' || $mode == 'mask' ]] && Set_Running_State stop
-
-			for i in "${aSERVICE_NAME[@]}"
-			do
-
-				local notify_index=0
-				systemctl $systemd_cmd "$service" || notify_index=1
-				G_DIETPI-NOTIFY $notify_index "$mode $i"
-
-			done
-
+			Set_Running_State $command $index
 
 		# status
-		elif [[ $mode == 'status' ]]; then
+		elif [[ $command == 'status' ]]; then
 
-			for i in "${aSERVICE_NAME[@]}"
+			local status_full space status
+			for i in $services
 			do
 
-				local status="$i\t$(systemctl status "$i" | grep -m1 'Active' | cut -c12-)"
+				status_full=$(systemctl -l --no-pager status "${aSERVICE_NAME[$i]}")
+				# - Align status output
+				space='\t'
+				(( ${#i} < 13 )) && space+='\t'
+				status="${aSERVICE_NAME[$i]}${space}$(mawk '/Active/ {print substr($0,12);exit}' <<< "$status_full")"
 				if [[ $status =~ 'failed' ]]; then
 
-					G_DIETPI-NOTIFY 1 "$status"
-					systemctl -l --no-pager status "$i"
+					G_DIETPI-NOTIFY 1 "$status_full"
 
 				elif [[ $status =~ 'inactive' ]]; then
 
@@ -602,14 +580,43 @@ _EOF_
 
 			done
 
-		# start/stop/restart
-		elif [[ $mode == 'start' || $mode == 'stop' || $mode == 'restart' ]]; then
-
-			Set_Running_State $mode
-
+		# dietpi_controlled/systemd_controlled/mask/unmask/enable/disable
 		else
 
-			G_DIETPI-NOTIFY 2 "Invalid command\e[0m\nAvailable options:\n$AVAILABLE_OPTIONS\n"
+			local systemd_cmd=''
+			if [[ $command == 'dietpi_controlled' ]]; then
+
+				systemd_cmd='disable'
+
+			elif [[ $command == 'systemd_controlled' ]]; then
+
+				systemd_cmd='enable'
+
+			elif [[ $command == 'enable' || $command == 'unmask' ]]; then
+
+				systemd_cmd='unmask'
+
+			elif [[ $command == 'disable' || $command == 'mask' ]]; then
+
+				systemd_cmd='mask'
+				# - Stop services before masking them
+				Set_Running_State stop $index
+
+			else
+
+				G_DIETPI-NOTIFY 2 "Invalid input command ($command). Aborting...\n$USAGE"
+				exit 1
+
+			fi
+
+			# Apply command
+			for i in $services
+			do
+
+				systemctl $systemd_cmd "${aSERVICE_NAME[$i]}" &> /dev/null
+				Print_Status $command "${aSERVICE_NAME[$i]}" $?
+
+			done
 
 		fi
 
@@ -632,15 +639,11 @@ _EOF_
 			# - Prompt to restart changed services.
 			local service_restart_list_menu=''
 			local service_restart_list_systemd=''
-			for i in ${!aSERVICE_NAME[@]}
+			for i in ${!aSERVICE_RESTART_REQUIRED[$i]}
 			do
 
-				if (( ${aSERVICE_RESTART_REQUIRED[$i]} )); then
-
-					service_restart_list_menu+="\n - ${aSERVICE_NAME[$i]}: Nice=${aCPU_NICE[$i]} | Affinity=${aCPU_AFFINITY[$i]} | CPU Scheduling Policy=${aCPU_SCHEDULE_POLICY[$i]} | CPU Scheduling Priority=${aCPU_SCHEDULE_PRIORITY[$i]} | IO Scheduling Policy=${aIO_SCHEDULE_POLICY[$i]} | IO Scheduling Priority=${aIO_PRIORITY[$i]}"
-					service_restart_list_systemd+="${aSERVICE_NAME[$i]} "
-
-				fi
+				service_restart_list_menu+="\n - ${aSERVICE_NAME[$i]}: Nice=${aCPU_NICE[$i]} | Affinity=${aCPU_AFFINITY[$i]} | CPU Scheduling Policy=${aCPU_SCHEDULE_POLICY[$i]} | CPU Scheduling Priority=${aCPU_SCHEDULE_PRIORITY[$i]} | IO Scheduling Policy=${aIO_SCHEDULE_POLICY[$i]} | IO Scheduling Priority=${aIO_PRIORITY[$i]}"
+				service_restart_list_systemd+="${aSERVICE_NAME[$i]} "
 
 			done
 
@@ -658,7 +661,7 @@ _EOF_
 
 		else
 
-			MENU_TARGETID=0 # Return to Main Menu
+			MENU_TARGETID=0 # Return to main menu
 
 		fi
 
@@ -666,8 +669,6 @@ _EOF_
 
 	# MENU_TARGETID=0
 	Menu_Main(){
-
-		MENU_TARGETID=0
 
 		G_WHIP_MENU_ARRAY=('' '●─ Single Service Options ')
 		for i in ${!aSERVICE_NAME[@]}
@@ -690,6 +691,7 @@ _EOF_
 			if [[ $G_WHIP_RETURNED_VALUE == 'Restart' || $G_WHIP_RETURNED_VALUE == 'Stop' ]]; then
 
 				Set_Running_State ${G_WHIP_RETURNED_VALUE,,}
+				aSERVICE_RESTART_REQUIRED=()
 				sleep 0.5
 
 			elif [[ $G_WHIP_RETURNED_VALUE ]]; then
@@ -719,9 +721,8 @@ _EOF_
 
 	}
 
+	# MENU_TARGETID=1
 	Menu_Service(){
-
-		MENU_TARGETID=1
 
 		local service_state=$(systemctl is-active "${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}" 2> /dev/null)
 		local service_mode_print=${aSERVICE_MODE[$MENU_SELECTED_SERVICE_INDEX]}
@@ -772,7 +773,7 @@ _EOF_
 
 				'Status')
 
-					systemctl status "${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}" -l > /tmp/.dietpi-services_systemctl.log
+					systemctl -l --no-pager status "${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"> /tmp/.dietpi-services_systemctl.log
 
 					log=0 G_WHIP_VIEWFILE /tmp/.dietpi-services_systemctl.log
 					rm /tmp/.dietpi-services_systemctl.log
@@ -928,15 +929,12 @@ _EOF_
 
 				'State')
 
-					local target_mode='restart'
-					[[ ${service_state,,} == 'active' ]] && target_mode='stop'
+					local command='restart'
+					[[ ${service_state,,} == 'active' ]] && command='stop'
 
-					G_DIETPI-NOTIFY -2 "${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"
-					systemctl $target_mode "${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}" &> /dev/null
-					Print_Status $target_mode "${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}" $?
+					Set_Running_State $command $MENU_SELECTED_SERVICE_INDEX
+					unset aSERVICE_RESTART_REQUIRED[$MENU_SELECTED_SERVICE_INDEX]
 					sleep 0.5
-
-					aSERVICE_RESTART_REQUIRED[$MENU_SELECTED_SERVICE_INDEX]=0
 
 				;;
 
@@ -1142,14 +1140,19 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 	Populate_Available_Array
 	#-----------------------------------------------------------------------------------
 	# Direct service control mode
-	if [[ $INPUT_MODE ]]; then
+	if [[ $INPUT_CMD ]]; then
 
-		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" "$INPUT_MODE $INPUT_SERVICE"
-		Apply_Service_States $INPUT_MODE
+		# - Exit if input service could not be found
+		[[ $INPUT_SERVICE && ! ${aSERVICE_NAME[@]} ]] && { G_DIETPI-NOTIFY 1 "Service ($INPUT_SERVICE) could not be found."; exit 1; }
+
+		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" "$INPUT_CMD $INPUT_SERVICE"
+		Apply_Service_States $INPUT_CMD $INPUT_SERVICE
 
 	#-----------------------------------------------------------------------------------
 	# Men You!
 	else
+
+		Load_Process_Tool_Arrays
 
 		while (( $MENU_TARGETID > -1 ))
 		do


### PR DESCRIPTION
**Status**: Ready

**ToDo**:
- ~[ ] Instead of allow editing the /lib/systemd/system/ or /etc/init.d/ service files (thus touching maintainer defaults and breaking file updates by APT), create a copy to /etc/systemd/system/ to edit, which overrides the /lib location file. In case of sysvinit either a wrapper needs to be created or a drop-in config to override the auto-generated systemd unit. The drop-in config is actually the safest way in general, allowing easy reverting. A commented copy of the original file could be used as template, so lines to be changed can be un-commented to edit, which makes the done changes transparent.~ **Move to last part 3**
- [x] Handle $2 input executions exactly the same way, simply by adding the input service name as only array entry.
- [x] Can be further simplified... but need to sleep over this 😉

**Commit list/description**:
+ DietPi-Services | Create systemd wrappers and drop-in configs inside /etc/systemd/system/ always, leave /lib/systemd/system/ for APT package installs only
+ DietPi-Services | Do not check /usr/lib/systemd/system/ for service files, since this is never used by systemd: https://manpages.debian.org/stretch/systemd/systemd.unit.5.en.html
+ DietPi-Services | Populate_Available_Array() only once each script execution, which renders $INIT_ALL_ARRAYS obsolete. In case values are changed from menu, re-estimate them per-service. This solves the issue that aSERVICE_RESTART_REQUIRED[] is overwritten for all services, e.g. when one gets reset.
+ DietPi-Services | Instead of looping through all known services and checking aSERVICE_AVAILABLE[], unset aSERVICE_NAME[] for all non-existent and excluded services. This reduces array memory size and loop counts vastly.
+ DietPi-Services | Pass aSERVICE_NAME[] always in double quotes as command argument, to be failsafe if service name contains spaces or magic characters
+ DietPi-Services | Merge single + all service modes, by adding the input service to the arrays only in case
+ DietPi-Services | Further coding simplification and enhancements: E.g. process tool arrays are only loaded in menu mode to further speed up regular input modes.
+ DietPi-Services | Align command usage output with Linux standards
+ DietPi-Services | Reorder: Separate "Service Control" and "Process Tool" functions
+ DietPi-Services | Minor coding and wording
+ DietPi-Services | Fix service restart on exit
+ DietPi-Services | Minor wording