### PR TITLE
DietPi-Software | Mosquitto: Use official APT repository where available

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@ Changes / Improvements / Optimisations:
 - DietPi-Software | Tautulli: Finally, directories, user and service are renamed from "plexpy" to "tautulli". Additionally it runs with Python 3 now instead of Python 2. These changes are applied as well during DietPi update.
 - DietPi-Software | Baikal: Update (re)install procedure to cover the new config directory and use the pre-packed release archives instead of raw source and composer. Additionally webserver configs have been added to harden access permissions.
 - DietPi-Software | Docker: On fresh installs or reinstalls, logs are now done with limited verbosity to systemd-journald (RAM), accessible via "journalctl -u docker -u containerd" to reduce disk writes. Docker can be reinstalled via "dietpi-software reinstall 162". Many thanks to @SaturnusDJ for doing this suggestion: https://github.com/MichaIng/DietPi/issues/2388
+- DietPi-Software | Mosquitto: The official APT repository is now used where possible, which currently excludes ARMv8/arm64 and Raspbian/Debian Bullseye. This change is applied via reinstall during DietPi update. Many thanks to @marcobrianza for doing this suggestion: https://github.com/MichaIng/DietPi/issues/3042
 
 Bug Fixes:
 - General | Resolved an issue where using AUTO_UNMASK_LOGIND=1 or enabling Amiberry fastboot did not allow to start systemd-logind as intended if the required dbus package was not installed before. Many thanks to @razerbann for reporting this issue: https://github.com/MichaIng/DietPi/issues/3770

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1496,7 +1496,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		#------------------
 		software_id=123
 
-		aSOFTWARE_NAME[$software_id]='Mosquitto '
+		aSOFTWARE_NAME[$software_id]='Mosquitto'
 		aSOFTWARE_DESC[$software_id]='MQTT messaging broker'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=11
@@ -4255,6 +4255,18 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
+
+			# Use official APT repository where available: https://repo.mosquitto.org/debian/pool/main/m/mosquitto/
+			if [[ $G_HW_ARCH != 3 && $G_DISTRO -le 5 ]]; then
+
+				INSTALL_URL_ADDRESS='https://repo.mosquitto.org/debian/mosquitto-repo.gpg.key'
+				G_CHECK_URL "$INSTALL_URL_ADDRESS"
+				G_EXEC eval "curl -sSLf '$INSTALL_URL_ADDRESS' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-mosquitto.gpg --yes"
+				G_EXEC eval "echo 'deb https://repo.mosquitto.org/debian/ $G_DISTRO_NAME main' > /etc/apt/sources.list.d/dietpi-mosquitto.list"
+				G_AGUP
+
+			fi
+
 			G_AGI mosquitto
 
 		fi
@@ -11148,19 +11160,22 @@ _EOF_
 			Banner_Configuration
 
 			# Remove obsolete sysvinit service
-			[[ -f '/etc/init.d/mosquitto' ]] && rm /etc/init.d/mosquitto
+			[[ -f '/etc/init.d/mosquitto' ]] && rm -v /etc/init.d/mosquitto
 			update-rc.d -f mosquitto remove
-			# Add systemd unit on Stretch, since Buster it is part of the APT package: https://github.com/eclipse/mosquitto/tree/master/service/systemd
-			(( $G_DISTRO > 4 )) || cat << _EOF_ > /etc/systemd/system/mosquitto.service
+
+			# Add systemd unit if missing, since Buster and with official repo it is part of the DEB package: https://github.com/eclipse/mosquitto/tree/master/service/systemd
+			[[ -f '/lib/systemd/system/mosquitto.service' ]] || cat << '_EOF_' > /etc/systemd/system/mosquitto.service
 [Unit]
-Description=Mosquitto MQTT v3.1/v3.1.1 Broker (DietPi)
+Description=Mosquitto MQTT Broker (DietPi)
 Documentation=man:mosquitto.conf(5) man:mosquitto(8)
-After=network-online.target
 Wants=network-online.target
+After=network-online.target dietpi-boot.service
 
 [Service]
 Type=notify
 NotifyAccess=main
+ExecStartPre=/bin/mkdir -m 740 -p /var/log/mosquitto
+ExecStartPre=/bin/chown mosquitto: /var/log/mosquitto
 ExecStart=/usr/sbin/mosquitto -c /etc/mosquitto/mosquitto.conf
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
@@ -11168,7 +11183,6 @@ Restart=on-failure
 [Install]
 WantedBy=multi-user.target
 _EOF_
-
 		fi
 
 		software_id=131 # Blynk Server
@@ -12883,7 +12897,7 @@ _EOF_
 
 		fi
 
-		software_id=123
+		software_id=123 # Mosquitto
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
@@ -12893,7 +12907,11 @@ _EOF_
 				rm -R /etc/systemd/system/mosquitto.service*
 
 			fi
+			[[ -d '/etc/systemd/system/mosquitto.service.d' ]] && rm -R /etc/systemd/system/mosquitto.service.d
 			G_AGP mosquitto
+
+			[[ -f '/etc/apt/sources.list.d/dietpi-mosquitto.list' ]] && rm -v /etc/apt/sources.list.d/dietpi-mosquitto.list
+			[[ -f '/etc/apt/trusted.gpg.d/dietpi-mosquitto.gpg' ]] && rm -v /etc/apt/trusted.gpg.d/dietpi-mosquitto.gpg
 
 		fi
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1043,10 +1043,10 @@ We strongly recommend you select "0 : Re-enable IPv6 on kernel level". By doing 
 			# v6.25	myMPD: https://github.com/MichaIng/DietPi/issues/2156#issue-372201367
 			#	RoonBridge: https://community.roonlabs.com/t/dietpi-allo-units-not-getting-the-roonbridge-b167-update-from-b164/52503/10?u=dan_knight
 			#	Radarr/Lidarr/Sonarr: https://github.com/MichaIng/DietPi/issues/2219
-			#	Mosquitto: https://github.com/MichaIng/DietPi/issues/2243#issuecomment-439492463
+			# v6.33	Mosquitto: https://github.com/MichaIng/DietPi/issues/2243#issuecomment-439492463
 			if (( $G_DIETPI_INSTALL_STAGE == 2 )); then
 
-				echo 106 121 123 144 145 >> /var/tmp/dietpi/dietpi-update_reinstalls
+				echo 106 121 144 145 >> /var/tmp/dietpi/dietpi-update_reinstalls
 				# - Switch to "mariadb" systemd service on Stretch+: https://github.com/MichaIng/DietPi/pull/2196
 				if grep -q '^aSOFTWARE_INSTALL_STATE\[88\]=2' /boot/dietpi/.installed; then
 
@@ -2508,7 +2508,7 @@ _EOF_
 			[[ -f '/etc/X11/xorg.conf.d/99-dietpi-dpms_off.conf' ]] && mv -v /etc/X11/xorg.conf.d/9{9-dietpi-dpms_off,8-dietpi-disable_dpms}.conf
 			#-------------------------------------------------------------------------------
 			# OctoPrint
-			if grep -q '^aSOFTWARE_INSTALL_STATE\[153\]=2' /boot/dietpi/.installed && [[ ! -d '/opt/octoprint' ]]; then
+			if (( $G_DIETPI_INSTALL_STAGE == 2 )) && grep -q '^aSOFTWARE_INSTALL_STATE\[153\]=2' /boot/dietpi/.installed && [[ ! -d '/opt/octoprint' ]]; then
 
 				G_DIETPI-NOTIFY 2 'Preparing OctoPrint reinstall to apply new Git dir and new run user'
 				[[ -d '/mnt/dietpi_userdata/octoprint' ]] && G_EXEC mv /{mnt/dietpi_userdata,opt}/octoprint
@@ -2519,7 +2519,7 @@ _EOF_
 			fi
 			#-------------------------------------------------------------------------------
 			# Transmission
-			if grep -q '^aSOFTWARE_INSTALL_STATE\[44\]=2' /boot/dietpi/.installed && [[ -f '/etc/systemd/system/transmission-daemon.service.d/dietpi-group.conf' ]] ; then
+			if (( $G_DIETPI_INSTALL_STAGE == 2 )) && grep -q '^aSOFTWARE_INSTALL_STATE\[44\]=2' /boot/dietpi/.installed && [[ -f '/etc/systemd/system/transmission-daemon.service.d/dietpi-group.conf' ]] ; then
 
 				G_DIETPI-NOTIFY 2 'Making "dietpi" the primary group for "debian-transmission" user instead of running the service as "dietpi" group'
 				G_EXEC usermod -g dietpi -aG debian-transmission debian-transmission
@@ -2529,7 +2529,7 @@ _EOF_
 			fi
 			#-------------------------------------------------------------------------------
 			# Tautulli: https://github.com/MichaIng/DietPi/pull/3784
-			if grep -q '^aSOFTWARE_INSTALL_STATE\[146\]=2' /boot/dietpi/.installed && [[ -d '/opt/plexpy' ]] ; then
+			if (( $G_DIETPI_INSTALL_STAGE == 2 )) && grep -q '^aSOFTWARE_INSTALL_STATE\[146\]=2' /boot/dietpi/.installed && [[ -d '/opt/plexpy' ]] ; then
 
 				G_WHIP_MSG '[ INFO ] Renaming PlexPy to Tautulli
 \nPlexPy has been renamed to Tautulli a while ago. To honour this, we will rename user, directories and service now accordingly:
@@ -2552,7 +2552,7 @@ _EOF_
 			fi
 			#-------------------------------------------------------------------------------
 			# Nextcloud + Lighttpd: https://dietpi.com/phpbb/viewtopic.php?p=27445#p27445
-			if grep -q '^aSOFTWARE_INSTALL_STATE\[114\]=2' /boot/dietpi/.installed && grep -q '^aSOFTWARE_INSTALL_STATE\[84\]=2' /boot/dietpi/.installed &&
+			if (( $G_DIETPI_INSTALL_STAGE == 2 )) && grep -q '^aSOFTWARE_INSTALL_STATE\[114\]=2' /boot/dietpi/.installed && grep -q '^aSOFTWARE_INSTALL_STATE\[84\]=2' /boot/dietpi/.installed &&
 				[[ -f '/etc/lighttpd/conf-available/99-dietpi-nextcloud.conf' ]] && grep -q opcache /etc/lighttpd/conf-available/99-dietpi-nextcloud.conf; then
 
 				G_DIETPI-NOTIFY 2 'Removing obsolete directive from Lighttpd Nextcloud config file'
@@ -2569,13 +2569,16 @@ opcache.max_accelerated_files=10000\nopcache.memory_consumption=128\nopcache.sav
 
 			fi
 			#-------------------------------------------------------------------------------
+			# Mosquitto reinstall: https://github.com/MichaIng/DietPi/issues/3042
+			(( $G_DIETPI_INSTALL_STAGE == 2 )) && echo 123 >> /var/tmp/dietpi/dietpi-update_reinstalls
+			#-------------------------------------------------------------------------------
 			# Last subversion patch completed
 			# - Apply reinstalls
 			if [[ -f '/var/tmp/dietpi/dietpi-update_reinstalls' ]]; then
 
 				# Coders NB: Assigning to array is not easily possible here since we need to split at newline AND space.
 				# shellcheck disable=SC2046
-				/boot/dietpi/dietpi-software reinstall $(</var/tmp/dietpi/dietpi-update_reinstalls) || exit 1
+				(( $G_DIETPI_INSTALL_STAGE == 2 )) && { /boot/dietpi/dietpi-software reinstall $(</var/tmp/dietpi/dietpi-update_reinstalls) || exit 1; }
 				rm /var/tmp/dietpi/dietpi-update_reinstalls
 
 			fi


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Software | Mosquitto: Use official APT repository where available (all but ARMv8 and Bullseye)
+ DietPi-Software | Mosquitto: Update systemd unit