### PR TITLE
DietPi-Software | Migrate to Python3-only software

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,9 +3,15 @@ v6.32
 
 Changes / Improvements / Optimisations:
 - DietPi-Drive_Manager | For NTFS mounts, the "big_writes" mount option is now added by default, which reduces CPU load and by this may increase performance. Many thanks to @balexandrov for suggesting this enhancement: https://github.com/MichaIng/DietPi/issues/3330#issuecomment-654072107
+- DietPi-Software | Python pip: We migrated this software selection to a Python3/pip3 install only, due to Python2 EOL in 2020/01. Where possible, dependant software selections have been migrated to Python3 builds, where not possible, Python2/pip2 is installed separately for now. We hope that most affected software titles will do Python3 releases soon, otherwise we will remove them form our portfolio, at latest in spring 2021. The strongest reason for this is that next Debian Bullseye (summer 2021) will not ship Python2 packages anymore.
+- DietPi-Software | SABnzbd: Migrated to a Python3-based install.
+- DietPi-Software | OctoPrint: On Debian Buster and up, migrated to a Python3-based install.
 
 Bug Fixes:
 - DietPi-Software | Node.js: Resolved an issue where the installer internet connection check fails due to new nodejs.org HTTPS redirection. For now we use our own fork.
+- DietPi-Software | HTPC Manager: Resolved an issue where install failed due to missing build-essential dependency.
+- DietPi-Software | HTPC Manager: Resolved an issue where the internal updater failed due to missing git meta files.
+- DietPi-Software | EmonPi: Resolved a failing primary UART activation on install.
 
 Known/Outstanding Issues:
 - DietPi-Config | Enabling WiFi + Ethernet adapters, both on different subnets, breaks WiFi connection in some cases: https://github.com/MichaIng/DietPi/issues/2103

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -920,6 +920,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=8043#p8043'
+		aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
 		aSOFTWARE_REQUIRES_GIT[$software_id]=1
 		# Python2 only, hence not supported on Bullseye
 		aSOFTWARE_AVAIL_G_DISTRO[$software_id,6]=0
@@ -5631,25 +5632,36 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://github.com/Hellowlol/HTPC-Manager.git'
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
+			if [[ -d $G_FP_DIETPI_USERDATA/htpc-manager/.git ]]; then
 
-			G_THREAD_START git clone --depth=1 "$INSTALL_URL_ADDRESS"
+				G_EXEC cd $G_FP_DIETPI_USERDATA/htpc-manager/.git
+				G_EXEC_OUTPUT=1 G_EXEC git checkout
+				G_EXEC cd /tmp/$G_PROGRAM_NAME
+
+			else
+
+				INSTALL_URL_ADDRESS='https://github.com/Hellowlol/HTPC-Manager.git'
+				G_CHECK_URL "$INSTALL_URL_ADDRESS"
+				G_THREAD_START git clone --depth=1 "$INSTALL_URL_ADDRESS"
+
+			fi
 
 			# Python2 pip + Image library: https://htpc.io/installation.html#linux
 			G_AGI python-pip python-dev python-pil # pip install PIL fails at least on Debian Buster x86_64
 
-			# Pre-reqs
+			# Python deps
 			# - psutil for system stats
-			pip2 install -U pip setuptools wheel
-			pip2 install -U psutil
+			G_EXEC_OUTPUT=1 G_EXEC pip2 install -U pip setuptools wheel
+			G_EXEC_OUTPUT=1 G_EXEC pip2 install -U psutil
 
-			G_THREAD_WAIT
+			if [[ ! -d $G_FP_DIETPI_USERDATA/htpc-manager/.git ]]; then
 
-			# Move HTPC Manager to a 'better' location
-			mkdir -p $G_FP_DIETPI_USERDATA/htpc-manager
-			cp -a HTPC-Manager/* $G_FP_DIETPI_USERDATA/htpc-manager/
-			rm -R HTPC-Manager
+				G_THREAD_WAIT
+				G_EXEC mkdir -p $G_FP_DIETPI_USERDATA/htpc-manager
+				G_EXEC cp -a HTPC-Manager/. $G_FP_DIETPI_USERDATA/htpc-manager/
+				G_EXEC_NOHALT=1 G_EXEC rm -R HTPC-Manager
+
+			fi
 
 		fi
 
@@ -11682,14 +11694,15 @@ _EOF_
 
 			Banner_Configuration
 
+			# Service
 			cat << _EOF_ > /etc/systemd/system/htpc-manager.service
 [Unit]
 Description=HTPC Manager (DietPi)
 Wants=network-online.target
-After=network-online.target
+After=network-online.target dietpi-boot.services
 
 [Service]
-ExecStart=$(command -v python) $G_FP_DIETPI_USERDATA/htpc-manager/Htpc.py
+ExecStart=$(command -v python2.7) $G_FP_DIETPI_USERDATA/htpc-manager/Htpc.py
 
 [Install]
 WantedBy=multi-user.target
@@ -13105,12 +13118,18 @@ _EOF_
 
 		fi
 
-		software_id=155
+		software_id=155 # HTPC Manager
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			rm -R $G_FP_DIETPI_USERDATA/htpc-manager
-			rm /etc/systemd/system/htpc-manager.service
+			if [[ -f '/etc/systemd/system/htpc-manager.service' ]]; then
+
+				systemctl disable --now htpc-manager
+				rm -R /etc/systemd/system/htpc-manager.service*
+
+			fi
+			[[ -d '/etc/systemd/system/htpc-manager.service.d' ]] && rm -R /etc/systemd/system/htpc-manager.service.d
+			[[ -d $G_FP_DIETPI_USERDATA/htpc-manager ]] && rm -R $G_FP_DIETPI_USERDATA/htpc-manager
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9962,7 +9962,7 @@ _EOF_
 			# Else, assure that primary UART is enabled, which is ttyAMA0 on non-onboard WiFi/BT models
 			else
 
-				G_CONFIG_INJECT 'enable_uart=' 'enable_uart=1' $FP_RPI_CONFIG
+				G_CONFIG_INJECT 'enable_uart=' 'enable_uart=1' /boot/config.txt
 
 			fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5634,7 +5634,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			if [[ -d $G_FP_DIETPI_USERDATA/htpc-manager/.git ]]; then
 
-				G_EXEC cd $G_FP_DIETPI_USERDATA/htpc-manager/.git
+				G_EXEC cd $G_FP_DIETPI_USERDATA/htpc-manager
 				G_EXEC_OUTPUT=1 G_EXEC git checkout
 				G_EXEC cd /tmp/$G_PROGRAM_NAME
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -478,7 +478,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		# - Odroid C1: No HDMI with current kernel
 		aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,10]=0
 		# - Odroid N1/C2: No support for arm64 on Debian Buster currently, disable if not found in repo: http://fuzon.co.uk/meveric/pool/main/k/kodi-odroid/
-		[[ $G_HW_MODEL == 1[24] ]] && ! apt-cache show kodi-odroid &> /dev/null && aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,$G_HW_MODEL]=0
+		[[ $G_HW_MODEL == 1[24] ]] && ! apt-cache dumpavail | grep -qE '^P(ackage|rovides):.* kodi-odroid(,|$)' && aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,$G_HW_MODEL]=0
 		#------------------
 		software_id=32
 
@@ -2336,7 +2336,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 
 			WIFIHOTSPOT_RTL8188C_DEVICE=1
 			# Some repos (e.g. ARMbian) provide special packages
-			apt-cache show hostapd-realtek &> /dev/null && WIFIHOTSPOT_RTL8188C_PACKAGE=1
+			apt-cache dumpavail | grep -qE '^P(ackage|rovides):.* hostapd-realtek(,|$)' && WIFIHOTSPOT_RTL8188C_PACKAGE=1
 
 		fi
 		# - Domoticz (140): https://github.com/MichaIng/DietPi/issues/129#issuecomment-596255110
@@ -6626,7 +6626,7 @@ sudo -u $ha_user dash -c '$ha_pyenv_activation; pip3 install -U homeassistant'" 
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			# APT deps: Distutils required since Buster: https://packages.debian.org/python3-distutils
-			if apt-cache show python3-distutils &> /dev/null; then
+			if apt-cache dumpavail | grep -qE '^P(ackage|rovides):.* python3-distutils(,|$)'; then
 
 				G_AGI python3-distutils
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -598,8 +598,8 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 
 		aSOFTWARE_NAME[$software_id]='Plex Media Server'
 		aSOFTWARE_DESC[$software_id]='web interface media streaming server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
 		aSOFTWARE_TYPE[$software_id]=0
+		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1949#p1949'
 		# - ARMv6: https://github.com/MichaIng/DietPi/issues/648
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
@@ -608,8 +608,8 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 
 		aSOFTWARE_NAME[$software_id]='Murmur'
 		aSOFTWARE_DESC[$software_id]='mumble voip server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
 		aSOFTWARE_TYPE[$software_id]=0
+		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1691#p1691'
 		#------------------
 		software_id=118
@@ -1385,8 +1385,8 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 
 		aSOFTWARE_NAME[$software_id]='VirtualHere'
 		aSOFTWARE_DESC[$software_id]='server: share USB devices over the network'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
 		aSOFTWARE_TYPE[$software_id]=0
+		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=6709#p6709'
 
 		# Hardware projects
@@ -1517,8 +1517,8 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 
 		aSOFTWARE_NAME[$software_id]='Google AIY'
 		aSOFTWARE_DESC[$software_id]='voice kit'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=11
 		aSOFTWARE_TYPE[$software_id]=0
+		aSOFTWARE_CATEGORY_INDEX[$software_id]=11
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
  		aSOFTWARE_REQUIRES_GIT[$software_id]=1
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=9486#p9486'
@@ -1992,10 +1992,10 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		#------------------
 		software_id=130
 
-		aSOFTWARE_NAME[$software_id]='Python Pip'
-		aSOFTWARE_DESC[$software_id]='python pip package installer'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
+		aSOFTWARE_NAME[$software_id]='Python3 pip'
+		aSOFTWARE_DESC[$software_id]='Python3 package installer'
 		aSOFTWARE_TYPE[$software_id]=1
+		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
 		#------------------
 		software_id=150
 
@@ -2301,7 +2301,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 
 			aSOFTWARE_INSTALL_STATE[69]=1 # RPi.GPIO
 			G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[69]} will be installed"
-			#aSOFTWARE_INSTALL_STATE[130]=1 # python-pip, enabled in "Software that requires Python-Pip"
+			#aSOFTWARE_INSTALL_STATE[130]=1 # Python3 pip, enabled in "Software that requires Python3 pip"
 
 		fi
 
@@ -2357,18 +2357,15 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 
 		fi
 
-		# Software that requires Python-Pip: https://github.com/MichaIng/DietPi/issues/784
-		# - Mopidy (118)
+		# Software that requires Python3 pip: https://github.com/MichaIng/DietPi/issues/784
+		# - Mopidy (118) from Buster on
+		# - SABnzbd (139)
 		# - OctoPrint (153)
-		# - HTPC Manager (155)
+		# - Google AIY (169)
 		software_id=130
-		if (( ${aSOFTWARE_INSTALL_STATE[99]} == 1 ||
-			${aSOFTWARE_INSTALL_STATE[118]} == 1 ||
-			${aSOFTWARE_INSTALL_STATE[136]} == 1 ||
+		if (( ( ${aSOFTWARE_INSTALL_STATE[118]} == 1 && $G_DISTRO > 4 ) ||
 			${aSOFTWARE_INSTALL_STATE[139]} == 1 ||
-			${aSOFTWARE_INSTALL_STATE[142]} == 1 ||
 			${aSOFTWARE_INSTALL_STATE[153]} == 1 ||
-			${aSOFTWARE_INSTALL_STATE[155]} == 1 ||
 			${aSOFTWARE_INSTALL_STATE[169]} == 1 )); then
 
 			aSOFTWARE_INSTALL_STATE[$software_id]=1
@@ -2377,9 +2374,9 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		fi
 
 		# Software that requires MPD
-		# - YMPD
+		# - ympd
 		# - Cava
-		# - OMPD
+		# - O!MPD
 		# - myMPD
 		software_id=128
 		if (( ${aSOFTWARE_INSTALL_STATE[32]} == 1 ||
@@ -3602,16 +3599,11 @@ _EOF_
 			# - This needs to be done prior to APT install, since this would otherwise install a default config file as well.
 			[[ -f '/etc/mopidy/mopidy.conf' ]] || dps_index=$software_id Download_Install 'mopidy.conf' /etc/mopidy/mopidy.conf
 
-			local pip='pip' pip_modules='Mopidy-Local-Images' apt_packages=
+			local pip='pip2' pip_modules='pip setuptools wheel Mopidy-Local-Images' apt_packages='python-pip python-dev'
 
-			# ARMv8: Not supported by official repo, using Debian instead: https://github.com/mopidy/apt/tree/master/dists/buster/main
-			if (( $G_HW_ARCH == 3 )); then
-
-				# Python3 since Bullseye, including Mopidy-Local-Images deprecation and dedicated mopidy-local APT package: https://packages.debian.org/mopidy
-				(( $G_DISTRO > 5 )) && pip+='3' pip_modules= apt_packages='mopidy-local'
-
+			# ARMv8 + Stretch: Not supported by official repo, using Debian instead: https://github.com/mopidy/apt/tree/master/dists/stretch/main
 			# Else use official repo
-			else
+			if (( $G_HW_ARCH != 3 || $G_DISTRO > 4 )); then
 
 				INSTALL_URL_ADDRESS='https://apt.mopidy.com/mopidy.gpg'
 				G_CHECK_URL "$INSTALL_URL_ADDRESS"
@@ -3620,13 +3612,13 @@ _EOF_
 				wget https://apt.mopidy.com/${G_DISTRO_NAME/bullseye/buster}.list -O /etc/apt/sources.list.d/mopidy.list
 				G_AGUP
 
-				# Python3 since Buster: https://raw.githubusercontent.com/mopidy/apt/master/dists/stretch/main/binary-armhf/Packages
-				(( $G_DISTRO > 4 )) && pip+='3' pip_modules= apt_packages='mopidy-local'
+				# Python3 since Buster, including Mopidy-Local-Images deprecation and dedicated mopidy-local APT package: https://raw.githubusercontent.com/mopidy/apt/master/dists/buster/main/binary-armhf/Packages
+				(( $G_DISTRO > 4 )) && pip='pip3' pip_modules= apt_packages='mopidy-local'
 
 			fi
 
 			G_AGI mopidy gstreamer1.0-alsa $apt_packages
-			$pip install Mopidy-MusicBox-Webclient $pip_modules
+			$pip install -U $pip_modules Mopidy-MusicBox-Webclient
 			unset pip pip_modules apt_packages
 
 		fi
@@ -4826,18 +4818,18 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 		fi
 
-		software_id=99 # EmonHub
+		software_id=99 # EmonPi
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
 
-			DEPS_LIST='minicom python-serial python-configobj'
+			DEPS_LIST='minicom python-serial python-configobj python-pip python-dev'
 			Download_Install 'https://github.com/Fourdee/emonhub/archive/emon-pi.zip'
 
-			pip install paho-mqtt pydispatcher
+			pip2 install -U pip setuptools wheel paho-mqtt pydispatcher
 
 			# Move everything to /etc/emonhub
-			rm -R /etc/emonhub
+			[[ -d '/etc/emonhub' ]] && rm -R /etc/emonhub
 			mv emonhub-* /etc/emonhub
 
 		fi
@@ -5253,10 +5245,10 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			Banner_Installing
 
 			# Prereqs + Motion
-			G_AGI v4l-utils python python-dev curl libssl-dev libcurl4-openssl-dev libjpeg-dev zlib1g-dev motion
+			G_AGI v4l-utils python-pip python-dev curl libssl-dev libcurl4-openssl-dev libjpeg-dev zlib1g-dev motion
 
 			# Motioneye
-			pip install motioneye
+			pip2 install -U pip setuptools wheel motioneye
 
 		fi
 
@@ -5297,9 +5289,9 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
-			mkdir -p /etc/vhusbd
-			wget "$INSTALL_URL_ADDRESS" -O /etc/vhusbd/vhusbd
-			chmod +x /etc/vhusbd/vhusbd
+			G_EXEC mkdir -p /etc/vhusbd
+			G_EXEC curl -sSfL "$INSTALL_URL_ADDRESS" -o /etc/vhusbd/vhusbd
+			G_EXEC chmod +x /etc/vhusbd/vhusbd
 
 		fi
 
@@ -5328,7 +5320,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			mv sabnzbd-master /etc/sabnzbd
 
 			# Required Python modules
-			pip install cheetah cryptography sabyenc
+			pip3 install -U cheetah cryptography sabyenc
 
 		fi
 
@@ -5372,13 +5364,13 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			Banner_Installing
 
-			DEPS_LIST='libffi-dev libssl-dev python-lxml python3-lxml'
+			DEPS_LIST='libffi-dev libssl-dev python-lxml python-pip python-dev'
 			Download_Install 'https://github.com/CouchPotato/CouchPotatoServer/archive/master.tar.gz'
 
 			[[ -d /etc/couchpotato ]] && rm -R /etc/couchpotato
 			mv CouchPotato* /etc/couchpotato
 
-			pip install -U pyopenssl
+			pip2 install -U pip setuptools wheel pyopenssl
 
 		fi
 
@@ -5624,11 +5616,12 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			G_THREAD_START git clone --depth=1 "$INSTALL_URL_ADDRESS"
 
+			# Python2 pip + Image library: https://htpc.io/installation.html#linux
+			G_AGI python-pip python-dev python-pil # pip install PIL fails at least on Debian Buster x86_64
+
 			# Pre-reqs
 			# - psutil for system stats
-			# - Python Image library: https://htpc.io/installation.html#linux
-			pip install psutil
-			G_AGI python-pil # pip install PIL fails at least on Debian Buster x86_64
+			pip2 install -U pip setuptools wheel psutil
 
 			G_THREAD_WAIT
 
@@ -5654,7 +5647,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			G_DIETPI-NOTIFY 2 'OctoPrint is now installing, please be patient and do not terminate this process, it may take some time...'
 			cd $G_FP_DIETPI_USERDATA/octoprint
-			G_EXEC pip install .
+			G_EXEC_OUTPUT=1 G_EXEC pip3 install -U .
 			cd /tmp/$G_PROGRAM_NAME
 
 		fi
@@ -6603,7 +6596,7 @@ sudo -u $ha_user dash -c '$ha_pyenv_activation; pip3 install -U homeassistant'" 
 
 		fi
 
-		software_id=130 # Python pip
+		software_id=130 # Python3 pip
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -6611,14 +6604,12 @@ sudo -u $ha_user dash -c '$ha_pyenv_activation; pip3 install -U homeassistant'" 
 			INSTALL_URL_ADDRESS='https://bootstrap.pypa.io/get-pip.py'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
-			# Preqs
-			G_AGI python python-dev
+			# APT deps
+			G_AGI python3-distutils
 
-			wget "$INSTALL_URL_ADDRESS" -O install.py
-			python ./install.py
-			rm install.py
-
-			G_AGI python-pip python3-pip
+			G_EXEC curl -sSfL "$INSTALL_URL_ADDRESS" -o install.py
+			G_EXEC_OUTPUT=1 G_EXEC python3 ./install.py
+			G_EXEC_NOHALT=1 G_EXEC rm install.py
 
 		fi
 
@@ -8101,7 +8092,7 @@ _EOF_
 			# JustBoom specials
 			if grep -q '^[[:blank:]]*CONFIG_SOUNDCARD=justboom' /boot/dietpi.txt; then
 
-				# Name displayed in YMPD sound button
+				# Name displayed in ympd sound button
 				local justboom_soundcard_desc='JustBoom DietPi'
 				G_CONFIG_INJECT 'name "' "name \"$justboom_soundcard_desc\"" /etc/mpd.conf
 				G_CONFIG_INJECT 'zeroconf_name "' "zeroconf_name \"$justboom_soundcard_desc\"" /etc/mpd.conf
@@ -8182,11 +8173,10 @@ _EOF_
 
 			Banner_Configuration
 
+			# User
 			local usercmd='useradd -rMU'
 			getent passwd ympd &> /dev/null && usercmd='usermod -a'
 			$usercmd -G dietpi,audio -s $(command -v nologin) ympd
-			# - Add to new "render" group on Buster
-			(( $G_DISTRO > 4 )) && usermod -aG render ympd
 
 			# Service
 			cat << _EOF_ > /etc/systemd/system/ympd.service
@@ -8210,8 +8200,7 @@ _EOF_
 
 			Banner_Configuration
 
-			# Use primary group "dietpi" to allow media access and create media files with "dietpi" group:
-			# - https://github.com/MichaIng/DietPi/issues/3382
+			# Use primary group "dietpi" to allow media access and create media files with "dietpi" group: https://github.com/MichaIng/DietPi/issues/3382
 			usermod -g dietpi mympd
 			getent group mympd &> /dev/null && delgroup mympd
 
@@ -9902,7 +9891,7 @@ _EOF_
 
 		fi
 
-		software_id=99 # EmonHub
+		software_id=99 # EmonPi
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -9918,7 +9907,6 @@ _EOF_
 			chmod +x -R /etc/emonhub
 
 			# Disable onboard Bluetooth, if present, to recover ttyAMA0
-			# RPi4: Test required
 			if (( $G_HW_ONBOARD_WIFI )); then
 
 				/boot/dietpi/func/dietpi-set_hardware bluetooth disable
@@ -9933,8 +9921,8 @@ _EOF_
 			# Disable console on ttyAMA0
 			/boot/dietpi/func/dietpi-set_hardware serialconsole disable ttyAMA0
 
-			# - Apply user API KEY
-			USER_EMONHUB_APIKEY_CURRENT=$(grep -m1 '^[[:blank:]]*SOFTWARE_EMONHUB_APIKEY=' /boot/dietpi.txt | sed 's/^[^=]*=//')
+			# Apply user API KEY
+			USER_EMONHUB_APIKEY_CURRENT=$(sed -n '/^[[:blank:]]*SOFTWARE_EMONHUB_APIKEY=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			sed -i "/apikey/c\        apikey = $USER_EMONHUB_APIKEY_CURRENT" /etc/emonhub/conf/emonhub.conf
 
 		fi
@@ -11114,10 +11102,10 @@ _EOF_
 
 			Banner_Configuration
 
+			# Service
 			cat << _EOF_ > /etc/systemd/system/virtualhere.service
 [Unit]
 Description=VirtualHere (DietPi)
-After=local-fs.target
 
 [Service]
 ExecStart=/etc/vhusbd/vhusbd -r /var/log/virtualhere.log
@@ -11125,7 +11113,7 @@ ExecStart=/etc/vhusbd/vhusbd -r /var/log/virtualhere.log
 [Install]
 WantedBy=multi-user.target
 _EOF_
-
+			# Config
 			echo "ServerName='DietPi'" > /etc/vhusbd/config.ini
 
 		fi
@@ -11156,7 +11144,7 @@ After=network-online.target
 [Service]
 User=sabnzbd
 Group=dietpi
-ExecStart=$(command -v python2.7) -OO /etc/sabnzbd/SABnzbd.py -b 0 -f /etc/sabnzbd/sabnzbd.ini
+ExecStart=$(command -v python3) -OO /etc/sabnzbd/SABnzbd.py -b 0 -f /etc/sabnzbd/sabnzbd.ini
 Restart=on-failure
 
 [Install]
@@ -11203,7 +11191,7 @@ _EOF_
 
 			# Install language packs: https://github.com/MichaIng/DietPi/issues/1917#issue-340631943
 			cd /etc/sabnzbd
-			G_EXEC python2.7 tools/make_mo.py
+			G_EXEC python3 tools/make_mo.py
 			cd /tmp/$G_PROGRAM_NAME
 
 		fi
@@ -12666,7 +12654,6 @@ _EOF_
 		software_id=148 # myMPD
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
-			#apt-mark auto libmpdclient2 cmake cppcheck pkg-config libmpdclient-dev libssl-dev libmediainfo-dev
 			if [[ -f '/lib/systemd/system/mympd.service' ]]; then
 
 				systemctl unmask mympd
@@ -12677,8 +12664,7 @@ _EOF_
 			getent passwd mympd &> /dev/null && userdel -rf mympd
 			getent group mympd &> /dev/null && groupdel mympd # pre-v6.29
 			command -v mympd &> /dev/null && rm $(command -v mympd)
-			rm -Rf /{etc,var/lib,usr/share}/mympd /etc/mympd.conf*
-			rm -f /usr/share/man/man1/mympd.*
+			rm -Rf /{etc,var/lib,usr/share}/mympd /etc/mympd.conf* /etc/systemd/system/mympd.service.d /usr/share/man/man1/mympd.*
 
 		fi
 
@@ -12693,10 +12679,10 @@ _EOF_
 				rm -R /lib/systemd/system/mpd.service*
 
 			fi
+			[[ -d '/etc/systemd/system/mpd.service.d' ]] && rm -R /etc/systemd/system/mpd.service.d
 			[[ -f '/lib/systemd/system/mpd.socket' ]] && rm /lib/systemd/system/mpd.socket
 			getent passwd mpd &> /dev/null && userdel -rf mpd
 			getent group mpd &> /dev/null && groupdel mpd # pre-v6.29
-			#apt-mark auto libavformat57 libupnp6 libao-common libao4 libasound2 libasound2-data libasyncns0 libaudiofile1 libavahi-client3 libavahi-common-data libavahi-common3 libavcodec56 libavformat56 libavresample2 libavutil54 libbinio1ldbl libcaca0 libcdio-cdda1 libcdio-paranoia1 libcdio13 libcups2 libcurl3-gnutls libdirectfb-1.2-9 libdnet libfaad2 libflac8 libfluidsynth1 libgme0 libgomp1 libgsm1 libice6 libid3tag0 libiso9660-8 libjack-jackd2-0 libjson-c2 libldb1 libmad0 libmikmod3 libmms0 libmodplug1 libmp3lame0 libmpcdec6 libmpg123-0 libnfs4 libntdb1 libogg0 libopenal-data libopenal1 libopenjpeg5 libopus0 liborc-0.4-0 libpulse0 libresid-builder0c2a libroar2 libsamplerate0 libschroedinger-1.0-0 libsdl1.2debian libshout3 libsidplay2 libsidutils0 libslp1 libsm6 libsmbclient libsndfile1 libsoxr0 libspeex1 libspeexdsp1 libsqlite3-0 libtalloc2 libtdb1 libtevent0 libtheora0 libva1 libvorbis0a libvorbisenc2 libvorbisfile3 libvpx1 libwavpack1 libwbclient0 libwildmidi-config libwildmidi1 libx11-6 libx11-data libx11-xcb1 libx264-142 libxau6 libxcb1 libxdmcp6 libxext6 libxi6 libxtst6 libxvidcore4 libyajl2 libzzip-0-13 mime-support python python-talloc python2.7 samba-libs x11-common file &> /dev/null
 			G_AGP mpd libmpdclient2
 			[[ -d '/var/log/mpd' ]] && rm -R /var/log/mpd
 			[[ -d $G_FP_DIETPI_USERDATA/.mpd_cache ]] && rm -R $G_FP_DIETPI_USERDATA/.mpd_cache
@@ -12781,14 +12767,6 @@ _EOF_
 
 		fi
 
-		software_id=130
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
-
-			Banner_Uninstalling
-			G_AGP python-pip python3-pip
-
-		fi
-
 		software_id=131 # Blynk Server
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
@@ -12856,18 +12834,17 @@ _EOF_
 
 		fi
 
-		software_id=134
+		software_id=134 # Tonido
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			#apt-mark auto libjpeg8 libpng12-0 libfontconfig1 libssl1.0.0 &> /dev/null
-
 			if [[ -f '/etc/systemd/system/tonido.service' ]]; then
 
 				systemctl disable --now tonido
 				rm -R /etc/systemd/system/tonido.service*
 
 			fi
+			[[ -d '/etc/systemd/system/tonido.service.d' ]] && rm -R /etc/systemd/system/tonido.service.d
 			getent passwd tonido &> /dev/null && userdel -rf tonido
 			[[ -d $G_FP_DIETPI_USERDATA/tonido ]] && rm -R $G_FP_DIETPI_USERDATA/tonido
 			[[ -d '/home/tonido' ]] && rm -R /home/tonido
@@ -12898,10 +12875,10 @@ _EOF_
 				rm -R /etc/systemd/system/motioneye.service*
 
 			fi
-			#apt-mark auto v4l-utils python python-dev libssl-dev libcurl4-openssl-dev libjpeg-dev zlib1g-dev libx264-142 libavcodec56 libavformat56 libmysqlclient18 libswscale3 libpq5 2> /dev/null
+			[[ -d '/etc/systemd/system/motioneye.service.d' ]] && rm -R /etc/systemd/system/motioneye.service.d
+			pip2 uninstall -y motioneye
 			G_AGP motion
 			[[ -d '/etc/motioneye' ]] && rm -R /etc/motioneye
-			pip uninstall -y motioneye
 
 		fi
 
@@ -12913,12 +12890,18 @@ _EOF_
 
 		fi
 
-		software_id=138
+		software_id=138 # VirtualHere
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			rm -R /etc/vhusbd
-			rm /etc/systemd/system/virtualhere.service
+			if [[ -f '/etc/systemd/system/virtualhere.service' ]]; then
+
+				systemctl disable --now virtualhere
+				rm -R /etc/systemd/system/virtualhere.service*
+
+			fi
+			[[ -d '/etc/systemd/system/virtualhere.service.d' ]] && rm -R /etc/systemd/system/virtualhere.service.d
+			[[ -d '/etc/vhusbd' ]] && rm -R /etc/vhusbd
 
 		fi
 
@@ -12963,14 +12946,22 @@ _EOF_
 
 		fi
 
-		software_id=142
+		software_id=142 # CouchPotato
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			rm -R /etc/couchpotato
-			rm -R $G_FP_DIETPI_USERDATA/couchpotato
-			rm /etc/init.d/couchpotato
-			#userdel -rf couchpotato
+			if [[ -f '/etc/init.d/couchpotato' ]]; then
+
+				systemctl unmask couchpotato
+				systemctl disable --now couchpotato
+				rm /etc/init.d/couchpotato
+				update-rc.d -f couchpotato remove
+
+			fi
+			[[ -d '/etc/systemd/system/couchpotato.service.d' ]] && rm -R /etc/systemd/system/couchpotato.service.d
+			getent passwd couchpotato &> /dev/null && userdel -rf couchpotato
+			[[ -d '/etc/couchpotato' ]] && rm -R /etc/couchpotato
+			[[ -d $G_FP_DIETPI_USERDATA/couchpotato ]] && rm -R $G_FP_DIETPI_USERDATA/couchpotato
 
 		fi
 
@@ -13092,12 +13083,12 @@ _EOF_
 
 		fi
 
-		software_id=150
+		software_id=150 # Mono
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
 			apt-mark auto mono-complete mono-devel mono-runtime libmono-cil-dev 2>/dev/null
-			rm /etc/apt/sources.list.d/mono-xamarin.list
+			[[ -f '/etc/apt/sources.list.d/mono-xamarin.list' ]] && rm /etc/apt/sources.list.d/mono-xamarin.list
 
 		fi
 
@@ -13124,7 +13115,6 @@ _EOF_
 			getent passwd shairport-sync &> /dev/null && userdel -rf shairport-sync
 			getent group shairport-sync &> /dev/null && groupdel shairport-sync
 			# Pre-v6.29
-			#apt-mark auto libssl1.0.0 openssl libsoxr0 libavahi-client3 libtool libconfig9 libpopt0 libdaemon0 2> /dev/null
 			rm -f /usr/local/bin/shairport-sync /usr/local/etc/shairport-sync.conf* /usr/local/share/man/man7/shairport-sync.7.gz
 
 		fi
@@ -13147,15 +13137,13 @@ _EOF_
 				rm -R /etc/systemd/system/octoprint.service*
 
 			fi
+			[[ -d '/etc/systemd/system/octoprint.service.d' ]] && rm -R /etc/systemd/system/octoprint.service.d
 			if [[ -d $G_FP_DIETPI_USERDATA/octoprint ]]; then
 
-				if command -v pip &> /dev/null; then
-
-					cd $G_FP_DIETPI_USERDATA/octoprint
-					pip uninstall .
-					cd /tmp/$G_PROGRAM_NAME
-
-				fi
+				cd $G_FP_DIETPI_USERDATA/octoprint
+				command -v pip3 &> /dev/null && pip3 uninstall -y .
+				command -v pip2 &> /dev/null && pip2 uninstall -y . # Pre-v6.32
+				cd /tmp/$G_PROGRAM_NAME
 				rm -R $G_FP_DIETPI_USERDATA/octoprint
 
 			fi
@@ -13206,7 +13194,6 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			#apt-mark auto libpulse0 libfftw3-3 libncursesw5 2> /dev/null
 			G_AGP cava
 			rm -Rf /{root,home/*}/.config/cava
 			rm -f /{root,home/*}/cava.psf
@@ -13217,10 +13204,10 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			G_AGP mopidy
+			G_AGP 'mopidy*'
 			[[ -f '/etc/apt/sources.list.d/mopidy.list' ]] && rm /etc/apt/sources.list.d/mopidy.list
 
-			command -v pip &> /dev/null && pip uninstall -y Mopidy-MusicBox-Webclient Mopidy-Local-Images
+			command -v pip2 &> /dev/null && pip2 uninstall -y Mopidy-MusicBox-Webclient Mopidy-Local-Images
 			command -v pip3 &> /dev/null && pip3 uninstall -y Mopidy-MusicBox-Webclient
 
 			getent passwd mopidy &> /dev/null && userdel -rf mopidy
@@ -13479,14 +13466,13 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			#apt-mark auto libpcre3-dev libssl-dev zlib1g-dev libsystemd-dev &> /dev/null
 			if [[ -f '/etc/systemd/system/haproxy.service' ]]; then
 
 				systemctl disable --now haproxy
 				rm -R /etc/systemd/system/haproxy.service*
 
 			fi
-			rm -Rf /{etc,var/lib,/usr/local/{doc,sbin}}/haproxy /usr/local/share/man/man1/haproxy.1
+			rm -Rf /{etc,var/lib,/usr/local/{doc,sbin}}/haproxy /usr/local/share/man/man1/haproxy.1 /etc/systemd/system/haproxy.service.d
 
 		fi
 
@@ -13709,7 +13695,6 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			#apt-mark auto libnl-3-200 libssl1.0.0 &> /dev/null
 			G_AGP hostapd isc-dhcp-server
 
 			[[ -f '/etc/dhcp/dhcpd.conf' ]] && rm /etc/dhcp/dhcpd.conf
@@ -13777,13 +13762,21 @@ _EOF_
 
 		fi
 
-		software_id=99
+		software_id=99 # EmonPi
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			rm -R /etc/emonhub
-			rm /etc/init.d/emonhub
-			rm /etc/default/emonhub
+			if [[ -f '/etc/init.d/emonhub' ]]; then
+
+				systemctl unmask emonhub
+				systemctl disable --now emonhub
+				rm /etc/init.d/emonhub
+				update-rc.d -f emonhub remove
+
+			fi
+			[[ -d '/etc/systemd/system/emonhub.service.d' ]] && rm -R /etc/systemd/system/emonhub.service.d
+			[[ -f '/etc/default/emonhub' ]] && rm /etc/default/emonhub
+			[[ -d '/etc/emonhub' ]] && rm -R /etc/emonhub
 
 		fi
 
@@ -13821,7 +13814,6 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			#apt-mark auto zlib1g-dev &> /dev/null
 
 			# 1.2.0+
 			G_AGP netdata
@@ -13976,7 +13968,7 @@ _EOF_
 
 		fi
 
-		software_id=116
+		software_id=116 # Medusa
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
@@ -13986,9 +13978,9 @@ _EOF_
 				rm -R /etc/systemd/system/medusa.service*
 
 			fi
+			[[ -d '/etc/systemd/system/medusa.service.d' ]] && rm -R /etc/systemd/system/medusa.service.d 
 			[[ -d $G_FP_DIETPI_USERDATA/medusa ]] && rm -R $G_FP_DIETPI_USERDATA/medusa
 			getent passwd medusa &> /dev/null && userdel -rf medusa
-			#apt-mark auto python python3 mediainfo libssl-dev
 
 		fi
 
@@ -14061,7 +14053,6 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			#apt-mark auto libgnome-keyring0 libnspr4 libnss3 libnss3-1d libspeechd2 libxslt1.1 libxss1 xdg-utils libgnome-keyring-common libltdl7 &> /dev/null
 
 			rm /etc/chromium.d/custom_flags
 			rm /var/lib/dietpi/dietpi-software/installed/chromium-autostart.sh
@@ -14075,8 +14066,6 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			#apt-mark auto gcc libc6-dev make zlib1g-dev libbz2-dev libreadline-dev libssl-dev libsqlite3-dev libffi-dev
-			# Pre-v6.27: cmake daemon gcc nmap net-tools swig uuid-dev libc-ares-dev libgnutls28-dev libgnutlsxx28 libglib2.0-dev libudev-dev libusb-1.0-0 libssl-dev libffi-dev libbz2-dev zlib1g-dev libreadline-dev libsqlite3-dev libncurses5-dev libncursesw5-dev
 
 			# Remove the service
 			if [[ -f '/etc/systemd/system/home-assistant.service' ]]; then
@@ -14085,6 +14074,7 @@ _EOF_
 				rm -R /etc/systemd/system/home-assistant.service*
 
 			fi
+			[[ -d '/etc/systemd/system/home-assistant.service.d' ]] && rm -R /etc/systemd/system/home-assistant.service.d
 
 			# Remove the user and all files which removes his home + pyenv incl. HA as well
 			getent passwd homeassistant &> /dev/null && userdel -rf homeassistant
@@ -14161,7 +14151,7 @@ _EOF_
 
 		fi
 
-		software_id=169
+		software_id=169 # Google AIY
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
@@ -14180,8 +14170,8 @@ _EOF_
 			# Service
 			if [[ -f '/etc/systemd/system/mycroft.service' ]]; then
 
-				systemctl disable mycroft
-				rm /etc/systemd/system/mycroft.service
+				systemctl disable --now mycroft
+				rm -R /etc/systemd/system/mycroft.service*
 
 			fi
 			[[ -d '/etc/systemd/system/mycroft.service.d' ]] && rm -R /etc/systemd/system/mycroft.service.d
@@ -14288,8 +14278,8 @@ _EOF_
 				rm -R /etc/systemd/system/gmrender.service*
 
 			fi
+			[[ -d '/etc/systemd/system/gmrender.service.d' ]] && rm -R /etc/systemd/system/gmrender.service.d
 			getent passwd gmrender &> /dev/null && userdel -rf gmrender
-			#apt-mark auto libupnp6 libupnp13 gstreamer1.0-alsa gstreamer1.0-libav gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly 2> /dev/null
 			[[ -f '/usr/local/bin/gmediarender' ]] && rm /usr/local/bin/gmediarender
 
 		fi
@@ -14527,13 +14517,8 @@ _EOF_
 			Banner_Uninstalling
 			umount -f /mnt/nfs_client
 
-			#nfs-kernel-server depends on nfs-common
-			if (( ${aSOFTWARE_INSTALL_STATE[109]} == 0 )); then
-
-				G_AGP nfs-common
-				#apt-mark auto netbase
-
-			fi
+			# nfs-kernel-server depends on nfs-common
+			(( ${aSOFTWARE_INSTALL_STATE[109]} == 0 )) && G_AGP nfs-common
 
 			# Disable in fstab
 			sed -i '/\/mnt\/nfs_client/c\#\/mnt\/nfs_client . Please use DietPi-Drive_Manager to setup this mount' /etc/fstab
@@ -14709,6 +14694,15 @@ _EOF_
 
 			Banner_Uninstalling
 			G_AGP unrar
+
+		fi
+
+		software_id=130 # Python3 pip
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
+
+			Banner_Uninstalling
+			pip3 uninstall -y pip
+			G_AGP python3-pip # Pre-v6.32
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2369,12 +2369,12 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		# Software that requires Python3 pip: https://github.com/MichaIng/DietPi/issues/784
 		# - Mopidy (118) from Buster on
 		# - SABnzbd (139)
-		# - OctoPrint (153)
+		# - OctoPrint (153) from Buster on
 		# - Google AIY (169)
 		software_id=130
 		if (( ( ${aSOFTWARE_INSTALL_STATE[118]} == 1 && $G_DISTRO > 4 ) ||
 			${aSOFTWARE_INSTALL_STATE[139]} == 1 ||
-			${aSOFTWARE_INSTALL_STATE[153]} == 1 ||
+		      ( ${aSOFTWARE_INSTALL_STATE[153]} == 1 && $G_DISTRO > 4 ) ||
 			${aSOFTWARE_INSTALL_STATE[169]} == 1 )); then
 
 			aSOFTWARE_INSTALL_STATE[$software_id]=1
@@ -5670,18 +5670,37 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://github.com/OctoPrint/OctoPrint.git'
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
+			if [[ -d $G_FP_DIETPI_USERDATA/octoprint/.git ]]; then
 
-			G_THREAD_START git clone "$INSTALL_URL_ADDRESS"
-			G_AGI libjpeg-dev
-			G_THREAD_WAIT
-			mv OctoPrint* $G_FP_DIETPI_USERDATA/octoprint
+				G_EXEC cd $G_FP_DIETPI_USERDATA/octoprint
+				G_EXEC_OUTPUT=1 G_EXEC git checkout
+				G_EXEC cd /tmp/$G_PROGRAM_NAME
+
+			else
+
+				INSTALL_URL_ADDRESS='https://github.com/OctoPrint/OctoPrint.git'
+				G_CHECK_URL "$INSTALL_URL_ADDRESS"
+				G_THREAD_START git clone --depth=1 "$INSTALL_URL_ADDRESS"
+
+			fi
+
+			local packages='libjpeg-dev' pip='pip3'
+			(( $G_DISTRO < 5 )) && packages+=' python-pip python-dev' pip='pip2' && G_EXEC_OUTPUT=1 G_EXEC pip2 install -U pip setuptools wheel
+			G_AGI $packages
+
+			if [[ ! -d $G_FP_DIETPI_USERDATA/octoprint/.git ]]; then
+
+				G_THREAD_WAIT
+				G_EXEC mkdir -p $G_FP_DIETPI_USERDATA/octoprint
+				G_EXEC cp -a OctoPrint/. $G_FP_DIETPI_USERDATA/octoprint/
+				G_EXEC_NOHALT=1 G_EXEC rm -R OctoPrint
+
+			fi
 
 			G_DIETPI-NOTIFY 2 'OctoPrint is now installing, please be patient and do not terminate this process, it may take some time...'
-			cd $G_FP_DIETPI_USERDATA/octoprint
-			G_EXEC_OUTPUT=1 G_EXEC pip3 install -U .
-			cd /tmp/$G_PROGRAM_NAME
+			G_EXEC cd $G_FP_DIETPI_USERDATA/octoprint
+			G_EXEC_OUTPUT=1 G_EXEC $pip install -U .
+			G_EXEC cd /tmp/$G_PROGRAM_NAME
 
 		fi
 
@@ -6633,20 +6652,9 @@ sudo -u $ha_user dash -c '$ha_pyenv_activation; pip3 install -U homeassistant'" 
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-
 			INSTALL_URL_ADDRESS='https://bootstrap.pypa.io/get-pip.py'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-
-			# APT deps: Distutils required since Buster: https://packages.debian.org/python3-distutils
-			if apt-cache dumpavail | grep -qE '^P(ackage|rovides):.* python3-distutils(,|$)'; then
-
-				G_AGI python3-distutils
-
-			else
-
-				G_AGI python3
-
-			fi
+			G_AGI python3-dev
 			G_EXEC curl -sSfL "$INSTALL_URL_ADDRESS" -o get-pip.py
 			G_EXEC_OUTPUT=1 G_EXEC python3 ./get-pip.py
 			G_EXEC_NOHALT=1 G_EXEC rm get-pip.py
@@ -11669,6 +11677,7 @@ _EOF_
 			sed -i "/ArticleCache=/c\ArticleCache=$(Optimise_BitTorrent 0)" $G_FP_DIETPI_USERDATA/nzbget/nzbget.conf
 			sed -i "/WriteBuffer=/c\WriteBuffer=$(Optimise_BitTorrent 0)" $G_FP_DIETPI_USERDATA/nzbget/nzbget.conf
 
+			# Service
 			cat << _EOF_ > /etc/systemd/system/nzbget.service
 [Unit]
 Description=NZBget (DietPi)
@@ -11683,7 +11692,6 @@ ExecStart=$G_FP_DIETPI_USERDATA/nzbget/nzbget -D
 [Install]
 WantedBy=multi-user.target
 _EOF_
-
 			# Permissions
 			chown -R nzbget:dietpi $G_FP_DIETPI_USERDATA/nzbget
 
@@ -11715,6 +11723,7 @@ _EOF_
 
 			Banner_Configuration
 
+			# Service
 			cat << _EOF_ > /etc/systemd/system/octoprint.service
 [Unit]
 Description=OctoPrint (DietPi)
@@ -11740,7 +11749,7 @@ _EOF_
 [Unit]
 Description=Roon Server (DietPi)
 Wants=network-online.target
-After=network-online.target
+After=network-online.target dietpi-boot.service
 
 [Service]
 SyslogIdentifier=roonserver
@@ -13192,7 +13201,7 @@ _EOF_
 
 				cd $G_FP_DIETPI_USERDATA/octoprint
 				command -v pip3 &> /dev/null && pip3 uninstall -y .
-				command -v pip2 &> /dev/null && pip2 uninstall -y . # Pre-v6.32
+				command -v pip2 &> /dev/null && pip2 uninstall -y . # Stretch + pre-v6.32
 				cd /tmp/$G_PROGRAM_NAME
 				rm -R $G_FP_DIETPI_USERDATA/octoprint
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5685,8 +5685,9 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			fi
 
 			local packages='libjpeg-dev' pip='pip3'
-			(( $G_DISTRO < 5 )) && packages+=' python-pip python-dev' pip='pip2' && G_EXEC_OUTPUT=1 G_EXEC pip2 install -U pip setuptools wheel
+			(( $G_DISTRO < 5 )) && packages+=' python-pip python-dev' pip='pip2'
 			G_AGI $packages
+			(( $G_DISTRO < 5 )) && G_EXEC_OUTPUT=1 G_EXEC pip2 install -U pip setuptools wheel
 
 			if [[ ! -d $G_FP_DIETPI_USERDATA/octoprint/.git ]]; then
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3599,27 +3599,32 @@ _EOF_
 			# - This needs to be done prior to APT install, since this would otherwise install a default config file as well.
 			[[ -f '/etc/mopidy/mopidy.conf' ]] || dps_index=$software_id Download_Install 'mopidy.conf' /etc/mopidy/mopidy.conf
 
-			local pip='pip2' pip_modules='pip setuptools wheel Mopidy-Local-Images' apt_packages='python-pip python-dev'
-
-			# ARMv8 + Stretch: Not supported by official repo, using Debian instead: https://github.com/mopidy/apt/tree/master/dists/stretch/main
-			# Else use official repo
+			# Official repo does not support ARMv8 + Stretch, using distro repo instead: https://github.com/mopidy/apt/tree/master/dists/stretch/main
 			if (( $G_HW_ARCH != 3 || $G_DISTRO > 4 )); then
 
 				INSTALL_URL_ADDRESS='https://apt.mopidy.com/mopidy.gpg'
 				G_CHECK_URL "$INSTALL_URL_ADDRESS"
 				curl -sSfL "$INSTALL_URL_ADDRESS" | apt-key add -
 				# No bullseye.list available yet, use buster.list instead: https://github.com/mopidy/apt/tree/master/dists
-				wget https://apt.mopidy.com/${G_DISTRO_NAME/bullseye/buster}.list -O /etc/apt/sources.list.d/mopidy.list
+				G_EXEC curl -sSfL https://apt.mopidy.com/${G_DISTRO_NAME/bullseye/buster}.list -o /etc/apt/sources.list.d/mopidy.list
 				G_AGUP
-
-				# Python3 since Buster, including Mopidy-Local-Images deprecation and dedicated mopidy-local APT package: https://raw.githubusercontent.com/mopidy/apt/master/dists/buster/main/binary-armhf/Packages
-				(( $G_DISTRO > 4 )) && pip='pip3' pip_modules= apt_packages='mopidy-local'
 
 			fi
 
-			G_AGI mopidy gstreamer1.0-alsa $apt_packages
-			$pip install -U $pip_modules Mopidy-MusicBox-Webclient
-			unset pip pip_modules apt_packages
+			# Stretch: Mopidy v2, pip2 and Mopidy-Local-Images
+			if (( $G_DISTRO < 5 )); then
+
+				G_AGI mopidy gstreamer1.0-alsa python-pip python-dev
+				pip2 install -U pip setuptools wheel
+				pip2 install -U Mopidy-MusicBox-Webclient Mopidy-Local-Images
+
+			# Buster+: Mopidy v3, pip3 (ID=130) and mopidy-local: https://mopidy.com/ext/local/
+			else
+
+				G_AGI mopidy gstreamer1.0-alsa mopidy-local
+				pip3 install -U Mopidy-MusicBox-Webclient
+
+			fi
 
 		fi
 
@@ -4826,7 +4831,8 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			DEPS_LIST='minicom python-serial python-configobj python-pip python-dev'
 			Download_Install 'https://github.com/Fourdee/emonhub/archive/emon-pi.zip'
 
-			pip2 install -U pip setuptools wheel paho-mqtt pydispatcher
+			pip2 install -U pip setuptools wheel
+			pip2 install -U paho-mqtt pydispatcher
 
 			# Move everything to /etc/emonhub
 			[[ -d '/etc/emonhub' ]] && rm -R /etc/emonhub
@@ -5248,7 +5254,8 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			G_AGI v4l-utils python-pip python-dev curl libssl-dev libcurl4-openssl-dev libjpeg-dev zlib1g-dev motion
 
 			# Motioneye
-			pip2 install -U pip setuptools wheel motioneye
+			pip2 install -U pip setuptools wheel
+			pip2 install -U motioneye
 
 		fi
 
@@ -5370,7 +5377,8 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			[[ -d /etc/couchpotato ]] && rm -R /etc/couchpotato
 			mv CouchPotato* /etc/couchpotato
 
-			pip2 install -U pip setuptools wheel pyopenssl
+			pip2 install -U pip setuptools wheel
+			pip2 install -U pyopenssl
 
 		fi
 
@@ -5621,7 +5629,8 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			# Pre-reqs
 			# - psutil for system stats
-			pip2 install -U pip setuptools wheel psutil
+			pip2 install -U pip setuptools wheel
+			pip2 install -U psutil
 
 			G_THREAD_WAIT
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5337,7 +5337,9 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			unset -v branch
 
 			# Required Python modules
-			pip3 install -U cheetah cryptography sabyenc
+			G_EXEC cd /etc/sabnzbd
+			G_EXEC_OUTPUT=1 G_EXEC pip3 install -Ur requirements.txt
+			G_EXEC cd /tmp/$G_PROGRAM_NAME
 
 		fi
 
@@ -6623,12 +6625,19 @@ sudo -u $ha_user dash -c '$ha_pyenv_activation; pip3 install -U homeassistant'" 
 			INSTALL_URL_ADDRESS='https://bootstrap.pypa.io/get-pip.py'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
-			# APT deps
-			G_AGI python3-distutils
+			# APT deps: Distutils required since Buster: https://packages.debian.org/python3-distutils
+			if apt-cache show python3-distutils &> /dev/null; then
 
-			G_EXEC curl -sSfL "$INSTALL_URL_ADDRESS" -o install.py
-			G_EXEC_OUTPUT=1 G_EXEC python3 ./install.py
-			G_EXEC_NOHALT=1 G_EXEC rm install.py
+				G_AGI python3-distutils
+
+			else
+
+				G_AGI python3
+
+			fi
+			G_EXEC curl -sSfL "$INSTALL_URL_ADDRESS" -o get-pip.py
+			G_EXEC_OUTPUT=1 G_EXEC python3 ./get-pip.py
+			G_EXEC_NOHALT=1 G_EXEC rm get-pip.py
 
 		fi
 
@@ -11145,7 +11154,7 @@ _EOF_
 			# User
 			local usercmd='useradd -rMU'
 			getent passwd sabnzbd &> /dev/null && usercmd='usermod -a'
-			$usercmd -G dietpi -d /etc/sabnzbd -s $(command -v nologin) sabnzbd
+			G_EXEC $usercmd -G dietpi -d /etc/sabnzbd -s $(command -v nologin) sabnzbd
 
 			# Service: https://github.com/sabnzbd/sabnzbd/blob/master/linux/sabnzbd%40.service
 			# - Options: https://sabnzbd.org/wiki/advanced/command-line-parameters
@@ -11171,8 +11180,8 @@ WantedBy=multi-user.target
 _EOF_
 
 			# Log dir and permissions
-			mkdir -p /var/log/sabnzbd
-			chown -R sabnzbd:sabnzbd /etc/sabnzbd /var/log/sabnzbd
+			G_EXEC mkdir -p /var/log/sabnzbd
+			G_EXEC chown -R sabnzbd:sabnzbd /etc/sabnzbd /var/log/sabnzbd
 
 			# Create config
 			# - Touch only if it does not yet exist, assume reinstall otherwise and preserve custom changes
@@ -11180,8 +11189,8 @@ _EOF_
 			# - We need to launch program, then apply our config tweaks, else, wizard setup in web interface simply loops without API keys.
 			if [[ ! -f '/etc/sabnzbd/sabnzbd.ini' ]]; then
 
-				systemctl daemon-reload
-				systemctl start sabnzbd
+				G_EXEC systemctl daemon-reload
+				G_EXEC systemctl start sabnzbd
 
 				G_DIETPI-NOTIFY 2 'Generating initial config, please wait...'
 				until [[ -f '/etc/sabnzbd/sabnzbd.ini' ]]
@@ -11192,7 +11201,7 @@ _EOF_
 				done
 				sleep 2
 
-				systemctl stop sabnzbd
+				G_EXEC_NOHALT=1 G_EXEC systemctl stop sabnzbd
 				sleep 2 # Additional wait, config being overwritten after below changes: https://dietpi.com/phpbb/viewtopic.php?p=7082#p7082
 
 				G_CONFIG_INJECT 'download_dir =' "download_dir = $G_FP_DIETPI_USERDATA/$FOLDER_DOWNLOADS/incomplete" /etc/sabnzbd/sabnzbd.ini
@@ -11200,7 +11209,7 @@ _EOF_
 				G_CONFIG_INJECT 'nzb_backup_dir =' "nzb_backup_dir = $G_FP_DIETPI_USERDATA/$FOLDER_DOWNLOADS/sabnzbd_nzb_backup" /etc/sabnzbd/sabnzbd.ini
 				G_CONFIG_INJECT 'admin_dir =' "admin_dir = $G_FP_DIETPI_USERDATA/$FOLDER_DOWNLOADS/sabnzbd_admin" /etc/sabnzbd/sabnzbd.ini
 				G_CONFIG_INJECT 'log_dir =' 'log_dir = /var/log/sabnzbd' /etc/sabnzbd/sabnzbd.ini
-				G_CONFIG_INJECT 'log_level =' 'log_level = 0' /etc/sabnzbd/sabnzbd.ini # Warning  errors only
+				G_CONFIG_INJECT 'log_level =' 'log_level = 0' /etc/sabnzbd/sabnzbd.ini # Warning errors only
 				G_CONFIG_INJECT 'refresh_rate =' 'refresh_rate = 2' /etc/sabnzbd/sabnzbd.ini
 				G_CONFIG_INJECT 'host =' 'host = 0.0.0.0' /etc/sabnzbd/sabnzbd.ini
 				G_CONFIG_INJECT 'permissions =' 'permissions = 0775' /etc/sabnzbd/sabnzbd.ini
@@ -11209,9 +11218,9 @@ _EOF_
 			fi
 
 			# Install language packs: https://github.com/MichaIng/DietPi/issues/1917#issue-340631943
-			cd /etc/sabnzbd
+			G_EXEC cd /etc/sabnzbd
 			G_EXEC python3 tools/make_mo.py
-			cd /tmp/$G_PROGRAM_NAME
+			G_EXEC cd /tmp/$G_PROGRAM_NAME
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -867,6 +867,8 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=7212#p7212'
 		aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
 		aSOFTWARE_REQUIRES_GIT[$software_id]=1
+		# Python2 only, hence not supported on Bullseye
+		aSOFTWARE_AVAIL_G_DISTRO[$software_id,6]=0
 		#------------------
 		software_id=144
 
@@ -915,10 +917,12 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 
 		aSOFTWARE_NAME[$software_id]='HTPC Manager'
 		aSOFTWARE_DESC[$software_id]='manage your HTPC from anywhere'
-		aSOFTWARE_REQUIRES_GIT[$software_id]=1
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
 		aSOFTWARE_TYPE[$software_id]=0
+		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=8043#p8043'
+		aSOFTWARE_REQUIRES_GIT[$software_id]=1
+		# Python2 only, hence not supported on Bullseye
+		aSOFTWARE_AVAIL_G_DISTRO[$software_id,6]=0
 
 		# Cloud / Backups
 		#--------------------------------------------------------------------------------
@@ -1272,6 +1276,8 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=6610#p6610'
  		aSOFTWARE_REQUIRES_FFMPEG[$software_id]=1
 		aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
+		# Python2 only, hence not supported on Bullseye
+		aSOFTWARE_AVAIL_G_DISTRO[$software_id,6]=0
 
 		# WiFi Hotspot
 		#--------------------------------------------------------------------------------
@@ -1839,6 +1845,8 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 			aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,$i]=0
 
 		done
+		# Python2 only, hence not supported on Bullseye
+		aSOFTWARE_AVAIL_G_DISTRO[$software_id,6]=0
 		#------------------
 		software_id=157
 
@@ -2404,7 +2412,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		# Software that requires UnRAR
 		# - rTorrent
 		# - Medusa
-		# - SABnzbd
+		# - SABnzbd (139)
 		software_id=170
 		if (( ${aSOFTWARE_INSTALL_STATE[107]} == 1 ||
 			${aSOFTWARE_INSTALL_STATE[116]} == 1 ||
@@ -5307,24 +5315,26 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			Banner_Installing # https://sabnzbd.org/wiki/installation/install-off-modules
 
-			# Pre-reqs
+			# APT deps
 			DEPS_LIST='par2 p7zip-full'
 			# - Pre-compiling required on ARM
 			(( $G_HW_ARCH < 10 )) && DEPS_LIST+=' libffi-dev libssl-dev'
 
-			Download_Install 'https://github.com/sabnzbd/sabnzbd/archive/master.tar.gz'
+			local branch='3.0.x' # Temporarily until v3 has been released: https://github.com/sabnzbd/sabnzbd/releases
+			Download_Install "https://github.com/sabnzbd/sabnzbd/archive/$branch.tar.gz"
 
 			# Reinstall: Clear old install dir
 			if [[ -d '/etc/sabnzbd' ]]; then
 
 				# Preserve old config file
-				[[ -f '/etc/sabnzbd/sabnzbd.ini' ]] && mv /etc/sabnzbd/sabnzbd.ini sabnzbd-master/
-				rm -R /etc/sabnzbd
+				[[ -f '/etc/sabnzbd/sabnzbd.ini' ]] && G_EXEC mv /etc/sabnzbd/sabnzbd.ini sabnzbd-$branch/
+				G_EXEC_NOHALT=1 G_EXEC rm -R /etc/sabnzbd
 
 			fi
 
 			# Install new files
-			mv sabnzbd-master /etc/sabnzbd
+			G_EXEC mv sabnzbd-$branch /etc/sabnzbd
+			unset -v branch
 
 			# Required Python modules
 			pip3 install -U cheetah cryptography sabyenc
@@ -11139,7 +11149,7 @@ _EOF_
 
 			# Service: https://github.com/sabnzbd/sabnzbd/blob/master/linux/sabnzbd%40.service
 			# - Options: https://sabnzbd.org/wiki/advanced/command-line-parameters
-			#	"-OO":	Optimise code and remove doc lines (default shebang of SABnzbd.py, but we run python2.7 explicitly to avoid version conflicts)
+			#	"-OO":	Optimise code and remove doc lines (default shebang of SABnzbd.py, but we run python3 explicitly to avoid version conflicts)
 			#	"-d": Run in daemon mode without terminal and browser start (requires "-f </path/to/config.ini>")
 			#	      NB: In systemd unit leads to unreliable long taking webserver start. A new process is forked which allows web access, but sometimes after very long time, sometimes never: https://github.com/sabnzbd/sabnzbd/issues/1283
 			#	"-b 0":	Do no start browser with daemon
@@ -11148,7 +11158,7 @@ _EOF_
 Description=SABnzbd (DietPi)
 Documentation=https://sabnzbd.org/wiki/
 Wants=network-online.target
-After=network-online.target
+After=network-online.target dietpi-boot.service
 
 [Service]
 User=sabnzbd
@@ -11174,7 +11184,7 @@ _EOF_
 				systemctl start sabnzbd
 
 				G_DIETPI-NOTIFY 2 'Generating initial config, please wait...'
-				while [[ ! -f '/etc/sabnzbd/sabnzbd.ini' ]]
+				until [[ -f '/etc/sabnzbd/sabnzbd.ini' ]]
 				do
 
 					sleep 0.5
@@ -12924,7 +12934,9 @@ _EOF_
 				rm -R /etc/systemd/system/sabnzbd.service*
 
 			fi
+			[[ -d '/etc/systemd/system/sabnzbd.service.d' ]] && rm -R /etc/systemd/system/sabnzbd.service.d
 			getent passwd sabnzbd &> /dev/null && userdel -rf sabnzbd
+			getent group sabnzbd &> /dev/null && groupdel sabnzbd
 			[[ -d '/etc/sabnzbd' ]] && rm -R /etc/sabnzbd
 
 		fi
@@ -12939,6 +12951,7 @@ _EOF_
 				rm -R /etc/systemd/system/firefox-sync.service*
 
 			fi
+			[[ -d '/etc/systemd/system/firefox-sync.service.d' ]] && rm -R /etc/systemd/system/firefox-sync.service.d
 			getent passwd ffsync &> /dev/null && userdel -rf ffsync
 			getent group ffsync &> /dev/null && groupdel ffsync
 			[[ -d '/opt/firefox-sync' ]] && rm -R /opt/firefox-sync


### PR DESCRIPTION
**Status**: Review

**Testing**:
- [x] Mopidy VM Stretch
- [x] Mopidy VM Buster
- [x] Mopidy VM Bullseye
- [x] MotionEye VM Stretch
- [x] MotionEye VM Buster
- 🈴 MotionEye VM Bullseye: Disabled until Python3-compatible version has been released
- [x] SABnzbd VM Stretch
- [x] SABnzbd VM Buster
- [x] SABnzbd VM Bullseye
- [x] HTPC Manager VM Stretch
- [x] HTPC ManagerVM Buster
- 🈴 HTPC ManagerVM Bullseye: Disabled until Python3-compatible version has been released
- [x] OctoPrint VM Stretch
- [x] OctoPrint VM Buster
- [x] OctoPrint VM Bullseye
- [x] Google AIY VM Stretch
- [x] Google AIY VM Buster
- [x] Google AIY VM Bullseye
- [x] CouchPotato VM Stretch
- [x] CouchPotato VM Buster
- 🈴 CouchPotato VM Bullseye: Disabled until Python3-compatible version has been released
- [x] EmonPi RPi Stretch
- [x] EmonPi RPi Buster
- 🈴 EmonPi RPi Bullseye : Disabled until Python3-compatible version has been released

**Commit list/description**:
+ DietPi-Software | Python pip: Make this a Python3 pip3 only install
+ DietPi-Software | Python pip: Install Python2 pip2 separately where still required, with the aim to either migrate to a Python3-compatible version soon or drop software support otherwise, since we cannot further maintain software that shows no effort in migrating away from EOL Python2.
+ DietPi-Software | Mopidy: The official Buster repo now supports ARMv8/arm64 as well
+ DietPi-Software | ympd: Do not add a music player frontend to DRM "render" group
+ DietPi-Software | Python3 pip: Uninstall pip last, so it is available for other module uninstalls
+ DietPi-Software | Several uninstall enhancements
+ DietPi-Software | pip2: pip setuptools and wheel need to be upgraded in a separate call first, otherwise those are not yet available for the actual target module(s) install(s)
+ DietPi-Software | Mopidy: Make install code more transparent
+ DietPi-Software | Disable all Python2-only titles on Bullseye, which does not serve Python2 packages anymore
+ DietPi-Software | SABnzbd: Pull v3 branch explicitly until it has been released
+ DietPi-Software | HTPC Manager: Requires build tools for psutil
+ DietPi-Software | HTPC Manager: Its internal updater requires git with .git dot dir/files. Copy dot files to final install dir as well and if it already exists, update/refresh via "git checkout"
+ DietPi-Software | "apt-cache show package" succeeds as well if package is listed as (optional) dependency/conflict/... by another package, hence is not a reliable measure. In case of python3-distutils on Stretch this causes an install failure if stretch-backports suite has been added, which contains a few packages that list python3-distutils as optional dependency aside of python3 << 3.6.something where Distutils was moved from stdlib into an own package. Allow to succeed if another package "provides" it, like php7.3-apcu provided by php-apcu or awk provided by mawk and gawk.
+ DietPi-Software | EmonPi: Fix applying enable_uart setting