### PR TITLE
DietPi-Software | MPD and myMPD: Several smaller updates

### DIFF
--- a/.conf/dps_128/mpd.conf
+++ b/.conf/dps_128/mpd.conf
@@ -2,13 +2,13 @@ music_directory "/mnt/dietpi_userdata/Music"
 playlist_directory "/mnt/dietpi_userdata/Music"
 db_file "/mnt/dietpi_userdata/.mpd_cache/db_file"
 log_file "/var/log/mpd/mpd.log"
-pid_file "/var/run/mpd/pid"
+pid_file "/run/mpd/pid"
 state_file "/mnt/dietpi_userdata/.mpd_cache/state"
 sticker_file "/mnt/dietpi_userdata/.mpd_cache/sticker.sql"
 
-#user "mpd" #Set via service to allow for mpd user to use assigned groups "audio" and "dietpi"
-#group "dietpi" #Set via service to allow for mpd user to use assigned groups "audio" and "dietpi"
+#user "mpd" # Set via systemd unit to preserve supplementary group permissions: "audio" "render" "dietpi"
 
+bind_to_address "/run/mpd/socket"
 bind_to_address "localhost"
 
 log_level "default"
@@ -45,12 +45,12 @@ max_connections "4"
 filesystem_charset "UTF-8"
 id3v1_encoding "UTF-8"
 
-#Audio Output / Processing
+# Audio Output / Processing
 
-#Disabled to allow native DSD output
-# replaygain "track"
-# replaygain_preamp "8"
-# volume_normalization "yes"
+# Disabled to allow native DSD output
+#replaygain "track"
+#replaygain_preamp "8"
+#volume_normalization "yes"
 
 audio_buffer_size "2048"
 #buffer_before_play "10%"
@@ -70,6 +70,6 @@ dop "no"
 
 }
 
-#Realtime audio conversion & upscaling
+# Realtime audio conversion & upscaling
 #audio_output_format "48000:16:2"
 #samplerate_converter "soxr very high"

--- a/.conf/dps_128/mpd.conf
+++ b/.conf/dps_128/mpd.conf
@@ -6,7 +6,7 @@ pid_file "/run/mpd/pid"
 state_file "/mnt/dietpi_userdata/.mpd_cache/state"
 sticker_file "/mnt/dietpi_userdata/.mpd_cache/sticker.sql"
 
-#user "mpd" # Set via systemd unit to preserve supplementary group permissions: "audio" "render" "dietpi"
+#user "mpd" # Set via systemd unit to preserve supplementary group permissions i.e. "dietpi" group
 
 bind_to_address "/run/mpd/socket"
 bind_to_address "localhost"

--- a/.conf/dps_128/mpd.conf
+++ b/.conf/dps_128/mpd.conf
@@ -43,7 +43,6 @@ max_connections "4"
 #max_output_buffer_size "8192"
 
 filesystem_charset "UTF-8"
-id3v1_encoding "UTF-8"
 
 # Audio Output / Processing
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,12 +7,15 @@ Changes / Improvements / Optimisations:
 - DietPi-Drive_Manager | GlusterFS fstab entries are now preserved. Many thanks to @Sudrien for implementing this addition: https://github.com/MichaIng/DietPi/issues/3374
 - DietPi-Software | phpBB: Updated to v3.3.0 which has PHP7.3 support, hence can be installed on all hardware models and distro versions.
 - DietPi-Software | Chromium: Unlocked install on ARMv6 RPi models: RPi1/Zero/Zero W. Browsing performance will not be perfect, but for kiosk mode or light usage there are use cases. Many thanks to @kmplngj for requesting and testing: https://github.com/MichaIng/DietPi/issues/3364
+- DietPi-Software | myMPD: Updated installer according to next upstream release v6.2.0. Many thanks to @jcorporation for informing us about the new version: https://github.com/MichaIng/DietPi/issues/3382
+- DietPi-Software | MPD: Assured that UNIX domain socket and systemd unit for socket activation is present on Stretch systems. As well the obsolete cache dir symlinks in "/var/lib/mpd" will not be present anymore. Any custom scripts must use the absolute paths in "/mnt/dietpi_userdata/.mpd_cache" from now on.
 
 Bug Fixes:
 - DietPi-Banner | Resolved an issue where clearing the screen fails due to missing G_TERM_CLEAR command. Many thanks to @Joulinar for reporting this issue: https://github.com/MichaIng/DietPi/issues/3313
 - DietPi-Config | Resolved an issue where, on RPi with vc4-fkms-v3d overlay/driver enabled, soundcard selection went wrong. Many thanks to @Cybolic for reporting this issue: https://github.com/MichaIng/DietPi/issues/3356
 - DietPi-Software | Resolved an issue where extraction of zip archives to current directory failed. Many thanks to @en0rism for reporting this issue: https://github.com/MichaIng/DietPi/issues/3320
 - DietPi-Software | Redis: Resolved an issue where service start fails on Stretch systems. Many thanks to @drieksje for reporting this issue: https://github.com/MichaIng/DietPi/issues/3314
+- DietPi-Software | myMPD: Resolved MPD connection issues on Stetch systems. Many thanks to @jcorporation for informing us on upstream changes, helping with debug and fixing the issues: https://github.com/MichaIng/DietPi/issues/3382
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7987,7 +7987,7 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 			# - Remove obsolete cache dir, preserve previous music and playlists, in case of an existing custom install
 			[[ ! -e '/var/lib/mpd/music' || -L '/var/lib/mpd/music' ]] || mv -n /var/lib/mpd/music/* $G_FP_DIETPI_USERDATA/$FOLDER_MUSIC/ &> /dev/null
 			[[ ! -e '/var/lib/mpd/playlists' || -L '/var/lib/mpd/playlists' ]] || mv -n /var/lib/mpd/playlists/* $G_FP_DIETPI_USERDATA/$FOLDER_MUSIC/ &> /dev/null
-			rm -R /var/lib/mpd
+			[[ -d '/var/lib/mpd' ]] && rm -R /var/lib/mpd
 
 			# Config
 			G_BACKUP_FP /etc/mpd.conf
@@ -8036,7 +8036,7 @@ RestrictNamespaces=yes
 WantedBy=multi-user.target
 Also=mpd.socket
 _EOF_
-			# - systemd socket, not shipped by our custom package
+			# - systemd socket activation, not shipped by our custom package
 			[[ -f '/lib/systemd/system/mpd.socket' ]] || cat << _EOF_ > /lib/systemd/system/mpd.socket
 [Socket]
 ListenStream=/run/mpd/socket

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8170,8 +8170,7 @@ _EOF_
 			if [[ ! -f '/etc/mympd.conf.dist' ]]; then
 
 				G_CONFIG_INJECT 'host[[:blank:]]*=' 'host = /run/mpd/socket' /etc/mympd.conf '^\[mpd\]'
-				# https://github.com/MichaIng/DietPi/issues/3382#issuecomment-586631818
-				#G_CONFIG_INJECT 'playlistdirectory[[:blank:]]*=' "playlistdirectory = $G_FP_DIETPI_USERDATA/Music" /etc/mympd.conf '^\[mpd\]'
+				G_CONFIG_INJECT 'playlistdirectory[[:blank:]]*=' "playlistdirectory = $G_FP_DIETPI_USERDATA/Music" /etc/mympd.conf '^\[mpd\]'
 				G_CONFIG_INJECT 'webport[[:blank:]]*=' 'webport = 1333' /etc/mympd.conf '^\[webserver\]'
 				G_CONFIG_INJECT 'ssl[[:blank:]]*=' 'ssl = false' /etc/mympd.conf '^\[webserver\]'
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8039,7 +8039,7 @@ _EOF_
 			# - systemd socket, not shipped by our custom package
 			[[ -f '/lib/systemd/system/mpd.socket' ]] || cat << _EOF_ > /lib/systemd/system/mpd.socket
 [Socket]
-ListenStream=%t/mpd/socket
+ListenStream=/run/mpd/socket
 ListenStream=6600
 Backlog=5
 KeepAlive=true

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -640,8 +640,8 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 
 		aSOFTWARE_NAME[$software_id]='MPD'
 		aSOFTWARE_DESC[$software_id]='music player daemon'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
 		aSOFTWARE_TYPE[$software_id]=0
+		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
 		#aSOFTWARE_ONLINEDOC_URL[$software_id]
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		#------------------
@@ -7974,65 +7974,48 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 
 			Banner_Configuration
 
-			# Create MPD user
+			# User
 			local usercmd='useradd -rMU'
 			getent passwd mpd &> /dev/null && usercmd='usermod -a'
 			$usercmd -G dietpi,audio -d $G_FP_DIETPI_USERDATA/.mpd_cache -s $(command -v nologin) mpd
 			# - Add to new "render" group on Buster
-			(( $G_DISTRO > 4 )) && usermod -aG render mpd
+			getent group render &> /dev/null && usermod -aG render mpd
 
-			# Runtime dirs/files
-			# - Log
-			mkdir -p /var/log/mpd
-			>> /var/log/mpd/mpd.log
-			# - Cache
-			mkdir -p $G_FP_DIETPI_USERDATA/.mpd_cache
-			>> $G_FP_DIETPI_USERDATA/.mpd_cache/db_file
-			>> $G_FP_DIETPI_USERDATA/.mpd_cache/state
-			>> $G_FP_DIETPI_USERDATA/.mpd_cache/sticker.sql
-			# - Symlink from MPD defaults that applications may still expect/use.
+			# Dirs
+			# - Purge old log and cache
+			rm -R /var/log/mpd $G_FP_DIETPI_USERDATA/.mpd_cache
+			# - Recreate log and cache dirs
+			mkdir -p /var/log/mpd $G_FP_DIETPI_USERDATA/.mpd_cache
+			# - Remove obsolete cache dir, preserve previous music and playlists, in case of an existing custom install
 			[[ ! -e '/var/lib/mpd/music' || -L '/var/lib/mpd/music' ]] || mv -n /var/lib/mpd/music/* $G_FP_DIETPI_USERDATA/$FOLDER_MUSIC/ &> /dev/null
 			[[ ! -e '/var/lib/mpd/playlists' || -L '/var/lib/mpd/playlists' ]] || mv -n /var/lib/mpd/playlists/* $G_FP_DIETPI_USERDATA/$FOLDER_MUSIC/ &> /dev/null
-			[[ ! -e '/var/lib/mpd/mpd.db' || -L '/var/lib/mpd/mpd.db' ]] || mv -n /var/lib/mpd/mpd.db $G_FP_DIETPI_USERDATA/.mpd_cache/db_file
-			[[ ! -e '/var/lib/mpd/state' || -L '/var/lib/mpd/state' ]] || mv -n /var/lib/mpd/state $G_FP_DIETPI_USERDATA/.mpd_cache/state
-			[[ ! -e '/var/lib/mpd/sticker.sql' || -L '/var/lib/mpd/sticker.sql' ]] || mv -n /var/lib/mpd/sticker.sql $G_FP_DIETPI_USERDATA/.mpd_cache/sticker.sql
-			[[ -d '/var/lib/mpd' ]] && rm -R /var/lib/mpd
-			mkdir -p /var/lib/mpd
-			ln -sf $G_FP_DIETPI_USERDATA/$FOLDER_MUSIC /var/lib/mpd/music
-			ln -sf $G_FP_DIETPI_USERDATA/$FOLDER_MUSIC /var/lib/mpd/playlists
-			ln -sf $G_FP_DIETPI_USERDATA/.mpd_cache/db_file /var/lib/mpd/mpd.db
-			ln -sf $G_FP_DIETPI_USERDATA/.mpd_cache/state /var/lib/mpd/state
-			ln -sf $G_FP_DIETPI_USERDATA/.mpd_cache/sticker.sql /var/lib/mpd/sticker.sql
+			rm -R /var/lib/mpd
 
-			# Default config
+			# Config
 			G_BACKUP_FP /etc/mpd.conf
 			dps_index=$software_id Download_Install 'mpd.conf' /etc/mpd.conf
-			# - On Stretch (custom build), symlink /etc/mpd.conf to /usr/local/etc/mpd.conf, where /usr/local/bin/mpd by default searches
-			if [[ $(command -v mpd) == '/usr/local/bin/mpd' ]]; then
 
-				mkdir -p /usr/local/etc
-				ln -sf /etc/mpd.conf /usr/local/etc/mpd.conf
-
-			fi
-
-			# MPD service/confs
+			# Service
+			# - Remove obsolete sysvinit service and config
+			[[ -f '/etc/init.d/mpd' ]] && rm /etc/init.d/mpd
+			update-rc.d -f mpd remove
 			[[ -f '/etc/default/mpd' ]] && rm /etc/default/mpd
-
 			# - Upstream systemd unit: https://github.com/MusicPlayerDaemon/MPD/blob/master/systemd/system/mpd.service.in
 			# - Debian package systemd unit: https://deb.debian.org/debian/pool/main/m/mpd/
+			# - Run systemd unit as mpd user instead of using config-file based user change, to preserve supplementary group permissions (i.e. dietpi)
+			# - Define config file explicitly, since custom /usr/local/bin/mpd binary searches for /usr/local/etc/mpd.conf by default
 			cat << _EOF_ > /lib/systemd/system/mpd.service
 [Unit]
 Description=Music Player Daemon (DietPi)
 Documentation=man:mpd(1) man:mpd.conf(5)
-Documentation=file:///usr/share/doc/mpd/user-manual.html
 After=network.target sound.target
 
 [Service]
+Type=notify
 User=mpd
-#Group=dietpi # Do not change, use system assigned groups, requires both dietpi and audio groups
 PermissionsStartOnly=true
 ExecStartPre=$(command -v mkdir) -p /run/mpd
-ExecStartPre=$(command -v chown) -R mpd:dietpi /run/mpd
+ExecStartPre=$(command -v chown) -R mpd:mpd /run/mpd
 ExecStart=$(command -v mpd) --no-daemon /etc/mpd.conf
 
 # allow MPD to use real-time priority 50
@@ -8055,9 +8038,21 @@ RestrictNamespaces=yes
 WantedBy=multi-user.target
 Also=mpd.socket
 _EOF_
+			# - systemd socket, not shipped by our custom package
+			[[ -f '/lib/systemd/system/mpd.socket' ]] || cat << _EOF_ > /lib/systemd/system/mpd.socket
+[Socket]
+ListenStream=%t/mpd/socket
+ListenStream=6600
+Backlog=5
+KeepAlive=true
+PassCredentials=true
+
+[Install]
+WantedBy=sockets.target
+_EOF_
 
 			# JustBoom specials
-			if grep -qi '^[[:blank:]]*CONFIG_SOUNDCARD=justboom' /DietPi/dietpi.txt; then
+			if grep -q '^[[:blank:]]*CONFIG_SOUNDCARD=justboom' /DietPi/dietpi.txt; then
 
 				# Name displayed in YMPD sound button
 				local justboom_soundcard_desc='JustBoom DietPi'
@@ -8072,17 +8067,15 @@ _EOF_
 
 				# Set SOXR quality
 				# - All RPi's can handle SOXR VH @ 192khz 32bit: https://github.com/MichaIng/DietPi/issues/581#issuecomment-256643079
-				G_CONFIG_INJECT 'samplerate_converter "' 'samplerate_converter "soxr very high"' /etc/mpd.conf #highest
+				G_CONFIG_INJECT 'samplerate_converter "' 'samplerate_converter "soxr very high"' /etc/mpd.conf # highest
 
 			fi
 
-			# Grab our test music for the user.
+			# Grab our test music for the user
 			Download_Test_Media
 
 			# Permissions
-			chmod 0664 /var/log/mpd/mpd.log /etc/mpd.conf
-			chmod -R 775 $G_FP_DIETPI_USERDATA/.mpd_cache
-			chown -R mpd:dietpi /etc/mpd.conf /var/log/mpd $G_FP_DIETPI_USERDATA/.mpd_cache
+			chown -R mpd:mpd /var/log/mpd $G_FP_DIETPI_USERDATA/.mpd_cache /etc/mpd.conf
 
 		fi
 
@@ -12597,17 +12590,25 @@ _EOF_
 
 		fi
 
-		software_id=128
+		software_id=128 # MPD
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
+			if [[ -f '/lib/systemd/system/mpd.service' ]]; then
+
+				systemctl unmask mpd
+				systemctl disable --now mpd
+				rm -R /lib/systemd/system/mpd.service*
+
+			fi
+			[[ -f '/lib/systemd/system/mpd.socket' ]] && rm /lib/systemd/system/mpd.socket
+			getent passwd mpd &> /dev/null && userdel -rf mpd
 			#apt-mark auto libavformat57 libupnp6 libao-common libao4 libasound2 libasound2-data libasyncns0 libaudiofile1 libavahi-client3 libavahi-common-data libavahi-common3 libavcodec56 libavformat56 libavresample2 libavutil54 libbinio1ldbl libcaca0 libcdio-cdda1 libcdio-paranoia1 libcdio13 libcups2 libcurl3-gnutls libdirectfb-1.2-9 libdnet libfaad2 libflac8 libfluidsynth1 libgme0 libgomp1 libgsm1 libice6 libid3tag0 libiso9660-8 libjack-jackd2-0 libjson-c2 libldb1 libmad0 libmikmod3 libmms0 libmodplug1 libmp3lame0 libmpcdec6 libmpg123-0 libnfs4 libntdb1 libogg0 libopenal-data libopenal1 libopenjpeg5 libopus0 liborc-0.4-0 libpulse0 libresid-builder0c2a libroar2 libsamplerate0 libschroedinger-1.0-0 libsdl1.2debian libshout3 libsidplay2 libsidutils0 libslp1 libsm6 libsmbclient libsndfile1 libsoxr0 libspeex1 libspeexdsp1 libsqlite3-0 libtalloc2 libtdb1 libtevent0 libtheora0 libva1 libvorbis0a libvorbisenc2 libvorbisfile3 libvpx1 libwavpack1 libwbclient0 libwildmidi-config libwildmidi1 libx11-6 libx11-data libx11-xcb1 libx264-142 libxau6 libxcb1 libxdmcp6 libxext6 libxi6 libxtst6 libxvidcore4 libyajl2 libzzip-0-13 mime-support python python-talloc python2.7 samba-libs x11-common file &> /dev/null
 			G_AGP mpd libmpdclient2
-			getent passwd mpd &> /dev/null && userdel -rf mpd
-			[[ -f '/lib/systemd/system/mpd.service' ]] && rm /lib/systemd/system/mpd.service
+			[[ -d '/var/log/mpd' ]] && rm -R /var/log/mpd
 			[[ -d $G_FP_DIETPI_USERDATA/.mpd_cache ]] && rm -R $G_FP_DIETPI_USERDATA/.mpd_cache
-			[[ -f '/usr/local/etc/mpd.conf' ]] && rm /usr/local/etc/mpd.conf && rmdir --ignore-fail-on-non-empty /usr/local/etc
 			[[ -f '/etc/mpd.conf' ]] && rm /etc/mpd.conf
+			[[ -f '/usr/local/etc/mpd.conf' ]] && rm /usr/local/etc/mpd.conf && rmdir --ignore-fail-on-non-empty /usr/local/etc # Pre-v6.29
 			[[ -f '/etc/default/mpd' ]] && rm /etc/default/mpd # pre-v6.20
 
 		fi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8169,8 +8169,11 @@ _EOF_
 			# - On reinstall /etc/mympd/mympd.conf.dist will be created, so use its existence as reinstall flag
 			if [[ ! -f '/etc/mympd.conf.dist' ]]; then
 
-				G_CONFIG_INJECT 'webport[[:blank:]]*=' 'webport = 1333' /etc/mympd.conf
-				G_CONFIG_INJECT 'ssl[[:blank:]]*=' 'ssl = false' /etc/mympd.conf
+				G_CONFIG_INJECT 'host[[:blank:]]*=' 'host = /run/mpd/socket' /etc/mympd.conf '^\[mpd\]'
+				# https://github.com/MichaIng/DietPi/issues/3382#issuecomment-586631818
+				#G_CONFIG_INJECT 'playlistdirectory[[:blank:]]*=' "playlistdirectory = $G_FP_DIETPI_USERDATA/Music" /etc/mympd.conf '^\[mpd\]'
+				G_CONFIG_INJECT 'webport[[:blank:]]*=' 'webport = 1333' /etc/mympd.conf '^\[webserver\]'
+				G_CONFIG_INJECT 'ssl[[:blank:]]*=' 'ssl = false' /etc/mympd.conf '^\[webserver\]'
 
 			fi
 
@@ -12582,8 +12585,9 @@ _EOF_
 
 			fi
 			getent passwd mympd &> /dev/null && userdel -rf mympd
+			getent group mympd &> /dev/null && groupdel mympd # pre-v6.29
 			command -v mympd &> /dev/null && rm $(command -v mympd)
-			rm -Rf /{etc,var/lib,usr/share}/mympd
+			rm -Rf /{etc,var/lib,usr/share}/mympd /etc/mympd.conf*
 			rm -f /usr/share/man/man1/mympd.*
 
 		fi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3511,12 +3511,13 @@ _EOF_
 
 			Banner_Installing
 
-			# Sourcebuild pre-reqs: https://github.com/jcorporation/myMPD#dependencies
-			DEPS_LIST='libmpdclient2 libmediainfo0v5 cmake cppcheck pkg-config libmpdclient-dev libssl-dev libmediainfo-dev'
+			# Download source
 			Download_Install 'https://github.com/jcorporation/myMPD/archive/master.tar.gz'
-
+			# Install dependencies, build and install myMPD
 			cd myMPD-master
+			G_RUN_CMD ./build.sh installdeps
 			G_RUN_CMD ./build.sh releaseinstall
+			# Cleanup
 			cd /tmp/$G_PROGRAM_NAME
 			rm -R myMPD-master
 
@@ -8168,10 +8169,10 @@ _EOF_
 
 			Banner_Configuration
 
-			# Add user to "dietpi" group
-			usermod -aG dietpi mympd
-			# Add to new "render" group on Buster
-			(( $G_DISTRO > 4 )) && usermod -aG render mympd
+			# Use primary group "dietpi" to allow media access and create media files with "dietpi" group:
+			# - https://github.com/MichaIng/DietPi/issues/3382
+			usermod -g dietpi mympd
+			getent group mympd &> /dev/null && delgroup mympd
 
 			# Adjust config file on fresh install
 			# - On reinstall /etc/mympd/mympd.conf.dist will be created, so use its existence as reinstall flag
@@ -12586,7 +12587,7 @@ _EOF_
 
 				systemctl unmask mympd
 				systemctl disable --now mympd
-				rm /lib/systemd/system/mympd.service
+				rm -R /lib/systemd/system/mympd.service*
 
 			fi
 			getent passwd mympd &> /dev/null && userdel -rf mympd

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7975,15 +7975,13 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 			Banner_Configuration
 
 			# User
-			local usercmd='useradd -rMU'
+			local usercmd='useradd -rNM'
 			getent passwd mpd &> /dev/null && usercmd='usermod -a'
-			$usercmd -G dietpi,audio -d $G_FP_DIETPI_USERDATA/.mpd_cache -s $(command -v nologin) mpd
-			# - Add to new "render" group on Buster
-			getent group render &> /dev/null && usermod -aG render mpd
+			$usercmd -G dietpi -g audio -d $G_FP_DIETPI_USERDATA/.mpd_cache -s $(command -v nologin) mpd
 
 			# Dirs
 			# - Purge old log and cache
-			rm -R /var/log/mpd $G_FP_DIETPI_USERDATA/.mpd_cache
+			rm -Rf /var/log/mpd $G_FP_DIETPI_USERDATA/.mpd_cache
 			# - Recreate log and cache dirs
 			mkdir -p /var/log/mpd $G_FP_DIETPI_USERDATA/.mpd_cache
 			# - Remove obsolete cache dir, preserve previous music and playlists, in case of an existing custom install
@@ -8015,7 +8013,7 @@ Type=notify
 User=mpd
 PermissionsStartOnly=true
 ExecStartPre=$(command -v mkdir) -p /run/mpd
-ExecStartPre=$(command -v chown) -R mpd:mpd /run/mpd
+ExecStartPre=$(command -v chown) -R mpd: /run/mpd
 ExecStart=$(command -v mpd) --no-daemon /etc/mpd.conf
 
 # allow MPD to use real-time priority 50
@@ -8075,7 +8073,7 @@ _EOF_
 			Download_Test_Media
 
 			# Permissions
-			chown -R mpd:mpd /var/log/mpd $G_FP_DIETPI_USERDATA/.mpd_cache /etc/mpd.conf
+			chown -R mpd: /var/log/mpd $G_FP_DIETPI_USERDATA/.mpd_cache /etc/mpd.conf
 
 		fi
 
@@ -12603,6 +12601,7 @@ _EOF_
 			fi
 			[[ -f '/lib/systemd/system/mpd.socket' ]] && rm /lib/systemd/system/mpd.socket
 			getent passwd mpd &> /dev/null && userdel -rf mpd
+			getent group mpd &> /dev/null && groupdel mpd # pre-v6.29
 			#apt-mark auto libavformat57 libupnp6 libao-common libao4 libasound2 libasound2-data libasyncns0 libaudiofile1 libavahi-client3 libavahi-common-data libavahi-common3 libavcodec56 libavformat56 libavresample2 libavutil54 libbinio1ldbl libcaca0 libcdio-cdda1 libcdio-paranoia1 libcdio13 libcups2 libcurl3-gnutls libdirectfb-1.2-9 libdnet libfaad2 libflac8 libfluidsynth1 libgme0 libgomp1 libgsm1 libice6 libid3tag0 libiso9660-8 libjack-jackd2-0 libjson-c2 libldb1 libmad0 libmikmod3 libmms0 libmodplug1 libmp3lame0 libmpcdec6 libmpg123-0 libnfs4 libntdb1 libogg0 libopenal-data libopenal1 libopenjpeg5 libopus0 liborc-0.4-0 libpulse0 libresid-builder0c2a libroar2 libsamplerate0 libschroedinger-1.0-0 libsdl1.2debian libshout3 libsidplay2 libsidutils0 libslp1 libsm6 libsmbclient libsndfile1 libsoxr0 libspeex1 libspeexdsp1 libsqlite3-0 libtalloc2 libtdb1 libtevent0 libtheora0 libva1 libvorbis0a libvorbisenc2 libvorbisfile3 libvpx1 libwavpack1 libwbclient0 libwildmidi-config libwildmidi1 libx11-6 libx11-data libx11-xcb1 libx264-142 libxau6 libxcb1 libxdmcp6 libxext6 libxi6 libxtst6 libxvidcore4 libyajl2 libzzip-0-13 mime-support python python-talloc python2.7 samba-libs x11-common file &> /dev/null
 			G_AGP mpd libmpdclient2
 			[[ -d '/var/log/mpd' ]] && rm -R /var/log/mpd


### PR DESCRIPTION
**Status**: Ready
- [x] Changelog

**Testing**:
- [x] Stretch
- [x] Buster
- [x] Bullseye

**Fixes: #3382**

**Commit list/description**:
+ DietPi-Software | myMPD: Re-assure that service runs with "dietpi" as primary group, since new webdav feature allows to push media to server. Remove now unused "mympd" group: https://github.com/MichaIng/DietPi/issues/3382
+ DietPi-Software | myMPD: Use new (?) installdeps build command to satisfy dependencies
+ DietPi-Software | myMPD: Do not add user to "render" group, which has no point here
+ DietPi-Software | myMPD: Assure that on uninstall all custom/dietpi-services systemd unit drop-ins are removed as well