### PR TITLE
DietPi-Software | Enhancement Fail2Ban

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -34,6 +34,7 @@ Bug Fixes:
 - DietPi-Software | Home Assistant: Resolved an issue where install failed on ARM due to missing new build dependency. Many thanks to @pbutterworth for reporting and @novitibo for providing the solution: https://dietpi.com/phpbb/viewtopic.php?f=11&t=8095
 - DietPi-Software | Kodi: Resolved an issue on Odroid XU4 where install failed due to missing librockchip-mpp1 package which instead was aimed to be installed on Odroid N1 only.
 - DietPi-Software | TigerVNC+LXDE: Resolved an issue where lxappearance start ("Customize Look and Feel") hangs within TigerVNC sessions.
+- DietPi-Software | Fail2Ban: Resolved an issue where the service could have failed to start due to a missing variable declaration in our default config. Many thanks to @mafioso12dk for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?f=11&t=8147
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4507,6 +4507,7 @@ enabled = true
 ignoreip = 127.0.0.1/8
 ignorecommand =
 backend = systemd
+mode = normal
 filter = %(__name__)s[mode=%(mode)s]
 findtime  = 600
 maxretry = 3

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -2623,6 +2623,9 @@ opcache.max_accelerated_files=10000\nopcache.memory_consumption=128\nopcache.sav
 			# TigerVNC + LXDE: https://github.com/MichaIng/DietPi/pull/3800
 			(( $G_DIETPI_INSTALL_STAGE == 2 )) && grep -q '^aSOFTWARE_INSTALL_STATE\[28\]=2' /boot/dietpi/.installed && grep -q '^aSOFTWARE_INSTALL_STATE\[23\]=2' /boot/dietpi/.installed && G_AGI dbus-user-session
 			#-------------------------------------------------------------------------------
+			# Fail2Ban: https://github.com/MichaIng/DietPi/pull/3813
+			[[ -f '/etc/fail2ban/jail.conf' ]] && GCI_PRESERVE=1 G_CONFIG_INJECT 'mode[[:blank:]]*=' 'mode = normal' /etc/fail2ban/jail.conf '\[DEFAULT\]'
+			#-------------------------------------------------------------------------------
 			# Last subversion patch completed
 			# - Apply reinstalls
 			if [[ -f '/var/tmp/dietpi/dietpi-update_reinstalls' ]]; then


### PR DESCRIPTION
At the moment Fail2Ban is failing after fresh installation with following error message

```
Oct 07 17:46:19 DietPiVM1 fail2ban-server[412]:  Failed during configuration: Bad value substitution: option 'filter' in section 'dropbear' contains an interpolation key 'mode' which is not a valid option name. Raw value: '%(__name__)s[mode=%(mode)s]'
```

Same behaviour on RPI3B+ as well as VM system. It is needed to add `mode = normal` before `filter` to get it working.

**Status**:  Ready 
- [x] Add Enhancement 
- [x] tested on VM 
- [x] tested on RPi 

**Reference**: https://dietpi.com/phpbb/viewtopic.php?f=11&t=8147

**Commit list/description**:
- DietPi-Software | Enhancement Fail2Ban as it is failing after fresh installation
