### PR TITLE
DietPi-Software | Desktops: Fix PolicyKit error when logging in via LightDM as non-root

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -30,6 +30,7 @@ Bug Fixes:
 - DietPi-Drive_Manager | Resolved an issue where transferring the RootFS to a BTRFS formated drive fails. Since BTRFS support is not natively built into the RPi and Odroid kernel, a warning prompts and the transfer is aborted. Many thanks to @dieitpi for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?p=18164#p18164
 - DietPi-Software | MotionEye: Resolved an issue on ARMv6 where install failed due to PHP Buster repo conflicts. Many thanks to @infinitejones for reporting this issue: https://github.com/MichaIng/DietPi/issues/2888
 - DietPi-Software | Ampache: Resolved an issue where database connection failed when a custom global software password (other than "dietpi") was chosen. Many thanks to @WarHawk for reporting this issue and solution: https://dietpi.com/phpbb/viewtopic.php?p=15771#p15771
+- DietPi-Software | Desktops: Resolved an issue where PolicyKit failed when logging in via LightDM as non-root user, which broke shutdown and reboot options from logout panel. Many thanks to @magus7091 for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?f=11&t=5850
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-login
+++ b/dietpi/dietpi-login
@@ -25,7 +25,7 @@
 
 	Show_License(){
 
-		if [[ -f /var/lib/dietpi/license.txt ]] && (( $G_USER_INPUTS )); then
+		if [[ -f '/var/lib/dietpi/license.txt' ]] && (( $G_USER_INPUTS )); then
 
 			G_WHIP_VIEWFILE /var/lib/dietpi/license.txt
 			rm /var/lib/dietpi/license.txt
@@ -101,7 +101,7 @@
 			# - LightDM
 			elif (( $auto_start_index == 16 )); then
 
-				/usr/sbin/lightdm
+				systemctl start lightdm
 
 			fi
 
@@ -118,7 +118,7 @@
 		# - Prompt and wait if this script runs in other session already
 		local pid_firstrunsetup=''
 		[[ -f $FP_DIETPI_FIRSTRUNSETUP_PID ]] && pid_firstrunsetup=$(<$FP_DIETPI_FIRSTRUNSETUP_PID)
-		if [[ $pid_firstrunsetup ]] && (( $pid_firstrunsetup != $$ )); then
+		if [[ $pid_firstrunsetup && $pid_firstrunsetup != $$ ]]; then
 
 			# - First run setup running in other session
 			local additional_text='Please resume setup on the active screen.'
@@ -150,7 +150,7 @@ Please login again as user "root" with password "dietpi", respectively the one y
 			if (( $G_DIETPI_INSTALL_STAGE == 0 )); then
 
 				# - Check internet
-				optional_cmd_inputs='--no-check-certificate' G_CHECK_URL "$(grep -m1 '^[[:blank:]]*deb ' /etc/apt/sources.list | mawk '{print $2}')" # Will exit on failure here then prompt user to configure network
+				optional_cmd_inputs='--no-check-certificate' G_CHECK_URL "$(grep -m1 '^[[:blank:]]*deb[[:blank:]]' /etc/apt/sources.list | mawk '{print $2}')" # Will exit on failure here then prompt user to configure network
 
 				# - Check NTP synced
 				/DietPi/dietpi/func/run_ntpd
@@ -164,7 +164,7 @@ Please login again as user "root" with password "dietpi", respectively the one y
 				# - Start DietPi-Software
 				/DietPi/dietpi/dietpi-software 2>&1 | tee $FP_DIETPI_FIRSTRUNSETUP_LOG # Sets G_DIETPI_INSTALL_STAGE=2
 
-				# - done
+				# - Done
 				[[ -f $FP_DIETPI_FIRSTRUNSETUP_PID ]] && rm $FP_DIETPI_FIRSTRUNSETUP_PID
 
 			fi
@@ -207,7 +207,7 @@ Please login again as user "root" with password "dietpi", respectively the one y
 				/DietPi/dietpi/func/dietpi-banner 1
 
 				local auto_start_index=0
-				[[ -f /DietPi/dietpi/.dietpi-autostart_index ]] && auto_start_index=$(</DietPi/dietpi/.dietpi-autostart_index)
+				[[ -f '/DietPi/dietpi/.dietpi-autostart_index' ]] && auto_start_index=$(</DietPi/dietpi/.dietpi-autostart_index)
 				(( $auto_start_index > 0 )) && Run_AutoStart
 
 				break


### PR DESCRIPTION
**Status**: Ready
- [x] Changelog

**Reference**: https://github.com/MichaIng/DietPi/issues/2857

**Commit list/description**:
+ DietPi-Login | Start LightDM via its systemd unit which allows correct PolicyKit access/communication