### PR TITLE
DietPi-Drive_Manager | For NTFS mounts, add "big_files" option

### DIFF
--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -235,10 +235,10 @@ $swap_mounts
 				(( ${aDRIVE_ISREADONLY_CURRENTLY[$index]} )) && options=',ro'
 
 				# Additional FS-specific options
-				# - NFTS: Enable POSIX permissions
+				# - NTFS: Enable POSIX permissions and prevent splitting write buffers into 4k chunks: https://manpages.debian.org/ntfs-3g#OPTIONS
 				if [[ ${aDRIVE_FSTYPE[$index]} == 'ntfs' ]]; then
 
-					options+=',permissions'
+					options+=',permissions,big_files'
 
 				fi
 


### PR DESCRIPTION
**Status**: Ready
- [x] Changelog: https://github.com/MichaIng/DietPi/commit/2712e901be733fc3a002de2355cb50627f862577

**Reference**: https://github.com/MichaIng/DietPi/issues/3330#issuecomment-654072107

**Commit list/description**:
+ DietPi-Drive_Manager | For NTFS mounts, add "big_files" option by default which prevents splitting write buffers into 4k chunks. This is generally seen as stable and is the default in new libfuse3: https://unix.stackexchange.com/a/544864
