### PR TITLE
Update gitea to 1.8.2

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6078,7 +6078,7 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://dl.gitea.io/gitea/1.8.2/gitea-1.8.2-'
+			INSTALL_URL_ADDRESS='https://dl.gitea.io/gitea/1.8/gitea-1.8-'
 
 			#armv6
 			if (( $G_HW_ARCH == 1 )); then

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6078,7 +6078,7 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://dl.gitea.io/gitea/1.7/gitea-1.7-'
+			INSTALL_URL_ADDRESS='https://dl.gitea.io/gitea/1.8.2/gitea-1.8.2-'
 
 			#armv6
 			if (( $G_HW_ARCH == 1 )); then


### PR DESCRIPTION
https://blog.gitea.io/2019/05/gitea-1.8.2-is-released/