### PR TITLE
DietPi-Software | Shairport-Sync: Install new self-compiled packages

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,6 +26,7 @@ Changes / Improvements / Optimisations:
 - DietPi-Software | myMPD: Updated installer according to next upstream release v6.2.0. Many thanks to @jcorporation for informing us about the new version: https://github.com/MichaIng/DietPi/issues/3382
 - DietPi-Software | MPD: Assured that UNIX domain socket and systemd unit for socket activation is present on Stretch systems. As well the obsolete cache dir symlinks in "/var/lib/mpd" will not be present anymore. Any custom scripts must use the absolute paths in "/mnt/dietpi_userdata/.mpd_cache" from now on.
 - DietPi-Software | Pi-hole: Enabled support for Pi-hole v5. Many thanks to @maartenlangeveld for reporting the required change: https://github.com/MichaIng/DietPi/issues/3391
+- DietPi-Software | Shairport-Sync: Updated to new version 3.3.6, using self-compiled deb packages. Many thanks to @kmplngj for doing this request: https://github.com/MichaIng/DietPi/issues/3216
 - DietPi-Software | HAProxy: Updated to newest stable upstream version 2.1.3 and the sysvinit service has been replaced with the officially provided systemd service. It will be reinstalled on all systems via DietPi-Update, your config files will not be touched on any reinstall.
 
 Bug Fixes:

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -552,10 +552,10 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 
 		aSOFTWARE_NAME[$software_id]='Shairport Sync'
 		aSOFTWARE_DESC[$software_id]='airplay audio player with multiroom sync'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
 		aSOFTWARE_TYPE[$software_id]=0
-		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
+		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1221#p1221'
+		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		#------------------
 		software_id=39
 
@@ -2263,7 +2263,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 			aSOFTWARE_INSTALL_STATE[124]=1 # NAA Daemon
 			#aSOFTWARE_INSTALL_STATE[128]=1 # MPD (pulled in by O!MPD)
 			aSOFTWARE_INSTALL_STATE[129]=1 # O!MPD
-			#aSOFTWARE_INSTALL_STATE[152]=1 # Avahi-Daemon (pulled in by O!MPD)
+			#aSOFTWARE_INSTALL_STATE[152]=1 # Avahi-Daemon (pulled in by O!MPD and Shairport-Sync)
 			aSOFTWARE_INSTALL_STATE[163]=1 # GMediaRender
 
 		fi
@@ -2278,6 +2278,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		fi
 
 		# Software that requires Avahi-Daemon
+		# - Shairport-Sync (37)
 		software_id=152
 		if (( ${aSOFTWARE_INSTALL_STATE[31]} == 1 ||
 			${aSOFTWARE_INSTALL_STATE[37]} == 1 ||
@@ -2303,8 +2304,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		# - Domoticz (140): https://github.com/MichaIng/DietPi/issues/129#issuecomment-596255110
 		# - Jackett (147)
 		software_id=126
-		if (( ${aSOFTWARE_INSTALL_STATE[37]} == 1 ||
-			( ${aSOFTWARE_INSTALL_STATE[60]} == 1 && $WIFIHOTSPOT_RTL8188C_DEVICE && ! $WIFIHOTSPOT_RTL8188C_PACKAGE && $G_HW_ARCH < 4 ) ||
+		if (( ( ${aSOFTWARE_INSTALL_STATE[60]} == 1 && $WIFIHOTSPOT_RTL8188C_DEVICE && ! $WIFIHOTSPOT_RTL8188C_PACKAGE && $G_HW_ARCH < 4 ) ||
 			${aSOFTWARE_INSTALL_STATE[134]} == 1 ||
 			${aSOFTWARE_INSTALL_STATE[140]} == 1 ||
 			${aSOFTWARE_INSTALL_STATE[147]} == 1 )); then
@@ -2871,9 +2871,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 
 		elif [[ $type == 'deb' ]]; then
 
-			# Allow error on first attempt, giving APT fix a change to resolve e.g. dependencies
-			G_INTERACTIVE=0 G_ERROR_HANDLER_INFO_ONLY=1 G_RUN_CMD dpkg --force-hold,confdef,confold -i $file
-			(( $G_ERROR_HANDLER_EXITCODE_RETURN )) && G_DIETPI-NOTIFY 2 'Trying automated APT fix' && G_AGF
+			G_AGI ./$file
 
 		elif [[ $type == 'zip' ]]; then
 
@@ -4749,13 +4747,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-
-			INSTALL_URL_ADDRESS="https://dietpi.com/downloads/binaries/all/shairport-sync_3.2.2_$G_HW_ARCH_NAME.7z"
-
-			# This occured on C2: shairport-sync : Depends: libpopt-dev but it is not installed
-			#G_AGI libpopt-dev
-			DEPS_LIST='openssl libsoxr0 libavahi-client3 libtool libconfig9 libpopt0 libdaemon0'
-			Download_Install "$INSTALL_URL_ADDRESS" /
+			Download_Install "https://dietpi.com/downloads/binaries/$G_DISTRO_NAME/shairport-sync_$G_HW_ARCH_NAME.deb"
 
 		fi
 
@@ -9857,48 +9849,6 @@ _EOF_
 
 		fi
 
-		software_id=37 # Shairport-Sync
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Configuration
-
-			# Enable SOXR by default:
-			G_BACKUP_FP /usr/local/etc/shairport-sync.conf
-			cat << _EOF_ >  /usr/local/etc/shairport-sync.conf
-general =
-{
-  name = "%H";
-  interpolation = "soxr";
-};
-
-metadata =
-{
-	enabled = "yes";
-	include_cover_art = "no";
-	pipe_name = "/tmp/shairport-sync-metadata";
-	pipe_timeout = 5000;
-	socket_address = "226.0.0.1";
-	socket_port = 5555;
-	socket_msglength = 65000;
-};
-
-alsa =
-{
-//  mixer_control_name = "PCM";
-//  output_rate = 44100; // can be 44100, 88200, 176400 or 352800
-//  output_format = "S16"; // can be "U8", "S8", "S16", "S24", "S24_3LE", "S24_3BE" or "S32"
-};
-_EOF_
-
-			# Create shairport user
-			local usercmd='useradd -rMU'
-			getent passwd shairport-sync &> /dev/null && usercmd='usermod -a'
-			$usercmd -G audio -s $(command -v nologin) shairport-sync
-
-			chmod +x /usr/local/bin/shairport-sync
-
-		fi
-
 		software_id=48 # Pydio
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
@@ -13728,16 +13678,16 @@ _EOF_
 
 		fi
 
-		software_id=37
+		software_id=37 # Shairport-Sync
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			#apt-mark auto libssl1.0.0 openssl libsoxr0 libavahi-client3 libtool libconfig9 libpopt0 libdaemon0 &> /dev/null
-			# No package is installed any more, files are directly extracted into places, need to remove them manually?
-			# https://github.com/MichaIng/DietPi/blob/testing/dietpi/dietpi-software#L5968
-			#G_AGP shairport-sync
+			G_AGP shairport-sync
+			# Pre-v6.29
+			#apt-mark auto libssl1.0.0 openssl libsoxr0 libavahi-client3 libtool libconfig9 libpopt0 libdaemon0 2> /dev/null
 			rm -f /lib/systemd/system/shairport-sync.service /usr/local/bin/shairport-sync /usr/local/etc/shairport-sync.conf* /usr/local/share/man/man7/shairport-sync.7.gz
-			userdel -rf shairport-sync
+			getent passwd shairport-sync &> /dev/null && userdel -rf shairport-sync
+			getent group shairport-sync &> /dev/null && groupdel shairport-sync
 
 		fi
 


### PR DESCRIPTION
**Status**: Ready

+ DietPi-Software | Shairport-Sync: Install new self-compiled packages with included config file, user creation and systemd service, hence no dedicated config step required anymore
+ DietPi-Software | Install deb packages via apt-get/G_AGI. The man pages are wrong about this, it works pretty fine and dependencies are pulled automatically, hence no apt-get -f install/G_AGF required to pull those, or install them in the first place.