### PR TITLE
Images | Add Pine H64 and ROCK Pi S support

### DIFF
--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -38,6 +38,7 @@
 	aHW_NAME[42]='RockPro64'
 	aHW_NAME[43]='Rock64'
 	aHW_NAME[44]='Pinebook A64'
+	aHW_NAME[45]='Pine H64'
 	aHW_NAME[50]='BananaPi M2+ (sinovoip)'
 	aHW_NAME[51]='BananaPi Pro (Lemaker)'
 	aHW_NAME[52]='Asus Tinker Board'
@@ -57,6 +58,7 @@
 	aHW_NAME[70]='Sparky SBC'
 	aHW_NAME[71]='Beagle Bone Black'
 	aHW_NAME[72]='ROCK Pi 4'
+	aHW_NAME[73]='ROCK Pi S'
 
 	# Core Benchmarks
 	aBENCH_CPU_INDEX=()

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,8 @@ v6.29
 
 Changes / Improvements / Optimisations:
 - NanoPi M4v2 | Initial hardware identifier (ID: 58) and support for this device has been added to DietPi. Many thanks to @purist doing this request: https://dietpi.com/phpbb/viewtopic.php?f=12&t=6451
+- Pine H64 | Initial hardware identifier (ID: 45) and support for this device has been added to DietPi. Many thanks to @unixino for doing this request: https://github.com/MichaIng/DietPi/issues/3286
+- ROCK Pi S | Initial hardware identifier (ID: 73) and support for this device has been added to DietPi. Many thanks to @lwqcz for doing this request: https://github.com/MichaIng/DietPi/issues/3365
 - Sparky SBC | Updated kernel drivers and SBC-specific service and config files
 - DietPi-Cron | Allows now to set the cron job output mail recipient. Cron mails are disabled by default since no MTA is preconfigured on DietPi. Additionally the execution times are now shown more clearly in 24h format.
 - DietPi-Drive_Manager | GlusterFS fstab entries are now preserved. Many thanks to @Sudrien for implementing this addition: https://github.com/MichaIng/DietPi/issues/3374

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -431,8 +431,10 @@
 			'40' ': Pine A64'
 			'43' ': Rock64'
 			'42' ': RockPro64'
+			'45' ': Pine H64'
 			'70' ': Sparky SBC'
 			'72' ': ROCK Pi 4'
+			'73' ': ROCK Pi S'
 
 		)
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -257,7 +257,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 	FP_ONLINEDOC_URL='https://dietpi.com/phpbb/viewtopic.php?'
 
 	# Available for (need to match highest value in dietpi-obtain_hw_model)
-	MAX_G_HW_MODEL=72
+	MAX_G_HW_MODEL=73
 	MAX_G_HW_ARCH=10
 	MAX_G_DISTRO=6
 	# - 2D array (well, bash style)

--- a/dietpi/func/dietpi-obtain_hw_model
+++ b/dietpi/func/dietpi-obtain_hw_model
@@ -12,11 +12,12 @@
 	# - Called from /DietPi/dietpi/preboot
 	#
 	# In DietPi-Software: Need to match highest values in dietpi-obtain_hw_model
-	# - MAX_G_HW_MODEL=72
+	# - MAX_G_HW_MODEL=73
 	# - MAX_G_HW_ARCH=10
 	# - MAX_G_DISTRO=6
 	#
 	# ---- Line 1 ----
+	# G_HW_MODEL 73 ROCK Pi S
 	# G_HW_MODEL 72 ROCK Pi 4
 	# G_HW_MODEL 71 Beagle Bone Black
 	# G_HW_MODEL 70 Sparky SBC
@@ -36,6 +37,7 @@
 	# G_HW_MODEL 52 Asus Tinker Board
 	# G_HW_MODEL 51 BananaPi Pro (Lemaker)
 	# G_HW_MODEL 50 BananaPi M2+ (sinovoip)
+	# G_HW_MODEL 45 Pine H64
 	# G_HW_MODEL 44 Pinebook A64
 	# G_HW_MODEL 43 Rock64
 	# G_HW_MODEL 42 RockPro64
@@ -89,12 +91,13 @@
 	# G_HW_ARCH_DESCRIPTION
 	# ---- Line 8 ----
 	# IMAGE_ADDITIONAL_CREDITS (eg: Meveric)
-	# ---- Line 9 ---- Group CPUs
+	# ---- Line 9 ---- SoC
 	# G_HW_CPUID 0 Not set
-	# G_HW_CPUID 1 H3
-	# G_HW_CPUID 2 H5
-	# G_HW_CPUID 3 RK3399
-	# G_HW_CPUID 4 S922X
+	# G_HW_CPUID 1 Allwinner H3
+	# G_HW_CPUID 2 Allwinner H5
+	# G_HW_CPUID 3 Rockchip RK3399
+	# G_HW_CPUID 4 Samsung S922X
+	# G_HW_CPUID 5 Allwinner H6
 	# ---- Line 10 ---- Onboard WiFi/BT Index
 	# HW_ONBOARD_WIFI 0 Not set
 	# HW_ONBOARD_WIFI 1 RPi3/4/Zero W (BCM43438)
@@ -538,8 +541,13 @@
 
 			G_HW_MODEL=$(mawk 'NR==1' $FP_G_HW_MODEL_INDENTIFIER)
 
+			# ROCK Pi S
+			if (( $G_HW_MODEL == 73 )); then
+
+				G_HW_MODEL_DESCRIPTION='ROCK Pi S'
+
 			# ROCK Pi 4
-			if (( $G_HW_MODEL == 72 )); then
+			elif (( $G_HW_MODEL == 72 )); then
 
 				G_HW_MODEL_DESCRIPTION='ROCK Pi 4'
 				G_HW_CPUID=3
@@ -644,6 +652,12 @@
 
 				G_HW_MODEL_DESCRIPTION='BananaPi M2+'
 				G_HW_CPUID=1
+
+			# Pine H64
+			elif (( $G_HW_MODEL == 45 )); then
+
+				G_HW_MODEL_DESCRIPTION='Pine H64'
+				G_HW_CPUID=5
 
 			# Pinebook A64
 			elif (( $G_HW_MODEL == 44 )); then


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Obtain_HW_model | Add initial Pine H64 + ROCK Pi S + Allwinner H6 definitions