### PR TITLE
DietPi-Obtain_HW_model | RPi: Remove special model names like alpha, beta or first ECN0001

### DIFF
--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -455,6 +455,15 @@
 	done
 	aSOFTWARE_NAME6_31[177]='Firefox Sync Server'
 
+	# v6.32
+	aSOFTWARE_NAME6_32=()
+	for i in ${!aSOFTWARE_NAME6_31[@]}
+	do
+
+		aSOFTWARE_NAME6_32[$i]=${aSOFTWARE_NAME6_31[$i]}
+
+	done
+
 	Main(){
 
 		# Copy files to RAM to speed up sourcing
@@ -566,6 +575,31 @@
 
 		# Optin count
 		SURVEY_COUNT_OPTIN=$(( $SURVEY_COUNT_TOTAL - $SURVEY_COUNT_EMPTY ))
+
+		# Merge old and new hardware model names
+		for i in "${!aDEVICE_NAME[@]}"
+		do
+
+			[[ $i == 'RPi B (ECN0001) (armv6l)' ]] && ((aDEVICE_NAME['RPi B (armv6l)']+=aDEVICE_NAME["$i"])) && unset "aDEVICE_NAME[$i]"
+			[[ $i == 'RPi  (armv6l)' ]] && ((aDEVICE_NAME['RPi (Unknown) (armv6l)']+=aDEVICE_NAME["$i"])) && unset "aDEVICE_NAME[$i]"
+			[[ $i == 'RPi  (armv7l)' ]] && ((aDEVICE_NAME['RPi (Unknown) (armv7l)']+=aDEVICE_NAME["$i"])) && unset "aDEVICE_NAME[$i]"
+			[[ $i == 'Odroid XU3/XU4/HC1/HC2 (armv7l)' ]] && ((aDEVICE_NAME['Odroid XU3/XU4/MC1/HC1/HC2 (armv7l)']+=aDEVICE_NAME["$i"])) && unset "aDEVICE_NAME[$i]"
+			[[ $i == 'Asus Tinker Board (armv7l)' ]] && ((aDEVICE_NAME['ASUS Tinker Board (armv7l)']+=aDEVICE_NAME["$i"])) && unset "aDEVICE_NAME[$i]"
+			[[ $i == 'Pine A64 (aarch64)' ]] && ((aDEVICE_NAME['PINE A64 (aarch64)']+=aDEVICE_NAME["$i"])) && unset "aDEVICE_NAME[$i]"
+			[[ $i == 'Pine H64 (aarch64)' ]] && ((aDEVICE_NAME['PINE H64 (aarch64)']+=aDEVICE_NAME["$i"])) && unset "aDEVICE_NAME[$i]"
+			[[ $i == 'Rock64 (aarch64)' ]] && ((aDEVICE_NAME['ROCK64 (aarch64)']+=aDEVICE_NAME["$i"])) && unset "aDEVICE_NAME[$i]"
+			[[ $i == 'RockPro64 (aarch64)' ]] && ((aDEVICE_NAME['ROCKPro64 (aarch64)']+=aDEVICE_NAME["$i"])) && unset "aDEVICE_NAME[$i]"
+			[[ $i == 'Pinebook A64 (aarch64)' ]] && ((aDEVICE_NAME['Pinebook (aarch64)']+=aDEVICE_NAME["$i"])) && unset "aDEVICE_NAME[$i]"
+			[[ $i == 'Pinebook 1080p (aarch64)' ]] && ((aDEVICE_NAME['Pinebook (aarch64)']+=aDEVICE_NAME["$i"])) && unset "aDEVICE_NAME[$i]"
+			[[ $i == 'NanoPi Neo (armv7l)' ]] && ((aDEVICE_NAME['NanoPi NEO (armv7l)']+=aDEVICE_NAME["$i"])) && unset "aDEVICE_NAME[$i]"
+			[[ $i == 'NanoPi NEO 2 (aarch64)' ]] && ((aDEVICE_NAME['NanoPi NEO2 (aarch64)']+=aDEVICE_NAME["$i"])) && unset "aDEVICE_NAME[$i]"
+			[[ $i == 'NanoPi M3/T3/F3 (aarch64)' ]] && ((aDEVICE_NAME['NanoPi M3/T3/Fire3 (aarch64)']+=aDEVICE_NAME["$i"])) && unset "aDEVICE_NAME[$i]"
+			[[ $i == 'NanoPi M3/T3/F3 (armv7l)' ]] && ((aDEVICE_NAME['NanoPi M3/T3/Fire3 (armv7l)']+=aDEVICE_NAME["$i"])) && unset "aDEVICE_NAME[$i]"
+			[[ $i == 'BBB (armv7l)' ]] && ((aDEVICE_NAME['BeagleBone Black (armv7l)']+=aDEVICE_NAME["$i"])) && unset "aDEVICE_NAME[$i]"
+			[[ $i == 'Unknown Device (armv7l)' ]] && ((aDEVICE_NAME['Generic Device (armv7l)']+=aDEVICE_NAME["$i"])) && unset "aDEVICE_NAME[$i]"
+			[[ $i == 'Unknown Device (aarch64)' ]] && ((aDEVICE_NAME['Generic Device (aarch64)']+=aDEVICE_NAME["$i"])) && unset "aDEVICE_NAME[$i]"
+
+		done
 
 		# Process all results, for later use in HTML printout
 		# - NB: HW_MODEL array based

--- a/dietpi/func/dietpi-obtain_hw_model
+++ b/dietpi/func/dietpi-obtain_hw_model
@@ -146,7 +146,7 @@
 				02) G_HW_MODEL_NAME='RPi A+';;
 				03) G_HW_MODEL_NAME='RPi B+';;
 				04) G_HW_MODEL_NAME='RPi 2 Model B' G_HW_MODEL=2;;
-				05) G_HW_MODEL_NAME='RPi Alpha';;
+				05) G_HW_MODEL_NAME='RPi B';;
 				06) G_HW_MODEL_NAME='RPi CM';;
 				08) G_HW_MODEL_NAME='RPi 3 Model B' G_HW_MODEL=3 G_HW_ONBOARD_WIFI=1;;
 				09) G_HW_MODEL_NAME='RPi Zero';;
@@ -174,7 +174,7 @@
 		elif [[ $G_HW_REVISION == *'Beta' ]]; then
 
 			G_HW_MODEL=0
-			G_HW_MODEL_NAME='RPi Beta'
+			G_HW_MODEL_NAME='RPi B'
 			G_HW_MEMORY_SIZE=256
 
 		elif [[ $G_HW_REVISION == *'0002' ]]; then
@@ -188,7 +188,7 @@
 		elif [[ $G_HW_REVISION == *'0003' ]]; then
 
 			G_HW_MODEL=0
-			G_HW_MODEL_NAME='RPi B (ECN0001)'
+			G_HW_MODEL_NAME='RPi B'
 			G_HW_PCB_REVISION='1.0'
 			G_HW_MEMORY_SIZE=256
 			G_HW_MANUFACTURER='Egoman'
@@ -295,8 +295,8 @@
 
 			G_HW_MODEL_NAME='RPi A+'
 			G_HW_PCB_REVISION='1.1'
-			# 256M and 512M versions exist
-			if (( $(mawk '/^MemTotal:/{print $2;exit}' /proc/meminfo) < 300000 )); then
+			# 256M and 512M versions exist: Below estimation can be wrong, since GPU memory can take >256M on a 512M model
+			if (( $(mawk '/^MemTotal:/{print $2;exit}' /proc/meminfo) < 262144 )); then
 
 				G_HW_MODEL=0
 				G_HW_MEMORY_SIZE=256

--- a/dietpi/func/dietpi-obtain_hw_model
+++ b/dietpi/func/dietpi-obtain_hw_model
@@ -39,7 +39,7 @@
 	# G_HW_MODEL 51 BananaPi Pro (Lemaker)
 	# G_HW_MODEL 50 BananaPi M2+ (sinovoip)
 	# G_HW_MODEL 45 PINE H64
-	# G_HW_MODEL 44 Pinebook A64
+	# G_HW_MODEL 44 Pinebook
 	# G_HW_MODEL 43 ROCK64
 	# G_HW_MODEL 42 ROCKPro64
 	# G_HW_MODEL 41 OrangePi PC Plus

--- a/dietpi/func/dietpi-obtain_hw_model
+++ b/dietpi/func/dietpi-obtain_hw_model
@@ -177,15 +177,7 @@
 			G_HW_MODEL_NAME='RPi B'
 			G_HW_MEMORY_SIZE=256
 
-		elif [[ $G_HW_REVISION == *'0002' ]]; then
-
-			G_HW_MODEL=0
-			G_HW_MODEL_NAME='RPi B'
-			G_HW_PCB_REVISION='1.0'
-			G_HW_MEMORY_SIZE=256
-			G_HW_MANUFACTURER='Egoman'
-
-		elif [[ $G_HW_REVISION == *'0003' ]]; then
+		elif [[ $G_HW_REVISION == *'000'[23] ]]; then
 
 			G_HW_MODEL=0
 			G_HW_MODEL_NAME='RPi B'
@@ -241,7 +233,7 @@
 			G_HW_MEMORY_SIZE=256
 			G_HW_MANUFACTURER='Qisda'
 
-		elif [[ $G_HW_REVISION == *'000d' ]]; then
+		elif [[ $G_HW_REVISION == *'000'[df] ]]; then
 
 			G_HW_MODEL_NAME='RPi B'
 			G_HW_PCB_REVISION='2.0'
@@ -252,12 +244,6 @@
 			G_HW_MODEL_NAME='RPi B'
 			G_HW_PCB_REVISION='2.0'
 			G_HW_MANUFACTURER='Sony UK'
-
-		elif [[ $G_HW_REVISION == *'000f' ]]; then
-
-			G_HW_MODEL_NAME='RPi B'
-			G_HW_PCB_REVISION='2.0'
-			G_HW_MANUFACTURER='Egoman'
 
 		elif [[ $G_HW_REVISION == *'0010' ]]; then
 


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Obtain_HW_model | RPi: Remove special model names like alpha, beta or first ECN0001, but differentiate by type A and B only, to simplify statistics. The exact revision can always be estimated through the revision code, if it should become relevant in an individual case.
+ DietPi-Obtain_HW_model | RPi: Merge code for assigning identical hardware info
+ DietPi-Obtain_HW_model | RPi: Reduce the risk that A+ total memory is estimated wrong due to theoretical larger GPU memory split. 262144 KiB is really the upper boarder of what an 256M model can have, probably even 245760 (minus 16 MiB min GPU memory) would be thinkable or using vcgencmd to estimate the exact values (overkill?).
+ DietPi-Obtain_HW_model | Pinebook: We do not add and name suffix anymore as our image works on all revisions
+ DietPi-Survey_report | Add DietPi v6.32 support
+ DietPi-Survey_report | Merge old and new hardware model names to cleanup statistic