### PR TITLE
DietPi-Software | Transmission: Fix web UI settings not being persistent

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -31,6 +31,7 @@ Bug Fixes:
 - DietPi-Software | MotionEye: Resolved an issue on ARMv6 where install failed due to PHP Buster repo conflicts. Many thanks to @infinitejones for reporting this issue: https://github.com/MichaIng/DietPi/issues/2888
 - DietPi-Software | Ampache: Resolved an issue where database connection failed when a custom global software password (other than "dietpi") was chosen. Many thanks to @WarHawk for reporting this issue and solution: https://dietpi.com/phpbb/viewtopic.php?p=15771#p15771
 - DietPi-Software | Desktops: Resolved an issue where PolicyKit failed when logging in via LightDM as non-root user, which broke shutdown and reboot options from logout panel. Many thanks to @magus7091 for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?f=11&t=5850
+- DietPi-Software | Transmission: Resolved an issue where settings applied via web UI did not survive a service restart or reboot. Many thanks to @chosen_too and @th0maz for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?p=17927#p17927
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8268,7 +8268,8 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 
 			# Run service as "dietpi" group: https://github.com/MichaIng/DietPi/issues/350#issuecomment-423763518
 			mkdir -p /etc/systemd/system/transmission-daemon.service.d
-			echo -e '[Service]\nGroup=dietpi' > /etc/systemd/system/transmission-daemon.service.d/dietpi-group.conf
+			# - Re-adding "debian-transmission" group somehow required: https://github.com/MichaIng/DietPi/issues/2793
+			echo -e '[Service]\nGroup=dietpi\nSupplementaryGroups=debian-transmission' > /etc/systemd/system/transmission-daemon.service.d/dietpi-group.conf
 
 			# Apply optimised settings
 			G_CONFIG_INJECT '"cache-size-mb"' '    "cache-size-mb": '$(Optimise_BitTorrent 0)',' /etc/transmission-daemon/settings.json '^\{$'
@@ -12583,13 +12584,13 @@ _EOF_
 
 		fi
 
-		software_id=44
+		software_id=44 # Transmission
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
 			G_AGP transmission-daemon
-			[[ -f /etc/systemd/system/transmission-daemon.service ]] && rm /etc/systemd/system/transmission-daemon.service # pre v6.17
-			[[ -d /etc/systemd/system/transmission-daemon.service.d ]] && rm -R /etc/systemd/system/transmission-daemon.service.d # post v6.17
+			[[ -f '/etc/systemd/system/transmission-daemon.service' ]] && rm /etc/systemd/system/transmission-daemon.service # pre v6.17
+			[[ -d '/etc/systemd/system/transmission-daemon.service.d' ]] && rm -R /etc/systemd/system/transmission-daemon.service.d # post v6.17
 
 		fi
 
@@ -12847,11 +12848,11 @@ _EOF_
 			apt-mark unhold mpd 1> /dev/null
 			G_AGP mpd libmpdclient2
 			getent passwd mpd &> /dev/null && userdel -rf mpd
-			[[ -f /lib/systemd/system/mpd.service ]] && rm /lib/systemd/system/mpd.service
+			[[ -f '/lib/systemd/system/mpd.service' ]] && rm /lib/systemd/system/mpd.service
 			[[ -d $G_FP_DIETPI_USERDATA/.mpd_cache ]] && rm -R $G_FP_DIETPI_USERDATA/.mpd_cache
-			[[ -f /usr/local/etc/mpd.conf ]] && rm /usr/local/etc/mpd.conf && rmdir --ignore-fail-on-non-empty /usr/local/etc
-			[[ -f /etc/mpd.conf ]] && rm /etc/mpd.conf
-			[[ -f /etc/default/mpd ]] && rm /etc/default/mpd # pre-v6.20
+			[[ -f '/usr/local/etc/mpd.conf' ]] && rm /usr/local/etc/mpd.conf && rmdir --ignore-fail-on-non-empty /usr/local/etc
+			[[ -f '/etc/mpd.conf' ]] && rm /etc/mpd.conf
+			[[ -f '/etc/default/mpd' ]] && rm /etc/default/mpd # pre-v6.20
 
 		fi
 
@@ -13030,12 +13031,7 @@ _EOF_
 
 			Banner_Uninstalling
 			G_AGP cloudprint-service
-			if (( $G_DISTRO == 3 )); then
-
-				rm /etc/apt/sources.list.d/cloudprint.list
-				G_AGUP
-
-			fi
+			(( $G_DISTRO == 3 )) && rm /etc/apt/sources.list.d/cloudprint.list
 
 		fi
 
@@ -13100,7 +13096,7 @@ _EOF_
 
 			systemctl start $MARIADB_SERVICE
 			mysqladmin drop koel -f
-			mysql -e "drop user 'koel'@'localhost'"
+			mysql -e 'drop user koel@localhost'
 
 			rm -R $G_FP_DIETPI_USERDATA/koel
 
@@ -13257,7 +13253,7 @@ _EOF_
 
 			Banner_Uninstalling
 			[[ -d $G_FP_DIETPI_USERDATA/roonserver ]] && rm -R $G_FP_DIETPI_USERDATA/roonserver
-			[[ -f /etc/systemd/system/roonserver.service ]] && rm /etc/systemd/system/roonserver.service
+			[[ -f '/etc/systemd/system/roonserver.service' ]] && rm /etc/systemd/system/roonserver.service
 
 		fi
 
@@ -13286,7 +13282,7 @@ _EOF_
 
 			Banner_Uninstalling
 			G_AGP mopidy
-			[[ -f /etc/apt/sources.list.d/mopidy.list ]] && rm /etc/apt/sources.list.d/mopidy.list
+			[[ -f '/etc/apt/sources.list.d/mopidy.list' ]] && rm /etc/apt/sources.list.d/mopidy.list
 
 			command -v pip &> /dev/null && pip uninstall -y Mopidy-MusicBox-Webclient Mopidy-Local-Images
 
@@ -13300,10 +13296,10 @@ _EOF_
 
 			Banner_Uninstalling
 			G_AGP kodi kodi-odroid
-			[[ -f /usr/share/applications/kodi.desktop ]] && rm /usr/share/applications/kodi.desktop
-			[[ -f /root/Desktop/kodi.desktop ]] && rm /root/Desktop/kodi.desktop
+			[[ -f '/usr/share/applications/kodi.desktop' ]] && rm /usr/share/applications/kodi.desktop
+			[[ -f '/root/Desktop/kodi.desktop' ]] && rm /root/Desktop/kodi.desktop
 			rm -f /home/*/Desktop/kodi.desktop
-			[[ -f /etc/udev/rules.d/99-dietpi-kodi.rules ]] && rm /etc/udev/rules.d/99-dietpi-kodi.rules
+			[[ -f '/etc/udev/rules.d/99-dietpi-kodi.rules' ]] && rm /etc/udev/rules.d/99-dietpi-kodi.rules
 
 		fi
 
@@ -13360,8 +13356,8 @@ _EOF_
 			Banner_Uninstalling
 			G_AGP deluged deluge-web deluge-console
 			userdel -rf debian-deluged
-			[[ -f /etc/systemd/system/deluged.service ]] && rm /etc/systemd/system/deluged.service
-			[[ -f /etc/systemd/system/deluge-web.service ]] && rm /etc/systemd/system/deluge-web.service
+			[[ -f '/etc/systemd/system/deluged.service' ]] && rm /etc/systemd/system/deluged.service
+			[[ -f '/etc/systemd/system/deluge-web.service' ]] && rm /etc/systemd/system/deluge-web.service
 			[[ -d $G_FP_DIETPI_USERDATA/deluge ]] && rm -R $G_FP_DIETPI_USERDATA/deluge
 
 		fi


### PR DESCRIPTION
**Status**: Ready
- [x] Changelog

**Reference**: https://github.com/MichaIng/DietPi/issues/2793

**Commit list/description**:
+ DietPi-Software | Transmission: Re-add "debian-transmission" group as supplementary group to systemd unit drop-in config, as "Group=dietpi" somehow overrides "debian-transmission" users primary group permission