### PR TITLE
DietPi-Boot | Tiny: Using 0.0.0.0/0 is more failsafe in catching default route

### DIFF
--- a/dietpi/boot
+++ b/dietpi/boot
@@ -36,7 +36,7 @@
 
 			G_DIETPI-NOTIFY 2 "$(date) | Waiting for valid network connection before continuing boot | Mode=$boot_wait_for_network"
 
-			if ip r s default &> /dev/null; then
+			if ip r s 0.0.0.0/0 &> /dev/null; then
 
 				G_DIETPI-NOTIFY 0 "$(date) | Valid network connection found"
 				break


### PR DESCRIPTION
+ DietPi-Boot | Tiny: Using 0.0.0.0/0 is more failsafe in catching default route