### PR TITLE
DietPi-Software | Node.js: Use fixed own installer fork

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,25 @@
+v6.32
+(XX/08/20)
+
+Changes / Improvements / Optimisations:
+
+Bug Fixes:
+- DietPi-Software | Node.js: Resolved an issue where the installer internet connection check fails due to new nodejs.org HTTPS redirection. For now we use our own fork.
+
+Known/Outstanding Issues:
+- DietPi-Config | Enabling WiFi + Ethernet adapters, both on different subnets, breaks WiFi connection in some cases: https://github.com/MichaIng/DietPi/issues/2103
+- RPi | On TigerVNC virtual desktop, LXAppearance hangs on dbus-launch: https://github.com/MichaIng/DietPi/issues/1791
+- Odroid C2 | Some WiFi adapters do no work as hotspot: https://github.com/MichaIng/DietPi/issues/1955
+- DietPi-Software | Node-RED: Pre-installed modules cannot be updated via web UI: https://github.com/MichaIng/DietPi/issues/2073
+- DietPi-Software | Raspimjpeg: With Lighttpd, streaming mjpeg does not work: https://github.com/MichaIng/DietPi/issues/1747
+- DietPi-Software | MATE desktop: When logging in as root, desktop items and right-click context menu is missing: https://github.com/MichaIng/DietPi/issues/3160
+- DietPi-Software | Sonarr/Mono: With current Mono version 6, import to a file system without UNIX permissions support (exFAT, FAT32/vfat, CIFS mounts and NTFS without "permissions" option) fails, regardless of user/umask mount options: https://github.com/MichaIng/DietPi/issues/3179
+- DietPi-Software | Transmission: On Raspbian/Debian Stretch, RAM usage raises unlimited over time: https://github.com/MichaIng/DietPi/issues/2413
+
+For all additional issues that may appear after release, please see the following link for active tickets: https://github.com/MichaIng/DietPi/issues
+
+-----------------------------------------------------------------------------------------------------------
+
 v6.31
 (05/07/20)
 
@@ -37,18 +59,6 @@ Bug Fixes:
 - DietPi-Software | XRDP: The above TigerVNC bug affected as well XRDP connections which have been resolved in the same turn: https://github.com/MichaIng/DietPi/issues/3615#issuecomment-650559035
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/3640
-
-Known/Outstanding Issues:
-- DietPi-Config | Enabling WiFi + Ethernet adapters, both on different subnets, breaks WiFi connection in some cases: https://github.com/MichaIng/DietPi/issues/2103
-- RPi | On TigerVNC virtual desktop, LXAppearance hangs on dbus-launch: https://github.com/MichaIng/DietPi/issues/1791
-- Odroid C2 | Some WiFi adapters do no work as hotspot: https://github.com/MichaIng/DietPi/issues/1955
-- DietPi-Software | Node-RED: Pre-installed modules cannot be updated via web UI: https://github.com/MichaIng/DietPi/issues/2073
-- DietPi-Software | Raspimjpeg: With Lighttpd, streaming mjpeg does not work: https://github.com/MichaIng/DietPi/issues/1747
-- DietPi-Software | MATE desktop: When logging in as root, desktop items and right-click context menu is missing: https://github.com/MichaIng/DietPi/issues/3160
-- DietPi-Software | Sonarr/Mono: With current Mono version 6, import to a file system without UNIX permissions support (exFAT, FAT32/vfat, CIFS mounts and NTFS without "permissions" option) fails, regardless of user/umask mount options: https://github.com/MichaIng/DietPi/issues/3179
-- DietPi-Software | Transmission: On Raspbian/Debian Stretch, RAM usage raises unlimited over time: https://github.com/MichaIng/DietPi/issues/2413
-
-For all additional issues that may appear after release, please see the following link for active tickets: https://github.com/MichaIng/DietPi/issues
 
 -----------------------------------------------------------------------------------------------------------
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6590,15 +6590,11 @@ sudo -u $ha_user dash -c '$ha_pyenv_activation; pip3 install -U homeassistant'" 
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://raw.githubusercontent.com/taaem/nodejs-linux-installer/master/node-install.sh'
+			INSTALL_URL_ADDRESS='https://raw.githubusercontent.com/MichaIng/nodejs-linux-installer/master/node-install.sh'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-
 			G_EXEC wget "$INSTALL_URL_ADDRESS"
-			# ARMv6 workaround: https://github.com/MichaIng/DietPi/issues/2755
-			(( $G_HW_ARCH == 1 )) && sed -i 's|nodejs.org/dist/latest/|nodejs.org/dist/latest-v11.x/|g' node-install.sh
-
-			G_EXEC mkdir -p /usr/local # failsafe
 			G_EXEC chmod +x node-install.sh
+			G_EXEC mkdir -p /usr/local # failsafe
 			G_EXEC_OUTPUT=1 G_EXEC ./node-install.sh
 			G_EXEC_NOHALT=1 G_EXEC rm node-install.sh
 


### PR DESCRIPTION
**Status**: Ready
- [x] Changelog
- [x] MOTD hacked fix

**Reference**: https://github.com/taaem/nodejs-linux-installer/pull/11

**Commit list/description**:
+ DietPi-Software | Node.js: Use fixed own installer fork for now