### PR TITLE
DietPi-Software | CloudPrint: Remove from software options

### DIFF
--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -475,10 +475,21 @@
 	for i in "${!aSOFTWARE_NAME6_32[@]}"
 	do
 
-		# shellcheck disable=SC2034
 		aSOFTWARE_NAME6_33[$i]=${aSOFTWARE_NAME6_32[$i]}
 
 	done
+	aSOFTWARE_NAME6_33[180]='Bazarr'
+
+	# v3.34
+	aSOFTWARE_NAME6_34=()
+	for i in "${!aSOFTWARE_NAME6_33[@]}"
+	do
+
+		aSOFTWARE_NAME6_34[$i]=${aSOFTWARE_NAME6_33[$i]}
+
+	done
+	# shellcheck disable=SC2034
+	aSOFTWARE_NAME6_34[137]='137' # CloudPrint
 
 	Main(){
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ v6.34
 (XX/11/20)
 
 Changes / Improvements / Optimisations:
+- DietPi-Software | CloudPrint: This software option has been removed, since the Google Cloud Print service will be shut down at the end of 2020 and we don't want to offer software options which will work for at most two months. Please migrate to another printing solution in time. Already installed CloudPrint instances will remain installed and the system service remains functional until the end of the year. With the first DietPi release in 2021 we will remove service handling and offer the package removal during the update process. Further information can be found here: https://www.google.com/cloudprint/learn/ 
 - DietPi-Software | OpenBazaar: Build is now done with the currently latest Go v1.15.3 and the service runs as unprivileged user "openbazaar" instead of root.
 
 Bug Fixes:

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -156,7 +156,7 @@ Available services:
 			'raspimjpeg'
 
 			# - Printing
-			'cups' 'cloudprintd'
+			'cups' 'cloudprintd' # Remove in 2021 due to Google Cloud Print service shutdown
 			'octoprint'
 
 			# - Social/Search

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1898,14 +1898,6 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		aSOFTWARE_REQUIRES_PHP[$software_id]=1
 
 		# Printing
-		#--------------------------------------------------------------------------------
-		software_id=137
-
-		aSOFTWARE_NAME[$software_id]='CloudPrint'
-		aSOFTWARE_DESC[$software_id]='print server for google cloud print'
-		aSOFTWARE_TYPE[$software_id]=0
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=19
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=6630#p6630'
 		#------------------
 		software_id=153
 
@@ -5379,17 +5371,6 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			# Motioneye
 			pip2 install -U pip setuptools wheel
 			pip2 install -U motioneye
-
-		fi
-
-		software_id=137 # CloudPrint
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			# Workaround for missing dependency on Debian Buster: https://github.com/davesteele/cloudprint-service/issues/56
-			local package=
-			(( $G_DISTRO == 5 )) && package='python3-requests'
-			G_AGI cloudprint-service $package
 
 		fi
 
@@ -11273,26 +11254,13 @@ _EOF_
 
 		fi
 
-		software_id=137 # CloudPrint
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Configuration
-
-			# Enable web admin
-			G_EXEC systemctl start cups
-			cupsctl --remote-admin
-			usermod -aG lpadmin root
-			systemctl stop cups
-
-		fi
-
 		software_id=138 # VirtualHere
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
 
 			# Service
-			cat << _EOF_ > /etc/systemd/system/virtualhere.service
+			cat << '_EOF_' > /etc/systemd/system/virtualhere.service
 [Unit]
 Description=VirtualHere (DietPi)
 
@@ -13223,14 +13191,6 @@ _EOF_
 			pip2 uninstall -y motioneye
 			G_AGP motion
 			[[ -d '/etc/motioneye' ]] && rm -R /etc/motioneye
-
-		fi
-
-		software_id=137 # CloudPrint
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
-
-			Banner_Uninstalling
-			G_AGP cloudprint-service
 
 		fi
 

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -327,7 +327,7 @@ _EOF_
 
 				G_WHIP_MSG 'DietPi will not use "/etc/rc.local" for its own scripts anymore.\n\nHowever, in case you manually added something, we safe a backup to "/mnt/dietpi_userdata/rc.local.bak", from where you can copy & paste back to the cleaned "/etc/rc.local".\n\nIt will work as before.'
 				mv /etc/rc.local /mnt/dietpi_userdata/rc.local.bak
-				cat << _EOF_ > /etc/rc.local
+				cat << '_EOF_' > /etc/rc.local
 #!/bin/sh -e
 #
 # rc.local
@@ -582,10 +582,9 @@ _EOF_'
 			# v6.12	AirSonic
 			# v6.23	SubSonic
 			#	Cava
-			#	CloudPrint
 			#	TigerVNC/RealVNC: https://github.com/MichaIng/DietPi/pull/1798#issuecomment-392594878
 			# v6.19	Xserver: https://github.com/MichaIng/DietPi/issues/1823
-			(( $G_DIETPI_INSTALL_STAGE == 2 )) && echo 23 28 119 120 137 >> /var/tmp/dietpi/dietpi-update_reinstalls
+			(( $G_DIETPI_INSTALL_STAGE == 2 )) && echo 23 28 119 120 >> /var/tmp/dietpi/dietpi-update_reinstalls
 			#-------------------------------------------------------------------------------
 			# Re-run set uid for sudo: https://github.com/MichaIng/DietPi/issues/794#issuecomment-392335392
 			chmod 4755 "$(command -v sudo)"

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -2629,6 +2629,9 @@ opcache.max_accelerated_files=10000\nopcache.memory_consumption=128\nopcache.sav
 		elif (( $G_DIETPI_VERSION_SUB == 33 )); then
 
 			#-------------------------------------------------------------------------------
+			# Remove CloudPrint install flag
+			[[ -f '/boot/dietpi/.installed' ]] && grep -q '^aSOFTWARE_INSTALL_STATE\[137\]=2' /boot/dietpi/.installed && sed -i '/^aSOFTWARE_INSTALL_STATE\[137\]=2/d' /boot/dietpi/.installed
+			#-------------------------------------------------------------------------------
 			# Last subversion patch completed
 			# - Apply reinstalls
 			if [[ -f '/var/tmp/dietpi/dietpi-update_reinstalls' ]]; then


### PR DESCRIPTION
**Status**: Ready

Google Cloud Print will be shut down at the end of the year. Let's do not offer an install option which is then working only for two months: https://www.google.com/cloudprint/learn/

The service will be handled by `dietpi-services` until end of the year. On first release in 2021 we'll remove it as well and suggest `cloudprint-service` + `cloudprint` package removals during `dietpi-update`.