### PR TITLE
Add new dependency "libjpeg-dev" for HA

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6213,7 +6213,7 @@ Mycroft AI requires at least 2 GiB memory on first start. We will now increase y
 			# - MariaDB support: G_AGI libmariadb-dev
 			# - Read custom build dependencies
 			local custom_apt_deps=$(sed -n '/^[[:blank:]]*SOFTWARE_HOMEASSISTANT_APT_DEPS=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-			DEPS_LIST="gcc libc6-dev make zlib1g-dev libbz2-dev libreadline-dev libssl-dev libsqlite3-dev libffi-dev $custom_apt_deps"
+			DEPS_LIST="gcc libc6-dev make zlib1g-dev libbz2-dev libreadline-dev libssl-dev libsqlite3-dev libffi-dev libjpeg-dev $custom_apt_deps"
 
 			# Install pyenv to $ha_home
 			mkdir -p $ha_home

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6199,7 +6199,7 @@ Mycroft AI requires at least 2 GiB memory on first start. We will now increase y
 
 			G_DIETPI-NOTIFY 2 "Home Assistant user:  $ha_user"
 			G_DIETPI-NOTIFY 2 "Home Assistent home:  $ha_home"
-			G_DIETPI-NOTIFY 2 "pyenv activation:   \"$ha_pyenv_activation\""
+			G_DIETPI-NOTIFY 2 "pyenv activation:     \"$ha_pyenv_activation\""
 			G_DIETPI-NOTIFY 2 "pyenv Python version: $ha_python_version"
 
 			# User
@@ -6213,7 +6213,8 @@ Mycroft AI requires at least 2 GiB memory on first start. We will now increase y
 			# - MariaDB support: G_AGI libmariadb-dev
 			# - Read custom build dependencies
 			local custom_apt_deps=$(sed -n '/^[[:blank:]]*SOFTWARE_HOMEASSISTANT_APT_DEPS=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-			DEPS_LIST="gcc libc6-dev make zlib1g-dev libbz2-dev libreadline-dev libssl-dev libsqlite3-dev libffi-dev libjpeg-dev $custom_apt_deps"
+			DEPS_LIST="gcc libc6-dev make zlib1g-dev libbz2-dev libreadline-dev libssl-dev libsqlite3-dev libffi-dev $custom_apt_deps"
+			(( $G_HW_ARCH == 10 )) || DEPS_LIST+=' libjpeg-dev' # Pillow compiling on ARM
 
 			# Install pyenv to $ha_home
 			mkdir -p $ha_home


### PR DESCRIPTION
There is a new dependency `libjpeg-dev` needed for HA. Otherwise HA will not start correctly and you will get a HTTP 404 error.

**Status**: Ready
- [x] Add `libjpeg-dev` to HA apt dependency list

**Reference**: https://dietpi.com/forum/t/home-assistant-404-error/4471

**Commit list/description**:
- DietPi-Software | Adding `libjpeg-dev` as APT dependency for Home Assistant
