### PR TITLE
DietPi-Software | FFmpeg: On RPi, install new package from archive.respberrypi.org

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ Changes / Improvements / Optimisations:
 - DietPi-Service 2.0 | Combines dietpi-process_tool into dietpi-services. Adds IO policies, single/global service control and much more: https://github.com/MichaIng/DietPi/pull/2786
 - DietPi-Process_tool | Has been replaced with DietPi-Services. Existing saved options will no longer be available, please use 'dietpi-services' to apply required process_tool options with the upgraded system.
 - DietPi-Software | Deluge: Lowered UMask (007 => 002) to allow read access from e.g. custom Samba shares without "dietpi" user. Many thanks to @radsb for reporting the limited access: https://dietpi.com/phpbb/viewtopic.php?f=11&t=5847
+- DietPi-Software | FFmpeg: On RPi, the new APT repo package will be installed, which now supports RPi hardware acceleration and is some subversion newer then the package hosted on dietpi.com: https://github.com/MichaIng/DietPi/issues/869#issuecomment-490047405
 
 Bug Fixes:
 - DietPi-Boot | Waiting for network timer now includes the start of 'ifup' for the device. This is to speed up boot time by threading the ifup command and allowing the wait timer to be more accurate.

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6695,21 +6695,7 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-
-			# RPi + OpenMAX HW Encoding: https://github.com/MichaIng/DietPi/issues/869
-			if (( $G_HW_MODEL < 10 )); then
-
-				Download_Install 'https://dietpi.com/downloads/binaries/rpi/ffmpeg_rpi.7z' ffmpeg_rpi
-
-				dpkg -i ffmpeg_rpi/*.deb
-				rm -R ffmpeg_rpi
-
-			# Everything else
-			else
-
-				G_AGI ffmpeg
-
-			fi
+			G_AGI ffmpeg
 
 		fi
 
@@ -14448,7 +14434,7 @@ _EOF_
 
 			Banner_Uninstalling
 			G_AGP ffmpeg
-			(( $G_HW_MODEL < 10 )) && apt-mark auto libx264 libmp3lame libfdk-aac
+			(( $G_HW_MODEL < 10 )) && apt-mark auto libx264 libmp3lame libfdk-aac # pre-v6.25
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -14434,7 +14434,6 @@ _EOF_
 
 			Banner_Uninstalling
 			G_AGP ffmpeg
-			(( $G_HW_MODEL < 10 )) && apt-mark auto libx264 libmp3lame libfdk-aac # pre-v6.25
 
 		fi
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1995,6 +1995,15 @@ opcache.max_accelerated_files=10000\nopcache.memory_consumption=128\nopcache.sav
 
 			fi
 			#-------------------------------------------------------------------------------
+			# FFmpeg on RPi: Failsafe reinstall new APT package and mark priorly required libraries as auto + autoremove
+			if (( $G_HW_MODEL < 10 )) && command -v ffmpeg &> /dev/null
+
+				[[ $(ffmpeg -version 2> /dev/null | sed -n '1{s/[^0-9]//g;p}') == 32* ]] && G_AGI --reinstall ffmpeg
+				apt-mark auto libx264 libmp3lame libfdk-aac
+				G_AGA
+
+			fi
+			#-------------------------------------------------------------------------------
 
 		fi
 


### PR DESCRIPTION
**Status**: Ready
- [x] Patch on DietPi-Update, if version 3.2.X was found (APT install not required, since it has been automatically done via APT upgrade, just mark libs as auto + autoremove)
- [x] Changelog
- [x] Wiki software list update

**Reference**: https://github.com/MichaIng/DietPi/issues/869#issuecomment-490047405

**Commit list/description**:
+ DietPi-Software | FFmpeg: On RPi, install new package from archive.respberrypi.org APT repo, which includes hardware acceleration and is some subversions newer then our own compiled package (on Buster even 4.X).
+ CHANGELOG | FFmpeg: On RPi, the new APT repo package will be installed
+ DietPi-Software | FFmpeg: Skip handling library marks on uninstall, these are marked on update to v6.25
+ DietPi-Patch | FFmpeg on RPi: Failsafe reinstall new APT package and mark priorly required libraries as auto + autoremove