### PR TITLE
Setup ha_userroot directory ownership

### DIFF
--- a/.conf/dps_114/nginx.nextcloud.conf
+++ b/.conf/dps_114/nginx.nextcloud.conf
@@ -37,7 +37,7 @@ location ^~ /nextcloud {
 	#pagespeed off;
 
 	location /nextcloud {
-		rewrite ^ /nextcloud/index.php$request_uri;
+		rewrite ^ /nextcloud/index.php;
 	}
 
 	location ~ ^\/nextcloud\/(?:build|tests|config|lib|3rdparty|templates|data)\/ {
@@ -49,14 +49,14 @@ location ^~ /nextcloud {
 
 	location ~ ^\/nextcloud\/(?:index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+)\.php(?:$|\/) {
 		fastcgi_split_path_info ^(.+?\.php)(\/.*|)$;
+		set $path_info $fastcgi_path_info;
+		try_files $fastcgi_script_name =404;
 		include fastcgi_params;
 		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 		fastcgi_param PATH_INFO $fastcgi_path_info;
-		# HTTPS forces redirection from http://, thus has to be enabled only on active HTTPS environment.
 		fastcgi_param HTTPS $https;
-		# Avoid sending the security headers twice
-		fastcgi_param modHeadersAvailable true;
-		fastcgi_param front_controller_active true;
+		fastcgi_param modHeadersAvailable true; # Avoid sending the security headers twice
+		fastcgi_param front_controller_active true; # Enable pretty URLs without /index.php/
 		fastcgi_pass php;
 		fastcgi_intercept_errors on;
 		fastcgi_request_buffering off;

--- a/.conf/dps_47/nginx.owncloud.conf
+++ b/.conf/dps_47/nginx.owncloud.conf
@@ -1,4 +1,4 @@
-# Based on: https://doc.owncloud.org/server/administration_manual/installation/nginx_configuration.html
+# Based on: https://doc.owncloud.org/server/latest/admin_manual/installation/nginx_configuration.html
 
 location ^~ /owncloud {
 
@@ -36,7 +36,7 @@ location ^~ /owncloud {
 	error_page 404 /owncloud/core/templates/404.php;
 
 	location /owncloud {
-		rewrite ^ /owncloud/index.php$uri;
+		rewrite ^ /owncloud/index.php;
 	}
 
 	location ~ ^/owncloud/(?:build|tests|config|lib|3rdparty|templates|data)/ {
@@ -48,15 +48,16 @@ location ^~ /owncloud {
 
 	location ~ ^/owncloud/(?:index|remote|public|cron|core/ajax/update|status|ocs/v[12]|updater/.+|ocs-provider/.+|core/templates/40[34])\.php(?:$|/) {
 		fastcgi_split_path_info ^(.+\.php)(/.*)$;
+		set $path_info $fastcgi_path_info;
+		try_files $fastcgi_script_name =404;
 		include fastcgi_params;
 		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-		fastcgi_param SCRIPT_NAME $fastcgi_script_name; # necessary for owncloud to detect the contextroot https://github.com/owncloud/core/blob/v10.0.0/lib/private/AppFramework/Http/Request.php#L603
+		fastcgi_param SCRIPT_NAME $fastcgi_script_name; # Necessary for owncloud to detect the contextroot https://github.com/owncloud/core/blob/v10.0.0/lib/private/AppFramework/Http/Request.php#L603
 		fastcgi_param PATH_INFO $fastcgi_path_info;
 		fastcgi_param HTTPS $https;
-		fastcgi_param modHeadersAvailable true; #Avoid sending the security headers twice
-		# EXPERIMENTAL: active the following if you need to get rid of the 'index.php' in the URLs
-		fastcgi_param front_controller_active true;
-		fastcgi_read_timeout 180; # increase default timeout e.g. for long running carddav/ caldav syncs with 1000+ entries
+		fastcgi_param modHeadersAvailable true; # Avoid sending the security headers twice
+		fastcgi_param front_controller_active true; # Enable pretty URLs without /index.php/
+		fastcgi_read_timeout 180; # Increase default timeout e.g. for long running carddav/caldav syncs with 1000+ entries
 		fastcgi_pass php;
 		fastcgi_intercept_errors on;
 		fastcgi_request_buffering off;

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -132,7 +132,7 @@ _EOF_
 	Check_Internet_and_NTPD(){
 
 		# Internet: Use /etc/apt/sources.list for connection test
-		G_CHECK_URL "$(grep -m1 '^[[:blank:]]*deb ' /etc/apt/sources.list | mawk '{print $2}')" # Will exit on failure here then prompt user to configure network
+		G_CHECK_URL "echo 'http'$(grep -m1 '^[[:blank:]]*deb ' /etc/apt/sources.list | mawk -F 'http' '{print $2}' | mawk '{print $1}')" # Will exit on failure here then prompt user to configure network
 
 		# Time sync
 		/DietPi/dietpi/func/run_ntpd

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -132,7 +132,7 @@ _EOF_
 	Check_Internet_and_NTPD(){
 
 		# Internet: Use /etc/apt/sources.list for connection test
-		G_CHECK_URL "echo 'http'$(grep -m1 '^[[:blank:]]*deb ' /etc/apt/sources.list | mawk -F 'http' '{print $2}' | mawk '{print $1}')" # Will exit on failure here then prompt user to configure network
+		G_CHECK_URL "http$(grep -m1 '^[[:blank:]]*deb ' /etc/apt/sources.list | mawk -F 'http' '{print $2}' | mawk '{print $1}')" # Will exit on failure here then prompt user to configure network
 
 		# Time sync
 		/DietPi/dietpi/func/run_ntpd

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -131,13 +131,15 @@ _EOF_
 
 	Check_Internet_and_NTPD(){
 
-		# Checking network connectivity via single ping to CloudFlare DNS, which is guaranteed to be available and fastest in average
-		local timeout=(sed -n '/^[[:blank:]]*CONFIG_G_CHECK_URL_TIMEOUT=/{s/^[^=]*=//p;q}' /DietPi/dietpi.txt)
-		l_message='Checking network connectivity' G_RUN_CMD ping -c 1 -W ${timeout:-5} 1.1.1.1
+		# Checking network connectivity
+		local timeout=$(sed -n '/^[[:blank:]]*CONFIG_G_CHECK_URL_TIMEOUT=/{s/^[^=]*=//p;q}' /DietPi/dietpi.txt)
+		local ip=$(sed -n '/^[[:blank:]]*CONFIG_CHECK_CONNECTION_IP=/{s/^[^=]*=//p;q}' /DietPi/dietpi.txt)
+		l_message='Checking network connectivity' G_RUN_CMD ping -c 1 -W ${timeout:-5} ${ip:-1.1.1.1}
 
-		# Cheking DNS resolving via single ping to CloudFlare DNS domain
-		# - NB: The timeout is only valid for ping response while DNS resolving timeout is controlled by: https://manpages.debian.org/resolv.conf
-		l_message='Checking DNS resolving' G_RUN_CMD ping -c 1 -W ${timeout:-5} one.one.one.one
+		# Checking DNS resolver
+		# - NB: The timeout is only valid for ping response while DNS resolver timeout is controlled by: https://manpages.debian.org/resolv.conf
+		local domain=$(sed -n '/^[[:blank:]]*CONFIG_CHECK_DNS_DOMAIN=/{s/^[^=]*=//p;q}' /DietPi/dietpi.txt)
+		l_message='Checking DNS resolver' G_RUN_CMD ping -c 1 -W ${timeout:-5} ${domain:-one.one.one.one}
 
 		# Network time sync
 		/DietPi/dietpi/func/run_ntpd

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6525,6 +6525,8 @@ Mycroft AI requires at least 2 GiB memory on first start. We will now increase y
 			usermod -G dietpi,dialout -a $ha_user
 			mkdir $ha_srvroot
 			chown $ha_user:$ha_user $ha_srvroot
+			# Setup ownership for user root directory
+			chwon $ha_user:$ha_user $ha_userroot
 
 			# Install pyenv
 			su --shell /bin/bash --command "cd $ha_userroot; curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash" $ha_user

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -131,10 +131,15 @@ _EOF_
 
 	Check_Internet_and_NTPD(){
 
-		# Internet: Use /etc/apt/sources.list for connection test
-		G_CHECK_URL "http$(grep -m1 '^[[:blank:]]*deb ' /etc/apt/sources.list | mawk -F 'http' '{print $2}' | mawk '{print $1}')" # Will exit on failure here then prompt user to configure network
+		# Checking network connectivity via single ping to CloudFlare DNS, which is guaranteed to be available and fastest in average
+		local timeout=(sed -n '/^[[:blank:]]*CONFIG_G_CHECK_URL_TIMEOUT=/{s/^[^=]*=//p;q}' /DietPi/dietpi.txt)
+		l_message='Checking network connectivity' G_RUN_CMD ping -c 1 -W ${timeout:-5} 1.1.1.1
 
-		# Time sync
+		# Cheking DNS resolving via single ping to CloudFlare DNS domain
+		# - NB: The timeout is only valid for ping response while DNS resolving timeout is controlled by: https://manpages.debian.org/resolv.conf
+		l_message='Checking DNS resolving' G_RUN_CMD ping -c 1 -W ${timeout:-5} one.one.one.one
+
+		# Network time sync
 		/DietPi/dietpi/func/run_ntpd
 
 	}


### PR DESCRIPTION
**Status**: WIP | Testing | Ready | ?
- [x] Change dietpi-software to add setup of directory ownership for ha_userroot

**Commit list/description**:
- DietPi-Software | Add setup of proper directory ownership for ha_userroot
   - Without this command HASS refuses to start with log record like:
     `homeassistant-start.sh[22948]: Fatal Error: Unable to create library directory /home/homeassistant/.homeassistant/deps`

