### PR TITLE
DietPi-Globals | Renamed G_USER_INPUTS to G_INTERACTIVE

### DIFF
--- a/dietpi/dietpi-login
+++ b/dietpi/dietpi-login
@@ -25,7 +25,7 @@
 
 	Show_License(){
 
-		if [[ -f '/var/lib/dietpi/license.txt' ]] && (( $G_USER_INPUTS )); then
+		if [[ -f '/var/lib/dietpi/license.txt' ]] && (( $G_INTERACTIVE )); then
 
 			G_WHIP_VIEWFILE /var/lib/dietpi/license.txt
 			rm /var/lib/dietpi/license.txt
@@ -113,7 +113,7 @@
 	Run_DietPi_First_Run_Setup(){
 
 		# - Set non-interactive shell if automated install chosen, as .bashrc run via STDIN check is interactive
-		grep -qi '^[[:blank:]]*AUTO_SETUP_AUTOMATED=1' /DietPi/dietpi.txt && export G_USER_INPUTS=0
+		grep -qi '^[[:blank:]]*AUTO_SETUP_AUTOMATED=1' /DietPi/dietpi.txt && export G_INTERACTIVE=0
 
 		# - Prompt and wait if this script runs in other session already
 		local pid_firstrunsetup=''
@@ -122,7 +122,7 @@
 
 			# - First run setup running in other session
 			local additional_text='Please resume setup on the active screen.'
-			(( $G_USER_INPUTS )) || additional_text='Automated setup is in progress. When completed, the system will be rebooted.'
+			(( $G_INTERACTIVE )) || additional_text='Automated setup is in progress. When completed, the system will be rebooted.'
 
 			G_WHIP_MSG "[INFO] DietPi first run setup: Currently running on another screen (PID=$pid_firstrunsetup).\n\n$additional_text"
 
@@ -228,7 +228,7 @@ Please login again as user "root" with password "dietpi", respectively the one y
 
 				# - Force interactive mode to show G_WHIP error prompts
 				#   NB: We need to write this to dietpi.txt as well to not have this overwritten on next loop.
-				export G_USER_INPUTS=1
+				export G_INTERACTIVE=1
 				G_CONFIG_INJECT 'AUTO_SETUP_AUTOMATED=' 'AUTO_SETUP_AUTOMATED=0' /DietPi/dietpi.txt
 
 				if G_WHIP_DEFAULT_ITEM='yes' G_WHIP_YESNO "[FAILED] Unknown install state/First run setup failed\n

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -392,8 +392,8 @@ _EOF_
 		# Enable ownCloud and Nextcloud maintenance mode before all services being stopped or restarted
 		if [[ $command == 'stop' || $command == 'restart' && ! $index ]]; then
 
-			[[ -f '/var/www/owncloud/config/config.php' ]] && grep -q "'maintenance' => false," /var/www/owncloud/config/config.php && G_USER_INPUTS=0 G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD occ maintenance:mode --on
-			[[ -f '/var/www/nextcloud/config/config.php' ]] && grep -q "'maintenance' => false," /var/www/nextcloud/config/config.php && G_USER_INPUTS=0 G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD ncc maintenance:mode --on
+			[[ -f '/var/www/owncloud/config/config.php' ]] && grep -q "'maintenance' => false," /var/www/owncloud/config/config.php && G_INTERACTIVE=0 G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD occ maintenance:mode --on
+			[[ -f '/var/www/nextcloud/config/config.php' ]] && grep -q "'maintenance' => false," /var/www/nextcloud/config/config.php && G_INTERACTIVE=0 G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD ncc maintenance:mode --on
 
 		fi
 
@@ -411,8 +411,8 @@ _EOF_
 		# Disable ownCloud and Nextcloud maintenance mode after all services being started or restarted
 		if [[ $command == 'start' || $command == 'restart' && ! $index ]]; then
 
-			[[ -f '/var/www/owncloud/config/config.php' ]] && grep -q "'maintenance' => true," /var/www/owncloud/config/config.php && G_USER_INPUTS=0 G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD occ maintenance:mode --off
-			[[ -f '/var/www/nextcloud/config/config.php' ]] && grep -q "'maintenance' => true," /var/www/nextcloud/config/config.php && G_USER_INPUTS=0 G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD ncc maintenance:mode --off
+			[[ -f '/var/www/owncloud/config/config.php' ]] && grep -q "'maintenance' => true," /var/www/owncloud/config/config.php && G_INTERACTIVE=0 G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD occ maintenance:mode --off
+			[[ -f '/var/www/nextcloud/config/config.php' ]] && grep -q "'maintenance' => true," /var/www/nextcloud/config/config.php && G_INTERACTIVE=0 G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD ncc maintenance:mode --off
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2370,7 +2370,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 	# Disable software installation, if user input is required for automated installs
 	Install_Disable_Requires_UserInput(){
 
-		if (( ! $G_USER_INPUTS )); then
+		if (( ! $G_INTERACTIVE )); then
 
 			for i in ${!aSOFTWARE_INSTALL_STATE[@]}
 			do
@@ -3077,7 +3077,7 @@ Package: *php7.3*\nPin: release *\nPin-Priority: -1' > /etc/apt/preferences.d/di
 		elif [[ $type == 'deb' ]]; then
 
 			# - Allow error on first attempt, giving APT fix a change to resolve e.g. dependencies
-			G_USER_INPUTS=0 G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD dpkg --force-hold,confdef,confold -i $file
+			G_INTERACTIVE=0 G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD dpkg --force-hold,confdef,confold -i $file
 			(( $G_ERROR_HANDLER_EXITCODE_RETURN )) && G_DIETPI-NOTIFY 2 'Trying automated APT fix' && G_AGF
 
 		elif [[ $type == 'zip' ]]; then

--- a/dietpi/dietpi-survey
+++ b/dietpi/dietpi-survey
@@ -109,7 +109,7 @@ _EOF_
  - https://github.com/MichaIng/DietPi/issues or https://dietpi.com/phpbb/viewforum.php?f=11'
 
 		# Check if we have a working internet connection beforehand
-		if G_USER_INPUTS=0 G_ERROR_HANDLER_INFO_ONLY=1 G_CHECK_URL $SFTP_ADDR; then
+		if G_INTERACTIVE=0 G_ERROR_HANDLER_INFO_ONLY=1 G_CHECK_URL $SFTP_ADDR; then
 
 			if (( $OPTED_IN )); then
 
@@ -161,7 +161,7 @@ _EOF_
 		OPTED_IN=$(sed -n '/^[[:blank:]]*SURVEY_OPTED_IN=[01]$/{s/^[^=]*=//;p;q}' /DietPi/dietpi.txt)
 
 	# Force interactive menu if no choice was done yet
-	elif (( $G_USER_INPUTS )); then
+	elif (( $G_INTERACTIVE )); then
 
 		INPUT=0
 

--- a/dietpi/func/dietpi-benchmark
+++ b/dietpi/func/dietpi-benchmark
@@ -13,7 +13,7 @@
 	# /DietPi/dietpi/func/dietpi-benchmark 0								= init vars for sourcing /var/lib/dietpi/dietpi-benchmark/results
 	# FP_BENCHFILE=/location BENCH_FILESIZE=optional_size_MiB /DietPi/dietpi/func/dietpi-benchmark 1	= Benchmark $FP_BENCHFILE filesystem read/write.
 	# /DietPi/dietpi/func/dietpi-benchmark 2								= Run all benchmarks and upload to dietpi.com
-	# G_USER_INPUTS=0 /DietPi/dietpi/func/dietpi-benchmark 2						= Same as above, automated
+	# G_INTERACTIVE=0 /DietPi/dietpi/func/dietpi-benchmark 2						= Same as above, automated
 	# /DietPi/dietpi/func/dietpi-benchmark 3								= iPerf server
 	# /DietPi/dietpi/func/dietpi-benchmark 4								= iPerf client with prompt
 	#
@@ -275,7 +275,7 @@ _EOF_
 		SHOW_RESULTS=0
 		mkdir -p /var/lib/dietpi/dietpi-benchmark
 
-		if (( $G_USER_INPUTS )); then
+		if (( $G_INTERACTIVE )); then
 
 			if G_WHIP_YESNO "$G_PROGRAM_NAME will now run the following benchmarks:\n - CPU performance\n - RootFS read/write performance\n - RAM read/write performance.
 The test duration will depend on hardware specs, however, most devices will not exceed 40 seconds.\n\nIf you are opted in to the DietPi-Survey, your scores will uploaded automatically.

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -34,7 +34,7 @@
 	#	OK | systemd	= no STDIN
 	#	OK | Cron	= no STDIN
 	#	NB | /etc/profile, ~/.profile, /etc/profile.d/, /etc/bash.bashrc, ~/.bashrc and /etc/bashrc.d/ can all be interactive since those are sourced from originating shell/bash session.
-	alias G_USER_INPUTS=G_INTERACTIVE
+	[[ -n ${G_USER_INPUTS+x} ]] && G_INTERACTIVE=$G_USER_INPUTS
 	if [[ $G_INTERACTIVE != [01] ]]; then
 
 		[[ -t 0 ]] && G_INTERACTIVE=1 || G_INTERACTIVE=0

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -34,6 +34,7 @@
 	#	OK | systemd	= no STDIN
 	#	OK | Cron	= no STDIN
 	#	NB | /etc/profile, ~/.profile, /etc/profile.d/, /etc/bash.bashrc, ~/.bashrc and /etc/bashrc.d/ can all be interactive since those are sourced from originating shell/bash session.
+	alias G_USER_INPUTS=G_INTERACTIVE
 	if [[ $G_INTERACTIVE != [01] ]]; then
 
 		[[ -t 0 ]] && G_INTERACTIVE=1 || G_INTERACTIVE=0

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -28,15 +28,15 @@
 
 	# Interactive mode
 	# - Affects whether G_ERROR_ and G_WHIP_ prompts are displayed or not
-	# - Run "export G_USER_INPUTS=0" prior to script call to force non-interactive/automated mode.
-	# - Run "unset G_USER_INPUTS" afterwards to return to auto detection.
+	# - Run "export G_INTERACTIVE=0" prior to script call to force non-interactive/automated mode.
+	# - Run "unset G_INTERACTIVE" afterwards to return to auto detection.
 	# - If not set, check for STDIN availability:
 	#	OK | systemd	= no STDIN
 	#	OK | Cron	= no STDIN
 	#	NB | /etc/profile, ~/.profile, /etc/profile.d/, /etc/bash.bashrc, ~/.bashrc and /etc/bashrc.d/ can all be interactive since those are sourced from originating shell/bash session.
-	if [[ $G_USER_INPUTS != [01] ]]; then
+	if [[ $G_INTERACTIVE != [01] ]]; then
 
-		[[ -t 0 ]] && G_USER_INPUTS=1 || G_USER_INPUTS=0
+		[[ -t 0 ]] && G_INTERACTIVE=1 || G_INTERACTIVE=0
 
 	fi
 
@@ -536,7 +536,7 @@ $(ps f -eo pid,user,tty,cmd | grep -i '[d]ietpi')"; then
 
 	#-----------------------------------------------------------------------------------
 	# Whiptail (Whippy-da-whip-whip-whip tail!)
-	# - Automatically detects/processes for G_USER_INPUTS
+	# - Automatically detects/processes for G_INTERACTIVE
 	#-----------------------------------------------------------------------------------
 	# Input:
 	# - G_WHIP_DEFAULT_ITEM		| Optional, to set the default selected/menu item or input box entry
@@ -784,7 +784,7 @@ $(ps f -eo pid,user,tty,cmd | grep -i '[d]ietpi')"; then
 
 		local WHIP_MESSAGE=$@
 
-		if (( $G_USER_INPUTS )); then
+		if (( $G_INTERACTIVE )); then
 
 			G_WHIP_INIT 0
 			whiptail --title "$G_PROGRAM_NAME" --msgbox "$WHIP_MESSAGE" --ok-button "$G_WHIP_BUTTON_OK_TEXT" --backtitle "$WHIP_BACKTITLE" $WHIP_SIZE_Y $WHIP_SIZE_X
@@ -805,7 +805,7 @@ $(ps f -eo pid,user,tty,cmd | grep -i '[d]ietpi')"; then
 
 		local WHIP_MESSAGE=$@
 
-		if (( $G_USER_INPUTS )); then
+		if (( $G_INTERACTIVE )); then
 
 			G_WHIP_INIT 0
 			whiptail --title "$G_PROGRAM_NAME" --scrolltext --msgbox "$WHIP_MESSAGE" --ok-button "$G_WHIP_BUTTON_OK_TEXT" --backtitle "$WHIP_BACKTITLE" $WHIP_SIZE_Y $WHIP_SIZE_X
@@ -827,7 +827,7 @@ $(ps f -eo pid,user,tty,cmd | grep -i '[d]ietpi')"; then
 
 		local result=1
 
-		if (( $G_USER_INPUTS )); then
+		if (( $G_INTERACTIVE )); then
 
 			local WHIP_MESSAGE=$@
 			G_WHIP_INIT 0
@@ -851,7 +851,7 @@ $(ps f -eo pid,user,tty,cmd | grep -i '[d]ietpi')"; then
 		local result=1
 		unset G_WHIP_RETURNED_VALUE # in case left from last G_WHIP
 
-		if (( $G_USER_INPUTS )); then
+		if (( $G_INTERACTIVE )); then
 
 			local WHIP_MESSAGE=$@
 			G_WHIP_INIT 0
@@ -881,7 +881,7 @@ $(ps f -eo pid,user,tty,cmd | grep -i '[d]ietpi')"; then
 		local return_value=1
 		result=''
 
-		if (( $G_USER_INPUTS )); then
+		if (( $G_INTERACTIVE )); then
 
 			local WHIP_MESSAGE=$@
 			G_WHIP_INIT 0
@@ -920,7 +920,7 @@ $(ps f -eo pid,user,tty,cmd | grep -i '[d]ietpi')"; then
 		local result=1
 		unset G_WHIP_RETURNED_VALUE # in case left from last G_WHIP
 
-		if (( $G_USER_INPUTS )); then
+		if (( $G_INTERACTIVE )); then
 
 			local WHIP_MESSAGE=$@
 			G_WHIP_INIT 1
@@ -944,7 +944,7 @@ $(ps f -eo pid,user,tty,cmd | grep -i '[d]ietpi')"; then
 		local result=1
 		unset G_WHIP_RETURNED_VALUE # in case left from last G_WHIP
 
-		if (( $G_USER_INPUTS )); then
+		if (( $G_INTERACTIVE )); then
 
 			local WHIP_MESSAGE=$@
 			G_WHIP_INIT 2
@@ -967,7 +967,7 @@ $(ps f -eo pid,user,tty,cmd | grep -i '[d]ietpi')"; then
 
 		local result=0
 
-		if (( $G_USER_INPUTS )); then
+		if (( $G_INTERACTIVE )); then
 
 			local log=${log:-0} # Optional yes/no prompt for viewing logs
 			local fp_file=$1
@@ -1011,7 +1011,7 @@ $(ps f -eo pid,user,tty,cmd | grep -i '[d]ietpi')"; then
 	# - G_ERROR_HANDLER_COMMAND=<cmd>		| Command name for print out
 	# - G_ERROR_HANDLER_EXITCODE=<int>		| Commands exit code
 	# Optional input:
-	# - G_ERROR_HANDLER_NO_FAIL=1			| Always report a success, regardless of the exit code | G_USER_INPUTS=0 is not required for this
+	# - G_ERROR_HANDLER_NO_FAIL=1			| Always report a success, regardless of the exit code | G_INTERACTIVE=0 is not required for this
 	# - G_ERROR_HANDLER_INFO_ONLY=1			| Only print info and retry options, no exit or bug report, sets G_ERROR_HANDLER_ONERROR_EXIT=0 automatically
 	# - G_ERROR_HANDLER_ONERROR_EXIT=0		| Do not exit the script on error
 	# - G_ERROR_HANDLER_RETRY=1			| Allow to retry the command. Requires loop in originating script!
@@ -1077,7 +1077,7 @@ $(ps f -eo pid,user,tty,cmd | grep -i '[d]ietpi')"; then
 			[[ $G_PROGRAM_NAME && $G_ERROR_HANDLER_INFO_ONLY != 1 ]] && G_DIETPI-NOTIFY 2 "$print_report_to_dietpi_info"
 
 			# If interactive, prompt whip message
-			if (( $G_USER_INPUTS )); then
+			if (( $G_INTERACTIVE )); then
 
 				local whip_msg="${G_PROGRAM_NAME+$G_PROGRAM_NAME: }$G_ERROR_HANDLER_COMMAND
  - Exit code: $G_ERROR_HANDLER_EXITCODE
@@ -1279,7 +1279,7 @@ $logfile_content
 	#	- $optional_cmd_inputs (eg: --no-check-certificate)
 	#	- G_CHECK_URL_TIMEOUT to override default and dietpi.txt set timeout
 	#	- G_CHECK_URL_ATTEMPTS to override default and dietpi.txt set attempts
-	#	In case of failure and $G_USER_INPUTS=1: Prompts user to configure network
+	#	In case of failure and $G_INTERACTIVE=1: Prompts user to configure network
 	G_CHECK_URL(){
 
 		local url=$@
@@ -2044,7 +2044,7 @@ $logfile_content
 			G_THREAD_COMMAND[$G_THREAD_COUNT]=$@
 
 			echo -1337 > /tmp/.G_THREAD_EXITCODE_$G_THREAD_COUNT
-			{ { G_USER_INPUTS=0 ${G_THREAD_COMMAND[$G_THREAD_COUNT]} &> /tmp/.G_THREAD_COMMAND_$G_THREAD_COUNT; echo $? > /tmp/.G_THREAD_EXITCODE_$G_THREAD_COUNT; } & disown; } &> /dev/null
+			{ { G_INTERACTIVE=0 ${G_THREAD_COMMAND[$G_THREAD_COUNT]} &> /tmp/.G_THREAD_COMMAND_$G_THREAD_COUNT; echo $? > /tmp/.G_THREAD_EXITCODE_$G_THREAD_COUNT; } & disown; } &> /dev/null
 
 			G_DIETPI-NOTIFY 2 "G_THREAD_START_$G_THREAD_COUNT | ${G_THREAD_COMMAND[$G_THREAD_COUNT]}"
 
@@ -2127,13 +2127,13 @@ $logfile_content
 
 		G_CHECK_ROOT_USER 1
 
-		export G_USER_INPUTS=0
+		export G_INTERACTIVE=0
 		/DietPi/dietpi/dietpi-backup -1
 		G_CONFIG_INJECT 'DEV_GITBRANCH=' 'DEV_GITBRANCH=dev' /DietPi/dietpi.txt
 		/DietPi/dietpi/dietpi-update -1
 		/DietPi/dietpi/dietpi-backup 1
 
-		unset G_USER_INPUTS
+		unset G_INTERACTIVE
 
 	}
 
@@ -2150,7 +2150,7 @@ $logfile_content
 	G_DEV_BENCH(){
 
 		echo 1 > /DietPi/dietpi/.dietpi-survey
-		G_USER_INPUTS=0 /DietPi/dietpi/func/dietpi-benchmark 2
+		G_INTERACTIVE=0 /DietPi/dietpi/func/dietpi-benchmark 2
 
 	}
 

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -34,10 +34,18 @@
 	#	OK | systemd	= no STDIN
 	#	OK | Cron	= no STDIN
 	#	NB | /etc/profile, ~/.profile, /etc/profile.d/, /etc/bash.bashrc, ~/.bashrc and /etc/bashrc.d/ can all be interactive since those are sourced from originating shell/bash session.
-	[[ -n ${G_USER_INPUTS+x} ]] && G_INTERACTIVE=$G_USER_INPUTS
 	if [[ $G_INTERACTIVE != [01] ]]; then
 
-		[[ -t 0 ]] && G_INTERACTIVE=1 || G_INTERACTIVE=0
+		# Backwards compatibility to keep user scripts valid for a while
+		if [[ $G_USER_INPUTS == [01] ]]; then
+
+			G_INTERACTIVE=$G_USER_INPUTS
+
+		else
+
+			[[ -t 0 ]] && G_INTERACTIVE=1 || G_INTERACTIVE=0
+
+		fi
 
 	fi
 

--- a/dietpi/func/run_ntpd
+++ b/dietpi/func/run_ntpd
@@ -32,7 +32,7 @@
 
 	Update_NTPD(){
 
-		# Loop NTP check until sucess, or, non-G_USER_INPUTS and timeout
+		# Loop NTP check until sucess, or, non-G_INTERACTIVE and timeout
 		while (( $EXIT_CODE == 1 ))
 		do
 
@@ -63,7 +63,7 @@
 
 						G_DIETPI-NOTIFY 2 'NTPD: Timeed out waiting for systemd-timesyncd'
 
-						if (( $G_USER_INPUTS )); then
+						if (( $G_INTERACTIVE )); then
 
 							# - Ask
 							G_WHIP_MENU_ARRAY=(


### PR DESCRIPTION
<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
**Status**: Ready
Needs checking that it actually works in the real world (specifically the backwards compatibility with scripts), but exporting a value to `G_USER_INPUTS` is picked up by `dietpi-globals` and `G_INTERACTIVE` is then given the value

**Reference**: https://github.com/MichaIng/DietPi/pull/3033#issuecomment-518043583

**Commit list/description**:
1. I used ~~skill~~ find to replace all instances of `G_USER_INPUTS` with `G_INTERACTIVE`
2. Ignore this commit, aliases don't work in scripts
3. I fixed it, making the variable name change backwards compatible

The point of the PR is basically to make the global variable's name more self-explanatory, while being backwards compatible for the sake of any existing users' scripts
