### PR TITLE
Edit Up and Down scripts from dietpi-nordvpn

### DIFF
--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -150,7 +150,7 @@ $GREEN_LINE"
 		[[ -f /DietPi/dietpi/.prep_info ]] && mawk 'NR==1 {sub(/^0$/,"DietPi Core Team");a=$0} NR==2 {print " Image           : "a" (pre-image: "$0")"}' /DietPi/dietpi/.prep_info
 
 		echo ' Web             : https://DietPi.com | https://twitter.com/dietpi_
- Patreon Legends : PINE64 community
+ Patreon Legends : PINE64 community | oct8l
  Donate          : https://DietPi.com/#donate'
 
 		local image_additional_credits=$(sed -n 8p /DietPi/dietpi/.hw_model)

--- a/dietpi/misc/dietpi-nordvpn
+++ b/dietpi/misc/dietpi-nordvpn
@@ -25,6 +25,8 @@
 
 	FP_SETTINGS_DIETPI='/var/lib/dietpi/dietpi-software/installed/dietpi-nordvpn/settings_dietpi.conf'
 	FP_SETTINGS_OVPN='/var/lib/dietpi/dietpi-software/installed/dietpi-nordvpn/settings_ovpn.conf'
+	FP_SETTINGS_UP='/var/lib/dietpi/dietpi-software/installed/dietpi-nordvpn/up.sh'
+	FP_SETTINGS_DOWN='/var/lib/dietpi/dietpi-software/installed/dietpi-nordvpn/down.sh'
 	NORDVPN_USERNAME=''
 	NORDVPN_PASSWORD=''
 	NORDVPN_SERVER=''
@@ -64,6 +66,23 @@
 		# Check service exists
 		[[ -f '/lib/systemd/system/dietpi-nordvpn.service' ]] && NORDVPN_SERVICE=1
 
+		# Check if up and down scripts exist, if not create them
+		if [ ! -f "$FP_SETTINGS_UP" ]; then
+			echo "$FP_SETTINGS_UP does not exist"
+			echo -e '#!/bin/bash' >> $FP_SETTINGS_UP
+		fi
+
+		chmod 700 $FP_SETTINGS_UP
+		chown root:root $FP_SETTINGS_UP
+
+		if [ ! -f "$FP_SETTINGS_DOWN" ]; then
+			echo "$FP_SETTINGS_DOWN does not exist"
+			echo -e '#!/bin/bash' >> $FP_SETTINGS_DOWN
+		fi
+
+		chmod 700 $FP_SETTINGS_DOWN
+		chown root:root $FP_SETTINGS_DOWN
+
 		Read_Settings
 
 	}
@@ -96,6 +115,9 @@ NORDVPN_SERVER='$NORDVPN_SERVER'
 PROTOCOL='$PROTOCOL'
 _EOF_
 		G_CONFIG_INJECT 'auth-user-pass' "auth-user-pass $FP_SETTINGS_OVPN" /etc/openvpn/ovpn_$PROTOCOL/$NORDVPN_SERVER
+		G_CONFIG_INJECT 'script-security' "script-security 2" /etc/openvpn/ovpn_$PROTOCOL/$NORDVPN_SERVER
+		G_CONFIG_INJECT 'up' "up /var/lib/dietpi/dietpi-software/installed/dietpi-nordvpn/up.sh" /etc/openvpn/ovpn_$PROTOCOL/$NORDVPN_SERVER
+		G_CONFIG_INJECT 'down' "down /var/lib/dietpi/dietpi-software/installed/dietpi-nordvpn/down.sh" /etc/openvpn/ovpn_$PROTOCOL/$NORDVPN_SERVER
 
 		chmod 600 $FP_SETTINGS_OVPN $FP_SETTINGS_DIETPI /etc/openvpn/ovpn_$PROTOCOL/$NORDVPN_SERVER
 		chown root:root $FP_SETTINGS_OVPN $FP_SETTINGS_DIETPI /etc/openvpn/ovpn_$PROTOCOL/$NORDVPN_SERVER
@@ -198,6 +220,9 @@ _EOF_
 			(( $NORDVPN_CONNECTED )) && G_WHIP_MENU_ARRAY+=('Disconnect' '')
 
 		fi
+		G_WHIP_MENU_ARRAY+=('' '●─ Connection Up and Down Scripts ')
+		G_WHIP_MENU_ARRAY+=('Edit Up' ': This script gets executed right after VPN is connected')
+		G_WHIP_MENU_ARRAY+=('Edit Down' ': This script gets executed right after the VPN is disconnected')
 		G_WHIP_MENU_ARRAY+=('' '●─ Save Settings ')
 		G_WHIP_MENU_ARRAY+=('Apply' ': Save settings and restart VPN connection')
 
@@ -210,6 +235,14 @@ _EOF_
 			if [[ $G_WHIP_RETURNED_VALUE == 'Apply' ]]; then
 
 				Save_Settings
+
+			elif [[ $G_WHIP_RETURNED_VALUE == 'Edit Up' ]]; then
+
+				nano $FP_SETTINGS_UP
+
+			elif [[ $G_WHIP_RETURNED_VALUE == 'Edit Down' ]]; then
+
+				nano $FP_SETTINGS_DOWN
 
 			elif [[ $G_WHIP_RETURNED_VALUE == 'Auto start' ]]; then
 
@@ -255,7 +288,7 @@ _EOF_
 				G_DIETPI-NOTIFY 2 'Populating NordVPN server list, please wait...'
 				cd /etc/openvpn/ovpn_$PROTOCOL
 				G_WHIP_MENU_ARRAY=()
-				for i in *
+				for i in *.ovpn
 				do
 
 					G_WHIP_MENU_ARRAY+=("$i" '')

--- a/dietpi/misc/dietpi-nordvpn
+++ b/dietpi/misc/dietpi-nordvpn
@@ -38,11 +38,7 @@
 	MAX_WAIT_FOR_CONNECTION=5
 	WAN_IP=''
 
-	Update_Wan_Ip(){
-
-		WAN_IP=$(curl -sLm 2 https://dietpi.com/myip.php 2>&1)
-
-	}
+	Update_Wan_Ip(){ WAN_IP=$(curl -sLm 2 https://dietpi.com/myip.php 2>&1); }
 
 	Init(){
 
@@ -65,23 +61,6 @@
 
 		# Check service exists
 		[[ -f '/lib/systemd/system/dietpi-nordvpn.service' ]] && NORDVPN_SERVICE=1
-
-		# Check if up and down scripts exist, if not create them
-		if [ ! -f "$FP_SETTINGS_UP" ]; then
-			echo "$FP_SETTINGS_UP does not exist"
-			echo -e '#!/bin/bash' >> $FP_SETTINGS_UP
-		fi
-
-		chmod 700 $FP_SETTINGS_UP
-		chown root:root $FP_SETTINGS_UP
-
-		if [ ! -f "$FP_SETTINGS_DOWN" ]; then
-			echo "$FP_SETTINGS_DOWN does not exist"
-			echo -e '#!/bin/bash' >> $FP_SETTINGS_DOWN
-		fi
-
-		chmod 700 $FP_SETTINGS_DOWN
-		chown root:root $FP_SETTINGS_DOWN
 
 		Read_Settings
 
@@ -114,13 +93,15 @@ NORDVPN_PASSWORD='${NORDVPN_PASSWORD//\'/\'\\\'\'}'
 NORDVPN_SERVER='$NORDVPN_SERVER'
 PROTOCOL='$PROTOCOL'
 _EOF_
-		G_CONFIG_INJECT 'auth-user-pass' "auth-user-pass $FP_SETTINGS_OVPN" /etc/openvpn/ovpn_$PROTOCOL/$NORDVPN_SERVER
-		G_CONFIG_INJECT 'script-security' "script-security 2" /etc/openvpn/ovpn_$PROTOCOL/$NORDVPN_SERVER
-		G_CONFIG_INJECT 'up' "up /var/lib/dietpi/dietpi-software/installed/dietpi-nordvpn/up.sh" /etc/openvpn/ovpn_$PROTOCOL/$NORDVPN_SERVER
-		G_CONFIG_INJECT 'down' "down /var/lib/dietpi/dietpi-software/installed/dietpi-nordvpn/down.sh" /etc/openvpn/ovpn_$PROTOCOL/$NORDVPN_SERVER
 
-		chmod 600 $FP_SETTINGS_OVPN $FP_SETTINGS_DIETPI /etc/openvpn/ovpn_$PROTOCOL/$NORDVPN_SERVER
-		chown root:root $FP_SETTINGS_OVPN $FP_SETTINGS_DIETPI /etc/openvpn/ovpn_$PROTOCOL/$NORDVPN_SERVER
+		local fp_ovpn="/etc/openvpn/ovpn_$PROTOCOL/$NORDVPN_SERVER"
+		G_CONFIG_INJECT 'auth-user-pass[[:blank:]]' "auth-user-pass $FP_SETTINGS_OVPN" $fp_ovpn
+		[[ -f $FP_SETTINGS_UP || -f $FP_SETTINGS_DOWN ]] && G_CONFIG_INJECT 'script-security[[:blank:]]' 'script-security 2' 'auth[[:blank:]]' $fp_ovpn || sed -i 's/^[[:blank:]]*script-security[[:blank:]]//' $fp_ovpn
+		[[ -f $FP_SETTINGS_UP ]] && G_CONFIG_INJECT 'up[[:blank:]]' "up $FP_SETTINGS_UP" 'auth[[:blank:]]' $fp_ovpn || sed -i 's/^[[:blank:]]*up[[:blank:]]//' $fp_ovpn
+		[[ -f $FP_SETTINGS_DOWN ]] && G_CONFIG_INJECT 'down[[:blank:]]' "down $FP_SETTINGS_DOWN" 'auth[[:blank:]]' $fp_ovpn || sed -i 's/^[[:blank:]]*down[[:blank:]]//' $fp_ovpn
+
+		chmod 600 $FP_SETTINGS_OVPN $FP_SETTINGS_DIETPI $fp_ovpn
+		chown root:root $FP_SETTINGS_OVPN $FP_SETTINGS_DIETPI $fp_ovpn
 
 		cat << _EOF_ > /lib/systemd/system/dietpi-nordvpn.service
 [Unit]
@@ -128,7 +109,7 @@ Description=NordVPN (DietPi)
 After=network.target dietpi-boot.service
 
 [Service]
-ExecStart=$(command -v openvpn) /etc/openvpn/ovpn_$PROTOCOL/$NORDVPN_SERVER
+ExecStart=$(command -v openvpn) $fp_ovpn
 
 [Install]
 WantedBy=multi-user.target
@@ -140,16 +121,10 @@ _EOF_
 		for (( i=1; i<=$MAX_WAIT_FOR_CONNECTION; i++ ))
 		do
 
-			if Check_Connected; then
+			Check_Connected && break
 
-				break
-
-			else
-
-				G_DIETPI-NOTIFY 2 "Waiting for connection ($i/$MAX_WAIT_FOR_CONNECTION)"
-				sleep 1
-
-			fi
+			G_DIETPI-NOTIFY 2 "Waiting for connection ($i/$MAX_WAIT_FOR_CONNECTION)"
+			sleep 1
 
 		done
 
@@ -185,15 +160,15 @@ _EOF_
 			local net_rx_mb='N/A'
 			local net_tx_mb='N/A'
 
-			if [[ -f /sys/class/net/$NET_DEV/statistics/rx_bytes && -f /sys/class/net/$NET_DEV/statistics/tx_bytes ]]; then
+			if [[ -f '/sys/class/net/$NET_DEV/statistics/rx_bytes' && -f '/sys/class/net/$NET_DEV/statistics/tx_bytes' ]]; then
 
 				net_rx_byte=$(</sys/class/net/$NET_DEV/statistics/rx_bytes)
 				net_rx_mb='Unknown'
-				disable_error=1 G_CHECK_VALIDINT "$net_rx_byte" 1 && net_rx_mb="$(( $net_rx_byte / 1024 / 1024 ))MB"
+				disable_error=1 G_CHECK_VALIDINT "$net_rx_byte" 1 && net_rx_mb="$(( $net_rx_byte / 1024 / 1024 )) MiB"
 
 				net_tx_byte=$(</sys/class/net/$NET_DEV/statistics/tx_bytes)
 				net_tx_mb='Unknown'
-				disable_error=1 G_CHECK_VALIDINT "$net_tx_byte" 1 && net_tx_mb="$(( $net_tx_byte / 1024 / 1024 ))MB"
+				disable_error=1 G_CHECK_VALIDINT "$net_tx_byte" 1 && net_tx_mb="$(( $net_tx_byte / 1024 / 1024 )) MiB"
 
 			fi
 
@@ -238,11 +213,15 @@ _EOF_
 
 			elif [[ $G_WHIP_RETURNED_VALUE == 'Edit Up' ]]; then
 
+				[[ -f $FP_SETTINGS_UP ]] || echo -e '#!/bin/bash\n# Clear this file completely, including line breaks, to have it removed.' > $FP_SETTINGS_UP
 				nano $FP_SETTINGS_UP
+				(( $(stat -c %s $FP_SETTINGS_UP) )) && chmod 700 $FP_SETTINGS_UP || rm $FP_SETTINGS_UP
 
 			elif [[ $G_WHIP_RETURNED_VALUE == 'Edit Down' ]]; then
 
+				[[ -f $FP_SETTINGS_DOWN ]] || echo -e '#!/bin/bash\n# Clear this file completely, including line breaks, to have it removed.' > $FP_SETTINGS_DOWN
 				nano $FP_SETTINGS_DOWN
+				(( $(stat -c %s $FP_SETTINGS_DOWN) )) && chmod 700 $FP_SETTINGS_DOWN || rm $FP_SETTINGS_DOWN
 
 			elif [[ $G_WHIP_RETURNED_VALUE == 'Auto start' ]]; then
 
@@ -297,7 +276,7 @@ _EOF_
 				cd /tmp/$G_PROGRAM_NAME
 
 				G_WHIP_DEFAULT_ITEM=$NORDVPN_SERVER
-				G_WHIP_MENU 'Please select a NordVPN server to use' && NORDVPN_SERVER=$G_WHIP_RETURNED_VALUE
+				G_WHIP_MENU 'Please select a NordVPN server to use:' && NORDVPN_SERVER=$G_WHIP_RETURNED_VALUE
 
 			fi
 
@@ -318,7 +297,7 @@ _EOF_
 	while (( $TARGETMENUID >= 0 ))
 	do
 
-		(( $TARGETMENUID == 0 )) && Menu_Main
+		Menu_Main
 
 	done
 	#-----------------------------------------------------------------------------------

--- a/dietpi/misc/dietpi-nordvpn
+++ b/dietpi/misc/dietpi-nordvpn
@@ -102,7 +102,7 @@ PROTOCOL='$PROTOCOL'
 _EOF_
 
 		local fp_ovpn="/etc/openvpn/ovpn_$PROTOCOL/$NORDVPN_SERVER"
-		G_CONFIG_INJECT 'auth-user-pass[[:blank:]]' "auth-user-pass $FP_SETTINGS_OVPN" $fp_ovpn
+		G_CONFIG_INJECT 'auth-user-pass([[:blank:]]|$)' "auth-user-pass $FP_SETTINGS_OVPN" $fp_ovpn
 		[[ -f $FP_SETTINGS_UP || -f $FP_SETTINGS_DOWN ]] && G_CONFIG_INJECT 'script-security[[:blank:]]' 'script-security 2' $fp_ovpn 'auth[[:blank:]]' || sed -i '/^[[:blank:]]*script-security[[:blank:]]/d' $fp_ovpn
 		[[ -f $FP_SETTINGS_UP ]] && G_CONFIG_INJECT 'up[[:blank:]]' "up $FP_SETTINGS_UP" $fp_ovpn 'auth[[:blank:]]' || sed -i '/^[[:blank:]]*up[[:blank:]]/d' $fp_ovpn
 		[[ -f $FP_SETTINGS_DOWN ]] && G_CONFIG_INJECT 'down[[:blank:]]' "down $FP_SETTINGS_DOWN" $fp_ovpn 'auth[[:blank:]]' || sed -i '/^[[:blank:]]*down[[:blank:]]/d' $fp_ovpn

--- a/dietpi/misc/dietpi-nordvpn
+++ b/dietpi/misc/dietpi-nordvpn
@@ -103,9 +103,9 @@ _EOF_
 
 		local fp_ovpn="/etc/openvpn/ovpn_$PROTOCOL/$NORDVPN_SERVER"
 		G_CONFIG_INJECT 'auth-user-pass[[:blank:]]' "auth-user-pass $FP_SETTINGS_OVPN" $fp_ovpn
-		[[ -f $FP_SETTINGS_UP || -f $FP_SETTINGS_DOWN ]] && G_CONFIG_INJECT 'script-security[[:blank:]]' 'script-security 2' $fp_ovpn 'auth[[:blank:]]' || sed -i 's/^[[:blank:]]*script-security[[:blank:]]//' $fp_ovpn
-		[[ -f $FP_SETTINGS_UP ]] && G_CONFIG_INJECT 'up[[:blank:]]' "up $FP_SETTINGS_UP" $fp_ovpn 'auth[[:blank:]]' || sed -i 's/^[[:blank:]]*up[[:blank:]]//' $fp_ovpn
-		[[ -f $FP_SETTINGS_DOWN ]] && G_CONFIG_INJECT 'down[[:blank:]]' "down $FP_SETTINGS_DOWN" $fp_ovpn 'auth[[:blank:]]' || sed -i 's/^[[:blank:]]*down[[:blank:]]//' $fp_ovpn
+		[[ -f $FP_SETTINGS_UP || -f $FP_SETTINGS_DOWN ]] && G_CONFIG_INJECT 'script-security[[:blank:]]' 'script-security 2' $fp_ovpn 'auth[[:blank:]]' || sed -i '/^[[:blank:]]*script-security[[:blank:]]/d' $fp_ovpn
+		[[ -f $FP_SETTINGS_UP ]] && G_CONFIG_INJECT 'up[[:blank:]]' "up $FP_SETTINGS_UP" $fp_ovpn 'auth[[:blank:]]' || sed -i '/^[[:blank:]]*up[[:blank:]]/d' $fp_ovpn
+		[[ -f $FP_SETTINGS_DOWN ]] && G_CONFIG_INJECT 'down[[:blank:]]' "down $FP_SETTINGS_DOWN" $fp_ovpn 'auth[[:blank:]]' || sed -i '/^[[:blank:]]*down[[:blank:]]/d' $fp_ovpn
 
 		chmod 600 $FP_SETTINGS_OVPN $FP_SETTINGS_DIETPI $fp_ovpn
 		chown root:root $FP_SETTINGS_OVPN $FP_SETTINGS_DIETPI $fp_ovpn

--- a/dietpi/misc/dietpi-nordvpn
+++ b/dietpi/misc/dietpi-nordvpn
@@ -102,7 +102,7 @@ PROTOCOL='$PROTOCOL'
 _EOF_
 
 		local fp_ovpn="/etc/openvpn/ovpn_$PROTOCOL/$NORDVPN_SERVER"
-		G_CONFIG_INJECT 'auth-user-pass[[:blank:]]' "auth-user-pass $FP_SETTINGS_OVPN" $fp_ovpn
+		G_CONFIG_INJECT 'auth-user-pass([[:blank:]]|$)' "auth-user-pass $FP_SETTINGS_OVPN" $fp_ovpn
 		[[ -f $FP_SETTINGS_UP || -f $FP_SETTINGS_DOWN ]] && G_CONFIG_INJECT 'script-security[[:blank:]]' 'script-security 2' $fp_ovpn 'auth[[:blank:]]' || sed -i '/^[[:blank:]]*script-security[[:blank:]]/d' $fp_ovpn
 		[[ -f $FP_SETTINGS_UP ]] && G_CONFIG_INJECT 'up[[:blank:]]' "up $FP_SETTINGS_UP" $fp_ovpn 'auth[[:blank:]]' || sed -i '/^[[:blank:]]*up[[:blank:]]/d' $fp_ovpn
 		[[ -f $FP_SETTINGS_DOWN ]] && G_CONFIG_INJECT 'down[[:blank:]]' "down $FP_SETTINGS_DOWN" $fp_ovpn 'auth[[:blank:]]' || sed -i '/^[[:blank:]]*down[[:blank:]]/d' $fp_ovpn
@@ -201,8 +201,8 @@ _EOF_
 
 		fi
 		G_WHIP_MENU_ARRAY+=('' '●─ Connection Up and Down Scripts ')
-		G_WHIP_MENU_ARRAY+=('Edit Up' ': This script gets executed right after VPN is connected')
-		G_WHIP_MENU_ARRAY+=('Edit Down' ': This script gets executed right after VPN is disconnected')
+		G_WHIP_MENU_ARRAY+=('Edit Up' ': This script gets executed right after the VPN is connected')
+		G_WHIP_MENU_ARRAY+=('Edit Down' ': This script gets executed right after the VPN is disconnected')
 		G_WHIP_MENU_ARRAY+=('' '●─ Save Settings ')
 		G_WHIP_MENU_ARRAY+=('Apply' ': Save settings and restart VPN connection')
 

--- a/dietpi/misc/dietpi-nordvpn
+++ b/dietpi/misc/dietpi-nordvpn
@@ -202,7 +202,7 @@ _EOF_
 		fi
 		G_WHIP_MENU_ARRAY+=('' '●─ Connection Up and Down Scripts ')
 		G_WHIP_MENU_ARRAY+=('Edit Up' ': This script gets executed right after VPN is connected')
-		G_WHIP_MENU_ARRAY+=('Edit Down' ': This script gets executed right after the VPN is disconnected')
+		G_WHIP_MENU_ARRAY+=('Edit Down' ': This script gets executed right after VPN is disconnected')
 		G_WHIP_MENU_ARRAY+=('' '●─ Save Settings ')
 		G_WHIP_MENU_ARRAY+=('Apply' ': Save settings and restart VPN connection')
 

--- a/dietpi/misc/dietpi-nordvpn
+++ b/dietpi/misc/dietpi-nordvpn
@@ -69,7 +69,7 @@
 	Check_Connected(){
 
 		NORDVPN_CONNECTED=0
-		#if systemctl status dietpi-nordvpn | grep -qi 'initialization sequence completed'; then
+		#systemctl status dietpi-nordvpn | grep -qi 'initialization sequence completed'
 		ip r s dev $NET_DEV &>/dev/null && NORDVPN_CONNECTED=1
 
 		return $(( ! $NORDVPN_CONNECTED ))
@@ -79,6 +79,13 @@
 	Read_Settings(){ [[ -f $FP_SETTINGS_DIETPI ]] && . $FP_SETTINGS_DIETPI; }
 
 	Save_Settings(){
+
+		if [[ ! $NORDVPN_SERVER || ! $NORDVPN_USERNAME || ! $NORDVPN_PASSWORD ]]; then
+
+			G_WHIP_MSG '[FAILED] You need to enter your NordVPN username + password and select a server, before settings can be applied.'
+			return 1
+
+		fi
 
 		(( $NORDVPN_SERVICE )) && systemctl stop dietpi-nordvpn
 
@@ -160,15 +167,13 @@ _EOF_
 			local net_rx_mb='N/A'
 			local net_tx_mb='N/A'
 
-			if [[ -f '/sys/class/net/$NET_DEV/statistics/rx_bytes' && -f '/sys/class/net/$NET_DEV/statistics/tx_bytes' ]]; then
+			if [[ -f /sys/class/net/$NET_DEV/statistics/rx_bytes && -f /sys/class/net/$NET_DEV/statistics/tx_bytes ]]; then
 
 				net_rx_byte=$(</sys/class/net/$NET_DEV/statistics/rx_bytes)
-				net_rx_mb='Unknown'
-				disable_error=1 G_CHECK_VALIDINT "$net_rx_byte" 1 && net_rx_mb="$(( $net_rx_byte / 1024 / 1024 )) MiB"
+				disable_error=1 G_CHECK_VALIDINT "$net_rx_byte" 0 && net_rx_mb="$(( $net_rx_byte / 1024 / 1024 )) MiB"
 
 				net_tx_byte=$(</sys/class/net/$NET_DEV/statistics/tx_bytes)
-				net_tx_mb='Unknown'
-				disable_error=1 G_CHECK_VALIDINT "$net_tx_byte" 1 && net_tx_mb="$(( $net_tx_byte / 1024 / 1024 )) MiB"
+				disable_error=1 G_CHECK_VALIDINT "$net_tx_byte" 0 && net_tx_mb="$(( $net_tx_byte / 1024 / 1024 )) MiB"
 
 			fi
 

--- a/dietpi/misc/dietpi-nordvpn
+++ b/dietpi/misc/dietpi-nordvpn
@@ -96,9 +96,9 @@ _EOF_
 
 		local fp_ovpn="/etc/openvpn/ovpn_$PROTOCOL/$NORDVPN_SERVER"
 		G_CONFIG_INJECT 'auth-user-pass[[:blank:]]' "auth-user-pass $FP_SETTINGS_OVPN" $fp_ovpn
-		[[ -f $FP_SETTINGS_UP || -f $FP_SETTINGS_DOWN ]] && G_CONFIG_INJECT 'script-security[[:blank:]]' 'script-security 2' 'auth[[:blank:]]' $fp_ovpn || sed -i 's/^[[:blank:]]*script-security[[:blank:]]//' $fp_ovpn
-		[[ -f $FP_SETTINGS_UP ]] && G_CONFIG_INJECT 'up[[:blank:]]' "up $FP_SETTINGS_UP" 'auth[[:blank:]]' $fp_ovpn || sed -i 's/^[[:blank:]]*up[[:blank:]]//' $fp_ovpn
-		[[ -f $FP_SETTINGS_DOWN ]] && G_CONFIG_INJECT 'down[[:blank:]]' "down $FP_SETTINGS_DOWN" 'auth[[:blank:]]' $fp_ovpn || sed -i 's/^[[:blank:]]*down[[:blank:]]//' $fp_ovpn
+		[[ -f $FP_SETTINGS_UP || -f $FP_SETTINGS_DOWN ]] && G_CONFIG_INJECT 'script-security[[:blank:]]' 'script-security 2' $fp_ovpn 'auth[[:blank:]]' || sed -i 's/^[[:blank:]]*script-security[[:blank:]]//' $fp_ovpn
+		[[ -f $FP_SETTINGS_UP ]] && G_CONFIG_INJECT 'up[[:blank:]]' "up $FP_SETTINGS_UP" $fp_ovpn 'auth[[:blank:]]' || sed -i 's/^[[:blank:]]*up[[:blank:]]//' $fp_ovpn
+		[[ -f $FP_SETTINGS_DOWN ]] && G_CONFIG_INJECT 'down[[:blank:]]' "down $FP_SETTINGS_DOWN" $fp_ovpn 'auth[[:blank:]]' || sed -i 's/^[[:blank:]]*down[[:blank:]]//' $fp_ovpn
 
 		chmod 600 $FP_SETTINGS_OVPN $FP_SETTINGS_DIETPI $fp_ovpn
 		chown root:root $FP_SETTINGS_OVPN $FP_SETTINGS_DIETPI $fp_ovpn


### PR DESCRIPTION
Hi all,

This pull request started out because I messed up the config as seen in this issue: https://github.com/MichaIng/DietPi/issues/3045
So, I thought an integration within the dietpi-nordvpn utility would be nice.

ps this is my first pull request for DietPi, so please be nice :)

**Status**: WIP
- [x] Automatically checks if exist and creates up.sh and down.sh scripts in /var/lib/dietpi/dietpi-software/installed/dietpi-nordvpn/ folder
- [x] Sets right permissions and ownership
- [x] Menu items added
- [x] Fix list script to only include *.ovpn files
- [x] On connect the up, down and script-security settings will be written to the .ovpn file
- [x] Need to fix the exit procedure, the blue screen of the tool remains on screen when the prompt is back

**Commit list/description**:
Add way to edit up and down scripts that OpenVPN can use
