### PR TITLE
DietPi-Software | rTorrent: Fix default config

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ Changes / Improvements / Optimisations:
 
 Bug Fixes:
 - DietPi-Software | GMediaRender+WireGuard: Resolved an issue where service start could have failed due to invalid network information. Many thanks to @fnsnyc for reporting this issue: https://github.com/MichaIng/DietPi/issues/3519
+- DietPi-Software | rTorrent: Resolved an issue where the default config set max memory allocation much too low, which caused startup issues. Many thanks to @PiTech for reporting and fixing this issue: https://dietpi.com/phpbb/viewtopic.php?f=15&t=7613
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,7 +5,7 @@ Changes / Improvements / Optimisations:
 
 Bug Fixes:
 - DietPi-Software | GMediaRender+WireGuard: Resolved an issue where service start could have failed due to invalid network information. Many thanks to @fnsnyc for reporting this issue: https://github.com/MichaIng/DietPi/issues/3519
-- DietPi-Software | rTorrent: Resolved an issue where the default config set max memory allocation much too low, which caused startup issues. Many thanks to @PiTech for reporting and fixing this issue: https://dietpi.com/phpbb/viewtopic.php?f=15&t=7613
+- DietPi-Software | rTorrent: Resolved an issue where startup fails because of invalid default config values. Many thanks to @PiTech and @vorrac for reporting and fixing this issue: https://dietpi.com/phpbb/viewtopic.php?f=15&t=7613, https://dietpi.com/phpbb/viewtopic.php?f=11&t=7607
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10467,7 +10467,7 @@ schedule2 = session_save, 240, 300, ((session.save))
 schedule2 = monitor_diskspace, 15, 60, ((close_low_diskspace, 1000M))
 system.umask.set = 002
 # Max memory mapping size, not max physical RAM usage!
-pieces.memory.max.set = $RAM_TOTAL
+pieces.memory.max.set = ${RAM_TOTAL}M
 pieces.hash.on_completion.set = no
 
 ### Connection settings

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10503,7 +10503,7 @@ throttle.max_peers.seed.set = -1
 trackers.numwant.set = $(Optimise_BitTorrent 2)
 # Public tracker support
 trackers.use_udp.set = yes
-dht.mode.set = enable
+dht.mode.set = on
 #dht.port.set = 6881
 protocol.pex.set = yes
 protocol.encryption.set = allow_incoming,try_outgoing,enable_retry


### PR DESCRIPTION
**Status**: Done

- [x] Live patch:
  ```
  if [[ -w '/boot/dietpi/dietpi-software' ]]; then

        # https://github.com/MichaIng/DietPi/pull/3531
        sed -i -e '/pieces\.memory\.max\.set/s/\$RAM_TOTAL/\${RAM_TOTAL}M/' -e '/dht\.mode\.set/s/enable/on/' /boot/dietpi/dietpi-software &> /dev/null

  fi
  ```
- [x] Changelog

**Testing:**
- [x] Stretch
- [x] Buster

🈴 Bullseye: Leaving as known issue, either PHP7.4 incompatibility or may be fixed by switching from TCP to UNIX socket.

**Commit list/description**:
+ DietPi-Software | rTorrent: Set default pieces.memory.max.set to total physical memory size in MiB as intended