### PR TITLE
DietPi-Software | Pi-hole: Disable pihole.log by default and enhance Lighttpd config

### DIFF
--- a/.conf/dps_93/lighttpd.pihole.conf
+++ b/.conf/dps_93/lighttpd.pihole.conf
@@ -1,0 +1,20 @@
+# Based on: https://github.com/pi-hole/pi-hole/blob/master/advanced/lighttpd.conf.debian
+
+# If the URL starts with /admin, it is the Web interface
+$HTTP["url"] =~ "^/admin/" {
+	# Create a response header for debugging using curl -I
+	setenv.add-response-header = (
+		"X-Pi-hole" => "The Pi-hole Web interface is working!",
+		"X-Frame-Options" => "DENY"
+	)
+
+	$HTTP["url"] =~ ".ttf$" {
+		# Allow Block Page access to local fonts
+		setenv.add-response-header = ( "Access-Control-Allow-Origin" => "*" )
+	}
+}
+
+# Block . files from being served, such as .git, .github, .gitignore
+$HTTP["url"] =~ "^/admin/\.(.*)" {
+	url.access-deny = ("")
+}

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,8 @@ v6.26
 
 Changes / Improvements / Optimisations:
 - General | Support for Debian Jessie has now been fully dropped from DietPi code. Jessie systems are moved to the "jessie-support" Git branch and will stay on v6.25. Critical bugs, if reported, may still be fixed, but DietPi-Software related issues and new features will not be handled anymore by the DietPi code team. However, everyone is free to open related pull requests against the jessie-support branch: https://github.com/MichaIng/DietPi/tree/jessie-support
+- DietPi-Software | Pi-hole: Logging to /var/log/pihole.log is now disabled by default, since it is not required in usual cases. Query logs, shown in web UI, are stored in database. This might also resolve possible pihole-FTL crashes in combination with DietPi-RAMlog and DietPi-Logclear. Many thanks to @kuerious for reporting and @Mcat12 for providing helpful information on this topic: https://github.com/pi-hole/FTL/issues/614
+- DietPi-Software | Pi-hole: Lighttpd config has been added to block access to .dot dirs (.git*) and enable local fonts for web UI, based on: https://github.com/pi-hole/pi-hole/blob/master/advanced/lighttpd.conf.debian
 
 Bug Fixes:
 - DietPi-Config | Resolved an issue on RPi where I2C baudrate was not applied correctly, thus selection was ineffective. Many thanks to @flashspys for reporting this issue: https://github.com/MichaIng/DietPi/issues/2966

--- a/dietpi/dietpi-cleaner
+++ b/dietpi/dietpi-cleaner
@@ -501,7 +501,7 @@ $G_PROGRAM_NAME simulation has finished: Press any key to continue..."
 		if (( ! $DRY_RUN )); then
 
 			/DietPi/dietpi/func/dietpi-logclear 1
-			rm -vf /var/tmp/dietpi/logs/*
+			rm -vRf /var/tmp/dietpi/logs/*
 
 		fi
 
@@ -515,8 +515,7 @@ $G_PROGRAM_NAME simulation has finished: Press any key to continue..."
 
 		if (( ! $DRY_RUN )); then
 
-			apt-get clean
-			rm -vf /var/lib/apt/lists/*
+			/DietPi/dietpi/func/dietpi-set_software apt-cache clean
 			G_AGUP
 
 		fi

--- a/dietpi/dietpi-cleaner
+++ b/dietpi/dietpi-cleaner
@@ -8,13 +8,13 @@
 	#////////////////////////////////////
 	#
 	# Info:
-	# - Location: /DietPi/dietpi/dietpi-cleaner
+	# - Location: /{DietPi,boot}/dietpi/dietpi-cleaner
 	# - Cleans "crap" on users system :)
 	#
 	# - Usage
 	# /DietPi/dietpi/dietpi-cleaner no-input	= menu
-	# /DietPi/dietpi/dietpi-cleaner 1 			= Run Enabled cleaners (no menu).
-	# /DietPi/dietpi/dietpi-cleaner 2 			= Run All cleaners (no menu).
+	# /DietPi/dietpi/dietpi-cleaner 1 		= Run Enabled cleaners (no menu).
+	# /DietPi/dietpi/dietpi-cleaner 2 		= Run All cleaners (no menu).
 	#////////////////////////////////////
 
 	# Import DietPi-Globals --------------------------------------------------------------
@@ -54,15 +54,7 @@
 	Menu_Exit(){
 
 		G_WHIP_SIZE_X_MAX=50
-		if G_WHIP_YESNO "Exit $G_PROGRAM_NAME?"; then
-
-			TARGETMENUID=-1 # Exit
-
-		else
-
-			TARGETMENUID=0 # Main menu
-
-		fi
+		G_WHIP_YESNO "Exit $G_PROGRAM_NAME?" && TARGETMENUID=-1 # Exit
 
 	}
 
@@ -85,7 +77,7 @@
 		)
 
 		G_WHIP_BUTTON_CANCEL_TEXT='Exit'
-		G_WHIP_MENU "Free up used space and system resources:\n - RootFS usage current = $ROOT_SPACE_USED_CURRENT MB\n - RootFS space cleared = $ROOT_SPACE_FREE_DELTA MB"
+		G_WHIP_MENU "Free up used space and system resources:\n - RootFS usage current = $ROOT_SPACE_USED_CURRENT MiB\n - RootFS space cleared = $ROOT_SPACE_FREE_DELTA MiB"
 		if (( $? == 0 )); then
 
 			case "$G_WHIP_RETURNED_VALUE" in
@@ -294,16 +286,15 @@ Would you like to continue and start the cleaning process?" && Run_Cleaners
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Cleaner stats
 	#/////////////////////////////////////////////////////////////////////////////////////
-	# Space free after running cleaner
+	# Space freed after running cleaner
 	ROOT_SPACE_USED_BEFORE=0
 	ROOT_SPACE_USED_AFTER=0
 	ROOT_SPACE_USED_CURRENT=0
 	ROOT_SPACE_FREE_DELTA='Cleaner has not been run - 0'
-	ROOTFS_DEVICE_PATH=$(sed -n 4p /DietPi/dietpi/.hw_model)
 
 	Update_Space_Used(){
 
-		ROOT_SPACE_USED_CURRENT=$(df --block-size MB | mawk -v pat="$ROOTFS_DEVICE_PATH" '$0~pat {print $3}' | tr -d 'MB')
+		ROOT_SPACE_USED_CURRENT=$(df -m --output=used / | mawk 'NR==2 {print $1;exit}')
 
 	}
 
@@ -370,7 +361,7 @@ $G_PROGRAM_NAME simulation has finished: Press any key to continue..."
 		Banner_Cleaning
 
 		# Find packages and convert into 1 line string
-		local string_package_names=''
+		local string_package_names
 		while read line
 		do
 
@@ -402,7 +393,7 @@ $G_PROGRAM_NAME simulation has finished: Press any key to continue..."
 		Banner_Cleaning
 
 		# Find packages and convert into 1 line string
-		local string_package_names=''
+		local string_package_names
 		while read line
 		do
 

--- a/dietpi/dietpi-cleaner
+++ b/dietpi/dietpi-cleaner
@@ -361,13 +361,7 @@ $G_PROGRAM_NAME simulation has finished: Press any key to continue..."
 		Banner_Cleaning
 
 		# Find packages and convert into 1 line string
-		local string_package_names
-		while read line
-		do
-
-			[[ $line ]] && string_package_names+="$line "
-
-		done <<< "$(dpkg --get-selections *-dev build-essential git make automake autoconf 2> /dev/null | mawk '{print $1}')"
+		local string_package_names=$(echo $(dpkg --get-selections *-dev build-essential make automake autoconf 2> /dev/null | mawk '{print $1}'))
 
 		# Mark for autoremoval
 		if (( $DRY_RUN )); then
@@ -393,13 +387,7 @@ $G_PROGRAM_NAME simulation has finished: Press any key to continue..."
 		Banner_Cleaning
 
 		# Find packages and convert into 1 line string
-		local string_package_names
-		while read line
-		do
-
-			[[ $line ]] && string_package_names+="$line "
-
-		done <<< "$(dpkg --get-selections man-db manpages 2> /dev/null | mawk '{print $1}')"
+		local string_package_names=$(echo $(dpkg --get-selections man-db manpages 2> /dev/null | mawk '{print $1}'))
 
 		# Mark for autoremoval
 		if (( $DRY_RUN )); then

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4151,7 +4151,7 @@ _EOF_
 			# Install
 			wget "$INSTALL_URL_ADDRESS" -O install.sh
 			chmod +x install.sh
-			# - Skip Lighttpd install, since user properly has chosen a different one, which was installed as pre-req.
+			# - Skip Lighttpd install, since we allow to choose and install prior to Pi-hole
 			./install.sh --disable-install-webserver
 			# - We can't do reasonable exit code check, since installer always returns 5!
 			rm install.sh
@@ -6965,9 +6965,11 @@ _EOF_
 
 			Banner_Configuration
 
-			# www path
-			G_BACKUP_FP /etc/lighttpd/lighttpd.conf
+			# Webroot
 			sed -i '/^server.document-root/c\server.document-root        = "/var/www"' /etc/lighttpd/lighttpd.conf
+			# - Move default page
+			mv /var/www/html/index.lighttpd.html /var/www/
+			rmdir --ignore-fail-on-non-empty /var/www/html
 
 			# Fix in case Lighttpd got updated to Buster version (on ARMv6 due to PHP7.3 libssl1.1 depedency)
 			# - "create-mime.assign.pl" has been renamed to "create-mime.conf.pl"
@@ -6987,14 +6989,9 @@ fastcgi.server += ( ".php" =>
         ))
 )
 _EOF_
-
-			# Enable cgi/php
+			# - Enable modules
 			lighttpd-enable-mod fastcgi
 			lighttpd-enable-mod fastcgi-php
-
-			# Move default page
-			mv /var/www/html/index.lighttpd.html /var/www/
-			rmdir --ignore-fail-on-non-empty /var/www/html
 
 		fi
 
@@ -8738,15 +8735,29 @@ _EOF_
 
 			Banner_Configuration
 
-			# - Create symlinks to align Pi-hole admin and blocking page relative to webroot
+			# Generate web interface PW: https://github.com/MichaIng/DietPi/issues/662
+			pihole -a -p "$GLOBAL_PW"
+
+			# Add Lighttpd config
+			if (( ${aSOFTWARE_INSTALL_STATE[84]} > 0 )); then
+
+				# Enable setenv module
+				G_CONFIG_INJECT '"mod_setenv",' '	"mod_setenv",' /etc/lighttpd/lighttpd.conf '"mod_.+",'
+				# Add and enable Pi-hole config
+				dps_index=$software_id Download_Install 'lighttpd.pihole.conf' /etc/lighttpd/conf-available/99-dietpi-pihole.conf
+				lighttpd-enable-mod dietpi-pihole
+
+			fi
+
+			# Create symlinks to align Pi-hole admin and blocking page relative to webroot
 			cd /var/www
-			#	Move existing files/dirs out of the way
-			[[ -L admin ]] || { [[ -e admin ]] && mv -v admin admin.bak; }
+			# - Move existing files/dirs out of the way
+			[[ -L 'admin' ]] || { [[ -e 'admin' ]] && mv -v admin admin.bak; }
 			ln -vsf html/admin admin
-			[[ -L pihole ]] || { [[ -e pihole ]] && mv -v pihole pihole.bak; }
+			[[ -L 'pihole' ]] || { [[ -e 'pihole' ]] && mv -v pihole pihole.bak; }
 			ln -vsf html/pihole pihole
 
-			# - Ask user whether to show blocking page
+			# Ask user whether to show blocking page
 			G_WHIP_BUTTON_OK_TEXT='YES'
 			G_WHIP_BUTTON_CANCEL_TEXT='NO'
 			if G_WHIP_YESNO 'Pi-hole can show a blocking page, when clients access a blocked website. This allows you to whitelist domains directly from the blocking page and prevents the need to access the admin page or use the Pi-hole CLI for this.\n
@@ -8754,8 +8765,8 @@ The downside is additional traffic and less performance compared to a silent req
 Do you want to enable the Pi-hole blocking page?'; then
 
 				G_CONFIG_INJECT 'BLOCKINGMODE=' 'BLOCKINGMODE=IP-NODATA-AAAA' /etc/pihole/pihole-FTL.conf
-				#	Link blocking page to webroot, where it is required
-				[[ -L index.php ]] || { [[ -e index.php ]] && mv -v index.php index.php.bak; }
+				# - Link blocking page to webroot, where it is required
+				[[ -L 'index.php' ]] || { [[ -e 'index.php' ]] && mv -v index.php index.php.bak; }
 				ln -vsf pihole/index.php index.php
 
 			else
@@ -8765,16 +8776,17 @@ Do you want to enable the Pi-hole blocking page?'; then
 			fi
 			cd /tmp/$G_PROGRAM_NAME
 
-			# - Fix service to disable syslog pre-req preventing start
+			# Fix service to disable syslog pre-req preventing start
 			G_CONFIG_INJECT '# Required-Stop:' '# Required-Stop: $network $remote_fs' /etc/init.d/pihole-FTL
 			G_CONFIG_INJECT '# Required-Start:' '# Required-Start: $network $remote_fs' /etc/init.d/pihole-FTL
 			systemctl enable pihole-FTL
 
-			# - Run Gravity
-			pihole -g
+			# Disable pihole.log: https://github.com/pi-hole/FTL/issues/614#issuecomment-510564476
+			pihole -l off
+			rm /var/log/pihole.log
 
-			# - Generate web interface PW: https://github.com/MichaIng/DietPi/issues/662
-			pihole -a -p "$GLOBAL_PW" &> /dev/null # do not print
+			# Run Gravity
+			pihole -g
 
 		fi
 
@@ -12412,10 +12424,10 @@ _EOF_
 			Banner_Uninstalling
 			G_AGP lighttpd
 
-			# Remove certbot renewal hook:
-			rm /etc/systemd/system/certbot.service.d/dietpi-lighttpd.conf &> /dev/null
-			# Remove hook directory only, if empty:
-			rmdir /etc/systemd/system/certbot.service.d &> /dev/null
+			# Remove certbot renewal hook
+			[[ -f 'etc/systemd/system/certbot.service.d/dietpi-lighttpd.conf' ]] && rm /etc/systemd/system/certbot.service.d/dietpi-lighttpd.conf
+			# Remove hook directory if empty
+			rmdir --ignore-fail-on-non-empty /etc/systemd/system/certbot.service.d
 
 		fi
 
@@ -13103,26 +13115,31 @@ _EOF_
 			Banner_Uninstalling
 			pihole uninstall
 
-			# - pihole-FTL service+binary
-			systemctl disable pihole-FTL &> /dev/null
-			systemctl stop pihole-FTL &> /dev/null
-			rm /etc/init.d/pihole-FTL &> /dev/null
-			rm /usr/bin/pihole-FTL &> /dev/null
+			# pihole-FTL service+binary
+			if [[ -f '/etc/init.d/pihole-FTL' ]]; then
 
-			rm -R /etc/pihole &> /dev/null
-			rm -R /etc/.pihole &> /dev/null
-			rm -R /opt/pihole &> /dev/null
-			rm -R /var/www/html/admin &> /dev/null
-			rm -R /var/www/html/pihole &> /dev/null
+				systemctl unmask pihole-FTL
+				systemctl disable --now pihole-FTL
+				rm /etc/init.d/pihole-FTL
 
-			# - symlinks
-			rm /var/www/pihole &> /dev/null
-			rm /var/www/admin &> /dev/null
+			fi
+			[[ -f '/usr/bin/pihole-FTL' ]] && rm /usr/bin/pihole-FTL
+
+			# Dirs
+			[[ -d '/etc/pihole' ]] && rm -R /etc/pihole
+			[[ -d '/etc/.pihole' ]] && rm -R /etc/.pihole
+			[[ -d '/opt/pihole' ]] && rm -R /opt/pihole
+			[[ -d '/var/www/html/admin' ]] && rm -R /var/www/html/admin
+			[[ -d '/var/www/html/pihole' ]] && rm -R /var/www/html/pihole
+
+			# Symlinks
+			[[ -L '/var/www/pihole' ]] && rm /var/www/pihole
+			[[ -L '/var/www/admin' ]] && rm /var/www/admin
 			[[ $(readlink /var/www/index.php) == 'pihole/index.php' ]] && rm /var/www/index.php
 
-			# - pre Pi-hole v4
+			# Pre Pi-hole v4
 			G_AGP dnsmasq
-			rm -R /etc/dnsmasq* &> /dev/null
+			rm -Rf /etc/dnsmasq*
 
 		fi
 

--- a/dietpi/func/dietpi-logclear
+++ b/dietpi/func/dietpi-logclear
@@ -96,7 +96,7 @@
 			if (( $PROCESS_FILE == 1 )); then
 
 				# Delete all compressed filetypes
-				elif (( $FILE_TYPE == 1 )); then
+				if (( $FILE_TYPE == 1 )); then
 
 					rm "${ARRAY_LOG_FILEPATH[$i]}"
 					((INFO_LOGS_DELETED++))
@@ -156,7 +156,7 @@
 	# Print usage
 	if (( $INPUT > 2 || $INPUT < 0 )); then
 
-		G_DIETPI-NOTIFY 2 "Available commands:
+		G_DIETPI-NOTIFY 2 "Available commands:\e[0m
 \n\e[1m dietpi-logclear 0\e[0m
 \e[38;5;244m Backup contents of all log files from $FILEPATH_LOGFOLDER to $FILEPATH_BACKUPFOLDER/*.\n Also clears the contents of all logs files in $FILEPATH_LOGFOLDER.\e[0m
 \n\e[1m dietpi-logclear 1\e[0m
@@ -174,10 +174,9 @@
 		[[ $INPUT == 2 && -f $FILEPATH_BACKUPFOLDER ]] && rm -R $FILEPATH_BACKUPFOLDER
 
 		# Print Info
-		local info="
+		info="
  - Log file directory      \e[90m|\e[0m $FILEPATH_LOGFOLDER
  - Processed files         \e[90m|\e[0m $INFO_FILES_PROCESSED
- - Excluded files          \e[90m|\e[0m $INFO_EXCLUDED_LOGFILES
  - Cleared log files       \e[90m|\e[0m $INFO_LOGS_CLEARED
  - Unsupported files       \e[90m|\e[0m $INFO_LOGS_NOTSUPPORTED
  - Deleted files           \e[90m|\e[0m $INFO_LOGS_DELETED

--- a/dietpi/func/dietpi-logclear
+++ b/dietpi/func/dietpi-logclear
@@ -16,35 +16,26 @@
 	# - dietpi-logclear 2		| Delete all logs in $FILEPATH_LOGFOLDER and backups.
 	#////////////////////////////////////
 
-	#Import DietPi-Globals ---------------------------------------------------------------
+	# Import DietPi-Globals --------------------------------------------------------------
 	. /DietPi/dietpi/func/dietpi-globals
 	G_PROGRAM_NAME='DietPi-Logclear'
 	G_CHECK_ROOT_USER
 	G_INIT
-	#Import DietPi-Globals ---------------------------------------------------------------
+	# Import DietPi-Globals --------------------------------------------------------------
 
-	INPUT=-1
-	disable_error=1 G_CHECK_VALIDINT "$1" && INPUT=$1
+	disable_error=1 G_CHECK_VALIDINT "$1" && INPUT=$1 || INPUT=-1
 
 	#////////////////////////////////////////////////////////////////
 	# Global
 	#////////////////////////////////////////////////////////////////
-	TEMP_FILE='dietpi-logclear'
-
 	FILEPATH_LOGFOLDER='/var/log'
-	FILEPATH_BACKUPFOLDER="$HOME/logfile_storage"
+	FILEPATH_BACKUPFOLDER='/root/logfile_storage'
 
 	FILE_NAME=''
-	#0=text log, 1=compressed, 2=Pi-hole
+	# 0=text log, 1=compressed
 	FILE_TYPE=0
 	FILESIZE_BYTES=0
 	PROCESS_FILE=0
-
-	#////////////////////////////////////////////////////////////////
-	#Excluded log files (user created)
-	#////////////////////////////////////////////////////////////////
-	FP_EXCLUDED_LOGFILES='/DietPi/dietpi/.dietpi-logclear_exclude'
-	INFO_EXCLUDED_LOGFILES=0
 
 	#////////////////////////////////////////////////////////////////
 	# Info Printouts
@@ -62,155 +53,83 @@
 	Process_Logfiles(){
 
 		#-----------------------------------------------------------------------------------
-		#Remove internally rotated LetsEncrypt log files, prior to log loop
+		# Remove internally rotated LetsEncrypt log files, prior to log loop
 		[[ -d $FILEPATH_LOGFOLDER/letsencrypt ]] && rm -f $FILEPATH_LOGFOLDER/letsencrypt/letsencrypt.log.*
 
 		#-----------------------------------------------------------------------------------
-		#Find existing logs and generate a filepath list.
-		find $FILEPATH_LOGFOLDER -type f > $TEMP_FILE
+		# Find existing logs and generate a filepath array, excluding symlinks
+		local ARRAY_LOG_FILEPATH=()
+		while read -r line
+		do
 
-		#Read logfile filepath list into array.
-		readarray -t ARRAY_LOG_FILEPATH < $TEMP_FILE
+			ARRAY_LOG_FILEPATH+=("$line")
+
+		done <<< "$(find $FILEPATH_LOGFOLDER -type f)"
 
 		#-----------------------------------------------------------------------------------
-		#Process Logfiles
+		# Process Logfiles
 		for ((i=0; i<${#ARRAY_LOG_FILEPATH[@]}; i++))
 		do
 
-			#File details
-			FILE_NAME=${ARRAY_LOG_FILEPATH[$i]//\/var\/log\/}
+			# File details
+			FILE_NAME=${ARRAY_LOG_FILEPATH[$i]#/var/log/}
 			FILESIZE_BYTES=$(stat -c%s "${ARRAY_LOG_FILEPATH[$i]}")
 			PROCESS_FILE=1
 			FILE_TYPE=0
 
-			#Special Filetypes
-			#Pi-hole logs (contains dns stats) | FILE_TYPE 2
-			if [[ ${ARRAY_LOG_FILEPATH[$i]} == '/var/log/pihole.log' ]]; then
-
-				FILE_TYPE=2
-
-			#Compessed files (zip etc) | FILE_TYPE 1
-			elif [[ ${FILE_NAME: -4} == '.zip' || ${FILE_NAME: -3} == '.gz' ]]; then
+			# Filetypes
+			# - Compessed files (zip etc) | FILE_TYPE 1
+			if [[ ${FILE_NAME: -4} == '.zip' || ${FILE_NAME: -3} == '.gz' ]]; then
 
 				FILE_TYPE=1
 
-			#Normal Log Files.
-			# - Exclude <= 10 byte size
-			# - Exclude .db* extentions SQLite (.db .db-shm .db.wal)
-			elif (( $FILESIZE_BYTES <= 10 )) || [[ $FILE_NAME =~ '.db' ]]; then
+			# - Normal Log Files
+			#	Exclude <= 10 byte size
+			#	Exclude .db* extentions SQLite (.db .db-shm .db.wal)
+			elif (( $FILESIZE_BYTES < 11 )) || [[ $FILE_NAME =~ '.db' ]]; then
 
 				PROCESS_FILE=0
 
 			fi
 
-			#Process File
+			# Process File
 			if (( $PROCESS_FILE == 1 )); then
 
-				#Pi-hole
-				if (( $FILE_TYPE == 2 )); then
-
-					local pihole_restart_required=0
-
-					#Find all non-matching lines with todays date
-					#	 NB: day is space padded without trailling 0 (eg: Sep  1, Sep 11)
-					local month_day_today="$(date +'%b %e')"
-
-					# - Check for at least 1 non-matching line before applying. Remove all lines in logfile for all other days, excluding today.
-					if grep -vqi "$month_day_today" /var/log/pihole.log; then
-
-						#	RAMlog mode 2:
-						if (( $INPUT == 0 )); then
-
-							sed "/$month_day_today/d" "${ARRAY_LOG_FILEPATH[$i]}" >> "$FILEPATH_BACKUPFOLDER/$FILE_NAME"
-							((INFO_BACKUPS_MADE++))
-
-						fi
-
-						G_DIETPI-NOTIFY 2 'Clearing log entries for Pi-hole, that are not from today, please wait...'
-						sed -i '/'"$month_day_today"'/!d' /var/log/pihole.log
-						pihole_restart_required=1
-
-					fi
-
-					#	recheck size again
-					FILESIZE_BYTES=$(stat -c%s "${ARRAY_LOG_FILEPATH[$i]}")
-
-					#Clear all entries if over (AUTO_SETUP_RAMLOG_MAXSIZE / 3) (we have to limit and prevent /var/log hitting the 50mb tmpfs limit)
-					local filesize_limit=$(( ( $(grep -m1 '^[[:blank:]]*AUTO_SETUP_RAMLOG_MAXSIZE=' /DietPi/dietpi.txt | sed 's/^[^=]*=//') / 3 ) * 1024 * 1024 ))
-					if (( $FILESIZE_BYTES >= $filesize_limit )); then
-
-						G_DIETPI-NOTIFY 2 "${ARRAY_LOG_FILEPATH[$i]} has exceeded ${filesize_limit}MB, clearing, please wait..."
-
-						#	RAMlog mode 2:
-						if (( $INPUT == 0 )); then
-
-							cat "${ARRAY_LOG_FILEPATH[$i]}" >> "$FILEPATH_BACKUPFOLDER/$FILE_NAME"
-							((INFO_BACKUPS_MADE++))
-
-						fi
-
-						> "${ARRAY_LOG_FILEPATH[$i]}"
-						((INFO_LOGS_CLEARED++))
-
-						pihole_restart_required=1
-
-					#Prevent size effecting results
-					else
-
-						FILESIZE_BYTES=0
-
-					fi
-
-					#restart PiHole if we modified the log file
-					if (( $pihole_restart_required )); then
-
-						G_DIETPI-NOTIFY 2 'PiHole logs have been changed, restarting, please wait...'
-						systemctl stop pihole-FTL
-						# Handle dnsmasq only, if enabled (+installed), otherwise assume FTLDNS, which would be broken by dnsmasq start: https://github.com/MichaIng/DietPi/issues/1696
-						systemctl is-enabled dnsmasq 2> /dev/null | grep -q '^enabled$' && systemctl stop dnsmasq
-						systemctl stop resolvconf
-						sleep 1
-						systemctl start resolvconf
-						systemctl is-enabled dnsmasq 2> /dev/null | grep -q '^enabled$' && systemctl start dnsmasq
-						systemctl start pihole-FTL
-
-					fi
-
-				#Delete all compressed filetypes.
+				# Delete all compressed filetypes
 				elif (( $FILE_TYPE == 1 )); then
 
 					rm "${ARRAY_LOG_FILEPATH[$i]}"
 					((INFO_LOGS_DELETED++))
 					((INFO_LOGS_NOTSUPPORTED++))
 
-				#Update current log files data to $FILEPATH_BACKUPFOLDER/*. Then clear.
+				# Update current log files data to $FILEPATH_BACKUPFOLDER/*, then clear
 				elif (( $INPUT == 0 )); then
 
-					#Generate filepaths
+					# Generate filepaths
 					if [[ ! -f $FILEPATH_BACKUPFOLDER/$FILE_NAME ]]; then
 
-						#This is a little "hack" to automatically generate the required subdirectories.
+						# This is a little "hack" to automatically generate the required subdirectories.
 						# EG: /this/is/my/logfile.txt | will create the folders /this/is/my
 						mkdir -p "$FILEPATH_BACKUPFOLDER/$FILE_NAME"
 						rm -R "$FILEPATH_BACKUPFOLDER/$FILE_NAME"
 
 					fi
 
-					#Write current logfile contents to existing.
+					# Write current logfile contents to existing.
 					cat "${ARRAY_LOG_FILEPATH[$i]}" >> "$FILEPATH_BACKUPFOLDER/$FILE_NAME"
 					((INFO_BACKUPS_MADE++))
 
-					#Clear logfile contents
+					# Clear logfile contents
 					> "${ARRAY_LOG_FILEPATH[$i]}"
 					((INFO_LOGS_CLEARED++))
 
-				#Clear logfile contents
+				# Clear logfile contents
 				elif (( $INPUT == 1 )); then
 
 					> "${ARRAY_LOG_FILEPATH[$i]}"
 					((INFO_LOGS_CLEARED++))
 
-				#Hard delete log files
+				# Hard delete log files
 				elif (( $INPUT == 2 )); then
 
 					rm "${ARRAY_LOG_FILEPATH[$i]}"
@@ -218,7 +137,7 @@
 
 				fi
 
-				#Update Size cleared.
+				# Update Size cleared
 				INFO_SIZE_CLEARED=$(($INFO_SIZE_CLEARED + $FILESIZE_BYTES))
 
 			fi
@@ -227,12 +146,6 @@
 
 		done
 
-		#Remove temp files
-		rm $TEMP_FILE
-
-		#delete[] array
-		unset ARRAY_LOG_FILEPATH
-
 	}
 
 	#////////////////////////////////////////////////////////////////
@@ -240,61 +153,47 @@
 	#////////////////////////////////////////////////////////////////
 
 	#----------------------------------------------------------------
-	#How to use print.
-	if (( $INPUT == -1 )); then
+	# Print usage
+	if (( $INPUT > 2 || $INPUT < 0 )); then
 
-		G_DIETPI-NOTIFY 2 'Available commands:'
-		echo ''
-		echo -e '\e[1m dietpi-logclear 0\e[0m'
-		echo -e "\e[38;5;244m Backup contents of all log files from $FILEPATH_LOGFOLDER to $FILEPATH_BACKUPFOLDER/*.\n Also clears the contents of all logs files in $FILEPATH_LOGFOLDER.\e[0m"
-		echo ''
-		echo -e '\e[1m dietpi-logclear 1\e[0m'
-		echo -e "\e[38;5;244m Clear contents of all logs files in $FILEPATH_LOGFOLDER.\e[0m"
-		echo ''
-		echo -e '\e[1m dietpi-logclear 2\e[0m'
-		echo -e "\e[38;5;244m Physically delete all files in $FILEPATH_LOGFOLDER and backups in $FILEPATH_BACKUPFOLDER/*.\n May prevent log files from being updated, restart services or reboot. \e[0m"
-		echo ''
+		G_DIETPI-NOTIFY 2 "Available commands:
+\n\e[1m dietpi-logclear 0\e[0m
+\e[38;5;244m Backup contents of all log files from $FILEPATH_LOGFOLDER to $FILEPATH_BACKUPFOLDER/*.\n Also clears the contents of all logs files in $FILEPATH_LOGFOLDER.\e[0m
+\n\e[1m dietpi-logclear 1\e[0m
+\e[38;5;244m Clear contents of all logs files in $FILEPATH_LOGFOLDER.\e[0m
+\n\e[1m dietpi-logclear 2\e[0m
+\e[38;5;244m Physically delete all files in $FILEPATH_LOGFOLDER and backups in $FILEPATH_BACKUPFOLDER/*.\n May prevent log files from being updated, restart services or reboot.\e[0m\n"
 
 	#----------------------------------------------------------------
-	#Process log files
-	elif (( $INPUT >= 0 )); then
+	# Process log files
+	else
 
 		Process_Logfiles
 
-		#Delete logfile backups
-		(( $INPUT == 2 )) && rm -R $FILEPATH_BACKUPFOLDER &> /dev/null
+		# Delete logfile backups
+		[[ $INPUT == 2 && -f $FILEPATH_BACKUPFOLDER ]] && rm -R $FILEPATH_BACKUPFOLDER
 
-		#Print Info
-		G_DIETPI-NOTIFY 2
-		echo -e " - Log file directory      \e[90m|\e[0m $FILEPATH_LOGFOLDER"
-		echo -e " - Processed files         \e[90m|\e[0m $INFO_FILES_PROCESSED"
+		# Print Info
+		local info="
+ - Log file directory      \e[90m|\e[0m $FILEPATH_LOGFOLDER
+ - Processed files         \e[90m|\e[0m $INFO_FILES_PROCESSED
+ - Excluded files          \e[90m|\e[0m $INFO_EXCLUDED_LOGFILES
+ - Cleared log files       \e[90m|\e[0m $INFO_LOGS_CLEARED
+ - Unsupported files       \e[90m|\e[0m $INFO_LOGS_NOTSUPPORTED
+ - Deleted files           \e[90m|\e[0m $INFO_LOGS_DELETED
+ - Space cleared           \e[90m|\e[0m $(($INFO_SIZE_CLEARED / 1024)) KiB"
 
-		#Excluded
-		echo -e " - Excluded files          \e[90m|\e[0m $INFO_EXCLUDED_LOGFILES"
-
-		#Cleared
-		echo -e " - Cleared log files       \e[90m|\e[0m $INFO_LOGS_CLEARED"
-
-		#Deleted
-		echo -e " - Unsupported files       \e[90m|\e[0m $INFO_LOGS_NOTSUPPORTED"
-		echo -e " - Deleted files           \e[90m|\e[0m $INFO_LOGS_DELETED"
-
-		#convert size to kb
-		#/= (i miss it)
-		INFO_SIZE_CLEARED=$(($INFO_SIZE_CLEARED / 1024))
-		echo -e " - Space cleared           \e[90m|\e[0m $INFO_SIZE_CLEARED KB"
-
-		#Backups
+		# + Backups
 		if (( $INPUT == 0 )); then
 
-			echo ''
-			echo -e ' \e[38;5;244mBackup Info:\e[0m'
-			echo -e " - Backup directory        \e[90m|\e[0m $FILEPATH_BACKUPFOLDER"
-			echo -e " - Updated log files       \e[90m|\e[0m $INFO_BACKUPS_MADE"
+			info+="
+ \e[38;5;244mBackup Info:\e[0m
+ - Backup directory        \e[90m|\e[0m $FILEPATH_BACKUPFOLDER
+ - Updated log files       \e[90m|\e[0m $INFO_BACKUPS_MADE"
 
 		fi
 
-		echo ''
+		G_DIETPI-NOTIFY 2 "\e[0mSummary:$info\n"
 
 	fi
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -2085,6 +2085,14 @@ A backup will be created to "/etc/mympd/mympd.conf.bak_DDMMYYY_N" from where you
 			# RPi: Remove invalid I2C baudrate entries from dietpi.txt. Do no apply any value to preserve current system state (default): https://github.com/MichaIng/DietPi/issues/2966
 			(( $G_HW_MODEL < 10 )) && sed -i '/^[[:blank:]]*i2c_arm_baudrate=/d' /DietPi/dietpi.txt
 			#-------------------------------------------------------------------------------
+			# Disable pihole.log: https://github.com/pi-hole/FTL/issues/614#issuecomment-510564476
+			if command -v pihole &> /dev/null; then
+
+				pihole -l off
+				rm /var/log/pihole.log
+
+			fi
+			#-------------------------------------------------------------------------------
 
 		fi
 


### PR DESCRIPTION
**Status**: Ready
- [x] DietPi-Software | Pi-hole: Lighttpd include config
- [x] DietPi-Logclear | Remove special pihole.log handling
- [x] DietPi-Patch | Disable pihole.log
- [x] Changelog

**Reference**: https://github.com/pi-hole/FTL/issues/614#issuecomment-510564476

**Commit list/description**:
+ DietPi-Software | Pi-hole: Add Pi-hole specific Lighttpd include config based on: https://github.com/pi-hole/pi-hole/blob/master/advanced/lighttpd.conf.debian
+ DietPi-Software | Pi-hole: Disable pihole.log by default: https://github.com/pi-hole/FTL/issues/614#issuecomment-510564476
+ DietPi-Software | Lighttpd: Do not create lighttpd.conf backup, since we only edit webroot or fix a Buster upgrade bug, which both is simply required and expected by user to have the just chosen software title + Lighttpd up and running.