### PR TITLE
DietPi-Software | Firefox Sync Server polish

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ v6.31
 (XX/06/20)
 
 Changes / Improvements / Optimisations:
+- DietPi-Software | Firefox Sync Server has been added to our software list, which allows to sync your Firefox bookmarks, history, tabs and passwords via your self-hosted server. Many thanks and all credits to @CedArctic for implementing this software title: https://github.com/MichaIng/DietPi/pull/3471
 
 Bug Fixes:
 - DietPi-Software | GMediaRender+WireGuard: Resolved an issue where service start could have failed due to invalid network information. Many thanks to @fnsnyc for reporting this issue: https://github.com/MichaIng/DietPi/issues/3519

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -146,6 +146,7 @@ Available services:
 			'tonido'
 			'gogs'
 			'gitea'
+			'firefox-sync'
 
 			# - Emulation/Gaming
 			'supervisor'
@@ -1064,7 +1065,7 @@ Info:\n - Negative values have a higher priority (eg: -10).\n - Positive values 
 
 				'CPU Scheduling Priority')
 
-					# - 7 step description scale
+					# 7 step description scale
 					local scale_value_lowest=1
 					local scale_value_highest=99
 					local scale_value_lower=$(( $scale_value_highest / 6 ))

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1039,7 +1039,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		aSOFTWARE_DESC[$software_id]='Sync bookmarks, tabs, history & passwords'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=42#p42'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=24713#p24713'
 		aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
 		aSOFTWARE_REQUIRES_SQLITE[$software_id]=1
 		# Bullseye: python(2)-virtualenv not available (yet): https://packages.debian.org/python-virtualenv
@@ -5331,6 +5331,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			# Build
 			cd /opt/firefox-sync
 			make build
+			cd /tmp/$G_PROGRAM_NAME
 
 		fi
 
@@ -11195,15 +11196,13 @@ _EOF_
 			getent passwd ffsync &> /dev/null && usercmd='usermod'
 			$usercmd -d /opt/firefox-sync -s $(command -v nologin) ffsync
 
-			# Create database directory
+			# Create database and config directory
 			mkdir -p $G_FP_DIETPI_USERDATA/firefox-sync
 
 			# Create database if it doesn't exist
-			if [[ ! -f $G_FP_DIETPI_USERDATA/firefox-sync/FF-Sync-DB.db ]]; then
-				sqlite3 $G_FP_DIETPI_USERDATA/firefox-sync/FF-Sync-DB.db "create table aTable(field1 int); drop table aTable;"
-			fi
+			[[ -f $G_FP_DIETPI_USERDATA/firefox-sync/FF-Sync-DB.db ]] || sqlite3 $G_FP_DIETPI_USERDATA/firefox-sync/FF-Sync-DB.db "create table aTable(field1 int); drop table aTable;"
 
-			# Copy and modify config file
+			# Copy and modify default config file if it doesn't exist
 			local ffsync_conf="$G_FP_DIETPI_USERDATA/firefox-sync/syncserver.ini"
 			if [[ ! -f $ffsync_conf ]]; then
 
@@ -11213,8 +11212,6 @@ _EOF_
 				G_CONFIG_INJECT 'port =' 'port = 5000' $ffsync_conf # To be failsafe if the default changes in future releases
 				G_CONFIG_INJECT 'public_url =' "public_url = http://$ffsync_ip:5000/" $ffsync_conf
 				G_CONFIG_INJECT 'sqluri = sqlite:' "sqluri = sqlite:///$G_FP_DIETPI_USERDATA/firefox-sync/FF-Sync-DB.db" $ffsync_conf
-				# Modify make file to point to external config
-				sed -i "s|--paste ./syncserver.ini|--paste $ffsync_conf|" /opt/firefox-sync/Makefile
 
 			fi
 
@@ -11227,8 +11224,16 @@ After=network-online.target dietpi-boot.service
 
 [Service]
 User=ffsync
-WorkingDirectory=/opt/firefox-sync
-ExecStart=$(command -v make) serve
+WorkingDirectory=$G_FP_DIETPI_USERDATA/firefox-sync
+ExecStart=/opt/firefox-sync/local/bin/gunicorn --paste $ffsync_conf
+
+# Hardening
+ProtectSystem=strict
+ProtectHome=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+ReadWritePaths=$G_FP_DIETPI_USERDATA/firefox-sync
 
 [Install]
 WantedBy=multi-user.target
@@ -11236,9 +11241,6 @@ _EOF_
 
 			# Permissions
 			chown -R ffsync:ffsync $G_FP_DIETPI_USERDATA/firefox-sync
-
-			# Enable startup on boot by default
-			systemctl enable firefox-sync
 
 		fi
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -2417,6 +2417,12 @@ To reinstall now, run: "dietpi-software reinstall 106 144 145"
 				/boot/dietpi/dietpi-drive_manager 3
 
 			fi
+
+		elif (( $G_DIETPI_VERSION_SUB == 30 )); then
+
+			#-------------------------------------------------------------------------------
+			# Make userdata dir world-executable so service users don't need to be in dietpi group to access their data dir: https://github.com/MichaIng/DietPi/pull/3536#issuecomment-628515444
+			G_EXEC chmod a+x /mnt/dietpi_userdata
 			#-------------------------------------------------------------------------------
 			# Last subversion patch completed
 			# - Apply reinstalls


### PR DESCRIPTION
**Status**: Ready
- [x] DietPi-Software | Do not enable service on install as it is not DietPi-controlled
- [x] Changelog
- [x] Online docs: https://dietpi.com/phpbb/viewtopic.php?p=24713#p24713

**Commit list/description**:
+ DietPi-Services | Add support for new Firefox Sync Server
+ DietPi-Software | Firefox Sync Server: Add online docs URL: https://dietpi.com/phpbb/viewtopic.php?p=24713#p24713
+ DietPi-Software | Firefox Sync Server: Do not edit Makefile to use our config, instead call gunicorn with correct option directly
+ DietPi-Software | Firefox Sync Server: Add strict service hardening to allow R/W only to our config+database dir, the ffsync users home
+ DietPi-Software | Firefox Sync Server: Do not enable service on install, since it is now controlled by DietPi-Services
+ CHANGELOG | Firefox Sync Server has been added to our software list