### PR TITLE
DietPi-Software | X.org/Kodi: Minor install update by comparing with setup-odroid

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6112,7 +6112,7 @@ Mycroft AI requires at least 2 GiB memory on first start. We will now increase y
 
 				G_AGI firmware-samsung xf86-video-armsoc-odroid malit628-odroid
 
-			# Pine64
+			# Pine A64
 			elif (( $G_HW_MODEL == 40 )); then
 
 				Download_Install 'https://dietpi.com/downloads/binaries/all/libump_1-1_arm64.deb'
@@ -6145,6 +6145,17 @@ Mycroft AI requires at least 2 GiB memory on first start. We will now increase y
 				#ln -sf /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libmali.so
 				#ln -sf /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libMaliOpenCL.so
 				#ln -sf /usr/lib/aarch64-linux-gnu/libMali.so /usr/lib/aarch64-linux-gnu/libOpenCL.so
+
+			# ASUS TB: On Stretch, install our prepared drivers archive
+			# - On Buster, new t76x driver packages require testing: https://packages.debian.org/buster/libegl1
+			elif (( $G_HW_MODEL == 52 && $G_DISTRO == 4 )); then
+
+				Download_Install 'https://dietpi.com/downloads/binaries/asus/ASUSTB_GPU.7z' gpu_driver
+				dpkg -i gpu_driver/*.deb
+				G_AGF
+				rm -R gpu_driver
+
+				dps_index=$software_id Download_Install 'xorg_asustb.conf' /etc/X11/xorg.conf
 
 			fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6150,10 +6150,10 @@ Mycroft AI requires at least 2 GiB memory on first start. We will now increase y
 			# - On Buster, new t76x driver packages require testing: https://packages.debian.org/buster/libegl1
 			elif (( $G_HW_MODEL == 52 && $G_DISTRO == 4 )); then
 
-				Download_Install 'https://dietpi.com/downloads/binaries/asus/ASUSTB_GPU.7z' gpu_driver
-				dpkg -i gpu_driver/*.deb
+				Download_Install 'https://dietpi.com/downloads/binaries/asus/ASUSTB_GPU.7z' gpu_drivers
+				dpkg --force-hold,confdef,confnew -i gpu_drivers/*.deb
 				G_AGF
-				rm -R gpu_driver
+				rm -R gpu_drivers
 
 				dps_index=$software_id Download_Install 'xorg_asustb.conf' /etc/X11/xorg.conf
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3861,32 +3861,21 @@ _EOF_
 
 				local package_list='kodi-odroid'
 
-				# - XU4: Requires pulse audio (fixes corrupt sound)
-				(( $G_HW_MODEL == 11 )) && package_list+=' pulseaudio'
-
 			# Everything else
 			else
 
 				local package_list='kodi'
 
-				# - RPi: Kodi 18 requires fbset to start with custom screen resolution: https://dietpi.com/phpbb/viewtopic.php?p=17550#p17550
+				# RPi: Kodi 18 requires fbset to start with custom screen resolution: https://dietpi.com/phpbb/viewtopic.php?p=17550#p17550
 				(( $G_HW_MODEL < 10 )) && package_list+=' fbset'
 
 			fi
 
-			# - libcurl3-gnutls required for C2. But lets apply to all: https://github.com/MichaIng/DietPi/issues/446
-			package_list+=' libcurl3-gnutls'
+			# CEC support + libcurl3-gnutls required for C2, but lets apply to all: https://github.com/MichaIng/DietPi/issues/446
+			package_list+=' libcec4 libcurl3-gnutls'
 
-			# - NFS/CEC support
-			if (( $G_DISTRO < 5 )); then
-
-				package_list+=' libnfs8 libcec4'
-
-			else
-
-				package_list+=' libnfs12 libcec4'
-
-			fi
+			# NFS support
+			(( $G_DISTRO < 5 )) && package_list+=' libnfs8' || package_list+=' libnfs12'
 
 			G_AGI $package_list
 
@@ -6114,7 +6103,7 @@ Mycroft AI requires at least 2 GiB memory on first start. We will now increase y
 			# Odroid C2
 			elif (( $G_HW_MODEL == 12 )); then
 
-				DEPS_LIST='aml-libs-odroid mali450-odroid xf86-video-mali-odroid libump-odroid xf86-video-fbturbo-odroid'
+				DEPS_LIST='aml-libs-odroid mali450-odroid libump-odroid xf86-video-fbturbo-odroid'
 				G_BACKUP_FP /etc/X11/xorg.conf
 				dps_index=$software_id Download_Install 'xorg_c2.conf' /etc/X11/xorg.conf
 
@@ -6161,7 +6150,6 @@ Mycroft AI requires at least 2 GiB memory on first start. We will now increase y
 			elif (( $G_HW_MODEL == 52 )); then
 
 				Download_Install 'https://dietpi.com/downloads/binaries/asus/ASUSTB_GPU.7z' gpu_driver
-
 				cd gpu_driver
 				dpkg -i *.deb
 				G_AGF
@@ -8363,18 +8351,16 @@ _EOF_
 			Banner_Configuration
 
 			# Remove Kodi user (Whilst waving)
-			userdel -r kodi &> /dev/null
+			getent passwd kodi &> /dev/null && userdel -r kodi
 
 			# Run Kodi as root
 			[[ -f '/etc/default/kodi' ]] && G_CONFIG_INJECT 'USER=' 'USER=root' /etc/default/kodi
 
 			# Copy udev rules, probably not needed for root, but we'll do it anyway
 			dps_index=$software_id Download_Install '99-dietpi-kodi.rules' /etc/udev/rules.d/99-dietpi-kodi.rules
-			chmod +x /etc/udev/rules.d/99-dietpi-kodi.rules
 
-			# Create .desktop SymLinks
+			# Create .desktop symlink
 			mkdir -p /root/Desktop
-			[[ -f '/usr/share/applications/kodi.desktop' ]] && rm /usr/share/applications/kodi.desktop
 			G_RUN_CMD wget https://raw.githubusercontent.com/MichaIng/DietPi/$G_GITBRANCH/.conf/desktop/apps/kodi.desktop -O /usr/share/applications/kodi.desktop
 			ln -sf /usr/share/applications/kodi.desktop /root/Desktop/kodi.desktop
 
@@ -12983,10 +12969,10 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
+			#apt-mark auto libcec4 libcurl3-gnutls libnfs*
 			G_AGP kodi kodi-odroid
 			[[ -f '/usr/share/applications/kodi.desktop' ]] && rm /usr/share/applications/kodi.desktop
-			[[ -f '/root/Desktop/kodi.desktop' ]] && rm /root/Desktop/kodi.desktop
-			rm -f /home/*/Desktop/kodi.desktop
+			rm -f /{root,home/*}/Desktop/kodi.desktop
 			[[ -f '/etc/udev/rules.d/99-dietpi-kodi.rules' ]] && rm /etc/udev/rules.d/99-dietpi-kodi.rules
 
 		fi


### PR DESCRIPTION
**Status**: Ready

**Reference**:
- https://github.com/MichaIng/DietPi/issues/3028
- https://github.com/MichaIng/DietPi/commit/e060bde70ffff86c686c13a1250166ba55acfcc8

**Commit list/description**:
+ DietPi-Software | X.org: On Odroid C2, skip install of xf86-video-mali-odroid, which is required for fbdev only, but we use fbturbo which is covered by xf86-video-fbturbo-odroid.
+ DietPi-Software | Kodi: On Odroid XU4, skip installing PulseAudio as recommended by Meveric and to not conflict with pure ALSA setup used by other software installs. If there is still a real benefit and not other solution for ALSA, we can re-add at a later date.