### PR TITLE
DietPi-Software | myMPD: Install latest master + fixes

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,7 +7,8 @@ Changes / Improvements / Optimisations:
 - DietPi-Process_tool | Has been replaced with DietPi-Services. Existing saved options will no longer be available, please use 'dietpi-services' to apply required process_tool options with the upgraded system.
 - DietPi-Software | Deluge: Lowered UMask (007 => 002) to allow read access from e.g. custom Samba shares without "dietpi" user. Many thanks to @radsb for reporting the limited access: https://dietpi.com/phpbb/viewtopic.php?f=11&t=5847
 - DietPi-Software | FFmpeg: On RPi, the new APT repo package will be installed, which now supports RPi hardware acceleration and is some subversion newer then the package hosted on dietpi.com: https://github.com/MichaIng/DietPi/issues/869#issuecomment-490047405
-- DietPi-Software | Gitea: Current stable v1.8.X will be installed now and existing installs will be upgraded during DietPi-Update. Many thanks to @msongz for implementing this: https://github.com/MichaIng/DietPi/pull/2881
+- DietPi-Software | Gitea: Current stable v1.8.X will be installed now and existing instances will be upgraded during DietPi-Update. Many thanks to @msongz for implementing this: https://github.com/MichaIng/DietPi/pull/2881
+- DietPi-Software | myMPD: Current upstream version will be installed now and existing instances will be upgraded during DietPi-Update, which requires a config file reset. A backup to recover custom settings from will be created: https://github.com/MichaIng/DietPi/issues/2156#issuecomment-497513129
 
 Bug Fixes:
 - DietPi-Boot | Waiting for network timer now includes the start of 'ifup' for the device. This is to speed up boot time by threading the ifup command and allowing the wait timer to be more accurate.

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8489,9 +8489,11 @@ _EOF_
 
 			Banner_Configuration
 
-			usercmd='useradd -rM'
-			getent passwd mympd &> /dev/null && usercmd='usermod'
-			$usercmd mympd -G dietpi,audio -s $(command -v nologin)
+			# Add user to "dietpi" group
+			usermod -a -G dietpi mympd
+
+			# Workaround until 5.4.0 release: https://github.com/jcorporation/myMPD/pull/125
+			[[ -f '/usr/lib/systemd/system/mympd.service' ]] || cp /usr/share/mympd/mympd.service /usr/lib/systemd/system/mympd.service
 
 			# Run service as "dietpi" group
 			mkdir -p /etc/systemd/systemd/mympd.service.d

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8493,25 +8493,13 @@ _EOF_
 			getent passwd mympd &> /dev/null && usercmd='usermod'
 			$usercmd mympd -G dietpi,audio -s $(command -v nologin)
 
-			cat << _EOF_ > /lib/systemd/system/mympd.service
-[Unit]
-Description=myMPD (DietPi)
-After=mpd.service
-
-[Service]
-#User=mympd # Changes at runlevel
-Group=dietpi
-ExecStart=$(command -v mympd) /etc/mympd/mympd.conf
-
-[Install]
-WantedBy=multi-user.target
-_EOF_
+			# Run service as "dietpi" group
+			mkdir -p /etc/systemd/systemd/mympd.service.d
+			echo -e '[Service]\nGroup=dietpi' > /etc/systemd/systemd/mympd.service.d/dietpi-group.conf
 
 			G_CONFIG_INJECT 'webport =' 'webport = 1333' /etc/mympd/mympd.conf
 			G_CONFIG_INJECT 'ssl =' 'ssl = false' /etc/mympd/mympd.conf
 			G_CONFIG_INJECT 'user =' 'user = mympd' /etc/mympd/mympd.conf
-
-			mkdir -p /var/lib/mympd/smartpls /var/lib/mympd/tmp
 
 			# Symlink music/libary folders used by myMPD
 			if [[ $(readlink /usr/share/mympd/htdocs/library) != $G_FP_DIETPI_USERDATA/Music ]]; then
@@ -12779,17 +12767,17 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			#apt-mark auto libmpdclient2 cmake cppcheck pkg-config libmpdclient-dev libssl-dev libmediainfo-dev
-			if [[ -f '/lib/systemd/system/mympd.service' ]]; then
+			if [[ -f '/usr/lib/systemd/system/mympd.service' ]]; then
 
 				systemctl unmask mympd
 				systemctl disable mympd
-				rm /lib/systemd/system/mympd.service
+				rm /usr/lib/systemd/system/mympd.service
 
 			fi
+			[[ -d '/etc/systemd/system/mympd.service.d' ]] && rm -R /etc/systemd/system/mympd.service.d
 			getent passwd mympd &> /dev/null && userdel -rf mympd
 			command -v mympd &> /dev/null && rm $(command -v mympd)
 			rm -Rf /{etc,var/lib,usr/share}/mympd
-			[[ -f '/usr/lib/systemd/system/mympd.service' ]] && rm /usr/lib/systemd/system/mympd.service
 			rm -f /usr/share/man/man1/mympd.*
 
 		fi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8492,18 +8492,20 @@ _EOF_
 			# Add user to "dietpi" group
 			usermod -a -G dietpi mympd
 
-			# Workaround until 5.4.0 release: https://github.com/jcorporation/myMPD/pull/125
-			[[ -f '/usr/lib/systemd/system/mympd.service' ]] || cp /usr/share/mympd/mympd.service /usr/lib/systemd/system/mympd.service
-
 			# Run service as "dietpi" group
 			mkdir -p /etc/systemd/systemd/mympd.service.d
 			echo -e '[Service]\nGroup=dietpi' > /etc/systemd/systemd/mympd.service.d/dietpi-group.conf
 
-			G_CONFIG_INJECT 'webport =' 'webport = 1333' /etc/mympd/mympd.conf
-			G_CONFIG_INJECT 'ssl =' 'ssl = false' /etc/mympd/mympd.conf
-			G_CONFIG_INJECT 'user =' 'user = mympd' /etc/mympd/mympd.conf
+			# Adjust config file on fresh install
+			# - On reinstall /etc/mympd/mympd.conf.dist will be created, so use its existence as reinstall flag
+			if [[ ! -f '/etc/mympd/mympd.conf.dist' ]]; then
 
-			# Symlink music/libary folders used by myMPD
+				G_CONFIG_INJECT 'webport[[:blank:]]*=' 'webport = 1333' /etc/mympd/mympd.conf
+				G_CONFIG_INJECT 'ssl[[:blank:]]*=' 'ssl = false' /etc/mympd/mympd.conf
+
+			fi
+
+			# Symlink music/libary dir to DietPi music dir
 			if [[ $(readlink /usr/share/mympd/htdocs/library) != $G_FP_DIETPI_USERDATA/Music ]]; then
 
 				rm -Rf /usr/share/mympd/htdocs/library

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -500,7 +500,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		#------------------
 		software_id=32
 
-		aSOFTWARE_WHIP_NAME[$software_id]='YMPD'
+		aSOFTWARE_WHIP_NAME[$software_id]='ympd'
 		aSOFTWARE_WHIP_DESC[$software_id]='lightweight web interface music player for mpd'
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
 		aSOFTWARE_TYPE[$software_id]=0
@@ -3850,7 +3850,7 @@ _EOF_
 
 			fi
 
-			mv "$binary_name" /usr/bin/ympd
+			mv $binary_name /usr/bin/ympd
 			chmod +x /usr/bin/ympd
 			rm ympd_*
 
@@ -3861,11 +3861,10 @@ _EOF_
 
 			Banner_Installing
 
-			# Sourcebuild pre-reqs
-			DEPS_LIST='cppcheck pkg-config libssl-dev libmpdclient-dev libmpdclient2 cmake'
+			# Sourcebuild pre-reqs: https://github.com/jcorporation/myMPD#dependencies
+			DEPS_LIST='libmpdclient2 cmake cppcheck pkg-config libmpdclient-dev libssl-dev libmediainfo-dev'
 
-			#Download_Install 'https://github.com/jcorporation/myMPD/archive/master.zip'
-			Download_Install 'https://github.com/jcorporation/myMPD/archive/006eb6d28ce3a124abcbf531f0b3cd3e680837df.zip'
+			Download_Install 'https://github.com/jcorporation/myMPD/archive/master.zip'
 
 			cd myMPD*
 			G_RUN_CMD ./mkrelease.sh
@@ -8466,12 +8465,12 @@ _EOF_
 
 			usercmd='useradd -rM'
 			getent passwd ympd &> /dev/null && usercmd='usermod'
-			$usercmd ympd -G dietpi -s /usr/sbin/nologin
+			$usercmd ympd -G dietpi,audio -s $(command -v nologin)
 
-			# YMPD service
+			# Service
 			cat << _EOF_ > /etc/systemd/system/ympd.service
 [Unit]
-Description=YMPD (DietPi)
+Description=ympd (DietPi)
 After=mpd.service
 
 [Service]
@@ -8492,7 +8491,7 @@ _EOF_
 
 			usercmd='useradd -rM'
 			getent passwd mympd &> /dev/null && usercmd='usermod'
-			$usercmd mympd -G dietpi,audio -s /usr/sbin/nologin
+			$usercmd mympd -G dietpi,audio -s $(command -v nologin)
 
 			cat << _EOF_ > /lib/systemd/system/mympd.service
 [Unit]
@@ -8511,14 +8510,13 @@ _EOF_
 			G_CONFIG_INJECT 'webport =' 'webport = 1333' /etc/mympd/mympd.conf
 			G_CONFIG_INJECT 'ssl =' 'ssl = false' /etc/mympd/mympd.conf
 			G_CONFIG_INJECT 'user =' 'user = mympd' /etc/mympd/mympd.conf
-			G_CONFIG_INJECT 'group =' 'group = dietpi' /etc/mympd/mympd.conf
 
 			mkdir -p /var/lib/mympd/smartpls /var/lib/mympd/tmp
 
-			# Symlink music/libary folders used by mympd
+			# Symlink music/libary folders used by myMPD
 			if [[ $(readlink /usr/share/mympd/htdocs/library) != $G_FP_DIETPI_USERDATA/Music ]]; then
 
-				[[ -d '/usr/share/mympd/htdocs/library' ]] && rm -R /usr/share/mympd/htdocs/library
+				rm -Rf /usr/share/mympd/htdocs/library
 				ln -sf $G_FP_DIETPI_USERDATA/Music /usr/share/mympd/htdocs/library
 
 			fi
@@ -12761,24 +12759,38 @@ _EOF_
 
 		fi
 
-		software_id=32
+		software_id=32 # ympd
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			userdel -rf ympd
-			rm /usr/bin/ympd
-			rm /etc/systemd/system/ympd.service
+			if [[ -f '/etc/systemd/system/ympd.service' ]]; then
+
+				systemctl unmask ympd
+				systemctl disable ympd
+				rm /etc/systemd/system/ympd.service
+
+			fi
+			getent passwd ympd &> /dev/null && userdel -rf ympd
+			[[ -f '/usr/bin/ympd' ]] && rm /usr/bin/ympd
 
 		fi
 
-		software_id=148
+		software_id=148 # myMPD
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
-			userdel -rf mympd
-			rm -R /etc/mympd
-			rm -R /usr/share/mympd
-			rm $(command -v mympd)
-			rm /lib/systemd/system/mympd.service
+			#apt-mark auto libmpdclient2 cmake cppcheck pkg-config libmpdclient-dev libssl-dev libmediainfo-dev
+			if [[ -f '/lib/systemd/system/mympd.service' ]]; then
+
+				systemctl unmask mympd
+				systemctl disable mympd
+				rm /lib/systemd/system/mympd.service
+
+			fi
+			getent passwd mympd &> /dev/null && userdel -rf mympd
+			command -v mympd &> /dev/null && rm $(command -v mympd)
+			rm -Rf /{etc,var/lib,usr/share}/mympd
+			[[ -f '/usr/lib/systemd/system/mympd.service' ]] && rm /usr/lib/systemd/system/mympd.service
+			rm -f /usr/share/man/man1/mympd.*
 
 		fi
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -2009,12 +2009,13 @@ opcache.max_accelerated_files=10000\nopcache.memory_consumption=128\nopcache.sav
 			#	Gitea update to v1.8.X: https://github.com/MichaIng/DietPi/pull/2881
 			if (( $G_DIETPI_INSTALL_STAGE == 2 )); then
 
-				if grep -q '^aSOFTWARE_INSTALL_STATE\[148\]=2' /DietPi/dietpi/.installed; then
+				if grep -q '^aSOFTWARE_INSTALL_STATE\[148\]=2' /DietPi/dietpi/.installed && [[ -f '/etc/mympd/mympd.conf' ]]; then
 
 					G_WHIP_MSG '[ INFO ] myMPD will be updated to latest upstream version\n
 Due to changes in how its configuration file "/etc/mympd/mympd.conf" is structured, we need to reset it.
 A backup will be created to "/etc/mympd/mympd.conf.bak_DDMMYYY_N" from where you can recover custom settings.'
 					G_BACKUP_FP /etc/mympd/mympd.conf
+					rm /etc/mympd/mympd.conf
 
 				fi
 				/DietPi/dietpi/dietpi-software reinstall 148 165

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -2016,6 +2016,7 @@ Due to changes in how its configuration file "/etc/mympd/mympd.conf" is structur
 A backup will be created to "/etc/mympd/mympd.conf.bak_DDMMYYY_N" from where you can recover custom settings.'
 					G_BACKUP_FP /etc/mympd/mympd.conf
 					[[ -f '/etc/mympd/mympd.conf' ]] && rm /etc/mympd/mympd.conf
+					[[ -f '/etc/mympd/mympd.conf.dist' ]] && rm /etc/mympd/mympd.conf.dist
 					# - Revert to systemd unit provided by installer
 					[[ -f '/lib/systemd/system/mympd.service' ]] && rm /lib/systemd/system/mympd.service
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -2005,10 +2005,19 @@ opcache.max_accelerated_files=10000\nopcache.memory_consumption=128\nopcache.sav
 			fi
 			#-------------------------------------------------------------------------------
 			# Reinstalls:
+			#	myMPD update to master: https://github.com/MichaIng/DietPi/pull/2883
 			#	Gitea update to v1.8.X: https://github.com/MichaIng/DietPi/pull/2881
 			if (( $G_DIETPI_INSTALL_STAGE == 2 )); then
 
-				dietpi-software reinstall 165
+				if grep -q '^aSOFTWARE_INSTALL_STATE\[148\]=2' /DietPi/dietpi/.installed; then
+
+					G_WHIP_MSG '[ INFO ] myMPD will be updated to latest upstream version\n
+Due to changes in how its configuration file "/etc/mympd/mympd.conf" is structured, we need to reset it.
+A backup will be created to "/etc/mympd/mympd.conf.bak_DDMMYYY_N" from where you can recover custom settings.'
+					G_BACKUP_FP /etc/mympd/mympd.conf
+
+				fi
+				/DietPi/dietpi/dietpi-software reinstall 148 165
 
 			fi
 			#-------------------------------------------------------------------------------

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1177,13 +1177,13 @@ _EOF_
 			#-------------------------------------------------------------------------------
 			#Reinstalls:
 			#	OMPD: https://github.com/MichaIng/DietPi/issues/2156#issue-372201367
-			#	MyMPD: https://github.com/MichaIng/DietPi/issues/2156#issue-372201367
+			# v6.25	myMPD: https://github.com/MichaIng/DietPi/issues/2156#issue-372201367
 			#	RoonBridge: https://community.roonlabs.com/t/dietpi-allo-units-not-getting-the-roonbridge-b167-update-from-b164/52503/10?u=dan_knight
 			#	Radarr/Lidarr/Sonarr: https://github.com/MichaIng/DietPi/issues/2219
 			#	Mosquitto: https://github.com/MichaIng/DietPi/issues/2243#issuecomment-439492463
 			if (( $G_DIETPI_INSTALL_STAGE == 2 )); then
 
-				/DietPi/dietpi/dietpi-software reinstall 106 121 123 129 144 145 148
+				/DietPi/dietpi/dietpi-software reinstall 106 121 123 129 144 145
 				# - Switch to "mariadb" systemd service on Stretch+: https://github.com/MichaIng/DietPi/pull/2196
 				if (( $G_DISTRO > 3 )) && grep -q '^aSOFTWARE_INSTALL_STATE\[88\]=2' /DietPi/dietpi/.installed; then
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -2009,13 +2009,15 @@ opcache.max_accelerated_files=10000\nopcache.memory_consumption=128\nopcache.sav
 			#	Gitea update to v1.8.X: https://github.com/MichaIng/DietPi/pull/2881
 			if (( $G_DIETPI_INSTALL_STAGE == 2 )); then
 
-				if grep -q '^aSOFTWARE_INSTALL_STATE\[148\]=2' /DietPi/dietpi/.installed && [[ -f '/etc/mympd/mympd.conf' ]]; then
+				if grep -q '^aSOFTWARE_INSTALL_STATE\[148\]=2' /DietPi/dietpi/.installed; then
 
 					G_WHIP_MSG '[ INFO ] myMPD will be updated to latest upstream version\n
 Due to changes in how its configuration file "/etc/mympd/mympd.conf" is structured, we need to reset it.
 A backup will be created to "/etc/mympd/mympd.conf.bak_DDMMYYY_N" from where you can recover custom settings.'
 					G_BACKUP_FP /etc/mympd/mympd.conf
-					rm /etc/mympd/mympd.conf
+					[[ -f '/etc/mympd/mympd.conf' ]] && rm /etc/mympd/mympd.conf
+					# - Revert to systemd unit provided by installer
+					[[ -f '/lib/systemd/system/mympd.service' ]] && rm /lib/systemd/system/mympd.service
 
 				fi
 				/DietPi/dietpi/dietpi-software reinstall 148 165


### PR DESCRIPTION
**Status**: Testing
- [x] Reinstall on v6.25 patch to update existing instances, requires removal (+backup) of config file due to new required settings section
- [x] Changelog
- [x] Wiki software list update

**Reference**: https://github.com/MichaIng/DietPi/issues/2156#issuecomment-497513129

**Commit list/description**:
+ DietPi-Software | ympd: Use official non-capital letters naming
+ DietPi-Software | ympd: On uninstall, unmask and disable service to remove all possible traces
+ DietPi-Software | myMPD: Do not apply wrong "group" setting
+ DietPi-Software | myMPD: Add libmediainfo to dependencies to support internal album covers
+ DietPi-Software | myMPD: Install latest master release, which works well now