### PR TITLE
DietPi-Software | Medusa: Install FFmpeg and mediainfo as deps and use Python3

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,7 @@ Changes / Improvements / Optimisations:
 - DietPi-Software | myMPD: Current upstream version will be installed now and existing instances will be upgraded during DietPi-Update, which requires a config file reset. A backup to recover custom settings from will be created: https://github.com/MichaIng/DietPi/issues/2156#issuecomment-497513129
 - DietPi-Software | O!MPD: Current upstream version will be installed now and existing instances will be upgraded during DietPi-Update. Existing config and database will be preserved. YouTube and Tidal support is added now by default. Many thanks to @ArturSierzant for giving valueable feedback and suggestions: https://github.com/MichaIng/DietPi/pull/2884
 - DietPi-Software | Ampache: Reinstalls will now preserve existing configs and database.
+- DietPi-Software | Medusa: FFmpeg and mediainfo is now installed to enable Medusa gathering meta data and resolving related warnings in log. Additionally, on Stretch and above, Python3 is now installed and used, as recommended by Medusa for a while. Many thanks to @bluesmoke for suggesting this enhancement: https://dietpi.com/phpbb/viewtopic.php?f=11&t=5945
 
 Bug Fixes:
 - DietPi-Boot | Waiting for network timer now includes the start of 'ifup' for the device. This is to speed up boot time by threading the ifup command and allowing the wait timer to be more accurate.

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5421,7 +5421,8 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 			Banner_Installing
 
-			DEPS_LIST='python3-minimal mediainfo'
+			DEPS_LIST='mediainfo python'
+			(( $G_DISTRO > 3 )) && DEPS_LIST+='3'
 
 			if [[ -d $G_FP_DIETPI_USERDATA/medusa ]]; then
 
@@ -11148,7 +11149,9 @@ _EOF_
 			# Service
 			cp $G_FP_DIETPI_USERDATA/medusa/runscripts/init.systemd /etc/systemd/system/medusa.service
 			G_CONFIG_INJECT 'Group=' 'Group=dietpi' /etc/systemd/system/medusa.service '\[Service\]'
-			G_CONFIG_INJECT 'ExecStart=' "ExecStart=$(command -v python3) $G_FP_DIETPI_USERDATA/medusa/start.py -q --nolaunch --datadir=$G_FP_DIETPI_USERDATA/medusa" /etc/systemd/system/medusa.service
+			local python_bin='python'
+			(( $G_DISTRO > 3 )) && python_bin+='3'
+			G_CONFIG_INJECT 'ExecStart=' "ExecStart=$(command -v $python_bin) $G_FP_DIETPI_USERDATA/medusa/start.py -q --nolaunch --datadir=$G_FP_DIETPI_USERDATA/medusa" /etc/systemd/system/medusa.service
 
 		fi
 
@@ -13972,13 +13975,17 @@ _EOF_
 
 			Banner_Uninstalling
 
-			[[ -f /etc/systemd/system/syncthing.service ]] && rm /etc/systemd/system/syncthing.service
-			[[ -f dietpi-syncthing.conf ]] && rm /etc/sysctl.d/dietpi-syncthing.conf # DietPi post-v6.18
+			if [[ -f '/etc/systemd/system/syncthing.service' ]]; then
 
-			[[ -f /usr/bin/syncthing ]] && rm /usr/bin/syncthing # DietPi pre-v158
-			[[ -d /etc/syncthing ]] && rm -R /etc/syncthing
+				systemctl disable syncthing
+				rm /etc/systemd/system/syncthing.service
 
+			fi
 			[[ -d $G_FP_DIETPI_USERDATA/syncthing ]] && rm -R $G_FP_DIETPI_USERDATA/syncthing
+			[[ -f '/etc/sysctl.d/dietpi-syncthing.conf' ]] && rm /etc/sysctl.d/dietpi-syncthing.conf # DietPi post-v6.18
+
+			[[ -f '/usr/bin/syncthing' ]] && rm /usr/bin/syncthing # DietPi pre-v158
+			[[ -d '/etc/syncthing' ]] && rm -R /etc/syncthing
 
 		fi
 
@@ -13986,10 +13993,15 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			rm /etc/systemd/system/medusa.service
-			rm -R $G_FP_DIETPI_USERDATA/medusa
-			userdel -rf medusa
-			#apt-mark auto python libssl-dev
+			if [[ -f '/etc/systemd/system/medusa.service' ]]; then
+
+				systemctl disable medusa
+				rm /etc/systemd/system/medusa.service
+
+			fi
+			[[ -d $G_FP_DIETPI_USERDATA/medusa ]] && rm -R $G_FP_DIETPI_USERDATA/medusa
+			getent passwd medusa &> /dev/null && userdel -rf medusa
+			#apt-mark auto python python3 mediainfo libssl-dev
 
 		fi
 
@@ -13998,23 +14010,28 @@ _EOF_
 
 			Banner_Uninstalling
 			G_AGP rtorrent
-			[[ -d /var/www/rutorrent ]] && rm -R /var/www/rutorrent
+			[[ -d '/var/www/rutorrent' ]] && rm -R /var/www/rutorrent
 			[[ -d $G_FP_DIETPI_USERDATA/rtorrent ]] && rm -R $G_FP_DIETPI_USERDATA/rtorrent
-			[[ -f /etc/systemd/system/rtorrent.service ]] && rm /etc/systemd/system/rtorrent.service
+			if [[ -f '/etc/systemd/system/rtorrent.service' ]]; then
+
+				systemctl disable rtorrent
+				rm /etc/systemd/system/rtorrent.service
+
+			fi
 
 			# - Webserver rutorrent user/pw settings
-			[[ -f /etc/.rutorrent-htaccess ]] && rm /etc/.rutorrent-htaccess
+			[[ -f '/etc/.rutorrent-htaccess' ]] && rm /etc/.rutorrent-htaccess
 
 			#	Lighttpd
 			#Remove from
 			#RUTORRENT_DIETPI to #RUTORRENT_DIETPI in /etc/lighttpd/lighttpd.conf
 
 			#	Nginx
-			[[ -f /etc/nginx/sites-dietpi/dietpi-rutorrent.conf ]] && rm /etc/nginx/sites-dietpi/dietpi-rutorrent.conf
+			[[ -f '/etc/nginx/sites-dietpi/dietpi-rutorrent.conf' ]] && rm /etc/nginx/sites-dietpi/dietpi-rutorrent.conf
 
 			#	Apache2
 			command -v a2dissite &> /dev/null && a2dissite dietpi-rutorrent
-			[[ -f /etc/apache2/sites-available/dietpi-rutorrent.conf ]] && rm /etc/apache2/sites-available/dietpi-rutorrent.conf
+			[[ -f '/etc/apache2/sites-available/dietpi-rutorrent.conf' ]] && rm /etc/apache2/sites-available/dietpi-rutorrent.conf
 
 		fi
 
@@ -14025,7 +14042,7 @@ _EOF_
 			rm -R $G_FP_DIETPI_USERDATA/amiberry
 			rm /etc/systemd/system/amiberry.service
 
-			#Disable autostart, revert boot index to console
+			# Disable autostart, revert boot index to console
 			/DietPi/dietpi/dietpi-autostart 0
 
 		fi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -895,6 +895,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=3327#p3327'
+		aSOFTWARE_REQUIRES_FFMPEG[$software_id]=1
 
 		#------------------
 		software_id=132
@@ -2389,7 +2390,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 
 	}
 
-	#Disable software installation, if user input is required for automated installs
+	# Disable software installation, if user input is required for automated installs
 	Install_Disable_Requires_UserInput(){
 
 		if (( ! $G_USER_INPUTS )); then
@@ -5367,13 +5368,13 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 			Banner_Installing
 
-			if (( $G_DISTRO >= 4 )); then
+			if (( $G_DISTRO > 3 )); then
 
 				G_AGI aria2
 
 			else
 
-				#aria2 binary
+				# aria2c binary
 				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/aria2_'
 
 				# - armv6
@@ -5410,8 +5411,8 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 			# Web interface
 			Download_Install 'https://github.com/ziahamza/webui-aria2/archive/master.zip'
 
-			cp -R webui-aria2* /var/www/aria2
-			rm -R webui-aria2*
+			cp -R webui-aria2-master /var/www/aria2
+			rm -R webui-aria2-master
 
 		fi
 
@@ -5420,14 +5421,14 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 			Banner_Installing
 
-			DEPS_LIST='python'
+			DEPS_LIST='python3-minimal mediainfo'
 
 			if [[ -d $G_FP_DIETPI_USERDATA/medusa ]]; then
 
 				G_AGI $DEPS_LIST
 				G_DIETPI-NOTIFY 2 "${aSOFTWARE_WHIP_NAME[$software_id]} install dir \"$G_FP_DIETPI_USERDATA/medusa\" already exists. Download and install steps will be skipped.
  - If you want to update ${aSOFTWARE_WHIP_NAME[$software_id]}, please use the internal updater from WebUI.
- - if you need to reinstall (e.g. broken instance), please manually backup your config files+data, remove the install dir and rerun \"dietpi-software (re)install $software_id\"."
+ - If you need to reinstall (e.g. broken instance), please manually backup your config files+data, remove the install dir and rerun \"dietpi-software (re)install $software_id\"."
 
 			else
 
@@ -5745,8 +5746,8 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 			# ARMv8 binary install: https://github.com/MichaIng/DietPi/issues/1502
 			if (( $G_HW_ARCH == 3 )); then
 
+				DEPS_LIST='mediainfo'
 				Download_Install 'https://update.sonarr.tv/v2/develop/mono/NzbDrone.develop.tar.gz' /opt
-				G_AGI mediainfo
 
 			# Repo install
 			else
@@ -6919,7 +6920,7 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 
 			Banner_Installing
 
-			# Raspbian "unrar-free" only available in repos
+			# Raspbian, only "unrar-free" available in repos
 			if (( $G_HW_MODEL < 10 )); then
 
 				#G_AGI unrar-free # Does not support all rar formats, better use "unrar-nonfree" from Debian repo
@@ -6927,7 +6928,7 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 
 			else
 
-				G_AGI unrar #https://github.com/MichaIng/DietPi/issues/176#issuecomment-240101365
+				G_AGI unrar # https://github.com/MichaIng/DietPi/issues/176#issuecomment-240101365
 
 			fi
 
@@ -11139,12 +11140,15 @@ _EOF_
 
 			Banner_Configuration
 
-			useradd -rM medusa -G dietpi -d $G_FP_DIETPI_USERDATA/medusa -s /usr/sbin/nologin
+			# User
+			usercmd='useradd -rM'
+			getent passwd medusa &> /dev/null && usercmd='usermod'
+			useradd -rM medusa -G dietpi -d $G_FP_DIETPI_USERDATA/medusa -s $(command -v nologin)
 
+			# Service
 			cp $G_FP_DIETPI_USERDATA/medusa/runscripts/init.systemd /etc/systemd/system/medusa.service
 			G_CONFIG_INJECT 'Group=' 'Group=dietpi' /etc/systemd/system/medusa.service '\[Service\]'
-			G_CONFIG_INJECT 'ExecStart=' "ExecStart=$(command -v python) $G_FP_DIETPI_USERDATA/medusa/start.py -q --nolaunch --datadir=$G_FP_DIETPI_USERDATA/medusa" /etc/systemd/system/medusa.service
-			chmod 644 /etc/systemd/system/medusa.service
+			G_CONFIG_INJECT 'ExecStart=' "ExecStart=$(command -v python3) $G_FP_DIETPI_USERDATA/medusa/start.py -q --nolaunch --datadir=$G_FP_DIETPI_USERDATA/medusa" /etc/systemd/system/medusa.service
 
 		fi
 
@@ -14498,7 +14502,7 @@ _EOF_
 
 		fi
 
-		software_id=7
+		software_id=7 # FFmpeg
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
@@ -14563,7 +14567,7 @@ _EOF_
 
 			mkdir -p /var/lib/dietpi/dietpi-ramlog
 			cat << _EOF_ > /var/lib/dietpi/dietpi-ramlog/disable.sh
-#!/bin/bash
+#!/bin/dash
 {
 	systemctl stop dietpi-ramlog
 	systemctl disable dietpi-ramlog
@@ -14603,20 +14607,20 @@ _EOF_
 			# - old install via repo
 			[[ -f '/etc/apt/sources.list.d/nodesource_nodejs.list' ]] && rm /etc/apt/sources.list.d/nodesource_nodejs.list
 
-			[[ -f /usr/local/bin/node ]] && rm /usr/local/bin/node
-			[[ -d /usr/local/n ]] && rm -R /usr/local/n
-			[[ -d /usr/local/yarn ]] && rm -R /usr/local/yarn
-			[[ -d /usr/local/include/node ]] && rm -R /usr/local/include/node
-			[[ -d /usr/local/lib/node_modules ]] && rm -R /usr/local/lib/node_modules
-			[[ -d /usr/local/share/doc/node ]] && rm -R /usr/local/share/doc/node
-			[[ -f /usr/local/man/man1/node.1 ]] && rm /usr/local/man/man1/node.1
-			[[ -f /usr/local/share/man/man1/node.1 ]] && rm /usr/local/share/man/man1/node.1
-			[[ -f /usr/local/README.md ]] && rm /usr/local/README.md
-			[[ -f /usr/local/CHANGELOG.md ]] && rm /usr/local/CHANGELOG.md
-			[[ -f /usr/local/LICENSE ]] && rm /usr/local/LICENSE
-			[[ -f /usr/local/share/systemtap/tapset/node.stp ]] && rm /usr/local/share/systemtap/tapset/node.stp
-			[[ -d /root/.npm ]] && rm -R /root/.npm
-			[[ -f /root/.config/configstore/update-notifier-npm.json ]] && rm /root/.config/configstore/update-notifier-npm.json
+			[[ -f '/usr/local/bin/node' ]] && rm /usr/local/bin/node
+			[[ -d '/usr/local/n' ]] && rm -R /usr/local/n
+			[[ -d '/usr/local/yarn' ]] && rm -R /usr/local/yarn
+			[[ -d '/usr/local/include/node' ]] && rm -R /usr/local/include/node
+			[[ -d '/usr/local/lib/node_modules' ]] && rm -R /usr/local/lib/node_modules
+			[[ -d '/usr/local/share/doc/node' ]] && rm -R /usr/local/share/doc/node
+			[[ -f '/usr/local/man/man1/node.1' ]] && rm /usr/local/man/man1/node.1
+			[[ -f '/usr/local/share/man/man1/node.1' ]] && rm /usr/local/share/man/man1/node.1
+			[[ -f '/usr/local/README.md' ]] && rm /usr/local/README.md
+			[[ -f '/usr/local/CHANGELOG.md' ]] && rm /usr/local/CHANGELOG.md
+			[[ -f '/usr/local/LICENSE' ]] && rm /usr/local/LICENSE
+			[[ -f '/usr/local/share/systemtap/tapset/node.stp' ]] && rm /usr/local/share/systemtap/tapset/node.stp
+			[[ -d '/root/.npm' ]] && rm -R /root/.npm
+			[[ -f '/root/.config/configstore/update-notifier-npm.json' ]] && rm /root/.config/configstore/update-notifier-npm.json
 
 		fi
 
@@ -14638,7 +14642,7 @@ _EOF_
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Finalise uninstall'
 
-		#Uninstall finished, set all uninstalled software to state 0 (not installed)
+		# Uninstall finished, set all uninstalled software to state 0 (not installed)
 		for i in ${!aSOFTWARE_INSTALL_STATE[@]}
 		do
 
@@ -14646,31 +14650,27 @@ _EOF_
 
 		done
 
-		#apt-get autoremove
+		# apt-get autoremove
 		G_AGA
 
-		#Check if we need to clear DietPi choices
+		# Check if we need to clear DietPi choices
 		local fp_temp='.dietpi-uninstall_dpkg'
 		dpkg --get-selections | mawk '{print $1}' > $fp_temp
-		if ! grep -q '^openssh-server' $fp_temp &&
-			! grep -q '^dropbear' $fp_temp; then
+		if ! grep -q '^openssh-server' $fp_temp && ! grep -q '^dropbear' $fp_temp; then
 
 			INDEX_SSHSERVER_CURRENT=0
 			INDEX_SSHSERVER_TARGET=0
 
 		fi
 
-		if ! grep -q '^samba$' $fp_temp &&
-			! grep -q '^proftpd-basic' $fp_temp; then
+		if ! grep -q '^samba$' $fp_temp && ! grep -q '^proftpd-basic' $fp_temp; then
 
 			INDEX_FILESERVER_CURRENT=0
 			INDEX_FILESERVER_TARGET=0
 
 		fi
 
-		if ! grep -q '[[:blank:]]/var/log[[:blank:]]' /etc/fstab &&
-			! grep -q '^rsyslog' $fp_temp &&
-			! grep -q '^logrotate' $fp_temp; then
+		if ! grep -q '[[:blank:]]/var/log[[:blank:]]' /etc/fstab && ! grep -q '^rsyslog' $fp_temp; then
 
 			INDEX_LOGGING_CURRENT=0
 			INDEX_LOGGING_TARGET=0
@@ -14682,10 +14682,10 @@ _EOF_
 		systemctl daemon-reload
 
 		#----------------------------------------------------------------------
-		#Done, reset uninstall flag
+		# Done, reset uninstall flag
 		UNINSTALL_REQUIRED=0
 		#----------------------------------------------------------------------
-		#Reset error handler (eg: for usermsg clear)
+		# Reset error handler (eg: for usermsg clear)
 		G_ERROR_HANDLER_RESET
 		#----------------------------------------------------------------------
 
@@ -14694,23 +14694,20 @@ _EOF_
 	Run_Installations(){
 
 		#------------------------------------------------------------
-		#Prevent continue if Network or NTPD is not completed: https://github.com/MichaIng/DietPi/issues/786
+		# Prevent continue if Network or NTPD is not completed: https://github.com/MichaIng/DietPi/issues/786
 		Check_Internet_and_NTPD
 		#------------------------------------------------------------
-		#Disable powersaving on main screen during installation
+		# Disable powersaving on main screen during installation
 		setterm -blank 0 -powersave off 2> /dev/null
 		#------------------------------------------------------------
 		# Unmask all services: https://github.com/MichaIng/DietPi/issues/1320
-		DISABLE_SERVICES_START=1 /DietPi/dietpi/dietpi-services unmask all
+		/DietPi/dietpi/dietpi-services unmask
 		# Stop services
 		[[ $G_SERVICE_CONTROL == 0 ]] || /DietPi/dietpi/dietpi-services stop
 		#------------------------------------------------------------
-		#Generate userdata folders:
+		# Generate userdata folders
 		Create_UserContent_Folders
 		#------------------------------------------------------------
-		# Set current path to home folder
-		cd /tmp/$G_PROGRAM_NAME
-
 		# Update & upgrade APT
 		Banner_Apt_Update
 
@@ -14737,7 +14734,7 @@ _EOF_
 		mkdir -p /var/lib/dietpi/dietpi-software/services
 		chmod -R +x /var/lib/dietpi/dietpi-software/services
 
-		# Disable software installation, if user input is required for automated installs
+		# Disable software installation for automated installs, if user input is required
 		Install_Disable_Requires_UserInput
 
 		# Apply DietPi choice systems
@@ -14752,7 +14749,6 @@ _EOF_
 		Install_Flag_Prereq_Software
 
 		# Install Linux Software
-		/DietPi/dietpi/dietpi-services stop
 		Install_Linux_Software
 
 		# Install DietPi Optimised Software
@@ -14771,7 +14767,7 @@ _EOF_
 
 		# Apply autostart index
 		local autostart_current=0
-		[[ -f /DietPi/dietpi/.dietpi-autostart_index ]] && autostart_current=$(</DietPi/dietpi/.dietpi-autostart_index)
+		[[ -f '/DietPi/dietpi/.dietpi-autostart_index' ]] && autostart_current=$(</DietPi/dietpi/.dietpi-autostart_index)
 		/DietPi/dietpi/dietpi-autostart $autostart_current
 
 		# Disable services so DietPi-services can take control (DietPi will start all services from dietpi-postboot.service)
@@ -14795,7 +14791,7 @@ _EOF_
 		if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
 
 			# - Remove fake-hwclock, if real hwclock is available
-			#REMOVED: Needs further work as SBC's without RTC's (XU4/Sparky SBC) are being flagged for this removal
+			# REMOVED: Needs further work as SBCs without RTC (XU4/Sparky SBC) are being flagged for this removal
 			#hwclock &> /dev/null && G_AGP fake-hwclock
 
 			# - x86_64 microcode installation
@@ -14808,7 +14804,7 @@ _EOF_
 
 			# - Custom 1st run Script (Local file)
 			local run_custom_script=0
-			if [[ -f /boot/Automation_Custom_Script.sh ]]; then
+			if [[ -f '/boot/Automation_Custom_Script.sh' ]]; then
 
 				cp /boot/Automation_Custom_Script.sh /root/AUTO_CustomScript.sh
 				run_custom_script=1
@@ -14860,14 +14856,11 @@ _EOF_
 	# First Run / Automation functions Vars (eg: on a fresh install)
 	#/////////////////////////////////////////////////////////////////////////////////////
 	AUTOINSTALL_ENABLED=0
-
 	AUTOINSTALL_SSHINDEX=0
 	AUTOINSTALL_FILESERVERINDEX=0
 	AUTOINSTALL_LOGGINGINDEX=0
 	AUTOINSTALL_WEBSERVERINDEX=0
-
 	AUTOINSTALL_AUTOSTARTTARGET=0
-
 	AUTOINSTALL_CUSTOMSCRIPTURL=0
 
 	FirstRun_Automation_Init(){
@@ -14885,7 +14878,7 @@ _EOF_
 
 	FirstRun_Automation_Set(){
 
-		#Automated install
+		# Automated install
 		if (( $AUTOINSTALL_ENABLED > 0 )); then
 
 			G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Running automated installation'
@@ -14904,7 +14897,6 @@ _EOF_
 				if disable_error=1 G_CHECK_VALIDINT "${aSOFTWARE_INSTALL_STATE[$software_id]}"; then
 
 					aSOFTWARE_INSTALL_STATE[$software_id]=1
-
 					G_DIETPI-NOTIFY 2 "Automation: ${aSOFTWARE_WHIP_NAME[$software_id]}. Flagged for installation."
 
 				fi
@@ -14920,11 +14912,7 @@ _EOF_
 		INDEX_WEBSERVER_TARGET=$AUTOINSTALL_WEBSERVERINDEX
 
 		# Re-flag RAMlog for install, if enabled, ensures AUTO_SETUP_RAMLOG_MAXSIZE gets applied
-		if (( $INDEX_LOGGING_TARGET == -1 || $INDEX_LOGGING_TARGET == -2 )); then
-
-			aSOFTWARE_INSTALL_STATE[103]=1
-
-		fi
+		(( $INDEX_LOGGING_TARGET == -1 || $INDEX_LOGGING_TARGET == -2 )) && aSOFTWARE_INSTALL_STATE[103]=1
 
 	}
 
@@ -14933,7 +14921,7 @@ _EOF_
 	#/////////////////////////////////////////////////////////////////////////////////////
 	Input_Modes(){
 
-		# - Skip menu
+		# Skip menu
 		TARGETMENUID=-1
 
 		DISABLE_REBOOT=1
@@ -15385,9 +15373,8 @@ You can free up the camera by selecting "Stop Camera" from the web interface:\n 
 			if (( ${aSOFTWARE_INSTALL_STATE[93]} == 1 )); then
 
 				# - prompt for static ip.
-				G_WHIP_YESNO 'A static IP address is essential for Pi-hole installations. DietPi-Config can be used to quickly setup your static IP address.\n
-If you have already setup your static IP, please ignore this message.\n\nWould you like to setup your static IP address now?'
-				if (( $? == 0 )); then
+				if G_WHIP_YESNO 'A static IP address is essential for Pi-hole installations. DietPi-Config can be used to quickly setup your static IP address.\n
+If you have already setup your static IP, please ignore this message.\n\nWould you like to setup your static IP address now?'; then
 
 					G_WHIP_MSG 'DietPi-Config will now be launched. Simply select your Ethernet or Wifi connection from the menu to access the IP address settings.\n
 The "copy current address to STATIC" menu option can be used to quickly setup your static IP. Please ensure you change the mode "DHCP" to "STATIC".\n
@@ -15474,19 +15461,19 @@ Once DietPi has completed your software installations, and rebooted, please foll
 			fi
 
 			# dietpi-config can be used to install/configure the following software. Ask user.
-			#	NoIp
+			# - NoIp
 			if (( ${aSOFTWARE_INSTALL_STATE[67]} == 1 )); then
 
 				if G_WHIP_YESNO 'NoIp can be setup and configured by using DietPi-Config. Would you like to complete this now? \n\n- Once finished, exit DietPi-Config to resume setup.\n
  - More information:\nhttps://dietpi.com/phpbb/viewtopic.php?f=8&t=5&start=10#p58'; then
 
-					#Write installed states to temp
+					# Write installed states to temp
 					Write_InstallFileList temp
 
-					#Launch DietPi-config
+					# Launch DietPi-config
 					/DietPi/dietpi/dietpi-config 16 1
 
-					#Read installed states from temp
+					# Read installed states from temp
 					Read_InstallFileList temp
 
 				fi
@@ -15705,7 +15692,6 @@ This will allow you to choose which program loads automatically, after the syste
 					if (( $INDEX_SSHSERVER_TARGET != $INDEX_SSHSERVER_CURRENT )); then
 
 						INSTALL_SSHSERVER_CHOICESMADE=1
-
 						G_WHIP_MSG "$G_WHIP_RETURNED_VALUE has been selected:\n- Your choice will be applied when 'Install Go >> Start installation' is selected.\n- $toberemoved_text installations will be automatically uninstalled."
 
 					fi
@@ -15760,7 +15746,6 @@ This will allow you to choose which program loads automatically, after the syste
 					if (( $INDEX_FILESERVER_TARGET != $INDEX_FILESERVER_CURRENT )); then
 
 						INSTALL_FILESERVER_CHOICESMADE=1
-
 						G_WHIP_MSG "$G_WHIP_RETURNED_VALUE has been selected:\n- Your choice will be applied when 'Install Go >> Start installation' is selected.\n- $toberemoved_text installations will be automatically uninstalled."
 
 					fi
@@ -15822,7 +15807,6 @@ This will allow you to choose which program loads automatically, after the syste
 					if (( $INDEX_LOGGING_TARGET != $INDEX_LOGGING_CURRENT )); then
 
 						INSTALL_LOGGING_CHOICESMADE=1
-
 						G_WHIP_MSG "$G_WHIP_RETURNED_VALUE has been selected:\n - Your choice will be applied when 'Install Go >> Start installation' is selected.\n - $toberemoved_text installations will be automatically uninstalled."
 
 					fi
@@ -15882,8 +15866,8 @@ More information on user data in DietPi:\n- https://dietpi.com/phpbb/viewtopic.p
 						if [[ $user_data_location_current != $move_data_target ]]; then
 
 							# - Ask before we begin
-							G_WHIP_YESNO "DietPi will now attempt to transfer your existing user data to the new location:\n\n- From: $user_data_location_current\n- To: $move_data_target\n\nWould you like to begin?"
-							if (( $? == 0 )); then
+							if G_WHIP_YESNO "DietPi will now attempt to transfer your existing user data to the new location:
+\n- From: $user_data_location_current\n- To: $move_data_target\n\nWould you like to begin?"; then
 
 								# - Move data, setup symlinks
 								if /DietPi/dietpi/func/dietpi-set_userdata "$user_data_location_current" "$move_data_target"; then
@@ -15916,13 +15900,12 @@ More information on user data in DietPi:\n- https://dietpi.com/phpbb/viewtopic.p
 
 					G_WHIP_DEFAULT_ITEM=$index_webserver_text
 					G_WHIP_BUTTON_CANCEL_TEXT='Back'
-					G_WHIP_MENU 'Please select a Webserver preference, more info https://dietpi.com/phpbb/viewtopic.php?f=8&t=5&p=1549#p1549:\n
+					if G_WHIP_MENU 'Please select a Webserver preference, more info https://dietpi.com/phpbb/viewtopic.php?f=8&t=5&p=1549#p1549:\n
 - Apache2: Feature-rich and popular. Recommended for beginners and users who are looking to follow Apache2 based guides.\n
 - Nginx: Lightweight alternative to Apache2. Nginx claims faster webserver performance compared to Apache2.\n
-- Lighttpd: Extremely lightweight and is generally considered to offer the \"best\" webserver performance for SBCs. Recommended for users who expect low webserver traffic.'
-					if (( $? == 0 )); then
+- Lighttpd: Extremely lightweight and is generally considered to offer the \"best\" webserver performance for SBCs. Recommended for users who expect low webserver traffic.'; then
 
-						#Assign target index
+						# Assign target index
 						if [[ $G_WHIP_RETURNED_VALUE == 'Apache2' ]]; then
 
 							INDEX_WEBSERVER_TARGET=0
@@ -16129,9 +16112,9 @@ Software details, usernames, passwords etc:\n - https://dietpi.com/software\n\nW
 			# 1st run install
 			if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
 
-				G_WHIP_YESNO 'DietPi was unable to detect any additional software selections for install.\n
-NB: You can use dietpi-software at a later date, to install optimised software from our catalogue as required.\n\nDo you wish to continue with DietPi as a pure minimal image?'
-				if (( $? == 0 )); then
+				if G_WHIP_YESNO 'DietPi was unable to detect any additional software selections for install.\n
+NB: You can use dietpi-software at a later date, to install optimised software from our catalogue as required.\n
+Do you wish to continue with DietPi as a pure minimal image?'; then
 
 					TARGETMENUID=-1 # Exit menu
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8490,7 +8490,7 @@ _EOF_
 
 			Banner_Configuration
 
-			usercmd='useradd -rM'
+			local usercmd='useradd -rM'
 			getent passwd ympd &> /dev/null && usercmd='usermod'
 			$usercmd ympd -G dietpi,audio -s $(command -v nologin)
 
@@ -8965,7 +8965,7 @@ _EOF_
 
 			Banner_Configuration
 
-			usercmd='useradd -r'
+			local usercmd='useradd -r'
 			getent passwd debian-deluged &> /dev/null && usercmd='usermod'
 			$usercmd debian-deluged -G dietpi -d $G_FP_DIETPI_USERDATA/deluge -s /usr/sbin/nologin
 
@@ -10506,7 +10506,7 @@ location = /.well-known/caldav {
 
 			Banner_Configuration
 
-			usercmd='useradd -rM'
+			local usercmd='useradd -rM'
 			getent passwd cuberite &> /dev/null && usercmd='usermod'
 			$usercmd cuberite -G dietpi -d $G_FP_DIETPI_USERDATA/cubrite -s $(command -v nologin)
 
@@ -10591,7 +10591,7 @@ _EOF_
 			Banner_Configuration
 
 			# User
-			usercmd='useradd -rM'
+			local usercmd='useradd -rM'
 			getent passwd gogs &> /dev/null && usercmd='usermod'
 			$usercmd gogs -d /etc/gogs -s $(command -v nologin)
 
@@ -11142,9 +11142,9 @@ _EOF_
 			Banner_Configuration
 
 			# User
-			usercmd='useradd -rM'
+			local usercmd='useradd -rM'
 			getent passwd medusa &> /dev/null && usercmd='usermod'
-			useradd -rM medusa -G dietpi -d $G_FP_DIETPI_USERDATA/medusa -s $(command -v nologin)
+			$usercmd -rM medusa -G dietpi -d $G_FP_DIETPI_USERDATA/medusa -s $(command -v nologin)
 
 			# Service
 			cp $G_FP_DIETPI_USERDATA/medusa/runscripts/init.systemd /etc/systemd/system/medusa.service
@@ -11160,7 +11160,7 @@ _EOF_
 
 			Banner_Configuration
 
-			usercmd='useradd -rm'
+			local usercmd='useradd -rm'
 			getent passwd tonido &> /dev/null && usercmd='usermod'
 			$usercmd tonido -G dietpi -s $(command -v nologin)
 
@@ -11435,7 +11435,7 @@ _EOF_
 			fi
 
 			# User
-			usercmd='useradd -rM'
+			local usercmd='useradd -rM'
 			getent passwd blynk &> /dev/null && usercmd='usermod'
 			$usercmd blynk -G dietpi -d $G_FP_DIETPI_USERDATA/blynk -s /usr/sbin/nologin
 
@@ -11680,7 +11680,7 @@ _EOF_
 
 			Banner_Configuration
 
-			usercmd='useradd -rM'
+			local usercmd='useradd -rM'
 			getent passwd sonarr &> /dev/null && usercmd='usermod'
 			$usercmd sonarr -G dietpi -d $G_FP_DIETPI_USERDATA/sonarr -s $(command -v nologin)
 
@@ -11715,7 +11715,7 @@ _EOF_
 
 			Banner_Configuration
 
-			usercmd='useradd -rM'
+			local usercmd='useradd -rM'
 			getent passwd radarr &> /dev/null && usercmd='usermod'
 			$usercmd radarr -G dietpi -d $G_FP_DIETPI_USERDATA/radarr -s $(command -v nologin)
 
@@ -11750,7 +11750,7 @@ _EOF_
 
 			Banner_Configuration
 
-			usercmd='useradd -rM'
+			local usercmd='useradd -rM'
 			getent passwd lidarr &> /dev/null && usercmd='usermod'
 			$usercmd lidarr -G dietpi -d $G_FP_DIETPI_USERDATA/lidarr -s $(command -v nologin)
 
@@ -11786,7 +11786,7 @@ _EOF_
 			Banner_Configuration
 
 			# User
-			usercmd='useradd -rM'
+			local usercmd='useradd -rM'
 			getent passwd plexpy &> /dev/null && usercmd='usermod'
 			$usercmd plexpy -G dietpi -d /opt/plexpy -s $(command -v nologin)
 
@@ -11818,7 +11818,7 @@ _EOF_
 			Banner_Configuration
 
 			# User
-			usercmd='useradd -rM'
+			local usercmd='useradd -rM'
 			getent passwd jackett &> /dev/null && usercmd='usermod'
 			$usercmd jackett -d /opt/jackett -s $(command -v nologin)
 


### PR DESCRIPTION
**Status**: Ready
- [x] Changelog

**Reference**: https://github.com/MichaIng/DietPi/issues/2862

**Commit list/description**:
+ DietPi-Software | Medusa: Install FFmpeg and mediainfo used to show and probe media info. If missing, warnings are created in log.
+ DietPi-Software | Medusa: Install and use Python3 as this is supported and recommended since some versions ago.
+ DietPi-Software | Skip one obsolete DietPi-Services stop call
+ DietPi-Software | Minor coding