### PR TITLE
DietPi-Logclear | Resolve an issue where .db-shm and .db-wal files are were not excluded from processing

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,10 +7,12 @@ Changes / Improvements / Optimisations:
 - DietPi-Software | Firefox Sync Server has been added to our software list, which allows to sync your Firefox bookmarks, history, tabs and passwords via your self-hosted server. Many thanks and all credits to @CedArctic for implementing this software title: https://github.com/MichaIng/DietPi/pull/3471
 - DietPi-Software | Folding@Home: Updated to latest v7.6.X, which includes an explicit option for prioritising COVID 19 projects: https://foldingathome.org/2020/04/17/new-foldinghome-software-with-the-option-to-prioritize-covid-19-projects/
                                   This update is applied to all systems with DietPi v6.31, existing config and data are preserved.
+- DietPi-Software | Sonarr/Radarr/Lidarr: The /media directory as second common mount point can now also be used as download/media directory without manually adding it to the systemd units ReadWritePaths list. Many thanks to @ricardoandren for doing this suggestion: https://github.com/MichaIng/DietPi/issues/3561
 
 Bug Fixes:
 - DietPi-Software | GMediaRender+WireGuard: Resolved an issue where service start could have failed due to invalid network information. Many thanks to @fnsnyc for reporting this issue: https://github.com/MichaIng/DietPi/issues/3519
 - DietPi-Software | rTorrent: Resolved an issue where startup fails because of invalid default config values. Many thanks to @PiTech and @vorrac for reporting and fixing this issue: https://dietpi.com/phpbb/viewtopic.php?f=15&t=7613, https://dietpi.com/phpbb/viewtopic.php?f=11&t=7607
+- DietPi-Software | Sonarr/Radarr/Lidarr: Resolved an issue where those software services crashed once an hour due to faulty SQLite database log file clearing. Many thanks to @Taloth from Sonarr and all the others who reported, investigated and finally solved the mystery: https://dietpi.com/phpbb/viewtopic.php?f=11&t=7598
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/func/dietpi-logclear
+++ b/dietpi/func/dietpi-logclear
@@ -49,7 +49,7 @@
 	INFO_BACKUPS_MADE=0
 
 	#////////////////////////////////////////////////////////////////
-	# Process log files.
+	# Process log files
 	#////////////////////////////////////////////////////////////////
 	Process_Logfiles(){
 
@@ -76,16 +76,16 @@
 			PROCESS_FILE=1
 			FILE_TYPE=0
 
-			# Filetypes
-			# - Compessed files (zip etc) | FILE_TYPE 1
+			# Special files
+			# - Compessed | FILE_TYPE 1
 			if [[ $FILE_NAME == *'.zip' || $FILE_NAME == *'.gz' ]]; then
 
 				FILE_TYPE=1
 
-			# - Normal Log Files
-			#	Exclude <= 10 byte size
-			#	Exclude .db* extentions SQLite (.db .db-shm .db.wal)
-			elif (( $FILESIZE_BYTES < 11 )) || [[ $FILE_NAME == *'.db' ]]; then
+			# - Excluded
+			#	Size < 11 byte
+			#	SQLite database files (Sonarr/Radarr/Lidarr): .db .db-shm .db-wal
+			elif (( $FILESIZE_BYTES < 11 )) || [[ $FILE_NAME == *'.db'* ]]; then
 
 				PROCESS_FILE=0
 
@@ -114,15 +114,15 @@
 
 					fi
 
-					# Write current logfile contents to existing.
+					# Write current log file contents to existing
 					cat "$i" >> "$FP_BACKUP/$FILE_NAME"
 					((INFO_BACKUPS_MADE++))
 
-					# Clear logfile contents
+					# Clear log file contents
 					> "$i"
 					((INFO_LOGS_CLEARED++))
 
-				# Clear logfile contents
+				# Clear log file contents
 				elif (( $INPUT == 1 )); then
 
 					> "$i"
@@ -136,7 +136,7 @@
 
 				fi
 
-				# Update Size cleared
+				# Update size cleared
 				INFO_SIZE_CLEARED=$(($INFO_SIZE_CLEARED + $FILESIZE_BYTES))
 
 			fi
@@ -169,7 +169,7 @@
 
 		Process_Logfiles
 
-		# Delete logfile backups
+		# Delete log file backups
 		[[ $INPUT == 2 && -f $FP_BACKUP ]] && rm -R $FP_BACKUP
 
 		# Print Info


### PR DESCRIPTION
**Status**: Ready

**Reference**: https://dietpi.com/phpbb/viewtopic.php?f=11&t=7598

**Commit list/description**:
+ DietPi-Logclear | Resolve an issue where .db-shm and .db-wal files are were not excluded from processing, bug implemented with v6.29