### PR TITLE
DietPi-Software | Nextcloud: Revert to v17.0.1 for fresh installs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -45,6 +45,7 @@ Bug Fixes:
 - DietPi-Software | Tor Hotspot: Resolved an issue where, since Buster, Tor fails to start due to deprecated config file entries. Many thanks to @blizarazu for reporting this issue: https://github.com/MichaIng/DietPi/issues/3261
 - DietPi-Software | Allo web GUI: Resolved an issue where web access fails due to wrong permissions. Many thanks to @Heroldgray for reporting this issue: https://github.com/MichaIng/DietPi/issues/3264
 - DietPi-Software | GMediaRender: Resolved an issue where service fails to start due to missing permissions. Many thanks to @fnsnyc for reporting this issue: https://github.com/MichaIng/DietPi/issues/3263
+- DietPi-Software | Nextcloud: Resolved an issue where install fails due to a bug in Nextcloud 17.0.2. DietPi will now install Nextcloud 17.0.1 until the bug has been fixed. Updates from web UI are still possible, this only affects the fresh install. Many thanks to @DevinCharles for reporting this issue: https://github.com/MichaIng/DietPi/issues/3275
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3483,7 +3483,9 @@ _EOF_
 
 				else
 
-					Download_Install 'https://download.nextcloud.com/server/releases/latest.tar.bz2' /var/www
+					# Workaround fresh install bug with Nextcloud v17.0.2: https://github.com/MichaIng/DietPi/issues/3275
+					# Revert after fix: https://download.nextcloud.com/server/releases/latest.tar.bz2
+					Download_Install 'https://download.nextcloud.com/server/releases/nextcloud-17.0.1.tar.bz2' /var/www
 
 				fi
 
@@ -7390,9 +7392,9 @@ location = /.well-known/caldav {
 
 			fi
 
-			# Start MariaDB and Redis for database creation and occ command
+			# Start MariaDB and Redis (required for reinstalls) for database creation and occ command
 			G_RUN_CMD systemctl restart mariadb
-			G_RUN_CMD systemctl start redis-server
+			G_RUN_CMD systemctl restart redis-server
 
 			# Initially add occ command shortcut, will be done by Dietpi-Globals automatically, if occ file exist:
 			occ(){ sudo -u www-data php /var/www/owncloud/occ "$@"; }
@@ -7623,9 +7625,9 @@ location = /.well-known/caldav {
 
 			fi
 
-			# Start MariaDB and Redis for database creation and ncc command
+			# Start MariaDB and Redis (required for reinstalls) for database creation and ncc command
 			G_RUN_CMD systemctl restart mariadb
-			G_RUN_CMD systemctl start redis-server
+			G_RUN_CMD systemctl restart redis-server
 
 			# Initially add occ command shortcut, will be done by Dietpi-Globals automatically, if occ file exist:
 			ncc(){ sudo -u www-data php /var/www/nextcloud/occ "$@"; }


### PR DESCRIPTION
**Status**: Ready
- [x] Changelog

Fixes: https://github.com/MichaIng/DietPi/issues/3275

**Commit list/description**:
+ DietPi-Software | Nextcloud: Revert to v17.0.1 for fresh installs due to a bug introduced with v17.0.2 which breaks "occ maintenance:install": https://github.com/MichaIng/DietPi/issues/3275