### PR TITLE
DietPi-Update | update medusa service

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ Changes / Improvements / Optimisations:
 
 Bug Fixes:
 - DietPi-Software | PiVPN: Resolved an issue where the installer hang since the interactive whiptail dialogues were not shown on console. Many thanks to @kelliegator for reporting this issue: https://github.com/MichaIng/DietPi/issues/3844
+- DietPi-Software | Medusa: Resolved an issue where Medusa failed to start after install. Many thanks to @Luan7805 for reporting this issue: https://github.com/MichaIng/DietPi/issues/3842
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10929,7 +10929,7 @@ _EOF_
 
 			# Service: https://github.com/pymedusa/Medusa/blob/master/runscripts/init.systemd
 			G_EXEC cp /mnt/dietpi_userdata/medusa/runscripts/init.systemd /etc/systemd/system/medusa.service
-			G_EXEC sed -i 's/^[[:blank:]]Group=/#Group=/' /etc/systemd/system/medusa.service
+			G_EXEC sed -i 's/Group=/#Group=/' /etc/systemd/system/medusa.service
 			G_CONFIG_INJECT 'ExecStart=' "ExecStart=$(command -v python3) /mnt/dietpi_userdata/medusa/start.py -q --nolaunch --datadir=/mnt/dietpi_userdata/medusa" /etc/systemd/system/medusa.service
 
 			# Permissions

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10929,7 +10929,7 @@ _EOF_
 
 			# Service: https://github.com/pymedusa/Medusa/blob/master/runscripts/init.systemd
 			G_EXEC cp /mnt/dietpi_userdata/medusa/runscripts/init.systemd /etc/systemd/system/medusa.service
-			G_EXEC sed -i 's/Group=/#Group=/' /etc/systemd/system/medusa.service
+			G_EXEC sed -i 's/^[[:blank:]]*Group=/#Group=/' /etc/systemd/system/medusa.service
 			G_CONFIG_INJECT 'ExecStart=' "ExecStart=$(command -v python3) /mnt/dietpi_userdata/medusa/start.py -q --nolaunch --datadir=/mnt/dietpi_userdata/medusa" /etc/systemd/system/medusa.service
 
 			# Permissions


### PR DESCRIPTION
medusa service needs to be updated as user group medusa is not existing

**Status**: Done
- [x] update `dietpi-software` to set correct value on `medusa.service`
- [x] test on VM Buster
- [x]  test on RPI Buster

**Reference**: 
- https://github.com/MichaIng/DietPi/issues/3842
- https://dietpi.com/phpbb/viewtopic.php?f=11&t=8193

**Commit list/description**:
- DietPi-Software | update `medusa.service` and remove medusa user group as it is not existing

@MichaIng 
I guess idea of the `sed` command was to set a `#` to disable `Group=medusa`. But this is not working. Medusa is still set as group and service is not starting. 

Another option would be to set `Group=dietpi` instead 
`G_CONFIG_INJECT 'Group=' 'Group=dietpi' /etc/systemd/system/medusa.service`