### PR TITLE
DietPi-Set_swapfile | Add initial zram support

### DIFF
--- a/dietpi/boot
+++ b/dietpi/boot
@@ -69,12 +69,18 @@
 	chmod 666 /run/dietpi/.network
 	#----------------------------------------------------------------
 	# Pre-installed image, 1st run
-	if (( $G_DIETPI_INSTALL_STAGE == 10 )); then
 
+	swap_location=$(sed -n '/^[[:blank:]]*AUTO_SETUP_SWAPFILE_LOCATION=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+	swap_size=$(sed -n '/^[[:blank:]]*AUTO_SETUP_SWAPFILE_SIZE=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+	disable_error=1 G_CHECK_VALIDINT "$swap_size" 0 || swap_size=1
+
+	# If using /dev/zram0 for swap, need to initialize every time
+	#
+	if [[ $swap_location == "/dev/zram0" ]]; then
+		/boot/dietpi/func/dietpi-set_swapfile $swap_size "$swap_location"
+
+	elif (( $G_DIETPI_INSTALL_STAGE == 10 )); then
 		# Create swap file
-		swap_size=$(sed -n '/^[[:blank:]]*AUTO_SETUP_SWAPFILE_SIZE=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-		disable_error=1 G_CHECK_VALIDINT "$swap_size" 0 || swap_size=1
-		swap_location=$(sed -n '/^[[:blank:]]*AUTO_SETUP_SWAPFILE_LOCATION=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 		[[ $swap_location == '/'* ]] || swap_location='/var/swap'
 		/boot/dietpi/func/dietpi-set_swapfile $swap_size "$swap_location"
 

--- a/dietpi/func/dietpi-set_swapfile
+++ b/dietpi/func/dietpi-set_swapfile
@@ -85,6 +85,22 @@
 
 			G_DIETPI-NOTIFY 1 "Swapfile not supported on file system: $fs_type"
 
+		elif [[ $SWAP_LOCATION_TARGET == "/dev/zram0" ]]; then
+			SWAP_SIZE=$SWAP_SIZE_TARGET
+			SWAP_LOCATION=$SWAP_LOCATION_TARGET
+
+			G_DIETPI-NOTIFY 0 "Creating ZRam drive for Swap"
+			G_DIETPI-NOTIFY 2 "Size     = $SWAP_SIZE MB"
+			G_DIETPI-NOTIFY 2 "Location = $SWAP_LOCATION"
+
+			grep -q ^zram /proc/modules && G_EXEC rmmod zram
+			G_EXEC modprobe zram num_devices=1
+			echo ${SWAP_SIZE_TARGET}M >/sys/block/zram0/disksize
+
+			G_EXEC mkswap "$SWAP_LOCATION"
+			chmod 600 "$SWAP_LOCATION"
+			G_EXEC swapon "$SWAP_LOCATION"
+
 		# Free spacey, checkey weckey
 		elif ! G_CHECK_FREESPACE "$swap_dir" $SWAP_SIZE_TARGET; then
 


### PR DESCRIPTION
**Status**: Ready

**Reference**: https://github.com/MichaIng/DietPi/issues/94

**Commit list/description**:
Add support for /dev/zram0 as swap target, Given linux kernel since 5.15 no longer requires swap per core and tmpfs in use in otherplaces (e.g. /tmp) no support for devices other than /dev/zram0 is included in this 

Only supported through dietpi.txt or invocation of ```/boot/dietpi/func/dietpi-set_swapfile <size> <device>```

AUTO_SETUP_SWAPFILE_SIZE=256
AUTO_SETUP_SWAPFILE_LOCATION=/dev/zram0
