### PR TITLE
DietPi-Software | Gogs: Install latest pre-compiled binaries from GitHub for ARMv7 + x86_64

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Changes / Improvements / Optimisations:
 - DietPi-Config | Some /etc/modprobe.d/ configs are merged to less files and mostly prefixed with "dietpi-", to allow easier differentiation between Debian/pre-image and DietPi files.
 - DietPi-Software | Pi-hole: Logging to /var/log/pihole.log is now disabled by default, since it is not required in usual cases. Query logs, shown in web UI, are stored in database. This might also resolve possible pihole-FTL crashes in combination with DietPi-RAMlog and DietPi-Logclear. Many thanks to @kuerious for reporting and @Mcat12 for providing helpful information on this topic: https://github.com/pi-hole/FTL/issues/614
 - DietPi-Software | Pi-hole: Lighttpd config has been added to block access to .dot dirs (.git*) and enable local fonts for web UI, based on: https://github.com/pi-hole/pi-hole/blob/master/advanced/lighttpd.conf.debian
+- DietPi-Software | Gogs: On ARMv7 and x86_64 now the latest version from GitHub is installed. Reinstalls will upgrade the version while preserving existing settings. Many thanks to @LazyLama for doing this suggestion: https://github.com/MichaIng/DietPi/issues/2999
 
 Bug Fixes:
 - General | Removed an obsolete OpenMediaVault cron job and binary that was leftover on at least one of our images (NanoPi NEO2) and is not part of the current OMV packages, thus save to remove in every case. Many thanks to @kt1024 for reporting this issue: https://github.com/MichaIng/DietPi/issues/2994

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10280,6 +10280,7 @@ _EOF_
 			# Database
 			if [[ ! -d '/var/lib/mysql/gogs' ]]; then
 
+				systemctl start mariadb
 				mysql < /etc/gogs/scripts/mysql.sql
 				mysql -e "grant all privileges on gogs.* to gogs@localhost identified by '$GLOBAL_PW'"
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5100,26 +5100,33 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/gogs_'
-
-			#armv6
+			# ARMv6: No pre-compiled binaries available, thus we use our own: https://github.com/gogs/gogs/releases
 			if (( $G_HW_ARCH == 1 )); then
 
-				INSTALL_URL_ADDRESS+='armv6.zip'
+				INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/gogs_armv6.zip'
 
-			#armv7+
-			elif (( $G_HW_ARCH == 2 )); then
+			# Else install latest binaries from GitHub
+			else
 
-				INSTALL_URL_ADDRESS+='armv7.zip'
+				# ARMv7
+				local file='raspi2_armv6.zip'
+				local fallback_url='https://github.com/gogs/gogs/releases/download/v0.11.86/raspi2_armv6.zip'
 
-			#x86_64
-			elif (( $G_HW_ARCH == 10 )); then
+				# x86_64
+				if (( $G_HW_ARCH == 10 )); then
 
-				INSTALL_URL_ADDRESS+='amd64.zip'
+					file='linux_amd64.tar.gz'
+					fallback_url='https://github.com/gogs/gogs/releases/download/v0.11.86/linux_amd64.tar.gz'
+
+				fi
+
+				G_CHECK_URL 'https://api.github.com/repos/gogs/gogs/releases/latest'
+				INSTALL_URL_ADDRESS=$(curl -s 'https://api.github.com/repos/gogs/gogs/releases/latest' | grep -m1 "browser_download_url.*$file" | cut -d \" -f 4)
+
 			fi
 
-			Download_Install "$INSTALL_URL_ADDRESS" /etc
-			mv /etc/gogs* /etc/gogs
+			Download_Install "$INSTALL_URL_ADDRESS"
+			mv gogs* /etc/gogs
 
 		fi
 
@@ -13640,7 +13647,7 @@ _EOF_
 
 			systemctl start mariadb
 			mysqladmin drop gogs -f
-			mysql -e "drop user 'gogs'@'localhost'"
+			mysql -e 'drop user gogs@localhost'
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10280,7 +10280,26 @@ _EOF_
 			# Database
 			if [[ ! -d '/var/lib/mysql/gogs' ]]; then
 
-				systemctl start mariadb
+				G_DIETPI-NOTIFY 2 'Enable 4-byte support for MariaDB.'
+				cat << _EOF_ > /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf
+[mysqld]
+innodb_large_prefix=1
+innodb_file_format=barracuda
+innodb_file_per_table=1
+character-set-server=utf8mb4
+collation-server=utf8mb4_general_ci
+_EOF_
+				# On Buster (MariaDB 10.3) the following settings are removed and default to our needs:
+				# - innodb_large_prefix: https://mariadb.com/kb/en/library/innodb-system-variables/#innodb_large_prefix
+				# - innodb_file_format: https://mariadb.com/kb/en/library/innodb-system-variables/#innodb_file_format
+				if (( $G_DISTRO > 4 )); then
+
+					sed -i '/innodb_large_prefix/d' /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf
+					sed -i '/innodb_file_format/d' /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf
+
+				fi
+				G_RUN_CMD systemctl restart mariadb
+
 				mysql < /etc/gogs/scripts/mysql.sql
 				mysql -e "grant all privileges on gogs.* to gogs@localhost identified by '$GLOBAL_PW'"
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5122,11 +5122,22 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 				G_CHECK_URL 'https://api.github.com/repos/gogs/gogs/releases/latest'
 				INSTALL_URL_ADDRESS=$(curl -s 'https://api.github.com/repos/gogs/gogs/releases/latest' | grep -m1 "browser_download_url.*$file" | cut -d \" -f 4)
+				local no_check_url=1 # G_CHECK_URL faces 403
 
 			fi
 
 			Download_Install "$INSTALL_URL_ADDRESS"
-			mv gogs* /etc/gogs
+
+			# Remove old install dir, but preserve existing configs
+			if [[ -d '/etc/gogs' ]]; then
+
+				[[ -d '/etc/gogs/custom' ]] && mv /etc/gogs/custom gogs
+				mv /etc/gogs/.??* gogs # dot files = SSH and Git user configs
+				rm -R /etc/gogs
+
+			fi
+
+			mv gogs /etc/gogs
 
 		fi
 
@@ -10267,7 +10278,12 @@ _EOF_
 			chown -R gogs:gogs $G_FP_DIETPI_USERDATA/gogs-repo /var/log/gogs
 
 			# Database
-			/DietPi/dietpi/func/create_mysql_db gogs gogs "$GLOBAL_PW"
+			if [[ ! -d '/var/lib/mysql/gogs' ]]; then
+
+				mysql < /etc/gogs/scripts/mysql.sql
+				mysql -e "grant all privileges on gogs.* to gogs@localhost identified by '$GLOBAL_PW'"
+
+			fi
 
 			# Service
 			cat << _EOF_ > /etc/systemd/system/gogs.service
@@ -10968,7 +10984,7 @@ _EOF_
 
 				G_RUN_CMD systemctl start mariadb
 				# - Create database user only, database will be created automatically
-				mysql -e "grant all privileges on ompd.* to ompd@localhost identified by '$GLOBAL_PW';"
+				mysql -e "grant all privileges on ompd.* to ompd@localhost identified by '$GLOBAL_PW'"
 				systemctl stop mariadb
 
 				cat << _EOF_ > /var/www/ompd/include/config.local.inc.php
@@ -13639,11 +13655,17 @@ _EOF_
 
 			Banner_Uninstalling
 
-			userdel -rf gogs
+			if [[ -f '/etc/systemd/system/gogs.service' ]]; then
 
-			rm -R /etc/gogs
-			rm /etc/systemd/system/gogs.service
-			rm -R /var/log/gogs
+				systemctl disable --now gogs
+				rm -R /etc/systemd/system/gogs.service*
+
+			fi
+
+			getent passwd gogs &> /dev/null && userdel -rf gogs
+
+			[[ -d '/etc/gogs' ]] && rm -R /etc/gogs
+			[[ -d '/var/log/gogs' ]] && rm -R /var/log/gogs
 
 			systemctl start mariadb
 			mysqladmin drop gogs -f

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3345,13 +3345,12 @@ Package: *php7.3*\nPin: release *\nPin-Priority: -1' > /etc/apt/preferences.d/di
 			(( ${aSOFTWARE_INSTALL_STATE[89]} == 2 )) && package_list+=" $PHP_NAME-mysql"
 			G_AGI "$package_list"
 
-			# - Remove mysql.service as we use mariadb.service, both cannot exist: https://github.com/MichaIng/DietPi/issues/1913#issuecomment-441343798
+			# Remove obsolete sysvinit service as we use the systemd mariadb.service
 			if [[ -f '/etc/init.d/mysql' ]]; then
 
 				G_DIETPI-NOTIFY 2 'Switching from /etc/init.d/mysql to mariadb.service'
-				systemctl stop mysql
+				systemctl disable --now mysql
 				rm /etc/init.d/mysql
-				systemctl daemon-reload
 
 			fi
 
@@ -7120,7 +7119,25 @@ _EOF_
 
 			Banner_Configuration
 
-			### Also for MariaDB?
+			G_DIETPI-NOTIFY 2 'Assuring 4-byte support and InnoDB Barracuda file format with large prefix'
+			cat << _EOF_ > /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf
+[mysqld]
+innodb_large_prefix=1
+innodb_file_format=barracuda
+innodb_file_per_table=1
+character-set-server=utf8mb4
+collation-server=utf8mb4_general_ci
+_EOF_
+			# Since Buster (MariaDB 10.3) the following settings are removed and default to our needs:
+			# - innodb_large_prefix: https://mariadb.com/kb/en/library/innodb-system-variables/#innodb_large_prefix
+			# - innodb_file_format: https://mariadb.com/kb/en/library/innodb-system-variables/#innodb_file_format
+			if (( $G_DISTRO > 4 )); then
+
+				sed -i '/innodb_large_prefix/d' /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf
+				sed -i '/innodb_file_format/d' /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf
+
+			fi
+
 			# Optimise for reduced memory use: https://github.com/MichaIng/DietPi/issues/605#issue-188930987
 			#cat << _EOF_ > /etc/mysql/mariadb.conf.d/99-dietpi.cnf
 #[mysqld]
@@ -7394,27 +7411,8 @@ location = /.well-known/caldav {
 
 			fi
 
-			G_DIETPI-NOTIFY 2 'Enable 4-byte support for MariaDB.' # https://doc.owncloud.org/server/administration_manual/configuration/database/linux_database_configuration.html#configure-mysql-for-4-byte-unicode-support
-			cat << _EOF_ > /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf
-[mysqld]
-innodb_large_prefix=1
-innodb_file_format=barracuda
-innodb_file_per_table=1
-character-set-server=utf8mb4
-collation-server=utf8mb4_general_ci
-_EOF_
-			# On Buster (MariaDB 10.3) the following settings are removed and default to our needs:
-			# - innodb_large_prefix: https://mariadb.com/kb/en/library/innodb-system-variables/#innodb_large_prefix
-			# - innodb_file_format: https://mariadb.com/kb/en/library/innodb-system-variables/#innodb_file_format
-			if (( $G_DISTRO > 4 )); then
-
-				sed -i '/innodb_large_prefix/d' /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf
-				sed -i '/innodb_file_format/d' /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf
-
-			fi
+			# Start MariaDB and Redis for database creation and occ command
 			G_RUN_CMD systemctl restart mariadb
-
-			# Start redis-server, which is required for ncc command:
 			G_RUN_CMD systemctl start redis-server
 
 			# Initially add occ command shortcut, will be done by Dietpi-Globals automatically, if occ file exist:
@@ -7643,27 +7641,8 @@ location = /.well-known/caldav {
 
 			fi
 
-			G_DIETPI-NOTIFY 2 'Enable 4-byte support for MariaDB' # https://docs.nextcloud.com/server/stable/admin_manual/configuration_database/mysql_4byte_support.html
-			cat << _EOF_ > /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf
-[mysqld]
-innodb_large_prefix=1
-innodb_file_format=barracuda
-innodb_file_per_table=1
-character-set-server=utf8mb4
-collation-server=utf8mb4_general_ci
-_EOF_
-			# On Buster (MariaDB 10.3) the following settings are removed and default to our needs:
-			# - innodb_large_prefix: https://mariadb.com/kb/en/library/innodb-system-variables/#innodb_large_prefix
-			# - innodb_file_format: https://mariadb.com/kb/en/library/innodb-system-variables/#innodb_file_format
-			if (( $G_DISTRO > 4 )); then
-
-				sed -i '/innodb_large_prefix/d' /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf
-				sed -i '/innodb_file_format/d' /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf
-
-			fi
+			# Start MariaDB and Redis for database creation and ncc command
 			G_RUN_CMD systemctl restart mariadb
-
-			# Start redis-server, which is required for ncc command:
 			G_RUN_CMD systemctl start redis-server
 
 			# Initially add occ command shortcut, will be done by Dietpi-Globals automatically, if occ file exist:
@@ -10280,26 +10259,7 @@ _EOF_
 			# Database
 			if [[ ! -d '/var/lib/mysql/gogs' ]]; then
 
-				G_DIETPI-NOTIFY 2 'Enable 4-byte support for MariaDB.'
-				cat << _EOF_ > /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf
-[mysqld]
-innodb_large_prefix=1
-innodb_file_format=barracuda
-innodb_file_per_table=1
-character-set-server=utf8mb4
-collation-server=utf8mb4_general_ci
-_EOF_
-				# On Buster (MariaDB 10.3) the following settings are removed and default to our needs:
-				# - innodb_large_prefix: https://mariadb.com/kb/en/library/innodb-system-variables/#innodb_large_prefix
-				# - innodb_file_format: https://mariadb.com/kb/en/library/innodb-system-variables/#innodb_file_format
-				if (( $G_DISTRO > 4 )); then
-
-					sed -i '/innodb_large_prefix/d' /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf
-					sed -i '/innodb_file_format/d' /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf
-
-				fi
 				G_RUN_CMD systemctl restart mariadb
-
 				mysql < /etc/gogs/scripts/mysql.sql
 				mysql -e "grant all privileges on gogs.* to gogs@localhost identified by '$GLOBAL_PW'"
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -2135,6 +2135,18 @@ A backup will be created to "/etc/mympd/mympd.conf.bak_DDMMYYY_N" from where you
 
 			done
 			#-------------------------------------------------------------------------------
+			# Reinstalls and software install changes
+			if (( $G_DIETPI_INSTALL_STAGE == 2 )); then
+
+				# Gogs: Remove /etc/__MACOSX that comes from our archive on ARMv6
+				if grep -q '^aSOFTWARE_INSTALL_STATE\[49\]=2' /DietPi/dietpi/.installed; then
+
+					[[ $G_HW_ARCH == 1 && -d '/etc/__MACOSX' ]] && rm -R /etc/__MACOSX
+
+				fi
+
+			fi
+			#-------------------------------------------------------------------------------
 
 		fi
 


### PR DESCRIPTION
**Status**: Testing
- [x] DietPi-Patch | Remove `/etc/__MACOSX` if present, coming from our archives
- [x] Changelog
- [ ] Testing on non-RPi ARMv7 to be failsafe
- [x] Test reinstall from pre-v6.26 instance to assure InnoDB 4byte support does not break existing database
- [ ] Compile and use ARMv6 binaries

Fixes #2999

**Commit list/description**:
+ DietPi-Software | Gogs: Install latest pre-compiled binaries from GitHub for ARMv7 + x86_64. For ARMv6 (RPi1/Zero) no binaries are available yet
+ DietPi-Software | Gogs: Download to /tmp first to avoid moving the "__MACOSX" dir to /etc that comes with our ARMv6 archive
+ DietPi-Software | Gogs: C_CHECK_URL receives 403 on GitHub download, thus skip it
+ DietPi-Software | Gogs: On reinstall, remove old install dir, but preserve existing configs
+ DietPi-Software | Gogs: Import pre-defined SQL file on fresh install to pre-create database. On current version otherwise an error occurs on access attempt
+ DietPi-Software | Gogs: InnoDB large table prefix with Barracuda file format is required
+ DietPi-Software | MariaDB: Assure/Enable 4-byte support (default since Stretch) and modern Barracuda file format + large table prefix (default since Buster) on all MariaDB installs. This has no effect on existing tables, setting this with ownCloud and Nextcloud installs never caused issues for other MariaDB databases and software using them, and, every Stretch to backports/Buster upgrade would break it the same way if so. However a special eye on this during Beta phase makes sense.