### PR TITLE
Dietpi-Imager | FIx formula to get starting sector of root partition

### DIFF
--- a/.meta/dietpi-imager
+++ b/.meta/dietpi-imager
@@ -188,7 +188,7 @@ Do you want to overwrite or backup the existing file to $OUTPUT_IMG_NAME.bak?" |
 		done
 
 		# Estimate minimum end sector
-		PART_START=$(fdisk -l -o Device,Start $FP_SOURCE | grep $FP_ROOT_DEV | mawk '{print $2}') # 512 byte sectors
+		PART_START=$(fdisk -l -o Device,Start $FP_SOURCE | grep "^$FP_ROOT_DEV" | mawk '{print $2}') # 512 byte sectors
 		PART_END=$(( $PART_START + $FS_SIZE ))
 
 		G_DIETPI-NOTIFY 2 "Shrinking root partition to: $(( $FS_SIZE / 2048 + 1 )) MiB"

--- a/.meta/dietpi-imager
+++ b/.meta/dietpi-imager
@@ -188,7 +188,7 @@ Do you want to overwrite or backup the existing file to $OUTPUT_IMG_NAME.bak?" |
 		done
 
 		# Estimate minimum end sector
-		PART_START=$(fdisk -l -o Start $FP_SOURCE | tail -1) # 512 byte sectors
+		PART_START=$(fdisk -l -o Device,Start $FP_SOURCE | grep $FP_ROOT_DEV | mawk '{print $2}') # 512 byte sectors
 		PART_END=$(( $PART_START + $FS_SIZE ))
 
 		G_DIETPI-NOTIFY 2 "Shrinking root partition to: $(( $FS_SIZE / 2048 + 1 )) MiB"


### PR DESCRIPTION
Current method of obtaining starting sector of root partition is making some assumptions that are not always met. When running fdisk you can't assume that the following is always true:
- root partition is the last partition of the disk
- fdisk will not display any warning (like 'Partition table entries are not in disk order.')
