### PR TITLE
Dietpi-Imager | Add indentation

### DIFF
--- a/.meta/dietpi-imager
+++ b/.meta/dietpi-imager
@@ -235,13 +235,13 @@ Do you want to overwrite or backup the existing file to $OUTPUT_IMG_NAME.bak?" |
 
 		# Generate hashes: MD5, SHA1, SHA256
 		G_DIETPI-NOTIFY 2 'Generating hashes to pack with image, please wait...'
-		cat << _EOF_ > hash.txt
-FILE:	$OUTPUT_IMG_NAME
-DATE:	$(date)
-MD5:	$(md5sum $OUTPUT_IMG_NAME | mawk '{print $1}')
-SHA1:	$(sha1sum $OUTPUT_IMG_NAME | mawk '{print $1}')
-SHA256:	$(sha256sum $OUTPUT_IMG_NAME | mawk '{print $1}')
-_EOF_
+                cat <<- _EOF_ > hash.txt
+                        FILE:   $OUTPUT_IMG_NAME
+                        DATE:   $(date)
+                        MD5:    $(md5sum $OUTPUT_IMG_NAME | mawk '{print $1}')
+                        SHA1:   $(sha1sum $OUTPUT_IMG_NAME | mawk '{print $1}')
+                        SHA256: $(sha256sum $OUTPUT_IMG_NAME | mawk '{print $1}')
+                _EOF_
 
 		# Download current README
 		G_DIETPI-NOTIFY 2 'Downloading current README.md to pack with image...'


### PR DESCRIPTION
From bash man page ("Here Documents" section):
"If the redirection operator is <<-, then all leading tab characters are stripped from input lines and the line containing delimiter. This allows here-documents within shell scripts to be indented in a natural fashion."