### PR TITLE
README.md | Add Clonezilla to Additional Software list

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,3 +241,4 @@ Links to additional software used in DietPi and their source and build instructi
 - [OpenBazaar](https://github.com/OpenBazaar/openbazaar-go)
 - [Medusa](https://github.com/pymedusa/Medusa)
 - [Grafana](https://github.com/grafana/grafana)
+- [Clonezilla](https://gitlab.com/stevenshiau/clonezilla)


### PR DESCRIPTION
Add Clonezilla to the list of software used in DietPi