### PR TITLE
DietPi-Software | OpenVPN: Remove rsyslog dependency and preserve existing configs on reinstall

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Changes / Improvements / Optimisations:
 - DietPi-Config | Some /etc/modprobe.d/ configs are merged to less files and mostly prefixed with "dietpi-", to allow easier differentiation between Debian/pre-image and DietPi files.
 - DietPi-Software | Pi-hole: Logging to /var/log/pihole.log is now disabled by default, since it is not required in usual cases. Query logs, shown in web UI, are stored in database. This might also resolve possible pihole-FTL crashes in combination with DietPi-RAMlog and DietPi-Logclear. Many thanks to @kuerious for reporting and @Mcat12 for providing helpful information on this topic: https://github.com/pi-hole/FTL/issues/614
 - DietPi-Software | Pi-hole: Lighttpd config has been added to block access to .dot dirs (.git*) and enable local fonts for web UI, based on: https://github.com/pi-hole/pi-hole/blob/master/advanced/lighttpd.conf.debian
+- DietPi-Software | OpenVPN: Rsyslog is not installed anymore together with OpenVPN server. Logs are available via "journalctl -u openvpn", all system logs via "journalctl". If you require persistent logs, uninstall DietPi-RAMlog via dietpi-software and make the journal boot persistent via: mkdir /var/log/journal
 
 Bug Fixes:
 - General | Removed an obsolete OpenMediaVault cron job and binary that was leftover on at least one of our images (NanoPi NEO2) and is not part of the current OMV packages, thus save to remove in every case. Many thanks to @kt1024 for reporting this issue: https://github.com/MichaIng/DietPi/issues/2994

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,7 @@ Bug Fixes:
 - DietPi-Software | Gitea: Resolved an issue where install fails on ARMv7 systems. Many thanks to @maschiw for reporting this issue: https://github.com/MichaIng/DietPi/issues/2959
 - DietPi-Software | Node-RED: Resolved an issue where install fails due to missing data dir creation. Many thanks to @Orfait for reporting this isssue: https://github.com/MichaIng/DietPi/issues/2975
 - DietPi-Software | Node-RED: Resolved an issue where user creation fails if "gpio" group is not present. Many thanks to @marcobrianza for reporting this issue: https://github.com/MichaIng/DietPi/issues/2975#issuecomment-513917360
+- DietPi-Software | OpenVPN: Resolved an issue where install failed on Debian Buster due to a new easy-rsa version with changed commands and options.
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9490,11 +9490,11 @@ verb 3
 # Web Forwarding (uncomment to enable)
 #push "redirect-gateway"
 #push "dhcp-option DNS 10.8.0.1"
-
 _EOF_
 
 				# Client config
-				cat << _EOF_ > easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
+				local fp='easy-rsa/keys/DietPi_OpenVPN_Client.ovpn'
+				cat << _EOF_ > $fp
 client
 proto udp
 dev tun
@@ -9514,25 +9514,28 @@ persist-tun
 ns-cert-type server
 comp-lzo
 verb 3
-
 _EOF_
-				# - Add Server cert auth
-				echo '<ca>' >> easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
-				cat ca.crt >> easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
-				echo '</ca>' >> easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
-				# - Add Client cert
-				echo '<cert>' >> easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
-				cat easy-rsa/keys/DietPi_OpenVPN_Client.crt >> easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
-				echo '</cert>' >> easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
-				# - Add Client key
-				echo '<key>' >> easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
-				cat easy-rsa/keys/DietPi_OpenVPN_Client.key >> easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
-				echo '</key>' >> easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
+				# Add CA and client cert and key
+				if (( $G_DISTRO < 5 )); then
+
+					echo -e "
+<ca>\n$(<ca.crt)\n</ca>
+<cert>\n$(<easy-rsa/keys/DietPi_OpenVPN_Client.crt)\n</cert>
+<key>\n$(<easy-rsa/keys/DietPi_OpenVPN_Client.key)\n</key>" >> $fp
+
+				else
+
+					echo -e "
+<ca>\n$(<ca.crt)\n</ca>
+<cert>\n$(<easy-rsa/keys/issued/DietPi_OpenVPN_Client.crt)\n</cert>
+<key>\n$(<easy-rsa/keys/private/DietPi_OpenVPN_Client.key)\n</key>" >> $fp
+
+				fi
 
 				# Copy client config to userdata location
-				cp easy-rsa/keys/DietPi_OpenVPN_Client.ovpn $G_FP_DIETPI_USERDATA/
+				cp $fp $G_FP_DIETPI_USERDATA/
 				# - and /boot partition
-				cp easy-rsa/keys/DietPi_OpenVPN_Client.ovpn /boot/
+				cp $fp /boot/
 
 				cd /tmp/$G_PROGRAM_NAME
 				break # Always break loop which is only for single wildcard file detection

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2481,12 +2481,10 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		fi
 
 		# Software that requires LibSSL1.0.0
-		# - OpenVPN (97) on Stretch for easy-rsa
 		# - Jackett (147)
 		software_id=126
 		if (( ${aSOFTWARE_INSTALL_STATE[37]} == 1 ||
 			${aSOFTWARE_INSTALL_STATE[60]} == 1 ||
-			( ${aSOFTWARE_INSTALL_STATE[97]} == 1 && G_DISTRO == 4 ) ||
 			${aSOFTWARE_INSTALL_STATE[134]} == 1 ||
 			${aSOFTWARE_INSTALL_STATE[147]} == 1 )); then
 
@@ -4640,7 +4638,7 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-			G_AGI openvpn easy-rsa iptables
+			G_AGI openvpn iptables
 			# Remove obsolete sysvinit service
 			[[ -f '/etc/init.d/openvpn' ]] && rm /etc/init.d/openvpn
 
@@ -9408,44 +9406,23 @@ _EOF_
 
 				fi
 
-				# Cert and key generation via easy-rsa
-				local key_size=2048
-				G_DIETPI-NOTIFY 2 'Generating unique OpenVPN certificates and keys. Please wait...\n'
+				# Pre-v6.26 cleanup
+				[[ -f '/etc/openvpn/dh2048.pem' ]] && rm /etc/openvpn/dh2048.pem
+				dpkg-query -s easy-rsa &> /dev/null && G_AGP easy-rsa
 
-				# - DH param
-				openssl dhparam -out /etc/openvpn/dh${key_size}.pem $key_size
-
-				# - Prepare easy-rsa
+				# Download latest easy-rsa from GitHub
+				G_DIETPI-NOTIFY 2 'Downloading latest easy-rsa for certificate and key generation...'
+				INSTALL_URL_ADDRESS='https://api.github.com/repos/OpenVPN/easy-rsa/releases/latest'
+				G_CHECK_URL "$INSTALL_URL_ADDRESS"
+				fallback_url='https://github.com/OpenVPN/easy-rsa/releases/download/v3.0.6/EasyRSA-unix-v3.0.6.tgz'
+				no_check_url=1 Download_Install "$(curl -s "$INSTALL_URL_ADDRESS" | grep -m1 '"browser_download_url.*EasyRSA-.*\.tgz' | cut -d \" -f 4)"
 				[[ -d '/etc/openvpn/easy-rsa' ]] && rm -R /etc/openvpn/easy-rsa
-				cp -a /usr/share/easy-rsa /etc/openvpn
+				mv EasyRSA-* /etc/openvpn/easy-rsa
+
+				# Cert and key generation via easy-rsa
+				G_DIETPI-NOTIFY 2 'Generating unique OpenVPN certificates and keys. Please wait...\n'
 				cd /etc/openvpn/easy-rsa
-
-				if (( $G_DISTRO < 5 )); then
-
-					cat << _EOF_ >> vars
-export KEY_SIZE=$key_size
-export KEY_COUNTRY='UK'
-export KEY_PROVINCE='DietPi'
-export KEY_CITY='DietPi'
-export KEY_ORG='DietPi'
-export KEY_EMAIL='noreply@dietpi.com'
-export KEY_OU='DietPi'
-export KEY_NAME='DietPi_OpenVPN_Server'
-_EOF_
-					cp -a openssl-1.0.0.cnf openssl.cnf # https://github.com/MichaIng/DietPi/issues/1450#issuecomment-362608574
-					. ./vars
-					./clean-all
-					./build-ca --batch
-					./build-key-server --batch DietPi_OpenVPN_Server
-					./build-key --batch DietPi_OpenVPN_Client
-					cp -a keys/{DietPi_OpenVPN_Server.crt,DietPi_OpenVPN_Server.key,ca.crt} /etc/openvpn/
-
-				else
-
-					cp -a vars.example vars
-					cat << _EOF_ >> vars
-set_var EASYRSA_PKI		"$PWD/keys"
-set_var EASYRSA_KEY_SIZE	$key_size
+				cat << _EOF_ > vars
 set_var EASYRSA_REQ_COUNTRY	"UK"
 set_var EASYRSA_REQ_PROVINCE	"DietPi"
 set_var EASYRSA_REQ_CITY	"DietPi"
@@ -9454,15 +9431,14 @@ set_var EASYRSA_REQ_EMAIL	"noreply@dietpi.com"
 set_var EASYRSA_REQ_OU		"DietPi"
 set_var EASYRSA_BATCH		"1"
 _EOF_
-					./easyrsa init-pki
-					./easyrsa build-ca nopass
-					./easyrsa build-server-full DietPi_OpenVPN_Server nopass
-					./easyrsa build-client-full DietPi_OpenVPN_Client nopass
-					cp -a keys/{issued/DietPi_OpenVPN_Server.crt,private/DietPi_OpenVPN_Server.key,ca.crt} /etc/openvpn/
-
-				fi
+				./easyrsa init-pki
+				./easyrsa build-ca nopass
+				./easyrsa gen-dh
+				./easyrsa build-server-full DietPi_OpenVPN_Server nopass
+				./easyrsa build-client-full DietPi_OpenVPN_Client nopass
 
 				# Server config
+				cp -a pki/{ca.crt,dh.pem,issued/DietPi_OpenVPN_Server.crt,private/DietPi_OpenVPN_Server.key} /etc/openvpn/
 				cd /etc/openvpn
 				cat << _EOF_ > server.conf
 port 1194
@@ -9472,7 +9448,7 @@ dev tun
 ca ca.crt
 cert DietPi_OpenVPN_Server.crt
 key DietPi_OpenVPN_Server.key
-dh dh$key_size.pem
+dh dh.pem
 
 server 10.8.0.0 255.255.255.0
 
@@ -9494,8 +9470,7 @@ verb 3
 _EOF_
 
 				# Client config
-				local fp='easy-rsa/keys/DietPi_OpenVPN_Client.ovpn'
-				cat << _EOF_ > $fp
+				cat << _EOF_ > DietPi_OpenVPN_Client.ovpn
 client
 proto udp
 dev tun
@@ -9516,27 +9491,16 @@ ns-cert-type server
 comp-lzo
 verb 3
 _EOF_
-				# Add CA and client cert and key
-				if (( $G_DISTRO < 5 )); then
-
-					echo -e "
+				# - Add CA cert, client cert and key
+				echo -e "
 <ca>\n$(<ca.crt)\n</ca>
-<cert>\n$(<easy-rsa/keys/DietPi_OpenVPN_Client.crt)\n</cert>
-<key>\n$(<easy-rsa/keys/DietPi_OpenVPN_Client.key)\n</key>" >> $fp
+<cert>\n$(<easy-rsa/pki/issued/DietPi_OpenVPN_Client.crt)\n</cert>
+<key>\n$(<easy-rsa/pki/private/DietPi_OpenVPN_Client.key)\n</key>" >> DietPi_OpenVPN_Client.ovpn
 
-				else
-
-					echo -e "
-<ca>\n$(<ca.crt)\n</ca>
-<cert>\n$(<easy-rsa/keys/issued/DietPi_OpenVPN_Client.crt)\n</cert>
-<key>\n$(<easy-rsa/keys/private/DietPi_OpenVPN_Client.key)\n</key>" >> $fp
-
-				fi
-
-				# Copy client config to userdata location
-				cp $fp $G_FP_DIETPI_USERDATA/
+				# - Copy to userdata
+				cp DietPi_OpenVPN_Client.ovpn $G_FP_DIETPI_USERDATA/
 				# - and /boot partition
-				cp $fp /boot/
+				cp DietPi_OpenVPN_Client.ovpn /boot/
 
 				cd /tmp/$G_PROGRAM_NAME
 				break # Always break loop which is only for single wildcard file detection

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9401,7 +9401,7 @@ _EOF_
 
 					G_DIETPI-NOTIFY 2 "Existing OpenVPN configuration found: $i
  - Config generation will be skipped.
- - If you need a fresh config set, please remove $i
+ - If you need a fresh key/cert/config set, please remove $i
    and run: dietpi-software reinstall 97"
 					break
 
@@ -9415,30 +9415,51 @@ _EOF_
 				openssl dhparam -out /etc/openvpn/dh${key_size}.pem $key_size
 
 				# - Prepare easy-rsa
+				[[ -d '/etc/openvpn/easy-rsa' ]] && rm -R /etc/openvpn/easy-rsa
 				cp -a /usr/share/easy-rsa /etc/openvpn
 				cd /etc/openvpn/easy-rsa
-				mkdir -p keys
-				cat << _EOF_ >> vars
+
+				if (( $G_DISTRO < 5 )); then
+
+					cat << _EOF_ >> vars
 export KEY_SIZE=$key_size
 export KEY_COUNTRY='UK'
 export KEY_PROVINCE='DietPi'
 export KEY_CITY='DietPi'
 export KEY_ORG='DietPi'
-export KEY_EMAIL='noreply@DietPi.com'
+export KEY_EMAIL='noreply@dietpi.com'
 export KEY_OU='DietPi'
 export KEY_NAME='DietPi_OpenVPN_Server'
 _EOF_
+					cp -a openssl-1.0.0.cnf openssl.cnf # https://github.com/MichaIng/DietPi/issues/1450#issuecomment-362608574
+					. ./vars
+					./clean-all
+					./build-ca --batch
+					./build-key-server --batch DietPi_OpenVPN_Server
+					./build-key --batch DietPi_OpenVPN_Client
+					cp -a keys/{DietPi_OpenVPN_Server.crt,DietPi_OpenVPN_Server.key,ca.crt} /etc/openvpn/
 
-				# - Server cert and key
-				cp -a openssl-1.0.0.cnf openssl.cnf # https://github.com/MichaIng/DietPi/issues/1450#issuecomment-362608574
-				. ./vars
-				./clean-all
-				./build-ca --batch DietPi_OpenVPN_Server
-				./build-key-server --batch DietPi_OpenVPN_Server
-				cp -a keys/{DietPi_OpenVPN_Server.crt,DietPi_OpenVPN_Server.key,ca.crt} /etc/openvpn/
+				else
 
-				# - Client cert and key
-				./build-key --batch DietPi_OpenVPN_Client
+					cp -a vars.example vars
+					cat << _EOF_ >> vars
+set_var EASYRSA_PKI		"$PWD/keys"
+set_var EASYRSA_KEY_SIZE	$key_size
+set_var EASYRSA_REQ_COUNTRY	"UK"
+set_var EASYRSA_REQ_PROVINCE	"DietPi"
+set_var EASYRSA_REQ_CITY	"DietPi"
+set_var EASYRSA_REQ_ORG		"DietPi"
+set_var EASYRSA_REQ_EMAIL	"noreply@dietpi.com"
+set_var EASYRSA_REQ_OU		"DietPi"
+set_var EASYRSA_BATCH		"1"
+_EOF_
+					./easyrsa init-pki
+					./easyrsa build-ca nopass
+					./easyrsa build-server-full DietPi_OpenVPN_Server nopass
+					./easyrsa build-client-full DietPi_OpenVPN_Client nopass
+					cp -a keys/{issued/DietPi_OpenVPN_Server.crt,private/DietPi_OpenVPN_Server.key,ca.crt} /etc/openvpn/
+
+				fi
 
 				# Server config
 				cd /etc/openvpn

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2480,12 +2480,13 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 
 		fi
 
-		# Software that requires LibSSL1.0.0, Stretch+ only
+		# Software that requires LibSSL1.0.0
+		# - OpenVPN (97) on Stretch for easy-rsa
 		# - Jackett (147)
 		software_id=126
 		if (( ${aSOFTWARE_INSTALL_STATE[37]} == 1 ||
 			${aSOFTWARE_INSTALL_STATE[60]} == 1 ||
-			${aSOFTWARE_INSTALL_STATE[97]} == 1 ||
+			( ${aSOFTWARE_INSTALL_STATE[97]} == 1 && G_DISTRO == 4 ) ||
 			${aSOFTWARE_INSTALL_STATE[134]} == 1 ||
 			${aSOFTWARE_INSTALL_STATE[147]} == 1 )); then
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1921,7 +1921,6 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		aSOFTWARE_WHIP_DESC[$software_id]='vpn server'
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=16
 		aSOFTWARE_TYPE[$software_id]=0
-		aSOFTWARE_REQUIRES_RSYSLOG[$software_id]=1
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=613#p613'
 
 		#------------------
@@ -4641,6 +4640,8 @@ _EOF_
 
 			Banner_Installing
 			G_AGI openvpn easy-rsa iptables
+			# Remove obsolete sysvinit service
+			[[ -f '/etc/init.d/openvpn' ]] && rm /etc/init.d/openvpn
 
 		fi
 
@@ -9389,12 +9390,35 @@ _EOF_
 
 			Banner_Configuration
 
-			local key_size=2048
+			# Create initial server and client configs, if not yet present
+			# - Wildcard config file detection via for loop
+			local i
+			for i in /etc/openvpn/*.conf
+			do
 
-			# Start Cert/Key generation.
-			cp -a /usr/share/easy-rsa/ /etc/openvpn
-			mkdir -p /etc/openvpn/easy-rsa/keys
-			cat << _EOF_ >> /etc/openvpn/easy-rsa/vars
+				# Inform user, if config exist, that config generation is skipped
+				if [[ -f $i ]]; then
+
+					G_DIETPI-NOTIFY 2 "Existing OpenVPN configuration found: $i
+ - Config generation will be skipped.
+ - If you need a fresh config set, please remove $i
+   and run: dietpi-software reinstall 97"
+					break
+
+				fi
+
+				# Cert and key generation via easy-rsa
+				local key_size=2048
+				G_DIETPI-NOTIFY 2 'Generating unique OpenVPN certificates and keys. Please wait...\n'
+
+				# - DH param
+				openssl dhparam -out /etc/openvpn/dh${key_size}.pem $key_size
+
+				# - Prepare easy-rsa
+				cp -a /usr/share/easy-rsa /etc/openvpn
+				cd /etc/openvpn/easy-rsa
+				mkdir -p keys
+				cat << _EOF_ >> vars
 export KEY_SIZE=$key_size
 export KEY_COUNTRY='UK'
 export KEY_PROVINCE='DietPi'
@@ -9405,32 +9429,20 @@ export KEY_OU='DietPi'
 export KEY_NAME='DietPi_OpenVPN_Server'
 _EOF_
 
-			# Create Server Cert Auth
-			G_DIETPI-NOTIFY 2 'Generating unique OpenVPN certificates and keys. Please wait...\n'
-			openssl dhparam -out /etc/openvpn/dh${key_size}.pem $key_size
+				# - Server cert and key
+				cp -a openssl-1.0.0.cnf openssl.cnf # https://github.com/MichaIng/DietPi/issues/1450#issuecomment-362608574
+				. ./vars
+				./clean-all
+				./build-ca --batch DietPi_OpenVPN_Server
+				./build-key-server --batch DietPi_OpenVPN_Server
+				cp -a keys/{DietPi_OpenVPN_Server.crt,DietPi_OpenVPN_Server.key,ca.crt} /etc/openvpn/
 
-			# Build Server certs/keys
-			chmod -R +x /etc/openvpn/easy-rsa
-			cd /etc/openvpn/easy-rsa
-			# - https://github.com/MichaIng/DietPi/issues/1450#issuecomment-362608574
-			cp -a openssl-1.0.0.cnf openssl.cnf
+				# - Client cert and key
+				./build-key --batch DietPi_OpenVPN_Client
 
-			. ./vars
-			./clean-all
-			./build-ca --batch DietPi_OpenVPN_Server
-			./build-key-server --batch DietPi_OpenVPN_Server
-
-			# Copy Server cert/keys
-			cp -a /etc/openvpn/easy-rsa/keys/{DietPi_OpenVPN_Server.crt,DietPi_OpenVPN_Server.key,ca.crt} /etc/openvpn/
-
-			# Build client cert/keys
-			./build-key --batch DietPi_OpenVPN_Client
-
-			cd /tmp/$G_PROGRAM_NAME
-			# End Cert/Key generation.
-
-			# Server config
-			cat << _EOF_ > /etc/openvpn/server.conf
+				# Server config
+				cd /etc/openvpn
+				cat << _EOF_ > server.conf
 port 1194
 proto udp
 dev tun
@@ -9460,13 +9472,13 @@ verb 3
 
 _EOF_
 
-			# Client config
-			cat << _EOF_ > /etc/openvpn/easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
+				# Client config
+				cat << _EOF_ > easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
 client
 proto udp
 dev tun
 
-# Ip/Domain name of DietPi system, running OpenVPN server.
+# IP/domain name of DietPi system, running OpenVPN server
 remote mywebsite.com 1194
 
 resolv-retry infinite
@@ -9483,25 +9495,28 @@ comp-lzo
 verb 3
 
 _EOF_
+				# - Add Server cert auth
+				echo '<ca>' >> easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
+				cat ca.crt >> easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
+				echo '</ca>' >> easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
+				# - Add Client cert
+				echo '<cert>' >> easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
+				cat easy-rsa/keys/DietPi_OpenVPN_Client.crt >> easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
+				echo '</cert>' >> easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
+				# - Add Client key
+				echo '<key>' >> easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
+				cat easy-rsa/keys/DietPi_OpenVPN_Client.key >> easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
+				echo '</key>' >> easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
 
-			# Unified client file. Add DietPi generated certs/keys.
-			# - Add Server Cert auth
-			echo '<ca>' >> /etc/openvpn/easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
-			cat /etc/openvpn/ca.crt >> /etc/openvpn/easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
-			echo '</ca>' >> /etc/openvpn/easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
-			# - Add Client Cert
-			echo '<cert>' >> /etc/openvpn/easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
-			cat /etc/openvpn/easy-rsa/keys/DietPi_OpenVPN_Client.crt >> /etc/openvpn/easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
-			echo '</cert>' >> /etc/openvpn/easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
-			# - Add Client Key
-			echo '<key>' >> /etc/openvpn/easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
-			cat /etc/openvpn/easy-rsa/keys/DietPi_OpenVPN_Client.key >> /etc/openvpn/easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
-			echo '</key>' >> /etc/openvpn/easy-rsa/keys/DietPi_OpenVPN_Client.ovpn
+				# Copy client config to userdata location
+				cp easy-rsa/keys/DietPi_OpenVPN_Client.ovpn $G_FP_DIETPI_USERDATA/
+				# - and /boot partition
+				cp easy-rsa/keys/DietPi_OpenVPN_Client.ovpn /boot/
 
-			# Copy client file to userdata location
-			cp /etc/openvpn/easy-rsa/keys/DietPi_OpenVPN_Client.ovpn $G_FP_DIETPI_USERDATA/
-			# - and /boot partition
-			cp /etc/openvpn/easy-rsa/keys/DietPi_OpenVPN_Client.ovpn /boot/
+				cd /tmp/$G_PROGRAM_NAME
+				break # Always break loop which is only for single wildcard file detection
+
+			done
 
 			# Enable IP forwarding
 			echo -e 'net.ipv4.ip_forward=1\nnet.ipv6.conf.all.forwarding=1\nnet.ipv6.conf.default.forwarding=1' > /etc/sysctl.d/dietpi-openvpn.conf
@@ -13331,7 +13346,7 @@ _EOF_
 
 		fi
 
-		software_id=97 # OpenVPN server
+		software_id=97 # OpenVPN Server
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9486,7 +9486,7 @@ group nogroup
 persist-key
 persist-tun
 
-ns-cert-type server
+remote-cert-tls server
 comp-lzo
 verb 3
 _EOF_

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3033,8 +3033,8 @@ Package: *php7.3*\nPin: release *\nPin-Priority: -1' > /etc/apt/preferences.d/di
 		local url=$1
 		[[ ! $url && $fallback_url ]] && url=$fallback_url
 		local target=$2 # Extract target
-		local type=${url##*.} # Grab ext from URL | compatbile with >> deb|zip|tar(.gz|.bz2)|7z
-		[[ $type == 'gz' || $type == 'bz2' ]] && type='tar'
+		local type=${url##*.} # Grab ext from URL | compatbile with >> deb|zip|tar(.gz|.bz2)|tgz|tbz2|7z
+		[[ $type =~ ^t?(gz|bz2)$ ]] && type='tar'
 		local file="$software_id.$type"
 
 		# DietPi-Software conf/service mode
@@ -3087,8 +3087,7 @@ Package: *php7.3*\nPin: release *\nPin-Priority: -1' > /etc/apt/preferences.d/di
 
 		elif [[ $type == 'tar' ]]; then
 
-			#[[ $target ]] && target="--one-top-level=$target" # Option exist not on Jessie
-			[[ $target ]] && G_RUN_CMD mkdir -p "$target" && target="-C $target"
+			[[ $target ]] && target="--one-top-level=$target"
 			G_RUN_CMD tar xf $file "$target"
 
 		elif [[ $type == '7z' ]]; then


### PR DESCRIPTION
**Status**: Ready

**Reference**: https://github.com/MichaIng/DietPi/issues/3014

**Commit list/description**:
+ DietPi-Software | OpenVPN: Remove rsyslog dependency
+ DietPi-Software | OpenVPN: Preserve existing configs, instead inform user that config creation, key and cert generation is skipped
+ DietPi-Software | OpenVPN: Fix install on Buster+ and skip non-required libssl1.0.0 install there, due to major update of easy-rsa
+ DietPi-Software | OpenVPN: Use most current easy-rsa form GitHub on all distro versions. The APT package will use outdated methods earlier or later and the binaries are standalone scripts anyway.
+ DietPi-Software | OpenVPN: LibSSL1.0.0 is and was never required on Stretch, LibSSL1.0.2 did well.
+ DietPi-Software | OpenVPN: Rely on default RSA key size, which is 2048 bit currently
+ DietPi-Software | OpenVPN: Create Diffie-Hellman param via easy-rsa as well
+ DietPi-Software | OpenVPN: On reinstall, if a fresh config set is created (no existing config found), do some pre-v6.26 cleanup by removing the obsolete easy-rsa package and dh2048.pem file