### PR TITLE
DietPi-Login/Autostart | Some fixes and enhancements

### DIFF
--- a/.conf/dps_51/run
+++ b/.conf/dps_51/run
@@ -6,22 +6,23 @@
 # Created by Daniel Knight / daniel.knight@dietpi.com / dietpi.com
 #
 # Info:
+# - Location: /usr/games/opentyrian/run
 # - Starts OpenTyrian
 # - Starts X if not already running
 #
 # Usage:
-# run
+# - run
 #////////////////////////////////////
-FP_DIR='/usr/games/opentyrian'
+readonly FP_DIR='/usr/games/opentyrian'
 
-# Xserver already running
-if pgrep Xorg &> /dev/null; then
+# X server already running
+if pgrep Xorg > /dev/null; then
 
-	$FP_DIR/opentyrian -t $FP_DIR/data
+	exec $FP_DIR/opentyrian -t $FP_DIR/data
 
-# No X (init X server)
+# No X, init it
 else
 
-	xinit $FP_DIR/opentyrian -t $FP_DIR/data
+	exec xinit $FP_DIR/opentyrian -t $FP_DIR/data
 
 fi

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,8 +5,11 @@ APT Changes:
 - DietPi-Globals | The G_FP_DIETPI_USERDATA variable has been removed. Variables cannot be used in every context, e.g. not in config files stored on GitHub or dietpi.com for download, its value "/mnt/dietpi_userdata" does not change and using the path literally allows slightly simplified and hardened coding.
 
 Changes / Improvements / Optimisations:
+- DietPi-Login | Logins do not wait for DietPi-PostBoot to finish anymore, as this is not strictly required. On local console, DietPi-PostBoot processing output practically blocks login until finished or timed out and logins on any other console like SSH or serial do not require it. DietPi-PostBoot only checks for DietPi updates, starts background services and prints the pre-login banner to local console, nothing that is required for console usage.
+- DietPi-Autostart | Autostart programs with a foreground process are now started as replacement for the DietPi-Login process via "exec" which saves 3-4 MiB RAM usage.
 
 Bug Fixes:
+- DietPi-Software | OpenTyrian: The autostart option and run script have been fixed and slightly enhanced to lower RAM usage a bid.
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-login
+++ b/dietpi/dietpi-login
@@ -37,32 +37,24 @@
 			# Kodi
 			if (( $auto_start_index == 1 )); then
 
-				/boot/dietpi/misc/start_kodi
+				exec /boot/dietpi/misc/start_kodi
 
 			# Desktop (LXDE/MATE etc)
 			elif (( $auto_start_index == 2 )); then
 
-				clear
-				if (( $G_HW_MODEL == 11 )); then
-
-					sleep 5 && startx &
-
-				else
-
-					startx
-
-				fi
+				unset -v G_DIETPI_LOGIN
+				exec startx
 
 			# RetroPie/Emulation station
 			elif (( $auto_start_index == 3 )); then
 
 				# emulationstation - can no longer be run as root
-				/opt/retropie/supplementary/emulationstation/emulationstation.sh
+				exec /opt/retropie/supplementary/emulationstation/emulationstation.sh
 
 			# OpenTyrian
 			elif (( $auto_start_index == 4 )); then
 
-				/usr/local/games/opentyrian/run
+				exec /usr/games/opentyrian/run
 
 			# DietPi-Cloudshell
 			elif (( $auto_start_index == 5 )); then
@@ -78,7 +70,7 @@
 			# DXX-Rebirth
 			elif (( $auto_start_index == 9 )); then
 
-				/mnt/dietpi_userdata/dxx-rebirth/run.sh
+				exec /mnt/dietpi_userdata/dxx-rebirth/run.sh
 
 			# CAVA
 			elif (( $auto_start_index == 10 )); then
@@ -90,7 +82,7 @@
 			# Chromium
 			elif (( $auto_start_index == 11 )); then
 
-				/var/lib/dietpi/dietpi-software/installed/chromium-autostart.sh
+				exec /var/lib/dietpi/dietpi-software/installed/chromium-autostart.sh
 
 			fi
 
@@ -224,16 +216,6 @@ Please login again as user "root" with password "dietpi", respectively the one y
 
 		# Prevent automated nested dietpi-login calls from subshells
 		export G_DIETPI_LOGIN=1
-
-		# Wait for full system boot
-		local i=0
-		while pgrep -f '/boot/dietpi/postboot' &> /dev/null
-		do
-
-			echo -ne "\e[90m[\e[0m INFO \e[90m]\e[0m Waiting for DietPi-Postboot to finish... (Press CTRL+C to abort) ($((i++)))\r"
-			sleep 1
-
-		done
 
 		while :
 		do


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Login | Fix v6.32 regression where terminal emulators started from desktop do not show the DietPi banner anymore
+ DietPi-Login | Do not wait for DietPi-PostBoot to finish for login, as this is not strictly required. On local console, DietPi-PostBoot processing output practically blocks login until finished or timed out and logins on any other console (SSH/serial/...) do not require it as DietPi-PostBoot only checks for DietPi updates, starts background services and prints the pre-login banner to local console, nothing that is required for console usage.
+ DietPi-Autostart | Start all autostart programs as replacements for the DietPi-Login process (via "exec") which saves 3-4 MiB RAM usage.
+ DietPi-Software | OpenTyrian: Fix autostart option since the executable is not located below /usr/local anymore for a long time
+ DietPi-Software | OpenTyrian: Fix bash vs dash syntax and start OpenTyrian process as replacement for the shell to safe ~1 MiB RAM
+ DietPi-Software | Desktops: Remove special autostart for Odroid XU4 for now, as it is likely not required and no reference given why it was introduced and many updates have happened meanwhile. ToDo: Owner of Odroid  XU4 required for testing, to be failsafe.