### PR TITLE
DietPi-Software | Grafana: Remove outdated bintray repo for ARMv6

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@ Bug Fixes:
 - DietPi-Software | Gitea: Resolved an issue where fresh Gitea installs failed to start due to missing permissions. Many thanks to @NZRob fore reporting this issue: https://dietpi.com/phpbb/viewtopic.php?f=11&t=6550
 - DietPi-Software | Home Assistant: Resolved on issue where fresh install failed to started to start due to missing permissions. Many thanks to @slopsjon, @tyjtyj and @pakikje for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?f=11&t=6531, https://dietpi.com/phpbb/viewtopic.php?p=20408#p20408
 - DietPi-Software | Google AIY: Resolved an issue where fresh install failed to start due to missing permissions
+- DietPi-Software | Grafana: Resolved an issue where install failed on RPi 1/Zero Buster systems. The fix includes an update of Grafana to the latest official version for those models. Many thanks to @TBail for reporting this issue: https://github.com/MichaIng/DietPi/issues/3213
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1340,8 +1340,8 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 
 		aSOFTWARE_NAME[$software_id]='Docker'
 		aSOFTWARE_DESC[$software_id]='Build, ship, and run distributed applications'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=9
 		aSOFTWARE_TYPE[$software_id]=0
+		aSOFTWARE_CATEGORY_INDEX[$software_id]=9
 		# - Bullseye
 		aSOFTWARE_AVAIL_G_DISTRO[$software_id,6]=0
 
@@ -1729,8 +1729,8 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 
 		aSOFTWARE_NAME[$software_id]='Samba Server'
 		aSOFTWARE_DESC[$software_id]='feature-rich file server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=15
 		aSOFTWARE_TYPE[$software_id]=0
+		aSOFTWARE_CATEGORY_INDEX[$software_id]=15
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=56#p56'
 		#------------------
 		software_id=109
@@ -3063,7 +3063,7 @@ _EOF_
 
 			# Link disk cache to RAM: https://github.com/MichaIng/DietPi/issues/2396
 			# - Remove previous disk cache dir or symlink
-			[[ -d '/var/cache/samba' || -L '/var/cache/samba' ]] && rm -R /var/cache/samba
+			rm -Rf /var/cache/samba
 			# - Pre-create RAM cache dir
 			mkdir -p /run/samba-cache
 			# - Link disk cache to RAM
@@ -13114,6 +13114,7 @@ _EOF_
 			G_AGP samba samba-common-bin
 			[[ -f '/etc/tmpfiles.d/dietpi-samba_cache.conf' ]] && rm /etc/tmpfiles.d/dietpi-samba_cache.conf
 			[[ -d '/run/samba-cache' ]] && rm -R /run/samba-cache
+			rm -Rf /var/cache/samba # Symlink
 
 		fi
 
@@ -13990,7 +13991,7 @@ _EOF_
 
 		fi
 
-		software_id=162
+		software_id=162 # Docker
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4448,25 +4448,27 @@ _EOF_
 
 			Banner_Installing
 
-			# APT repo GPG key
-			INSTALL_URL_ADDRESS='https://packages.grafana.com/gpg.key'
-			local deb_address='deb https://packages.grafana.com/oss/deb/ stable main'
+			# ARMv6: Install package manually since repo is not compatible
 			if (( $G_HW_ARCH == 1 )); then
 
-				INSTALL_URL_ADDRESS='https://bintray.com/user/downloadSubjectPublicKey?username=bintray'
-				deb_address="deb https://dl.bintray.com/fg2it/deb-rpi-1b/ $G_DISTRO_NAME main"
+				Download_Install 'https://dl.grafana.com/oss/release/grafana-rpi_6.4.3_armhf.deb'
+
+			# Else use official APT repo
+			else
+
+				# APT key
+				INSTALL_URL_ADDRESS='https://packages.grafana.com/gpg.key'
+				G_CHECK_URL "$INSTALL_URL_ADDRESS"
+				curl -sSL "$INSTALL_URL_ADDRESS" | apt-key add -
+
+				# APT list
+				echo 'deb https://packages.grafana.com/oss/deb/ stable main' > /etc/apt/sources.list.d/grafana.list
+				G_AGUP
+
+				# APT package
+				G_AGI grafana
 
 			fi
-
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-			curl -sSL "$INSTALL_URL_ADDRESS" | apt-key add -
-
-			# APT repo source & update
-			echo "$deb_address" > /etc/apt/sources.list.d/grafana.list
-			G_AGUP
-
-			# APT package
-			G_AGI grafana
 
 		fi
 
@@ -9203,25 +9205,29 @@ _EOF_
 
 			Banner_Configuration
 
-			# Move DB/plugins to userdata location, if not already existent
+			# Link DB/plugins to userdata location
 			if [[ -d $G_FP_DIETPI_USERDATA/grafana ]]; then
 
 				G_DIETPI-NOTIFY 2 "Existing database/plugin directory $G_FP_DIETPI_USERDATA/grafana found. Will not overwrite..."
-				rm -Rf /var/lib/grafana
 
-			else
+			elif [[ -d '/var/lib/grafana' ]]; then
 
 				mv /var/lib/grafana $G_FP_DIETPI_USERDATA/
 
+			else
+
+				mkdir -p $G_FP_DIETPI_USERDATA/grafana
+				chown -R grafana:grafana $G_FP_DIETPI_USERDATA/grafana
+
 			fi
-			ln -sf $G_FP_DIETPI_USERDATA/grafana /var/lib/grafana
+			rm -Rf /var/lib/grafana
+			ln -s $G_FP_DIETPI_USERDATA/grafana /var/lib/grafana
 
-			# Permissions
-			chown -R grafana:grafana $G_FP_DIETPI_USERDATA/grafana
-
-			# Set password, wrap into trippled double quotes in case of ; or # being contained, according to docs: http://docs.grafana.org/installation/configuration/#password
-			GCI_PASSWORD=1 GCI_PRESERVE=1 G_CONFIG_INJECT 'admin_password[[:blank:]]*=' "admin_password = \"\"\"$GLOBAL_PW\"\"\"" /etc/grafana/grafana.ini
-			G_CONFIG_INJECT 'http_port = ' 'http_port = 3001' /etc/grafana/grafana.ini
+			# Config: Apply our defaults only if nothing was set before
+			# - Set password, wrap into trippled double quotes in case of ; or # being contained, according to docs: http://docs.grafana.org/installation/configuration/#password
+			GCI_PRESERVE=1 GCI_PASSWORD=1 G_CONFIG_INJECT 'admin_password[[:blank:]]*=' "admin_password = \"\"\"$GLOBAL_PW\"\"\"" /etc/grafana/grafana.ini
+			# - Set port to 3001 (away from default 3000) to avoid conflict with Gogs and Gitea
+			GCI_PRESERVE=1 G_CONFIG_INJECT 'http_port[[:blank:]]*=' 'http_port = 3001' /etc/grafana/grafana.ini
 
 		fi
 
@@ -14084,9 +14090,8 @@ _EOF_
 
 			G_AGP grafana
 			[[ -f '/etc/apt/sources.list.d/grafana.list' ]] && rm /etc/apt/sources.list.d/grafana.list
-
-			[[ -e '/var/lib/grafana' ]] && rm -R /var/lib/grafana
-			[[ -d $G_FP_DIETPI_USERDATA/grafana ]] && rm -R $G_FP_DIETPI_USERDATA/grafana
+			getent passwd grafana &> /dev/null && userdel -rf grafana
+			rm -Rf {$G_FP_DIETPI_USERDATA,/var/lib,/var/log,/etc}/grafana
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1527,16 +1527,16 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 
 		aSOFTWARE_NAME[$software_id]='InfluxDB'
 		aSOFTWARE_DESC[$software_id]='time-series database'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=11
 		aSOFTWARE_TYPE[$software_id]=0
+		aSOFTWARE_CATEGORY_INDEX[$software_id]=11
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=12523#p12523'
 		#------------------
 		software_id=77
 
 		aSOFTWARE_NAME[$software_id]='Grafana'
 		aSOFTWARE_DESC[$software_id]='platform for analytics and monitoring'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=11
 		aSOFTWARE_TYPE[$software_id]=0
+		aSOFTWARE_CATEGORY_INDEX[$software_id]=11
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=12524#p12524'
 
 		# System security
@@ -4448,12 +4448,12 @@ _EOF_
 
 			Banner_Installing
 
-			# ARMv6: Install package manually since repo is not compatible
+			# ARMv6: Install package manually since repo is not compatible: https://grafana.com/grafana/download?platform=arm
 			if (( $G_HW_ARCH == 1 )); then
 
 				Download_Install 'https://dl.grafana.com/oss/release/grafana-rpi_6.4.3_armhf.deb'
 
-			# Else use official APT repo
+			# Else use official APT repo: https://grafana.com/docs/installation/debian/#apt-repository
 			else
 
 				# APT key
@@ -9204,6 +9204,10 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
+
+			# Remove obsolete sysvinit service
+			[[ -f '/etc/init.d/grafana-server' ]] && rm /etc/init.d/grafana-server
+			update-rc.d -f grafana-server remove
 
 			# Link DB/plugins to userdata location
 			if [[ -d $G_FP_DIETPI_USERDATA/grafana ]]; then


### PR DESCRIPTION
**Status**: Ready
- [x] Reinstall + active bintray repo removal on ARMv6: https://github.com/MichaIng/DietPi/commit/7b84e3af11f131c1443aa5e833bf116e0675b848
- [x] Changelog

**Reference**: https://github.com/MichaIng/DietPi/issues/3213

**Commit list/description**:
+ DietPi-Software | Grafana: Remove outdated bintray repo for ARMv6 installs and use latest package from official Grafana downloads instead: https://github.com/MichaIng/DietPi/issues/3213
+ DietPi-Software | Grafana: Failsafe data dir preparation in case /var/lib/grafana is missing and never overwrite permissions on existing dir.
+ DietPi-Software | Grafana: Cleanup on software uninstall, since the package purge leaves user, /var and /etc data in place