### PR TITLE
DietPi-Software | Lighttpd: Fix lighty-enable-mod "failing" with exit code 2

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Bug Fixes:
 - DietPi-Bugreport | Resolved an issue where bug report uploads were cancelled if connection test on port 80/443 failed even that uploads are done via SFTP on port 22.
 - DietPi-Software | PiVPN: Resolved an issue where the installer hang since the interactive whiptail dialogues were not shown on console. Many thanks to @kelliegator for reporting this issue: https://github.com/MichaIng/DietPi/issues/3844
 - DietPi-Software | Medusa: Resolved an issue where Medusa failed to start after install. Many thanks to @Luan7805 for reporting this issue: https://github.com/MichaIng/DietPi/issues/3842
+- DietPi-Software | Lighttpd: Resolved an issue where (re)install failed if the fastcgi or fastcgi-php module was enabled already.
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Bug Fixes:
 - DietPi-Bugreport | Resolved an issue where bug report uploads were cancelled if connection test on port 80/443 failed even that uploads are done via SFTP on port 22.
 - DietPi-Software | PiVPN: Resolved an issue where the installer hang since the interactive whiptail dialogues were not shown on console. Many thanks to @kelliegator for reporting this issue: https://github.com/MichaIng/DietPi/issues/3844
 - DietPi-Software | Medusa: Resolved an issue where Medusa failed to start after install. Many thanks to @Luan7805 for reporting this issue: https://github.com/MichaIng/DietPi/issues/3842
+- DietPi-Software | Webservers: Resolved an issue where reinstall failed if /var/www/html did not exist.
 - DietPi-Software | Lighttpd: Resolved an issue where (re)install failed if the fastcgi or fastcgi-php module was enabled already.
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6256,7 +6256,8 @@ Mycroft AI requires at least 2 GiB memory on first start. We will now increase y
 				fi
 				dps_index=$software_id Download_Install 'lighttpd.tasmoadmin.conf' $tasmoadmin_conf
 				# Enable required modules + our config
-				lighty-enable-mod rewrite dietpi-tasmoadmin
+				G_EXEC_POST_FUNC(){ [[ $exit_code == 2 ]] && exit_code=0; } # Do not fail if modules are enabled already
+				G_EXEC lighty-enable-mod rewrite dietpi-tasmoadmin
 
 			elif (( ${aSOFTWARE_INSTALL_STATE[85]} > 0 )); then
 
@@ -7194,8 +7195,8 @@ fastcgi.server += ( ".php" =>
 )
 _EOF_
 			# - Enable modules
-			G_EXEC lighty-enable-mod fastcgi
-			G_EXEC lighty-enable-mod fastcgi-php
+			G_EXEC_POST_FUNC(){ [[ $exit_code == 2 ]] && exit_code=0; } # Do not fail if modules are enabled already
+			G_EXEC lighty-enable-mod fastcgi fastcgi-php
 
 		fi
 
@@ -7337,7 +7338,8 @@ _EOF_
 			elif (( ${aSOFTWARE_INSTALL_STATE[84]} > 0 )); then
 
 				dps_index=$software_id Download_Install 'lighttpd.phpmyadmin.conf' /etc/lighttpd/conf-available/98-dietpi-phpmyadmin.conf
-				lighty-enable-mod dietpi-phpmyadmin
+				G_EXEC_POST_FUNC(){ [[ $exit_code == 2 ]] && exit_code=0; } # Do not fail if modules are enabled already
+				G_EXEC lighty-enable-mod dietpi-phpmyadmin
 
 			# - Nginx
 			elif (( ${aSOFTWARE_INSTALL_STATE[85]} > 0 )); then
@@ -7571,7 +7573,6 @@ Redirect permanent /.well-known/caldav /owncloud/remote.php/dav' > /etc/apache2/
 				# Enable required modules
 				G_CONFIG_INJECT '"mod_access",' '	"mod_access",' /etc/lighttpd/lighttpd.conf '"mod_.+",'
 				G_CONFIG_INJECT '"mod_setenv",' '	"mod_setenv",' /etc/lighttpd/lighttpd.conf '"mod_.+",'
-				lighty-enable-mod rewrite
 
 				# Move ownCloud configuration file in place and activate it
 				owncloud_conf='/etc/lighttpd/conf-available/99-dietpi-owncloud.conf'
@@ -7582,7 +7583,8 @@ Redirect permanent /.well-known/caldav /owncloud/remote.php/dav' > /etc/apache2/
 
 				fi
 				dps_index=$software_id Download_Install 'lighttpd.owncloud.conf' $owncloud_conf
-				lighty-enable-mod dietpi-owncloud
+				G_EXEC_POST_FUNC(){ [[ $exit_code == 2 ]] && exit_code=0; } # Do not fail if modules are enabled already
+				G_EXEC lighty-enable-mod rewrite dietpi-owncloud
 
 				# Cal/CardDAV redirects to ownCloud DAV endpoint
 				if [[ ! -f '/etc/lighttpd/conf-enabled/99-dietpi-dav_redirect.conf' ]]; then
@@ -7592,7 +7594,8 @@ url.redirect += (
 	"^/.well-known/caldav"  => "/owncloud/remote.php/dav",
 	"^/.well-known/carddav" => "/owncloud/remote.php/dav"
 )' > /etc/lighttpd/conf-available/99-dietpi-dav_redirect.conf
-					lighty-enable-mod dietpi-dav_redirect
+					G_EXEC_POST_FUNC(){ [[ $exit_code == 2 ]] && exit_code=0; } # Do not fail if modules are enabled already
+					G_EXEC lighty-enable-mod dietpi-dav_redirect
 
 				fi
 
@@ -7788,7 +7791,6 @@ Redirect permanent /.well-known/caldav /nextcloud/remote.php/dav' > /etc/apache2
 				# Enable required modules
 				G_CONFIG_INJECT '"mod_access",' '	"mod_access",' /etc/lighttpd/lighttpd.conf '"mod_.+",'
 				G_CONFIG_INJECT '"mod_setenv",' '	"mod_setenv",' /etc/lighttpd/lighttpd.conf '"mod_.+",'
-				lighty-enable-mod rewrite
 
 				# Move Nextcloud configuration file in place and activate it
 				nextcloud_conf='/etc/lighttpd/conf-available/99-dietpi-nextcloud.conf'
@@ -7799,7 +7801,8 @@ Redirect permanent /.well-known/caldav /nextcloud/remote.php/dav' > /etc/apache2
 
 				fi
 				dps_index=$software_id Download_Install 'lighttpd.nextcloud.conf' $nextcloud_conf
-				lighty-enable-mod dietpi-nextcloud
+				G_EXEC_POST_FUNC(){ [[ $exit_code == 2 ]] && exit_code=0; } # Do not fail if modules are enabled already
+				G_EXEC lighty-enable-mod rewrite dietpi-nextcloud
 
 				# Cal/CardDAV redirects to Nextcloud DAV endpoint
 				if [[ ! -f '/etc/lighttpd/conf-enabled/99-dietpi-dav_redirect.conf' ]]; then
@@ -7809,7 +7812,8 @@ url.redirect += (
 	"^/.well-known/caldav"  => "/nextcloud/remote.php/dav",
 	"^/.well-known/carddav" => "/nextcloud/remote.php/dav"
 )' > /etc/lighttpd/conf-available/99-dietpi-dav_redirect.conf
-					lighty-enable-mod dietpi-dav_redirect
+					G_EXEC_POST_FUNC(){ [[ $exit_code == 2 ]] && exit_code=0; } # Do not fail if modules are enabled already
+					G_EXEC lighty-enable-mod dietpi-dav_redirect
 
 				fi
 
@@ -8866,7 +8870,8 @@ _EOF_
 
 				# Add and enable Pi-hole config
 				dps_index=$software_id Download_Install 'lighttpd.pihole.conf' /etc/lighttpd/conf-available/99-dietpi-pihole.conf
-				lighty-enable-mod dietpi-pihole
+				G_EXEC_POST_FUNC(){ [[ $exit_code == 2 ]] && exit_code=0; } # Do not fail if modules are enabled already
+				G_EXEC lighty-enable-mod dietpi-pihole
 
 				# Optional config to block public access to admin panel
 				dps_index=$software_id Download_Install 'lighttpd.block_public_admin.conf' /etc/lighttpd/conf-available/99-dietpi-pihole-block_public_admin.conf
@@ -10075,11 +10080,11 @@ _EOF_
 				# Enable Lighttpd setenv, access and rewrite modules
 				G_CONFIG_INJECT '"mod_access",' '	"mod_access",' /etc/lighttpd/lighttpd.conf '"mod_.+",'
 				G_CONFIG_INJECT '"mod_setenv",' '	"mod_setenv",' /etc/lighttpd/lighttpd.conf '"mod_.+",'
-				lighty-enable-mod rewrite
 
 				# Move Pydio Lighttpd config in place
 				dps_index=$software_id Download_Install 'lighttpd.pydio.conf' /etc/lighttpd/conf-available/99-dietpi-pydio.conf
-				lighty-enable-mod dietpi-pydio
+				G_EXEC_POST_FUNC(){ [[ $exit_code == 2 ]] && exit_code=0; } # Do not fail if modules are enabled already
+				G_EXEC lighty-enable-mod rewrite dietpi-pydio
 
 			# - Nginx
 			elif (( ${aSOFTWARE_INSTALL_STATE[85]} > 0 )); then
@@ -10257,13 +10262,13 @@ Redirect permanent /.well-known/caldav /baikal/html/dav.php' > /etc/apache2/conf
 			elif (( ${aSOFTWARE_INSTALL_STATE[84]} > 0 )); then
 
 				dps_index=$software_id Download_Install 'lighttpd.baikal.conf' /etc/lighttpd/conf-available/99-dietpi-baikal.conf
-				lighty-enable-mod dietpi-baikal
 				echo '# Redirect Cal/CardDAV requests to Baïkal endpoint:
 url.redirect += (
 	"^/.well-known/caldav"  => "/baikal/html/dav.php",
 	"^/.well-known/carddav" => "/baikal/html/dav.php"
 )' > /etc/lighttpd/conf-available/99-dietpi-dav_redirect.conf
-				lighty-enable-mod dietpi-dav_redirect
+				G_EXEC_POST_FUNC(){ [[ $exit_code == 2 ]] && exit_code=0; } # Do not fail if modules are enabled already
+				G_EXEC lighty-enable-mod dietpi-baikal dietpi-dav_redirect
 
 			# - Nginx
 			elif (( ${aSOFTWARE_INSTALL_STATE[85]} > 0 )); then
@@ -11122,7 +11127,8 @@ _EOF_
 			if (( ${aSOFTWARE_INSTALL_STATE[84]} > 0 )); then
 
 				dps_index=$software_id Download_Install 'lighttpd.ompd.conf' /etc/lighttpd/conf-available/99-dietpi-ompd.conf
-				lighty-enable-mod dietpi-ompd
+				G_EXEC_POST_FUNC(){ [[ $exit_code == 2 ]] && exit_code=0; } # Do not fail if modules are enabled already
+				G_EXEC lighty-enable-mod dietpi-ompd
 
 			fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7129,7 +7129,7 @@ _EOF_
 _EOF_
 			# Webroot
 			[[ -f '/var/www/html/index.html' ]] && G_EXEC mv /var/www/html/index.html /var/www/
-			G_EXEC rmdir --ignore-fail-on-non-empty /var/www/html
+			[[ -d '/var/www/html' ]] && G_EXEC rmdir --ignore-fail-on-non-empty /var/www/html
 
 			# Change error log level
 			G_EXEC sed -i '/LogLevel[[:blank:]]/c\	LogLevel error' /etc/apache2/sites-available/*

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7157,7 +7157,7 @@ _EOF_
 
 			# Webroot
 			[[ -f '/var/www/html/index.nginx-debian.html' ]] && G_EXEC mv /var/www/html/index.nginx-debian.html /var/www/
-			G_EXEC rmdir --ignore-fail-on-non-empty /var/www/html
+			[[ -d '/var/www/html' ]] && G_EXEC rmdir --ignore-fail-on-non-empty /var/www/html
 
 		fi
 
@@ -7174,7 +7174,7 @@ _EOF_
 			G_CONFIG_INJECT 'server.document-root' 'server.document-root = "/var/www"' /etc/lighttpd/lighttpd.conf
 			# - Move default page
 			[[ -f '/var/www/html/index.lighttpd.html' ]] && G_EXEC mv /var/www/html/index.lighttpd.html /var/www/
-			G_EXEC rmdir --ignore-fail-on-non-empty /var/www/html
+			[[ -d '/var/www/html' ]] && G_EXEC rmdir --ignore-fail-on-non-empty /var/www/html
 
 			# Fix in case Lighttpd got updated to Buster version (on ARMv6 due to PHP7.3 libssl1.1 depedency)
 			# - "create-mime.assign.pl" has been renamed to "create-mime.conf.pl"


### PR DESCRIPTION
**Status**: Ready

+ DietPi-Software | Webservers: Do not attempt to remove /var/www/html if it does not exist
+ DietPi-Software | Lighttpd: lighty-enable-mod "fails" with exit code 2 if a module is enabled already. Override this exit code with success (0) when using G_EXEC.
+ DietPi-Software | Consequently use G_EXEC for all lighty-enable-mod calls and override exit code 2 to not cause the same bug anymore.
