### PR TITLE
General | Add initial support for NanoPi R2S and NanoPi K2

### DIFF
--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -47,6 +47,8 @@
 	aHW_NAME[51]='BananaPi Pro (Lemaker)'
 	aHW_NAME[52]='ASUS Tinker Board'
 	aHW_NAME[53]='BananaPi (sinovoip)'
+	aHW_NAME[54]='NanoPi K2'
+	aHW_NAME[55]='NanoPi R2S'
 	aHW_NAME[56]='NanoPi NEO3'
 	aHW_NAME[57]='NanoPi NEO Plus2'
 	aHW_NAME[58]='NanoPi M4V2'

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,8 @@ API Changes:
 
 Changes / Improvements / Optimisations:
 - NanoPi NEO3 | Initial support for this SBC has been added.
+- NanoPi R2S | Initial support for this SBC has been added.
+- NanoPi K2 | Initial support for this SBC has been added.
 - DietPi-Set_swapfile | Added support for zram-based swap space. Use "zram" as swap location to have a zram device created (persistently via udev rule) at /dev/zram0 and used for compressed in-memory swap space. The auto-size option "1" will result in a zram size of 50% of physical RAM size, else the MiB value will be used, as long as its smaller than physical RAM size. Many thanks to @rickalm for pushing this topic with an initial implementation: https://github.com/MichaIng/DietPi/pull/3705
 - DietPi-Drive_Manager | For NTFS mounts, the "big_writes" mount option is now added by default, which reduces CPU load and by this may increase performance. Many thanks to @balexandrov for suggesting this enhancement: https://github.com/MichaIng/DietPi/issues/3330#issuecomment-654072107
 - DietPi-Config | Added selection of schedutil and userspace CPU frequency governors. Schedutil is a modern dynmic governor which sets frequency tightly related and according to metrics of the CPU scheduling driver itself. Userspace is a no-op governor, i.e. it does not touch CPU frequencies at all which allows setting manual/custom frequencies according to own metrics or via scripts. Read more about native Linux CPU frequency scaling: https://www.kernel.org/doc/html/latest/admin-guide/pm/cpufreq.html#generic-scaling-governors

--- a/dietpi/func/dietpi-obtain_hw_model
+++ b/dietpi/func/dietpi-obtain_hw_model
@@ -35,6 +35,8 @@
 	# G_HW_MODEL 58 NanoPi M4V2
 	# G_HW_MODEL 57 NanoPi NEO Plus2
 	# G_HW_MODEL 56 NanoPi NEO3
+	# G_HW_MODEL 55 NanoPi R2S
+	# G_HW_MODEL 54 NanoPi K2
 	# G_HW_MODEL 53 BananaPi (sinovoip)
 	# G_HW_MODEL 52 ASUS Tinker Board
 	# G_HW_MODEL 51 BananaPi Pro (Lemaker)
@@ -84,6 +86,7 @@
 	# G_HW_CPUID 4 Amlogic S922X
 	# G_HW_CPUID 5 Allwinner H6
 	# G_HW_CPUID 6 Rockchip RK3328
+	# G_HW_CPUID 7 Amlogic S905
 	# ----------------
 	# G_DISTRO 0 unknown/unsupported
 	# G_DISTRO 1 Debian Wheezy (No longer supported: https://dietpi.com/phpbb/viewtopic.php?p=1898)
@@ -390,6 +393,16 @@
 				G_HW_MODEL_NAME='NanoPi NEO3'
 				G_HW_CPUID=6
 
+			elif (( $G_HW_MODEL == 55 )); then
+
+				G_HW_MODEL_NAME='NanoPi R2S'
+				G_HW_CPUID=6
+
+			elif (( $G_HW_MODEL == 54 )); then
+
+				G_HW_MODEL_NAME='NanoPi K2'
+				G_HW_CPUID=7
+
 			elif (( $G_HW_MODEL == 53 )); then
 
 				G_HW_MODEL_NAME='BananaPi'
@@ -511,6 +524,7 @@
 			elif (( $G_HW_MODEL == 12 )); then
 
 				G_HW_MODEL_NAME='Odroid C2'
+				G_HW_CPUID=7
 
 			elif (( $G_HW_MODEL == 11 )); then
 


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Obtain_HW_model | Add hardware IDs for NanoPi R2S (ID=55, Rockchip RK3328) and NanoPi K2 (ID=54, Amlogic S905 with new G_HW_CPUID=7)
+ DietPi-PREP | https://github.com/MichaIng/DietPi/commit/322bf0d9872a4afb26fb30258c87cf66f0c6a86b