### PR TITLE
dietpi-imager | Simplify command

### DIFF
--- a/.meta/dietpi-imager
+++ b/.meta/dietpi-imager
@@ -51,7 +51,7 @@
 		if [[ $G_WHIP_RETURNED_VALUE == 'Drive' ]]; then
 
 			# Detect drives and list for selection
-			G_WHIP_MENU_ARRAY=($(lsblk -npo NAME,SIZE | grep '^/'))
+			G_WHIP_MENU_ARRAY=($(lsblk -dnpo NAME,SIZE))
 			# - Visually separate dev name and space
 			for ((i=1;i<${#G_WHIP_MENU_ARRAY[@]};i+=2)); do G_WHIP_MENU_ARRAY[$i]=": ${G_WHIP_MENU_ARRAY[$i]}"; done
 			[[ $G_WHIP_MENU_ARRAY ]] && G_WHIP_MENU 'Please select the drive you wish to create the image from:' || Exit_On_Fail


### PR DESCRIPTION
lsblk with option -d will not print slave devices, avoiding the need of a subsequent grep.