### PR TITLE
dietpi-installer | Replace fdisk/gdisk by sfdisk/sgdisk

### DIFF
--- a/.meta/dietpi-imager
+++ b/.meta/dietpi-imager
@@ -146,13 +146,13 @@ Do you want to overwrite or backup the existing file to $OUTPUT_IMG_NAME.bak?" |
 		# GPT images:
 		# - "GPT PMBR size mismatch (4458495 != 15523839)"
 		# - "Error: The backup GPT table is corrupt, but the primary appears OK, so that will be used."
-		# - gdisk write will correct this
+		# - gdisk will correct this
 		elif [[ $(parted -s $FP_SOURCE print) == *'Partition Table: gpt'* ]]; then
 
 			G_DIETPI-NOTIFY 2 'GPT partition table detected, applying gdisk fix...'
 			GPT=1
 			G_AG_CHECK_INSTALL_PREREQ gdisk
-			echo -e 'w\ny\nq\n' | gdisk $FP_SOURCE
+			sgdisk -g $FP_SOURCE
 
 		else
 
@@ -206,8 +206,8 @@ Do you want to overwrite or backup the existing file to $OUTPUT_IMG_NAME.bak?" |
 		done
 
 		# Estimate minimum end sector
-		PART_START=$(fdisk -l -o Device,Start $FP_SOURCE | grep "^$FP_ROOT_DEV" | mawk '{print $2}') # 512 byte sectors
-		PART_END_CURRENT=$(fdisk -l -o Device,End $FP_SOURCE | grep "^$FP_ROOT_DEV" | mawk '{print $2}')
+		PART_START=$(sfdisk -qlo Device,Start $FP_SOURCE | grep "^$FP_ROOT_DEV" | mawk '{print $2}') # 512 byte sectors
+		PART_END_CURRENT=$(sfdisk -qlo Device,End $FP_SOURCE | grep "^$FP_ROOT_DEV" | mawk '{print $2}')
 		PART_END_TARGET=$(( $PART_START + $FS_SIZE ))
 
 		# Only try to shrink partition when new end sector is less than current end sector
@@ -226,12 +226,12 @@ Do you want to overwrite or backup the existing file to $OUTPUT_IMG_NAME.bak?" |
 		# GPT images:
 		# - "GPT PMBR size mismatch (4458495 != 15523839)"
 		# - "Error: The backup GPT table is corrupt, but the primary appears OK, so that will be used."
-		# - gdisk write will correct this
-		(( $GPT )) && echo -e 'w\ny\nq\n' | gdisk $FP_SOURCE
+		# - gdisk will correct this
+		(( $GPT )) && sgdisk -g $FP_SOURCE
 
 		# Finished: Derive final image size from last partition end + failsafe buffer
 		partprobe $FP_SOURCE
-		IMAGE_SIZE=$(( ( $(fdisk -l -o End $FP_SOURCE | tail -1) + 1 ) * 512 )) # 512 byte sectors => Byte
+		IMAGE_SIZE=$(( ( $(sfdisk -qlo End $FP_SOURCE | tail -1) + 1 ) * 512 )) # 512 byte sectors => Byte
 		IMAGE_SIZE=$(( $IMAGE_SIZE + ( 512 * 256 ) )) # 64 byte for secondary GPT + safety net
 
 		# Created final image + archive in /root


### PR DESCRIPTION
Replace fdisk and gdisk commands by their command-line counterparts sfdisk and sgdisk, which are more suitable for a script.