### PR TITLE
Update dietpi-imager

### DIFF
--- a/.meta/dietpi-imager
+++ b/.meta/dietpi-imager
@@ -26,6 +26,7 @@
 	FP_ROOT_DEV=''
 	ROOT_PARTITION_INDEX=0
 	OUTPUT_IMG_NAME=''
+	OUTPUT_IMG_EXT='img'
 	GPT=0
 
 	Delete_Loopback(){ [[ -b $FP_SOURCE ]] && G_RUN_CMD losetup -d $FP_SOURCE; }
@@ -115,12 +116,12 @@
 		OUTPUT_IMG_NAME=$G_WHIP_RETURNED_VALUE
 
 		# Check for existing file, in case offer backup. Skip if source is image file and matches output file already.
-		if [[ /root/$OUTPUT_IMG_NAME.img != $FP_SOURCE_IMG && -f $OUTPUT_IMG_NAME.img ]]; then
+		if [[ /root/$OUTPUT_IMG_NAME.$OUTPUT_IMG_EXT != $FP_SOURCE_IMG && -f $OUTPUT_IMG_NAME.$OUTPUT_IMG_EXT ]]; then
 
 			G_WHIP_BUTTON_OK_TEXT='Overwrite'
 			G_WHIP_BUTTON_CANCEL_TEXT='Backup'
-			G_WHIP_YESNO "[WARNING] /root/$OUTPUT_IMG_NAME.img already exists\n
-Do you want to overwrite or backup the existing file to /root/$OUTPUT_IMG_NAME.img.bak?" || mv $OUTPUT_IMG_NAME.img{,.bak}
+			G_WHIP_YESNO "[WARNING] /root/$OUTPUT_IMG_NAME.$OUTPUT_IMG_EXT already exists\n
+Do you want to overwrite or backup the existing file to /root/$OUTPUT_IMG_NAME.$OUTPUT_IMG_EXT.bak?" || mv $OUTPUT_IMG_NAME.$OUTPUT_IMG_EXT{,.bak}
 
 		fi
 
@@ -243,24 +244,24 @@ Do you want to overwrite or backup the existing file to /root/$OUTPUT_IMG_NAME.i
 			truncate --size=$IMAGE_SIZE "$FP_SOURCE_IMG"
 
 			# Rename and move to /root, if source image != output image already
-			[[ /root/$OUTPUT_IMG_NAME.img != $FP_SOURCE_IMG ]] && mv "$FP_SOURCE_IMG" $OUTPUT_IMG_NAME.img
+			[[ /root/$OUTPUT_IMG_NAME.$OUTPUT_IMG_EXT != $FP_SOURCE_IMG ]] && mv "$FP_SOURCE_IMG" $OUTPUT_IMG_NAME.$OUTPUT_IMG_EXT
 
 		# Drive source
 		else
 
 			G_DIETPI-NOTIFY 2 "Creating final image with actually used size: $(( $IMAGE_SIZE / 1024 / 1024 + 1 )) MiB"
-			dd if=$FP_SOURCE of=$OUTPUT_IMG_NAME.img bs=1M status=progress count=$(( $IMAGE_SIZE / 1024 / 1024 + 1 ))
+			dd if=$FP_SOURCE of=$OUTPUT_IMG_NAME.$OUTPUT_IMG_EXT bs=1M status=progress count=$(( $IMAGE_SIZE / 1024 / 1024 + 1 ))
 
 		fi
 
 		# Generate hashes: MD5, SHA1, SHA256
 		G_DIETPI-NOTIFY 2 'Generating hashes to pack with image, please wait...'
 		cat << _EOF_ > hash.txt
-FILE:	$OUTPUT_IMG_NAME.img
+FILE:	$OUTPUT_IMG_NAME.$OUTPUT_IMG_EXT
 DATE:	$(date)
-MD5:	$(md5sum $OUTPUT_IMG_NAME.img | mawk '{print $1}')
-SHA1:	$(sha1sum $OUTPUT_IMG_NAME.img | mawk '{print $1}')
-SHA256:	$(sha256sum $OUTPUT_IMG_NAME.img | mawk '{print $1}')
+MD5:	$(md5sum $OUTPUT_IMG_NAME.$OUTPUT_IMG_EXT | mawk '{print $1}')
+SHA1:	$(sha1sum $OUTPUT_IMG_NAME.$OUTPUT_IMG_EXT | mawk '{print $1}')
+SHA256:	$(sha256sum $OUTPUT_IMG_NAME.$OUTPUT_IMG_EXT | mawk '{print $1}')
 _EOF_
 
 		# Download current README
@@ -271,11 +272,11 @@ _EOF_
 		# NB: LZMA2 ultra compression method requires 2G RAM
 		[[ -f $OUTPUT_IMG_NAME.7z ]] && rm $OUTPUT_IMG_NAME.7z
 		G_DIETPI-NOTIFY 2 'Creating final 7zip archive...'
-		if 7zr a -m0=lzma2 -mx=9 $OUTPUT_IMG_NAME.7z $OUTPUT_IMG_NAME.img hash.txt README.md; then
+		if 7zr a -m0=lzma2 -mx=9 $OUTPUT_IMG_NAME.7z $OUTPUT_IMG_NAME.$OUTPUT_IMG_EXT hash.txt README.md; then
 
 			rm hash.txt README.md
 			G_WHIP_MSG "[  OK  ] DietPi-Imager has successfully finished.\n
-Final image file: /root/$OUTPUT_IMG_NAME.img
+Final image file: /root/$OUTPUT_IMG_NAME.$OUTPUT_IMG_EXT
 Final 7z archive: /root/$OUTPUT_IMG_NAME.7z"
 
 		fi


### PR DESCRIPTION
Add new var 'OUTPUT_IMG_EXT' to store extension of the image file. This is currently fixed to 'img', but is needed to allow creation of .iso files when integrating Clonezilla.