### PR TITLE
DietPi-LetsEncrypt | Initial Lighttpd-only support for multiple comma-separated domains

### DIFF
--- a/dietpi/dietpi-letsencrypt
+++ b/dietpi/dietpi-letsencrypt
@@ -90,8 +90,9 @@
 		elif pgrep '[l]ighttpd' &> /dev/null; then
 
 			G_DIETPI-NOTIFY 0 'Lighttpd webserver detected'
-			
-			fp_cert_dir="${fp_cert_dir//,*/}"
+
+			# Lighttpd-only support for multiple domains
+			fp_cert_dir=${fp_cert_dir%%,*}
 			# Cert me up
 			if [[ -f $fp_cert_dir'/cert.pem' ]]; then
 

--- a/dietpi/dietpi-letsencrypt
+++ b/dietpi/dietpi-letsencrypt
@@ -45,7 +45,7 @@
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Running CertBot'
 
-		local fp_cert_dir="/etc/letsencrypt/live/${LETSENCRYPT_DOMAIN//,*/}"
+		local fp_cert_dir="/etc/letsencrypt/live/$LETSENCRYPT_DOMAIN"
 
 		#------------------------------------------------------------------------------------------------------
 		# Apache2
@@ -90,7 +90,8 @@
 		elif pgrep '[l]ighttpd' &> /dev/null; then
 
 			G_DIETPI-NOTIFY 0 'Lighttpd webserver detected'
-
+			
+			fp_cert_dir="${fp_cert_dir//,*/}"
 			# Cert me up
 			if [[ -f $fp_cert_dir'/cert.pem' ]]; then
 

--- a/dietpi/dietpi-letsencrypt
+++ b/dietpi/dietpi-letsencrypt
@@ -45,7 +45,7 @@
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Running CertBot'
 
-		local fp_cert_dir="/etc/letsencrypt/live/$LETSENCRYPT_DOMAIN"
+		local fp_cert_dir="/etc/letsencrypt/live/${LETSENCRYPT_DOMAIN//,*/}"
 
 		#------------------------------------------------------------------------------------------------------
 		# Apache2


### PR DESCRIPTION
Fixed problem when entering multiple domains separated by commas

<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
**Status**: Ready

**Reference**: https://github.com/MichaIng/DietPi/issues/1622 (only fixed problem with multiple domains)

**Commit list/description**:
<!--
- DietPi-Config | Add "Fan control" option to "Performance Options"
![Screenshot](https://xxx.github.com/images/xxx.png)
- DietPi-Config | Add "Fan control" support for Odroid C2
- DietPi-Config | Syntax fix
-->
- DietPi-LetsEncrypt | fixed problem with multiple domains separated by commas
