### PR TITLE
DietPi-Software | Mopidy: Version 3 requires Python3, hence pip3

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -50,6 +50,7 @@ Bug Fixes:
 - DietPi-Software | RPi Cam Control: Resolved an issue where camera through the web UI failed because of missing permissions. Many thanks to @arkhub for reporting this issue: https://github.com/MichaIng/DietPi/issues/3431
 - DietPi-Software | OctoPrint: Resolved an issue where install failed. Many thanks to @zell-mbc and @Joulinar for reporting the issue and providing the solution: https://github.com/MichaIng/DietPi/issues/3474
 - DietPi-Software | Koel: Resolved an issue where download failed because of changed GitHub link. Many thanks to @C-Fu and @Joulinar for reporting and identifying the issue: https://github.com/MichaIng/DietPi/issues/3482
+- DietPi-Software | Mopidy: Resolved an issue where installs on Debian Buster and above were not complete since Mopidy v3 uses Python3. Many thanks to @lupa18 for reporting this issue: https://github.com/MichaIng/DietPi/issues/3485
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -615,8 +615,8 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 
 		aSOFTWARE_NAME[$software_id]='Mopidy'
 		aSOFTWARE_DESC[$software_id]='web interface music & radio player'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
 		aSOFTWARE_TYPE[$software_id]=0
+		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=3611#p3611'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		#------------------
@@ -2334,6 +2334,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		fi
 
 		# Software that requires Python-Pip: https://github.com/MichaIng/DietPi/issues/784
+		# - Mopidy (118)
 		# - OctoPrint (153)
 		# - HTPC Manager (155)
 		software_id=130
@@ -3600,30 +3601,36 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://apt.mopidy.com/mopidy.gpg'
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-
 			# Install our config file only, if not yet existent, to preserve manual user config.
 			# - This needs to be done prior to APT install, since this would otherwise install a default config file as well.
 			[[ -f '/etc/mopidy/mopidy.conf' ]] || dps_index=$software_id Download_Install 'mopidy.conf' /etc/mopidy/mopidy.conf
 
-			curl -sSL "$INSTALL_URL_ADDRESS" | apt-key add -
-			# No bullseye.list available yet, use buster.list instead
-			wget https://apt.mopidy.com/${G_DISTRO_NAME/bullseye/buster}.list -O /etc/apt/sources.list.d/mopidy.list
-			G_AGUP
-			G_AGI mopidy gstreamer1.0-alsa
+			local pip='pip' pip_modules='Mopidy-Local-Images' apt_packages=
 
-			# ARMv8
-			# NB: No ARM64 packages currently exist in mopidy repo. So it will throw a minor error when updating apt.
-			# Mopidy web client extensions not loading in webpage...
-			#if (( $G_HW_ARCH == 3 )); then
+			# ARMv8: Not supported by official repo, using Debian instead: https://github.com/mopidy/apt/tree/master/dists/buster/main
+			if (( $G_HW_ARCH == 3 )); then
 
-				#G_AGI build-essential python-dev
-				#pip install mopidy #no effect, claims already upto date.
+				# Python3 since Bullseye, including Mopidy-Local-Images deprecation and dedicated mopidy-local APT package: https://packages.debian.org/mopidy
+				(( $G_DISTRO > 5 )) && pip+='3' pip_modules= apt_packages='mopidy-local'
 
-			#fi
+			# Else use official repo
+			else
 
-			pip install Mopidy-MusicBox-Webclient Mopidy-Local-Images
+				INSTALL_URL_ADDRESS='https://apt.mopidy.com/mopidy.gpg'
+				G_CHECK_URL "$INSTALL_URL_ADDRESS"
+				curl -sSfL "$INSTALL_URL_ADDRESS" | apt-key add -
+				# No bullseye.list available yet, use buster.list instead: https://github.com/mopidy/apt/tree/master/dists
+				wget https://apt.mopidy.com/${G_DISTRO_NAME/bullseye/buster}.list -O /etc/apt/sources.list.d/mopidy.list
+				G_AGUP
+
+				# Python3 since Buster: https://raw.githubusercontent.com/mopidy/apt/master/dists/stretch/main/binary-armhf/Packages
+				(( $G_DISTRO > 5 )) && pip+='3' pip_modules= apt_packages='mopidy-local'
+
+			fi
+
+			G_AGI mopidy gstreamer1.0-alsa $apt_packages
+			$pip install Mopidy-MusicBox-Webclient $pip_modules
+			unset pip
 
 		fi
 
@@ -8331,8 +8338,6 @@ _EOF_
 
 			# Adjust user group and home dir
 			usermod -aG dietpi,audio -d $G_FP_DIETPI_USERDATA/mopidy mopidy
-			# - Add to new "render" group on Buster
-			(( $G_DISTRO > 4 )) && usermod -aG render mopidy
 
 			# Adjust systemd unit to match new group and do not pre-create obsolete cache dir
 			mkdir -p /etc/systemd/system/mopidy.service.d
@@ -13104,9 +13109,11 @@ _EOF_
 			[[ -f '/etc/apt/sources.list.d/mopidy.list' ]] && rm /etc/apt/sources.list.d/mopidy.list
 
 			command -v pip &> /dev/null && pip uninstall -y Mopidy-MusicBox-Webclient Mopidy-Local-Images
+			command -v pip3 &> /dev/null && pip3 uninstall -y Mopidy-MusicBox-Webclient
 
 			getent passwd mopidy &> /dev/null && userdel -rf mopidy
 			[[ -d $G_FP_DIETPI_USERDATA/mopidy ]] && rm -R $G_FP_DIETPI_USERDATA/mopidy
+			[[ -d '/etc/systemd/system/mopidy.service.d' ]] && rm -R /etc/systemd/system/mopidy.service.d
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3624,13 +3624,13 @@ _EOF_
 				G_AGUP
 
 				# Python3 since Buster: https://raw.githubusercontent.com/mopidy/apt/master/dists/stretch/main/binary-armhf/Packages
-				(( $G_DISTRO > 5 )) && pip+='3' pip_modules= apt_packages='mopidy-local'
+				(( $G_DISTRO > 4 )) && pip+='3' pip_modules= apt_packages='mopidy-local'
 
 			fi
 
 			G_AGI mopidy gstreamer1.0-alsa $apt_packages
 			$pip install Mopidy-MusicBox-Webclient $pip_modules
-			unset pip
+			unset pip pip_modules apt_packages
 
 		fi
 


### PR DESCRIPTION
**Status**: WIP

**Commit list/description**:
+ DietPi-Software | Mopidy: Version 3 requires Python3, hence pip3. Also Mopidy-Local-Images has been deprecated last year with Mopidy v3 and Mopidy-Local functionality has been separated into a dedicated package. Mopidy v3 is available since Buster from official repo and since Bullseye from Debian repo. The latter needs to be used for ARMv8. Install package and Python modules from correct sources and with correct method according to above information: https://github.com/MichaIng/DietPi/issues/3485