### PR TITLE
DietPi-Software | Firefox Sync Server: Fix broken install due to started Rust migration

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -27,6 +27,7 @@ Bug Fixes:
 - DietPi-Config | Resolved an issue where on devices with old Linux kernel versions (e.g. Sparky SBC with Linux 3.10.38) the Performance Options failed to open with a syntax error. Many thanks to @dsnyder0pc for reporting this issue: https://github.com/MichaIng/DietPi/issues/3799
 - DietPi-Software | OpenTyrian: The autostart option and run script have been fixed and slightly enhanced to lower RAM usage a bid.
 - DietPi-Software | Firefox Sync Server: Resolved an issue where the build failed due to missing MySQL/MariaDB headers, newly required. Many thanks to @kinoushe for reporting this issue: https://github.com/MichaIng/DietPi/issues/3774
+- DietPi-Software | Firefox Sync Server: Resolved another issue where the build failed due to transition of the whole project from Python to Rust. We now stay on a fixed commit and won't ship newer Firefox Sync Server versions until this transition has been fully completed, as the install process and requirements will constantly change. Many thanks again to @kinoushe for reporting this issue.
 - DietPi-Software | LXDE: Resolved several issues due to conflicts between the RPi desktop LXDE packages with native LXDE.
 - DietPi-Software | Webmin: Worked around an issue where install failed. Webmin depends on apt-show-versions which does not support compressed APT list files, which be implemented as default with DietPi v6.32.
 - DietPi-Software | WebIOPi: Resolved an issue where the download failed.

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5459,10 +5459,11 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			(( $G_HW_ARCH < 10 )) && DEPS_LIST+=' libffi-dev libssl-dev'
 
 			# Download & Install
-			INSTALL_URL_ADDRESS='https://github.com/mozilla-services/syncserver/archive/master.tar.gz'
+			local commit='bfbc3abd36ee4db70df13a9c43f7758a1528c965'
+			INSTALL_URL_ADDRESS="https://github.com/mozilla-services/syncserver/archive/$commit.tar.gz"
 			Download_Install "$INSTALL_URL_ADDRESS"
 			[[ -d '/opt/firefox-sync' ]] && G_EXEC rm -R /opt/firefox-sync
-			G_EXEC mv syncserver-master /opt/firefox-sync
+			G_EXEC mv syncserver-$commit /opt/firefox-sync
 
 			# Build
 			G_EXEC cd /opt/firefox-sync

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5459,7 +5459,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			(( $G_HW_ARCH < 10 )) && DEPS_LIST+=' libffi-dev libssl-dev'
 
 			# Download & Install
-			local commit='bfbc3abd36ee4db70df13a9c43f7758a1528c965'
+			local commit='bfbc3abd36ee4db70df13a9c43f7758a1528c965' # https://github.com/MichaIng/DietPi/issues/3774#issuecomment-703230290
 			INSTALL_URL_ADDRESS="https://github.com/mozilla-services/syncserver/archive/$commit.tar.gz"
 			Download_Install "$INSTALL_URL_ADDRESS"
 			[[ -d '/opt/firefox-sync' ]] && G_EXEC rm -R /opt/firefox-sync


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Software | Firefox Sync Server: Fix broken install due to started Rust migration. We'll keep the pure Python-based server as long as the Rust migration is in process which will probably take until end of the year. Until then it is likely impossible to provide a reliable install method: https://github.com/MichaIng/DietPi/issues/3774#issuecomment-691745477