### PR TITLE
DietPi-Software | XRDP: On Stretch, install version from backports

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,7 +4,7 @@ v6.26
 Changes / Improvements / Optimisations:
 - General | Support for Debian Jessie has now been fully dropped from DietPi code. Jessie systems are moved to the "jessie-support" Git branch and will stay on v6.25. Critical bugs, if reported, may still be fixed, but DietPi-Software related issues and new features will not be handled anymore by the DietPi code team. However, everyone is free to open pull requests against the jessie-support branch: https://github.com/MichaIng/DietPi/tree/jessie-support
 - General | Initial support and definitions for Debian Bullseye, the new Debian testing version, have been added to DietPi code. You can now create Bullseye systems via DietPi-PREP: https://github.com/MichaIng/DietPi/issues/3009
-- DietPi-Config | Audio Options: Menu has been reworked. Audio capabilities (ALSA) can be enabled and disabled as a separate option. If enabled, generic soundcard auto-detection has been added to the bottom of the list for all devices. This allows the selection of generic sound devices on all SBCs, e.g. if unknown to DietPi or if our hardcoded card/device IDs are wrong due to additional attached audio hardware.
+- DietPi-Config | Audio Options: Menu has been reworked. Audio capabilities (ALSA) can be enabled and disabled as a separate option. If enabled, generic sound card auto-detection has been added to the bottom of the list for all devices. This allows the selection of generic sound devices on all SBCs, e.g. if unknown to DietPi or if our hard-coded card/device IDs are wrong due to additional attached audio hardware.
 - DietPi-Config | RPi: Update certain config.txt settings to match new firmware version. WiFi and Bluetooth is now disabled via related dtoverlays, which should further reduce hardware and firmware loads.
 - DietPi-Config | Some /etc/modprobe.d/ configs are merged to less files and mostly prefixed with "dietpi-", to allow easier differentiation between Debian/pre-image and DietPi files.
 - DietPi-Software | Pi-hole: Logging to /var/log/pihole.log is now disabled by default, since it is not required in usual cases. Query logs, shown in web UI, are stored in database. This might also resolve possible pihole-FTL crashes in combination with DietPi-RAMlog and DietPi-Logclear. Many thanks to @kuerious for reporting and @Mcat12 for providing helpful information on this topic: https://github.com/pi-hole/FTL/issues/614
@@ -17,9 +17,10 @@ Bug Fixes:
 - General | Resolved an issue where install of required APT packages for certain scripts could fail in the rare case that APT lists are outdated and old packages are not available in the repo anymore. Many thanks to @Paulisper for reporting this issue: https://github.com/MichaIng/DietPi/issues/2996
 - DietPi-Config | Resolved an issue on RPi where I2C baudrate was not applied correctly, thus selection was ineffective. Many thanks to @flashspys for reporting this issue: https://github.com/MichaIng/DietPi/issues/2966
 - DietPi-Software | Gitea: Resolved an issue where install fails on ARMv7 systems. Many thanks to @maschiw for reporting this issue: https://github.com/MichaIng/DietPi/issues/2959
-- DietPi-Software | Node-RED: Resolved an issue where install fails due to missing data dir creation. Many thanks to @Orfait for reporting this isssue: https://github.com/MichaIng/DietPi/issues/2975
+- DietPi-Software | Node-RED: Resolved an issue where install fails due to missing data dir creation. Many thanks to @Orfait for reporting this issue: https://github.com/MichaIng/DietPi/issues/2975
 - DietPi-Software | Node-RED: Resolved an issue where user creation fails if "gpio" group is not present. Many thanks to @marcobrianza for reporting this issue: https://github.com/MichaIng/DietPi/issues/2975#issuecomment-513917360
-- DietPi-Software | OpenVPN: Resolved an issue where install failed on Debian Buster due to a new easy-rsa version with changed commands and options. Now the most recent easy-rsa is manually downloaded on all systems to generate server and client key + cert with modern methods and the client config is slighly updated to match modern settings.
+- DietPi-Software | OpenVPN: Resolved an issue where install failed on Debian Buster due to a new easy-rsa version with changed commands and options. Now the most recent easy-rsa is manually downloaded on all systems to generate server and client key + cert with modern methods and the client config is slightly updated to match modern settings.
+- DietPi-Software | XRDP: On Stretch, new the version from backports is installed. This resolves a critical issue where /etc/profile was not loaded to the session and, due to incomplete $PATH variable, important system binaries were not available on terminal emulators which broke many install and upgrade tasks. Furthermore this resolves an issue where install and connection of XRDP failed if IPv6 was disabled. Many thanks to @aspinks for the debug session which allowed us to track the issue down to its root: https://github.com/MichaIng/DietPi/issues/3017
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 
@@ -45,7 +46,7 @@ Changes / Improvements / Optimisations:
 - DietPi-FirstBoot | First boot setup steps have been moved into a separate script and systemd unit. This allows further cleanup of the regular boot process and more targeted debugging and development. Many thanks for @FredericGuilbault for implementing this enhancement: https://github.com/MichaIng/DietPi/issues/2791
 - DietPi-Autostart | When choosing an autostart option that does not require a manual UNIX user login, the autologin user can now be chosen (which was always "root" previously). This can be applied automatically on firstrun setup with the new "AUTO_SETUP_AUTOSTART_LOGIN_USER" setting within dietpi.txt. If the user does not exist, is a system user (UID < 1000) or does not have a valid login shell, it will be reverted to root. Many thanks to @FredericGuilbault for suggesting this feature: https://github.com/MichaIng/DietPi/pull/2926
 - DietPi-Globals | G_OBTAIN_CPU_TEMP(): Added support for Core2Duo CPU temperature to be printed on e.g. DietPi-Banner and "cpu" command output. Many thanks to @OstrovCity for posting the required information: https://github.com/MichaIng/DietPi/pull/2563#issuecomment-494388278
-- DietPi-Service 2.0 | Combines dietpi-process_tool into dietpi-services. Adds IO policies, single/global service control and much more: https://github.com/MichaIng/DietPi/pull/2786
+- DietPi-Service 2.0 | Combines dietpi-process_tool into dietpi-services. Adds I/O policies, single/global service control and much more: https://github.com/MichaIng/DietPi/pull/2786
 - DietPi-Process_tool | Has been replaced with DietPi-Services. Existing saved options will no longer be available, please use 'dietpi-services' to apply required process_tool options with the upgraded system.
 - DietPi-Explorer | Disabled opening of files in nano under select a file/folder mode.
 - DietPi-Drive_Manager | Added the option to change the I/O scheduler per drive. Many thanks to @Generator for pointing us onto this topic: https://github.com/MichaIng/DietPi/issues/2233
@@ -59,7 +60,7 @@ Changes / Improvements / Optimisations:
 - DietPi-Software | FFmpeg: On RPi, the new APT repo package will be installed, which now supports RPi hardware acceleration and is some subversion newer then the package hosted on dietpi.com: https://github.com/MichaIng/DietPi/issues/869#issuecomment-490047405
 - DietPi-Software | Gitea: Current stable v1.8.X will be installed now and existing instances will be upgraded during DietPi-Update. Many thanks to @msongz for implementing this: https://github.com/MichaIng/DietPi/pull/2881
 - DietPi-Software | myMPD: Current upstream version will be installed now and existing instances will be upgraded during DietPi-Update, which requires a config file reset. A backup to recover custom settings from will be created: https://github.com/MichaIng/DietPi/issues/2156#issuecomment-497513129
-- DietPi-Software | O!MPD: Current upstream version will be installed now and existing instances will be upgraded during DietPi-Update. Existing config and database will be preserved. YouTube and Tidal support is added now by default. Many thanks to @ArturSierzant for giving valueable feedback and suggestions: https://github.com/MichaIng/DietPi/pull/2884
+- DietPi-Software | O!MPD: Current upstream version will be installed now and existing instances will be upgraded during DietPi-Update. Existing config and database will be preserved. YouTube and Tidal support is added now by default. Many thanks to @ArturSierzant for giving valuable feedback and suggestions: https://github.com/MichaIng/DietPi/pull/2884
 - DietPi-Software | Ampache: Reinstalls will now preserve existing configs and database.
 - DietPi-Software | Medusa: mediainfo is now installed to enable Medusa gathering meta data and resolving related warnings in log. Additionally, on Stretch and above, Python3 is now installed and used, as recommended by Medusa for a while. Many thanks to @bluesmoke for suggesting this enhancement: https://dietpi.com/phpbb/viewtopic.php?f=11&t=5945
 - DietPi-Software | Node-RED: "sudo" permissions are now enabled by default: https://github.com/MichaIng/DietPi/issues/2910
@@ -73,9 +74,9 @@ Bug Fixes:
 - DietPi-PREP | Resolved an issue where ifupdown (networking service) was autoremoved, which broke running network connections.
 - DietPi-Drive_Manager | Resolved an issue where idle spin down selection would always default to 241, instead of currently active value: https://github.com/MichaIng/DietPi/issues/2852
 - DietPi-Drive_Manager | Resolved an issue where eCryptfs fstab entries were not detected and preserved correctly. Many thanks to @johnvick for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?p=18428#p18283
-- DietPi-Drive_Manager | Resolved an issue where transferring the RootFS to a BTRFS formated drive fails. Since BTRFS support is not natively built into the RPi and Odroid kernel, a warning prompts and the transfer is aborted. Many thanks to @dieitpi for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?p=18164#p18164
+- DietPi-Drive_Manager | Resolved an issue where transferring the RootFS to a BTRFS formatted drive fails. Since BTRFS support is not natively built into the RPi and Odroid kernel, a warning prompts and the transfer is aborted. Many thanks to @dieitpi for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?p=18164#p18164
 - DietPi-Drive_Manager | Resolved an issue where on x86_64 systems a specific Seagate drive, attached via USB, does not spin down on idle. Many thanks to @tomillr for reporting this issue: https://github.com/MichaIng/DietPi/issues/2905
-- DietPi-Config | (RPi) Resolved an issue where selecting sound cards with vc4 enabled would result with incorrect alsa card index: https://github.com/MichaIng/DietPi/issues/2173
+- DietPi-Config | (RPi) Resolved an issue where selecting sound cards with vc4 enabled would result with incorrect ALSA card index: https://github.com/MichaIng/DietPi/issues/2173
 - DietPi-Config | Resolved an issue where selecting any locale (language) failed, which does not contain "UTF-8" in its name. DietPi only supports UTF-8 locales, but those available with UTF-8 only, do not have the ".UTF-8" suffix in their name.
 - DietPi-Software | Resolved an issue on Buster systems that were dist-upgraded manually from Stretch, where DietPi-Software failed to obtain the global software password. Many thanks to @MattL0 for reporting this issue: https://github.com/MichaIng/DietPi/issues/2937
 - DietPi-Software | Resolved an issue where audio software failed to use hardware acceleration on Buster. Users need to be part of the new "render" group on Buster to have permissions. Many thanks to @tomillr for reporting this issue: https://github.com/MichaIng/DietPi/issues/2916
@@ -94,7 +95,7 @@ v6.24.1
 
 Bug Fixes:
 - DietPi-WiFi-Monitor | Resolved an issue where the service leads to a constant high CPU load. Many thanks for @GulyFMG for reporting this issue: https://github.com/MichaIng/DietPi/issues/2802
-- DietPi-Software | PHP: On ARMv6, fine tuned the required Buster branch priority pins to avoid certain ATP dependency errors. Many thanks to @maartenlangeveld for reporting this issue: https://github.com/MichaIng/DietPi/issues/2808, https://github.com/MichaIng/DietPi/issues/2811
+- DietPi-Software | PHP: On ARMv6, fine tuned the required Buster branch priority pins to avoid certain APT dependency errors. Many thanks to @maartenlangeveld for reporting this issue: https://github.com/MichaIng/DietPi/issues/2808, https://github.com/MichaIng/DietPi/issues/2811
 - DietPi-Software | Lighttpd: Resolved an issue where Lighttpd fails to start on ARMv6. Many thanks to @maartenlangeveld for reporting this issue: https://github.com/MichaIng/DietPi/issues/2808
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/2819
@@ -133,11 +134,11 @@ Buster support:
 Changes / Improvements / Optimisations:
 - DietPi-Banner | Added support for DietPi message of the day (MOTD). This is enabled by default, however, can be disabled. Checks for latest MOTD once a day.
 - DietPi-Banner | Always prints the local IP during boot mode display: https://github.com/MichaIng/DietPi/issues/2681
-- DietPi-Benchmark | Increased default survey RootFS and RAM benchmark sizes. 100MB (from 10MB) for RootFS. RAM is 1/4 of available. This is ensure a more accurate calculation of throughput when we divide bytes against time, to obtain the MB/s result. Benchmarks now also run at Nice -19 and realtime IO with priority 0 (highest).
+- DietPi-Benchmark | Increased default survey RootFS and RAM benchmark sizes. 100MB (from 10MB) for RootFS. RAM is 1/4 of available. This is ensure a more accurate calculation of throughput when we divide bytes against time, to obtain the MB/s result. Benchmarks now also run at Nice -19 and realtime I/O with priority 0 (highest).
 - DietPi-Cleaner | Added a confirmation prompt, before removal of offline docs and man pages, as this may cause APT issues in some circumstances. Many thanks to @maartenlangeveld for reporting this issue: https://github.com/MichaIng/DietPi/issues/2751
 - DietPi-LetsEncrypt | When applying to Lighttpd, "webroot" authentication is now used instead of "standalone". This allows the auto-renewal service to succeed while Lighttpd is running. Many thanks to @minnux for testing this method: https://github.com/MichaIng/DietPi/issues/2680#issuecomment-480095449
 - DietPi-Arr_to_RAM | With v6.18 we silently added a new script (for Stretch and above) that allows linking Sonarr/Radarr/Lidarr database files to RAM, increasing access performance, reducing disk I/O and avoiding constant external HDD spinning due to the very regular access to these files. This script has gone through some rework and polishing and can now be enabled to automatically link those databases to RAM on boot and store them back to disk on shutdown. For more details read: https://dietpi.com/phpbb/viewtopic.php?f=8&t=5828. Many thanks to @Dr0bac for providing valuable input and testing the development progress constantly: https://github.com/MichaIng/DietPi/issues/2689
-- DietPi-Drive_Manager | encryptfs and vboxsf (VirtualBox shared folder) fstab entries are now preserved. Many thanks to @johnvick and @Phil1988 for suggesting: https://github.com/MichaIng/DietPi/issues/2078, https://github.com/MichaIng/DietPi/issues/2202
+- DietPi-Drive_Manager | eCryptfs and vboxsf (VirtualBox shared folder) fstab entries are now preserved. Many thanks to @johnvick and @Phil1988 for suggesting: https://github.com/MichaIng/DietPi/issues/2078, https://github.com/MichaIng/DietPi/issues/2202
 - DietPi-PREP | The script execution can now be fully automated via environment variables. Many thanks to @FredericGuilbault for adding this feature: https://github.com/MichaIng/DietPi/pull/2756
 - DietPi-Config | Added support to toggle Intel CPU turbo/boost mode. Requires Intel CPU that supports the feature.
 - DietPi-Config | G_CHECK_URL: Added ability to change the connection attempts and timeout, before DietPi URL checking assumes a dead link and failure: https://github.com/MichaIng/DietPi/issues/2717
@@ -152,7 +153,7 @@ Changes / Improvements / Optimisations:
 - DietPi-Software | Plex Media Server: All systems are migrated to the new official APT repository. This allows easy and consistent upgrades via APT. On ARM systems the until now used 3rd party dev2day repo receives no further updates and will be shut down soon, which makes the migration mandatory. Many thanks to @WolfganP for keeping us informed with news about Plex v1.15 and the new APT repo: https://github.com/MichaIng/DietPi/issues/2655
 - DietPi-Software | Logitech Media Server: Now installs the latest nightly version, since no public "releases" are done. As well the systemd service has gone through some update and now runs as limited user to align with other media servers, enhance security and follow the defaults of the DPKG package. The update/change is applied to existing installs via DietPi-Update as well. Your settings/date are preserved.
 - DietPi-Software | Nextcloud Talk: We do not apply (D)TLS settings to coTURN any more. Since WebRTC is encrypted by itself there is no security benefit. More importantly Nextcloud Talk does not make use of the required TURNS protocol, so there is absolutely no point to apply these settings. The (D)TLS feature is meant to allow passing firewalls that only allow encrypted traffic. WebRTC, although encrypted, might not pass such firewalls since the encryption is not on transport layer. For those how are interested in further details and discussion: https://github.com/coturn/coturn/issues/33, https://github.com/nextcloud/spreed/issues/257
-- DietPi-Software | SABnzbd: Install latest version via GitHub master and skip adjusting existing config file. Systemd unit and dependencies have been adjusted to match minimum requirements and official documentation. The update will be applied via DietPi v6.23 patch as well. Many thanks to @19eighties for reporting the outdated version: https://github.com/MichaIng/DietPi/issues/2762
+- DietPi-Software | SABnzbd: Install latest version via GitHub master and skip adjusting existing config file. systemd unit and dependencies have been adjusted to match minimum requirements and official documentation. The update will be applied via DietPi v6.23 patch as well. Many thanks to @19eighties for reporting the outdated version: https://github.com/MichaIng/DietPi/issues/2762
 - DietPi-Software | Jackett: On non-ARMv6 devices the new (v0.11+) standalone (non-mono) binary is installed now. This is applied on DietPi-Update as well, preserving your settings: https://github.com/MichaIng/DietPi/pull/2773
 - DietPi-Software | Blynk: Enabled support for Debian Buster by using the new Java 11 binary.
 - DietPi-Software | UrBackup: New version 2.3.8 is installed now. Many thanks to @DeathIsUnknown for informing us about the update: https://github.com/MichaIng/DietPi/issues/2783
@@ -165,7 +166,7 @@ Bug Fixes:
 - DietPi-Login | Resolved an issue where login as non-root user could result in a "sudo" password prompt or endless failure loop due to missing sudo permissions. Many thanks to @xsak for reporting this issue: https://github.com/MichaIng/DietPi/issues/2667
 - DietPi-Software | Emby Server: Resolved an issue where download failed if the latest release does not contain a Debian package. Many thanks to @niblettr for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?f=11&t=5755
 - DietPi-Software | Transmission: Resolved an issue where double quotes in global software password caused a service startup failure. Many thanks to @Drew80 for reporting this issue: https://github.com/MichaIng/DietPi/issues/2484#issuecomment-480675168
-- DietPi-Software | WireGuard: Resolved an issue where IPv6 connections did not work with enabled IPv6 forwarding. Many thats to @schnuckz for reporting this issue: https://github.com/MichaIng/DietPi/issues/2691
+- DietPi-Software | WireGuard: Resolved an issue where IPv6 connections did not work with enabled IPv6 forwarding. Many thanks to @schnuckz for reporting this issue: https://github.com/MichaIng/DietPi/issues/2691
 - DietPi-Software | Subsonic: Resolved an issue where FFmpeg transcoder might not have been applied correctly. Many thanks to @spectrumcomputing for reporting this issue: https://github.com/MichaIng/DietPi/issues/2697
 - DietPi-Software | AmiBerry: Resolved an issue where no login prompt was present when exiting AmiBerry from fastboot mode. Many thanks to @Trigger58 for reporting this issue: https://github.com/MichaIng/DietPi/issues/2703#issuecomment-482471440
 - DietPi-Software | Logitech Media Server: Resolved an issue where certain plugins failed due to missing "libio-socket-ssl-perl". Many thanks to @noobian and @Edward for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?f=9&t=5824
@@ -219,7 +220,7 @@ Bug Fixes:
 - DietPi-Config | RPi: Resolved an issue where I-Sabre-K2M sound card selection failed. Thanks to @klasLiesen for reporting this issue: https://github.com/MichaIng/DietPi/issues/2547
 - DietPi-Config | RPi: Resolved an issue where serial console must be disabled, for Bluetooth to function correctly. This is now done automatically during BT enable: https://github.com/MichaIng/DietPi/issues/2607
 - DietPi-Config/Banner | Resolved an issue where wrong adapter state is shown if it is not connected but has an IP assigned. Thanks to @msongz for reporting this issue: https://github.com/MichaIng/DietPi/issues/2573
-- DietPi-Drive_Manager | Resolved an issue where RootFS RO would not remain during reboots. Many thanks to @JBatSEEDLING for reporting this issue: https://github.com/MichaIng/DietPi/issues/2604
+- DietPi-Drive_Manager | Resolved an issue where RootFS R/O would not remain during reboots. Many thanks to @JBatSEEDLING for reporting this issue: https://github.com/MichaIng/DietPi/issues/2604
 - DietPi-Software | XU4 + X11: Resolved various issues related to incorrect xorg.conf settings on this device. xorg.conf now used is installed automatically from Meveric's repo, which auto detects 3.x and 4.x kernel configuration and required settings automatically: https://github.com/MichaIng/DietPi/issues/2584 + https://github.com/MichaIng/DietPi/issues/2351
 - DietPi-Software | MineOS/Koel: Resolved an issue where installs on ARMv8 devices failed. Many thanks to @DeathIsUnknown for reporting this issue and providing the solution: https://github.com/MichaIng/DietPi/issues/1880#issuecomment-464097174
 - DietPi-Software | GMediaRender: Resolved an issue where the daemon can attach to a wrong IP if multiple network devices are present. As well resolved a failing service start on fresh install if/as the log file does not yet exist. Many thanks to @WilburWalsh for reporting these issues and providing the fix: https://github.com/MichaIng/DietPi/issues/2576
@@ -267,7 +268,7 @@ Image line-up:
 
 Changes / Improvements / Optimisations:
 - DietPi-PREP | Removed the option to install a Jessie system. Removed the option to install DietPi on top of a Wheezy image, since an upgrade over two distro version would be required, which is not reliable. It is still possible to install DietPi on top of a Jessie image, where a distro upgrade to Stretch would be applied: https://github.com/MichaIng/DietPi/issues/2332
-- General | RPi-Update: In our effort to improve system stability, and, offer software installations which build custom modules (eg: WireGuard), we can not longer support systems with non-stock APT kernel installed. If "rpi-update" is installed during update, DietPi will prompt and return you back to stock APT kernel.
+- General | RPi-Update: In our effort to improve system stability, and, offer software installations which build custom modules (e.g. WireGuard), we can not longer support systems with non-stock APT kernel installed. If "rpi-update" is installed during update, DietPi will prompt and return you back to stock APT kernel.
 - General | Moved the remaining conf/* files located on DietPi-RAMdisk to /var/lib/dietpi or into DietPi-PREP, and removed /DietPi/dietpi/conf completely. These files were only used once or never, thus have no business inside the RAMdisk.
 - DietPi-Config | RPi: Improved available options for HDMI boost setting: https://github.com/MichaIng/DietPi/issues/2350
 - DietPi-Config | RPi: Headless display mode is now applied via undocumented config.txt setting. Removed/Replaced some other obsolete config.txt entries: https://github.com/MichaIng/DietPi/pull/2402
@@ -283,7 +284,7 @@ Changes / Improvements / Optimisations:
 - DietPi-Software | Nextcloud Talk: Disabled the very verbose coturn logging by default to reduce disk I/O. This can be overridden via /etc/turnserver.conf: https://github.com/MichaIng/DietPi/issues/2321
 - DietPi-Software | Deluge: UMask 002 applied to all downloads: https://github.com/MichaIng/DietPi/issues/2339
 - DietPi-Software | Netdata: Updated to v1.11.1 and now runs as user "netdata": https://github.com/MichaIng/DietPi/pull/2337
-- DietPi-Software | ownCloud/Nextcloud: Updated webserver configs to match current recommendations and security hardenings. Only applied on new installs. To apply manually, run "dietpi-software reinstall 47" (owncloud) or "dietpi-software reinstall 114" (Nextcloud). You will be informed about the new configs, which then need to be manually moved to overwrite the old ones, since we don't want to mess with manual changes: https://github.com/MichaIng/DietPi/pull/2361
+- DietPi-Software | ownCloud/Nextcloud: Updated webserver configs to match current recommendations and security hardenings. Only applied on new installs. To apply manually, run "dietpi-software reinstall 47" (ownCloud) or "dietpi-software reinstall 114" (Nextcloud). You will be informed about the new configs, which then need to be manually moved to overwrite the old ones, since we don't want to mess with manual changes: https://github.com/MichaIng/DietPi/pull/2361
 - DietPi-Software | OpenSSH: Host keys won't be recreated anymore on reinstall, only on first boot of a fresh image, using now "dpkg-reconfigure openssh-server" to generate default key types based on distro.
 - DietPi-Software | Dropbear: Now installs only the "dropbear-run" package on Stretch (and above), which matches the default DietPi setup on our images and PREP script.
 - DietPi-Software | NAA Daemon: Updated to 3.5.5-39. Thanks to @volpone for the heads up: https://github.com/MichaIng/DietPi/issues/2387#issue-395321320
@@ -306,7 +307,7 @@ Bug Fixes:
 - DietPi-Software | Nextcloud: Resolved an issue, where the Nextcloud Apache config was not downloaded correctly. Thanks to @Stefan3v for reporting this issue: https://github.com/MichaIng/DietPi/issues/2383
 - DietPi-Software | ownCloud/Nextcloud (Talk): Resolved an issue, where occ/ncc commands could fail, if Redis server is not running: https://github.com/MichaIng/DietPi/issues/2321
 - DietPi-Software | ownCloud/Nextcloud: Resolved an issue, where during fresh installs on v6.19, Apache configs were not enabled correctly.
-- DietPi-Software | MPD: Resolved an issue on Stretch, where the mpd binary could not find the configuration file without giving it explicitely as argument. Thanks to @mfeif for reporting this issue: https://github.com/MichaIng/DietPi/issues/2378
+- DietPi-Software | MPD: Resolved an issue on Stretch, where the mpd binary could not find the configuration file without giving it explicitly as argument. Thanks to @mfeif for reporting this issue: https://github.com/MichaIng/DietPi/issues/2378
 - DietPi-Software | Mopidy: Resolved an issue, where playlist files could not be created due to missing permissions. Further improved handling of existing configs, data and cache directories on (re)install. Thanks to @cyberlussi for reporting this issue: https://github.com/MichaIng/DietPi/issues/2384
 - DietPi-Software | Deluge: Resolved a visual-only error in systemd unit, since same-line comments are not allowed anymore. Thanks to @Gabba for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=5378
 - DietPi-Software | No-IP: Fixed an issue, where on "Generic device" (ID 22), the wrong binary could have been installed. As well added failsafe "/usr/local/[bin|etc]" directory pre-creation, in case not present on the system or manually removed by user. Thanks to @walker93 for reporting this issue: https://github.com/MichaIng/DietPi/issues/2426
@@ -377,14 +378,14 @@ Changes / Improvements / Optimisations:
  - General | Concurrent execution detection: Now has a 5 second buffer to wait for exit (G_INIT_WAIT_CONCURRENT), before failing: https://github.com/MichaIng/DietPi/issues/2159#issuecomment-433619721
  - DietPi-Config | Added support for changing the brightness of the RPi touchscreen: https://github.com/MichaIng/DietPi/issues/2169
  - DietPi-Config | Added support for setting Xorg DPI scale.
- - DietPi-Services | MariaDB: DietPi now uses the pre-installed "mariadb" systemd service instead of obsoleve "mysql" init.d service: https://github.com/MichaIng/DietPi/pull/2196
+ - DietPi-Services | MariaDB: DietPi now uses the pre-installed "mariadb" systemd service instead of obsolete "mysql" init.d service: https://github.com/MichaIng/DietPi/pull/2196
  - DietPi-Software | Nextcloud Talk video calls with configured TURN server is now available for install: https://github.com/MichaIng/DietPi/pull/2197
  - DietPi-Software | NAA Daemon: Added installation support for ARMv8 and x86_64. Thanks Jussi!
  - DietPi-Software | Pi-hole: During (re)install you can now decide whether to show a blocking page to clients or not: https://github.com/MichaIng/DietPi/issues/2007
  - DietPi-Software | MotionEye: Now available to install for all devices. Removed support from Jessie: https://github.com/MichaIng/DietPi/issues/2229
  - DietPi-Software | G_BACKUP_FP: New feature rolled out to MPD and web server base DietPi-Software installations, in which config files are backed up before DietPi overwrites them: https://github.com/MichaIng/DietPi/issues/2187#issuecomment-433626639
  - DietPi-Software | SickRage: Is no longer available for installation. We will asses a replacement in v6.19. Sonarr is an excellent alternative with faster performance and stability.: https://github.com/MichaIng/DietPi/issues/2239
- - DietPi-Software | Docker: Now runs under 'simple' service type (previously 'notify'), to prevent service start delay which can occur on ARM based devices (eg: RPi), from delaying other applications starting on the system: https://github.com/MichaIng/DietPi/issues/2238#issuecomment-439474766
+ - DietPi-Software | Docker: Now runs under 'simple' service type (previously 'notify'), to prevent service start delay which can occur on ARM based devices (e.g. RPi), from delaying other applications starting on the system: https://github.com/MichaIng/DietPi/issues/2238#issuecomment-439474766
  - DietPi-Software | Mosquito: Service updated to systemd: https://github.com/MichaIng/DietPi/issues/2243
  - DietPi-Software | Radarr/Sonarr/Lidarr: logs (both .txt and .db*) have been moved to DietPi-RAMlog: https://github.com/MichaIng/DietPi/issues/2223
  - DietPi-Software | Pydio: WebUI warnings (security, performance) are now resolved for Nginx and Lighttpd webservers as well. Separate config files are created instead of touching the defaults, to enable required settings for Pydio only. Required PHP modules are installed and enabled, to be failsafe. Preserve existing install dirs on (re)install and inform user to update via WebUI updater: https://github.com/MichaIng/DietPi/issues/1913
@@ -393,31 +394,31 @@ Changes / Improvements / Optimisations:
  - DietPi-Software | Tautulli: Install enabled for ARMv8 devices.
 
 Bug Fixes:
- - PREP: Resovled an issue where master.zip would always be downloaded, regardless of selected branch.
+ - PREP: Resolved an issue where master.zip would always be downloaded, regardless of selected branch.
  - PREP: Resolved failed rootFS resize: https://github.com/MichaIng/DietPi/issues/2181#issuecomment-433715556
  - General | Resolved various gwtcwd errors during boot and software installations on VM: https://github.com/MichaIng/DietPi/issues/2237
  - General | NanoPi Fire3: Resolved an issue with blank HDMI output. Device is now switched to tty2 during boot, as a workaround/fix due to tty1 failing: https://github.com/MichaIng/DietPi/issues/2225
  - General | Resolved an issue, where entering passwords via our internal whiptail password box leads to "invalid match", when special characters are used, forcing a retry: https://github.com/MichaIng/DietPi/issues/2215#issuecomment-437683709
  - DietPi-Cleaner | Resolved an issue where test runs on -dev package removal, would remove the packages.
  - DietPi-Cleaner | Resolved a syntax error with function 'Run_Cleaners', disabling the ability to run cleaners. Many thanks to @optio50 for reporting this issue! https://github.com/MichaIng/DietPi/issues/2241
- - DietPi-Config | Resovled an visual error when selecting network options due to 'G_CHECK_VALIDINT'.
+ - DietPi-Config | Resolved an visual error when selecting network options due to 'G_CHECK_VALIDINT'.
  - DietPi-Config | Locale: Resolved an issue where DietPi would always display en_GB as the current locale: https://github.com/MichaIng/DietPi/issues/2216#issuecomment-435599419
  - DietPi-Config | Resolved an issue where on Odroid C1/2 with current kernel 3.5" LCD shield does not work anymore. Thanks to @Kreeblah for reporting this issue and solution: https://github.com/MichaIng/DietPi/issues/2256
  - DietPi-Automation | CONFIG_NTP_MODE is now applied after APT cache, and, initial time sync is updated. Due to packages required for some modes: https://github.com/MichaIng/DietPi/issues/2181#issuecomment-433444882
  - DietPi-Software | Resolved an issue where rsyslog APT installation would report a failure, if service was already running previously but not installed via APT (mostly in backup/restore situations): https://github.com/MichaIng/DietPi/pull/2277/#issuecomment-441461982
- - DietPi-Software | Kodi: Resolved an issue where restart/shutdown options were not visable, due to lack of systemd-logind: https://github.com/MichaIng/DietPi/issues/2155
- - DietPi-Software | Mono applications (Radarr/Sonarr/Lidarr/Jackett): Rolled out "-O=-aot" (ahead of time optimzation) to all applications, which resolves a known external bug with recent Mono update. Many thanks to @Generator for testing and confirming this issue: https://github.com/MichaIng/DietPi/issues/2219#issuecomment-437594645
+ - DietPi-Software | Kodi: Resolved an issue where restart/shutdown options were not visible, due to lack of systemd-logind: https://github.com/MichaIng/DietPi/issues/2155
+ - DietPi-Software | Mono applications (Radarr/Sonarr/Lidarr/Jackett): Rolled out "-O=-aot" (ahead of time optimisation) to all applications, which resolves a known external bug with recent Mono update. Many thanks to @Generator for testing and confirming this issue: https://github.com/MichaIng/DietPi/issues/2219#issuecomment-437594645
  - DietPi-Software | Roon Bridge: Resolved an issue where the remote update would fail due to underpriv permissions: https://community.roonlabs.com/t/dietpi-allo-units-not-getting-the-roonbridge-b167-update-from-b164/52503/6
  - DietPi-Software | Nextcloud: Resolved an issue with failed installation: https://github.com/MichaIng/DietPi/issues/2184
- - DietPi-Software | Nextcloud/Owncloud: Resolved an issue where userdata located on external drive would fail the installation: https://github.com/MichaIng/DietPi/issues/2221
- - DietPi-Software | OMPD/MyMPD: Resolved inability to update database. Currently we have rolled back the versions of these programs to a working state. We will investigate with the devs to find out the cause for future release: https://github.com/MichaIng/DietPi/issues/2156
+ - DietPi-Software | Nextcloud/ownCloud: Resolved an issue where userdata located on external drive would fail the installation: https://github.com/MichaIng/DietPi/issues/2221
+ - DietPi-Software | OMPD/myMPD: Resolved inability to update database. Currently we have rolled back the versions of these programs to a working state. We will investigate with the devs to find out the cause for future release: https://github.com/MichaIng/DietPi/issues/2156
  - DietPi-Software | Jackett: Resolved an issue where reinstall created an additional nested install dir. Thanks @msdos for reporting this issue: https://github.com/MichaIng/DietPi/issues/2212
  - DietPi-Software | RoonServer: Resolved an issue where reinstall created an additional nested install dir. Since RoonServer has an automated internal updater, download and install will be skipped, if install already exists.
  - DietPi-Software | PHP/databases: Resolved an issue where PHP database modules were not installed, when installing a new database and PHP was already installed before.
  - DietPi-Software | PHP: On Buster, moved to PHP7.3, since php-apcu and php-redis are not available for PHP7.2 any more. This resolves both PHP versions being installed concurrently.
  - DietPi-Software | OpenBazaar: Resolved an issue where remote OB clients could not connect to server with default configuration: https://github.com/MichaIng/DietPi/pull/2224
  - DietPi-Software | Resolved an issue where a global password with special characters lead to failing installs, due to missing escaping within our internal function G_CONFIG_INJECT. Thanks to @MistahDarcy for reporting this issue: https://github.com/MichaIng/DietPi/issues/2215
- - DietPi-Software | Docker: Resolved an issue where the Docker daemon failes to start due to invalid command argument. Thanks to @mspieth376 for reporting this issue: https://github.com/MichaIng/DietPi/issues/2238
+ - DietPi-Software | Docker: Resolved an issue where the Docker daemon fails to start due to invalid command argument. Thanks to @mspieth376 for reporting this issue: https://github.com/MichaIng/DietPi/issues/2238
  - DietPi-Software | Grafana: Resolved an issue, where WebUI password is not applied correctly, when containing ";" or "#". Thanks to @Warmbadger for reporting this issue and solution: https://dietpi.com/phpbb/viewtopic.php?f=11&t=5248
  - DietPi-Software | Tautulli: Resolved an issue where Tautulli service failed to start up. As well improved reinstall, if install dir is already existent. Thanks to @Comfubar for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?f=11&t=5256
  - DietPi-Obtain_network_details | Resolved a tiny visual-only error message on non-root logins. Thanks to @AndrewZ for reporting: https://dietpi.com/phpbb/viewtopic.php?f=9&t=5194
@@ -431,10 +432,10 @@ v6.17
 (25/10/18)
 
 Changes / Improvements / Optimisations:
- - General | NanoPC T4: Image updated to include lastest kernel (4.4.154). Many thanks to @carlosedp for providing this kernel! https://github.com/MichaIng/DietPi/issues/1829#issuecomment-429324437
+ - General | NanoPC T4: Image updated to include latest kernel (4.4.154). Many thanks to @carlosedp for providing this kernel! https://github.com/MichaIng/DietPi/issues/1829#issuecomment-429324437
  - General | DietPi now has 3 branches (master=stable, beta=public testing, dev=dev). By default, all users are on master/stable branch: https://github.com/MichaIng/DietPi/issues/2083#issuecomment-426842537
  - General | Improved detection of permissions support during user data transfers: https://github.com/MichaIng/DietPi/issues/2096
- - General | IPv6: Due to the requirements of various software titles available in dietpi-software (eg: nginx, redis-server), and that IPv6 is slowly becoming more common place, IPv6 is now disabled via sysctl on interface level, while it stays enabled on kernel level: https://github.com/MichaIng/DietPi/issues/2027
+ - General | IPv6: Due to the requirements of various software titles available in dietpi-software (e.g. Nginx, Redis), and that IPv6 is slowly becoming more common place, IPv6 is now disabled via sysctl on interface level, while it stays enabled on kernel level: https://github.com/MichaIng/DietPi/issues/2027
  - DietPi-Autostart | Chromium: You will now be prompted to enter a homepage URL, which will be loaded when the application starts: https://github.com/MichaIng/DietPi/issues/2169#issuecomment-432297343
  - DietPi-Config | RPi: Added support for LCD panel "Elecrow ESP01215E 7 inch HDMI IPS with touch input" (basically a cheaper RPi touchscreen): https://www.amazon.co.uk/gp/product/B07H79XMLT/ref=oh_aui_detailpage_o01_s00?ie=UTF8&psc=1
  - DietPi-Config | Added ability to benchmark network LAN transfer rates using 2 DietPi systems.
@@ -443,17 +444,17 @@ Changes / Improvements / Optimisations:
  - DietPi-Config | Online Benchmarks Database! Now available. Simply run the benchmark from the tools menu, to upload your scores and compare against others: https://dietpi.com/survey
  - DietPi-Automation | Added settings to dietpi.txt to toggle IPv6 and IPv4 preference on first boot.
  - DietPi-Update | You now have the option to view the changelog, prior to updating: https://github.com/MichaIng/DietPi/issues/2081
- - DietPi-Software | Sabnzbd: Updated to 2.3.5 for new installations only. Now runs under its own limited user account, and, umask of 0775 for downloads: https://github.com/MichaIng/DietPi/issues/2172
+ - DietPi-Software | SABnzbd: Updated to 2.3.5 for new installations only. Now runs under its own limited user account, and, umask of 0775 for downloads: https://github.com/MichaIng/DietPi/issues/2172
  - DietPi-Software | Card/CalDAV request redirection was added to new Baikal, ownCloud and Nextcloud installs. Now only the servers domain/IP need to be entered on Card/CalDAV clients, without any further path to the DAV endpoints: https://github.com/MichaIng/DietPi/issues/2057
  - DietPi-Software | Plex Media Server and Transmission services run now as group "dietpi", to allow cross access with download managers and media software: https://github.com/MichaIng/DietPi/issues/2067#issuecomment-427579779
  - DietPi-Set_Hardware | Odroid C2: When selecting USB DAC, smp affinity will be applied for USB IRQ's to improve stability: https://github.com/MichaIng/DietPi/issues/2101
- - DietPi-Drive_Manager | Formatting: Now has the option to format the whole drive, or patition only, for drives with existing partitions.
- - DietPi-Drive_Manager | Mounting NTFS drives now enabled native linux permissions support (eg: you can use this as your userdata location). Many thanks to @Random90 for making this possible! https://github.com/MichaIng/DietPi/issues/2096#issuecomment-425553333
+ - DietPi-Drive_Manager | Formatting: Now has the option to format the whole drive, or partition only, for drives with existing partitions.
+ - DietPi-Drive_Manager | Mounting NTFS drives now enabled native linux permissions support (e.g. you can use this as your userdata location). Many thanks to @Random90 for making this possible! https://github.com/MichaIng/DietPi/issues/2096#issuecomment-425553333
  - DietPi-Drive_Manager | Improved detection and formatting for NVMe based drives: https://github.com/MichaIng/DietPi/issues/2102
  - DietPi-Drive_Manager | Removed /proc from fstab. No longer required as this created at kernel/systemd level: https://github.com/MichaIng/DietPi/issues/2154
 
 Bug Fixes:
- - General | G_THREAD_START: Resolved issue where this was running in blocking mode. Now uses exit code to indentify finished tasks instead of PID.
+ - General | G_THREAD_START: Resolved issue where this was running in blocking mode. Now uses exit code to identify finished tasks instead of PID.
  - DietPi-Cloudshell | Resolved various issues with inability to run service via SSH on another screen, and, G_DIETPI-NOTIFY errors. Many thanks to @potter-91 for reporting this issue! https://github.com/MichaIng/DietPi/issues/2104
  - DietPi-Config | WiFi-Monitor: Resolved an issue with syntax, and, incorrectly pinging the default gateway, instead of whats assigned to the wlan interface: https://github.com/MichaIng/DietPi/issues/2103
  - DietPi-Config | dietpi-wifi.db code has been optimized, and, also resolves an issue where '/var/lib/dietpi/dietpi-wifi.db' was not generated automatically: https://github.com/MichaIng/DietPi/issues/2087#issuecomment-423836528
@@ -465,8 +466,8 @@ Bug Fixes:
  - DietPi-Software | Fixed an issue where software uninstalls could have failed due to dependant packages. Thanks to @dynobot for reporting this issue: https://github.com/MichaIng/DietPi/issues/2091
  - DietPi-Software | Webservers/PHP: Fixed an issue, where PHP was not installed when a webserver was installed directly via "dietpi-software install 8X".
  - DietPi-Software | Nextcloud: On Jessie systems, no newer version than latest NC13 will be installed, because PHP5 support was dropped with NC14: https://github.com/MichaIng/DietPi/issues/1778#issuecomment-419918372
- - DietPi-Software | MyMPD: Resolved an issue where the service would fail to run: https://github.com/MichaIng/DietPi/issues/2088
- - DietPi-Software | MyMPD: Resolved an issue where the installation would fail, due to a recent MyMPD update with new pre-reqs: https://github.com/MichaIng/DietPi/issues/2088#issuecomment-423852124
+ - DietPi-Software | myMPD: Resolved an issue where the service would fail to run: https://github.com/MichaIng/DietPi/issues/2088
+ - DietPi-Software | myMPD: Resolved an issue where the installation would fail, due to a recent myMPD update with new pre-reqs: https://github.com/MichaIng/DietPi/issues/2088#issuecomment-423852124
  - DietPi-Software | SiCKRAGE: Resolved failing install due to changed capitalization of SiCKRAGE GitHub repo, and, various additional pre-reqs due to new install method required by SiCKRAGE. Thanks to @mdoary for reporting this issue: https://github.com/MichaIng/DietPi/issues/2126
  - DietPi-Software | VNC Server: Resolved an issue where VNC server would fail to start under shared desktop mode, many thanks to @LieDanG for reporting this issue: https://github.com/MichaIng/DietPi/issues/2142#issuecomment-430492281
  - DietPi-Process_tool | Resolved an issue where applying process settings on Plex Media Server failed, thanks to @symbios24 for reporting this issue: https://github.com/MichaIng/DietPi/issues/2089
@@ -511,8 +512,8 @@ Changes / Improvements / Optimizations:
 General | Changed Survey and Bugreport uploads to use ssh.dietpi.com (previously IP): https://github.com/MichaIng/DietPi/issues/2022#issuecomment-415470064
 General | 1st run setup and dietpi-update logs are now created in RAM, then copied to disk once completed '/var/tmp/dietpi/logs/dietpi-firstrun-setup.log'. This will speed up 1st run setup installation for slow SBCs and/or rootFS.
 General | PineA64: Image updated to v6.14, also contains the latest kernel/uboot by Ayufan (0.6.2): https://github.com/MichaIng/DietPi/issues/2026
-General | Resolved an isssue where the initial 1st run connection test would fail, if timesync had not yet completed, and, the SSL cert of the connection test site is not valid for current date on system: https://github.com/MichaIng/DietPi/issues/2039
-General| SparkySBC: Support for native DSD playback on iFi Pro iDSD. Many thanks @sudeep: https://github.com/sparky-sbc/sparky-test/tree/master/dsd-marantz
+General | Resolved an issue where the initial 1st run connection test would fail, if timesync had not yet completed, and, the SSL cert of the connection test site is not valid for current date on system: https://github.com/MichaIng/DietPi/issues/2039
+General | Sparky SBC: Support for native DSD playback on iFi Pro iDSD. Many thanks @sudeep: https://github.com/sparky-sbc/sparky-test/tree/master/dsd-marantz
 DietPi-Backup/Sync | rsync transfer: Now shows progress information during the transfer: https://github.com/MichaIng/DietPi/issues/2044#issuecomment-417779406
 DietPi-Backup | Added an option to delete the currently selected backup, if it exists.
 DietPi-Config | Advanced Options: You can now toggle if a real RTC is installed. This adds/removes 'fake-hwclock' package installation as requested: https://github.com/MichaIng/DietPi/issues/2041
@@ -545,7 +546,7 @@ Changes / Improvements / Optimizations:
 DietPi-Software | GLOBAL_PW: The global password used by DietPi-Software is now encrypted with AES-256, removed from '/boot/dietpi.txt' and stored securely on rootFS with root:root/700 access only: https://github.com/MichaIng/DietPi/issues/2021
 DietPi-Software | FreshRSS, a self-hosted RSS feed aggregator, now available for installation. Thanks @msongz for requesting an RSS reader: https://github.com/MichaIng/DietPi/issues/1996
 DietPi-Software | BruteFIR: Due to low install count (7), we have removed this software from the DietPi database, and, is no longer available for installation.
-DietPi-Software | NAA Daemon: Installation updated to 3.5.4-38. Thanks Volpone for the heads up!: https://dietpi.com/phpbb/viewtopic.php?f=11&t=4420
+DietPi-Software | NAA Daemon: Installation updated to 3.5.4-38. Thanks @Volpone for the heads up!: https://dietpi.com/phpbb/viewtopic.php?f=11&t=4420
 General | '/etc/machine-id' is now unique for each DietPi installation. Regenerated during patch: https://github.com/MichaIng/DietPi/issues/2015
 
 Bug Fixes:
@@ -563,14 +564,14 @@ v6.13
 
 Changes / Improvements / Optimizations:
 General | Sparky SBC: Added driver to support RTL8812AU WiFi based chipsets: https://github.com/sparky-sbc/sparky-test/tree/master/rtl8812au
-DietPi-Globals | G_THREAD_WAIT: Now displays errors for each thread, if they occured.
+DietPi-Globals | G_THREAD_WAIT: Now displays errors for each thread, if they occurred.
 DietPi-Config | NTP mirror selection has been reworked. It allows now to add local and external non-pool.ntp.org servers and local gateway auto detection: https://github.com/MichaIng/DietPi/issues/1688
 DietPi-Config | Display Options > Backlight Brightness: Now available for Intel compatible backlight devices.
 DietPi-Explorer | Whiptail based, minimial/lightweight file explorer and manager now available for use!
 DietPi-Services | You can now include custom services, and, exclude DietPi controlling services known to it. Please see the following file '/DietPi/dietpi/.dietpi-services_include_exclude' for more information: https://github.com/MichaIng/DietPi/issues/1114#issuecomment-411325075
 DietPi-Software | A new unified download&install function is implemented, which allows more consistent download and install of software, using /tmp RAMFS as working directory and parallel dependencies installation via G_THREAD.
 DietPi-Software | Koel: Installation will now skip webserver, as Koel uses PHP-CLI instead. To not mess with webserver served pages, Koel install directory is moved to "/mnt/dietpi_userdata/koel", for existing installs as well.
-DietPi-Software | Mono: Now installs 'mono-complete' by default, required for Mono based applications (eg: Radarr/Sonarr/Lidarr/Jackett etc)
+DietPi-Software | Mono: Now installs 'mono-complete' by default, required for Mono based applications (e.g. Radarr/Sonarr/Lidarr/Jackett etc)
 DietPi-Software | Lidarr: Now available for installation, automatically download music: https://github.com/MichaIng/DietPi/issues/1874
 DietPi-Software | Samba Server: Now creates and defaults to the login creds for the 'dietpi' user (previously 'root'). For fresh installations of Samba only: https://github.com/MichaIng/DietPi/issues/1991#issuecomment-410505982
 DietPi-Software | Folding@Home: Now available for installation on x86_64 machines. Folding@home is a distributed computing project for disease research that simulates protein folding, computational drug design, and other types of molecular dynamics. As of today, the project is using the idle resources of personal computers owned by volunteers from all over the world. Thousands of people contribute to the success of this project. Thanks to @nnovaes for bringing this to our attention!
@@ -594,7 +595,7 @@ DietPi-Software | WiringPi: Resolved failed installation with RPi.
 DietPi-Software | Sonarr: Fixed APT install due to HTTPS error. Reverted to HTTP as of official install instructions. Thanks for report @GulyFMG: https://github.com/MichaIng/DietPi/issues/1953
 DietPi-Software | qBitTorrent: Resolved an issue with inability to save webUI settings: https://github.com/MichaIng/DietPi/issues/1957
 DietPi-Software | NZBget: Resolved an issue where application would apply incorrect umask to downloaded data, preventing other programs with allowed access, from accessing it: https://github.com/MichaIng/DietPi/issues/1999
-DietPi-Software | Plex: Resolved an issue with ARMv8 installations, where an exisiting install of Mono would cause a failed installation do to package dep issues: https://github.com/MichaIng/DietPi/issues/2006#issuecomment-412653984
+DietPi-Software | Plex: Resolved an issue with ARMv8 installations, where an existing install of Mono would cause a failed installation do to package dep issues: https://github.com/MichaIng/DietPi/issues/2006#issuecomment-412653984
 DietPi-Survey | Resolved an issue where a failed connection test would generate an error with UI blocking. As this program is not critical to device operation, the error is now silent without UI blocking: https://github.com/MichaIng/DietPi/issues/1968#issuecomment-408615457
 DietPi-Login | Resolved an issue on Jessie systems, that prevented automated "dietpi-software" execution on first login. This was due to Jessie "pgrep" does not support "-i" argument (ignore cases).
 General | Resolved other minor issues related to pgrep "-i" argument not being supported on Jessie.
@@ -609,7 +610,7 @@ v6.12
 Changes / Improvements / Optimizations:
 DietPi-Drive_Manager | Samba/CIFS mounting: Now automatically uses the highest available CIFS version supported on client and server: https://github.com/MichaIng/DietPi/issues/1893#issuecomment-403034799
 DietPi-Software | Jackett: Now runs as its own user, and, from the /opt/jackett directory, for new installations only. Many thanks to @userdeveloper98 for contributing this improvement: https://github.com/MichaIng/DietPi/pull/1895
-DietPi-Software | MiniDLNA: Now uses a SystemD service, also updates its library during service start.
+DietPi-Software | MiniDLNA: Now uses a systemd service, also updates its library during service start.
 DietPi-Software | JRiver: Removed and no longer available for installation: https://github.com/MichaIng/DietPi/issues/1080#issuecomment-403489246
 DietPi-Software | Various titles: Now run under their own system user account, with limited permissions (previously root): https://github.com/MichaIng/DietPi/issues/1877#issuecomment-403298679
 DietPi-Software | SABnzbd: Language packs are now installed by default: https://github.com/MichaIng/DietPi/issues/1917#issue-340631943
@@ -618,13 +619,13 @@ DietPi-RAMlog | Service is now disabled when RAMlog mode is not selected: https:
 
 Bug Fixes:
 General | Resolved an issue where cron jobs, containing DietPi scripts, failed: https://github.com/MichaIng/DietPi/issues/1923
-General | Resolved an issue on ARM64 + Jessie with APT, due to debian-security removing suppport and packages for those devices. If you experience this issue, and are unable to update DietPi, please see : https://github.com/MichaIng/DietPi/issues/1915
+General | Resolved an issue on ARM64 + Jessie with APT, due to debian-security removing support and packages for those devices. If you experience this issue, and are unable to update DietPi, please see : https://github.com/MichaIng/DietPi/issues/1915
 General | Resolved an issue where NFSv3 network drives could not be mounted: https://github.com/MichaIng/DietPi/issues/1898
 DietPi-Config | ASUS TB: Resolved loss of WiFi device after a reboot: https://github.com/MichaIng/DietPi/issues/1760
 DietPi-Drive_Manager | Resolved an issue where the program could remove a non-empty directory in rare situations.
 DietPi-Software | Resolved a potential Mono instability issue with Radarr, Sonarr and Jackett, due to using '--optimize=all --server'. This has now been removed for new installations. Many thanks to @hellfirehd for debugging/testing and @Taloth for dev insights: https://github.com/MichaIng/DietPi/issues/1896
 DietPi-Software | Mono: Temp mono files are now cleared from memory once installed, preventing out of memory errors for additional software installs afterwards: https://github.com/MichaIng/DietPi/issues/1877#issuecomment-403856446
-DietPi-Software | Xserver: Resolved rarely occuring uninstall issus by not purging dependencies, but leaving them for autoremove: https://github.com/MichaIng/DietPi/issues/1921
+DietPi-Software | Xserver: Resolved rarely occurring uninstall issues by not purging dependencies, but leaving them for autoremove: https://github.com/MichaIng/DietPi/issues/1921
 DietPi-Software | MineOS: Resolved failed installation due to incompatibilities with nodejs v10. v8 is now installed: https://github.com/MichaIng/DietPi/issues/1880
 DietPi-Update | Resolved an issue where incorrect version would be displayed, once update was completed. This is due to '| tee' on a function, making var changes local: https://github.com/MichaIng/DietPi/issues/1877#issuecomment-403866204
 
@@ -657,14 +658,14 @@ General | 'firmware-iwlwifi': Is now a pre-req to WiFi enable. Adds support for 
 General | "net-tools" commands (ifconfig, netstat, route, ...) were replaced by modern "ip" commands (ip a, ip r, ...) within DietPi scripts and the package therefore removed from DietPi core packages: https://github.com/MichaIng/DietPi/issues/1666
 General | Removed unused "/DietPi/config.txt" from non-RPi devices: https://github.com/MichaIng/DietPi/pull/1863
 General | CurlFTPFS: Removed from DietPi scripts and is no longer supported. Due to lack of security, and, single digit install count (survey).
-General | Timesync: DietPi will now only check for a sucessful sync once per system boot, and, again hourly/daily if set. This is to prevent excess delay of systemd-timesyncd service, once the time has already been synced.
+General | Timesync: DietPi will now only check for a successful sync once per system boot, and, again hourly/daily if set. This is to prevent excess delay of systemd-timesyncd service, once the time has already been synced.
 General | Sparky SBC: Designs patch added for DSD on MPD-5 dac , new Ids added Mytek Manhatten , LH labs 1V5 2V0 ,HD-AVP/AVA IDA-8: https://github.com/sparky-sbc/sparky-test/tree/master/dsd-marantz
 DietPi-Backup | Rewritten. Userdata option removed, included by default backup. Added options to edit include/exclude filters in the GUI. Existing backups (v6.9 or less) are no longer supported: https://github.com/MichaIng/DietPi/issues/1851
-DietPi-Config | Soundcards (RPi): Allo Katana, now available for selection. https://github.com/MichaIng/DietPi/issues/1849
-DietPi-Config | IntelGPU Driver: Installation code added: https://github.com/MichaIng/DietPi/issues/1855#issue-333150262
+DietPi-Config | Sound cards (RPi): Allo Katana, now available for selection. https://github.com/MichaIng/DietPi/issues/1849
+DietPi-Config | Intel GPU Driver: Installation code added: https://github.com/MichaIng/DietPi/issues/1855#issue-333150262
 DietPi-Config | Networking: You can now view the sent and recieved totals for both network devices. NB: 32bit devices will reset the values after 32bit int limit is reached (roughly 4.3GB~), this is a kernel/arch limitation: https://github.com/MichaIng/DietPi/issues/1666#issuecomment-401546728
 DietPi-Drive_Manager | Rewrite and improvements:
- - Now supports ROM devices (eg: DVD). NB: compatibility for DVD/CD devices relies on kernel support. Not all devices will support DVD/CD devices, and/or their filesystem format: https://github.com/MichaIng/DietPi/issues/1858
+ - Now supports ROM devices (e.g. DVD). NB: compatibility for DVD/CD devices relies on kernel support. Not all devices will support DVD/CD devices, and/or their filesystem format: https://github.com/MichaIng/DietPi/issues/1858
  - Resize ext4 options added: https://github.com/MichaIng/DietPi/issues/1821
  - Support for detecting and formatting non-partitioned drives
  - You can now benchmark read/write for all available mounted drives: https://github.com/MichaIng/DietPi/issues/1858
@@ -691,7 +692,7 @@ DietPi-Software | GMrender: Resolved an issue where two systems on the same netw
 DietPi-Software | Apache2: Fixed a syntax error that leads to Apache logging to "/error.log" instead of "/var/log/apache2/error.log"
 DietPi-Software | Nukkit: Fixed the broken download link on installation. Many thanks to @symbios24 for reporting bug and providing solution: https://github.com/MichaIng/DietPi/issues/1875
 DietPi-Software | Linux software: Resolved an issue with NULL entry being displayed: https://github.com/MichaIng/DietPi/pull/1830#issuecomment-401612168
-DietPi-Config | Fixen an issue, where IPv6 could not be disabled on RPi. On current kernel version it is no dedicated kernel module any more and needs to be toggled via "/boot/cmdline.txt".
+DietPi-Config | Fixed an issue, where IPv6 could not be disabled on RPi. On current kernel version it is no dedicated kernel module any more and needs to be toggled via "/boot/cmdline.txt".
 
 AlloGUI v9:
 - Changing the root password, no longer breaks web interface: https://github.com/MichaIng/DietPi/issues/1841
@@ -709,38 +710,38 @@ General | During first run of DietPi (and during this patch), you will now be gi
 General | Increased verbosity and logging of DietPi boot scripts to assist with debugging: https://github.com/MichaIng/DietPi/issues/1772
 General | G_ERROR_HANDLER: Retry mechanic added, allows you to re-run and retry the last command when an error occurs. Also included option to send DietPi a bug report when an issue occurs.
 General | NTP removed from DietPi-Config time sync options and DietPi core packages. All time sync modes are now offered via systemd-timesyncd, which is part of every Debian based core system: https://github.com/MichaIng/DietPi/pull/1628
-Generel | DietPi-Set_Core_Environment was removed. DietPi service and system config files are now updates automatically via new update system, other environment setup steps are moved into DietPi-PREP: https://github.com/MichaIng/DietPi/issues/1749
+General | DietPi-Set_Core_Environment was removed. DietPi service and system config files are now updates automatically via new update system, other environment setup steps are moved into DietPi-PREP: https://github.com/MichaIng/DietPi/issues/1749
 DietPi-BugReport | Has been revised and improved to remove end user security concerns.
 DietPi-Drive_Manager | Swapfile: Added ability to move the swapfile and set size. This replaces the previous option in DietPi-Config.
 DietPi-Process_Tool | NoMachine + Webmin: Processes can now be controlled.
 DietPi-Services | Webmin: Added and now controlled.
-DietPi-Software | Fail2Ban: Install now uses the systemD backend. No longer requires Rsyslog pre-req. For new installations only.
+DietPi-Software | Fail2Ban: Install now uses the systemd backend. No longer requires Rsyslog pre-req. For new installations only.
 DietPi-Software | Search: Feature now available. Find the software you require for install, faster! https://twitter.com/DietPi_/status/1000858660682305536
 DietPi-Software | InfluxDB and Grafana now available for installation. Many thanks to @marcobrianza for the install code and documentation guides: https://github.com/MichaIng/DietPi/issues/1784
 DietPi-Software | LXDE: Resolved missing icons with 'pcmanfm' under RPi devices: https://github.com/MichaIng/DietPi/issues/1558#issuecomment-390328173
-DietPi-Software | Webmin: Resolved failed installation due to missing package pre-reqs. Upgraded to use a systemD service: https://github.com/MichaIng/DietPi/issues/1741
+DietPi-Software | Webmin: Resolved failed installation due to missing package pre-reqs. Upgraded to use a systemd service: https://github.com/MichaIng/DietPi/issues/1741
 DietPi-Software | Removed npm root access error during installs: https://github.com/MichaIng/DietPi/issues/1340#issuecomment-389899081
 DietPi-Software | OpenJDK/JRE now installs Java version 8 across all DietPi system. This is for stability across all programs that require it: https://github.com/MichaIng/DietPi/issues/1340#issuecomment-389889264
 DietPi-Software | Updated several non-APT software titles for fresh installs and reinstalls: https://github.com/MichaIng/DietPi/pull/1774
 DietPi-Software | Transmission: General clean up of install config file. G_CONFIG_INJECT is now used to replace/add our optimized entries. Also cleaned up the service, now runs as forking: https://github.com/MichaIng/DietPi/issues/1754
-DietPi-Software | sabnzbd: Updated to latest version 2.3.4 (for new installations only): https://github.com/MichaIng/DietPi/issues/1340
+DietPi-Software | SABnzbd: Updated to latest version 2.3.4 (for new installations only): https://github.com/MichaIng/DietPi/issues/1340
 DietPi-Software | CAVA: Updated to latest version 0.6.1. Enabled for x86_64: https://github.com/MichaIng/DietPi/issues/1340
-DietPi-Software | OctoPrint: libjpeg-dev now installed by default, this is required for additional plugin installations (eg: Astroprintcloud Plugin): https://github.com/MichaIng/DietPi/issues/1800
+DietPi-Software | OctoPrint: libjpeg-dev now installed by default, this is required for additional plugin installations (e.g. Astroprintcloud Plugin): https://github.com/MichaIng/DietPi/issues/1800
 DietPi-Software | Xserver: DPMS and all known screen blanking/saving is now disabled by default. To re-enable this feature, remove the following file '/etc/X11/xorg.conf.d/99-dietpi-dpms_off.conf': https://github.com/MichaIng/DietPi/issues/1823
 DietPi-Survey | Has been revised and improved to remove end user security concerns.
 DietPi-Update | Implemented an automated update system for DietPi files, placed outside of /DietPi, e.g. system configurations and service files. This allows significant reduction of script code and assures consistency across all systems: https://github.com/MichaIng/DietPi/pull/1802
 
 Bug Fixes:
 General | Login and globals moved to /etc/bashrc.d/*, due to issues with remote shell and desktop terms under /etc/profile.d/99-dietpi-login.sh: https://github.com/MichaIng/DietPi/issues/1777#issuecomment-390248960
-General | Completely removed root permission requirements from login scirpts and banner. Also users without sudo permissions will see the login banner and will be able to use dietpi-* and G_* functions: https://github.com/MichaIng/DietPi/pull/1790
+General | Completely removed root permission requirements from login scripts and banner. Also users without sudo permissions will see the login banner and will be able to use dietpi-* and G_* functions: https://github.com/MichaIng/DietPi/pull/1790
 General | Sparky SBC + USB-DAC unmute fix (v2), now sets volume to max: https://github.com/MichaIng/DietPi/pull/1779
 General | UID bit reapplied for Sudo. Reported not applied on current XU4 image: https://github.com/MichaIng/DietPi/issues/794#issuecomment-392335392
 DietPi-Config | WiFi HotSpot: Resolved inability to toggle state (enable/disable) and change channel: https://github.com/MichaIng/DietPi/issues/1810#issuecomment-394126835
 DietPi-Drive_Manager | Format: Resolved an issue where formatting any drive, would reset the swapfile back to auto size and default location: https://dietpi.com/phpbb/viewtopic.php?f=11&t=3851&p=12864#p12864
 DietPi-set_dphys-swapfile | Resolved issues with fallocate on vfat partitions which caused a failure.
-DietPi-Software | SickRage: SystemD service updated to prevent timeouts, allowing the process to fully init. Experienced by some users installs: https://github.com/MichaIng/DietPi/issues/1762
-DietPi-Software | AirSonic: Resolved issues with incorrect memory limit being set during installation: https://github.com/MichaIng/DietPi/issues/1764
-DietPi-Software | AirSonic/SubSonic: Resolved 503 error when accessing web interface: https://github.com/MichaIng/DietPi/issues/1764
+DietPi-Software | SickRage: systemd service updated to prevent timeouts, allowing the process to fully init. Experienced by some users installs: https://github.com/MichaIng/DietPi/issues/1762
+DietPi-Software | Airsonic: Resolved issues with incorrect memory limit being set during installation: https://github.com/MichaIng/DietPi/issues/1764
+DietPi-Software | Airsonic/Subsonic: Resolved 503 error when accessing web interface: https://github.com/MichaIng/DietPi/issues/1764
 DietPi-Software | CloudPrint: Resolved an issue where the CUPS web interface would fail to connect: https://github.com/MichaIng/DietPi/issues/1797
 DietPi-Software | VNC + LXDE: Resolved error message 'no session for PID x'.:
 
@@ -753,18 +754,18 @@ Changes / Improvements / Optimizations:
 General | All future DietPi images (v6.8 and onwards), now has serial console enabled by default for the 1st run setup. It will be disabled automatically after first run setup to save on resources, unless 'CONFIG_SERIAL_CONSOLE_ENABLE=1' is set in dietpi.txt: https://github.com/MichaIng/DietPi/issues/1759
 General | DietPi.com website: Server has been upgraded to Debian Stretch, featuring HTTPS redirect.
 General | FBset is no longer a pre-req package for DietPi systems. This will be removed on fresh installations (not existing, to avoid any package conflicts): https://github.com/MichaIng/DietPi/issues/1716
-General | DietPi login script and globals init moved to /etc/profile.d/99-dietpi-login.sh. Ensuring any user on system with sudo permissions can load them. Global commands are also now supported across multiple users, eg: either 'sudo -i G_AGI pacakge' or 'G_SUDO G_AGI package': https://github.com/MichaIng/DietPi/issues/1477
+General | DietPi login script and globals init moved to /etc/profile.d/99-dietpi-login.sh. Ensuring any user on system with sudo permissions can load them. Global commands are also now supported across multiple users, e.g. either 'sudo -i G_AGI package' or 'G_SUDO G_AGI package': https://github.com/MichaIng/DietPi/issues/1477
 General | G_WHIP*: Improved scaling detection based on character count and line count. We now also calculate character count per line, to determine if additional lines are required against X. In other words, it should be a more 'snug' fit :) https://github.com/MichaIng/DietPi/issues/1740
 DietPi-Automation | 'AUTO_SETUP_RAMLOG_MAXSIZE' added to dietpi.txt. Sets max /var/log tmpfs size during 1st run. Requires v6.8 or higher image.
-DietPi-Config | Native PC > Soundcard: 'firmware-intel-sound' is now installed automatically for Intel based CPUs.
+DietPi-Config | Native PC > Sound card: 'firmware-intel-sound' is now installed automatically for Intel based CPUs.
 DietPi-Drive_Manager | Added ability to adjust reserved blocks percentage on ext4 file system: https://github.com/MichaIng/DietPi/issues/1662
 DietPi-Drive_Manager | Added ability to check and optionally repair a filesystem. Many thanks to MonZon for the feature request! rootFS and /boot checks will be added in v6.9, currently additional drives are supported by this feature https://github.com/MichaIng/DietPi/issues/1740
 DietPi-Drive_Manager | Enabled access for virtual machines: https://github.com/MichaIng/DietPi/issues/1765
 DietPi-LetsEncrypt | Lighttpd: SSL configuration upgrade according to Mozillas SSL generator: https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=lighttpd-1.4.35&openssl=1.0.1t&hsts=yes&profile=intermediate
-DietPi-LetsEncrypt | Minor code and error handling improvements, as well increasing transparancy of what the script is currently doing: https://github.com/MichaIng/DietPi/pull/1738
+DietPi-LetsEncrypt | Minor code and error handling improvements, as well increasing transparency of what the script is currently doing: https://github.com/MichaIng/DietPi/pull/1738
 DietPi-Process_tool | Rewrite of save file, to allow for stringed entries. The save file will be cleared during the update, to support this feature: https://github.com/MichaIng/DietPi/issues/1750
 DietPi-Process_tool | Added Plex Media Server to process tool, however, transcoding will not be affected by this: https://github.com/MichaIng/DietPi/issues/1750#issuecomment-386826317
-DietPi-Set_Hardware | Allo Piano firmware is now installed on demand and will be removed on update, if not chosen as soundcard: https://github.com/MichaIng/DietPi/issues/1656
+DietPi-Set_Hardware | Allo Piano firmware is now installed on demand and will be removed on update, if not chosen as sound card: https://github.com/MichaIng/DietPi/issues/1656
 DietPi-Software | AmiBerry (Amiga Emulator): Updated to v2.19, contains bug fixes and improvements: https://github.com/MichaIng/DietPi/issues/1707#issue-314377609
 DietPi-Software | Chromium: No longer requires a desktop and can be installed as a lightweight single use program, using dietpi-autostart to run under kiosk mode. Many thanks to @AYapejian! 720p is the default window size, please see '/var/lib/dietpi/dietpi-software/installed/chromium-autostart.sh' for full options when running under 'dietpi-autostart' mode: https://github.com/MichaIng/DietPi/issues/1737
 DietPi-Software | Readymedia (MiniDLNA): Removed ALSA pre-req as it is not required. Many thanks to @bokiroki: https://github.com/MichaIng/DietPi/issues/1712
@@ -773,7 +774,7 @@ DietPi-Software | Gitea: Updated to latest version (1.4), for new installations 
 DietPi-Software | PHPBB3: Latest version update (3.2.2), for new installations only.
 DietPi-Software | Docker: Enabled for ARMv8 devices: https://github.com/MichaIng/DietPi/issues/1736
 PREP | G_HW_MODEL: Added for 'OrangePi PC Plus'. Many thanks to @SuBLiNeR: https://github.com/MichaIng/DietPi/pull/1704
-PREP | Optimized rootfs re-parition and resize. This will reduced the required intial system reboot count by one. Will take affect from official v6.8 DietPi images and onwards.
+PREP | Optimized rootfs re-parition and resize. This will reduced the required inital system reboot count by one. Will take affect from official v6.8 DietPi images and onwards.
 
 Bug Fixes:
 General | Remote SCP/Rsync fix when running under 'dietpi' user: https://github.com/MichaIng/DietPi/issues/1703
@@ -806,10 +807,10 @@ DietPi-Backup | Free space check is now run, prior to backup: https://github.com
 DietPi-Banner | Added additional credits and support for displaying image creator + pre-image name: https://github.com/MichaIng/DietPi/issues/1621
 DietPi-Config | MPEG2/VC1 keys: GPU memory is now increased automatically to 128 (if currently lower), required for this features to function: https://github.com/MichaIng/DietPi/issues/1487
 DietPi-Drive_Manager | When formatting EXT4, reserved block size is now set to 0%. This will provide the max available storage for the device (previously 5% was reserved): https://github.com/MichaIng/DietPi/issues/1662#issuecomment-378860605
-DietPi-PREP | Updated to G_WHIP. Added image creator and pre-image name input box (used in banner). All user input questions/prompts at begining of script: https://github.com/MichaIng/DietPi/issues/1621
+DietPi-PREP | Updated to G_WHIP. Added image creator and pre-image name input box (used in banner). All user input questions/prompts at beginning of script: https://github.com/MichaIng/DietPi/issues/1621
 DietPi-Software | Samba Server: Reduced the process count of smbd from 4 to 3, by fully disabling printer support. Applied to new installations only: https://github.com/MichaIng/DietPi/issues/1689#issuecomment-379038594
 DietPi-Software | Samba Server: Max connections is now limited to 'CPU cores * 2'. This will prevent excess connections and resource usage. Applied to new installations only.
-DietPi-Software | (RPi): 'rpi-bcm2835-ultrahq' is now the default installed soundcard, if no other soundcard has been selected. Previously this was 'rpi-bcm2835', which offered a lower quality audio output when compared to 'rpi-bcm2835-ultrahq'.
+DietPi-Software | (RPi): 'rpi-bcm2835-ultrahq' is now the default installed sound card, if no other sound card has been selected. Previously this was 'rpi-bcm2835', which offered a lower quality audio output when compared to 'rpi-bcm2835-ultrahq'.
 DietPi-Sync | Free space check is now run, prior to sync: https://github.com/MichaIng/DietPi/pull/1686
 
 Bug Fixes:
@@ -847,7 +848,7 @@ Bug Fixes:
 General | RPi: Resolved issue with updating 'raspberrypi-sys-mods', where the patch would incorrectly apply a new apt mirror, breaking the ability to update: https://github.com/MichaIng/DietPi/issues/1659#issuecomment-377297103
 General | firmware-misc-nonfree is now installed by default on all DietPi systems (minus those via PREP with WiFi disabled). Mostly Intel/Nvidia firmware, however, it also contains ralink WiFi firmware: https://github.com/MichaIng/DietPi/issues/1675#issuecomment-377806609
 DietPi-Globals | G_RPI_UPDATE: Added APT hold state for "libraspberrypi0", to include all "raspberrypi-firmware" packages, that are overwritten by "rpi-update": https://github.com/MichaIng/DietPi/pull/1657
-DietPi-Process_Tool | Deluge: Is now a SystemD service, which resolves failed process tool apply on forking deluge process: https://github.com/MichaIng/DietPi/issues/1658
+DietPi-Process_Tool | Deluge: Is now a systemd service, which resolves failed process tool apply on forking deluge process: https://github.com/MichaIng/DietPi/issues/1658
 
 -----------------------------------------------------------------------------------------------------------
 
@@ -863,7 +864,7 @@ DietPi-Environment | Move sudoers adjustments to "/etc/sudoers.d/dietpi": https:
 DietPi-Environment | Move sysctl adjustments to "/etc/sysctl.d/dietpi.conf" to assure higher priority than "/etc/sysctl.d/99-sysctl.conf": https://github.com/MichaIng/DietPi/pull/1635
 DietPi-Config | Enabled possibility to adjust display resolution for VMs, but max guest display resolution might need to be adjusted within VM software as well: https://github.com/MichaIng/DietPi/issues/1227
 DietPi-Config | Advanced options: You can now define the swapfile location: https://github.com/MichaIng/DietPi/issues/1602
-DietPi-Config | Soundcards (RPi): Added option for ApplePi DAC: https://github.com/MichaIng/DietPi/issues/1626
+DietPi-Config | Sound cards (RPi): Added option for ApplePi DAC: https://github.com/MichaIng/DietPi/issues/1626
 DietPi-Process_Tool | Added ability to add custom process entries to "/DietPi/dietpi/.dietpi-process_tool_include". Add one process each line with the format <chosenName>:<executableFileName>. Check via htop, e.g. "DHCP client:dhclient"
 DietPi-Software | NoMachine: Installation updated to 6.0.78 (new installations only): https://github.com/MichaIng/DietPi/issues/1340#issuecomment-372845397
 DietPi-Software | Squeezebox server: Updated to systemd native service: https://github.com/MichaIng/DietPi/issues/1613
@@ -877,7 +878,7 @@ General | dphys-swapfile: Has been removed and replace with our own swapfile gen
 General | RPi: Resolved issue with gettext error during login due to /etc/profile.d/wifi-country.sh: https://github.com/MichaIng/DietPi/issues/1631
 General | RPi: Resolved missing Allo Piano DAC firmware.
 General | RPi 3B+: Resolved inability to scan/connect with WiFi: https://github.com/MichaIng/DietPi/issues/1627#issuecomment-375912747
-DietPi-Drive_Manager | Resolved an issue where x-systemd.automount would fail if autofs4 was disabled in kernel/modules (eg: Rock64). x-systemd.automount is now disabled for systems which fail autofs4 detection: https://github.com/MichaIng/DietPi/issues/1607
+DietPi-Drive_Manager | Resolved an issue where x-systemd.automount would fail if autofs4 was disabled in kernel/modules (e.g. Rock64). x-systemd.automount is now disabled for systems which fail autofs4 detection: https://github.com/MichaIng/DietPi/issues/1607
 DietPi-Config | Removed 'firmware-ralink' pre-req from WiFi enable. This is a virtual package for 'firmware-misc-nonfree': https://github.com/MichaIng/DietPi/issues/1631
 DietPi-Config | RPi: Resolved missing Allo Piano DAC 2.1 entry.
 DietPi-Software | PineA64: Resolved issue with failure to run fbturbo driver on Debian Stretch: https://github.com/MichaIng/DietPi/issues/1604
@@ -892,7 +893,7 @@ v6.4 - HotFix
 (09/03/18)
 
 Changes / Improvements / Optimizations:
-DietPi-Cron | Added ability to set minutely based cron jobs (eg: every 3 minutes), using /etc/cron.minutely. Many thanks to @d5c0d3 for adding this feature: https://github.com/MichaIng/DietPi/pull/1578
+DietPi-Cron | Added ability to set minutely based cron jobs (e.g. every 3 minutes), using /etc/cron.minutely. Many thanks to @d5c0d3 for adding this feature: https://github.com/MichaIng/DietPi/pull/1578
 DietPi-Software | UrBackupServer: Updated to latest version 2.2.8: https://github.com/MichaIng/DietPi/issues/1600
 
 Bug Fixes:
@@ -914,11 +915,11 @@ Native PC BIOS | Image now available: https://dietpi.com/download
 NanoPi Neo | Image now available (based on FriendlyARM official image): https://github.com/MichaIng/DietPi/issues/1588
 
 Changes / Improvements / Optimizations:
-General | DietPi now uses its own "dietpi-postboot.service" to initiate dietpi-services, instead of /etc/rc.local. The latter will be reset on update, but in case of manual adjustments, a backup is safed to dietpi_userdata. The initiating "rc-local.service" will stay in place as well, so /etc/rc.local can be used as before: https://github.com/MichaIng/DietPi/issues/1376
+General | DietPi now uses its own "dietpi-postboot.service" to initiate dietpi-services, instead of /etc/rc.local. The latter will be reset on update, but in case of manual adjustments, a backup is saved to dietpi_userdata. The initiating "rc-local.service" will stay in place as well, so /etc/rc.local can be used as before: https://github.com/MichaIng/DietPi/issues/1376
 General | Additional getty's (2-6) are now disabled via mask. This reduces resource usage for unneeded screens: https://github.com/MichaIng/DietPi/issues/1541
 General | APT: 'Disabled install recommends' is now standard and default across all DietPi images: https://github.com/MichaIng/DietPi/issues/1482#issuecomment-368031044
 General | Sparky SBC kernel patches: Pro-Ject-S2 dac DSD native support on sparky, also other few dac ids. Thanks @sudeep.
-General | /tmp tmpfs size is now automatically set to 50% of RAM+SWAP, (previously 50% RAM only). To prevent out of memory errors during certain software installations (eg: Mono), where the swapfile can be used only when needed: https://github.com/MichaIng/DietPi/issues/1027#issuecomment-369435049
+General | /tmp tmpfs size is now automatically set to 50% of RAM+SWAP, (previously 50% RAM only). To prevent out of memory errors during certain software installations (e.g. Mono), where the swapfile can be used only when needed: https://github.com/MichaIng/DietPi/issues/1027#issuecomment-369435049
 DietPi-Automation | dietpi.txt entries and support added for WPA2 Enterprise (WPA-EAP). Many thanks to @symo for implementing this feature!: https://github.com/MichaIng/DietPi/pull/1547
 DietPi-Backup | Once backup is completed, you will be asked if you wish to view the log file, for the full rsync log.
 DietPi-Banner | Improved notification when no network is detected: https://github.com/MichaIng/DietPi/issues/1576
@@ -932,15 +933,15 @@ DietPi-Software | Sonarr: Now uses the develop repo branch, inline with our Rada
 DietPi-Software | Mono: Raspbian dist is now used for RPi devices: https://github.com/MichaIng/DietPi/issues/1566
 DietPi-Software | FFmpeg: Fix backports dependency issues for all Odroids: https://github.com/MichaIng/DietPi/issues/1556
 DietPi-Software | Improved UI options during NTPD failure. You will now be given multiple options that will assist in resolving NTPD time sync issues on your network: https://github.com/MichaIng/DietPi/issues/1580#issuecomment-370153882
-DietPi-Software | NTPD check will now run after the internet connection test, to prevent unnecessary delay when network is not yet configured:
-DietPi-Software | SubSonic 5: Replaced with Airsonic: https://github.com/MichaIng/DietPi/issues/1585
+DietPi-Software | NTPD check will now run after the internet connection test, to prevent unnecessary delay when network is not yet configured.
+DietPi-Software | Subsonic 5: Replaced with Airsonic: https://github.com/MichaIng/DietPi/issues/1585
 DietPi-Software | Aria2: Optimized installation and connection settings based on hardware. Now uses a configuration file '/var/lib/dietpi/dietpi-software/installed/aria2.conf', which will allow users to change aria2 settings permanently. Please note, the aria2-webui does not support saving settings after session shutdown, this is a known limitation with the software, please use the aria2.conf to make changes: https://github.com/MichaIng/DietPi/issues/1575
 DietPi-Sync | Once sync is completed, you will be asked if you wish to view the log file, for the full rsync log.
 DietPi-Update | G_AGUP/G_AGUG: Now runs prior to our patch system. Ensuring APT is upto date during our updates: https://dietpi.com/phpbb/viewtopic.php?f=11&t=2894&p=11150#p11149
 
 Bug Fixes:
 General | G_AGUG: --allow-unauthenticated added for Stretch+ by default (inline with other G_AG commands)
-General | Resolved POSIX issues with dropbear (limitation) and SSH sessions. We now detect for presence of POSIX and set user selected locale during session load: https://github.com/MichaIng/DietPi/issues/1540
+General | Resolved POSIX issues with Dropbear (limitation) and SSH sessions. We now detect for presence of POSIX and set user selected locale during session load: https://github.com/MichaIng/DietPi/issues/1540
 General | Resolved multiple issues with failed GNU key management during APT installs from non-standard repos. Dirmngr is now installed on all DietPi systems by default: https://github.com/MichaIng/DietPi/issues/1388
 General | Resolved basic APT issues with Meveric's repo and failing dependencies. Debian repo is now used in the first instance: https://github.com/MichaIng/DietPi/pull/1571#issuecomment-369973745
 General | DietPi-Globals are now loaded prior to login script. Ensures aliases are functional during exit of 1st run setup: https://github.com/MichaIng/DietPi/issues/1580#issuecomment-370149636
@@ -952,7 +953,7 @@ DietPi-Software | Desktops: USB drive removed from .gtk-bookmarks as no longer u
 DietPi-Software | Shairport-Sync: Resolved ARMv6 binary Illegal instruction: https://github.com/MichaIng/DietPi/issues/1548
 DietPi-Software | Lighttpd: Resolved an issue with failed enable of php module, due to perl being a undocumented pre-req for 'lighttpd-enable-mod'.
 DietPi-Software | MotionEye: Resolved failed installation due to missing build-essential pre-req: https://github.com/MichaIng/DietPi/issues/1564
-DietPi-Software | SubSonic6: Resolved broken URL link. Binary now hosted on dietpi.com: https://github.com/MichaIng/DietPi/issues/1582
+DietPi-Software | Subsonic6: Resolved broken URL link. Binary now hosted on dietpi.com: https://github.com/MichaIng/DietPi/issues/1582
 DietPi-Services | Service stop order is now reversed: https://github.com/MichaIng/DietPi/issues/1462#issue-294140894
 DietPi-Set_Hardware | Resolved issues with serial consoles not be disabled without dbus installed. Serial consoles are now masked/unmasked (previously disabled): https://github.com/MichaIng/DietPi/issues/1482
 DietPi-Update | Resolved an issue where .update_available would exist during reboot, causing banner to display update available incorrectly: https://github.com/MichaIng/DietPi/issues/1535
@@ -963,19 +964,19 @@ v6.2
 (18/02/18)
 
 Changes / Improvements / Optimizations:
-Native PC UEFI | Image now includes options to install to either EMMC (eg: onboard) or SDA (1st HDD) device: https://github.com/MichaIng/DietPi/issues/1171#issuecomment-336522021 | https://dietpi.com/phpbb/viewtopic.php?f=9&t=2809&p=10808#p10808
+Native PC UEFI | Image now includes options to install to either EMMC (e.g. onboard) or SDA (1st HDD) device: https://github.com/MichaIng/DietPi/issues/1171#issuecomment-336522021 | https://dietpi.com/phpbb/viewtopic.php?f=9&t=2809&p=10808#p10808
 DietPi-Backup | Rsync: Error control now handled by G_RUN_CMD
 DietPi-Config | Locale: Reworked, now only lists UTF-8 items, no longer using dpkg-reconfigure. Our custom set_software script handles all locales ensuring en_GB is always installed, and selected item is applied as system default.
 DietPi-Config | Display options > Resolution: Added fkms/kms (OpenGL) modes for RPi 2/3.
-DietPi-Config | Sparky SBC: Added option to select usb-dac-1.1 soundcard, which will enable USB1.1 compatibility.
+DietPi-Config | Sparky SBC: Added option to select usb-dac-1.1 sound card, which will enable USB1.1 compatibility.
 DietPi-Config | WiFi: Now supports connecting to hidden WiFi networks, thanks @shahwahed : https://github.com/MichaIng/DietPi/pull/1497
 DietPi-LetsEncrypt | On Jessie, changed certificate auto renewal to native certbot renew command, to prevent certificate duplication: https://github.com/MichaIng/DietPi/issues/734
 DietPi-LetsEncrypt | On Stretch, added automated Minio certificate renewal. Rerun "dietpi-letsencrypt" on your Stretch system to gain this feature.
 DietPi-Process_tool | Reduction of onscreen print. Additional status print will only occur when HIERARCHY is less than 2 and/or an error occurs.
-DietPi-Software | AmiBerry: Massive update to v2.14 and SDL2, new installations only. Currently for RPi's under Stretch only, however, we have plans to impliment for other devices: https://dietpi.com/phpbb/viewtopic.php?f=8&t=5&p=64#p64 https://github.com/MichaIng/DietPi/issues/1410
+DietPi-Software | AmiBerry: Massive update to v2.14 and SDL2, new installations only. Currently for RPi's under Stretch only, however, we have plans to implement for other devices: https://dietpi.com/phpbb/viewtopic.php?f=8&t=5&p=64#p64 https://github.com/MichaIng/DietPi/issues/1410
 DietPi-Software | LMS/Squeezebox: Has undergone an install review and re-write. All archs are now supported for Stretch + Jessie: https://github.com/MichaIng/DietPi/issues/1496
 DietPi-Software | Pydio: Add PHP module 'intl' on installation, as requested via web ui warning: https://github.com/MichaIng/DietPi/issues/1240
-DietPi-Software | Nginx: To further reduce recource usage, by default 'nginx-light' will be installed now: https://github.com/MichaIng/DietPi/issues/1240
+DietPi-Software | Nginx: To further reduce resource usage, by default 'nginx-light' will be installed now: https://github.com/MichaIng/DietPi/issues/1240
 DietPi-Software | PHP: Removed some unused PHP modules from default installation: https://github.com/MichaIng/DietPi/issues/1240
 DietPi-Software | Added information regarding DietPi controlling services (stopping them), prior to install/uninstall. Thanks @gpioneer90: https://github.com/MichaIng/DietPi/issues/1484#issuecomment-363802523
 DietPi-Software | PiJuice: Available for installation: https://dietpi.com/phpbb/viewtopic.php?f=8&t=5&p=10740#p10740 | https://github.com/MichaIng/DietPi/issues/1488
@@ -989,12 +990,12 @@ G_AGP | Will now only remove packages which are installed. Non matching items wi
 G_DIETPI-NOTIFY | Added initiating program name, to start of line print.
 
 Bug Fixes:
-General | Resolved an issue where externally launched DietPi-Config with target menu, (eg: dietpi-config 8 1) had no effect. EG: fail connection, should go straight to networking submenu.
+General | Resolved an issue where externally launched DietPi-Config with target menu, (e.g. dietpi-config 8 1) had no effect. E.g. fail connection, should go straight to networking submenu.
 General | Locales have been reworked and reset: To resolve broken Locales, they have been reset to en_GB.UTF-8.\n\nIf you had a different locale configured on this system, please use dietpi-config at a later date to re-configure. Backups of previous env and locale settings, are created in /mnt/dietpi_userdata/*.bak: https://github.com/MichaIng/DietPi/issues/1430
 DietPi-Autostart | Custom: Resolved issue with the dietpi-autostart_custom service failing to run: https://dietpi.com/phpbb/viewtopic.php?f=11&t=2832&p=10862
 DietPi-Config | AudioPhonics I-Sabre-K2M: Resolved issue with failed installation. This is now a source build ondemand: https://github.com/MichaIng/DietPi/issues/1437
 DietPi-LetsEncrypt | Work around a non-DietPi issue, that prevents certificate renewal via Apache and Nginx on Stretch systems: https://github.com/MichaIng/DietPi/issues/734#issuecomment-361774084
-DietPi-Services | OpenVPN and DNSMASQ (PiHole): Are no longer controlled. This is to prevent unexpected loss of connection during DietPi scripts: https://github.com/MichaIng/DietPi/issues/1501
+DietPi-Services | OpenVPN and DNSMASQ (Pi-hole): Are no longer controlled. This is to prevent unexpected loss of connection during DietPi scripts: https://github.com/MichaIng/DietPi/issues/1501
 DietPi-Software | Jessie: Pi-hole is now disabled, pending release of FTL 4.0, which is required to resolve incompatible logging with outdated dnsmasq options under Jessie: https://github.com/MichaIng/DietPi/issues/1524
 DietPi-Software | Nginx: Resolved failed installation when IPv6 is disabled, thanks @MichaIng: https://github.com/MichaIng/DietPi/pull/1441
 DietPi-Software | OpenVPN Server: Resolved failed installation under Debian Stretch: https://github.com/MichaIng/DietPi/issues/1450
@@ -1011,7 +1012,7 @@ DietPi-Software | NodeRed: resolved an issue where the nodered user lacked a hom
 
 Allo Web Interface v6:
 Sparky SBC: Resolved an issue where USB1.1 compatibility setting would always be applied, when usb-dac selected.
-Sparky SBC: Added option to select usb-dac-1.1 soundcard, which will enable USB1.1 compatibility.
+Sparky SBC: Added option to select usb-dac-1.1 sound card, which will enable USB1.1 compatibility.
 
 -----------------------------------------------------------------------------------------------------------
 
@@ -1052,9 +1053,9 @@ General | Swapfile generation is now completed during 1st run of dietpi-software
 General | DietPi-Funtime: Removed from DietPi. Although it looked pretty, it did absolutely nothing (except slow down a program)
 DietPi-Automation | All dietpi.txt entries have been renamed and cleaned up.
 DietPi-Automation | dietpi.txt: CONFIG_NTP_MODE will now be applied during 1st run of device: https://github.com/MichaIng/DietPi/issues/1379
-DietPi-Boot | Improved the method of initial FS_partition and FS_expansion during 1st run, via systemD services. 'fs_force_resize=' in dietpi.txt is no longer supported: https://github.com/MichaIng/DietPi/issues/1285#issuecomment-352159930
-DietPi-Banner | IP: Will now also list the active network adapter used (eg: eth0/wlan0)
-DietPi-Config | Dion Audio LOCO V1/V2: Soundcards added for RPi.
+DietPi-Boot | Improved the method of initial FS_partition and FS_expansion during 1st run, via systemd services. 'fs_force_resize=' in dietpi.txt is no longer supported: https://github.com/MichaIng/DietPi/issues/1285#issuecomment-352159930
+DietPi-Banner | IP: Will now also list the active network adapter used (e.g. eth0/wlan0)
+DietPi-Config | Dion Audio LOCO V1/V2: Sound cards added for RPi.
 DietPi-Config | Locale: en_GB.UTF-8 is now automatically installed, alongside user selected choice. Required for DietPi scripts to function.
 DietPi-Drive_Manager | Added support for exFAT, many thanks @MichaIng : https://github.com/MichaIng/DietPi/pull/1312
 DietPi-Globals | Global variables and functions are now exported during login. Please see the sourcecode for more information: https://github.com/MichaIng/DietPi/issues/1311
@@ -1064,7 +1065,7 @@ DietPi-Software | NAA Daemon: Updated to latest (3.5.2-36). Existing installs wi
 DietPi-Software | PHP-FPM: Increased from "$CPU_CORES_TOTAL" to "pm.max_children = $(( $CPU_CORES_TOTAL * 3 ))". This should avoid failed forking of PHP-FPM processes/requests : https://github.com/MichaIng/DietPi/issues/1298
 DietPi-Software | ownCloud/Nextcloud: Added option to choose data directory via dietpi.txt pre installation: https://github.com/MichaIng/DietPi/issues/1314#issuecomment-352782055
 DietPi-Software | ownCloud/Nextcloud: Switch to pretty URLs (without "index.php") on Apache
-DietPi-Software | ownCloud/Nextcloud: Automated backup restoring on install and creation und uninstall to ownCloud/Nextcloud data directory
+DietPi-Software | ownCloud/Nextcloud: Automated backup restoring on install and creation on uninstall to ownCloud/Nextcloud data directory
 DietPi-Software | ownCloud: Switch to non-package/archive installation. This allows usage of preferred web based updater.
 DietPi-Software | Nextcloud: Resolved OPcache admin panel warnings now also on Lighttpd
 DietPi-Software | UrBackup: Installation updated to latest version 2.1.20. For new installations only: https://github.com/MichaIng/DietPi/issues/1335
@@ -1086,7 +1087,7 @@ DietPi-Software | qBittorrent: Resolved an issue with inability to log into web 
 DietPi-Software | Resolved an issue where our custom LD_LIBRARY_PATH would cause APT failures. LD_LIBRARY_PATH has now been reverted, apologies if this effected your system: https://github.com/MichaIng/DietPi/issues/1329
 DietPi-Software | Resolved an issue where APT installations would fail if services were masked. All known DietPi software services, will be enabled/unmasked, before installation: https://github.com/MichaIng/DietPi/issues/1320
 DietPi-Software | WiFi Hotspot (Stretch): Resolved an issue where hostapd would fail to run due to missing libssl1.0.0 lib, not available in repos: https://github.com/MichaIng/DietPi/issues/1299
-DietPi-Software | Shairport-sync (Stretch): Resolved an issue where this would fail to install, due to pre-req URLS becomming invalid: https://github.com/MichaIng/DietPi/issues/1303
+DietPi-Software | Shairport-sync (Stretch): Resolved an issue where this would fail to install, due to pre-req URLS becoming invalid: https://github.com/MichaIng/DietPi/issues/1303
 DietPi-Software | Plex Media Server: Resolved uninstall to include /var/lib/plexmediaserver in removal (which is not completed via apt purge).
 DietPi-Software | MariaDB: Resolved an issue where MariaDB would fail to uninstall correctly: https://github.com/MichaIng/DietPi/pull/1280
 DietPi-Software | Aira2 (Stretch): Resolved installation, now used APT installation: https://github.com/MichaIng/DietPi/issues/1310

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3212,6 +3212,12 @@ Package: *php7.3*\nPin: release *\nPin-Priority: -1' > /etc/apt/preferences.d/di
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
+			# On Stretch, use backports, which resolves missing /etc/profile (e.g. $PATH) load and failing install+service if IPv6 is disabled: https://github.com/MichaIng/DietPi/issues/3017
+			(( $G_DISTRO == 4 )) && cat << _EOF_ > /etc/apt/preferences.d/dietpi-xrdp
+Package: xrdp
+Pin: release n=stretch-backports
+Pin-Priority: 501
+_EOF_
 			G_AGI xrdp
 
 		fi
@@ -12290,6 +12296,7 @@ _EOF_
 
 			Banner_Uninstalling
 			G_AGP xrdp
+			[[ -f '/etc/apt/preferences.d/dietpi-xrdp' ]] && rm /etc/apt/preferences.d/dietpi-xrdp
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3216,7 +3216,7 @@ Package: *php7.3*\nPin: release *\nPin-Priority: -1' > /etc/apt/preferences.d/di
 			(( $G_DISTRO == 4 )) && cat << _EOF_ > /etc/apt/preferences.d/dietpi-xrdp
 Package: xrdp
 Pin: release n=stretch-backports
-Pin-Priority: 501
+Pin-Priority: 500
 _EOF_
 			G_AGI xrdp
 

--- a/dietpi/pre-patch_file
+++ b/dietpi/pre-patch_file
@@ -45,7 +45,7 @@
 
 		#-------------------------------------------------------------------------------
 		# Pre-patch 1: RAMlog 0 free space check due to issues with failing DietPi cron jobs in v6.11
-		if (( $G_DIETPI_VERSION_SUB < 12 && $(df -B1M --output=avail /var/log | sed -n 2p) < 2 )); then
+		if (( $G_DIETPI_VERSION_SUB < 12 && $(df -m --output=avail /var/log | tail -1) < 2 )); then
 
 			echo -e '\e[90m[\e[0m INFO \e[90m]\e[0m Pre-patch 1 | Clearing /var/log files to free up RAMlog space (<2MB) before update will continue'
 			/DietPi/dietpi/func/dietpi-logclear 1 || { EXIT_CODE=1; break; }
@@ -53,8 +53,7 @@
 		fi
 		#-------------------------------------------------------------------------------
 		# Pre-patch 2: https://github.com/MichaIng/DietPi/pull/2490
-		if (( $G_DIETPI_VERSION_SUB < 21 )) && [[ -f '/etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf' ]] &&
-			grep -qi 'buster' /etc/os-release; then
+		if (( $G_DIETPI_VERSION_SUB < 21 )) && [[ -f '/etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf' ]] && grep -qi 'buster' /etc/os-release; then
 
 			echo -e '\e[90m[\e[0m INFO \e[90m]\e[0m Pre-patch 2 | Patching /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf for MariaDB v10.3/Buster support'
 			sed -i '/innodb_large_prefix/d' /etc/mysql/mariadb.conf.d/99-dietpi-4byte.cnf || { EXIT_CODE=2; break; }
@@ -90,49 +89,29 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 		fi
 		#-------------------------------------------------------------------------------
 		# Pre-patch 6: Move Jessie systems to "jessie-support" branch: https://github.com/MichaIng/DietPi/issues/2332
-		# Pre-patch 7: https://github.com/MichaIng/DietPi/pull/2728
 		if grep -qi 'jessie' /etc/os-release; then
 
-			if ! grep -q '^[[:blank:]]*DEV_GITBRANCH=jessie-support' /DietPi/dietpi.txt; then
+			echo -e '\e[90m[\e[0m INFO \e[90m]\e[0m Pre-patch 7 | Migrating Jessie systems to "jessie-support" update branch'
+			if grep -q '^[[:blank:]]*DEV_GITBRANCH=' /DietPi/dietpi.txt; then
 
-				echo -e '\e[90m[\e[0m INFO \e[90m]\e[0m Pre-patch 7 | Migrating Jessie systems to "jessie-support" update branch'
-				if grep -q '^[[:blank:]]*DEV_GITBRANCH=' /DietPi/dietpi.txt; then
+				sed -i '/^[[:blank:]]*DEV_GITBRANCH=/c\DEV_GITBRANCH=jessie-support' /DietPi/dietpi.txt
 
-					sed -i '/^[[:blank:]]*DEV_GITBRANCH=/c\DEV_GITBRANCH=jessie-support' /DietPi/dietpi.txt
+			else
 
-				else
-
-					echo 'DEV_GITBRANCH=jessie-support' >> /DietPi/dietpi.txt
-
-				fi
-
-				# Remove DietPi-Update working directory to allow concurrent execution.
-				cd /tmp
-				[[ -d '/tmp/DietPi-Update' ]] && rm -R /tmp/DietPi-Update
-
-				# Apply update forcefully, since user has already chosen to do so.
-				/DietPi/dietpi/dietpi-update 1
-
-				# Kill parental dietpi-update instance and exit this script to avoid deprecated update finish.
-				kill $PPID
-				exit
+				echo 'DEV_GITBRANCH=jessie-support' >> /DietPi/dietpi.txt
 
 			fi
 
-			if (( $G_DIETPI_VERSION_SUB < 23 && $(sed -n 1p /DietPi/dietpi/.hw_model) > 9 )); then
+			# Remove DietPi-Update working directory to allow concurrent execution.
+			cd /tmp
+			[[ -d '/tmp/DietPi-Update' ]] && rm -R /tmp/DietPi-Update
 
-				echo -e '\e[90m[\e[0m INFO \e[90m]\e[0m Pre-patch 7 | Applying changes to APT sources.list since Debian dropped support for Jessie systems'
-				if [[ $(uname -m) == 'aarch64' ]]; then
+			# Apply update forcefully, since user has already chosen to do so.
+			/DietPi/dietpi/dietpi-update 1
 
-					echo 'deb http://archive.debian.org/debian/ main contrib non-free' > /etc/apt/sources.list || { EXIT_CODE=7; break; }
-
-				else
-
-					sed -Ei '/jessie-(backports|updates)/d' /etc/apt/sources.list || { EXIT_CODE=7; break; }
-
-				fi
-
-			fi
+			# Kill parental dietpi-update instance and exit this script to avoid deprecated update finish.
+			kill $PPID
+			exit
 
 		fi
 		#-------------------------------------------------------------------------------
@@ -156,7 +135,19 @@ Pin: release n=buster\nPin-Priority: 501\n
 # Pin down all other Buster packages to only allow upgrades of already installed ones via: "apt upgrade"
 Package: *\nPin: release n=buster\nPin-Priority: 100' > /etc/apt/preferences.d/dietpi-php || { EXIT_CODE=9; break; }
 
-		fi	
+		fi
+		#-------------------------------------------------------------------------------
+		# Pre-patch 10: https://github.com/MichaIng/DietPi/pull/3020
+		if (( $G_DISTRO_VERSION_SUB < 26 )) && command -v xrdp &> /dev/null && grep -qi 'stretch' /etc/os-release; then
+
+			echo -e '\e[90m[\e[0m INFO \e[90m]\e[0m Pre-patch 10 | Allow upgrade of XRDP from backports to resolve certain issues with current Stretch version'
+			cat << _EOF_ > /etc/apt/preferences.d/dietpi-xrdp || { EXIT_CODE=10; break; }
+Package: xrdp
+Pin: release n=stretch-backports
+Pin-Priority: 500
+_EOF_
+
+		fi
 		#-------------------------------------------------------------------------------
 		# Finished
 		echo -e '\e[90m[\e[0m  \e[32mOK\e[0m  \e[90m]\e[0m Successfully applied pre-patches\n'


### PR DESCRIPTION
**Status**: Ready
- [x] DietPi-Pre_patch | Apply APT preferences on pre-patches to have the package upgraded with DietPi-Update regular G_AGUP and prevent other users from running into related issues
- [x] Changelog

Fixes: #3017

**Commit list/description**:
+ DietPi-Software | XRDP: On Stretch, install version from backports, which resolves missing /etc/profile (e.g. $PATH) load and failing install+service if IPv6 is disabled: https://github.com/MichaIng/DietPi/issues/3017
+ DietPi-Pre-patch | XRDP: On Stretch allow upgrade of XRDP from backports to resolve certain issues
+ DietPi-Pre-patch | Remove pre-patch 7 which will be applied from pre-patch_file of jessie-support branch
+ DietPi-Pre-patch | Simplify pre-patch 6: Every Jessie system which reaches this pre-patch_file is obviously not yet on jessie-support branch
+ DietPi-Pre-patch | Minor coding