### PR TITLE
DietPi-Software | change ownership for /var/www/wordpress/

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4345,6 +4345,8 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 
 			Banner_Installing
 			Download_Install 'https://wordpress.org/latest.tar.gz' /var/www
+			
+			chown -R www-data:www-data /var/www/wordpress/
 
 		fi
 


### PR DESCRIPTION
change ownership for /var/www/wordpress/ after installation. The *tar.gz file downloaded from wordpress.org contains incorrect user/group settings.

<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
**Status**:  Ready 
- [x] check installation procedure

**Reference**: https://dietpi.com/phpbb/viewtopic.php?p=26547#p26547

**Commit list/description**:
- DietPi-Software | Change ownership for /var/www/wordpress/ after installation
