### PR TITLE
Automatic login as dietpi

### DIFF
--- a/dietpi.txt
+++ b/dietpi.txt
@@ -100,7 +100,7 @@ AUTO_SETUP_WEB_SERVER_INDEX=-2
 
 #    DietPi-Autostart | Requires AUTO_SETUP_AUTOMATED=1
 #    After installation is completed, which program should the system boot to?
-#        0=Console 7=Console+auto root login | 1=Kodi 2=Desktops (LXDE/MATE etc) 5=DietPi-Cloudshell 6=Uae4ARM (Fastboot) 8=Uae4ARM (standard boot) 9=dxx-rebirth
+#        0=Console 7=Console+auto root login | 1=Kodi 2=Desktops (LXDE/MATE etc) 5=DietPi-Cloudshell 6=Uae4ARM (Fastboot) 8=Uae4ARM (standard boot) 9=dxx-rebirth 17=Desktop(as dietpi)
 AUTO_SETUP_AUTOSTART_TARGET_INDEX=0
 
 #    Language/Regional settings | Requires AUTO_SETUP_AUTOMATED=1

--- a/dietpi/dietpi-autostart
+++ b/dietpi/dietpi-autostart
@@ -117,6 +117,16 @@ ExecStart=
 ExecStart=-/sbin/agetty --autologin root %I $TERM
 _EOF_
 
+# - Enable auto login
+elif (( $AUTO_START_INDEX > 17 )); then
+
+			mkdir -p /etc/systemd/system/getty@tty1.service.d
+			cat << _EOF_ > /etc/systemd/system/getty@tty1.service.d/dietpi-autologin.conf
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty --autologin dietpi %I $TERM
+_EOF_
+
 		else
 
 			[[ -f /DietPi/dietpi/.dietpi-autostart_index ]] && rm /DietPi/dietpi/.dietpi-autostart_index
@@ -143,8 +153,9 @@ _EOF_
 			'0' ': Manual login (default)'
 			'7' ': Automatic login'
 			'' '●─ Desktops '
-			'2' ': Automatic login (recommended)'
+			'2' ': Automatic login as root (recommended)'
 			'16' ': LightDM login prompt'
+			'17' ': Automatic login as dietpi'
 			'' '●─ Browser Kiosk '
 			'11' ': Chromium - Dedicated use, without desktop'
 			'' '●─ Media '


### PR DESCRIPTION
<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
**Status**: WIP

**Reference**: https://github.com/MichaIng/DietPi/issues/XXXX

**Commit list/description**:

 Add an other option for automatic login option to log as dietpi user instead of root.

In fact, best solution would be to log as UID 1000 What ever de the name is. but agetty does not support it . 
