### PR TITLE
DietPi-Software | Netdata: Fix install on Stretch

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,5 @@
 v6.26
-(XX/08/19)
+(XX/09/19)
 
 Changes / Improvements / Optimisations:
 - General | Support for Debian Jessie has now been fully dropped from DietPi code. Jessie systems are moved to the "jessie-support" Git branch and will stay on v6.25. Critical bugs, if reported, may still be fixed, but DietPi-Software related issues and new features will not be handled anymore by the DietPi code team. However, everyone is free to open pull requests against the jessie-support branch: https://github.com/MichaIng/DietPi/tree/jessie-support
@@ -35,6 +35,7 @@ Bug Fixes:
 - DietPi-Software | Pi-hole: Resolved an issue, where the blocking page was only shown, if the blocked URL contained the domain only, without any appending path: https://github.com/MichaIng/DietPi/pull/3072
 - DietPi-Software | TigerVNC: Resolved an issue on Debian Buster, where the VNC connection fails immediately due to an external bug, if no read-only password has been applied via vncpasswd. Many thanks to @Trunkzeh for reporting this issue and providing the workaround: https://github.com/MichaIng/DietPi/issues/3070
 - DietPi-Software | TigerVNC: Resolved minor error messages on login and in logs: "No session for PID ...", "DE is (null); No desktop environnement set, fallback to LXDE", "Use of uninitialized value $proto in socket at /usr/bin/tigervncserver"
+- DietPi-Software | Netdata: Resolved an issue where install failed on Stretch systems. Many thanks to @Velociraptor85 for reporting this issue: https://github.com/MichaIng/DietPi/issues/3062
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1429,7 +1429,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		#------------------
 		software_id=65
 
-		aSOFTWARE_NAME[$software_id]='NetData'
+		aSOFTWARE_NAME[$software_id]='Netdata'
 		aSOFTWARE_DESC[$software_id]='real-time performance monitoring'
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=9
 		aSOFTWARE_TYPE[$software_id]=0
@@ -4966,7 +4966,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 					Download_Install "https://dietpi.com/downloads/binaries/stretch/netdata_$G_HW_ARCH_DESCRIPTION.7z"
 					dpkg --force-hold,confdef,confnew -i netdata{-core,-plugins-bash,-web,}_*.deb
 					G_AGF
-					rm netdata-*
+					rm netdata*
 
 				fi
 
@@ -10104,29 +10104,26 @@ _EOF_
 			# Only required for our self-compiled package, leave defaults for Debian APT package otherwise
 			if (( $G_HW_ARCH == 1 && $G_DISTRO < 5 )); then
 
-				# - Service
+				# Service
 				dps_index=$software_id Download_Install 'netdata.service' /etc/systemd/system/netdata.service
 
-				# - Dir (failsafe)
+				# Dir (failsafe)
 				mkdir -p /var/lib/netdata
 
-				# - User
+				# User
 				local usercmd='useradd -rMU'
 				getent passwd netdata &> /dev/null && usercmd='usermod'
 				$usercmd -d /var/lib/netdata -s $(command -v nologin) netdata
 
-				# - Permissions: https://docs.netdata.cloud/docs/netdata-security/#netdata-directories
-				#	R/O
+				# Permissions: https://docs.netdata.cloud/docs/netdata-security/#netdata-directories
+				# - R/O
 				chown -R root:netdata /etc/netdata /usr/lib/netdata /usr/libexec/netdata /usr/share/netdata
 				chmod -R 0750 /etc/netdata /usr/lib/netdata /usr/libexec/netdata /usr/share/netdata
-				#	apps.plugin requires root privileges to read disk I/O
+				# - apps.plugin requires root privileges to read disk I/O
 				chmod 4750 /usr/libexec/netdata/plugins.d/apps.plugin
-				#	R/W
-				chown -R netdata:netdata /var/cache/netdata /var/lib/netdata /var/log/netdata
+				# - R/W (web access: https://github.com/MichaIng/DietPi/issues/2336#issuecomment-450196178)
+				chown -R netdata:netdata /var/cache/netdata /var/lib/netdata /var/log/netdata /usr/share/netdata/web
 				chmod -R 0770 /var/cache/netdata /var/lib/netdata /var/log/netdata
-
-				#	Required: https://github.com/MichaIng/DietPi/issues/2336#issuecomment-450196178
-				chown -R netdata:netdata /usr/share/netdata/web
 
 			fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4964,7 +4964,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 				else
 
 					Download_Install "https://dietpi.com/downloads/binaries/stretch/netdata_$G_HW_ARCH_DESCRIPTION.7z"
-					dpkg --force-hold,confdef,confnew -i netdata-{core,plugins-bash,web,}_*.deb
+					dpkg --force-hold,confdef,confnew -i netdata{-core,-plugins-bash,-web,}_*.deb
 					G_AGF
 					rm netdata-*
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1433,8 +1433,8 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		aSOFTWARE_DESC[$software_id]='real-time performance monitoring'
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=9
 		aSOFTWARE_TYPE[$software_id]=0
-		# Node.js only required for our custom package
-		(( $G_HW_MODEL < 10 && $G_DISTRO < 5 )) && aSOFTWARE_REQUIRES_NODEJS[$software_id]=1
+		# Node.js only required for our custom v1.11 package for Stretch ARMv6 RPi
+		(( $G_HW_ARCH == 1 && $G_DISTRO < 5 )) && aSOFTWARE_REQUIRES_NODEJS[$software_id]=1
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1611#p1611'
 
 		#------------------
@@ -4951,12 +4951,24 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=sid\nPin-Prior
 
 			Banner_Installing
 
-			# Netdata v1.12 available on Debian stretch-backports and Raspbian/Debian Buster
-			# => Only install our custom package on Jessie and RPi Stretch
-			if (( $G_HW_MODEL < 10 && $G_DISTRO < 5 )); then
+			# No package available on Stretch
+			if (( $G_DISTRO < 5 )); then
 
-				DEPS_LIST='zlib1g-dev'
-				Download_Install "https://dietpi.com/downloads/binaries/all/netdata_1.11.1-1_$G_HW_ARCH_DESCRIPTION.deb"
+				# For ARMv6 RPi use our self-compiled package
+				if (( $G_HW_ARCH == 1 )); then
+
+					DEPS_LIST='zlib1g-dev'
+					Download_Install 'https://dietpi.com/downloads/binaries/all/netdata_1.11.1-1_armv6l.deb'
+
+				# Else use the packages from Debian Stretch backports snapshot, that were removed recently, hosted now on dietpi.com
+				else
+
+					Download_Install "https://dietpi.com/downloads/binaries/stretch/netdata_$G_HW_ARCH_DESCRIPTION.7z"
+					dpkg --force-hold,confdef,confnew -i netdata-{core,plugins-bash,web,}_*.deb
+					G_AGF
+					rm netdata-*
+
+				fi
 
 			else
 
@@ -10089,8 +10101,8 @@ _EOF_
 
 			Banner_Configuration
 
-			# Only required for our custom package, leave defaults for Debian APT package otherwise
-			if (( $G_HW_MODEL < 10 && $G_DISTRO < 5 )); then
+			# Only required for our self-compiled package, leave defaults for Debian APT package otherwise
+			if (( $G_HW_ARCH == 1 && $G_DISTRO < 5 )); then
 
 				# - Service
 				dps_index=$software_id Download_Install 'netdata.service' /etc/systemd/system/netdata.service
@@ -13679,7 +13691,7 @@ _EOF_
 			# 1.2.0+
 			G_AGP netdata
 
-			# Pre v6.22 || Raspbian Stretch + All Jessie
+			# Pre-v6.22 Raspbian Stretch + Pre-v6.26 Raspbian Stretch ARMv6 only
 			[[ -f '/etc/systemd/system/netdata.service' ]] && rm /etc/systemd/system/netdata.service
 			getent passwd netdata &> /dev/null && userdel netdata
 


### PR DESCRIPTION
**Status**: Testing
- [x] Changelog

Fixes: https://github.com/MichaIng/DietPi/issues/3062

**Commit list/description**:
+ DietPi-Software | Netdata: The package has been removed from Debian Stretch backports repo. We recovered them from snapshots and host them on dietpi.com. They are installed on all Stretch systems but ARMv6. For ARMv6 the old self-compiled v1.11 package is installed as before on all RPi Stretch.