### PR TITLE
dietpi-image | Fix trying to reduce partition size to a not smaller size

### DIFF
--- a/.meta/dietpi-imager
+++ b/.meta/dietpi-imager
@@ -189,13 +189,14 @@ Do you want to overwrite or backup the existing file to $OUTPUT_IMG_NAME.bak?" |
 
 		# Estimate minimum end sector
 		PART_START=$(fdisk -l -o Device,Start $FP_SOURCE | grep "^$FP_ROOT_DEV" | mawk '{print $2}') # 512 byte sectors
-		PART_END=$(( $PART_START + $FS_SIZE ))
+		PART_END_CURRENT=$(fdisk -l -o Device,End $FP_SOURCE | grep "^$FP_ROOT_DEV" | mawk '{print $2}')
+		PART_END_TARGET=$(( $PART_START + $FS_SIZE ))
 
 		# Only try to shrink partition when new end sector is less than current end sector
-		if [ $PART_END -lt $(fdisk -l -o Device,End $FP_SOURCE | grep "^$FP_ROOT_DEV" | mawk '{print $2}') ]; then
+		if (( $PART_END_CURRENT > $PART_END_TARGET )); then
 
 			G_DIETPI-NOTIFY 2 "Shrinking root partition to: $(( $FS_SIZE / 2048 + 1 )) MiB"
-			parted $FP_SOURCE unit s resizepart $ROOT_PARTITION_INDEX $PART_END yes
+			parted $FP_SOURCE unit s resizepart $ROOT_PARTITION_INDEX $PART_END_TARGET yes
 			partprobe $FP_SOURCE
 
 		fi
@@ -210,10 +211,10 @@ Do you want to overwrite or backup the existing file to $OUTPUT_IMG_NAME.bak?" |
 		# - gdisk write will correct this
 		(( $GPT )) && echo -e 'w\ny\nq\n' | gdisk $FP_SOURCE
 
-		# Finished: Re-estimate partition end (failsafe) and derive final image size
+		# Finished: Derive final image size from last partition end + failsafe buffer
 		partprobe $FP_SOURCE
-		PART_END=$(( ( $(fdisk -l -o End $FP_SOURCE | tail -1) + 1 ) * 512 )) # 512 byte sectors => Byte
-		IMAGE_SIZE=$(( $PART_END + ( 512 * 256 ) )) # 64 byte for secondary GPT + safety net
+		IMAGE_SIZE=$(( ( $(fdisk -l -o End $FP_SOURCE | tail -1) + 1 ) * 512 )) # 512 byte sectors => Byte
+		IMAGE_SIZE=$(( $IMAGE_SIZE + ( 512 * 256 ) )) # 64 byte for secondary GPT + safety net
 
 		# Created final image + archive in /root
 		cd /root

--- a/.meta/dietpi-imager
+++ b/.meta/dietpi-imager
@@ -191,9 +191,14 @@ Do you want to overwrite or backup the existing file to $OUTPUT_IMG_NAME.bak?" |
 		PART_START=$(fdisk -l -o Device,Start $FP_SOURCE | grep "^$FP_ROOT_DEV" | mawk '{print $2}') # 512 byte sectors
 		PART_END=$(( $PART_START + $FS_SIZE ))
 
-		G_DIETPI-NOTIFY 2 "Shrinking root partition to: $(( $FS_SIZE / 2048 + 1 )) MiB"
-		parted $FP_SOURCE unit s resizepart $ROOT_PARTITION_INDEX $PART_END yes
-		partprobe $FP_SOURCE
+		# Only try to shrink partition when new end sector is less than current end sector
+		if [ $PART_END -lt $(fdisk -l -o Device,End $FP_SOURCE | grep "^$FP_ROOT_DEV" | mawk '{print $2}') ]; then
+
+			G_DIETPI-NOTIFY 2 "Shrinking root partition to: $(( $FS_SIZE / 2048 + 1 )) MiB"
+			parted $FP_SOURCE unit s resizepart $ROOT_PARTITION_INDEX $PART_END yes
+			partprobe $FP_SOURCE
+
+		fi
 
 		G_DIETPI-NOTIFY 2 'Overriding root partition free space with zeros to purge removed data and allow further archive size reduction...'
 		zerofree -v $FP_ROOT_DEV


### PR DESCRIPTION
When $PART_END is not smaller than current partition size 'parted' will produce an error because it is not expecting an extra 'yes' option to confirm the operation.