### PR TITLE
Release v6.28

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,32 @@
+v6.28
+(03/01/20 Hotfix)
+
+Changes / Improvements / Optimisations:
+- DietPi-Software | Home Assistant: The new homeassistant-update.sh script to quickly update your Home Assistant version, now gets execute permissions on install.
+
+Bug Fixes:
+- System | Resolved an issue were the chosen CPU governor was not applied correctly. Many thanks to @bbsixzz for reporting the issue and @Joulinar for providing the solution: https://github.com/MichaIng/DietPi/issues/3299
+- DietPi-Software | Resolved an issue were zip archive extraction failed. Many thanks to @dcallen7 for reporting this issue: https://github.com/MichaIng/DietPi/issues/3300
+- DietPi-Software | phpMyAdmin: Resolved an issue where reinstalls failed if phpMyAdmin was installed prior DietPi v6.27 with Lighttpd or Nginx as webserver. Many thanks to @Nightliss for reporting the issue and @Joulinar for providing the solution: https://github.com/MichaIng/DietPi/issues/3304
+
+Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
+
+Known/Outstanding Issues:
+- DietPi-Config | Enabling WiFi + Ethernet adapters, both on different subnets, breaks WiFi connection in some cases: https://github.com/MichaIng/DietPi/issues/2103
+- RPi | On TigerVNC virtual desktop, LXAppearance hangs on dbus-launch: https://github.com/MichaIng/DietPi/issues/1791
+- Odroid C2 | Some WiFi adapters do no work as hotspot: https://github.com/MichaIng/DietPi/issues/1955
+- Odroid XU4 | Kodi freezes shortly on video playback: https://github.com/MichaIng/DietPi/issues/2584
+- Rock64 | 3.5mm A/V jack is currently not functional: https://github.com/MichaIng/DietPi/issues/2522
+- DietPi-Software | Node-RED: Pre-installed modules cannot be updated via web UI: https://github.com/MichaIng/DietPi/issues/2073
+- DietPi-Software | Raspimjpeg: With Lighttpd, streaming mjpeg does not work: https://github.com/MichaIng/DietPi/issues/1747
+- DietPi-Software | MATE desktop: When logging in as root, desktop items and right-clock context menu is missing: https://github.com/MichaIng/DietPi/issues/3160
+- DietPi-Software | Sonarr/Mono: With current Mono version 6, import to a file system without UNIX permissions support (exFAT, FAT32/vfat and NTFS without "permissions" option) fails, regardless of user/umask mount options: https://github.com/MichaIng/DietPi/issues/3179
+- DietPi-Software | Transmission: On Raspbian/Debian Stretch, RAM usage raises unlimited over time: https://github.com/MichaIng/DietPi/issues/2413
+
+For all additional issues that may appear after release, please see the following link for active tickets: https://github.com/MichaIng/DietPi/issues
+
+-----------------------------------------------------------------------------------------------------------
+
 v6.27
 (01/01/20)
 
@@ -56,20 +85,6 @@ Bug Fixes:
 - DietPi-Software | Redis: Resolved an issue where service start failed in some cases. File logging is now disabled and replaced by journal logging, hence all combined Redis logs are now available via: journalctl -u redis-server. Many thanks to @dankerthrone for reporting this issue: https://github.com/MichaIng/DietPi/issues/3291
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/3290
-
-Known/Outstanding Issues:
-- DietPi-Config | Enabling WiFi + Ethernet adapters, both on different subnets, breaks WiFi connection in some cases: https://github.com/MichaIng/DietPi/issues/2103
-- RPi | On TigerVNC virtual desktop, LXAppearance hangs on dbus-launch: https://github.com/MichaIng/DietPi/issues/1791
-- Odroid C2 | Some WiFi adapters do no work as hotspot: https://github.com/MichaIng/DietPi/issues/1955
-- Odroid XU4 | Kodi freezes shortly on video playback: https://github.com/MichaIng/DietPi/issues/2584
-- Rock64 | 3.5mm A/V jack is currently not functional: https://github.com/MichaIng/DietPi/issues/2522
-- DietPi-Software | Node-RED: Pre-installed modules cannot be updated via web UI: https://github.com/MichaIng/DietPi/issues/2073
-- DietPi-Software | Raspimjpeg: With Lighttpd, streaming mjpeg does not work: https://github.com/MichaIng/DietPi/issues/1747
-- DietPi-Software | MATE desktop: When logging in as root, desktop items and right-clock context menu is missing: https://github.com/MichaIng/DietPi/issues/3160
-- DietPi-Software | Sonarr/Mono: With current Mono version 6, import to a file system without UNIX permissions support (exFAT, FAT32/vfat and NTFS without "permissions" option) fails, regardless of user/umask mount options: https://github.com/MichaIng/DietPi/issues/3179
-- DietPi-Software | Transmission: On Raspbian/Debian Stretch, RAM usage raises unlimited over time: https://github.com/MichaIng/DietPi/issues/2413
-
-For all additional issues that may appear after release, please see the following link for active tickets: https://github.com/MichaIng/DietPi/issues
 
 -----------------------------------------------------------------------------------------------------------
 
@@ -350,8 +365,8 @@ As always, many smaller code performance and stability improvements, visual and 
 
 -----------------------------------------------------------------------------------------------------------
 
-v6.21 (Hotfix)
-(07/02/19)
+v6.21
+(07/02/19 Hotfix)
 
 Changes / Improvements / Optimisations:
 - DietPi-Software | VNC4: Automated VNC password based on $GLOBAL_PW.
@@ -1125,8 +1140,8 @@ Sparky SBC: Added option to select usb-dac-1.1 sound card, which will enable USB
 
 -----------------------------------------------------------------------------------------------------------
 
-v6.1 | Hotfix
-(29/01/18)
+v6.1
+(29/01/18 Hotfix)
 
 Bug Fixes:
 DietPi-Software | Kodi: Resolved failed installation due to libcec package naming. Patched re-install during dietpi-update: https://github.com/MichaIng/DietPi/issues/1428#issuecomment-361092857

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Bug Fixes:
 - System | Resolved an issue were the chosen CPU governor was not applied correctly. Many thanks to @bbsixzz for reporting the issue and @Joulinar for providing the solution: https://github.com/MichaIng/DietPi/issues/3299
 - DietPi-Software | Resolved an issue were zip archive extraction failed. Many thanks to @dcallen7 for reporting this issue: https://github.com/MichaIng/DietPi/issues/3300
 - DietPi-Software | phpMyAdmin: Resolved an issue where reinstalls failed if phpMyAdmin was installed prior DietPi v6.27 with Lighttpd or Nginx as webserver. Many thanks to @Nightliss for reporting the issue and @Joulinar for providing the solution: https://github.com/MichaIng/DietPi/issues/3304
+- DietPi-Software | Home Assistant: Resolved an issue where the service failed to start if prior to reinstall the data dir permissions were not correctly. Many thanks to @huettenwirt for reporting this issue: https://github.com/MichaIng/DietPi/issues/3219#issuecomment-570582486
 
 Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,13 +2,13 @@ v6.28
 (03/01/20 Hotfix)
 
 Changes / Improvements / Optimisations:
-- DietPi-Software | Home Assistant: The new homeassistant-update.sh script to quickly update your Home Assistant version, now gets execute permissions on install.
+- DietPi-Software | Home Assistant: The new homeassistant-update.sh script, for quickly updating your Home Assistant version, now gets execute permissions on install.
 
 Bug Fixes:
 - System | Resolved an issue were the chosen CPU governor was not applied correctly. Many thanks to @bbsixzz for reporting the issue and @Joulinar for providing the solution: https://github.com/MichaIng/DietPi/issues/3299
 - DietPi-Software | Resolved an issue were zip archive extraction failed. Many thanks to @dcallen7 for reporting this issue: https://github.com/MichaIng/DietPi/issues/3300
 - DietPi-Software | phpMyAdmin: Resolved an issue where reinstalls failed if phpMyAdmin was installed prior DietPi v6.27 with Lighttpd or Nginx as webserver. Many thanks to @Nightliss for reporting the issue and @Joulinar for providing the solution: https://github.com/MichaIng/DietPi/issues/3304
-- DietPi-Software | Home Assistant: Resolved an issue where the service failed to start if prior to reinstall the data dir permissions were not correctly. Many thanks to @huettenwirt for reporting this issue: https://github.com/MichaIng/DietPi/issues/3219#issuecomment-570582486
+- DietPi-Software | Home Assistant: Resolved an issue where the service failed to start if prior to reinstall the data dir permissions were not set correctly. Many thanks to @huettenwirt for reporting this issue: https://github.com/MichaIng/DietPi/issues/3219#issuecomment-570582486
 
 Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3284,7 +3284,7 @@ Package: openssl libssl*\nPin: origin packages.sury.org\nPin-Priority: -1' > /et
 			Download_Install "https://files.phpmyadmin.net/phpMyAdmin/$version/phpMyAdmin-$version-english.tar.gz"
 			# - Reinstall: Clean install but preserve existing config file
 			[[ -f '/var/www/phpmyadmin/config.inc.php' ]] && G_RUN_CMD mv /var/www/phpmyadmin/config.inc.php phpMyAdmin-*-english/
-			[[ -d '/var/www/phpmyadmin' ]] && G_RUN_CMD rm -R /var/www/phpmyadmin
+			G_RUN_CMD rm -Rf /var/www/phpmyadmin # Include pre-v6.27 symlink: https://github.com/MichaIng/DietPi/issues/3304
 			# - Remove GUI setup: https://docs.phpmyadmin.net/en/latest/setup.html#securing-your-phpmyadmin-installation
 			rm -R phpMyAdmin-*-english/setup
 			# - Move new instance in place

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6593,6 +6593,7 @@ hass -c '$G_FP_DIETPI_USERDATA/homeassistant'" > $ha_home/homeassistant-start.sh
 			# Generate script to update HA within pyenv
 			echo "#!/bin/dash
 sudo -u $ha_user dash -c '$ha_pyenv_activation; pip3 install -U homeassistant'" > $ha_home/homeassistant-update.sh
+			chmod +x $ha_home/homeassistant-update.sh
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11693,6 +11693,7 @@ Description=Roon Server (DietPi)
 After=network.target
 
 [Service]
+SyslogIdentifier=roonserver
 Environment=ROON_DATAROOT=$G_FP_DIETPI_USERDATA/roonserver
 ExecStart=$G_FP_DIETPI_USERDATA/roonserver/start.sh
 
@@ -11730,6 +11731,7 @@ Wants=network-online.target
 After=network-online.target mariadb.service
 
 [Service]
+SyslogIdentifier=homeassistant
 User=homeassistant
 ExecStart=/home/homeassistant/homeassistant-start.sh
 
@@ -11745,11 +11747,11 @@ _EOF_
 
 				[[ -d '/home/homeassistant/.homeassistant' ]] && mv /home/homeassistant/.homeassistant $G_FP_DIETPI_USERDATA/homeassistant
 				mkdir -p $G_FP_DIETPI_USERDATA/homeassistant
-				chown -R homeassistant:homeassistant $G_FP_DIETPI_USERDATA/homeassistant
 
 			fi
 			rm -Rf /home/homeassistant/.homeassistant
 			ln -s $G_FP_DIETPI_USERDATA/homeassistant /home/homeassistant/.homeassistant
+			chown -R homeassistant:homeassistant $G_FP_DIETPI_USERDATA/homeassistant
 
 		fi
 
@@ -11837,6 +11839,7 @@ _EOF_
 Description=nukkit (DietPi)
 
 [Service]
+SyslogIdentifier=Nukkit
 WorkingDirectory=/usr/local/bin/nukkit
 ExecStart=/bin/bash -c 'java -jar /usr/local/bin/nukkit/nukkit.jar'
 

--- a/dietpi/func/dietpi-set_cpu
+++ b/dietpi/func/dietpi-set_cpu
@@ -69,7 +69,7 @@
 
 		# Apply governor
 		local i
-		for i in /sys/devices/system/cpu/cpu[0-9]*/cpufreq/scaling_available_governors
+		for i in /sys/devices/system/cpu/cpu[0-9]*/cpufreq/scaling_governor
 		do
 
 			echo $CPU_GOVERNOR > $i


### PR DESCRIPTION
### v6.28
_(03/01/20 Hotfix)_

#### Changes / Improvements / Optimisations
- DietPi-Software | Home Assistant: The new homeassistant-update.sh script, for quickly updating your Home Assistant version, now gets execute permissions on install.

#### Bug Fixes
- System | Resolved an issue were the chosen CPU governor was not applied correctly. Many thanks to @bbsixzz for reporting the issue and @Joulinar for providing the solution: https://github.com/MichaIng/DietPi/issues/3299
- DietPi-Software | Resolved an issue were zip archive extraction failed. Many thanks to @dcallen7 for reporting this issue: https://github.com/MichaIng/DietPi/issues/3300
- DietPi-Software | phpMyAdmin: Resolved an issue where reinstalls failed if phpMyAdmin was installed prior DietPi v6.27 with Lighttpd or Nginx as webserver. Many thanks to @Nightliss for reporting the issue and @Joulinar for providing the solution: https://github.com/MichaIng/DietPi/issues/3304
- DietPi-Software | Home Assistant: Resolved an issue where the service failed to start if prior to reinstall the data dir permissions were not set correctly. Many thanks to @huettenwirt for reporting this issue: https://github.com/MichaIng/DietPi/issues/3219#issuecomment-570582486