### PR TITLE
DietPi-Autostart | Allow to define a login user for all autologin options

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ v6.25
 
 Changes / Improvements / Optimisations:
 - DietPi-FirstBoot | First boot setup steps have been moved into a separate script and systemd unit. This allows further cleanup of the regular boot process and more targeted debugging and development. Many thanks for @FredericGuilbault for implementing this enhancement: https://github.com/MichaIng/DietPi/issues/2791
+- DietPi-Autostart | When choosing an autostart option that does not require a manual UNIX user login, the autologin user can now be chosen (which was always "root" previously). This can be applied automatically on firstrun setup with the new "AUTO_SETUP_AUTOSTART_LOGIN_USER" setting within dietpi.txt. If the user does not exist, is a system user (UID < 1000) or does not have a valid login shell, it will be reverted to root. Many thanks to @FredericGuilbault for suggesting this feature: https://github.com/MichaIng/DietPi/pull/2926
 - DietPi-Globals | G_OBTAIN_CPU_TEMP(): Added support for Core2Duo CPU temperature to be printed on e.g. DietPi-Banner and "cpu" command output. Many thanks to @OstrovCity for posting the required information: https://github.com/MichaIng/DietPi/pull/2563#issuecomment-494388278
 - DietPi-Service 2.0 | Combines dietpi-process_tool into dietpi-services. Adds IO policies, single/global service control and much more: https://github.com/MichaIng/DietPi/pull/2786
 - DietPi-Process_tool | Has been replaced with DietPi-Services. Existing saved options will no longer be available, please use 'dietpi-services' to apply required process_tool options with the upgraded system.

--- a/dietpi.txt
+++ b/dietpi.txt
@@ -45,42 +45,48 @@ AUTO_SETUP_SWAPFILE_SIZE=1
 # Swapfile location
 AUTO_SETUP_SWAPFILE_LOCATION=/var/swap
 
-# Disable HDMI (and GPU/VPU where supported) output for supported devices: RPi, Odroid C1, Odroid C2
+# Disable HDMI output (and GPU/VPU where supported) for supported devices: RPi, Odroid C1, Odroid C2
 AUTO_SETUP_HEADLESS=0
 
 # Unmask (enable) systemd-logind service, which is masked by default on DietPi
 AUTO_UNMASK_LOGIND=0
 
-# Custom Script (pre-networking and pre-DietPi install) | Runs before DietPi installation and networking
-# - Allows you to automatically execute a custom script before networking and DietPi installation is started
+# Custom Script (pre-networking and pre-DietPi install)
+# - Allows you to automatically execute a custom script before network is up on first boot.
 # - Copy your script to /boot/Automation_Custom_PreScript.sh and it will be executed automatically.
 # - Executed script log: /var/tmp/dietpi/logs/dietpi-automation_custom_prescript.log
 
-# Custom Script (post-networking and post-DietPi install) | Runs after DietPi installation is completed
-# - Allows you to automatically execute a custom script at the end of DietPi installation.
+# Custom Script (post-networking and post-DietPi install)
+# - Allows you to automatically execute a custom script at the end of DietPi install.
 # - Option 0 = Copy your script to /boot/Automation_Custom_Script.sh and it will be executed automatically.
 # - Option 1 = Host your script online, then use e.g. AUTO_SETUP_CUSTOM_SCRIPT_EXEC=http://myweb.com/myscript.sh and it will be downloaded and executed automatically.
 # - Executed script log: /var/tmp/dietpi/logs/dietpi-automation_custom_script.log
 AUTO_SETUP_CUSTOM_SCRIPT_EXEC=0
 
 ##### Software Options #####
-# SSH Server Selection: 0=none | -1=Dropbear | -2=OpenSSH
+# SSH Server Selection: 0=none/custom | -1=Dropbear | -2=OpenSSH
 AUTO_SETUP_SSH_SERVER_INDEX=-1
 
-# File Server Selection: 0=none/manual | -1=ProFTP | -2=Samba
+# File Server Selection: 0=none/custom | -1=ProFTP | -2=Samba
 AUTO_SETUP_FILE_SERVER_INDEX=0
 
-# Logging Mode Selection: 0=none/manual | -1=RAMlog 1h clear | -2=RAMlog 1h save clear | -3=logrotate + rsyslog
+# Logging Mode Selection: 0=none/custom | -1=RAMlog 1h clear | -2=RAMlog 1h save clear | -3=rsyslog + logrotate
 AUTO_SETUP_LOGGING_INDEX=-1
 # RAMlog max tmpfs size (MB). 50MB should be fine for single use. 200MB+ for heavy webserver and access log etc.
 AUTO_SETUP_RAMLOG_MAXSIZE=50
 
 # Webserver Preference Selection: 0=Apache2 | -1=Nginx | -2=Lighttpd
-# - This will get ignored, if you have manually selected any webserver stack.
+# - This will be ignored if you have manually selected any webserver stack.
 AUTO_SETUP_WEB_SERVER_INDEX=-2
 
-# DietPi-Autostart: 0=Console | 7=Console + auto login | 1=Kodi | 2=Desktop | 5=DietPi-Cloudshell | 6=Uae4ARM (fastboot) | 8=Uae4ARM (standard boot) | 9=DDX-Rebirth
+# DietPi-Autostart: 0=Console | 7=Console autologin | 1=Kodi | 2=Desktop autologin | 16=Desktop | 3=RetroPie | 4=OpenTyrian | 5=DietPi-Cloudshell | 6=Uae4ARM fastboot | 8=Uae4ARM standard boot | 9=DDX-Rebirth | 10=CAVA Spectrum | 11=Chromium kiosk | 14=Custom autostart service
+# - This will be effective on 2nd boot, after firstrun update and installs have been done.
+# - Related software titles must be installed either on firstrun installs or via AUTO_SETUP_AUTOMATED=1 + AUTO_SETUP_INSTALL_SOFTWARE_ID (see below).
 AUTO_SETUP_AUTOSTART_TARGET_INDEX=0
+# Autologin user name
+# - This user must exist before firstrun installs, otherwise it will be reverted to root.
+# - Applies to all autostart options but: 0, 6, 14 and 16
+AUTO_SETUP_AUTOSTART_LOGIN_USER=root
 
 ##### Non-interactive Firstrun Setup #####
 # On first login, run update, initial setup and software installs without any user input
@@ -106,26 +112,25 @@ AUTO_SETUP_GLOBAL_PASSWORD=dietpi
 # D I E T - P I
 # Misc DietPi program settings
 #------------------------------------------------------------------------------------------------------
-# DietPi-Survey: https://dietpi.com/phpbb/viewtopic.php?p=34#p34
-# - 1=opt in | 0=opt out | -1=ask on first call
+# DietPi-Survey: 1=opt in | 0=opt out | -1=ask on first call
+# - https://dietpi.com/phpbb/viewtopic.php?p=34#p34
 SURVEY_OPTED_IN=-1
 
 #------------------------------------------------------------------------------------------------------
 # D I E T - P I
 # DietPi-Config settings
 #------------------------------------------------------------------------------------------------------
-# CPU Governor | ondemand | powersave | performance | conservative
+# CPU Governor: ondemand | powersave | performance | conservative
 CONFIG_CPU_GOVERNOR=ondemand
 CONFIG_CPU_USAGE_THROTTLE_UP=50
 
-# CPU Frequency Limits: 
+# CPU Frequency Limits: Disabled=disabled
 # - Intel CPUs use a percentage value (%) from 0-100, eg: 55
 # - All other devices must use a specific MHz value, eg: 1600
-# - Disabled=disabled
 CONFIG_CPU_MAX_FREQ=Disabled
 CONFIG_CPU_MIN_FREQ=Disabled
 
-# Disable Intel-based turbo/boost stepping. This flag should not be required, setting <100% MAX frequency should disable Turbo on Intel CPU's.
+# Disable Intel-based turbo/boost stepping. This flag should not be required, setting <100% MAX frequency should disable Turbo on Intel CPUs.
 CONFIG_CPU_DISABLE_TURBO=0
 
 # Sampling Rate: Min value 10000 microseconds (10ms)
@@ -151,15 +156,15 @@ CONFIG_G_CHECK_URL_TIMEOUT=5
 # - Set this to "0" to disable URL checking completely, however this is not recommended to avoid harder to debug follow-up errors during APT and download attempts.
 CONFIG_G_CHECK_URL_ATTEMPTS=3
 
-# DietPi checks for updates (allows dietpi to check for updates on a daily basis and boot using a <1kb file download.)
+# DietPi checks for updates: Allows DietPi to check for updates on a daily basis and boot using a <1kb file download.
 CONFIG_CHECK_DIETPI_UPDATES=1
-# Optional: Automatically update DietPi when updates are available. | requires CONFIG_CHECK_DIETPI_UPDATES=1
+# Optional: Automatically update DietPi when updates are available. Requires: CONFIG_CHECK_DIETPI_UPDATES=1
 CONFIG_AUTO_DIETPI_UPDATES=0
 
-#NTPD Update Mode: 0=disabled | 1=boot only | 2=boot + daily | 3=boot + hourly | 4=Daemon + Drift
+# Network time sync: 0=disabled | 1=boot only | 2=boot + daily | 3=boot + hourly | 4=Daemon + Drift
 CONFIG_NTP_MODE=2
 
-# WiFi country code. 2 character value (eg GB US DE JP): https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+# WiFi country code: 2 character value (eg GB US DE JP): https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 CONFIG_WIFI_COUNTRY_CODE=GB
 
 # Serial Console: Set to 0 if you do not require serial console.
@@ -193,7 +198,7 @@ CONFIG_NTP_MIRROR=debian.pool.ntp.org
 # D I E T - P I
 # DietPi-Software settings
 #------------------------------------------------------------------------------------------------------
-# Enter your EmonCMS.org write API key here. It will be applied automatically during EmonPi/Hub installation.
+# Enter your EmonCMS.org write API key here. It will be applied automatically during EmonPi/Hub install.
 # - Eg: SOFTWARE_EMONHUB_APIKEY=b4dfmk2o203mmxx93a
 SOFTWARE_EMONHUB_APIKEY=
 
@@ -204,31 +209,28 @@ SOFTWARE_VNCSERVER_DEPTH=16
 SOFTWARE_VNCSERVER_DISPLAY_INDEX=1
 SOFTWARE_VNCSERVER_SHARE_DESKTOP=0
 
-# Optional username for ownCloud/Nextcloud admin account, the default is 'admin'. Applied during installation.
+# Optional username for ownCloud/Nextcloud admin account, the default is 'admin'. Applied during install.
 SOFTWARE_OWNCLOUD_NEXTCLOUD_USERNAME=admin
 
-# Optional data directory for ownCloud, default is '/mnt/dietpi_userdata/owncloud_data'. Applied during installation.
+# Optional data directory for ownCloud/Nextcloud, default is '/mnt/dietpi_userdata/owncloud_data' respectively '/mnt/dietpi_userdata/nextcloud_data'. Applied during install.
 # - This option is for advanced users. For full compatibility, please keep this options defaults, and, use dietpi-drive_manager to move the DietPi user data location.
 SOFTWARE_OWNCLOUD_DATADIR=/mnt/dietpi_userdata/owncloud_data
-
-# Optional data directory for Nextcloud, default is '/mnt/dietpi_userdata/nextcloud_data'. Applied during installation.
-# - This option is for advanced users. For full compatibility, please keep this options defaults, and, use dietpi-drive_manager to move the DietPi user data location.
 SOFTWARE_NEXTCLOUD_DATADIR=/mnt/dietpi_userdata/nextcloud_data
 
 # WiFi Hotspot
 SOFTWARE_WIFI_HOTSPOT_SSID=DietPi-HotSpot
-# - minimum of 8 characters
+# - Key requires a minimum of 8 characters
 SOFTWARE_WIFI_HOTSPOT_KEY=dietpihotspot
 SOFTWARE_WIFI_HOTSPOT_CHANNEL=3
 
 # X.org options
-#	DPI 96(default) 120(+25%) 144(+50%) 168(+75%) 192(+100%)
+# - DPI 96(default) 120(+25%) 144(+50%) 168(+75%) 192(+100%)
 SOFTWARE_XORG_DPI=96
 
 # Chromium options
 SOFTWARE_CHROMIUM_RES_X=1280
 SOFTWARE_CHROMIUM_RES_Y=720
-SOFTWARE_CHROMIUM_AUTOSTART_URL=https://google.com
+SOFTWARE_CHROMIUM_AUTOSTART_URL=https://dietpi.com
 
 #------------------------------------------------------------------------------------------------------
 # D I E T - P I


### PR DESCRIPTION
**Status**: Ready
- [x] DietPi-Autostart: https://github.com/MichaIng/DietPi/commit/07435ba162cf51ae9298b6b71a8d2a9c8c30f085 (whoopsie, accidentally merged to dev)
- [x] Changelog

**Reference**: https://github.com/MichaIng/DietPi/pull/2926

**Commit list/description**:
+ dietpi.txt | Add new AUTO_SETUP_AUTOSTART_LOGIN_USER to define the user for all autologin autostart options
+ dietpi.txt | Minor wording and format for consistency