### PR TITLE
add opt To allow survey subscription without sending the data on subscribe. 

### DIFF
--- a/dietpi/dietpi-survey
+++ b/dietpi/dietpi-survey
@@ -170,29 +170,7 @@ _EOF_
 
 	}
 
-	#/////////////////////////////////////////////////////////////////////////////////////
-	# Main Loop
-	#/////////////////////////////////////////////////////////////////////////////////////
-
-	# Read data from .dietpi-survey file
-	if [[ -f $FP_SETTINGS ]]; then
-
-		Read_Settings
-
-	# Force interactive user choice, if no settings file found = no choice made yet
-	elif (( $G_USER_INPUTS )); then
-
-		INPUT=0
-
-	fi
-
-	# Input mode: Send survey if opted in or empty file if opted out
-	if (( $INPUT == 1 )); then
-
-		Generate_File
-		Send_File
-
-	else
+	Optin_dialog(){
 
 		# Generate file to show content on user prompt
 		Generate_File
@@ -216,10 +194,46 @@ $(<$UPLOAD_FILENAME)
 
 Would you like to join DietPi-Survey?"; then
 
-			OPTED_IN=$G_WHIP_RETURNED_VALUE
-			Send_File
+		OPTED_IN=$G_WHIP_RETURNED_VALUE
 
 		fi
+
+	}
+
+
+
+	#/////////////////////////////////////////////////////////////////////////////////////
+	# Main Loop
+	#/////////////////////////////////////////////////////////////////////////////////////
+
+	# Read data from .dietpi-survey file
+	if [[ -f $FP_SETTINGS ]]; then
+
+		Read_Settings
+
+	# Force interactive user choice, if no settings file found = no choice made yet
+	elif (( $G_USER_INPUTS )); then
+
+		INPUT=0
+
+	fi
+
+	# Input mode: Send survey if opted in or empty file if opted out
+	if (( $INPUT == 1 )); then
+
+		Send_File
+
+	elif (( $INPUT == 2 )); then
+
+		Optin_dialog
+		Write_Settings
+		EXIT_CODE=0
+		G_DIETPI-NOTIFY 0 'Your preference have been stored.'
+
+	else
+
+		Optin_dialog
+		Send_File
 
 	fi
 


### PR DESCRIPTION
<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
**Status**:  Testing 

**Commit list/description**:

This is allow to optin on survey before network is ready. Or just avoid sending a report right at the subscription time.  

