### PR TITLE
DietPi-Services 2.0 | Fine tuning part 3

### DIFF
--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -668,7 +668,7 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 			for i in ${!aSERVICE_RESTART_REQUIRED[@]}
 			do
 
-				service_restart_list_menu+="\n - ${aSERVICE_NAME[$i]}: Nice=${aCPU_NICE[$i]} | Affinity=${aCPU_AFFINITY[$i]} | CPU Scheduling Policy=${aCPU_SCHEDULE_POLICY[$i]} | CPU Scheduling Priority=${aCPU_SCHEDULE_PRIORITY[$i]} | IO Scheduling Policy=${aIO_SCHEDULE_POLICY[$i]} | IO Scheduling Priority=${aIO_PRIORITY[$i]}"
+				service_restart_list_menu+="\n - ${aSERVICE_NAME[$i]}: Nice=${aCPU_NICE[$i]:-0} | Affinity=${aCPU_AFFINITY[$i]:-0-$(( $G_HW_CPU_CORES - 1 ))} | CPU Scheduling Policy=${aCPU_SCHEDULE_POLICY[$i]:-other} | CPU Scheduling Priority=${aCPU_SCHEDULE_PRIORITY[$i]:-0} | IO Scheduling Policy=${aIO_SCHEDULE_POLICY[$i]:-best-effort} | IO Scheduling Priority=${aIO_PRIORITY[$i]:-$(( ( ${aCPU_NICE[$i]:-0} + 20 ) / 5 ))}"
 				service_restart_list_systemd+="${aSERVICE_NAME[$i]} "
 
 			done
@@ -700,7 +700,7 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 		for i in ${!aSERVICE_NAME[@]}
 		do
 
-			G_WHIP_MENU_ARRAY+=("${aSERVICE_NAME[$i]}" ": $(systemctl is-active "${aSERVICE_NAME[$i]}") | Nice ${aCPU_NICE[$i]} | Affinity ${aCPU_AFFINITY[$i]}")
+			G_WHIP_MENU_ARRAY+=("${aSERVICE_NAME[$i]}" ": $(systemctl is-active "${aSERVICE_NAME[$i]}") | Nice ${aCPU_NICE[$i]:-0} | Affinity ${aCPU_AFFINITY[$i]:-0-$(( $G_HW_CPU_CORES - 1 ))}")
 
 		done
 
@@ -762,7 +762,7 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 
 		fi
 		local cpu_nice=${aCPU_NICE[$MENU_SELECTED_SERVICE_INDEX]:-0}
-		local cpu_affinity=${aCPU_NICE[$MENU_SELECTED_SERVICE_INDEX]:-0-$(( $G_HW_CPU_CORES - 1 ))}
+		local cpu_affinity=${aCPU_AFFINITY[$MENU_SELECTED_SERVICE_INDEX]:-0-$(( $G_HW_CPU_CORES - 1 ))}
 		local cpu_policy=${aCPU_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]:-other}
 		local cpu_priority=${aCPU_SCHEDULE_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]:-0}
 		local io_policy=${aIO_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]:-best-effort}

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -209,14 +209,14 @@ Available services:
 			aSERVICE_NAME+=('ssh') 				# OpenSSH Server
 
 			# - Misc
-			#aSERVICE_NAME+=('systemd-timesyncd') 		# Timesync. DietPi stops this by default after success, may confuse user/prompt questions.
+			#aSERVICE_NAME+=('systemd-timesyncd') 		# Network time sync: DietPi stops this by default after success, may confuse user/prompt questions.
 			aSERVICE_NAME+=('dnsmasq') 			# https://github.com/MichaIng/DietPi/issues/1501
 			aSERVICE_NAME+=('pihole-FTL')			# https://github.com/MichaIng/DietPi/issues/1696
 			aSERVICE_NAME+=('openvpn') 			# https://github.com/MichaIng/DietPi/issues/1501
-			aSERVICE_NAME+=('vncserver') 			# DietPi vnc server service/script
-			aSERVICE_NAME+=('nxserver') 			# NoMachine
+			aSERVICE_NAME+=('vncserver') 			# DietPi VNC Server
+			aSERVICE_NAME+=('nxserver') 			# NoMachine Server
 			aSERVICE_NAME+=('xrdp') 			# XRDP Server
-			aSERVICE_NAME+=('amiberry') 			# DietPi Amiberry run service
+			aSERVICE_NAME+=('amiberry') 			# DietPi Amiberry service
 			#aSERVICE_NAME+=('wg-quick@wg0') 		# WireGuard: Currently instantiated services are not supported 
 
 			# - DietPi
@@ -795,11 +795,11 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 			G_WHIP_MENU_ARRAY+=(
 
 				'' '●─ Presets '
-				'Reset' ': Resets all service and CPU/IO options to default'
-				'Lowest Priority' ': Lowest priority background CPU/IO preset'
-				'Low Priority' ': Low priority CPU/IO preset'
-				'High Priority' ': High priority CPU/IO preset'
+				'Reset' ': Resets all CPU/IO settings to default'
 				'Highest Priority' ': Highest priority for critical CPU/IO preset'
+				'High Priority' ': High priority CPU/IO preset'
+				'Low Priority' ': Low priority CPU/IO preset'
+				'Lowest Priority' ': Lowest priority background CPU/IO preset'
 
 			)
 
@@ -836,7 +836,7 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 					aCPU_NICE[$MENU_SELECTED_SERVICE_INDEX]=19
 					#aCPU_AFFINITY[$MENU_SELECTED_SERVICE_INDEX]=
 					aCPU_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]='idle'
-					unset aCPU_SCHEDULE_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]
+					unset aCPU_SCHEDULE_PRIORITY[$MENU_SELECTED_SERVICE_INDEX] # Has no effect in idle
 					aIO_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]='idle'
 					unset aIO_PRIORITY[$MENU_SELECTED_SERVICE_INDEX] # Has no effect in idle
 					Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX
@@ -920,7 +920,7 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 
 					local desc
 
-					G_WHIP_MENU_ARRAY=('Reset       :' ' Reset IO Scheduling Priority to system defaults')
+					G_WHIP_MENU_ARRAY=('Reset' ' Reset IO Scheduling Priority to system defaults')
 					for i in {0..7}
 					do
 						desc=''
@@ -985,7 +985,7 @@ Please uncomment and edit only the lines that you need to change.\n\nTo undo cha
 
 					local desc
 
-					G_WHIP_MENU_ARRAY=('Reset:' ' Reset CPU Nice to system defaults')
+					G_WHIP_MENU_ARRAY=('Reset' ' Reset CPU Nice to system defaults')
 					for i in {-20..19}
 					do
 						desc=''

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -741,7 +741,7 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 
 							if [[ $G_WHIP_RETURNED_VALUE == "$i" ]]; then
 
-								not_found="[FAILED] The service name you entered ($G_WHIP_RETURNED_VALUE) is already handled by DietPi-Service. Please retry or cancel.\n\n"
+								not_found="[FAILED] The service name you entered ($G_WHIP_RETURNED_VALUE) is already handled by DietPi-Services. Please retry or cancel.\n\n"
 								continue 2
 
 							fi
@@ -924,7 +924,7 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 
 					G_WHIP_MENU_ARRAY=('Include' 'Exclude')
 					G_WHIP_DEFAULT_ITEM='Include'
-					if G_WHIP_MENU "Please choose whether to include or exclude ${aSERVICE_NAME[$MENU_SERVICE_INDEX]} from automated DietPi-Service control:"; then
+					if G_WHIP_MENU "Please choose whether to include or exclude ${aSERVICE_NAME[$MENU_SERVICE_INDEX]} from automated DietPi-Services control:"; then
 
 						if [[ $G_WHIP_RETURNED_VALUE == 'Include' ]]; then
 

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -950,7 +950,7 @@ This affects e.g. auto-stop/start during DietPi-Software installs, DietPi-Update
 							if grep -q "^+ ${aSERVICE_NAME[$MENU_SERVICE_INDEX]}" $FP_INCLUDE_EXCLUDE; then
 
 								sed -i "/^+ ${aSERVICE_NAME[$MENU_SERVICE_INDEX]}/d" $FP_INCLUDE_EXCLUDE
-								unset aSERVICE_NAME[$MENU_SERVICE_INDEX]}
+								unset aSERVICE_NAME[$MENU_SERVICE_INDEX]
 								# - Service needs to be re-added from main menu
 								MENU_TARGETID=0 # Return to main menu
 

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -48,7 +48,6 @@ Available services:
 	G_INIT
 	# Import DietPi-Globals --------------------------------------------------------------
 
-
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Service Control
 	#/////////////////////////////////////////////////////////////////////////////////////
@@ -240,7 +239,6 @@ Available services:
 
 	}
 
-
 	# Apply custom include/exclude choices
 	FP_INCLUDE_EXCLUDE='/DietPi/dietpi/.dietpi-services_include_exclude'
 	Process_Includes_Excludes(){
@@ -325,6 +323,7 @@ _EOF_
 
 		# Check service availability
 		aFP_SERVICE=()
+		aSERVICE_MODE=() # enabled/disabled/masked
 		local i j
 		for i in ${!aSERVICE_NAME[@]}
 		do
@@ -334,9 +333,11 @@ _EOF_
 			for j in /{etc,lib}/systemd/system/"${aSERVICE_NAME[$i]}.service" /etc/init.d/"${aSERVICE_NAME[$i]}"
 			do
 
-				if [[ -f $j ]]; then
+				if [[ -e $j ]]; then
 
 					aFP_SERVICE[$i]=$j
+					# - Check masked state
+					[[ -L $j && $(readlink -m "$j") == '/dev/null' ]] && aSERVICE_MODE[$i]='masked'
 					break
 
 				fi
@@ -359,7 +360,7 @@ _EOF_
 	# $2 = index (optional)
 	Set_Running_State(){
 
-		local command=$1
+		local command=${1,,}
 		local index=$2
 		local services i
 
@@ -398,6 +399,7 @@ _EOF_
 		for i in $services
 		do
 
+			[[ ${aSERVICE_MODE[$i]} == 'masked' ]] && continue
 			G_DIETPI-NOTIFY -2 "${aSERVICE_NAME[$i]}"
 			systemctl $command "${aSERVICE_NAME[$i]}" &> /dev/null
 			Print_Status $command "${aSERVICE_NAME[$i]}" $?
@@ -418,7 +420,7 @@ _EOF_
 	# $2 = index (optional)
 	Apply_Service_State(){
 
-		local command=$1
+		local command=${1,,}
 		local index=$2
 		local services i
 
@@ -490,6 +492,8 @@ _EOF_
 			for i in $services
 			do
 
+				# - Skip masked services, if not to be unmasked
+				[[ ${aSERVICE_MODE[$i]} == 'masked' && $systemctl_cmd != 'unmask' ]] && continue
 				systemctl $systemctl_cmd "${aSERVICE_NAME[$i]}" &> /dev/null
 				Print_Status $command "${aSERVICE_NAME[$i]}" $?
 
@@ -503,8 +507,7 @@ _EOF_
 	# Process Tool
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# $1=index
-	FP_PROCESS_TOOL_CONF='dietpi-process_tool.conf'
-	Save_Process_Tool(){
+	Prepare_Service_Dropin(){
 
 		local index=$1
 
@@ -524,23 +527,73 @@ ExecStop=/etc/init.d/${aSERVICE_NAME[$index]} stop
 [Install]
 WantedBy=multi-user.target
 _EOF_
-			G_WHIP_MSG "[ INFO ] DietPi has created a systemd service wrapper for /etc/init.d/${aSERVICE_NAME[$index]}. This is required to allow support for applying process tool options.\n
-If you experience any issues with the wrapper, simply remove the file:\n - rm /etc/systemd/system/${aSERVICE_NAME[$index]}.service\n - Then restart the service."
+			G_WHIP_MSG "[ INFO ] DietPi has created a systemd service wrapper for /etc/init.d/${aSERVICE_NAME[$index]}. This is required to allow support for applying process tool options and custom changes.\n
+If you experience any issues with the wrapper, remove the file, reload and restart the service:\n - rm /etc/systemd/system/${aSERVICE_NAME[$index]}.service\n - systemctl daemon-reload\n - systemctl restart ${aSERVICE_NAME[$index]}"
 
 		fi
 
 		# Always create drop-in configs in: /etc/systemd/system/
 		mkdir -p "/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d"
-		cat << _EOF_ > "/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d/$FP_PROCESS_TOOL_CONF"
-# WARNING: Do not manually edit this file, use "dietpi-services" to adjust values!
-[Service]
-Nice=${aCPU_NICE[$index]}
-CPUAffinity=${aCPU_AFFINITY[$index]}
-CPUSchedulingPolicy=${aCPU_SCHEDULE_POLICY[$index]}
-CPUSchedulingPriority=${aCPU_SCHEDULE_PRIORITY[$index]}
-IOSchedulingClass=${aIO_SCHEDULE_POLICY[$index]}
-IOSchedulingPriority=${aIO_PRIORITY[$index]}
-_EOF_
+
+	}
+
+	# $1=index
+	# $2=setting (<empty>=apply ALL settings, reset=reset ALL settings, 0=Nice, 1=CPUAffinity, 2=CPUSchedulingPolicy, 3=CPUSchedulingPriority, 4=IOSchedulingClass, 5=IOSchedulingPriority)
+	# $3=value (reset=reset $2 setting)
+	FP_PROCESS_TOOL_CONF='dietpi-process_tool.conf'
+	Apply_Process_Tool(){
+
+		local index=$1
+		local setting=$2
+		local value=${3,,}
+		local dp="/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d"
+		local fp="$dp/$FP_PROCESS_TOOL_CONF"
+		local i
+
+		# Arrays to translate $2 integer to settings names
+		local asetting=('Nice' 'CPUAffinity' 'CPUSchedulingPolicy' 'CPUSchedulingPriority' 'IOSchedulingClass' 'IOSchedulingPriority')
+		local aarray=('aCPU_NICE' 'aCPU_AFFINITY' 'aCPU_SCHEDULE_POLICY' 'aCPU_SCHEDULE_PRIORITY' 'aIO_SCHEDULE_POLICY' 'aIO_PRIORITY')
+
+		# Reset all process tool settings
+		if [[ $setting == reset ]]; then
+
+			for i in {0..5}; do unset ${aarray[$i]}[$index]; done
+			[[ -f $fp ]] && G_RUN_CMD rm "$fp"
+			[[ -f $dp ]] && G_RUN_CMD rmdir --ignore-fail-on-non-empty "$dp"
+
+		# Reset single process tool setting
+		elif [[ $value == 'reset' ]]; then
+
+			unset ${aarray[$setting]}[$index]
+			[[ -f $fp ]] && G_RUN_CMD sed -i "/^${asetting[$setting]}=/d" "$fp"
+
+		# Apply process tool setting(s)
+		else
+
+			Prepare_Service_Dropin $index
+
+			# Apply single setting
+			if [[ $setting ]]; then
+
+				[[ -f $fp ]] || echo -e '# WARNING: Do not manually edit this file, use "dietpi-services" to adjust values!\n[Service]' > "$fp"
+				declare -ag ${aarray[$setting]}[$index]=$value
+				G_CONFIG_INJECT "${asetting[$setting]}=" "${asetting[$setting]}=$value" "$fp"
+
+			# Apply ALL settings, stored in arrays (presets)
+			else
+
+				echo -e '# WARNING: Do not manually edit this file, use "dietpi-services" to adjust values!\n[Service]' > "$fp"
+				[[ ${aCPU_NICE[$index]} ]] && echo "Nice=${aCPU_NICE[$index]}" > "$fp"
+				[[ ${aCPU_AFFINITY[$index]} ]] && echo "CPUAffinity=${aCPU_AFFINITY[$index]}" > "$fp"
+				[[ ${aCPU_SCHEDULE_POLICY[$index]} ]] && echo "CPUSchedulingPolicy=${aCPU_SCHEDULE_POLICY[$index]}" > "$fp"
+				[[ ${aCPU_SCHEDULE_PRIORITY[$index]} ]] && echo "CPUSchedulingPriority=${aCPU_SCHEDULE_PRIORITY[$index]}" > "$fp"
+				[[ ${aIO_SCHEDULE_POLICY[$index]} ]] && echo "IOSchedulingClass=${aIO_SCHEDULE_POLICY[$index]}" > "$fp"
+				[[ ${aIO_PRIORITY[$index]} ]] && echo "IOSchedulingPriority=${aIO_PRIORITY[$index]}" > "$fp"
+
+			fi
+
+		fi
+
 		G_RUN_CMD systemctl daemon-reload
 		aSERVICE_RESTART_REQUIRED[$index]=1
 
@@ -550,15 +603,6 @@ _EOF_
 	Load_Process_Tool(){
 
 		local index=$1
-
-		# Defaults
-		aCPU_NICE[$index]=0
-		aCPU_AFFINITY[$index]="0-$(( $G_HW_CPU_CORES - 1 ))"
-		aCPU_SCHEDULE_POLICY[$index]='other'
-		aCPU_SCHEDULE_PRIORITY[$index]=0
-		aIO_SCHEDULE_POLICY[$index]='best-effort'
-		aIO_PRIORITY[$index]='4' # best-effort default == (cpu_nice + 20) / 5: https://manpages.debian.org/stretch/util-linux/ionice.1.en.html
-
 		local fp="/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d/$FP_PROCESS_TOOL_CONF"
 		[[ -f $fp ]] || return
 
@@ -577,27 +621,9 @@ _EOF_
 
 	}
 
-	# $1=index
-	Reset_Process_Tool(){
-
-		local index=$1
-
-		local fp="/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d/$FP_PROCESS_TOOL_CONF"
-		[[ -f $fp ]] || return
-
-		G_RUN_CMD rm "$fp"
-		G_RUN_CMD rmdir --ignore-fail-on-non-empty "/etc/systemd/system/${aSERVICE_NAME[$index]}.service.d"
-		G_RUN_CMD systemctl unmask "${aSERVICE_NAME[$index]}"
-		G_RUN_CMD systemctl daemon-reload
-		Load_Process_Tool $index
-		aSERVICE_RESTART_REQUIRED[$index]=1
-
-	}
-
 	Load_Process_Tool_Arrays(){
 
-		aSERVICE_MODE=() 		# Enabled/disabled/masked/unmasked
-		aSERVICE_RESTART_REQUIRED=() 	# eg, made changes, prompt to restart this service.
+		aSERVICE_RESTART_REQUIRED=() # Prompt to restart service on exit, when changes to unit file were done
 
 		aCPU_NICE=()
 		aCPU_AFFINITY=()
@@ -649,7 +675,7 @@ _EOF_
 
 			if [[ $service_restart_list_systemd ]]; then
 
-				if G_WHIP_YESNO "[INFO] The following services require a restart, in order to apply your recently modified settings: $service_restart_list_menu\n\nDo you wish to continue, and, restart the above services now?"; then
+				if G_WHIP_YESNO "[ INFO ] The following services require a restart, in order to apply your recently modified settings: $service_restart_list_menu\n\nDo you wish to continue, and, restart the above services now?"; then
 
 					G_RUN_CMD systemctl restart $service_restart_list_systemd
 
@@ -690,7 +716,7 @@ _EOF_
 
 			if [[ $G_WHIP_RETURNED_VALUE == 'Restart' || $G_WHIP_RETURNED_VALUE == 'Stop' ]]; then
 
-				Set_Running_State ${G_WHIP_RETURNED_VALUE,,}
+				Set_Running_State $G_WHIP_RETURNED_VALUE
 				aSERVICE_RESTART_REQUIRED=()
 				sleep 0.5
 
@@ -735,6 +761,12 @@ _EOF_
 			service_mode_print='Systemd controlled'
 
 		fi
+		local cpu_nice=${aCPU_NICE[$MENU_SELECTED_SERVICE_INDEX]:-0}
+		local cpu_affinity=${aCPU_NICE[$MENU_SELECTED_SERVICE_INDEX]:-0-$(( $G_HW_CPU_CORES - 1 ))}
+		local cpu_policy=${aCPU_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]:-other}
+		local cpu_priority=${aCPU_SCHEDULE_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]:-0}
+		local io_policy=${aIO_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]:-best-effort}
+		local io_priority=${aIO_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]:-$(( ( $cpu_nice + 20 ) / 5 ))}
 
 		G_WHIP_DEFAULT_ITEM=$MENU_LAST_SELECTED_SUB_0
 		G_WHIP_BUTTON_CANCEL_TEXT='Back'
@@ -742,28 +774,36 @@ _EOF_
 
 			'' '●─ Service Control '
 			'State' ": [$service_state]"
-			'Status' ': Display systemd status log'
-			'Edit' ": [${aFP_SERVICE[$MENU_SELECTED_SERVICE_INDEX]}]"
 			'Mode' ": [$service_mode_print]"
-			'' '●─ Process Tool '
-			'CPU Nice' ": [${aCPU_NICE[$MENU_SELECTED_SERVICE_INDEX]}]"
-			'CPU Affinity' ": [${aCPU_AFFINITY[$MENU_SELECTED_SERVICE_INDEX]}]"
-			'CPU Schedule Policy' ": [${aCPU_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]}]"
-			'CPU Schedule Priority' ": [${aCPU_SCHEDULE_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]}]"
-			'IO Scheduling Policy' ": [${aIO_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]}]"
+			'Status' ': Display systemd status log'
 
 		)
-		[[ ${aIO_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]} != 'idle' ]] && G_WHIP_MENU_ARRAY+=('IO Scheduling Priority' ": [${aIO_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]}]")
-		G_WHIP_MENU_ARRAY+=(
+		if [[ $service_mode_print != 'masked' ]]; then
 
-			'' '●─ Presets '
-			'Reset' ': Resets all service and CPU/IO options to default'
-			'Lowest Priority' ': Lowest priority background CPU/IO preset'
-			'Low Priority' ': Low priority CPU/IO preset'
-			'High Priority' ': High priority CPU/IO preset'
-			'Highest Priority' ': Highest priority for critical CPU/IO preset'
+			G_WHIP_MENU_ARRAY+=(
 
-		)
+				'Edit' ": [${aFP_SERVICE[$MENU_SELECTED_SERVICE_INDEX]}]"
+				'' '●─ Process Tool '
+				'CPU Nice' ": [$cpu_nice]"
+				'CPU Affinity' ": [$cpu_affinity]"
+				'CPU Schedule Policy' ": [$cpu_policy]"
+				'CPU Schedule Priority' ": [$cpu_priority]"
+				'IO Scheduling Policy' ": [$io_policy]"
+
+			)
+			[[ $io_policy != 'idle' ]] && G_WHIP_MENU_ARRAY+=('IO Scheduling Priority' ": [$io_priority]")
+			G_WHIP_MENU_ARRAY+=(
+
+				'' '●─ Presets '
+				'Reset' ': Resets all service and CPU/IO options to default'
+				'Lowest Priority' ': Lowest priority background CPU/IO preset'
+				'Low Priority' ': Low priority CPU/IO preset'
+				'High Priority' ': High priority CPU/IO preset'
+				'Highest Priority' ': Highest priority for critical CPU/IO preset'
+
+			)
+
+		fi
 
 		if G_WHIP_MENU "Please select an option for ${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}:"; then
 
@@ -774,7 +814,6 @@ _EOF_
 				'Status')
 
 					systemctl -l --no-pager status "${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}" &> systemctl.log
-
 					log=0 G_WHIP_VIEWFILE systemctl.log
 					rm systemctl.log
 
@@ -784,11 +823,11 @@ _EOF_
 
 					aCPU_NICE[$MENU_SELECTED_SERVICE_INDEX]=10
 					#aCPU_AFFINITY[$MENU_SELECTED_SERVICE_INDEX]=
-					aCPU_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]='other'
-					aCPU_SCHEDULE_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]=0
-					aIO_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]='best-effort'
+					unset aCPU_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]
+					unset aCPU_SCHEDULE_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]
+					unset aIO_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]
 					aIO_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]=7
-					Save_Process_Tool $MENU_SELECTED_SERVICE_INDEX
+					Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX
 
 				;;
 
@@ -797,10 +836,10 @@ _EOF_
 					aCPU_NICE[$MENU_SELECTED_SERVICE_INDEX]=19
 					#aCPU_AFFINITY[$MENU_SELECTED_SERVICE_INDEX]=
 					aCPU_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]='idle'
-					aCPU_SCHEDULE_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]=0
+					unset aCPU_SCHEDULE_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]
 					aIO_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]='idle'
-					aIO_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]=3 # Has no effect in idle
-					Save_Process_Tool $MENU_SELECTED_SERVICE_INDEX
+					unset aIO_PRIORITY[$MENU_SELECTED_SERVICE_INDEX] # Has no effect in idle
+					Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX
 
 				;;
 
@@ -808,11 +847,11 @@ _EOF_
 
 					aCPU_NICE[$MENU_SELECTED_SERVICE_INDEX]=-10
 					#aCPU_AFFINITY[$MENU_SELECTED_SERVICE_INDEX]=
-					aCPU_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]='other'
+					unset aCPU_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]
 					aCPU_SCHEDULE_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]=10
-					aIO_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]='best-effort'
+					unset aIO_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]
 					aIO_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]=0
-					Save_Process_Tool $MENU_SELECTED_SERVICE_INDEX
+					Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX
 
 				;;
 
@@ -824,13 +863,13 @@ _EOF_
 					aCPU_SCHEDULE_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]=50
 					aIO_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]='realtime'
 					aIO_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]=0
-					Save_Process_Tool $MENU_SELECTED_SERVICE_INDEX
+					Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX
 
 				;;
 
 				'Reset')
 
-					Reset_Process_Tool $MENU_SELECTED_SERVICE_INDEX
+					Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX reset
 
 				;;
 
@@ -847,22 +886,11 @@ _EOF_
 					G_WHIP_DEFAULT_ITEM='DietPi controlled'
 					if G_WHIP_MENU "Please select the desired Service Mode for :\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"; then
 
-						local cmd_out=$G_WHIP_RETURNED_VALUE
-						local unmask_required=0
-						if [[ $cmd_out == 'DietPi controlled' ]]; then
-
-							cmd_out='disable'
-							unmask_required=1
-
-						elif [[ $cmd_out == 'Systemd controlled' ]]; then
-
-							cmd_out='enable'
-							unmask_required=1
-
-						fi
-
-						(( $unmask_required )) && systemctl unmask ${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]} &> /dev/null
-						G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD systemctl $cmd_out ${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}
+						local command=$G_WHIP_RETURNED_VALUE
+						# Unmask services before enable/disable
+						[[ $command == *'controlled' ]] && Apply_Service_State unmask $MENU_SELECTED_SERVICE_INDEX
+						Apply_Service_State ${command/ /_} $MENU_SELECTED_SERVICE_INDEX
+						# Re-estimate service mode
 						aSERVICE_MODE[$MENU_SELECTED_SERVICE_INDEX]=$(systemctl is-enabled "${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}" 2> /dev/null)
 
 					fi
@@ -871,7 +899,7 @@ _EOF_
 
 				'IO Scheduling Policy')
 
-					G_WHIP_MENU_ARRAY=()
+					G_WHIP_MENU_ARRAY=('Reset' ': Reset IO Scheduling Policy to system defaults')
 					for i in ${!aIO_SCHEDULE_POLICY_TYPE[@]}
 					do
 
@@ -882,8 +910,7 @@ _EOF_
 					G_WHIP_DEFAULT_ITEM=${aIO_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]}
 					if G_WHIP_MENU "Please select the desired IO Scheduling Class for:\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"; then
 
-						aIO_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]=$G_WHIP_RETURNED_VALUE
-						Save_Process_Tool $MENU_SELECTED_SERVICE_INDEX
+						Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX 4 $G_WHIP_RETURNED_VALUE
 
 					fi
 
@@ -892,8 +919,8 @@ _EOF_
 				'IO Scheduling Priority')
 
 					local desc
-					G_WHIP_MENU_ARRAY=()
 
+					G_WHIP_MENU_ARRAY=('Reset' ': Reset IO Scheduling Priority to system defaults')
 					for i in {7..0}
 					do
 						desc=''
@@ -914,9 +941,7 @@ _EOF_
 					G_WHIP_DEFAULT_ITEM=${aIO_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]}
 					if G_WHIP_MENU "Please select the desired IO Scheduling Priority level for:\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}."; then
 
-						# Convert back to int
-						aIO_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]=${G_WHIP_RETURNED_VALUE##*: }
-						Save_Process_Tool $MENU_SELECTED_SERVICE_INDEX
+						Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX 5 ${G_WHIP_RETURNED_VALUE##*: } # Convert back to int
 
 					fi
 
@@ -924,7 +949,19 @@ _EOF_
 
 				'Edit')
 
-					nano ${aFP_SERVICE[$MENU_SELECTED_SERVICE_INDEX]}
+					local fp="/etc/systemd/system/${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}.service.d/dietpi-services_edit.conf"
+
+					Prepare_Service_Dropin $MENU_SELECTED_SERVICE_INDEX
+					if [[ ! -f $fp ]]; then
+
+						cp -a "${aFP_SERVICE[$MENU_SELECTED_SERVICE_INDEX]}" "$fp"
+						sed -Ei 's/^([^[#])/#\1/' "$fp"
+						G_WHIP_MSG "[ INFO ] To allow safe service editing, we created a drop-in config with commented original service file content.\n
+Please uncomment and edit only the lines that you need to change.\n\nTo undo changes, remove the drop-in, reload and restart the service:
+ - rm $fp\n - systemctl daemon-reload\n - systemctl restart ${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"
+
+					fi
+					nano "$fp"
 					G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD systemctl daemon-reload
 
 				;;
@@ -946,8 +983,8 @@ _EOF_
 					# - Note: Whiptail will not work with negative numbers. The string cannot start with "-" as it throws subscript error.
 					local nice_current="Nice : ${aCPU_NICE[$MENU_SELECTED_SERVICE_INDEX]}"
 					local desc
-					G_WHIP_MENU_ARRAY=()
 
+					G_WHIP_MENU_ARRAY=('Reset' ': Reset CPU Nice to system defaults')
 					for i in {-20..19}
 					do
 						desc=''
@@ -989,9 +1026,7 @@ _EOF_
 					if G_WHIP_MENU "Please select the desired Nice level for:\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}\n
 Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values have a lower priority (eg: 15).\n - The default value is 0."; then
 
-						# Convert back to int
-						aCPU_NICE[$MENU_SELECTED_SERVICE_INDEX]=${G_WHIP_RETURNED_VALUE##*: }
-						Save_Process_Tool $MENU_SELECTED_SERVICE_INDEX
+						Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX 0 ${G_WHIP_RETURNED_VALUE##*: } # Convert back to int
 
 					fi
 
@@ -1002,7 +1037,6 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 					# Get existing affinity
 					# NB: currently enables all
 					G_WHIP_CHECKLIST_ARRAY=()
-
 					for ((i=0; i<$G_HW_CPU_CORES; i++))
 					do
 
@@ -1011,32 +1045,21 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 					done
 
 					if G_WHIP_CHECKLIST "Please select the desired CPU Affinity for:\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}\n
- - Use the spacebar to enable/disable access to specific cores, for this program.\n - The default value is to enable all items."; then
+ - Use the spacebar to enable/disable access to specific cores, for this program.\n - The default value is to enable all items.\n - De-select all items to reset to system defaults."; then
 
 						local new_affinity=''
 						local loop_count=0
 						for i in ${G_WHIP_RETURNED_VALUE[@]}
 						do
 
-							# taskset requires , (comma) seperated cpu index indexs after 1st entry.
-							if (( $loop_count == 0 )); then
-
-								new_affinity+=$i
-
-							# Add comma for future entries
-							else
-
-								new_affinity+=",$i"
-
-							fi
-
+							# taskset requires comma-seperated CPU indices
+							(( $loop_count == 0 )) && new_affinity+=$i || new_affinity+=",$i"
 							((loop_count++))
 
 						done
 
-						# Update affinity array with new value, if at least 1 item was selected.
-						[[ $new_affinity ]] && aCPU_AFFINITY[$MENU_SELECTED_SERVICE_INDEX]=$new_affinity
-						Save_Process_Tool $MENU_SELECTED_SERVICE_INDEX
+						# Update affinity array with new value, if at least 1 item was selected, otherwise reset
+						Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX 1 ${new_affinity:-reset}
 
 					fi
 
@@ -1044,7 +1067,7 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 
 				'CPU Schedule Policy')
 
-					G_WHIP_MENU_ARRAY=()
+					G_WHIP_MENU_ARRAY=('Reset' ': Reset CPU Schedule Policy to system defaults')
 					for i in ${!aCPU_SCHEDULE_POLICY_TYPE[@]}
 					do
 
@@ -1055,16 +1078,13 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 					G_WHIP_DEFAULT_ITEM=${aCPU_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]}
 					if G_WHIP_MENU "Please select the desired CPU Scheduling Policy for:\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"; then
 
-						aCPU_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]=$G_WHIP_RETURNED_VALUE
-						Save_Process_Tool $MENU_SELECTED_SERVICE_INDEX
+						Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX 2 $G_WHIP_RETURNED_VALUE
 
 					fi
 
 				;;
 
 				'CPU Schedule Priority')
-
-					G_WHIP_MENU_ARRAY=()
 
 					# - 7 step description scale
 					local scale_value_lowest=0
@@ -1075,6 +1095,8 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 					local scale_value_high=$(( $scale_value_highest / 6 * 4 ))
 					local scale_value_higher=$(( $scale_value_highest / 6 * 5 ))
 					local desc
+
+					G_WHIP_MENU_ARRAY=('Reset' ': Reset CPU Schedule Priority to system defaults')
 					for ((i=0; i<=$scale_value_highest; i++))
 					do
 
@@ -1117,8 +1139,7 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 					if G_WHIP_MENU "Please select the desired CPU Scheduling Priority level for:\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}\n
  - Lower values are low priority\n - Higher values are high priority"; then
 
-						aCPU_SCHEDULE_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]=$G_WHIP_RETURNED_VALUE
-						Save_Process_Tool $MENU_SELECTED_SERVICE_INDEX
+						Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX 3 $G_WHIP_RETURNED_VALUE
 
 					fi
 
@@ -1144,7 +1165,7 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 	if [[ $INPUT_CMD ]]; then
 
 		# - Exit if input service could not be found
-		[[ $INPUT_SERVICE && ! ${aSERVICE_NAME[@]} ]] && { G_DIETPI-NOTIFY 1 "Service ($INPUT_SERVICE) could not be found."; exit 1; }
+		[[ $INPUT_SERVICE && ! ${aSERVICE_NAME[0]} ]] && { G_DIETPI-NOTIFY 1 "Service ($INPUT_SERVICE) could not be found."; exit 1; }
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" "$INPUT_CMD $INPUT_SERVICE"
 		Apply_Service_State $INPUT_CMD $INPUT_SERVICE

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -258,6 +258,7 @@ Available services:
 #- transmission-daemon
 
 _EOF_
+		aSERVICE_EXCLUDED=()
 		local i
 
 		while read line
@@ -622,8 +623,6 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 
 		SYSTEMD_RELOAD_REQUIRED=0 # Set to 1 after systemd unit/drop-in changes
 		aSERVICE_RESTART_REQUIRED=() # Prompt to restart service on exit, when changes to unit file were done
-
-		aSERVICE_EXCLUDED=()
 
 		aCPU_NICE=()
 		aCPU_AFFINITY=()

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -908,7 +908,7 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 					done
 
 					G_WHIP_DEFAULT_ITEM=$io_policy
-					if G_WHIP_MENU "Please select the desired IO Scheduling Class for:\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"; then
+					if G_WHIP_MENU "Please select the desired IO Scheduling Class for: ${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"; then
 
 						Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX 4 $G_WHIP_RETURNED_VALUE
 
@@ -920,10 +920,14 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 
 					local desc
 
-					G_WHIP_MENU_ARRAY=('Reset' ': Reset IO Scheduling Priority to system defaults')
-					for i in {7..0}
+					G_WHIP_MENU_ARRAY=('Reset       :' ' Reset IO Scheduling Priority to system defaults')
+					for i in {0..7}
 					do
 						desc=''
+						if (( $i == ( $cpu_nice + 20 ) / 5 )); then
+
+							desc='(Default priority)'
+
 						if (( $i == 0 )); then
 
 							desc='(Highest priority)'
@@ -939,7 +943,7 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 					done
 
 					G_WHIP_DEFAULT_ITEM="IO Priority : $io_priority"
-					if G_WHIP_MENU "Please select the desired IO Scheduling Priority level for:\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}."; then
+					if G_WHIP_MENU "Please select the desired IO Scheduling Priority level for: ${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"; then
 
 						Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX 5 ${G_WHIP_RETURNED_VALUE##*: } # Convert back to int
 
@@ -981,7 +985,7 @@ Please uncomment and edit only the lines that you need to change.\n\nTo undo cha
 
 					local desc
 
-					G_WHIP_MENU_ARRAY=('Reset' ': Reset CPU Nice to system defaults')
+					G_WHIP_MENU_ARRAY=('Reset:' ' Reset CPU Nice to system defaults')
 					for i in {-20..19}
 					do
 						desc=''
@@ -1021,7 +1025,7 @@ Please uncomment and edit only the lines that you need to change.\n\nTo undo cha
 					done
 
 					G_WHIP_DEFAULT_ITEM="Nice : $cpu_nice"
-					if G_WHIP_MENU "Please select the desired Nice level for:\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}\n
+					if G_WHIP_MENU "Please select the desired Nice level for: ${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}\n
 Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values have a lower priority (eg: 15).\n - The default value is 0."; then
 
 						Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX 0 ${G_WHIP_RETURNED_VALUE##*: } # Convert back to int
@@ -1042,7 +1046,7 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 
 					done
 
-					if G_WHIP_CHECKLIST "Please select the desired CPU Affinity for:\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}\n
+					if G_WHIP_CHECKLIST "Please select the desired CPU Affinity for: ${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}\n
  - Use the spacebar to enable/disable access to specific cores, for this program.\n - The default value is to enable all items.\n - De-select all items to reset to system defaults."; then
 
 						local new_affinity=''
@@ -1072,7 +1076,7 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 					done
 
 					G_WHIP_DEFAULT_ITEM=$cpu_policy
-					if G_WHIP_MENU "Please select the desired CPU Scheduling Policy for:\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"; then
+					if G_WHIP_MENU "Please select the desired CPU Scheduling Policy for: ${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"; then
 
 						Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX 2 $G_WHIP_RETURNED_VALUE
 
@@ -1093,7 +1097,7 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 					local desc
 
 					G_WHIP_MENU_ARRAY=('Reset' ': Reset CPU Schedule Priority to system defaults')
-					for ((i=0; i<=$scale_value_highest; i++))
+					for ((i=$scale_value_highest; i>=$scale_value_lowest; i--))
 					do
 
 						desc=''
@@ -1132,7 +1136,7 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 					done
 
 					G_WHIP_DEFAULT_ITEM=$cpu_priority
-					if G_WHIP_MENU "Please select the desired CPU Scheduling Priority level for:\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}\n
+					if G_WHIP_MENU "Please select the desired CPU Scheduling Priority level for: ${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}\n
  - Lower values are low priority\n - Higher values are high priority"; then
 
 						Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX 3 $G_WHIP_RETURNED_VALUE

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -728,8 +728,14 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 
 			if [[ $G_WHIP_RETURNED_VALUE == 'Add' ]]; then
 
-				local not_found
-				local new_index=${#aSERVICE_MODE[$i]}
+				local not_found new_index
+				# Find first empty index
+				for ((i=0;i<=${#aSERVICE_MODE[@]};i++))
+				do
+
+					 [[ ${aSERVICE_NAME[$i]} ]] || { new_index=$i; break; }
+
+				done
 				while G_WHIP_INPUTBOX "${not_found}Please add the name of the service to be added, without the \".service\" file ending:"
 				do
 
@@ -922,9 +928,15 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 
 				'Include/Exclude')
 
-					G_WHIP_MENU_ARRAY=('Include' 'Exclude')
+					G_WHIP_MENU_ARRAY=(
+
+						'Include' ': Allow DietPi auto-control'
+						'Exclude' ': Deny DietPi auto-control'
+
+					)
 					G_WHIP_DEFAULT_ITEM='Include'
-					if G_WHIP_MENU "Please choose whether to include or exclude ${aSERVICE_NAME[$MENU_SERVICE_INDEX]} from automated DietPi-Services control:"; then
+					if G_WHIP_MENU "Please choose whether to include or exclude ${aSERVICE_NAME[$MENU_SERVICE_INDEX]} from automated DietPi-Services control.
+This affects e.g. auto-stop/start during DietPi-Software installs, DietPi-Update, DietPi-Backup and similar maintenance tasks."; then
 
 						if [[ $G_WHIP_RETURNED_VALUE == 'Include' ]]; then
 

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -297,7 +297,7 @@ _EOF_
 
 						else
 
-							sSERVICE_EXCLUDED[$i]=1
+							aSERVICE_EXCLUDED[$i]=1
 
 						fi
 
@@ -623,7 +623,7 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 		SYSTEMD_RELOAD_REQUIRED=0 # Set to 1 after systemd unit/drop-in changes
 		aSERVICE_RESTART_REQUIRED=() # Prompt to restart service on exit, when changes to unit file were done
 
-		sSERVICE_EXCLUDED=()
+		aSERVICE_EXCLUDED=()
 
 		aCPU_NICE=()
 		aCPU_AFFINITY=()

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -926,9 +926,9 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 						desc=''
 						if (( $i == ( $cpu_nice + 20 ) / 5 )); then
 
-							desc='(Default priority)'
+							desc='(Default priority, based on your Nice level)'
 
-						if (( $i == 0 )); then
+						elif (( $i == 0 )); then
 
 							desc='(Highest priority)'
 

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -907,7 +907,7 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 
 					done
 
-					G_WHIP_DEFAULT_ITEM=${aIO_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]}
+					G_WHIP_DEFAULT_ITEM=$io_policy
 					if G_WHIP_MENU "Please select the desired IO Scheduling Class for:\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"; then
 
 						Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX 4 $G_WHIP_RETURNED_VALUE
@@ -938,7 +938,7 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 
 					done
 
-					G_WHIP_DEFAULT_ITEM=${aIO_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]}
+					G_WHIP_DEFAULT_ITEM="IO Priority : $io_priority"
 					if G_WHIP_MENU "Please select the desired IO Scheduling Priority level for:\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}."; then
 
 						Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX 5 ${G_WHIP_RETURNED_VALUE##*: } # Convert back to int
@@ -979,9 +979,6 @@ Please uncomment and edit only the lines that you need to change.\n\nTo undo cha
 
 				'CPU Nice')
 
-					# Get existing nice level
-					# - Note: Whiptail will not work with negative numbers. The string cannot start with "-" as it throws subscript error.
-					local nice_current="Nice : ${aCPU_NICE[$MENU_SELECTED_SERVICE_INDEX]}"
 					local desc
 
 					G_WHIP_MENU_ARRAY=('Reset' ': Reset CPU Nice to system defaults')
@@ -1018,11 +1015,12 @@ Please uncomment and edit only the lines that you need to change.\n\nTo undo cha
 
 						fi
 
+						# - Note: Whiptail will not work with negative numbers. The string cannot start with "-" as it throws subscript error.
 						G_WHIP_MENU_ARRAY+=("Nice : $i" " $desc")
 
 					done
 
-					G_WHIP_DEFAULT_ITEM=$nice_current
+					G_WHIP_DEFAULT_ITEM="Nice : $cpu_nice"
 					if G_WHIP_MENU "Please select the desired Nice level for:\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}\n
 Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values have a lower priority (eg: 15).\n - The default value is 0."; then
 
@@ -1048,13 +1046,11 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
  - Use the spacebar to enable/disable access to specific cores, for this program.\n - The default value is to enable all items.\n - De-select all items to reset to system defaults."; then
 
 						local new_affinity=''
-						local loop_count=0
 						for i in ${G_WHIP_RETURNED_VALUE[@]}
 						do
 
 							# taskset requires comma-seperated CPU indices
-							(( $loop_count == 0 )) && new_affinity+=$i || new_affinity+=",$i"
-							((loop_count++))
+							[[ $new_affinity ]] && new_affinity+=",$i" || new_affinity=$i
 
 						done
 
@@ -1075,7 +1071,7 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 
 					done
 
-					G_WHIP_DEFAULT_ITEM=${aCPU_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]}
+					G_WHIP_DEFAULT_ITEM=$cpu_policy
 					if G_WHIP_MENU "Please select the desired CPU Scheduling Policy for:\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"; then
 
 						Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX 2 $G_WHIP_RETURNED_VALUE
@@ -1135,7 +1131,7 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 
 					done
 
-					G_WHIP_DEFAULT_ITEM=${aCPU_SCHEDULE_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]}
+					G_WHIP_DEFAULT_ITEM=$cpu_priority
 					if G_WHIP_MENU "Please select the desired CPU Scheduling Priority level for:\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}\n
  - Lower values are low priority\n - Higher values are high priority"; then
 

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -9,7 +9,7 @@
 	# Info:
 	# - Allows service control for all listed programs available through dietpi-software
 	# - By default known services are "disabled", thus not started by systemd, but
-	#   started by this script at later boot stage from: /DietPi/dietpi/postboot
+	#   started by /DietPi/dietpi/postboot at later boot stage.
 	#
 	USAGE='
 Usage: dietpi-services <command> [<service>]
@@ -21,8 +21,8 @@ Available commands:
   restart		Restart service
   dietpi_controlled	Let service be started by DietPi on boot
   systemd_controlled	Let service be started by systemd on boot
-  enable/unmask		Enable service to allow its startup
-  disable/mask		Disable service to prevent its startup
+  enable, unmask	Enable service to allow its startup
+  disable, mask		Disable service to prevent its startup
 Available services:
   <service_name>	Add any systemd or sysvinit service available on your system.
   <empty>		Apply command to all services known to DietPi
@@ -37,7 +37,7 @@ Available services:
 	# - pre-v6.25 compatibility
 	[[ $INPUT_SERVICE == 'all' ]] && unset INPUT_SERVICE
 
-	# - Optional env vars to prevent service handling
+	# - Optional env vars to prevent service control
 	[[ $G_DIETPI_SERVICES_DISABLE == 1 ]] && exit 0
 	[[ $DISABLE_SERVICES_START == 1 ]] && [[ $INPUT_CMD == 'start' || $INPUT_CMD == 'restart' ]] && exit 0
 
@@ -55,7 +55,7 @@ Available services:
 
 		aSERVICE_NAME=(
 
-			# Core -----------------------------------------------------------------
+			# Core ---------------------------------------------------------------
 			# - Network
 			'fail2ban'
 			'avahi-daemon'
@@ -67,13 +67,13 @@ Available services:
 			'vsftpd'
 			'nmbd' 'smbd'
 			'nfs-kernel-server'
-			# Core -----------------------------------------------------------------
+			# Core ---------------------------------------------------------------
 
-			# Backends -------------------------------------------------------------
+			# Backends -----------------------------------------------------------
 			# - Databases
 			'redis-server'
 			'mariadb'
-			#'mysql' # Applied on Jessie systems during availablility check: https://github.com/MichaIng/DietPi/issues/1000#issuecomment-30776051
+			#'mysql' # Applied on Jessie systems during availability check: https://github.com/MichaIng/DietPi/issues/1000#issuecomment-30776051
 
 			# - PHP
 			'php5-fpm'
@@ -110,9 +110,9 @@ Available services:
 			'rtorrent'
 			'nzbget'
 			'deluged'
-			# Backends -------------------------------------------------------------
+			# Backends -----------------------------------------------------------
 
-			# Frontends / Misc -----------------------------------------------------
+			# Frontends / Misc ---------------------------------------------------
 			# - Media
 			'ympd'
 			'mympd'
@@ -194,7 +194,7 @@ Available services:
 			'docker'
 			'cron'
 			'fahclient'
-			# Frontends / Misc -----------------------------------------------------
+			# Frontends / Misc ---------------------------------------------------
 
 		)
 
@@ -258,49 +258,49 @@ Available services:
 #- transmission-daemon
 
 _EOF_
-		local scrape i
+		local i
 
 		while read line
 		do
 
-			# - Skip empty and comment lines
-			[[ ! $line || $line == '#'* ]] && continue
-
-			scrape=${line: +2}
-
 			# - Include
 			if [[ $line == '+ '* ]]; then
 
-				local service_known_already_to_dietpi=0
+				line=${line: +2}
+
+				# - Skip known services
 				for i in "${aSERVICE_NAME[@]}"
 				do
 
-					if [[ $scrape == "$i" ]]; then
-
-						service_known_already_to_dietpi=1
-						break
-
-					fi
+					[[ $line == "$i" ]] && continue 2
 
 				done
 
-				if (( ! $service_known_already_to_dietpi )); then
-
-					[[ $G_DEBUG == 1 ]] && G_DIETPI-NOTIFY 2 "Including custom service: $scrape"
-					aSERVICE_NAME+=("$scrape")
-
-				fi
+				[[ $G_DEBUG == 1 ]] && G_DIETPI-NOTIFY 2 "Including custom service: $line"
+				aSERVICE_NAME+=("$line")
 
 			# - Exclude
 			elif [[ $line == '- '* ]]; then
 
+				line=${line: +2}
+
 				for i in ${!aSERVICE_NAME[@]}
 				do
 
-					if [[ $scrape == "${aSERVICE_NAME[$i]}" ]]; then
+					if [[ $line == "${aSERVICE_NAME[$i]}" ]]; then
 
-						[[ $G_DEBUG == 1 ]] && G_DIETPI-NOTIFY 2 "Excluding service: $scrape"
-						unset aSERVICE_NAME[$i]
+						# - Show in menu, but mark as excluded
+						if [[ $INPUT_CMD ]]; then
+
+							[[ $G_DEBUG == 1 ]] && G_DIETPI-NOTIFY 2 "Excluding service: $line"
+							unset aSERVICE_NAME[$i]
+
+						else
+
+							sSERVICE_EXCLUDED[$i]=1
+
+						fi
+
 						break
 
 					fi
@@ -335,9 +335,10 @@ _EOF_
 
 				if [[ -e $j ]]; then
 
+					# - Check masked state, in case continue to catch real file
+					[[ -L $j && $(readlink -m "$j") == '/dev/null' ]] && aSERVICE_MODE[$i]='masked' && continue
+
 					aFP_SERVICE[$i]=$j
-					# - Check masked state
-					[[ -L $j && $(readlink -m "$j") == '/dev/null' ]] && aSERVICE_MODE[$i]='masked'
 					break
 
 				fi
@@ -538,7 +539,7 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 	}
 
 	# $1=index
-	# $2=setting (<empty>=apply ALL settings, reset=reset ALL settings, 0=Nice, 1=CPUAffinity, 2=CPUSchedulingPolicy, 3=CPUSchedulingPriority, 4=IOSchedulingClass, 5=IOSchedulingPriority)
+	# $2=setting (reset=reset ALL settings, 0=CPUAffinity, 1=CPUSchedulingPolicy, 2=Nice, 3=CPUSchedulingPriority, 4=IOSchedulingClass, 5=IOSchedulingPriority)
 	# $3=value (reset=reset $2 setting)
 	FP_PROCESS_TOOL_CONF='dietpi-process_tool.conf'
 	Apply_Process_Tool(){
@@ -551,8 +552,20 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 		local i
 
 		# Arrays to translate $2 integer to settings names
-		local asetting=('Nice' 'CPUAffinity' 'CPUSchedulingPolicy' 'CPUSchedulingPriority' 'IOSchedulingClass' 'IOSchedulingPriority')
-		local aarray=('aCPU_NICE' 'aCPU_AFFINITY' 'aCPU_SCHEDULE_POLICY' 'aCPU_SCHEDULE_PRIORITY' 'aIO_SCHEDULE_POLICY' 'aIO_PRIORITY')
+		local asetting=('CPUAffinity' 'CPUSchedulingPolicy' 'Nice' 'CPUSchedulingPriority' 'IOSchedulingClass' 'IOSchedulingPriority')
+		local aarray=('aCPU_AFFINITY' 'aCPU_POLICY' 'aCPU_NICE' 'aCPU_PRIORITY' 'aIO_CLASS' 'aIO_PRIORITY')
+
+		# Reset priority values if scheduling policy/class is changed
+		if [[ $setting == 1 ]]; then
+
+			Apply_Process_Tool $index 2 reset
+			Apply_Process_Tool $index 3 reset
+
+		elif [[ $setting == 4 ]]; then
+
+			Apply_Process_Tool $index 5 reset
+
+		fi
 
 		# Reset all process tool settings
 		if [[ $setting == reset ]]; then
@@ -567,34 +580,18 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 			unset ${aarray[$setting]}[$index]
 			[[ -f $fp ]] && G_RUN_CMD sed -i "/^${asetting[$setting]}=/d" "$fp"
 
-		# Apply process tool setting(s)
+		# Apply process tool setting
 		else
 
 			Prepare_Service_Dropin $index
 
-			# Apply single setting
-			if [[ $setting ]]; then
-
-				[[ -f $fp ]] || echo -e '# WARNING: Do not manually edit this file, use "dietpi-services" to adjust values!\n[Service]' > "$fp"
-				declare -ag ${aarray[$setting]}[$index]=$value
-				G_CONFIG_INJECT "${asetting[$setting]}=" "${asetting[$setting]}=$value" "$fp"
-
-			# Apply ALL settings, stored in arrays (presets)
-			else
-
-				echo -e '# WARNING: Do not manually edit this file, use "dietpi-services" to adjust values!\n[Service]' > "$fp"
-				[[ ${aCPU_NICE[$index]} ]] && echo "Nice=${aCPU_NICE[$index]}" > "$fp"
-				[[ ${aCPU_AFFINITY[$index]} ]] && echo "CPUAffinity=${aCPU_AFFINITY[$index]}" > "$fp"
-				[[ ${aCPU_SCHEDULE_POLICY[$index]} ]] && echo "CPUSchedulingPolicy=${aCPU_SCHEDULE_POLICY[$index]}" > "$fp"
-				[[ ${aCPU_SCHEDULE_PRIORITY[$index]} ]] && echo "CPUSchedulingPriority=${aCPU_SCHEDULE_PRIORITY[$index]}" > "$fp"
-				[[ ${aIO_SCHEDULE_POLICY[$index]} ]] && echo "IOSchedulingClass=${aIO_SCHEDULE_POLICY[$index]}" > "$fp"
-				[[ ${aIO_PRIORITY[$index]} ]] && echo "IOSchedulingPriority=${aIO_PRIORITY[$index]}" > "$fp"
-
-			fi
+			[[ -f $fp ]] || echo -e '# WARNING: Do not manually edit this file, use "dietpi-services" to adjust values!\n[Service]' > "$fp"
+			declare -ag ${aarray[$setting]}[$index]=$value
+			G_CONFIG_INJECT "${asetting[$setting]}=" "${asetting[$setting]}=$value" "$fp"
 
 		fi
 
-		G_RUN_CMD systemctl daemon-reload
+		SYSTEMD_RELOAD_REQUIRED=1
 		aSERVICE_RESTART_REQUIRED[$index]=1
 
 	}
@@ -609,36 +606,39 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 		# Source values from config file
 		# - [Service] line throws an effectless error that we can simply hide.
 		# - All values are single word strings, so bash assigns them correctly.
-		local Nice CPUAffinity CPUSchedulingPolicy CPUSchedulingPriority IOSchedulingClass IOSchedulingPriority
+		local CPUAffinity CPUSchedulingPolicy Nice CPUSchedulingPriority IOSchedulingClass IOSchedulingPriority
 		. $fp &> /dev/null
 
-		[[ $Nice ]] && aCPU_NICE[$index]=$Nice
 		[[ $CPUAffinity ]] && aCPU_AFFINITY[$index]=$CPUAffinity
-		[[ $CPUSchedulingPolicy ]] && aCPU_SCHEDULE_POLICY[$index]=$CPUSchedulingPolicy
-		[[ $CPUSchedulingPriority ]] && aCPU_SCHEDULE_PRIORITY[$index]=$CPUSchedulingPriority
-		[[ $IOSchedulingClass ]] && aIO_SCHEDULE_POLICY[$index]=$IOSchedulingClass
+		[[ $CPUSchedulingPolicy ]] && aCPU_POLICY[$index]=$CPUSchedulingPolicy
+		[[ $Nice ]] && aCPU_NICE[$index]=$Nice
+		[[ $CPUSchedulingPriority ]] && aCPU_PRIORITY[$index]=$CPUSchedulingPriority
+		[[ $IOSchedulingClass ]] && aIO_CLASS[$index]=$IOSchedulingClass
 		[[ $IOSchedulingPriority ]] && aIO_PRIORITY[$index]=$IOSchedulingPriority
 
 	}
 
 	Load_Process_Tool_Arrays(){
 
+		SYSTEMD_RELOAD_REQUIRED=0 # Set to 1 after systemd unit/drop-in changes
 		aSERVICE_RESTART_REQUIRED=() # Prompt to restart service on exit, when changes to unit file were done
+
+		sSERVICE_EXCLUDED=()
 
 		aCPU_NICE=()
 		aCPU_AFFINITY=()
-		aCPU_SCHEDULE_POLICY=()
-		aCPU_SCHEDULE_PRIORITY=()
-		aIO_SCHEDULE_POLICY=()
+		aCPU_POLICY=()
+		aCPU_PRIORITY=()
+		aIO_CLASS=()
 		aIO_PRIORITY=()
 
 		# https://manpages.debian.org/stretch/manpages/sched.7.en.html
-		aCPU_SCHEDULE_POLICY_TYPE=('other' 'fifo' 'rr' 'batch' 'idle')
-		aCPU_SCHEDULE_POLICY_DESC=('Normal (Default)' 'First In, First Out (Real-time, time-critical)' 'Round Robin (Real-time, time-critical)' 'Batch style execution' 'Background Jobs (Very low priority)')
+		aCPU_POLICY_TYPE=('fifo' 'rr' 'other' 'batch' 'idle')
+		aCPU_POLICY_DESC=('First In, First Out (Real-time, time-critical)' 'Round Robin (Real-time, time-critical)' 'Normal (Default)' 'Batch style execution' 'Background Jobs (Very low priority)')
 
 		# https://manpages.debian.org/stretch/util-linux/ionice.1.en.html
-		aIO_SCHEDULE_POLICY_TYPE=('best-effort' 'realtime' 'idle')
-		aIO_SCHEDULE_POLICY_DESC=('Normal (Default)' 'Time-critical (Highest priority)' 'Background Jobs (Very low priority)')
+		aIO_CLASS_TYPE=('realtime' 'best-effort' 'idle')
+		aIO_CLASS_DESC=('Time-critical (Highest priority)' 'Normal (Default)' 'Background Jobs (Very low priority)')
 
 		for i in ${!aSERVICE_NAME[@]}
 		do
@@ -654,7 +654,7 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 	# Menu System
 	#/////////////////////////////////////////////////////////////////////////////////////
 	MENU_TARGETID=0
-	MENU_SELECTED_SERVICE_INDEX=-1
+	MENU_SERVICE_INDEX=-1
 	MENU_LAST_SELECTED_MAIN='' # Main menu
 	MENU_LAST_SELECTED_SUB_0='' # Sub menus, level 0
 
@@ -663,23 +663,29 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 		G_WHIP_SIZE_X_MAX=50
 		if G_WHIP_YESNO "Exit $G_PROGRAM_NAME?"; then
 
+			# Reload systemd, if required
+			(( $SYSTEMD_RELOAD_REQUIRED )) && G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD systemctl daemon-reload
+
 			# Prompt to restart changed services
 			local service_restart_list_menu service_restart_list_systemd i
 			for i in ${!aSERVICE_RESTART_REQUIRED[@]}
 			do
 
-				service_restart_list_menu+="\n - ${aSERVICE_NAME[$i]}: Nice=${aCPU_NICE[$i]:-0} | Affinity=${aCPU_AFFINITY[$i]:-0-$(( $G_HW_CPU_CORES - 1 ))} | CPU Scheduling Policy=${aCPU_SCHEDULE_POLICY[$i]:-other} | CPU Scheduling Priority=${aCPU_SCHEDULE_PRIORITY[$i]:-0} | IO Scheduling Policy=${aIO_SCHEDULE_POLICY[$i]:-best-effort} | IO Scheduling Priority=${aIO_PRIORITY[$i]:-$(( ( ${aCPU_NICE[$i]:-0} + 20 ) / 5 ))}"
+				service_restart_list_menu+="\n - ${aSERVICE_NAME[$i]}: "
+				[[ ${aCPU_AFFINITY[$i]} ]] && service_restart_list_menu+="Affinity=${aCPU_AFFINITY[$i]} | "
+				[[ ${aCPU_POLICY[$i]} ]] && service_restart_list_menu+="CPU Scheduling Policy=${aCPU_POLICY[$i]} | "
+				[[ ${aCPU_NICE[$i]} ]] && service_restart_list_menu+="Nice=${aCPU_NICE[$i]} | "
+				[[ ${aCPU_PRIORITY[$i]} ]] && service_restart_list_menu+="CPU Scheduling Priority=${aCPU_PRIORITY[$i]} | "
+				[[ ${aIO_CLASS[$i]} ]] && service_restart_list_menu+="I/O Scheduling Class=${aIO_CLASS[$i]} | "
+				[[ ${aIO_PRIORITY[$i]} ]] && service_restart_list_menu+="I/O Scheduling Priority=${aIO_PRIORITY[$i]} | "
 				service_restart_list_systemd+="${aSERVICE_NAME[$i]} "
 
 			done
 
-			if [[ $service_restart_list_systemd ]]; then
+			if [[ $service_restart_list_systemd ]] &&
+				G_WHIP_YESNO "[ INFO ] The following services require a restart, in order to apply your chosen settings:${service_restart_list_menu%[|:] }\n\nDo you wish to restart the above services now?"; then
 
-				if G_WHIP_YESNO "[ INFO ] The following services require a restart, in order to apply your recently modified settings: $service_restart_list_menu\n\nDo you wish to continue, and, restart the above services now?"; then
-
-					G_RUN_CMD systemctl restart $service_restart_list_systemd
-
-				fi
+				G_RUN_CMD systemctl restart $service_restart_list_systemd
 
 			fi
 
@@ -696,17 +702,23 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 	# MENU_TARGETID=0
 	Menu_Main(){
 
+		local i
+
 		G_WHIP_MENU_ARRAY=('' '●─ Single Service Options ')
 		for i in ${!aSERVICE_NAME[@]}
 		do
 
-			G_WHIP_MENU_ARRAY+=("${aSERVICE_NAME[$i]}" ": $(systemctl is-active "${aSERVICE_NAME[$i]}") | Nice ${aCPU_NICE[$i]:-0} | Affinity ${aCPU_AFFINITY[$i]:-0-$(( $G_HW_CPU_CORES - 1 ))}")
+			G_WHIP_MENU_ARRAY+=("${aSERVICE_NAME[$i]}" ": $(systemctl is-active "${aSERVICE_NAME[$i]}") | Affinity ${aCPU_AFFINITY[$i]:-0-$(( $G_HW_CPU_CORES - 1 ))}")
 
 		done
+		G_WHIP_MENU_ARRAY+=(
 
-		G_WHIP_MENU_ARRAY+=('' '●─ Global Service Options ')
-		G_WHIP_MENU_ARRAY+=('Stop' ': Stop ALL services')
-		G_WHIP_MENU_ARRAY+=('Restart' ': Start/restart ALL services')
+			'Add' ': Add missing service to DietPi-Services'
+			'' '●─ Global Service Options '
+			'Stop' ': Stop ALL above services'
+			'Restart' ': Start/restart ALL above services'
+
+		)
 
 		G_WHIP_DEFAULT_ITEM=$MENU_LAST_SELECTED_MAIN
 		G_WHIP_BUTTON_CANCEL_TEXT='Exit'
@@ -714,8 +726,55 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 
 			MENU_LAST_SELECTED_MAIN=$G_WHIP_RETURNED_VALUE
 
-			if [[ $G_WHIP_RETURNED_VALUE == 'Restart' || $G_WHIP_RETURNED_VALUE == 'Stop' ]]; then
+			if [[ $G_WHIP_RETURNED_VALUE == 'Add' ]]; then
 
+				local not_found
+				local new_index=${#aSERVICE_MODE[$i]}
+				while G_WHIP_INPUTBOX "${not_found}Please add the name of the service to be added, without the \".service\" file ending:"
+				do
+
+					if [[ $G_WHIP_RETURNED_VALUE ]]; then
+
+						# - Check for known services
+						for i in "${aSERVICE_NAME[@]}"
+						do
+
+							if [[ $G_WHIP_RETURNED_VALUE == "$i" ]]; then
+
+								not_found="[FAILED] The service name you entered ($G_WHIP_RETURNED_VALUE) is already handled by DietPi-Service. Please retry or cancel.\n\n"
+								continue 2
+
+							fi
+
+						done
+
+						for i in /{etc,lib}/systemd/system/"$G_WHIP_RETURNED_VALUE.service" /etc/init.d/"$G_WHIP_RETURNED_VALUE"
+						do
+
+							if [[ -f $i ]]; then
+
+								aSERVICE_NAME[$new_index]=$G_WHIP_RETURNED_VALUE
+								aFP_SERVICE[$new_index]=$i
+								aSERVICE_MODE[$new_index]=$(systemctl is-enabled "$G_WHIP_RETURNED_VALUE" 2> /dev/null)
+								Load_Process_Tool $new_index
+								G_CONFIG_INJECT "+ ${aSERVICE_NAME[$new_index]}" "+ ${aSERVICE_NAME[$new_index]}" $FP_INCLUDE_EXCLUDE
+								break
+
+							fi
+
+						done
+
+					fi
+
+					[[ ${aSERVICE_NAME[$new_index]} ]] && break
+
+					not_found="FAILED] Could not find a service file that matches your input ($G_WHIP_RETURNED_VALUE). Please retry or cancel.\n\n"
+
+				done
+
+			elif [[ $G_WHIP_RETURNED_VALUE == 'Restart' || $G_WHIP_RETURNED_VALUE == 'Stop' ]]; then
+
+				(( $SYSTEMD_RELOAD_REQUIRED )) && G_RUN_CMD systemctl daemon-reload && SYSTEMD_RELOAD_REQUIRED=0
 				Set_Running_State $G_WHIP_RETURNED_VALUE
 				aSERVICE_RESTART_REQUIRED=()
 				sleep 0.5
@@ -723,19 +782,19 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 			elif [[ $G_WHIP_RETURNED_VALUE ]]; then
 
 				# Find selected program index
-				MENU_SELECTED_SERVICE_INDEX=-1
+				MENU_SERVICE_INDEX=-1
 				for i in ${!aSERVICE_NAME[@]}
 				do
 
 					if [[ ${aSERVICE_NAME[$i]} == "$G_WHIP_RETURNED_VALUE" ]]; then
 
-						MENU_SELECTED_SERVICE_INDEX=$i
+						MENU_SERVICE_INDEX=$i
 						break
 
 					fi
 
 				done
-				(( $MENU_SELECTED_SERVICE_INDEX >= 0 )) && MENU_TARGETID=1
+				(( $MENU_SERVICE_INDEX >= 0 )) && MENU_TARGETID=1
 
 			fi
 
@@ -750,8 +809,8 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 	# MENU_TARGETID=1
 	Menu_Service(){
 
-		local service_state=$(systemctl is-active "${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}" 2> /dev/null)
-		local service_mode_print=${aSERVICE_MODE[$MENU_SELECTED_SERVICE_INDEX]}
+		local service_state=$(systemctl is-active "${aSERVICE_NAME[$MENU_SERVICE_INDEX]}" 2> /dev/null)
+		local service_mode_print=${aSERVICE_MODE[$MENU_SERVICE_INDEX]}
 		if [[ $service_mode_print == 'disabled' ]]; then
 
 			service_mode_print='DietPi controlled'
@@ -761,12 +820,16 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 			service_mode_print='Systemd controlled'
 
 		fi
-		local cpu_nice=${aCPU_NICE[$MENU_SELECTED_SERVICE_INDEX]:-0}
-		local cpu_affinity=${aCPU_AFFINITY[$MENU_SELECTED_SERVICE_INDEX]:-0-$(( $G_HW_CPU_CORES - 1 ))}
-		local cpu_policy=${aCPU_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]:-other}
-		local cpu_priority=${aCPU_SCHEDULE_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]:-0}
-		local io_policy=${aIO_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]:-best-effort}
-		local io_priority=${aIO_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]:-$(( ( $cpu_nice + 20 ) / 5 ))}
+		local service_exclusion='included'
+		[[ ${aSERVICE_EXCLUDED[MENU_SERVICE_INDEX]} == 1 ]] && service_exclusion='excluded'
+		local cpu_affinity=${aCPU_AFFINITY[$MENU_SERVICE_INDEX]:-0-$(( $G_HW_CPU_CORES - 1 ))}
+		local cpu_policy=${aCPU_POLICY[$MENU_SERVICE_INDEX]:-other}
+		local cpu_nice=${aCPU_NICE[$MENU_SERVICE_INDEX]:-0}
+		local cpu_priority=${aCPU_PRIORITY[$MENU_SERVICE_INDEX]:-1}
+		local io_class=${aIO_CLASS[$MENU_SERVICE_INDEX]:-best-effort}
+		local io_priority_default=0
+		[[ $io_class == 'best-effort' ]] && io_priority_default=$(( ( $cpu_nice + 20 ) / 5 ))
+		local io_priority=${aIO_PRIORITY[$MENU_SERVICE_INDEX]:-$io_priority_default}
 
 		G_WHIP_DEFAULT_ITEM=$MENU_LAST_SELECTED_SUB_0
 		G_WHIP_BUTTON_CANCEL_TEXT='Back'
@@ -775,6 +838,7 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 			'' '●─ Service Control '
 			'State' ": [$service_state]"
 			'Mode' ": [$service_mode_print]"
+			'Include/Exclude' ": [$service_exclusion]"
 			'Status' ': Display systemd status log'
 
 		)
@@ -782,21 +846,30 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 
 			G_WHIP_MENU_ARRAY+=(
 
-				'Edit' ": [${aFP_SERVICE[$MENU_SELECTED_SERVICE_INDEX]}]"
+				'Edit' ": [${aFP_SERVICE[$MENU_SERVICE_INDEX]}]"
 				'' '●─ Process Tool '
-				'CPU Nice' ": [$cpu_nice]"
 				'CPU Affinity' ": [$cpu_affinity]"
-				'CPU Schedule Policy' ": [$cpu_policy]"
-				'CPU Schedule Priority' ": [$cpu_priority]"
-				'IO Scheduling Policy' ": [$io_policy]"
+				'CPU Scheduling Policy' ": [$cpu_policy]"
 
 			)
-			[[ $io_policy != 'idle' ]] && G_WHIP_MENU_ARRAY+=('IO Scheduling Priority' ": [$io_priority]")
+			# Real-time CPU schedulers use CPU priority while "other" and "batch" use nice and "idle" none of them: https://manpages.debian.org/stretch/manpages/sched.7.en.html
+			if [[ $cpu_policy == 'other' || $cpu_policy == 'batch' ]]; then
+
+				G_WHIP_MENU_ARRAY+=('CPU Nice' ": [$cpu_nice]")
+
+			elif [[ $cpu_policy == 'fifo' || $cpu_policy == 'rr' ]]; then
+
+				G_WHIP_MENU_ARRAY+=('CPU Scheduling Priority' ": [$cpu_priority]")
+
+			fi
+			G_WHIP_MENU_ARRAY+=('I/O Scheduling Class' ": [$io_class]")
+			# idle IO scheduler does not use IO priority: https://manpages.debian.org/stretch/util-linux/ionice.1.en.html
+			[[ $io_class != 'idle' ]] && G_WHIP_MENU_ARRAY+=('I/O Scheduling Priority' ": [$io_priority]")
 			G_WHIP_MENU_ARRAY+=(
 
 				'' '●─ Presets '
-				'Reset' ': Resets all CPU/IO settings to default'
-				'Highest Priority' ': Highest priority for critical CPU/IO preset'
+				'Reset' ': Resets all CPU/IO settings to system defaults'
+				'Highest Priority' ': Highest priority realtime CPU/IO preset'
 				'High Priority' ': High priority CPU/IO preset'
 				'Low Priority' ': Low priority CPU/IO preset'
 				'Lowest Priority' ': Lowest priority background CPU/IO preset'
@@ -805,71 +878,21 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 
 		fi
 
-		if G_WHIP_MENU "Please select an option for ${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}:"; then
+		if G_WHIP_MENU "Please select an option for ${aSERVICE_NAME[$MENU_SERVICE_INDEX]}:"; then
 
 			MENU_LAST_SELECTED_SUB_0=$G_WHIP_RETURNED_VALUE
 
 			case "$G_WHIP_RETURNED_VALUE" in
 
-				'Status')
+				'State')
 
-					systemctl -l --no-pager status "${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}" &> systemctl.log
-					log=0 G_WHIP_VIEWFILE systemctl.log
-					rm systemctl.log
+					local command='restart'
+					[[ ${service_state,,} == 'active' ]] && command='stop'
 
-				;;
-
-				'Low Priority')
-
-					aCPU_NICE[$MENU_SELECTED_SERVICE_INDEX]=10
-					#aCPU_AFFINITY[$MENU_SELECTED_SERVICE_INDEX]=
-					unset aCPU_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]
-					unset aCPU_SCHEDULE_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]
-					unset aIO_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]
-					aIO_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]=7
-					Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX
-
-				;;
-
-				'Lowest Priority')
-
-					aCPU_NICE[$MENU_SELECTED_SERVICE_INDEX]=19
-					#aCPU_AFFINITY[$MENU_SELECTED_SERVICE_INDEX]=
-					aCPU_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]='idle'
-					unset aCPU_SCHEDULE_PRIORITY[$MENU_SELECTED_SERVICE_INDEX] # Has no effect in idle
-					aIO_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]='idle'
-					unset aIO_PRIORITY[$MENU_SELECTED_SERVICE_INDEX] # Has no effect in idle
-					Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX
-
-				;;
-
-				'High Priority')
-
-					aCPU_NICE[$MENU_SELECTED_SERVICE_INDEX]=-10
-					#aCPU_AFFINITY[$MENU_SELECTED_SERVICE_INDEX]=
-					unset aCPU_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]
-					aCPU_SCHEDULE_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]=10
-					unset aIO_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]
-					aIO_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]=0
-					Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX
-
-				;;
-
-				'Highest Priority')
-
-					aCPU_NICE[$MENU_SELECTED_SERVICE_INDEX]=-20
-					#aCPU_AFFINITY[$MENU_SELECTED_SERVICE_INDEX]=
-					aCPU_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]='fifo'
-					aCPU_SCHEDULE_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]=50
-					aIO_SCHEDULE_POLICY[$MENU_SELECTED_SERVICE_INDEX]='realtime'
-					aIO_PRIORITY[$MENU_SELECTED_SERVICE_INDEX]=0
-					Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX
-
-				;;
-
-				'Reset')
-
-					Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX reset
+					(( $SYSTEMD_RELOAD_REQUIRED )) && G_RUN_CMD systemctl daemon-reload && SYSTEMD_RELOAD_REQUIRED=0
+					Set_Running_State $command $MENU_SERVICE_INDEX
+					unset aSERVICE_RESTART_REQUIRED[$MENU_SERVICE_INDEX]
+					sleep 0.5
 
 				;;
 
@@ -877,107 +900,132 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 
 					G_WHIP_MENU_ARRAY=(
 
-						'DietPi controlled' ': Recommended (DietPi controls service order)'
-						'Systemd controlled' ': Systemd controls service order'
+						'DietPi controlled' ': DietPi controls start on boot (Recommended)'
+						'Systemd controlled' ': Systemd controls start on boot'
 						'mask'	': Hide service from system and prevent use'
 						'unmask' ': Un-hide service from system and allow use'
 
 					)
 					G_WHIP_DEFAULT_ITEM='DietPi controlled'
-					if G_WHIP_MENU "Please select the desired Service Mode for :\n${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"; then
+					if G_WHIP_MENU "Please select the desired Service Mode for: ${aSERVICE_NAME[$MENU_SERVICE_INDEX]}"; then
 
 						local command=$G_WHIP_RETURNED_VALUE
 						# Unmask services before enable/disable
-						[[ $command == *'controlled' ]] && Apply_Service_State unmask $MENU_SELECTED_SERVICE_INDEX
-						Apply_Service_State ${command/ /_} $MENU_SELECTED_SERVICE_INDEX
+						[[ $command == *'controlled' ]] && Apply_Service_State unmask $MENU_SERVICE_INDEX
+						Apply_Service_State ${command/ /_} $MENU_SERVICE_INDEX
 						# Re-estimate service mode
-						aSERVICE_MODE[$MENU_SELECTED_SERVICE_INDEX]=$(systemctl is-enabled "${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}" 2> /dev/null)
+						aSERVICE_MODE[$MENU_SERVICE_INDEX]=$(systemctl is-enabled "${aSERVICE_NAME[$MENU_SERVICE_INDEX]}" 2> /dev/null)
 
 					fi
 
 				;;
 
-				'IO Scheduling Policy')
+				'Include/Exclude')
 
-					G_WHIP_MENU_ARRAY=('Reset' ': Reset IO Scheduling Policy to system defaults')
-					for i in ${!aIO_SCHEDULE_POLICY_TYPE[@]}
-					do
+					G_WHIP_MENU_ARRAY=('Include' 'Exclude')
+					G_WHIP_DEFAULT_ITEM='Include'
+					if G_WHIP_MENU "Please choose whether to include or exclude ${aSERVICE_NAME[$MENU_SERVICE_INDEX]} from automated DietPi-Service control:"; then
 
-						G_WHIP_MENU_ARRAY+=("${aIO_SCHEDULE_POLICY_TYPE[$i]}" ": ${aIO_SCHEDULE_POLICY_DESC[$i]}" )
+						if [[ $G_WHIP_RETURNED_VALUE == 'Include' ]]; then
 
-					done
+							# If service is listed here, it was excluded via include/exclude file.
+							sed -i "/^- ${aSERVICE_NAME[$MENU_SERVICE_INDEX]}/d" $FP_INCLUDE_EXCLUDE
 
-					G_WHIP_DEFAULT_ITEM=$io_policy
-					if G_WHIP_MENU "Please select the desired IO Scheduling Class for: ${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"; then
+						else
 
-						Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX 4 $G_WHIP_RETURNED_VALUE
+							# Remove include entry, if existent, else add exclude entry.
+							if grep -q "^+ ${aSERVICE_NAME[$MENU_SERVICE_INDEX]}" $FP_INCLUDE_EXCLUDE; then
 
-					fi
+								sed -i "/^+ ${aSERVICE_NAME[$MENU_SERVICE_INDEX]}/d" $FP_INCLUDE_EXCLUDE
 
-				;;
+							else
 
-				'IO Scheduling Priority')
+								G_CONFIG_INJECT "- ${aSERVICE_NAME[$MENU_SERVICE_INDEX]}" "- ${aSERVICE_NAME[$MENU_SERVICE_INDEX]}" $FP_INCLUDE_EXCLUDE
 
-					local desc
+							fi
 
-					G_WHIP_MENU_ARRAY=('Reset' ' Reset IO Scheduling Priority to system defaults')
-					for i in {0..7}
-					do
-						desc=''
-						if (( $i == ( $cpu_nice + 20 ) / 5 )); then
-
-							desc='(Default priority, based on your Nice level)'
-
-						elif (( $i == 0 )); then
-
-							desc='(Highest priority)'
-
-						elif (( $i == 7 )); then
-
-							desc='(Lowest priority)'
+							unset aSERVICE_NAME[$MENU_SERVICE_INDEX]}
 
 						fi
 
-						G_WHIP_MENU_ARRAY+=("IO Priority : $i" " $desc")
-
-					done
-
-					G_WHIP_DEFAULT_ITEM="IO Priority : $io_priority"
-					if G_WHIP_MENU "Please select the desired IO Scheduling Priority level for: ${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"; then
-
-						Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX 5 ${G_WHIP_RETURNED_VALUE##*: } # Convert back to int
-
 					fi
+
+				;;
+
+				'Status')
+
+					systemctl -l --no-pager status "${aSERVICE_NAME[$MENU_SERVICE_INDEX]}" &> systemctl.log
+					log=0 G_WHIP_VIEWFILE systemctl.log
+					rm systemctl.log
 
 				;;
 
 				'Edit')
 
-					local fp="/etc/systemd/system/${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}.service.d/dietpi-services_edit.conf"
+					local fp="/etc/systemd/system/${aSERVICE_NAME[$MENU_SERVICE_INDEX]}.service.d/dietpi-services_edit.conf"
 
-					Prepare_Service_Dropin $MENU_SELECTED_SERVICE_INDEX
+					Prepare_Service_Dropin $MENU_SERVICE_INDEX
 					if [[ ! -f $fp ]]; then
 
-						cp -a "${aFP_SERVICE[$MENU_SELECTED_SERVICE_INDEX]}" "$fp"
+						cp -a "${aFP_SERVICE[$MENU_SERVICE_INDEX]}" "$fp"
 						sed -Ei 's/^([^[#])/#\1/' "$fp"
 						G_WHIP_MSG "[ INFO ] To allow safe service editing, we created a drop-in config with commented original service file content.\n
 Please uncomment and edit only the lines that you need to change.\n\nTo undo changes, remove the drop-in, reload and restart the service:
- - rm $fp\n - systemctl daemon-reload\n - systemctl restart ${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"
+ - rm $fp\n - systemctl daemon-reload\n - systemctl restart ${aSERVICE_NAME[$MENU_SERVICE_INDEX]}"
 
 					fi
 					nano "$fp"
-					G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD systemctl daemon-reload
+					SYSTEMD_RELOAD_REQUIRED=1
 
 				;;
 
-				'State')
+				'CPU Affinity')
 
-					local command='restart'
-					[[ ${service_state,,} == 'active' ]] && command='stop'
+					# ToDo: Preset selection based on current affinity
+					G_WHIP_CHECKLIST_ARRAY=()
+					for ((i=0; i<$G_HW_CPU_CORES; i++))
+					do
 
-					Set_Running_State $command $MENU_SELECTED_SERVICE_INDEX
-					unset aSERVICE_RESTART_REQUIRED[$MENU_SELECTED_SERVICE_INDEX]
-					sleep 0.5
+						G_WHIP_CHECKLIST_ARRAY+=($i 'CPU                           ' 'on')
+
+					done
+
+					if G_WHIP_CHECKLIST "Please select the desired CPU Affinity for: ${aSERVICE_NAME[$MENU_SERVICE_INDEX]}\n
+ - Use the spacebar to enable/disable access to specific cores, for this program.\n - The default value is to enable all items.\n - De-select all items to reset to system defaults."; then
+
+						local new_affinity=''
+						for i in ${G_WHIP_RETURNED_VALUE[@]}
+						do
+
+							# taskset requires comma-seperated CPU indices
+							[[ $new_affinity ]] && new_affinity+=",$i" || new_affinity=$i
+
+						done
+
+						# Update affinity array with new value, if at least 1 item was selected, otherwise reset
+						Apply_Process_Tool $MENU_SERVICE_INDEX 0 ${new_affinity:-reset}
+
+					fi
+
+				;;
+
+				'CPU Scheduling Policy')
+
+					G_WHIP_MENU_ARRAY=('Reset' ': Reset CPU Scheduling Policy to system defaults')
+					for i in ${!aCPU_POLICY_TYPE[@]}
+					do
+
+						G_WHIP_MENU_ARRAY+=("${aCPU_POLICY_TYPE[$i]}" ": ${aCPU_POLICY_DESC[$i]}" )
+
+					done
+
+					G_WHIP_DEFAULT_ITEM=$cpu_policy
+					if G_WHIP_MENU "Please select the desired CPU Scheduling Policy for: ${aSERVICE_NAME[$MENU_SERVICE_INDEX]}\n\nRead about CPU scheduling:
+ - https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/performance_tuning_guide/s-cpu-scheduler"; then
+
+						Apply_Process_Tool $MENU_SERVICE_INDEX 1 $G_WHIP_RETURNED_VALUE
+
+					fi
 
 				;;
 
@@ -1025,69 +1073,19 @@ Please uncomment and edit only the lines that you need to change.\n\nTo undo cha
 					done
 
 					G_WHIP_DEFAULT_ITEM="Nice : $cpu_nice"
-					if G_WHIP_MENU "Please select the desired Nice level for: ${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}\n
+					if G_WHIP_MENU "Please select the desired Nice level for: ${aSERVICE_NAME[$MENU_SERVICE_INDEX]}\n
 Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values have a lower priority (eg: 15).\n - The default value is 0."; then
 
-						Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX 0 ${G_WHIP_RETURNED_VALUE##*: } # Convert back to int
+						Apply_Process_Tool $MENU_SERVICE_INDEX 2 ${G_WHIP_RETURNED_VALUE##*: } # Convert back to int
 
 					fi
 
 				;;
 
-				'CPU Affinity')
-
-					# Get existing affinity
-					# NB: currently enables all
-					G_WHIP_CHECKLIST_ARRAY=()
-					for ((i=0; i<$G_HW_CPU_CORES; i++))
-					do
-
-						G_WHIP_CHECKLIST_ARRAY+=($i 'CPU                           ' 'on')
-
-					done
-
-					if G_WHIP_CHECKLIST "Please select the desired CPU Affinity for: ${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}\n
- - Use the spacebar to enable/disable access to specific cores, for this program.\n - The default value is to enable all items.\n - De-select all items to reset to system defaults."; then
-
-						local new_affinity=''
-						for i in ${G_WHIP_RETURNED_VALUE[@]}
-						do
-
-							# taskset requires comma-seperated CPU indices
-							[[ $new_affinity ]] && new_affinity+=",$i" || new_affinity=$i
-
-						done
-
-						# Update affinity array with new value, if at least 1 item was selected, otherwise reset
-						Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX 1 ${new_affinity:-reset}
-
-					fi
-
-				;;
-
-				'CPU Schedule Policy')
-
-					G_WHIP_MENU_ARRAY=('Reset' ': Reset CPU Schedule Policy to system defaults')
-					for i in ${!aCPU_SCHEDULE_POLICY_TYPE[@]}
-					do
-
-						G_WHIP_MENU_ARRAY+=("${aCPU_SCHEDULE_POLICY_TYPE[$i]}" ": ${aCPU_SCHEDULE_POLICY_DESC[$i]}" )
-
-					done
-
-					G_WHIP_DEFAULT_ITEM=$cpu_policy
-					if G_WHIP_MENU "Please select the desired CPU Scheduling Policy for: ${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}"; then
-
-						Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX 2 $G_WHIP_RETURNED_VALUE
-
-					fi
-
-				;;
-
-				'CPU Schedule Priority')
+				'CPU Scheduling Priority')
 
 					# - 7 step description scale
-					local scale_value_lowest=0
+					local scale_value_lowest=1
 					local scale_value_highest=99
 					local scale_value_lower=$(( $scale_value_highest / 6 ))
 					local scale_value_low=$(( $scale_value_highest / 6 * 2 ))
@@ -1096,7 +1094,7 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 					local scale_value_higher=$(( $scale_value_highest / 6 * 5 ))
 					local desc
 
-					G_WHIP_MENU_ARRAY=('Reset' ': Reset CPU Schedule Priority to system defaults')
+					G_WHIP_MENU_ARRAY=('Reset' ': Reset CPU Scheduling Priority to system defaults')
 					for ((i=$scale_value_highest; i>=$scale_value_lowest; i--))
 					do
 
@@ -1136,12 +1134,108 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 					done
 
 					G_WHIP_DEFAULT_ITEM=$cpu_priority
-					if G_WHIP_MENU "Please select the desired CPU Scheduling Priority level for: ${aSERVICE_NAME[$MENU_SELECTED_SERVICE_INDEX]}\n
+					if G_WHIP_MENU "Please select the desired CPU Scheduling Priority level for: ${aSERVICE_NAME[$MENU_SERVICE_INDEX]}\n
  - Lower values are low priority\n - Higher values are high priority"; then
 
-						Apply_Process_Tool $MENU_SELECTED_SERVICE_INDEX 3 $G_WHIP_RETURNED_VALUE
+						Apply_Process_Tool $MENU_SERVICE_INDEX 3 $G_WHIP_RETURNED_VALUE
 
 					fi
+
+				;;
+
+				'I/O Scheduling Class')
+
+					G_WHIP_MENU_ARRAY=('Reset' ': Reset I/O Scheduling Class to system defaults')
+					for i in ${!aIO_CLASS_TYPE[@]}
+					do
+
+						G_WHIP_MENU_ARRAY+=("${aIO_CLASS_TYPE[$i]}" ": ${aIO_CLASS_DESC[$i]}" )
+
+					done
+
+					G_WHIP_DEFAULT_ITEM=$io_class
+					if G_WHIP_MENU "Please select the desired I/O Scheduling Class for: ${aSERVICE_NAME[$MENU_SERVICE_INDEX]}\n
+NB: This only has an effect on drives handled by the CFQ scheduler.\nRead about I/O scheduling:
+ - https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/performance_tuning_guide/ch06s04"; then
+
+						Apply_Process_Tool $MENU_SERVICE_INDEX 4 $G_WHIP_RETURNED_VALUE
+
+					fi
+
+				;;
+
+				'I/O Scheduling Priority')
+
+					local desc
+
+					G_WHIP_MENU_ARRAY=('Reset' ': Reset I/O Scheduling Priority to system defaults')
+					for i in {0..7}
+					do
+						desc=''
+						if (( $i == $io_priority_default )); then
+
+							desc=': (Default, based on I/O Scheduling Class and Nice level)'
+
+						elif (( $i == 0 )); then
+
+							desc=': (Highest priority)'
+
+						elif (( $i == 7 )); then
+
+							desc=': (Lowest priority)'
+
+						fi
+
+						G_WHIP_MENU_ARRAY+=($i ": $desc")
+
+					done
+
+					G_WHIP_DEFAULT_ITEM=$io_priority
+					if G_WHIP_MENU "Please select the desired I/O Scheduling Priority level for: ${aSERVICE_NAME[$MENU_SERVICE_INDEX]}\n
+NB: This only has an effect on drives handled by the CFQ scheduler."; then
+
+						Apply_Process_Tool $MENU_SERVICE_INDEX 5 $G_WHIP_RETURNED_VALUE
+
+					fi
+
+				;;
+
+				'Reset')
+
+					Apply_Process_Tool $MENU_SERVICE_INDEX reset
+
+				;;
+
+				'Highest Priority')
+
+					Apply_Process_Tool $MENU_SERVICE_INDEX 1 fifo
+					Apply_Process_Tool $MENU_SERVICE_INDEX 3 50
+					Apply_Process_Tool $MENU_SERVICE_INDEX 4 realtime
+
+				;;
+
+				'High Priority')
+
+					Apply_Process_Tool $MENU_SERVICE_INDEX 1 reset
+					Apply_Process_Tool $MENU_SERVICE_INDEX 2 -10
+					Apply_Process_Tool $MENU_SERVICE_INDEX 4 reset
+					Apply_Process_Tool $MENU_SERVICE_INDEX 5 0
+
+				;;
+
+				'Low Priority')
+
+					Apply_Process_Tool $MENU_SERVICE_INDEX 1 reset
+					Apply_Process_Tool $MENU_SERVICE_INDEX 2 10
+					Apply_Process_Tool $MENU_SERVICE_INDEX 4 reset
+					Apply_Process_Tool $MENU_SERVICE_INDEX 5 7
+
+				;;
+
+				'Lowest Priority')
+
+					Apply_Process_Tool $MENU_SERVICE_INDEX 1 idle
+					Apply_Process_Tool $MENU_SERVICE_INDEX 4 idle
 
 				;;
 

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -930,6 +930,7 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 
 							# If service is listed here, it was excluded via include/exclude file.
 							sed -i "/^- ${aSERVICE_NAME[$MENU_SERVICE_INDEX]}/d" $FP_INCLUDE_EXCLUDE
+							aSERVICE_EXCLUDED[MENU_SERVICE_INDEX]=0
 
 						else
 
@@ -937,14 +938,17 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 							if grep -q "^+ ${aSERVICE_NAME[$MENU_SERVICE_INDEX]}" $FP_INCLUDE_EXCLUDE; then
 
 								sed -i "/^+ ${aSERVICE_NAME[$MENU_SERVICE_INDEX]}/d" $FP_INCLUDE_EXCLUDE
+								unset aSERVICE_NAME[$MENU_SERVICE_INDEX]}
+								# - Service needs to be re-added from main menu
+								MENU_TARGETID=0 # Return to main menu
 
 							else
 
 								G_CONFIG_INJECT "- ${aSERVICE_NAME[$MENU_SERVICE_INDEX]}" "- ${aSERVICE_NAME[$MENU_SERVICE_INDEX]}" $FP_INCLUDE_EXCLUDE
+								# - Keep in menu like other excluded known services
+								aSERVICE_EXCLUDED[MENU_SERVICE_INDEX]=1
 
 							fi
-
-							unset aSERVICE_NAME[$MENU_SERVICE_INDEX]}
 
 						fi
 

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -12,20 +12,20 @@
 	#   started by /DietPi/dietpi/postboot at later boot stage.
 	#
 	USAGE='
-Usage: dietpi-services <command> [<service>]
+Usage: dietpi-services [<command>] [<service>]
 Available commands:
   <empty>		Interactive menu to apply service modes and settings
   status		Print service status info
   start			Start service
   stop			Stop service
   restart		Restart service
-  dietpi_controlled	Let service be started by DietPi on boot
-  systemd_controlled	Let service be started by systemd on boot
+  dietpi_controlled	Let DietPi control start on boot
+  systemd_controlled	Let systemd control start on boot
   enable, unmask	Enable service to allow its startup
-  disable, mask		Disable service to prevent its startup
+  disable, mask		Disable service to prevent its startup completely
 Available services:
-  <service_name>	Add any systemd or sysvinit service available on your system.
-  <empty>		Apply command to all services known to DietPi
+  <service_name>	Apply command to a single available systemd or sysvinit service
+  <empty>		Apply command to all available services known to DietPi
   			NB: Services required for network or shell session will be skipped.
 			NB: You can include/exclude services by editing the following file:
 			    - /DietPi/dietpi/.dietpi-services_include_exclude
@@ -331,6 +331,9 @@ _EOF_
 
 			[[ ${aSERVICE_NAME[$i]} ]] || { unset aSERVICE_NAME[$i]; continue; } # Failsafe
 
+			# Below Stretch, "mariadb" systemd service does not exist, thus "mysql" init.d service will be used.
+			(( $G_DISTRO < 4 )) && [[ ${aSERVICE_NAME[$i]} == 'mariadb' ]] && aSERVICE_NAME[$i]='mysql'
+
 			for j in /{etc,lib}/systemd/system/"${aSERVICE_NAME[$i]}.service" /etc/init.d/"${aSERVICE_NAME[$i]}"
 			do
 
@@ -401,7 +404,7 @@ _EOF_
 		for i in $services
 		do
 
-			[[ ${aSERVICE_MODE[$i]} == 'masked' ]] && continue
+			[[ ${aSERVICE_MODE[$i]} == 'masked' ]] && { G_DIETPI-NOTIFY 2 "skip : ${aSERVICE_NAME[$i]} (due to mask)"; continue; }
 			G_DIETPI-NOTIFY -2 "${aSERVICE_NAME[$i]}"
 			systemctl $command "${aSERVICE_NAME[$i]}" &> /dev/null
 			Print_Status $command "${aSERVICE_NAME[$i]}" $?
@@ -480,8 +483,9 @@ _EOF_
 			elif [[ $command == 'disable' || $command == 'mask' ]]; then
 
 				systemctl_cmd='mask'
-				# - Stop services before masking them
-				Set_Running_State stop $index
+				# - Disable and stop services before masking them
+				Apply_Service_State dietpi_controlled $services
+				Set_Running_State stop $services
 
 			else
 
@@ -495,7 +499,7 @@ _EOF_
 			do
 
 				# - Skip masked services, if not to be unmasked
-				[[ ${aSERVICE_MODE[$i]} == 'masked' && $systemctl_cmd != 'unmask' ]] && continue
+				[[ ${aSERVICE_MODE[$i]} == 'masked' && $systemctl_cmd != 'unmask' ]] && { G_DIETPI-NOTIFY 2 "skip : ${aSERVICE_NAME[$i]} (due to mask)"; continue; }
 				systemctl $systemctl_cmd "${aSERVICE_NAME[$i]}" &> /dev/null
 				Print_Status $command "${aSERVICE_NAME[$i]}" $?
 
@@ -569,7 +573,7 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 		fi
 
 		# Reset all process tool settings
-		if [[ $setting == reset ]]; then
+		if [[ $setting == 'reset' ]]; then
 
 			for i in {0..5}; do unset ${aarray[$i]}[$index]; done
 			[[ -f $fp ]] && G_RUN_CMD rm "$fp"
@@ -621,8 +625,8 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 
 	Load_Process_Tool_Arrays(){
 
-		SYSTEMD_RELOAD_REQUIRED=0 # Set to 1 after systemd unit/drop-in changes
-		aSERVICE_RESTART_REQUIRED=() # Prompt to restart service on exit, when changes to unit file were done
+		SYSTEMD_RELOAD_REQUIRED=0 # Set to 1 after any systemd unit/drop-in changes, apply on exit or running state changes
+		aSERVICE_RESTART_REQUIRED=() # Set to 1 after single systemd unit/drop-in changes, ask to apply on exit
 
 		aCPU_NICE=()
 		aCPU_AFFINITY=()
@@ -772,7 +776,6 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 					fi
 
 					[[ ${aSERVICE_NAME[$new_index]} ]] && break
-
 					not_found="FAILED] Could not find a service file that matches your input ($G_WHIP_RETURNED_VALUE). Please retry or cancel.\n\n"
 
 				done
@@ -836,8 +839,6 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 		[[ $io_class == 'best-effort' ]] && io_priority_default=$(( ( $cpu_nice + 20 ) / 5 ))
 		local io_priority=${aIO_PRIORITY[$MENU_SERVICE_INDEX]:-$io_priority_default}
 
-		G_WHIP_DEFAULT_ITEM=$MENU_LAST_SELECTED_SUB_0
-		G_WHIP_BUTTON_CANCEL_TEXT='Back'
 		G_WHIP_MENU_ARRAY=(
 
 			'' '●─ Service Control '
@@ -883,6 +884,8 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 
 		fi
 
+		G_WHIP_DEFAULT_ITEM=$MENU_LAST_SELECTED_SUB_0
+		G_WHIP_BUTTON_CANCEL_TEXT='Back'
 		if G_WHIP_MENU "Please select an option for ${aSERVICE_NAME[$MENU_SERVICE_INDEX]}:"; then
 
 			MENU_LAST_SELECTED_SUB_0=$G_WHIP_RETURNED_VALUE
@@ -911,6 +914,7 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 						'unmask' ': Un-hide service from system and allow use'
 
 					)
+
 					G_WHIP_DEFAULT_ITEM='DietPi controlled'
 					if G_WHIP_MENU "Please select the desired Service Mode for: ${aSERVICE_NAME[$MENU_SERVICE_INDEX]}"; then
 
@@ -933,9 +937,10 @@ If you experience any issues with the wrapper, remove the file, reload and resta
 						'Exclude' ': Deny DietPi auto-control'
 
 					)
+
 					G_WHIP_DEFAULT_ITEM='Include'
 					if G_WHIP_MENU "Please choose whether to include or exclude ${aSERVICE_NAME[$MENU_SERVICE_INDEX]} from automated DietPi-Services control.
-This affects e.g. auto-stop/start during DietPi-Software installs, DietPi-Update, DietPi-Backup and similar maintenance tasks."; then
+This affects starts/stops/restarts during DietPi-Software installs, DietPi-Update, DietPi-Backup and similar maintenance tasks."; then
 
 						if [[ $G_WHIP_RETURNED_VALUE == 'Include' ]]; then
 
@@ -1267,7 +1272,6 @@ NB: This only has an effect on drives handled by the CFQ scheduler."; then
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Main
 	#/////////////////////////////////////////////////////////////////////////////////////
-	# Load array of available/chosen services
 	Load_Service_Array
 	#-----------------------------------------------------------------------------------
 	# Direct service control

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -979,14 +979,14 @@ This affects e.g. auto-stop/start during DietPi-Software installs, DietPi-Update
 
 					local fp="/etc/systemd/system/${aSERVICE_NAME[$MENU_SERVICE_INDEX]}.service.d/dietpi-services_edit.conf"
 
-					Prepare_Service_Dropin $MENU_SERVICE_INDEX
 					if [[ ! -f $fp ]]; then
 
+						G_WHIP_YESNO "[ INFO ] To allow safe service editing, a drop-in config with commented original service file content will be created.\n
+Please uncomment and edit only the lines that you need to change.\n\nTo undo changes, remove the drop-in, reload and restart the service:
+ - rm $fp\n - systemctl daemon-reload\n - systemctl restart ${aSERVICE_NAME[$MENU_SERVICE_INDEX]}\n\nDo you want to continue?" || return
+						Prepare_Service_Dropin $MENU_SERVICE_INDEX
 						cp -a "${aFP_SERVICE[$MENU_SERVICE_INDEX]}" "$fp"
 						sed -Ei 's/^([^[#])/#\1/' "$fp"
-						G_WHIP_MSG "[ INFO ] To allow safe service editing, we created a drop-in config with commented original service file content.\n
-Please uncomment and edit only the lines that you need to change.\n\nTo undo changes, remove the drop-in, reload and restart the service:
- - rm $fp\n - systemctl daemon-reload\n - systemctl restart ${aSERVICE_NAME[$MENU_SERVICE_INDEX]}"
 
 					fi
 					nano "$fp"


### PR DESCRIPTION
**Status**: Testing/Review

**Commit list/description**:
+ DietPi-Services | Service control: Fix masked service handling: Detection via [[ -e ]] required. Skip when applying service states, besides with unmask or status command. Hide process tool settings if masked.
+ DietPi-Services | Process tool: Merge saving and resetting process tool into one function. Allow to apply single settings or all saved ones. Do not apply default values to config file if not explicitly set by user. Allow to reset individual values to system defaults.
+ DietPi-Services | Edit: Do not allow to edit service file directly, instead create a drop-in config with commented original file content. Allows user to un-comment and edit single required lines, while having overview over remaining file and allows easy reverting by commenting/removing changed lines or the whole drop-in file.
+ DietPi-Services | Fix masked service path identification; Service will be skipped if only the /dev/null symlink exists but no actual service file.
+ DietPi-Services | Show also excluded services in menu and allow to add/exclude/include services.
+ DietPi-Services | Show/hide/reset process tool settings and set defaults correctly, based on chosen scheduling policy/class.
+ DietPi-Services | Code reorder: Sort menu handlers in same order as entries
+ DietPi-Services | Minor coding and wording