### PR TITLE
Pi 4 SDTV support

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -25,6 +25,8 @@
 
 # SDTV_MODES
 #sdtv_mode=0
+# On the Raspberry Pi 4, composite output is disabled by default, # Uncomment to enable SDTV
+#enable_tvout=1
 
 # Uncomment to force a specific HDMI mode (this will force VGA).
 #hdmi_group=1


### PR DESCRIPTION
from https://www.raspberrypi.org/documentation/configuration/config-txt/video.md

enable_tvout (Pi 4B only)
On the Raspberry Pi 4, composite output is disabled by default, due to the way the internal clocks are interrelated and allocated. Because composite video requires a very specific clock, setting that clock to the required speed on the Pi 4 means that other clocks connected to it are detrimentally affected, which slightly slows down the entire system. Since composite video is a less commonly used function, we decided to disable it by default to prevent this system slowdown.

To enable composite output, use the enable_tvout=1 option. As described above, this will detrimentally affect performance to a small degree.

On older Pi models, the composite behaviour remains the same.

<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
**Status**: Ready 


**Reference**: from https://www.raspberrypi.org/documentation/configuration/config-txt/video.md
