### PR TITLE
DietPi-Software | NoMachine: Update to latest version 6.9.2

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,7 @@ Changes / Improvements / Optimisations:
 - DietPi-Software | Amiberry: Since we ship a tailored SDL2 version, this has now been merged right into the Amiberry download archive and install directory, to not interfere with other system-wide installed SDL2 instances.
 - DietPi-Software | Kodi: Add GPU-accelerated support for Odroid N2 via fbdev driver and special Kodi build, provided by Meveric. Many thanks to @ernero93 for doing this request: https://github.com/MichaIng/DietPi/issues/3255
 - DietPi-Software | Koel: The latest upstream release will be pulled automatically now, v4.2.2 at date of writing. Dependencies have been updated accordingly, e.g. latest Koel supports latest Node.js v13.5.0.
++ DietPi-Software | NoMachine: Updated to latest version 6.9.2 and switched to URL with no version string, which allows us to update downloads on-the-fly without code changes. Download URLs from official website have been simplified and follow some logic, but there are no "latest" URLs available and older versions are not kept, hence we must go on hosting those packages on dietpi.com.
 
 Bug Fixes:
 - DietPi-PREP | Resolved an issue, where in rare cases a wrong $PATH variable could break command calls. Many thanks to @dtm2001 for reporting this issue: https://github.com/MichaIng/DietPi/issues/3206

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -430,8 +430,8 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 
 		aSOFTWARE_NAME[$software_id]='NoMachine'
 		aSOFTWARE_DESC[$software_id]='multi-platform server and client access'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=1
 		aSOFTWARE_TYPE[$software_id]=0
+		aSOFTWARE_CATEGORY_INDEX[$software_id]=1
 		aSOFTWARE_REQUIRES_DESKTOP[$software_id]=1
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=2071#p2071'
 		#------------------
@@ -3035,7 +3035,7 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-			Download_Install "https://dietpi.com/downloads/binaries/all/nomachine_6.4.6_$G_HW_ARCH_DESCRIPTION.deb"
+			Download_Install "https://dietpi.com/downloads/binaries/all/nomachine_$G_HW_ARCH_DESCRIPTION.deb"
 
 		fi
 
@@ -12360,7 +12360,7 @@ _EOF_
 
 		fi
 
-		software_id=30
+		software_id=30 # NoMachine
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling


### PR DESCRIPTION
**Status**: WIP
- [x] Changelog
- [x] Update DietPi-Software list wiki entry

**Commit list/description**:
+ DietPi-Software | NoMachine: Updated to latest version 6.9.2 and switched to URL with no version string, which allows us to update downloads on-the-fly without code changes. Download URLs from official website have been simplified and follow some logic, but there are no "latest" URLs available and older versions are not kept, hence we must go on hosting those packages on dietpi.com.