### PR TITLE
DietPi-Patch | Little hotfix (on master patch_file) for ARMv7 Gitea installs

### DIFF
--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -2132,6 +2132,8 @@ A backup will be created to "/etc/mympd/mympd.conf.bak_DDMMYYY_N" from where you
 					[[ -f '/lib/systemd/system/mympd.service' ]] && rm /lib/systemd/system/mympd.service
 
 				fi
+				# - Little hotfix for ARMv7 Gitea installs, since ARMv7 binaries are not available for v1.8.X but ARMv6 binaries are backwards compatible
+				sed -i 's/arm-7/arm-6/' /DietPi/dietpi/dietpi-software
 				/DietPi/dietpi/dietpi-software reinstall 129 148 165
 
 			fi


### PR DESCRIPTION
**Status**: Ready
- Commit to master patch_file to prevent further error reports. Waiting for last verification it works, just to be failsafe.

**Reference**: https://github.com/MichaIng/DietPi/issues/2959

**Commit list/description**:
+ DietPi-Patch | Little hotfix (on master patch_file) for ARMv7 Gitea installs, since ARMv7 binaries are not available for v1.8.X but ARMv6 binaries are forwards compatible. It is fixed dietpi-software code-wise for v6.26.