### PR TITLE
RPi | Disable idle frequency setting on all models but RPi4

### DIFF
--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -1689,7 +1689,7 @@ Please reboot this system once, the HW bit which allows USB boot support will th
 
 			local arm_freq_min=$(sed -n '/^[[:blank:]]*arm_freq_min=/{s/^[^=]*=//p;q}' /boot/config.txt)
 			[[ $arm_freq_min ]] || { [[ $G_HW_MODEL == [01] ]] && arm_freq_min=700 || arm_freq_min=600; } # 700 on RPi1+Zero, 600 on all others
-			G_WHIP_MENU_ARRAY+=('ARM Idle Frequency' ": [$arm_freq_min MHz]")
+			(( $G_HW_MODEL == 4 )) && G_WHIP_MENU_ARRAY+=('ARM Idle Frequency' ": [$arm_freq_min MHz]") # https://github.com/MichaIng/DietPi/issues/3690
 
 			local initial_turbo=$(sed -n '/^[[:blank:]]*initial_turbo=/{s/^[^=]*=//p;q}' /boot/config.txt)
 			G_WHIP_MENU_ARRAY+=('ARM Initial Turbo' ": [${initial_turbo:=0} seconds]")

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -2449,6 +2449,13 @@ _EOF_
 
 			fi
 			#-------------------------------------------------------------------------------
+			if [[ $G_HW_MODEL == [0-3] ]]; then
+
+				G_DIETPI-NOTIFY 2 'Commenting arm_freq_min until related system hang/crash issues have been solved: https://github.com/MichaIng/DietPi/issues/3690'
+				G_EXEC sed -i 's/^[[:blank:]]*arm_freq_min/#arm_freq_min/' /boot/config.txt
+
+			fi
+			#-------------------------------------------------------------------------------
 			# Last subversion patch completed
 			# - Apply reinstalls
 			if [[ -f '/var/tmp/dietpi/dietpi-update_reinstalls' ]]; then


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Config | RPi: Hide idle frequency setting on all models but RPi4 until related system hang/crash issues have been solved: #3690
+ DietPi-Patch | Comment arm_freq_min until related system hang/crash issues have been solved