### PR TITLE
DietPi-Software | Folding@Home: Update to new v7.6 and minor install enhancements

### DIFF
--- a/.conf/dps_2/config.xml
+++ b/.conf/dps_2/config.xml
@@ -1,0 +1,27 @@
+<config>
+  <!-- Configuration: Do not create a config backup on each change -->
+  <config-rotate v='false'/>
+
+  <!-- HTTP Server: Allow remote access -->
+  <allow v='0/0'/>
+
+  <!-- Logging: Minimal logs to "journalctl -u fahclient" only -->
+  <log v='/dev/null'/>
+  <log-rotate v='false'/>
+  <log-time v='false'/>
+  <verbosity v='0'/>
+
+  <!-- Slot Control: Do not start folding right after install -->
+  <paused v='true'/>
+
+  <!-- User Information: Fold as user "DietPi" for team "DietPi" -->
+  <passkey v='06c869246e88c00cb05cc4d1758a97f9'/>
+  <team v='234437'/>
+  <user v='DietPi'/>
+
+  <!-- Web Server: Allow remote web UI access -->
+  <web-allow v='0/0'/>
+
+  <!-- Folding Slots: Enable GPU slots if supported -->
+  <gpu v='true'/>
+</config>

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ Changes / Improvements / Optimisations:
 - Odroid C4 | Support for this new Hardkernel SBC has been added to allow image creation based on Meverics Odroid repository, including Kodi support.
 - DietPi-Config | Added Ethernet link speed selection to Network>Ethernet menu. The function and dietpi.txt entry exists for a long time but it was only exposed as first run setup option.
 - DietPi-Software | Firefox Sync Server has been added to our software list, which allows to sync your Firefox bookmarks, history, tabs and passwords via your self-hosted server. Many thanks and all credits to @CedArctic for implementing this software title: https://github.com/MichaIng/DietPi/pull/3471
+- DietPi-Software | Folding@Home: Updated to latest 7.6.X version which includes an explicit option to priotize COVID-19 projects: https://foldingathome.org/2020/04/17/new-foldinghome-software-with-the-option-to-prioritize-covid-19-projects/
 
 Bug Fixes:
 - DietPi-Software | GMediaRender+WireGuard: Resolved an issue where service start could have failed due to invalid network information. Many thanks to @fnsnyc for reporting this issue: https://github.com/MichaIng/DietPi/issues/3519

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,7 +5,8 @@ Changes / Improvements / Optimisations:
 - Odroid C4 | Support for this new Hardkernel SBC has been added to allow image creation based on Meverics Odroid repository, including Kodi support.
 - DietPi-Config | Added Ethernet link speed selection to Network>Ethernet menu. The function and dietpi.txt entry exists for a long time but it was only exposed as first run setup option.
 - DietPi-Software | Firefox Sync Server has been added to our software list, which allows to sync your Firefox bookmarks, history, tabs and passwords via your self-hosted server. Many thanks and all credits to @CedArctic for implementing this software title: https://github.com/MichaIng/DietPi/pull/3471
-- DietPi-Software | Folding@Home: Updated to latest 7.6.X version which includes an explicit option to priotize COVID-19 projects: https://foldingathome.org/2020/04/17/new-foldinghome-software-with-the-option-to-prioritize-covid-19-projects/
+- DietPi-Software | Folding@Home: Updated to latest v7.6.X, which includes an explicit option for prioritising COVID 19 projects: https://foldingathome.org/2020/04/17/new-foldinghome-software-with-the-option-to-prioritize-covid-19-projects/
+                                  This update is applied to all systems with DietPi v6.31, existing config and data are preserved.
 
 Bug Fixes:
 - DietPi-Software | GMediaRender+WireGuard: Resolved an issue where service start could have failed due to invalid network information. Many thanks to @fnsnyc for reporting this issue: https://github.com/MichaIng/DietPi/issues/3519

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1232,8 +1232,8 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 
 		aSOFTWARE_NAME[$software_id]='Folding@Home'
 		aSOFTWARE_DESC[$software_id]='distributed disease research project'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=20
 		aSOFTWARE_TYPE[$software_id]=0
+		aSOFTWARE_CATEGORY_INDEX[$software_id]=20
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=13704#p13704'
 		# x86_64 only
 		for ((i=1; i<$MAX_G_HW_ARCH; i++))
@@ -3385,7 +3385,7 @@ _EOF_
 
 			Banner_Installing
 
-			# We must uninstall previous package for reinstall, else it will fail: https://github.com/MichaIng/DietPi/issue_comments#issuecomment-411688073
+			# We must uninstall previous package for reinstall, else it will fail: https://github.com/MichaIng/DietPi/issues/1985#issuecomment-411688073
 			if dpkg-query -s 'fahclient' &> /dev/null; then
 
 				G_DIETPI-NOTIFY 2 'Removing previous package before installing the latest version'
@@ -3400,7 +3400,7 @@ _EOF_
 			debconf-set-selections <<< 'fahclient fahclient/user string DietPi' # Default, until user chooses an own username
 			debconf-set-selections <<< 'fahclient fahclient/passkey string 06c869246e88c00cb05cc4d1758a97f9'
 
-			Download_Install 'https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v7.5/latest.deb'
+			Download_Install 'https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v7.6/latest.deb'
 
 			killall -w FAHClient # Due to https://github.com/FoldingAtHome/fah-issues/issues/1193
 
@@ -7341,6 +7341,7 @@ _EOF_
 			# Remove old data + config directories and init.d service
 			[[ -d '/var/lib/fahclient' ]] && rm -R /var/lib/fahclient
 			[[ -d '/etc/fahclient' ]] && rm -R /etc/fahclient
+			[[ -f '/etc/default/fahclient' ]] && rm /etc/default/fahclient
 			[[ -f '/etc/init.d/FAHClient' ]] && rm /etc/init.d/FAHClient
 			update-rc.d -f FAHClient remove
 
@@ -7352,10 +7353,11 @@ _EOF_
 			cat << _EOF_ > /lib/systemd/system/fahclient.service
 [Unit]
 Description=Folding@Home (DietPi)
+Wants=network-online.target
+After=network-online.target dietpi-boot.service
 
 [Service]
 User=fahclient
-Group=dietpi
 WorkingDirectory=$G_FP_DIETPI_USERDATA/fahclient
 ExecStart=$(command -v FAHClient) --allow='0/0' --web-allow='0/0' --daemon=false --user=DietPi --team=234437 --passkey=06c869246e88c00cb05cc4d1758a97f9 --gpu=true --log-rotate=false --log=/var/log/fahclient.log --power=light --data-directory=$G_FP_DIETPI_USERDATA/fahclient
 
@@ -7364,7 +7366,7 @@ WantedBy=multi-user.target
 _EOF_
 
 			# Permissions
-			chown -R fahclient:dietpi $G_FP_DIETPI_USERDATA/fahclient /var/log/fahclient.log
+			chown -R fahclient: $G_FP_DIETPI_USERDATA/fahclient /var/log/fahclient.log
 
 		fi
 
@@ -12849,10 +12851,16 @@ _EOF_
 			# Un-check out all work units, so they can be picked up by other donors prior to timeout: https://github.com/FoldingAtHome/fah-issues/issues/1255
 			FAHClient --dump
 
+			if [[ -f '/lib/systemd/system/fahclient.service' ]]; then
+
+				systemctl unmask fahclient
+				systemctl disable --now fahclient
+				rm -Rf /{lib,etc}/systemd/system/fahclient.service*
+
+			fi
 			G_AGP fahclient
-			rm -R $G_FP_DIETPI_USERDATA/fahclient
-			rm /lib/systemd/system/fahclient.service
-			rm /var/log/fahclient.log
+			[[ -d $G_FP_DIETPI_USERDATA/fahclient ]] && rm -R $G_FP_DIETPI_USERDATA/fahclient
+			[[ -f '/var/log/fahclient.log' ]] && rm /var/log/fahclient.log
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3385,24 +3385,14 @@ _EOF_
 
 			Banner_Installing
 
-			# We must uninstall previous package for reinstall, else it will fail: https://github.com/MichaIng/DietPi/issues/1985#issuecomment-411688073
-			if dpkg-query -s 'fahclient' &> /dev/null; then
-
-				G_DIETPI-NOTIFY 2 'Removing previous package before installing the latest version'
-				G_AGP fahclient
-
-			fi
-
 			G_DIETPI-NOTIFY 2 'Pre-configuring FAHClient deb package'
-			debconf-set-selections <<< 'fahclient fahclient/autostart boolean true' # external bug with setting false https://github.com/FoldingAtHome/fah-issues/issues/1193
+			debconf-set-selections <<< 'fahclient fahclient/autostart boolean false' # Do not start SysV service after package install
 			debconf-set-selections <<< 'fahclient fahclient/power select light'
 			debconf-set-selections <<< 'fahclient fahclient/team string 234437' # Team "DietPi"
-			debconf-set-selections <<< 'fahclient fahclient/user string DietPi' # Default, until user chooses an own username
-			debconf-set-selections <<< 'fahclient fahclient/passkey string 06c869246e88c00cb05cc4d1758a97f9'
+			debconf-set-selections <<< 'fahclient fahclient/user string DietPi' # User "DietPi"
+			debconf-set-selections <<< 'fahclient fahclient/passkey string 06c869246e88c00cb05cc4d1758a97f9' # Passkey for user "DietPi"
 
 			Download_Install 'https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v7.6/latest.deb'
-
-			killall -w FAHClient # Due to https://github.com/FoldingAtHome/fah-issues/issues/1193
 
 		fi
 
@@ -7338,19 +7328,23 @@ _EOF_
 
 			Banner_Configuration
 
-			# Remove old data + config directories and init.d service
+			# Remove obsolete config + data directories and SysV service + config
 			[[ -d '/var/lib/fahclient' ]] && rm -R /var/lib/fahclient
 			[[ -d '/etc/fahclient' ]] && rm -R /etc/fahclient
 			[[ -f '/etc/default/fahclient' ]] && rm /etc/default/fahclient
 			[[ -f '/etc/init.d/FAHClient' ]] && rm /etc/init.d/FAHClient
 			update-rc.d -f FAHClient remove
 
-			# Create new working (data + config) directory and log file
-			mkdir -p $G_FP_DIETPI_USERDATA/fahclient
-			> /var/log/fahclient.log
+			# Prepare our new config + data directory if not yet present
+			if [[ ! -f $G_FP_DIETPI_USERDATA/fahclient/config.xml ]]; then
 
-			# Create new systemd service
-			cat << _EOF_ > /lib/systemd/system/fahclient.service
+				mkdir -p $G_FP_DIETPI_USERDATA/fahclient
+				dps_index=$software_id Download_Install 'config.xml' $G_FP_DIETPI_USERDATA/fahclient/config.xml
+
+			fi
+
+			# Service
+			cat << _EOF_ > /etc/systemd/system/fahclient.service
 [Unit]
 Description=Folding@Home (DietPi)
 Wants=network-online.target
@@ -7359,14 +7353,14 @@ After=network-online.target dietpi-boot.service
 [Service]
 User=fahclient
 WorkingDirectory=$G_FP_DIETPI_USERDATA/fahclient
-ExecStart=$(command -v FAHClient) --allow='0/0' --web-allow='0/0' --daemon=false --user=DietPi --team=234437 --passkey=06c869246e88c00cb05cc4d1758a97f9 --gpu=true --log-rotate=false --log=/var/log/fahclient.log --power=light --data-directory=$G_FP_DIETPI_USERDATA/fahclient
+ExecStart=$(command -v FAHClient)
 
 [Install]
 WantedBy=multi-user.target
 _EOF_
 
 			# Permissions
-			chown -R fahclient: $G_FP_DIETPI_USERDATA/fahclient /var/log/fahclient.log
+			chown -R fahclient $G_FP_DIETPI_USERDATA/fahclient
 
 		fi
 
@@ -12849,18 +12843,16 @@ _EOF_
 
 			Banner_Uninstalling
 			# Un-check out all work units, so they can be picked up by other donors prior to timeout: https://github.com/FoldingAtHome/fah-issues/issues/1255
-			FAHClient --dump
+			FAHClient --chdir $G_FP_DIETPI_USERDATA/fahclient --dump all
 
-			if [[ -f '/lib/systemd/system/fahclient.service' ]]; then
+			if [[ -f '/etc/systemd/system/fahclient.service' ]]; then
 
-				systemctl unmask fahclient
 				systemctl disable --now fahclient
-				rm -Rf /{lib,etc}/systemd/system/fahclient.service*
+				rm -R /etc/systemd/system/fahclient.service*
 
 			fi
 			G_AGP fahclient
 			[[ -d $G_FP_DIETPI_USERDATA/fahclient ]] && rm -R $G_FP_DIETPI_USERDATA/fahclient
-			[[ -f '/var/log/fahclient.log' ]] && rm /var/log/fahclient.log
 
 		fi
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -2424,6 +2424,22 @@ To reinstall now, run: "dietpi-software reinstall 106 144 145"
 			# Make userdata dir world-executable so service users don't need to be in dietpi group to access their data dir: https://github.com/MichaIng/DietPi/pull/3536#issuecomment-628515444
 			G_EXEC chmod a+x /mnt/dietpi_userdata
 			#-------------------------------------------------------------------------------
+			# Reinstalls
+			#	Folding@Home: https://github.com/MichaIng/DietPi/pull/3546
+			if (( $G_DIETPI_INSTALL_STAGE == 2 )); then
+
+				if grep -q '^aSOFTWARE_INSTALL_STATE\[2\]=2' /boot/dietpi/.installed; then
+
+					G_DIETPI-NOTIFY 2 'Preparing Folding@Home update...'
+					[[ -f '/lib/systemd/system/fahclient.service' ]] && rm /etc/systemd/system/fahclient.service
+					[[ -f '/var/log/fahclient.log' ]] && rm /var/log/fahclient.log
+					dpkg-query -s 'fahclient' &> /dev/null && G_AGP fahclient
+
+				fi
+				echo 2 >> /var/tmp/dietpi/dietpi-update_reinstalls
+
+			fi
+			#-------------------------------------------------------------------------------
 			# Last subversion patch completed
 			# - Apply reinstalls
 			if [[ -f '/var/tmp/dietpi/dietpi-update_reinstalls' ]]; then


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Software | Folding@Home: Update to new v7.6 and minor install enhancements
+ DietPi-Software | Folding@Home: The previous package does not need to be purged anymore before the new one can be installed
+ DietPi-Software | Folding@Home: It is now possible to prevent the service start on package install
+ DietPi-Software | Folding@Home: FAHClient will not store given command line options to a new config file anymore, hence we need to create our own default config but can skip all command line options within the systemd unit
+ DietPi-Software | Folding@Home: File logging is now disabled by default, logs can be reviewed via journalctl -u fahclient anyway
+ DietPi-Software | Folding@Home: Fix signing out from all work units on uninstall
+ DietPi-Software | Folding@Home: Reinstall to apply v7.6.X update, remove obsolete files and purge installed package, since the old one caused issues on reinstall