### PR TITLE
DietPi-Drive_Manager | Preserve glusterfs fstab entries

### DIFF
--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -135,8 +135,8 @@ tmpfs /var/log tmpfs size=${var_log_size:-50}M,noatime,lazytime,nodev,nosuid,mod
 
 			swap_mounts=$(grep '^[[:blank:]]*[^#].*[[:blank:]]swap[[:blank:]]' $fp_fstab_tmp)
 			tmpfs_mounts=$(grep '^[[:blank:]]*tmpfs[[:blank:]]' $fp_fstab_tmp)
-			# ecryptfs, vboxsf, bind mounts
-			misc_mounts=$(grep -E '^[[:blank:]]*[^#].*([[:blank:]](ecryptfs|vboxsf)[[:blank:]]|[[:blank:],]bind[[:blank:],])' $fp_fstab_tmp)
+			# ecryptfs, vboxsf, glusterfs, bind mounts
+			misc_mounts=$(grep -E '^[[:blank:]]*[^#].*([[:blank:]](ecryptfs|vboxsf|glusterfs)[[:blank:]]|[[:blank:],]bind[[:blank:],])' $fp_fstab_tmp)
 			# CurlFtpFS, CIFS/SMB/Samba, NFS
 			net_mounts=$(grep -E '^[[:blank:]]*(curlftpfs|[^#].*[[:blank:]](cifs|nfs4?)[[:blank:]])' $fp_fstab_tmp)
 
@@ -154,7 +154,7 @@ $net_mounts
 $tmpfs_mounts
 
 #----------------------------------------------------------------
-# MISC: ecryptfs, vboxsf (VirtualBox shared folder), bind mounts
+# MISC: ecryptfs, vboxsf (VirtualBox shared folder), gluster, bind mounts
 #----------------------------------------------------------------
 $misc_mounts
 


### PR DESCRIPTION
**Status**: Ready

**Reference**: https://github.com/MichaIng/DietPi/issues/3374

**Commit list/description**:
- DietPi-Drive_Manager | Preserve glusterfs fstab entries: 