### PR TITLE
NanoPi NEO3 | Add initial support

### DIFF
--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -47,6 +47,7 @@
 	aHW_NAME[51]='BananaPi Pro (Lemaker)'
 	aHW_NAME[52]='ASUS Tinker Board'
 	aHW_NAME[53]='BananaPi (sinovoip)'
+	aHW_NAME[56]='NanoPi NEO3'
 	aHW_NAME[57]='NanoPi NEO Plus2'
 	aHW_NAME[58]='NanoPi M4V2'
 	aHW_NAME[59]='ZeroPi'

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ API Changes:
 - DietPi-Set_swapfile | Running the script without input arguments does not print the current swap file location and size anymore but will apply the settings stored in dietpi.txt, refresh the current swap file or apply defaults as fallback. Currently active swap files can be reliably checked via /proc/swaps or htop.
 
 Changes / Improvements / Optimisations:
+- NanoPi NEO3 | Initial support for this SBC has been added.
 - DietPi-Drive_Manager | For NTFS mounts, the "big_writes" mount option is now added by default, which reduces CPU load and by this may increase performance. Many thanks to @balexandrov for suggesting this enhancement: https://github.com/MichaIng/DietPi/issues/3330#issuecomment-654072107
 - DietPi-Software | Jellyfin: A FOSS web interface media streaming server available for install. Many thanks to all who voted for it: https://feathub.com/MichaIng/DietPi/+63
 - DietPi-Software | On the uninstall information prompt, the info has been added that uninstalling usually means that related userdata and configs are purged as well. Additionally "dietpi-software reinstall <ID>" is mentioned now as alternative to repair/update installed software. Many thanks to @kpine for doing this request: https://github.com/MichaIng/DietPi/issues/3550

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -427,6 +427,7 @@ _EOF_
 			'59' ': ZeroPi'
 			'60' ': NanoPi NEO'
 			'65' ': NanoPi NEO2'
+			'56' ': NanoPi NEO3'
 			'57' ': NanoPi NEO Plus2'
 			'64' ': NanoPi NEO Air'
 			'63' ': NanoPi M1/T1'

--- a/dietpi/func/dietpi-obtain_hw_model
+++ b/dietpi/func/dietpi-obtain_hw_model
@@ -34,6 +34,7 @@
 	# G_HW_MODEL 59 ZeroPi
 	# G_HW_MODEL 58 NanoPi M4V2
 	# G_HW_MODEL 57 NanoPi NEO Plus2
+	# G_HW_MODEL 56 NanoPi NEO3
 	# G_HW_MODEL 53 BananaPi (sinovoip)
 	# G_HW_MODEL 52 ASUS Tinker Board
 	# G_HW_MODEL 51 BananaPi Pro (Lemaker)
@@ -82,6 +83,7 @@
 	# G_HW_CPUID 3 Rockchip RK3399
 	# G_HW_CPUID 4 Amlogic S922X
 	# G_HW_CPUID 5 Allwinner H6
+	# G_HW_CPUID 6 Rockchip RK3328
 	# ----------------
 	# G_DISTRO 0 unknown/unsupported
 	# G_DISTRO 1 Debian Wheezy (No longer supported: https://dietpi.com/phpbb/viewtopic.php?p=1898)
@@ -383,6 +385,11 @@
 				G_HW_MODEL_NAME='NanoPi NEO Plus2'
 				G_HW_CPUID=2
 
+			elif (( $G_HW_MODEL == 56 )); then
+
+				G_HW_MODEL_NAME='NanoPi NEO3'
+				G_HW_CPUID=6
+
 			elif (( $G_HW_MODEL == 53 )); then
 
 				G_HW_MODEL_NAME='BananaPi'
@@ -412,6 +419,7 @@
 			elif (( $G_HW_MODEL == 43 )); then
 
 				G_HW_MODEL_NAME='ROCK64'
+				G_HW_CPUID=6
 
 			elif (( $G_HW_MODEL == 42 )); then
 


### PR DESCRIPTION
**Status**: WIP

**Commit list/description**:
+ DietPi-Obtain_HW_model | Add support for NanoPi NEO3 (ID=56) and RK3328 SoC detection (ID=6), which ROCK64 uses as well and where GPU support (Mali-450 MP2) is still outstanding, likely resolved with newest Mesa drivers: https://github.com/MichaIng/DietPi/issues/1794