### PR TITLE
Update dietpi-imager

### DIFF
--- a/.meta/dietpi-imager
+++ b/.meta/dietpi-imager
@@ -53,18 +53,20 @@
 
 			# Detect drives and list for selection
 			G_WHIP_MENU_ARRAY=($(lsblk -dnpo NAME,SIZE))
-			# - Visually separate dev name and space
-			for ((i=1;i<${#G_WHIP_MENU_ARRAY[@]};i+=2)); do G_WHIP_MENU_ARRAY[$i]=": ${G_WHIP_MENU_ARRAY[$i]}"; done
-			if [[ $G_WHIP_MENU_ARRAY ]]; then
 
-				G_WHIP_MENU 'Please select the drive you wish to create the image from:' || Exit_On_Fail
-
-			else
+			if [[ ! $G_WHIP_MENU_ARRAY ]]; then
 
 				G_DIETPI-NOTIFY 1 'No drives found, aborting...'
+				G_DIETPI-NOTIFY 2 'Hint: This is the list of available block devices'
+				lsblk -npo NAME,SIZE,MAJ:MIN,FSTYPE,MOUNTPOINT,MODEL
 				Exit_On_Fail
 
 			fi
+
+			# - Visually separate dev name and size and add model and serial
+			for ((i=1;i<${#G_WHIP_MENU_ARRAY[@]};i+=2)); do G_WHIP_MENU_ARRAY[$i]=": $(lsblk -drno SIZE,MODEL,SERIAL ${G_WHIP_MENU_ARRAY[$i-1]})"; done
+			G_WHIP_MENU 'Please select the drive you wish to create the image from:
+\nNB: All mounted partitions of the selected drive will be unmounted.' || Exit_On_Fail
 			FP_SOURCE=$G_WHIP_RETURNED_VALUE
 
 			G_DIETPI-NOTIFY 2 'Unmounting all mounted file systems of the selected source drive...'


### PR DESCRIPTION
- If $G_WHIP_MENU_ARRAY is empty, exit right away (in line with coding style across the script)
- Add extra info about devices (model and serial). This will help user when presented with the list of devices
- Add a note to warn user about partitions about to be unmounted