### PR TITLE
DietPi-Software | PHP: On ARMv6 add libcurl4-openssl-dev to be pulled from Buster repo

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3449,7 +3449,7 @@ ExecStartPre=$(command -v chown) -R redis:redis /run/redis /var/lib/redis" > /et
 					# - Set priority for Buster: No auto install but auto upgrade
 					echo -e '# Allow to install PHP7.3 dependencies and meta packages from Buster
 # - Lighttpd must be pulled as well from Buster since the Stretch version does not support Buster libssl1.1 (1.1.1)
-Package: php libapache2-mod-php php-* libssl* libc6* libc-* libgssapi-krb5-2 libpcre2-8-0 libk5crypto3 libkrb5-3 libkrb5support0 locales libzip4 curl lighttpd
+Package: php libapache2-mod-php php-* libssl* libc6* libc-* libgssapi-krb5-2 libpcre2-8-0 libk5crypto3 libkrb5-3 libkrb5support0 locales libzip4 curl libcurl4-openssl-dev lighttpd
 Pin: release n=buster\nPin-Priority: 501\n
 # Pin down all other Buster packages to only allow upgrades of already installed ones via: "apt upgrade"
 Package: *\nPin: release n=buster\nPin-Priority: 100' > /etc/apt/preferences.d/dietpi-php

--- a/dietpi/pre-patch_file
+++ b/dietpi/pre-patch_file
@@ -151,7 +151,7 @@ Package: openssl libssl*\nPin: origin packages.sury.org\nPin-Priority: -1' > /et
 			echo -e '\e[90m[\e[0m INFO \e[90m]\e[0m Pre-patch 9 | Patching Buster APT repo preferences to prevent possible APT issues'
 			echo -e '# Allow to install PHP7.3 dependencies and meta packages from Buster
 # - Lighttpd must be pulled as well from Buster since the Stretch version does not support Buster libssl1.1 (1.1.1)
-Package: php libapache2-mod-php php-* libssl* libc6* libc-* libgssapi-krb5-2 libpcre2-8-0 libk5crypto3 libkrb5-3 libkrb5support0 locales libzip4 curl lighttpd
+Package: php libapache2-mod-php php-* libssl* libc6* libc-* libgssapi-krb5-2 libpcre2-8-0 libk5crypto3 libkrb5-3 libkrb5support0 locales libzip4 curl libcurl4-openssl-dev lighttpd
 Pin: release n=buster\nPin-Priority: 501\n
 # Pin down all other Buster packages to only allow upgrades of already installed ones via: "apt upgrade"
 Package: *\nPin: release n=buster\nPin-Priority: 100' > /etc/apt/preferences.d/dietpi-php || { EXIT_CODE=9; break; }


### PR DESCRIPTION
**Status**: WIP
- [x] DietPi-Patch
- [x] Changelog: https://github.com/MichaIng/DietPi/commit/572526895181800084ca15f78ebd5f6403583b9b

**Reference**: https://github.com/MichaIng/DietPi/issues/2888

**Commit list/description**:
+ DietPi-Software | PHP: On ARMv6 add libcurl4-openssl-dev to be pulled from Buster repo, as Stretch version depends on libcurl3 which conflicts libcurl4 from Buster. This resolves a failing Motion cam install.