### PR TITLE
DietPi-Software | Ubooquity: Version update, logs and permissions

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,7 +19,8 @@ Bug Fixes:
 - DietPi-Software | GMediaRender+WireGuard: Resolved an issue where service start could have failed due to invalid network information. Many thanks to @fnsnyc for reporting this issue: https://github.com/MichaIng/DietPi/issues/3519
 - DietPi-Software | rTorrent: Resolved an issue where startup fails because of invalid default config values. Many thanks to @PiTech and @vorrac for reporting and fixing this issue: https://dietpi.com/phpbb/viewtopic.php?f=15&t=7613, https://dietpi.com/phpbb/viewtopic.php?f=11&t=7607
 - DietPi-Software | Sonarr/Radarr/Lidarr: Resolved an issue where those software services crashed once an hour due to faulty SQLite database log file clearing. Many thanks to @Taloth from Sonarr and all the others who reported, investigated and finally solved the mystery: https://dietpi.com/phpbb/viewtopic.php?f=11&t=7598
-- DietPi-Software | Resolved an issue where WireGuard in client mode failed to start due to missing resolvconf. It is now installed together with WireGuard when choosing client setup. Many thanks to @yahoo456 for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?f=11&t=7783
+- DietPi-Software | WireGuard: Resolved an issue where WireGuard in client mode failed to start due to missing resolvconf. It is now installed together with WireGuard when choosing client setup. Many thanks to @yahoo456 for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?f=11&t=7783
+- DietPi-Software | Ubooquity: Updated the installer to pull the latest version from Vae Mendis Software directly and enhanced permissions to better integrate with other software. Many thanks to @Mr.Roboto for doing this suggestion: https://dietpi.com/phpbb/viewtopic.php?f=12&t=7786
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4483,11 +4483,11 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/binaries/all/Ubooquity.jar'
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-
-			mkdir -p $G_FP_DIETPI_USERDATA/ubooquity
-			G_EXEC wget "$INSTALL_URL_ADDRESS" -O $G_FP_DIETPI_USERDATA/ubooquity/Ubooquity.jar
+			G_EXEC curl -sSfL https://vaemendis.net/ubooquity/service/download.php -o Ubooquity.zip
+			G_EXEC unzip -o Ubooquity.zip
+			G_EXEC_NOEXIT=1 G_EXEC rm Ubooquity.zip
+			G_EXEC mkdir -p $G_FP_DIETPI_USERDATA/ubooquity
+			G_EXEC mv {,$G_FP_DIETPI_USERDATA/ubooquity/}Ubooquity.tar 
 
 		fi
 
@@ -9301,9 +9301,9 @@ _EOF_
 
 			Banner_Configuration
 
-			local usercmd='useradd -rMU'
-			getent passwd ubooquity &> /dev/null && usercmd='usermod -a'
-			$usercmd -G dietpi -s $(command -v nologin) ubooquity
+			local usercmd='useradd -rMN'
+			getent passwd ubooquity &> /dev/null && usercmd='usermod'
+			$usercmd -g dietpi -s $(command -v nologin) ubooquity
 
 			mkdir -p $G_FP_DIETPI_USERDATA/{ebooks,comics}
 
@@ -9315,16 +9315,18 @@ After=network-online.target dietpi-boot.service
 
 [Service]
 User=ubooquity
+UMask=002
 WorkingDirectory=$G_FP_DIETPI_USERDATA/ubooquity
 ExecStart=$(command -v java) -jar $G_FP_DIETPI_USERDATA/ubooquity/Ubooquity.jar --headless --remoteadmin --adminport 2038 --libraryport 2039
 
 [Install]
 WantedBy=multi-user.target
 _EOF_
-
 			# Permissions
 			chmod +x $G_FP_DIETPI_USERDATA/ubooquity/Ubooquity.jar
-			chown -R ubooquity:dietpi $G_FP_DIETPI_USERDATA/ubooquity
+			chown -R ubooquity:root $G_FP_DIETPI_USERDATA/ubooquity
+			chown -R ubooquity:dietpi $G_FP_DIETPI_USERDATA/{ebooks,comics}
+			chmod 775 $G_FP_DIETPI_USERDATA/{ebooks,comics}
 
 		fi
 
@@ -14365,6 +14367,7 @@ _EOF_
 
 			fi
 			getent passwd ubooquity &> /dev/null && userdel -rf ubooquity
+			getent group ubooquity &> /dev/null && groupdel ubooquity
 			[[ -d $G_FP_DIETPI_USERDATA/ubooquity ]] && rm -R $G_FP_DIETPI_USERDATA/ubooquity
 
 		fi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4487,7 +4487,7 @@ _EOF_
 			G_EXEC unzip -o Ubooquity.zip
 			G_EXEC_NOEXIT=1 G_EXEC rm Ubooquity.zip
 			G_EXEC mkdir -p $G_FP_DIETPI_USERDATA/ubooquity
-			G_EXEC mv {,$G_FP_DIETPI_USERDATA/ubooquity/}Ubooquity.tar 
+			G_EXEC mv {,$G_FP_DIETPI_USERDATA/ubooquity/}Ubooquity.jar 
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9310,9 +9310,9 @@ _EOF_
 			G_EXEC mkdir -p $G_FP_DIETPI_USERDATA/{ebooks,comics}
 
 			# Logs
-			G_EXEC rm -Rf $G_FP_DIETPI_USERDATA/ubooquity/logs /var/logs/ubooquity
-			G_EXEC mkdir -p /var/logs/ubooquity
-			G_EXEC ln -s $G_FP_DIETPI_USERDATA/ubooquity/logs /var/logs/ubooquity
+			G_EXEC rm -Rf $G_FP_DIETPI_USERDATA/ubooquity/logs /var/log/ubooquity
+			G_EXEC mkdir -p /var/log/ubooquity
+			G_EXEC ln -s /var/log/ubooquity $G_FP_DIETPI_USERDATA/ubooquity/logs
 
 			# Service
 			G_DIETPI-NOTIFY 2 "Generating systemd service to start ${aSOFTWARE_NAME[$software_id]} on boot"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4487,7 +4487,7 @@ _EOF_
 			G_EXEC unzip -o Ubooquity.zip
 			G_EXEC_NOEXIT=1 G_EXEC rm Ubooquity.zip
 			G_EXEC mkdir -p $G_FP_DIETPI_USERDATA/ubooquity
-			G_EXEC mv {,$G_FP_DIETPI_USERDATA/ubooquity/}Ubooquity.jar 
+			G_EXEC mv {,$G_FP_DIETPI_USERDATA/ubooquity/}Ubooquity.jar
 
 		fi
 
@@ -9301,12 +9301,21 @@ _EOF_
 
 			Banner_Configuration
 
-			local usercmd='useradd -rMN'
+			# User
+			local usercmd='useradd -rMU'
 			getent passwd ubooquity &> /dev/null && usercmd='usermod'
-			$usercmd -g dietpi -s $(command -v nologin) ubooquity
+			G_EXEC $usercmd -G dietpi -d $G_FP_DIETPI_USERDATA/ubooquity -s $(command -v nologin) ubooquity
 
-			mkdir -p $G_FP_DIETPI_USERDATA/{ebooks,comics}
+			# Data
+			G_EXEC mkdir -p $G_FP_DIETPI_USERDATA/{ebooks,comics}
 
+			# Logs
+			G_EXEC rm -Rf $G_FP_DIETPI_USERDATA/ubooquity/logs /var/logs/ubooquity
+			G_EXEC mkdir -p /var/logs/ubooquity
+			G_EXEC ln -s $G_FP_DIETPI_USERDATA/ubooquity/logs /var/logs/ubooquity
+
+			# Service
+			G_DIETPI-NOTIFY 2 "Generating systemd service to start ${aSOFTWARE_NAME[$software_id]} on boot"
 			cat << _EOF_ > /etc/systemd/system/ubooquity.service
 [Unit]
 Description=Ubooquity (DietPi)
@@ -9315,7 +9324,6 @@ After=network-online.target dietpi-boot.service
 
 [Service]
 User=ubooquity
-UMask=002
 WorkingDirectory=$G_FP_DIETPI_USERDATA/ubooquity
 ExecStart=$(command -v java) -jar $G_FP_DIETPI_USERDATA/ubooquity/Ubooquity.jar --headless --remoteadmin --adminport 2038 --libraryport 2039
 
@@ -9323,10 +9331,10 @@ ExecStart=$(command -v java) -jar $G_FP_DIETPI_USERDATA/ubooquity/Ubooquity.jar 
 WantedBy=multi-user.target
 _EOF_
 			# Permissions
-			chmod +x $G_FP_DIETPI_USERDATA/ubooquity/Ubooquity.jar
-			chown -R ubooquity:root $G_FP_DIETPI_USERDATA/ubooquity
-			chown -R ubooquity:dietpi $G_FP_DIETPI_USERDATA/{ebooks,comics}
-			chmod 775 $G_FP_DIETPI_USERDATA/{ebooks,comics}
+			G_EXEC chmod +x $G_FP_DIETPI_USERDATA/ubooquity/Ubooquity.jar
+			G_EXEC chown -R ubooquity {$G_FP_DIETPI_USERDATA,/var/log}/ubooquity
+			G_EXEC chown ubooquity:dietpi $G_FP_DIETPI_USERDATA/{ebooks,comics}
+			G_EXEC chmod 775 $G_FP_DIETPI_USERDATA/{ebooks,comics}
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9303,7 +9303,7 @@ _EOF_
 
 			# User
 			local usercmd='useradd -rMU'
-			getent passwd ubooquity &> /dev/null && usercmd='usermod'
+			getent passwd ubooquity &> /dev/null && usercmd='usermod -a'
 			G_EXEC $usercmd -G dietpi -d $G_FP_DIETPI_USERDATA/ubooquity -s $(command -v nologin) ubooquity
 
 			# Data


### PR DESCRIPTION
**Status**: Review
- [x] Update download from dietpi.com regardless
- [x] Changelog
- [x] Wiki software list

**Testing**:
- [x] VM Stretch
- [x] VM Buster
- [x] VM Bullseye

**Commit list/description**:
+ DietPi-Software | Ubooquity: Download newest version from Vae Mendis Software directly
+ DietPi-Software | Ubooquity: Make comics and ebooks dirs writable for "dietpi" group members (downloaders, file servers, ...) by default.
+ DietPi-Software | Ubooquity: Set users home dir and move logs to /var/log/ubooquity (DietPi-RAMlog). Sadly we cannot disable the log file since "journalctl -u ubooquity" doubles it.
+ DietPi-Software | Ubooquity: Use G_EXEC thoroughly to be most verbose about what we're doing and prevent unexpected situations because of failed user/dir creation and such.