### PR TITLE
Update dietpi-imager: Exit if fsck ends with an error

### DIFF
--- a/.meta/dietpi-imager
+++ b/.meta/dietpi-imager
@@ -188,7 +188,7 @@ Do you want to overwrite or backup the existing file to /root/$OUTPUT_IMG_NAME.$
 
 		fi
 
-		e2fsck -f $FP_ROOT_DEV
+		e2fsck -f $FP_ROOT_DEV || Exit_On_Fail
 
 		# Remount image for any required edits
 		fp_mnt='tmp_rootfs'
@@ -201,8 +201,9 @@ Do you want to overwrite or backup the existing file to /root/$OUTPUT_IMG_NAME.$
 			partprobe $FP_SOURCE # Failsafe
 
 		fi
+		rmdir /mnt/$fp_mnt
 
-		e2fsck -f $FP_ROOT_DEV # Failsafe
+		e2fsck -f $FP_ROOT_DEV || Exit_On_Fail # Failsafe
 
 		# Shrink file system to minimum
 		# - Run multiple times until no change is done any more


### PR DESCRIPTION
Sometimes fsck ends with this error:
```
e2fsck: No such file or directory while trying to open /dev/sda2
Possibly non-existent device?
```
This has the side effect of entering in an infinite loop:
```
[ INFO ] DietPi-Imager | Shrinking RootFS to minimum size...
resize2fs 1.45.3 (14-Jul-2019)                                                                      
Please run 'e2fsck -f /dev/sda2' first.

resize2fs 1.45.3 (14-Jul-2019)
Please run 'e2fsck -f /dev/sda2' first.

resize2fs 1.45.3 (14-Jul-2019)
Please run 'e2fsck -f /dev/sda2' first.

resize2fs 1.45.3 (14-Jul-2019)
Please run 'e2fsck -f /dev/sda2' first.
```