### PR TITLE
DietPi-Software | Koel: Pull latest version automatically and update dependencies

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,7 @@ Changes / Improvements / Optimisations:
 - DietPi-Software | Amiberry: Updated to v3.0.9, a large update from v2.25 with many improvements, see: https://github.com/midwan/amiberry/releases
 - DietPi-Software | Amiberry: Since we ship a tailored SDL2 version, this has now been merged right into the Amiberry download archive and install directory, to not interfere with other system-wide installed SDL2 instances.
 - DietPi-Software | Kodi: Add GPU-accelerated support for Odroid N2 via fbdev driver and special Kodi build, provided by Meveric. Many thanks to @ernero93 for doing this request: https://github.com/MichaIng/DietPi/issues/3255
+- DietPi-Software | Koel: The latest upstream release will be pulled automatically now, v4.2.2 at date of writing. Dependencies have been updated accordingly, e.g. latest Koel supports latest Node.js v13.5.0.
 
 Bug Fixes:
 - DietPi-PREP | Resolved an issue, where in rare cases a wrong $PATH variable could break command calls. Many thanks to @dtm2001 for reporting this issue: https://github.com/MichaIng/DietPi/issues/3206

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5378,7 +5378,8 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			Banner_Installing
 
-			# Needed PHP modules, (re)install to be failsafe: https://koel.phanan.net/docs/#/?id=requirements, https://laravel.com/docs/5.8/installation#server-requirements
+			# APT dependencies: https://koel.phanan.net/docs/#/?id=requirements, https://laravel.com/docs/5.8/installation#server-requirements
+			# - python: "gyp verb check python checking for Python executable "python2"/"python" in the PATH"
 			# - libpng-dev: "Error: pngquant failed to build, make sure that libpng-dev is installed"
 			DEPS_LIST="python libpng-dev $PHP_NAME-bcmath $PHP_NAME-json $PHP_NAME-mbstring $PHP_NAME-xml"
 
@@ -5389,26 +5390,32 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			local fallback_url='https://github.com/phanan/koel/archive/v4.2.2.tar.gz'
 			Download_Install "https://github.com/phanan/koel/archive/$version.tar.gz"
 
-			# Reinstall: Clear previous install
-			[[ -d $G_FP_DIETPI_USERDATA/koel ]] && rm -R $G_FP_DIETPI_USERDATA/koel
+			# Reinstall: Clear previous install, but keep existing config file
+			if [[ -d $G_FP_DIETPI_USERDATA/koel ]]; then
+
+				[[ -f $G_FP_DIETPI_USERDATA/koel/.env ]] && mv $G_FP_DIETPI_USERDATA/koel/.env koel-*/
+				rm -R $G_FP_DIETPI_USERDATA/koel
+
+			fi
 			mv koel-* $G_FP_DIETPI_USERDATA/koel
 
 			# Download external assets manually, not included in download archive: https://github.com/phanan/koel/tree/master/resources
 			# - NB: We pull master archive, but this might not match to Koel latest release. Requires testing, else we need to switch to git clone.
 			Download_Install 'https://github.com/koel/core/archive/master.tar.gz'
 			rmdir $G_FP_DIETPI_USERDATA/koel/resources/assets
-			mv core-master $G_FP_DIETPI_USERDATA/koel/resources/assets
+			G_RUN_CMD mv core-master $G_FP_DIETPI_USERDATA/koel/resources/assets
 
-			# Install pre-req yarn
+			# Node.js dependencies
 			npm i -g --unsafe-perm yarn
 
 			# Download and install Composer
 			$PHP_NAME -r "readfile('https://getcomposer.org/installer');" > composer-setup.php
 			$PHP_NAME composer-setup.php
 			$PHP_NAME -r "unlink('composer-setup.php');"
-			mv composer.phar /usr/local/bin/composer
+			G_RUN_CMD mv composer.phar /usr/local/bin/composer
 			rm composer-setup.php
 
+			# Install Koel
 			cd $G_FP_DIETPI_USERDATA/koel
 			composer install
 			cd /tmp/$G_PROGRAM_NAME
@@ -11343,23 +11350,32 @@ _EOF_
 
 			Download_Test_Media
 
-			/DietPi/dietpi/func/create_mysql_db koel koel "$GLOBAL_PW"
-
 			cd $G_FP_DIETPI_USERDATA/koel
 
-			G_CONFIG_INJECT 'DB_CONNECTION=' 'DB_CONNECTION=mysql' .env
-			G_CONFIG_INJECT 'DB_HOST=' 'DB_HOST=127.0.0.1' .env
-			G_CONFIG_INJECT 'DB_DATABASE=' 'DB_DATABASE=koel' .env
-			G_CONFIG_INJECT 'DB_USERNAME=' 'DB_USERNAME=koel' .env
-			GCI_PASSWORD=1 G_CONFIG_INJECT 'DB_PASSWORD=' "DB_PASSWORD=$GLOBAL_PW" .env
-			# ADMIN env vars are not used any more, user prompt will ask for info.
-			#G_CONFIG_INJECT 'ADMIN_EMAIL=' 'ADMIN_EMAIL=dietpi@dietpi.com' .env
-			#G_CONFIG_INJECT 'ADMIN_NAME=' 'ADMIN_NAME=admin' .env
-			#GCI_PASSWORD=1 G_CONFIG_INJECT 'ADMIN_PASSWORD=' "ADMIN_PASSWORD=$GLOBAL_PW" .env
-			G_CONFIG_INJECT 'FFMPEG_PATH=' "FFMPEG_PATH=$(command -v ffmpeg)" .env
+			# Create database and apply to config file, if it does not exist yet
+			if [[ ! -d $G_FP_DIETPI_USERDATA/mysql/koel ]]; then
 
-			G_RUN_CMD systemctl restart mariadb # Assure database server runs, even if database did already exist
+				/DietPi/dietpi/func/create_mysql_db koel koel "$GLOBAL_PW"
+				G_CONFIG_INJECT 'DB_CONNECTION=' 'DB_CONNECTION=mysql' .env
+				G_CONFIG_INJECT 'DB_HOST=' 'DB_HOST=127.0.0.1' .env
+				G_CONFIG_INJECT 'DB_DATABASE=' 'DB_DATABASE=koel' .env
+				G_CONFIG_INJECT 'DB_USERNAME=' 'DB_USERNAME=koel' .env
+				GCI_PASSWORD=1 G_CONFIG_INJECT 'DB_PASSWORD=' "DB_PASSWORD=$GLOBAL_PW" .env
+				# ADMIN env vars are not used any more, user prompt will ask for info.
+				#G_CONFIG_INJECT 'ADMIN_EMAIL=' 'ADMIN_EMAIL=dietpi@dietpi.com' .env
+				#G_CONFIG_INJECT 'ADMIN_NAME=' 'ADMIN_NAME=admin' .env
+				#GCI_PASSWORD=1 G_CONFIG_INJECT 'ADMIN_PASSWORD=' "ADMIN_PASSWORD=$GLOBAL_PW" .env
+				G_CONFIG_INJECT 'FFMPEG_PATH=' "FFMPEG_PATH=$(command -v ffmpeg)" .env
+
+			# Else assure database server runs
+			else
+
+				G_RUN_CMD systemctl restart mariadb
+
+			fi
+
 			$PHP_NAME artisan koel:init
+			$PHP_NAME artisan key:generate # Required with current setup, else .env APP_KEY is missing, leading to 500 on web UI login attempt
 			#$PHP_NAME artisan db:seed --force
 
 			cd /tmp/$G_PROGRAM_NAME
@@ -11377,7 +11393,6 @@ ExecStart=$(command -v $PHP_NAME) $G_FP_DIETPI_USERDATA/koel/artisan serve --hos
 [Install]
 WantedBy=multi-user.target
 _EOF_
-
 			# Permissions
 			chown -R koel:dietpi $G_FP_DIETPI_USERDATA/koel
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5379,7 +5379,8 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			Banner_Installing
 
 			# Needed PHP modules, (re)install to be failsafe: https://koel.phanan.net/docs/#/?id=requirements, https://laravel.com/docs/5.8/installation#server-requirements
-			DEPS_LIST="python $PHP_NAME-bcmath $PHP_NAME-json $PHP_NAME-mbstring $PHP_NAME-xml"
+			# - libpng-dev: "Error: pngquant failed to build, make sure that libpng-dev is installed"
+			DEPS_LIST="python libpng-dev $PHP_NAME-bcmath $PHP_NAME-json $PHP_NAME-mbstring $PHP_NAME-xml"
 
 			# Grab latest release
 			INSTALL_URL_ADDRESS='https://api.github.com/repos/phanan/koel/releases/latest'
@@ -9025,6 +9026,7 @@ _EOF_
 			if [[ -d $G_FP_DIETPI_USERDATA/mysql/freshrss ]]; then
 
 				G_DIETPI-NOTIFY 2 'FreshRSS MariaDB database found, will NOT overwrite.'
+				G_RUN_CMD systemctl restart mariadb
 
 			else
 
@@ -11356,6 +11358,7 @@ _EOF_
 			#GCI_PASSWORD=1 G_CONFIG_INJECT 'ADMIN_PASSWORD=' "ADMIN_PASSWORD=$GLOBAL_PW" .env
 			G_CONFIG_INJECT 'FFMPEG_PATH=' "FFMPEG_PATH=$(command -v ffmpeg)" .env
 
+			G_RUN_CMD systemctl restart mariadb # Assure database server runs, even if database did already exist
 			$PHP_NAME artisan koel:init
 			#$PHP_NAME artisan db:seed --force
 
@@ -11883,6 +11886,7 @@ _EOF_
 			echo 'allo ALL=NOPASSWD: ALL' > /etc/sudoers.d/allo
 
 			# Always Drop DB, and, recreate it, due to error issue with reinstall over the top.
+			G_RUN_CMD systemctl restart mariadb
 			mysqladmin drop allo_db -f &> /dev/null
 			mysql -e 'drop user allo_db@localhost' &> /dev/null
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -691,8 +691,8 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 
 		aSOFTWARE_NAME[$software_id]='Koel'
 		aSOFTWARE_DESC[$software_id]='web interface audio streamer'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
 		aSOFTWARE_TYPE[$software_id]=0
+		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=7305#p7305'
 		aSOFTWARE_REQUIRES_PHP[$software_id]=1
  		aSOFTWARE_REQUIRES_MYSQL[$software_id]=1
@@ -822,9 +822,9 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		aSOFTWARE_DESC[$software_id]='bittorrent server with rutorrent web interface'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=2603#p2603'
 		aSOFTWARE_REQUIRES_WEBSERVER[$software_id]=1
 		aSOFTWARE_REQUIRES_PHP[$software_id]=1
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=2603#p2603'
 		#------------------
 		software_id=116
 
@@ -3551,7 +3551,7 @@ _EOF_
 
 			# Sourcebuild pre-reqs: https://github.com/jcorporation/myMPD#dependencies
 			DEPS_LIST='libmpdclient2 libmediainfo0v5 cmake cppcheck pkg-config libmpdclient-dev libssl-dev libmediainfo-dev'
-			Download_Install 'https://github.com/jcorporation/myMPD/archive/master.zip'
+			Download_Install 'https://github.com/jcorporation/myMPD/archive/master.tar.gz'
 
 			cd myMPD-master
 			G_RUN_CMD ./build.sh releaseinstall
@@ -3928,7 +3928,7 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-n2-kodi.conf
 			Banner_Installing
 
 			DEPS_LIST='gpac motion'
-			Download_Install 'https://github.com/silvanmelchior/RPi_Cam_Web_Interface/archive/master.zip'
+			Download_Install 'https://github.com/silvanmelchior/RPi_Cam_Web_Interface/archive/master.tar.gz'
 
 			cd RPi_Cam*
 
@@ -3996,7 +3996,7 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-n2-kodi.conf
 			G_THREAD_START curl -L "$INSTALL_URL_ADDRESS/youtube-dl" -o /usr/local/bin/youtube-dl
 			DEPS_LIST='python-requests'
 
-			Download_Install 'https://github.com/ArturSierzant/OMPD/archive/master.zip' /var/www
+			Download_Install 'https://github.com/ArturSierzant/OMPD/archive/master.tar.gz' /var/www
 			# Replace existing installs but preserve local config override
 			if [[ -d '/var/www/ompd' ]]; then
 
@@ -4021,7 +4021,7 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-n2-kodi.conf
 
 			Banner_Installing
 
-			Download_Install 'https://github.com/afaqurk/linux-dash/archive/master.zip'
+			Download_Install 'https://github.com/afaqurk/linux-dash/archive/master.tar.gz'
 			mkdir -p /var/www/linuxdash
 			cp -a linux-dash-master/* /var/www/linuxdash/
 			rm -R linux-dash-master
@@ -4131,7 +4131,7 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-n2-kodi.conf
 			# Odroids
 			elif (( $G_HW_MODEL < 20 )); then
 
-				Download_Install 'https://github.com/hardkernel/wiringPi/archive/master.zip'
+				Download_Install 'https://github.com/hardkernel/wiringPi/archive/master.tar.gz'
 
 			# BPi Pro
 			elif (( $G_HW_MODEL == 51 )); then
@@ -4367,7 +4367,7 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-n2-kodi.conf
 			# Install required PHP modules: https://github.com/FreshRSS/FreshRSS#example-of-full-installation-on-linux-debianubuntu
 			DEPS_LIST="$PHP_NAME-curl $PHP_NAME-gmp $PHP_NAME-intl $PHP_NAME-json $PHP_NAME-mbstring $PHP_NAME-xml $PHP_NAME-zip"
 
-			Download_Install 'https://github.com/FreshRSS/FreshRSS/archive/master.zip' /opt
+			Download_Install 'https://github.com/FreshRSS/FreshRSS/archive/master.tar.gz' /opt
 			mv /opt/FreshRSS-master /opt/FreshRSS
 
 		fi
@@ -4480,7 +4480,7 @@ _EOF_
 
 			Banner_Installing
 
-			Download_Install 'https://github.com/phpsysinfo/phpsysinfo/archive/master.zip' /var/www
+			Download_Install 'https://github.com/phpsysinfo/phpsysinfo/archive/master.tar.gz' /var/www
 			mv /var/www/phpsysinfo-* /var/www/phpsysinfo
 
 		fi
@@ -4511,7 +4511,7 @@ _EOF_
 
 			Banner_Installing
 
-			Download_Install 'https://github.com/ampache/ampache/archive/master.zip'
+			Download_Install 'https://github.com/ampache/ampache/archive/master.tar.gz'
 			# Preserve existing config files
 			[[ -f '/var/www/ampache/config/ampache.cfg.php' ]] && mv /var/www/ampache/config/ampache.cfg.php ampache-*/config/
 			[[ -f '/var/www/ampache/config/motd.php' ]] && mv /var/www/ampache/config/motd.php ampache-*/config/
@@ -4904,7 +4904,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			# Pre-reqs: https://github.com/sabre-io/Baikal/wiki/Baïkal-dependencies
 			DEPS_LIST="$PHP_NAME-xml $PHP_NAME-mbstring $PHP_NAME-mysql"
 
-			Download_Install 'https://github.com/fruux/Baikal/archive/master.zip'
+			Download_Install 'https://github.com/fruux/Baikal/archive/master.tar.gz'
 			# Reinstall: http://sabre.io/baikal/upgrade/
 			if [[ -d '/var/www/baikal' ]]; then
 
@@ -5097,11 +5097,12 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			(( $G_DISTRO < 5 )) && DEPS_LIST+=' screen'
 
 			# Install ruTorrent: Web UI for rTorrent
-			# - Get current version string
+			# - Grab current version
 			INSTALL_URL_ADDRESS='https://api.github.com/repos/Novik/ruTorrent/releases/latest'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-			local version_string=$(curl -s "$INSTALL_URL_ADDRESS" | grep -m1 '^[[:blank:]]*"tag_name":' | cut -d \" -f 4)
-			Download_Install "https://github.com/Novik/ruTorrent/archive/$version_string.tar.gz"
+			local version=$(curl -s "$INSTALL_URL_ADDRESS" | grep -m1 '^[[:blank:]]*"tag_name":' | cut -d \" -f 4)
+			local fallback_url='https://github.com/Novik/ruTorrent/archive/v3.9.tar.gz'
+			Download_Install "https://github.com/Novik/ruTorrent/archive/$version.tar.gz"
 
 			# - Reinstall
 			if [[ -d '/var/www/rutorrent' ]]; then
@@ -5141,7 +5142,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			G_AGI aria2
 
 			# Web UI: Settings are stored client-wise, web UI files are never written by webserver. Thus root:root 022 permissions existing dir removal on reinstall can be done.
-			Download_Install 'https://github.com/ziahamza/webui-aria2/archive/master.zip'
+			Download_Install 'https://github.com/ziahamza/webui-aria2/archive/master.tar.gz'
 			[[ -d '/var/www/aria2' ]] && rm -R /var/www/aria2
 			mv webui-aria2-master /var/www/aria2
 
@@ -5163,7 +5164,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			else
 
-				Download_Install 'https://github.com/pymedusa/Medusa/archive/master.zip' $G_FP_DIETPI_USERDATA
+				Download_Install 'https://github.com/pymedusa/Medusa/archive/master.tar.gz' $G_FP_DIETPI_USERDATA
 				mv $G_FP_DIETPI_USERDATA/Medusa-master $G_FP_DIETPI_USERDATA/medusa
 
 			fi
@@ -5326,12 +5327,12 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			# - Pre-compiling required on ARM
 			(( $G_HW_ARCH < 10 )) && DEPS_LIST+=' libffi-dev libssl-dev'
 
-			Download_Install 'https://github.com/sabnzbd/sabnzbd/archive/master.zip'
+			Download_Install 'https://github.com/sabnzbd/sabnzbd/archive/master.tar.gz'
 
-			# Clear old install dir (in case of reinstall)
+			# Reinstall: Clear old install dir
 			if [[ -d '/etc/sabnzbd' ]]; then
 
-				# - Preserve old config file
+				# Preserve old config file
 				[[ -f '/etc/sabnzbd/sabnzbd.ini' ]] && mv /etc/sabnzbd/sabnzbd.ini sabnzbd-master/
 				rm -R /etc/sabnzbd
 
@@ -5363,7 +5364,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			Banner_Installing
 
 			DEPS_LIST='libffi-dev libssl-dev python-lxml python3-lxml'
-			Download_Install 'https://github.com/CouchPotato/CouchPotatoServer/archive/master.zip'
+			Download_Install 'https://github.com/CouchPotato/CouchPotatoServer/archive/master.tar.gz'
 
 			[[ -d /etc/couchpotato ]] && rm -R /etc/couchpotato
 			mv CouchPotato* /etc/couchpotato
@@ -5377,25 +5378,35 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			Banner_Installing
 
-			# Needed PHP modules, (re)install to be failsafe: https://koel.phanan.net/docs/#/?id=server, https://laravel.com/docs/5.6/installation#server-requirements
-			DEPS_LIST="python $PHP_NAME-json $PHP_NAME-mbstring $PHP_NAME-xml"
+			# Needed PHP modules, (re)install to be failsafe: https://koel.phanan.net/docs/#/?id=requirements, https://laravel.com/docs/5.8/installation#server-requirements
+			DEPS_LIST="python $PHP_NAME-bcmath $PHP_NAME-json $PHP_NAME-mbstring $PHP_NAME-xml"
 
-			Download_Install 'https://github.com/phanan/koel/archive/v3.7.2.zip'
+			# Grab latest release
+			INSTALL_URL_ADDRESS='https://api.github.com/repos/phanan/koel/releases/latest'
+			G_CHECK_URL "$INSTALL_URL_ADDRESS"
+			local version=$(curl -s "$INSTALL_URL_ADDRESS" | grep -m1 '^[[:blank:]]*"tag_name":' | cut -d \" -f 4)
+			local fallback_url='https://github.com/phanan/koel/archive/v4.2.2.tar.gz'
+			Download_Install "https://github.com/phanan/koel/archive/$version.tar.gz"
+
+			# Reinstall: Clear previous install
+			[[ -d $G_FP_DIETPI_USERDATA/koel ]] && rm -R $G_FP_DIETPI_USERDATA/koel
 			mv koel-* $G_FP_DIETPI_USERDATA/koel
 
-			# Install pre-req yarn and "n" to downgrade to Node 8, as Node 10 is not (yet) compatible with Koel build.
-			npm i -g --unsafe-perm yarn n
-			# - On ARMv8 explicitly add arch info, since it is not recognized by "n": https://github.com/MichaIng/DietPi/issues/1880#issuecomment-464097174
-			local arch=''
-			(( $G_HW_ARCH == 3 )) && arch='-a arm64'
-			n $arch 8
+			# Download external assets manually, not included in download archive: https://github.com/phanan/koel/tree/master/resources
+			# - NB: We pull master archive, but this might not match to Koel latest release. Requires testing, else we need to switch to git clone.
+			Download_Install 'https://github.com/koel/core/archive/master.tar.gz'
+			rmdir $G_FP_DIETPI_USERDATA/koel/resources/assets
+			mv core-master $G_FP_DIETPI_USERDATA/koel/resources/assets
 
-			# Download and install Composer:
-			php -r "readfile('https://getcomposer.org/installer');" > composer-setup.php
-			php composer-setup.php
-			php -r "unlink('composer-setup.php');"
+			# Install pre-req yarn
+			npm i -g --unsafe-perm yarn
+
+			# Download and install Composer
+			$PHP_NAME -r "readfile('https://getcomposer.org/installer');" > composer-setup.php
+			$PHP_NAME composer-setup.php
+			$PHP_NAME -r "unlink('composer-setup.php');"
 			mv composer.phar /usr/local/bin/composer
-			rm composer-setup.php &> /dev/null
+			rm composer-setup.php
 
 			cd $G_FP_DIETPI_USERDATA/koel
 			composer install
@@ -11326,7 +11337,7 @@ _EOF_
 
 			local usercmd='useradd -rMU'
 			getent passwd koel &> /dev/null && usercmd='usermod -a'
-			$usercmd -G dietpi -s $(command -v nologin) koel
+			$usercmd -G dietpi -d $G_FP_DIETPI_USERDATA/koel -s $(command -v nologin) koel
 
 			Download_Test_Media
 
@@ -11345,8 +11356,8 @@ _EOF_
 			#GCI_PASSWORD=1 G_CONFIG_INJECT 'ADMIN_PASSWORD=' "ADMIN_PASSWORD=$GLOBAL_PW" .env
 			G_CONFIG_INJECT 'FFMPEG_PATH=' "FFMPEG_PATH=$(command -v ffmpeg)" .env
 
-			php artisan koel:init
-			#php artisan db:seed --force
+			$PHP_NAME artisan koel:init
+			#$PHP_NAME artisan db:seed --force
 
 			cd /tmp/$G_PROGRAM_NAME
 
@@ -11358,7 +11369,7 @@ Description=Koel (DietPi)
 User=koel
 Group=dietpi
 WorkingDirectory=$G_FP_DIETPI_USERDATA/koel
-ExecStart=$(command -v php) $G_FP_DIETPI_USERDATA/koel/artisan serve --host 0.0.0.0
+ExecStart=$(command -v $PHP_NAME) $G_FP_DIETPI_USERDATA/koel/artisan serve --host 0.0.0.0
 
 [Install]
 WantedBy=multi-user.target
@@ -12886,7 +12897,7 @@ _EOF_
 
 		fi
 
-		software_id=143
+		software_id=143 # Koel
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
@@ -12894,7 +12905,7 @@ _EOF_
 			if [[ -f '/etc/systemd/system/koel.service' ]]; then
 
 				systemctl disable --now koel
-				rm /etc/systemd/system/koel.service
+				rm -R /etc/systemd/system/koel.service*
 
 			fi
 


### PR DESCRIPTION
**Status**: Ready
- [x] Changelog

**Testing**:
- [x] VM Stretch
- [x] VM Buster
- [x] VM Bullseye

**Commit list/description**:
+ DietPi-Software | Koel: Pull latest version automatically and update dependencies + pull submodules. Use php binary for explicit version, to not accidentally call wrong PHP version in case of multiple PHP installs.
+ DietPi-Software | GitHub serves tar.gz archives, which are usually smaller and faster, theoretically allow UNIX permissions and symlinks. Hence we'll now always use tar.gz archives when downloading archives from GitHub.