### PR TITLE
DietPi-Software: fix docker install on debian buster

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5736,10 +5736,10 @@ Pin-Priority: -1' > /etc/apt/preferences.d/dietpi-docker_fix
 			chmod +x DockerInstall.sh
 			./DockerInstall.sh
 			rm DockerInstall.sh
-			# - Raspbian Buster branch is missing, so revert to Stretch: https://download.docker.com/linux/raspbian/dists/
-			if (( $G_DISTRO > 4 && $G_HW_MODEL < 10 )) && ! G_ERROR_HANDLER_INFO_ONLY=1 G_USER_INPUTS=0 G_CHECK_URL 'https://download.docker.com/linux/raspbian/dists/buster/'; then
+			# - Raspbian packages are missing in Buster branch, so revert to Stretch: https://download.docker.com/linux/raspbian/dists/
+			if (( $G_DISTRO > 4 && $G_HW_MODEL < 10 )); then
 
-				G_DIETPI-NOTIFY 2 'Docker repo misses a Raspbian Buster branch, reverting to Stretch...'
+				G_DIETPI-NOTIFY 2 'Docker repo misses Raspbian Buster packages, reverting to Stretch...'
 				sed -i 's/[[:blank:]]buster[[:blank:]]/ stretch /' /etc/apt/sources.list.d/docker.list
 				G_AGUP
 				G_AGI docker-ce docker-ce-cli


### PR DESCRIPTION
**Status**: Ready, tested on RPI
DietPi-Software: Reverts to stretch repo to complete docker install

**Issue description:**
Docker packages are missing in Buster branch: https://download.docker.com/linux/raspbian/dists/buster/stable/binary-armhf/Packages

From `dietpi-software install 162` output: 
```
 Mode: Installing Docker: Build, ship, and run distributed applications

[  OK  ] DietPi-Software | Connection test: https://get.docker.com
--2019-07-25 12:01:15--  https://get.docker.com/
Resolving get.docker.com (get.docker.com)... 13.226.42.34, 13.226.42.107, 13.226.42.61, ...
Connecting to get.docker.com (get.docker.com)|13.226.42.34|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 13185 (13K) [text/plain]
Saving to: ‘DockerInstall.sh’

DockerInstall.sh                            100%[========================================================================================>]  12.88K  --.-KB/s    in 0.01s   

2019-07-25 12:01:15 (1.07 MB/s) - ‘DockerInstall.sh’ saved [13185/13185]

# Executing docker install script, commit: 6bf300318ebaab958c4adc341a8c7bb9f3a54a1a
+ sh -c apt-get update -qq >/dev/null
+ sh -c apt-get install -y -qq apt-transport-https ca-certificates curl >/dev/null
+ sh -c curl -fsSL "https://download.docker.com/linux/raspbian/gpg" | apt-key add -qq - >/dev/null
Warning: apt-key output should not be parsed (stdout is not a terminal)
+ sh -c echo "deb [arch=armhf] https://download.docker.com/linux/raspbian buster stable" > /etc/apt/sources.list.d/docker.list
+ sh -c apt-get update -qq >/dev/null
+ [ -n  ]
+ sh -c apt-get install -y -qq --no-install-recommends docker-ce >/dev/null
E: Package 'docker-ce' has no installation candidate
```

After that DietPi-Software continues as normal and even marks Docker as installed but no docker packages were downloaded:

```
 DietPi-Software
─────────────────────────────────────────────────────
 Mode: Automated install

[ INFO ] DietPi-Software | 162: Docker is already installed
[ INFO ] DietPi-Software | Use "dietpi-software reinstall 162", to force rerun of installation and configuration scripts for Docker.
[  OK  ] DietPi-Software | No changes applied for: Docker
```

Run `dpkg -l | grep docker` to verify packages are missing.

**Fix:** Update `if` statement to get packages from stretch branch. 