### PR TITLE
General | Add Raspberry Pi OS (64-bit) support

### DIFF
--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -142,13 +142,12 @@
 	declare -A aDISTRO_VERSION
 	declare -A aAUTOSTART_OPTION
 	declare -A aSOFTWARE
-	aAUTO_SETUP_AUTOMATED=(
-		[0]=0
-		[1]=0
-	)
+	aAUTO_SETUP_AUTOMATED=(0 0)
 	declare -A aNETWORK_INTERFACE
 	# v6.17 addition
 	declare -A aGIT_BRANCH
+	# v6.31 addition
+	aRASPBIAN=(0 0)
 
 	# Convert autostart index to name array
 	aAUTOSTART_NAME=()
@@ -341,7 +340,7 @@
 	aSOFTWARE_NAME[168]=168
 	aSOFTWARE_NAME[169]='Google AIY'
 
-	# v6.14 (earliest version that uploads to ssh.dietpi.com) + v6.15
+	# v6.14 (earliest version that can currently upload) + v6.15
 	aSOFTWARE_NAME6_14=()
 	aSOFTWARE_NAME6_15=()
 	for i in ${!aSOFTWARE_NAME[@]}
@@ -740,13 +739,13 @@
 				background-color: black;
 				font-family: Verdana, Arial, Helvetica, sans-serif;
 			}
-			th, td {
-				padding: 5px;
-			}
+			th, td { padding: 5px; }
 			table, th, td {
 				font-size: 14px;
 				border: 1px solid grey;
 			}
+			a { color: white; }
+			a:hover { color: #c5ff00; }
 		</style>
 	</head>
 	<body>
@@ -760,57 +759,62 @@
 			<tr><td>Systems opted out DietPi-Survey</td><td align="right">$SURVEY_COUNT_EMPTY</td><td align="right">$(( $SURVEY_COUNT_EMPTY * 100 / $SURVEY_COUNT_TOTAL ))%</td></tr>
 		</table>
 
-		<h4 id="version">DietPi versions:</h4>
+		<a href="#version"><h4 id="version">DietPi versions:</h4></a>
 		<table>
 			$(for i in "${!aDIETPI_VERSION[@]}"; do echo "<tr><td>DietPi v$i</td><td align=\"right\">	${aDIETPI_VERSION[$i]}</td><td align="right">$(( ${aDIETPI_VERSION[$i]} * 100 / $SURVEY_COUNT_OPTIN ))%</td></tr>"; done | sort -nrk 1.17,1.20 -t '	')
 		</table>
 
-		<h4 id="git">Git branches:</h4>
+		<a href="#git"><h4 id="git">Git branches:</h4></a>
 		<table>
 			$(for i in "${!aGIT_BRANCH[@]}"; do echo "<tr><td>$i</td><td align=\"right\">	${aGIT_BRANCH[$i]}</td><td align="right">$(( ${aGIT_BRANCH[$i]} * 100 / $SURVEY_COUNT_OPTIN ))%</td></tr>"; done | sort -nrk 2 -t '	')
 		</table>
 
-		<h4 id="device">Devices:</h4>
+		<a href="#device"><h4 id="device">Devices:</h4></a>
 		<table>
 			$(for i in "${!aDEVICE_NAME[@]}"; do echo "<tr><td>$i</td><td align=\"right\">	${aDEVICE_NAME[$i]}</td><td align="right">$(( ${aDEVICE_NAME[$i]} * 100 / $SURVEY_COUNT_OPTIN ))%</td></tr>"; done | sort -nrk 2 -t '	')
 		</table>
 
-                <h4 id="arch">CPU architectures:</h4>
-                <table>
-                        $(for i in "${!aCPU_ARCH[@]}"; do echo "<tr><td>$i</td><td align=\"right\">	${aCPU_ARCH[$i]}</td><td align="right">$(( ${aCPU_ARCH[$i]} * 100 / $SURVEY_COUNT_OPTIN ))%</td></tr>"; done | sort -nrk 2 -t '	')
-                </table>
+		<a href="#arch"><h4 id="arch">CPU architectures:</h4></a>
+		<table>
+			$(for i in "${!aCPU_ARCH[@]}"; do echo "<tr><td>$i</td><td align=\"right\">	${aCPU_ARCH[$i]}</td><td align="right">$(( ${aCPU_ARCH[$i]} * 100 / $SURVEY_COUNT_OPTIN ))%</td></tr>"; done | sort -nrk 2 -t '	')
+		</table>
 
-                <h4 id="cores">CPU core counts:</h4>
-                <table>
-                        $(for i in ${!aCPU_COUNT[@]}; do echo "<tr><td>$i Core(s)</td><td align=\"right\">	${aCPU_COUNT[$i]}</td><td align="right">$(( ${aCPU_COUNT[$i]} * 100 / $SURVEY_COUNT_OPTIN ))%</td></tr>"; done | sort -nrk 2 -t '	')
-                </table>
+		<a href="#cores"><h4 id="cores">CPU core counts:</h4></a>
+		<table>
+			$(for i in ${!aCPU_COUNT[@]}; do echo "<tr><td>$i Core(s)</td><td align=\"right\">	${aCPU_COUNT[$i]}</td><td align="right">$(( ${aCPU_COUNT[$i]} * 100 / $SURVEY_COUNT_OPTIN ))%</td></tr>"; done | sort -nrk 2 -t '	')
+		</table>
 
-		<h4 id="distro">Distro versions:</h4>
+		<a href="#distro"><h4 id="distro">Distro versions:</h4></a>
 		<table>
 			$(for i in "${!aDISTRO_VERSION[@]}"; do echo "<tr><td>$i</td><td align=\"right\">	${aDISTRO_VERSION[$i]}</td><td align="right">$(( ${aDISTRO_VERSION[$i]} * 100 / $SURVEY_COUNT_OPTIN ))%</td></tr>"; done | sort -nrk 2 -t '	')
 		</table>
 
-		<h4 id="autostart">Autostart options:</h4>
+		<a href="#raspbian"><h4 id="raspbian">RPi Debian (64-bit) vs Raspbian (32-bit):</h4></a>
+		<table>
+			<tr><td>Debian (64-bit) is used by</td><td align="right">${aRASPBIAN[0]} of $(( ${aRASPBIAN[0]} + ${aRASPBIAN[1]} )) RPi systems</td><td align="right">$(( ${aRASPBIAN[0]} * 100 / ( ${aRASPBIAN[0]} + ${aRASPBIAN[1]} ) ))%</td></tr>
+		</table>
+
+		<a href="#autostart"><h4 id="autostart">Autostart options:</h4></a>
 		<table>
 			$(for i in "${!aAUTOSTART_OPTION[@]}"; do echo "<tr><td>$i</td><td align=\"right\">	${aAUTOSTART_OPTION[$i]}</td><td align="right">$(( ${aAUTOSTART_OPTION[$i]} * 100 / $SURVEY_COUNT_OPTIN ))%</td></tr>"; done | sort -nrk 2 -t '	')
 		</table>
 
-		<h4 id="automation">DietPi-Automation:</h4>
+		<a href="#automation"><h4 id="automation">DietPi-Automation:</h4></a>
 		<table>
 			<tr><td>Used by</td><td align="right">${aAUTO_SETUP_AUTOMATED[1]} of $SURVEY_COUNT_OPTIN systems</td><td align="right">$(( ${aAUTO_SETUP_AUTOMATED[1]} * 100 / $SURVEY_COUNT_OPTIN ))%</td></tr>
 		</table>
 
-		<h4 id="network">Network interfaces:</h4>
+		<a href="#network"><h4 id="network">Network interfaces:</h4></a>
 		<table>
 			$(for i in "${!aNETWORK_INTERFACE[@]}"; do echo "<tr><td>$i</td><td align=\"right\">	${aNETWORK_INTERFACE[$i]}</td><td align="right">$(( ${aNETWORK_INTERFACE[$i]} * 100 / $SURVEY_COUNT_OPTIN ))%</td></tr>"; done | sort -nrk 2 -t '	')
 		</table>
 
-		<h4 id="software">Installed software titles:</h4>
+		<a href="#software"><h4 id="software">Installed software titles:</h4></a>
 		<table>
 			$(for i in "${!aSOFTWARE[@]}"; do echo "<tr><td>$i</td><td align=\"right\">	${aSOFTWARE[$i]}</td><td align="right">$(( ${aSOFTWARE[$i]} * 100 / $SURVEY_COUNT_OPTIN ))%</td></tr>"; done | sort -nrk 2 -t '	')
 		</table>
 
-		<h4 id="benchmark">DietPi-Benchmarks | CPU:</h4>
+		<a href="#benchmark"><h4 id="benchmark">DietPi-Benchmarks | CPU:</h4></a>
 		<table>
 			<tr>
 				<td colspan="2"/>
@@ -834,7 +838,7 @@
 			$(for i in "${!aBENCH_CPU_INDEX[@]}"; do echo "<tr><td>${aHW_NAME[$i]:=$i}</td><td>${aBENCH_CPU_INDEX[$i]}</td><td bgcolor="#34005D">	${aBENCH_RESULT_CPU_AVG[$i]}</td><td bgcolor="#2B5D00">${aBENCH_RESULT_CPU_MIN[$i]}</td><td bgcolor="#5D0000">${aBENCH_RESULT_CPU_MAX[$i]}</td><td bgcolor="#34005D">${aBENCH_RESULT_CPU_TEMP_START_AVG[$i]}</td><td bgcolor="#2B5D00">${aBENCH_RESULT_CPU_TEMP_START_MIN[$i]}</td><td bgcolor="#5D0000">${aBENCH_RESULT_CPU_TEMP_START_MAX[$i]}</td><td bgcolor="#34005D">${aBENCH_RESULT_CPU_TEMP_END_AVG[$i]}</td><td bgcolor="#2B5D00">${aBENCH_RESULT_CPU_TEMP_END_MIN[$i]}</td><td bgcolor="#5D0000">${aBENCH_RESULT_CPU_TEMP_END_MAX[$i]}</td></tr>"; done | sort -nk 2 -t '	')
 		</table>
 
-		<h4 id="bench_ram">DietPi-Benchmarks | IO (RAM):</h4>
+		<a href="#bench_ram"><h4 id="bench_ram">DietPi-Benchmarks | IO (RAM):</h4></a>
 		<table>
 			<tr>
 				<td colspan="2"/>
@@ -854,7 +858,7 @@
 			$(for i in "${!aBENCH_RAM_INDEX[@]}"; do echo "<tr><td>${aHW_NAME[$i]:=$i}</td><td>${aBENCH_RAM_INDEX[$i]}</td><td bgcolor="#34005D">	${aBENCH_RESULT_RAM_WRITE_AVG[$i]}</td><td bgcolor="#2B5D00">${aBENCH_RESULT_RAM_WRITE_MAX[$i]}</td><td bgcolor="#5D0000">${aBENCH_RESULT_RAM_WRITE_MIN[$i]}</td><td bgcolor="#34005D">${aBENCH_RESULT_RAM_READ_AVG[$i]}</td><td bgcolor="#2B5D00">${aBENCH_RESULT_RAM_READ_MAX[$i]}</td><td bgcolor="#5D0000">${aBENCH_RESULT_RAM_READ_MIN[$i]}</td></tr>"; done | sort -nrk 2 -t '	')
 		</table>
 
-		<h4 id="bench_disk">DietPi-Benchmarks | IO (RootFS):</h4>
+		<a href="#bench_disk"><h4 id="bench_disk">DietPi-Benchmarks | IO (RootFS):</h4></a>
 		<table>
 			<tr>
 				<td colspan="2"/>
@@ -874,7 +878,7 @@
 			$(for i in "${!aBENCH_ROOTFS_INDEX[@]}"; do echo "<tr><td>${aHW_NAME[$i]:=$i}</td><td>${aBENCH_ROOTFS_INDEX[$i]}</td><td bgcolor="#34005D">	${aBENCH_RESULT_ROOTFS_WRITE_AVG[$i]}</td><td bgcolor="#2B5D00">${aBENCH_RESULT_ROOTFS_WRITE_MAX[$i]}</td><td bgcolor="#5D0000">${aBENCH_RESULT_ROOTFS_WRITE_MIN[$i]}</td><td bgcolor="#34005D">${aBENCH_RESULT_ROOTFS_READ_AVG[$i]}</td><td bgcolor="#2B5D00">${aBENCH_RESULT_ROOTFS_READ_MAX[$i]}</td><td bgcolor="#5D0000">${aBENCH_RESULT_ROOTFS_READ_MIN[$i]}</td></tr>"; done | sort -nrk 2 -t '	')
 		</table>
 
-		<h4 id="bench_custom">DietPi-Benchmarks | IO (Custom FS):</h4>
+		<a href="#bench_custom"><h4 id="bench_custom">DietPi-Benchmarks | IO (Custom FS):</h4></a>
 		<table>
 			<tr>
 				<td colspan="2"/>
@@ -894,7 +898,7 @@
 			$(for i in "${!aBENCH_CUSTOMFS_INDEX[@]}"; do echo "<tr><td>${aHW_NAME[$i]:=$i}</td><td>${aBENCH_CUSTOMFS_INDEX[$i]}</td><td bgcolor="#34005D">	${aBENCH_RESULT_CUSTOMFS_WRITE_AVG[$i]}</td><td bgcolor="#2B5D00">${aBENCH_RESULT_CUSTOMFS_WRITE_MAX[$i]}</td><td bgcolor="#5D0000">${aBENCH_RESULT_CUSTOMFS_WRITE_MIN[$i]}</td><td bgcolor="#34005D">${aBENCH_RESULT_CUSTOMFS_READ_AVG[$i]}</td><td bgcolor="#2B5D00">${aBENCH_RESULT_CUSTOMFS_READ_MAX[$i]}</td><td bgcolor="#5D0000">${aBENCH_RESULT_CUSTOMFS_READ_MIN[$i]}</td></tr>"; done | sort -nrk 2 -t '	')
 		</table>
 
-		<h4 id="bench_lan">DietPi-Benchmarks | IO (Network LAN):</h4>
+		<a href="#bench_lan"><h4 id="bench_lan">DietPi-Benchmarks | IO (Network LAN):</h4></a>
 		<table>
 			<tr>
 				<td colspan="2"/>

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ v6.31
 (XX/06/20)
 
 Changes / Improvements / Optimisations:
+- RPi | Support for Raspberry Pi OS (64-bit) has been added, including any other Debian pre-image on RPi. Many thanks to @FusionPlmH for doing this request: https://github.com/MichaIng/DietPi/issues/3570
 - Odroid C4 | Support for this new Hardkernel SBC has been added to allow image creation based on Meverics Odroid repository, including Kodi support.
 - Network | "ping" can now be used by all users without any file capabilities, sudo or setuid. For this we allow all users to create native ICMP sockets which are available since Linux 3.X but disabled by default on Debian. Other distributions and systemd (upstream) have this enabled by default and for security and usability reasons we follow them: https://fedoraproject.org/wiki/Changes/EnableSysctlPingGroupRange
 - DietPi-Cleaner | Enhanced performance of the files cleaner if /mnt is skipped, especially in combination with large drives or network mounts. Many thanks to @maartenlangeveld for revealing the underlying issue: https://github.com/MichaIng/DietPi/issues/3609

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -1508,7 +1508,7 @@ _EOF_
 
 		elif (( $G_HW_ARCH == 3 )); then
 
-			G_EXEC_DESC='Removing foreign armhf DPKG architecture' G_EXEC dpkg --remove-architecture armhf
+			(( $G_HW_MODEL > 9 )) && G_EXEC_DESC='Removing foreign armhf DPKG architecture' G_EXEC dpkg --remove-architecture armhf
 
 		fi
 

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -251,15 +251,7 @@
 			# - Overscan sizes
 			if (( ! $overscan_disabled )); then
 
-				local overscan_options=(
-
-					'overscan_left'
-					'overscan_right'
-					'overscan_top'
-					'overscan_bottom'
-
-				)
-
+				local overscan_options=( 'overscan_left' 'overscan_right' 'overscan_top' 'overscan_bottom' )
 				local overscan_left=$(grep -m1 '^[[:blank:]]*overscan_left=' /boot/config.txt || vcgencmd get_config overscan_left); overscan_left=${overscan_left#*=}
 				local overscan_right=$(grep -m1 '^[[:blank:]]*overscan_right=' /boot/config.txt || vcgencmd get_config overscan_right); overscan_right=${overscan_right#*=}
 				local overscan_top=$(grep -m1 '^[[:blank:]]*overscan_top=' /boot/config.txt || vcgencmd get_config overscan_top); overscan_top=${overscan_top#*=}
@@ -286,7 +278,7 @@
 			local rpi_camera_led_disabled=$(grep -cm1 '^[[:blank:]]*disable_camera_led=1' /boot/config.txt)
 			local rpi_camera_led_text='On'
 			(( $rpi_camera_led_disabled )) && rpi_camera_led_text='Off'
-			G_WHIP_MENU_ARRAY+=('9' ": RPI Camera led      : [$rpi_camera_led_text]")
+			G_WHIP_MENU_ARRAY+=('9' ": RPi Camera LED      : [$rpi_camera_led_text]")
 
 			# JustBoom IR Remote
 			local justboom_ir_remote_text='Off'
@@ -307,20 +299,18 @@
 			local mpeg2_key_current=$(sed -n '/^[[:blank:]]*decode_MPG2=/{s/^[^=]*=//p;q}' /boot/config.txt)
 			G_WHIP_MENU_ARRAY+=('13' ": MPEG2 Key           : [${mpeg2_key_current:=none}]")
 
-		fi
+		# Odroids only
+		elif (( $G_HW_MODEL < 13 )); then
 
-		# Odroid Remote
-		if (( $G_HW_MODEL > 9 && $G_HW_MODEL < 13 )); then
-
+			# Remote
 			local odroid_remote_text='Off'
 			local odroid_remote_enabled=0
-			if [[ -f /etc/systemd/system/odroid-remote.service ]]; then
+			if [[ -f '/etc/systemd/system/odroid-remote.service' ]]; then
 
 				odroid_remote_text='On'
 				odroid_remote_enabled=1
 
 			fi
-
 			G_WHIP_MENU_ARRAY+=('10' ": Odroid remote : [$odroid_remote_text]")
 
 		fi
@@ -339,7 +329,7 @@
 				do
 
 					G_WHIP_DEFAULT_ITEM=${!i}
-					G_WHIP_INPUTBOX "Please enter a value (pixel count) for $i\n - EG: 16" || break
+					G_WHIP_INPUTBOX "Please enter a value (pixel count) for $i\n - E.g.: 16" || break
 
 					G_CONFIG_INJECT "$i=" "$i=$G_WHIP_RETURNED_VALUE" /boot/config.txt
 					REBOOT_REQUIRED=1
@@ -631,8 +621,7 @@ A long (or insufficiently manufactured) cable may required a higher boost settin
 
 				MIN_VALUE=0
 				MAX_VALUE=255
-				local fp_brightness=''
-				local current_brightness=''
+				local fp_brightness current_brightness
 
 				for fp_brightness in "${afp_current_set_brightness[@]}"
 				do
@@ -720,12 +709,12 @@ A long (or insufficiently manufactured) cable may required a higher boost settin
 
 			G_WHIP_MENU_ARRAY=(
 
+				'System default' ''
 				'1600x1200' ''
 				'1280x1024' ''
 				'1152x864' ''
 				'1024x768' ''
 				'800x600' ''
-				'System default' ''
 
 			)
 
@@ -758,7 +747,7 @@ A long (or insufficiently manufactured) cable may required a higher boost settin
 			if dpkg-query -s nvidia-driver &> /dev/null; then
 
 				nvidia_installed=1
-				nvidia_text='Uninstall GPU driver'
+				nvidia_text='[Installed] Uninstall GPU driver'
 
 			fi
 
@@ -767,7 +756,16 @@ A long (or insufficiently manufactured) cable may required a higher boost settin
 			if dpkg-query -s xserver-xorg-video-intel &> /dev/null; then
 
 				intel_installed=1
-				intel_text='Uninstall GPU driver'
+				intel_text='[Installed] Uninstall GPU driver'
+
+			fi
+
+			local amd_installed=0
+			local amd_text='Install GPU driver'
+			if dpkg-query -s xserver-xorg-video-amdgpu &> /dev/null; then
+
+				amd_installed=1
+				amd_text='[Installed] Uninstall GPU driver'
 
 			fi
 
@@ -775,6 +773,7 @@ A long (or insufficiently manufactured) cable may required a higher boost settin
 
 				'Nvidia' ": $nvidia_text"
 				'Intel' ": $intel_text"
+				'AMD' ": $amd_text"
 
 			)
 
@@ -808,6 +807,19 @@ A long (or insufficiently manufactured) cable may required a higher boost settin
 
 					fi
 
+				elif [[ $G_WHIP_RETURNED_VALUE == 'AMD' ]]; then
+
+					if (( $amd_installed )); then
+
+						G_AGP firmware-amd-graphics xserver-xorg-video-amdgpu
+
+					else
+
+						G_AG_CHECK_INSTALL_PREREQ firmware-amd-graphics xserver-xorg-video-amdgpu libgl1-mesa-dri
+						Xorg_Configure
+
+					fi
+
 				fi
 
 			fi
@@ -830,8 +842,8 @@ A long (or insufficiently manufactured) cable may required a higher boost settin
 
 			fi
 
-			# RPi4 doesn't support full KMS driver currently
-			(( $G_HW_MODEL == 4 )) && G_WHIP_MENU_ARRAY=() || G_WHIP_MENU_ARRAY=('vc4-kms-v3d' ': OpenGL | 1920 x 1080')
+			# RPi4 has its own full KMS overlay
+			(( $G_HW_MODEL == 4 )) && G_WHIP_MENU_ARRAY=('vc4-kms-v3d-pi4' ': OpenGL | 1920 x 1080') || G_WHIP_MENU_ARRAY=('vc4-kms-v3d' ': OpenGL | 1920 x 1080')
 
 			G_WHIP_MENU_ARRAY+=(
 
@@ -1502,7 +1514,7 @@ Further information: https://www.raspberrypi.org/documentation/hardware/raspberr
 				if (( $rpi_max_usb_current_enabled )); then
 
 					if G_WHIP_YESNO "Current setting: [$rpi_max_usb_current_text] (1.2AMP)\nWould you like to disable this setting?
-\nOnce Disabled:\n - Max USB current will be limited to 0.6AMP.\n - Shared by all USB ports."; then
+\nOnce disabled:\n - Max USB current will be limited to 0.6AMP.\n - Shared by all USB ports."; then
 
 						G_CONFIG_INJECT 'max_usb_current=' 'max_usb_current=0' /boot/config.txt
 						REBOOT_REQUIRED=1
@@ -1510,7 +1522,7 @@ Further information: https://www.raspberrypi.org/documentation/hardware/raspberr
 					fi
 
 				elif G_WHIP_YESNO "Current setting: [$rpi_max_usb_current_text] (0.6AMP)\nWould you like to enable this setting?
-\nOnce Enabled:\n - Max USB current will be set to 1.2AMP.\n - Shared by all USB ports."; then
+\nOnce enabled:\n - Max USB current will be set to 1.2AMP.\n - Shared by all USB ports."; then
 
 					G_CONFIG_INJECT 'max_usb_current=' 'max_usb_current=1' /boot/config.txt
 					REBOOT_REQUIRED=1
@@ -4002,16 +4014,20 @@ The following will now be applied:\n - CPU governor = Powersave\n - Display outp
 					G_WHIP_MENU_ARRAY+=('hifiberry-dacplus' ': HifiBerry DAC+ / DAC+ Pro / AMP2')
 					G_WHIP_MENU_ARRAY+=('hifiberry-dacplusadc' ': HifiBerry DAC+ADC')
 					G_WHIP_MENU_ARRAY+=('hifiberry-dacplusadcpro' ': HifiBerry DAC+ADC Pro')
+					G_WHIP_MENU_ARRAY+=('hifiberry-dacplusdsp' ': HifiBerry DAC+DSP')
+					G_WHIP_MENU_ARRAY+=('hifiberry-dacplushd' ': HifiBerry DAC+ HD')
 					G_WHIP_MENU_ARRAY+=('hifiberry-digi' ': HifiBerry Digi / Digi+')
 					G_WHIP_MENU_ARRAY+=('hifiberry-digi-pro' ': HifiBerry Digi+ Pro')
 					G_WHIP_MENU_ARRAY+=('i-sabre-q2m' ': AudioPhonics I-Sabre ES9028Q2M / ES9038Q2M')
-					G_WHIP_MENU_ARRAY+=('iqaudio-dac' ': IQaudio DAC audio card')
-					G_WHIP_MENU_ARRAY+=('iqaudio-dacplus' ': Pi-DAC+, Pi-DACZero, Pi-DAC Pro, Pi-DigiAMP+')
-					G_WHIP_MENU_ARRAY+=('iqaudio-digi-wm8804-audio' ': Pi-DIGI+')
+					G_WHIP_MENU_ARRAY+=('iqaudio-codec' ': IQaudIO Pi-Codec HAT')
+					G_WHIP_MENU_ARRAY+=('iqaudio-dac' ': IQaudIO DAC audio card')
+					G_WHIP_MENU_ARRAY+=('iqaudio-dacplus' ': Pi-DAC+, Pi-DACZero, Pi-DAC+ Pro, Pi-DigiAMP+')
+					G_WHIP_MENU_ARRAY+=('iqaudio-digi-wm8804-audio' ': Pi-Digi+')
 					G_WHIP_MENU_ARRAY+=('iqaudio-dacplus,auto_mute_amp' ': Pi-DigiAMP+')
 					G_WHIP_MENU_ARRAY+=('iqaudio-dacplus,unmute_amp' ': Pi-DigiAMP+')
 					G_WHIP_MENU_ARRAY+=('justboom-dac' ': JustBoom: DAC HAT, Amp HAT, DAC Zero and Amp Zero')
 					G_WHIP_MENU_ARRAY+=('justboom-digi' ': JustBoom: Digi HAT and Digi Zero')
+					G_WHIP_MENU_ARRAY+=('justboom-both' ': JustBoom: Simultaneous DAC and Digi usage')
 					G_WHIP_MENU_ARRAY+=('rpi-dac' ': Soekris DAM1021 (pcm1794a)')
 
 				# - C2
@@ -4378,7 +4394,7 @@ Please enter a value between $min and $max." && G_CHECK_VALIDINT "$G_WHIP_RETURN
 						G_WHIP_MENU_ARRAY=('Custom' ': Manually enter APT mirror')
 
 						# - Raspbian
-						if (( $G_HW_MODEL < 10 )); then
+						if (( $G_HW_MODEL < 10 )) && (( $G_RASPBIAN )); then
 
 							local mirror_list='https://www.raspbian.org/RaspbianMirrors/'
 							G_WHIP_MENU_ARRAY+=('http://raspbian.raspberrypi.org/raspbian/' ': Global mirror director (default)')

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -251,12 +251,12 @@
 			# - Overscan sizes
 			if (( ! $overscan_disabled )); then
 
-				local overscan_options=( 'overscan_left' 'overscan_right' 'overscan_top' 'overscan_bottom' )
+				local overscan_options=('overscan_left' 'overscan_right' 'overscan_top' 'overscan_bottom')
 				local overscan_left=$(grep -m1 '^[[:blank:]]*overscan_left=' /boot/config.txt || vcgencmd get_config overscan_left); overscan_left=${overscan_left#*=}
 				local overscan_right=$(grep -m1 '^[[:blank:]]*overscan_right=' /boot/config.txt || vcgencmd get_config overscan_right); overscan_right=${overscan_right#*=}
 				local overscan_top=$(grep -m1 '^[[:blank:]]*overscan_top=' /boot/config.txt || vcgencmd get_config overscan_top); overscan_top=${overscan_top#*=}
 				local overscan_bottom=$(grep -m1 '^[[:blank:]]*overscan_bottom=' /boot/config.txt || vcgencmd get_config overscan_bottom); overscan_bottom=${overscan_bottom#*=}
-				G_WHIP_MENU_ARRAY+=('15' ": Overscan Compensation [L:${overscan_left:=N/A}] [R:${overscan_right:=N/A}] [T:${overscan_top:=N/A}] [B:${overscan_bottom:=N/A}]")
+				G_WHIP_MENU_ARRAY+=('15' ": Overscan Compensation [L:${overscan_left:-N/A}] [R:${overscan_right:-N/A}] [T:${overscan_top:-N/A}] [B:${overscan_bottom:-N/A}]")
 
 			fi
 
@@ -264,7 +264,7 @@
 			if (( $G_HW_MODEL < 4 )); then
 
 				local hdmi_boost_current=$(grep -m1 '^[[:blank:]]*config_hdmi_boost=' /boot/config.txt || vcgencmd get_config config_hdmi_boost); hdmi_boost_current=${hdmi_boost_current#*=}
-				G_WHIP_MENU_ARRAY+=('7'	": HDMI Boost          : [${hdmi_boost_current:=N/A}]")
+				G_WHIP_MENU_ARRAY+=('7'	": HDMI Boost          : [${hdmi_boost_current:-N/A}]")
 
 			fi
 
@@ -293,11 +293,11 @@
 
 			# VC1 key
 			local vc1_key_current=$(sed -n '/^[[:blank:]]*decode_WVC1=/{s/^[^=]*=//p;q}' /boot/config.txt)
-			G_WHIP_MENU_ARRAY+=('12' ": VC1 Key             : [${vc1_key_current:=none}]")
+			G_WHIP_MENU_ARRAY+=('12' ": VC1 Key             : [${vc1_key_current:-none}]")
 
 			# MPEG2 key
 			local mpeg2_key_current=$(sed -n '/^[[:blank:]]*decode_MPG2=/{s/^[^=]*=//p;q}' /boot/config.txt)
-			G_WHIP_MENU_ARRAY+=('13' ": MPEG2 Key           : [${mpeg2_key_current:=none}]")
+			G_WHIP_MENU_ARRAY+=('13' ": MPEG2 Key           : [${mpeg2_key_current:-none}]")
 
 		# Odroids only
 		elif (( $G_HW_MODEL < 13 )); then

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -4303,18 +4303,20 @@ The following will now be applied:\n - CPU governor = Powersave\n - Display outp
 		# Network boot wait
 		local boot_wait_for_network=$(sed -n '/^[[:blank:]]*CONFIG_BOOT_WAIT_FOR_NETWORK=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 		local boot_wait_for_network_text='10 Seconds MAX (default)'
-		if (( $boot_wait_for_network == 0 )); then
+		if [[ $boot_wait_for_network == 0 ]]; then
 
-			boot_wait_for_network_text+='Off'
+			boot_wait_for_network_text='Off'
 
-		elif (( $boot_wait_for_network == 2 )); then
+		elif [[ $boot_wait_for_network == 2 ]]; then
 
-			boot_wait_for_network_text+='Infinite wait'
+			boot_wait_for_network_text='Infinite wait'
 
 		fi
 
 		local check_url_timeout=$(sed -n '/^[[:blank:]]*CONFIG_G_CHECK_URL_TIMEOUT=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+		disable_error=1 G_CHECK_VALIDINT "$check_url_timeout" 0 || check_url_timeout=10
 		local check_url_attempts=$(sed -n '/^[[:blank:]]*CONFIG_G_CHECK_URL_ATTEMPTS=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+		disable_error=1 G_CHECK_VALIDINT "$check_url_attempts" 1 || check_url_attempts=2
 
 		G_WHIP_MENU_ARRAY=(
 
@@ -4339,10 +4341,10 @@ The following will now be applied:\n - CPU governor = Powersave\n - Display outp
 
 				'G_CHECK_URL Timeout')
 
-					local min=5 max=60
+					local min=0 max=60
 					G_WHIP_DEFAULT_ITEM=$check_url_timeout
-					if G_WHIP_INPUTBOX "This setting tells DietPi how long to wait, before G_CHECK_URL assumes a dead connection attempt (and failure).\nIncrease this value if you have a 'flaky' connection.\n
-Please enter a value between $min and $max." && G_CHECK_VALIDINT "$G_WHIP_RETURNED_VALUE" $min $max; then
+					if G_WHIP_INPUTBOX "This setting tells DietPi how long to wait, before DietPi-internal connection and URL checks assume a dead connection attempt (and failure).\nIncrease this value if you have a 'flaky' connection.\n
+Please enter a value in seconds between $min and $max. \"0\" means unlimited, however this is not recommended to avoid unlimited background job hang." && G_CHECK_VALIDINT "$G_WHIP_RETURNED_VALUE" $min $max; then
 
 						G_CONFIG_INJECT 'CONFIG_G_CHECK_URL_TIMEOUT=' "CONFIG_G_CHECK_URL_TIMEOUT=$G_WHIP_RETURNED_VALUE" /boot/dietpi.txt
 
@@ -4352,9 +4354,9 @@ Please enter a value between $min and $max." && G_CHECK_VALIDINT "$G_WHIP_RETURN
 
 				'G_CHECK_URL Attempts')
 
-					local min=2 max=10
+					local min=1 max=10
 					G_WHIP_DEFAULT_ITEM=$check_url_attempts
-					if G_WHIP_INPUTBOX "This setting tells DietPi how many times to check a URL, before G_CHECK_URL assumes a dead URL link (and failure).\nIncrease this value if you have a 'flaky' connection.\n
+					if G_WHIP_INPUTBOX "This setting tells DietPi how many times to test a connection or URL, before assuming a dead connection or URL link (and failure).\nIncrease this value if you have a 'flaky' connection.\n
 Please enter a value between $min and $max." && G_CHECK_VALIDINT "$G_WHIP_RETURNED_VALUE" $min $max; then
 
 						G_CONFIG_INJECT 'CONFIG_G_CHECK_URL_ATTEMPTS=' "CONFIG_G_CHECK_URL_ATTEMPTS=$G_WHIP_RETURNED_VALUE" /boot/dietpi.txt

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1701,8 +1701,8 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=4316#p4316'
 		aSOFTWARE_REQUIRES_JAVA_JRE_JDK[$software_id]=1
-		# - non-RPi Buster: https://packages.debian.org/tomcat8
-		(( $G_HW_MODEL > 9 )) && aSOFTWARE_AVAIL_G_DISTRO[$software_id,5]=0 && aSOFTWARE_AVAIL_G_DISTRO[$software_id,6]=0
+		# - non-Raspbian Buster: https://packages.debian.org/tomcat8
+		(( $G_HW_MODEL > 9 )) || (( ! $G_RASPBIAN )) && aSOFTWARE_AVAIL_G_DISTRO[$software_id,5]=0 aSOFTWARE_AVAIL_G_DISTRO[$software_id,6]=0
 
 		# Pi-hole
 		#--------------------------------------------------------------------------------
@@ -2926,7 +2926,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 			Banner_Installing
 
 			# For desktop entries/icons hosted on dietpi.com
-			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/conf/desktop'
+			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/conf/desktop/'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			# APT deps: upower policykit-1 are needed for LXDE logout menu item to show shutdown/restart ...
@@ -2943,7 +2943,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 			Banner_Installing
 
 			# For desktop entries/icons hosted on dietpi.com
-			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/conf/desktop'
+			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/conf/desktop/'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			# Buster: No leafpad available, use featherpad instead: https://github.com/MichaIng/DietPi/issues/1918#issuecomment-489319719
@@ -2960,7 +2960,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 			Banner_Installing
 
 			# For desktop entries/icons hosted on dietpi.com
-			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/conf/desktop'
+			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/conf/desktop/'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			G_AGI mate-desktop-environment-extras upower policykit-1 firefox-esr
@@ -2973,7 +2973,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 			Banner_Installing
 
 			# For desktop entries/icons hosted on dietpi.com
-			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/conf/desktop'
+			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/conf/desktop/'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			G_AGI x-window-system-core wmaker gnustep gnustep-devel gnustep-games libc-dbg upower policykit-1 firefox-esr
@@ -2986,7 +2986,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 			Banner_Installing
 
 			# For desktop entries/icons hosted on dietpi.com
-			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/conf/desktop'
+			INSTALL_URL_ADDRESS='https://dietpi.com/downloads/conf/desktop/'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			G_AGI xfce4 xfce4-terminal gnome-icon-theme tango-icon-theme upower policykit-1 firefox-esr
@@ -3196,7 +3196,7 @@ _EOF_
 				# Debian (+sury.org) armhf is not ARMv6 compatible: https://github.com/MichaIng/DietPi/issues/2794
 				if (( $G_HW_ARCH < 2 )); then
 
-					INSTALL_URL_ADDRESS='http://raspbian.raspberrypi.org/raspbian'
+					INSTALL_URL_ADDRESS='http://raspbian.raspberrypi.org/raspbian/'
 					# Actually we do not support any non-RPi ARMv6 devices currently, but lets be failsafe here
 					(( $G_HW_MODEL > 9 )) && INSTALL_URL_ADDRESS='https://deb.debian.org/debian/'
 
@@ -3899,10 +3899,12 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 
 			Banner_Installing
 
-			if (( $G_HW_MODEL > 9 )); then
+			# Debian
+			if (( $G_HW_MODEL > 9 )) || (( ! $G_RASPBIAN )); then
 
 				G_AGI opentyrian
 
+			# Raspbian: No build available: http://raspbian.raspberrypi.org/raspbian/pool/contrib/o/opentyrian/
 			else
 
 				DEPS_LIST='ibsdl1.2debian libsdl-net1.2'
@@ -4617,12 +4619,12 @@ _EOF_
 			# Since G_AGUG does not upgrade packages with changed dependencies, in case of kernel image meta packages, those need to be installed+upgraded via G_AGI.
 			G_AGI $kernel_packages # apt-get install overrides hold state
 
-			# Package available on Buster backports and Bullseye: For Stretch and RPi Buster add Bullseye repo
-			if (( $G_DISTRO < 5 || ( $G_HW_MODEL < 10 && $G_DISTRO == 5 ) )); then
+			# Package available on Buster backports and Bullseye: For Stretch and Raspbian Buster add Bullseye repo
+			if (( $G_DISTRO < 5 || ( $G_HW_MODEL < 10 && ${G_RASPBIAN:-1} && $G_DISTRO == 5 ) )); then
 
 				# Raspbian or Debian?
 				local url='http://raspbian.raspberrypi.org/raspbian/'
-				(( $G_HW_MODEL > 9 )) && url='https://deb.debian.org/debian/'
+				(( $G_HW_MODEL > 9 )) || (( ! $G_RASPBIAN )) && url='https://deb.debian.org/debian/'
 
 				echo "deb $url bullseye main" > /etc/apt/sources.list.d/dietpi-wireguard.list
 
@@ -6168,7 +6170,7 @@ sudo -u $ha_user dash -c '$ha_pyenv_activation; pip3 install -U homeassistant'" 
 			# Enable defaults, if set to "none"
 			if [[ $soundcard == 'none' ]]; then
 
-				# - RPi: Onboard auto, Others: default
+				# RPi: Onboard auto, Others: default
 				(( $G_HW_MODEL < 10 )) && soundcard='rpi-bcm2835-auto' || soundcard='default'
 
 			fi
@@ -6636,7 +6638,7 @@ sudo -u $ha_user dash -c '$ha_pyenv_activation; pip3 install -U homeassistant'" 
 
 			# On RPi use separate Raspbian repo: https://github.com/MichaIng/DietPi/issues/1023
 			# Use Buster branch on Bullseye
-			if (( $G_HW_MODEL < 10 )); then
+			if (( $G_HW_MODEL < 10 )) && (( $G_RASPBIAN )); then
 
 				echo "deb https://download.mono-project.com/repo/debian/ raspbian${G_DISTRO_NAME/bullseye/buster} main" > /etc/apt/sources.list.d/mono-xamarin.list
 
@@ -6658,8 +6660,8 @@ sudo -u $ha_user dash -c '$ha_pyenv_activation; pip3 install -U homeassistant'" 
 
 			Banner_Installing
 
-			# On Raspbian, only "unrar-free" is available in repos, but does not support all rar formats, thus we use "unrar" [non-free] from Debian repo
-			if (( $G_HW_MODEL < 10 )); then
+			# On Raspbian, only "unrar-free" is available in repos, but does not support all rar formats, thus we use "unrar" [non-free] from Debian repo: http://raspbian.raspberrypi.org/raspbian/pool/non-free/u/unrar-nonfree/
+			if (( $G_HW_MODEL < 10 )) && (( $G_RASPBIAN )); then
 
 				Download_Install "https://dietpi.com/downloads/binaries/rpi/unrar-armhf-$G_DISTRO_NAME.deb"
 
@@ -13281,7 +13283,7 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			if (( $G_HW_MODEL >= 10 )); then
+			if (( $G_HW_MODEL > 9 )) || (( ! $G_RASPBIAN )); then
 
 				G_AGP opentyrian
 

--- a/dietpi/dietpi-survey
+++ b/dietpi/dietpi-survey
@@ -72,6 +72,9 @@
 ((aNETWORK_INTERFACE[$network_interface]++))
 _EOF_
 
+		# RPi: Raspbian/Raspberry Pi OS (32-bt) or Debian/Raspberry Pi OS (64-bit)?
+		(( $G_HW_MODEL < 10 )) && echo "((aRASPBIAN[$G_RASPBIAN]++))" >> $FP_UPLOAD
+
 		# DietPi-Software installs
 		if [[ -f '/boot/dietpi/.installed' ]]; then
 

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -976,7 +976,7 @@ $(ps f -eo pid,user,tty,cmd | grep -i '[d]ietpi')"; then
 - Pre-image      | $preimage_name
 - Hardware       | $G_HW_MODEL_NAME (ID=$G_HW_MODEL)
 - Kernel version | $(uname -a)
-- Distro         | $G_DISTRO_NAME (ID=$G_DISTRO)
+- Distro         | $G_DISTRO_NAME (ID=$G_DISTRO${G_RASPBIAN:+,RASPBIAN=$G_RASPBIAN})
 - Command        | $*
 - Exit code      | $exit_code
 - Software title | $G_PROGRAM_NAME

--- a/dietpi/func/dietpi-obtain_hw_model
+++ b/dietpi/func/dietpi-obtain_hw_model
@@ -116,6 +116,7 @@
 	G_HW_UUID=${G_HW_UUID:-$(</proc/sys/kernel/random/uuid)}
 
 	# RPi extras
+	G_RASPBIAN=1
 	G_HW_ONBOARD_WIFI=0
 	G_HW_REVISION=
 	G_HW_PCB_REVISION='Unknown'
@@ -126,6 +127,9 @@
 
 		G_HW_MODEL=1
 		G_HW_MODEL_NAME='RPi (Unknown)'
+
+		# Detect if this is Raspbian/Raspberry Pi OS (32-bit) or Debian/Raspberry Pi OS (64-bit)
+		grep -q '^ID=debian' /etc/os-release && G_RASPBIAN=0
 
 		# Obtain device info by revision code: https://github.com/raspberrypi/documentation/tree/master/hardware/raspberrypi/revision-codes
 		G_HW_REVISION=$(mawk '/^Revision/{print $3;exit}' /proc/cpuinfo)
@@ -530,13 +534,13 @@
 
 			fi
 
-		# RPi/Raspbian
-		elif grep -q '^ID=raspbian' /etc/os-release; then
+		# RPi? Detect via ondisk device tree file instead of /proc content, for chroot/systemd-nspawn support
+		elif for i in /boot/bcm*-rpi-*\.dtb; do [[ -f $i ]] && break; done; then
 
-			# Grab hardware description from /proc/cpuinfo revision code
+			# Detect exact RPi model
 			RPi_BoardInfo
 
-		# No hardware identifier and no Raspbian, revert to "Generic Device"
+		# No hardware identifier and no RPi, revert to "Generic Device"
 		else
 
 			echo $G_HW_MODEL > $FP_G_HW_MODEL_IDENTIFIER
@@ -601,7 +605,8 @@ G_ROOTFS_DEV='$G_ROOTFS_DEV'
 G_HW_UUID='$G_HW_UUID'" > /boot/dietpi/.hw_model
 
 		# - RPi extras
-		(( $G_HW_MODEL < 10 )) && echo "G_HW_ONBOARD_WIFI=$G_HW_ONBOARD_WIFI
+		(( $G_HW_MODEL < 10 )) && echo "G_RASPBIAN=$G_RASPBIAN
+G_HW_ONBOARD_WIFI=$G_HW_ONBOARD_WIFI
 G_HW_REVISION='$G_HW_REVISION'
 G_HW_PCB_REVISION=$G_HW_PCB_REVISION
 G_HW_MEMORY_SIZE=$G_HW_MEMORY_SIZE

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -592,7 +592,7 @@ _EOF_
 		if [[ $INPUT_DEVICE_VALUE == 'vc4-kms-v3d' || $INPUT_DEVICE_VALUE == 'vc4-kms-v3d-pi4' || $INPUT_DEVICE_VALUE == 'vc4-fkms-v3d' ]]; then
 
 			# Failsafe: Switch to correct full KMS overlay based on RPi model
-			[[ $G_HW_MODEL =! 4 && $INPUT_DEVICE_VALUE == 'vc4-kms-v3d-pi4' ]] && INPUT_DEVICE_VALUE='vc4-kms-v3d'
+			[[ $G_HW_MODEL != 4 && $INPUT_DEVICE_VALUE == 'vc4-kms-v3d-pi4' ]] && INPUT_DEVICE_VALUE='vc4-kms-v3d'
 			[[ $G_HW_MODEK == 4 && $INPUT_DEVICE_VALUE == 'vc4-kms-v3d' ]] && INPUT_DEVICE_VALUE='vc4-kms-v3d-pi4'
 
 			# GL packages

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -27,7 +27,7 @@ $FP_SCRIPT	lcdpanel		target_panel (none to remove all)
 $FP_SCRIPT	headless		enable/disable
 $FP_SCRIPT	gpumemsplit		64/128/256 # RPi only
 $FP_SCRIPT	rpi-camera		enable/disable
-$FP_SCRIPT	rpi-opengl		vc4-kms-v3d/vc4-fkms-v3d/disable
+$FP_SCRIPT	rpi-opengl		vc4-kms-v3d/vc4-kms-v3d-pi4/vc4-fkms-v3d/disable
 $FP_SCRIPT	rpi3_usb_boot		enable
 $FP_SCRIPT	rpi-eeprom
 "	#////////////////////////////////////
@@ -589,7 +589,11 @@ _EOF_
 		# Always remove previous vc4 overlay entry
 		sed -i '/^[[:blank:]]*dtoverlay=vc4-/d' /boot/config.txt
 
-		if [[ $INPUT_DEVICE_VALUE == 'vc4-kms-v3d' || $INPUT_DEVICE_VALUE == 'vc4-fkms-v3d' ]]; then
+		if [[ $INPUT_DEVICE_VALUE == 'vc4-kms-v3d' || $INPUT_DEVICE_VALUE == 'vc4-kms-v3d-pi4' || $INPUT_DEVICE_VALUE == 'vc4-fkms-v3d' ]]; then
+
+			# Failsafe: Switch to correct full KMS overlay based on RPi model
+			[[ $G_HW_MODEL =! 4 && $INPUT_DEVICE_VALUE == 'vc4-kms-v3d-pi4' ]] && INPUT_DEVICE_VALUE='vc4-kms-v3d'
+			[[ $G_HW_MODEK == 4 && $INPUT_DEVICE_VALUE == 'vc4-kms-v3d' ]] && INPUT_DEVICE_VALUE='vc4-kms-v3d-pi4'
 
 			# GL packages
 			local libegl1='libegl1'
@@ -1986,13 +1990,8 @@ _EOF_
 			;;
 
 			# dtoverlay
-			#	hifiberry-dac
-			#	hifiberry-dacplus
-			#	hifiberry-digi
-			#	hifiberry-digi-pro
-			#	hifiberry-amp
-			#	JustBoom-dac: DAC HAT, Amp HAT, DAC Zero and Amp Zero
-			#	JustBoom-digi: Digi HAT and Digi Zero
+			#	hifiberry-*
+			#	JustBoom-[dac|digi|both]
 			#	allo-boss-dac-pcm512x-audio
 			#	allo-digione
 			#	allo-katana-dac-audio

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -104,17 +104,24 @@ $FP_SCRIPT	passwords		NULL=Prompt user to change DietPi related passwords | X=op
 
 		if [[ $INPUT_MODE_VALUE ]]; then
 
-			# Raspbian
+			# RPi
 			if (( $G_HW_MODEL < 10 )); then
+
+				# Component "ui" is in use until Stretch
+				local components='main'
+				(( $G_DISTRO < 5 )) && components+=' ui'
+				# Bullseye is not yet available, revert to Buster
+				echo "deb https://archive.raspberrypi.org/debian/ ${G_DISTRO_NAME/bullseye/buster} $components" > /etc/apt/sources.list.d/raspi.list
+
+			fi
+
+			# Raspbian
+			if (( $G_HW_MODEL < 10 )) && (( $G_RASPBIAN )); then
 
 				# Default?
 				[[ $INPUT_MODE_VALUE == 'default' ]] && INPUT_MODE_VALUE='http://raspbian.raspberrypi.org/raspbian/'
 
 				echo "deb $INPUT_MODE_VALUE $G_DISTRO_NAME main contrib non-free" > /etc/apt/sources.list
-				# Component "ui" is in use until Stretch
-				local components='main'
-				(( $G_DISTRO < 5 )) && components+=' ui'  
-				echo "deb https://archive.raspberrypi.org/debian/ $G_DISTRO_NAME $components" > /etc/apt/sources.list.d/raspi.list
 
 				# Update dietpi.txt entry
 				G_CONFIG_INJECT 'CONFIG_APT_RASPBIAN_MIRROR=' "CONFIG_APT_RASPBIAN_MIRROR=$INPUT_MODE_VALUE" /boot/dietpi.txt

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -489,10 +489,10 @@ _EOF_'
 
 			#-------------------------------------------------------------------------------
 			# RPi APT mirror fix: https://github.com/MichaIng/DietPi/issues/1659
-			if (( $G_HW_MODEL < 10 )); then
+			if (( $G_HW_MODEL < 10 )) && (( $G_RASPBIAN )); then
 
 				G_AGDUG
-				/boot/dietpi/func/dietpi-set_software apt-mirror 'http://raspbian.raspberrypi.org/raspbian'
+				/boot/dietpi/func/dietpi-set_software apt-mirror 'http://raspbian.raspberrypi.org/raspbian/'
 				G_AGUP
 
 			fi
@@ -970,7 +970,7 @@ We strongly recommend you select "0 : Re-enable IPv6 on kernel level". By doing 
 						sed -i '/^[[:blank:]]*root=/s/ipv6.disable=1[[:blank:]]//' /boot/cmdline.txt
 
 					# - Odroid
-					elif (( $G_HW_MODEL < 15 )); then
+					elif (( $G_HW_MODEL < 20 )); then
 
 						sed -i '/^[[:blank:]]*setenv boot/s/[[:blank:]]ipv6.disable=1//' /boot/boot.ini
 						sed -i '/^[[:blank:]]*setenv boot/s/ipv6.disable=1[[:blank:]]//' /boot/boot.ini
@@ -1305,9 +1305,6 @@ Also have a look at "Sonarr", another alternative TV show manager, available for
 			#-------------------------------------------------------------------------------
 			# Mopidy fix: https://github.com/MichaIng/DietPi/issues/2536
 			getent passwd mopidy &> /dev/null && usermod -aG dietpi,audio -d $G_FP_DIETPI_USERDATA/mopidy mopidy
-			#-------------------------------------------------------------------------------
-			# Remove obsolete workaround for archive.raspberrypi.org repo on Buster: https://github.com/MichaIng/DietPi/issues/1286#issuecomment-463856159
-			(( $G_DISTRO == 5 && $G_HW_MODEL < 10 )) && sed -i 's/stretch/buster/g' /etc/apt/sources.list.d/raspi.list
 			#-------------------------------------------------------------------------------
 			# Removed dependency on "p7zip-full", use "7zr" (p7zip) instead: https://github.com/MichaIng/DietPi/pull/2559
 			G_AGI p7zip
@@ -1757,16 +1754,16 @@ _EOF_
 
 			fi
 			#-------------------------------------------------------------------------------
-			# RPi Buster: Re-apply firmware Buster-only repo, remove Stretch branch, reinstall raspi-copies-and-fills which is now compatible
+			# RPi Buster: Re-apply firmware Buster-only repo, remove Stretch branch, reinstall raspi-copies-and-fills (on ARMv6/7 models) which is now compatible
 			if (( $G_HW_MODEL < 10 && $G_DISTRO > 4 )); then
 
 				echo 'deb https://archive.raspberrypi.org/debian/ buster main ui' > /etc/apt/sources.list.d/raspi.list
 				G_AGUP
-				G_AGI raspi-copies-and-fills
+				(( $G_HW_ARCH == 3 )) || G_AGI raspi-copies-and-fills
 
 			fi
 			#-------------------------------------------------------------------------------
-			# Install "haveged" entropy daemon by default on all DietPi systems: https://github.com/MichaIng/DietPi/issues/2806
+			# Install "haveged" entropy daemon by default on all non-RPi systems: https://github.com/MichaIng/DietPi/issues/2806
 			(( $G_HW_MODEL > 9 )) && G_AGI haveged
 			#-------------------------------------------------------------------------------
 			# RPi3: Remove doubled config.txt temp_limit value due to: https://github.com/MichaIng/DietPi/commit/cafcbc599ef23c337e75003fb8eacc446877eaba#diff-68acf994541fd7b6ea4f6b02d04ee328L60

--- a/dietpi/pre-patch_file
+++ b/dietpi/pre-patch_file
@@ -181,7 +181,7 @@ _EOF_
 
 			echo -e '\e[90m[\e[0m INFO \e[90m]\e[0m Pre-patch 14 | Switch to "bullseye" repo for WireGuard installs'
 			# Raspbian
-			if (( $G_HW_MODEL < 10 && ${G_RASPBIAN:=1} )); then
+			if (( $G_HW_MODEL < 10 )) && (( ${G_RASPBIAN:=1} )); then
 
 				echo 'deb http://raspbian.raspberrypi.org/raspbian/ bullseye main' > /etc/apt/sources.list.d/dietpi-wireguard.list || exit 14
 

--- a/dietpi/pre-patch_file
+++ b/dietpi/pre-patch_file
@@ -180,8 +180,8 @@ _EOF_
 		if [[ -f '/etc/apt/sources.list.d/dietpi-wireguard.list' ]]; then
 
 			echo -e '\e[90m[\e[0m INFO \e[90m]\e[0m Pre-patch 14 | Switch to "bullseye" repo for WireGuard installs'
-			# RPi
-			if (( $G_HW_MODEL < 10 )); then
+			# Raspbian
+			if (( $G_HW_MODEL < 10 && ${G_RASPBIAN:=1} )); then
 
 				echo 'deb http://raspbian.raspberrypi.org/raspbian/ bullseye main' > /etc/apt/sources.list.d/dietpi-wireguard.list || exit 14
 

--- a/rootfs/var/lib/dietpi/services/dietpi-firstboot.bash
+++ b/rootfs/var/lib/dietpi/services/dietpi-firstboot.bash
@@ -177,7 +177,7 @@
 
 		# Set APT mirror
 		local target_repo='CONFIG_APT_DEBIAN_MIRROR'
-		(( $G_HW_MODEL < 10 )) && target_repo='CONFIG_APT_RASPBIAN_MIRROR'
+		(( $G_HW_MODEL < 10 )) && (( $G_RASPBIAN )) && target_repo='CONFIG_APT_RASPBIAN_MIRROR'
 		/boot/dietpi/func/dietpi-set_software apt-mirror "$(sed -n "/^[[:blank:]]*$target_repo=/{s/^[^=]*=//p;q}" /boot/dietpi.txt)"
 
 		# Regenerate unique Dropbear host keys


### PR DESCRIPTION
**Status**: Review

**Commit list/description**:
+ DietPi-Obtain_HW_model | Add support for Raspberry Pi OS (64-bit) by separating RPi detection from Raspbian detection and adding new global variable: $G_RASPBIAN
+ DietPi-FirstBoot | Apply Raspbian repo only on Raspbian/Raspberry Pi OS (32-bit) images, supporting Debian/Raspberry Pi OS (64-bit) by this
+ DietPi-PREP | DietPi-Globals never creates .hw_model anymore, hence skip explicit script removal
+ DietPi-PREP | Since RPi can run Debian and Raspbian 32 and 64 bit images and kernel can be loaded in 64-bit mode on 32-bin image, we need to check if its a Debian or Raspbian image and if the primary deb package architecture is arm64 or not (armhf) to be sure what the target image should be. Override G_HW_ARCH with intended minimal CPU arch requirement and set + pass new G_RASPBIAN variable.
+ DietPi-PREP | raspi-copies-and-fills is only made for armhf hence skip it on 64-bit RPi images
+ DietPi-PREP | Prevent potential failure on u-boot install on C4 since it is pre-installed on the image but not yet present in the repo. The intention is to leave the package installed, if it was before, to allow automated upgrade to the actual C4 u-boot image once it is pushed to the repo.