### PR TITLE
DietPi-Set_swapfile | Enhance zram-swap hardening and input tolerance

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ v6.34
 (XX/11/20)
 
 Changes / Improvements / Optimisations:
+- DietPi-Set_swapfile | Hardened permissions of the /dev/zram0 zram-swap device to be only accessible by root user (mode 0600) and interpret input argument "/dev/zram0" and "zram0" as zram-swap as well, aside of "zram" only. Many thanks to @hansjuergenmay for reporting a related issue: https://github.com/MichaIng/DietPi/issues/3869
 - DietPi-Software | PaperMC: Highly optimised Minecraft server, written in Java, extensible via plugins, now available for install. Many thanks to @ravenclaw900 for implementing this software option: https://github.com/MichaIng/DietPi/pull/3828
 - DietPi-Software | CloudPrint: This software option has been removed, since the Google Cloud Print service will be shut down at the end of 2020 and we don't want to offer software options which will work for at most two months. Please migrate to another printing solution in time. Already installed CloudPrint instances will remain installed and the system service remains functional until the end of the year. With the first DietPi release in 2021 we will remove service handling and offer the package removal during the update process. Further information can be found here: https://www.google.com/cloudprint/learn/ 
 - DietPi-Software | OpenBazaar: Build is now done with the currently latest Go v1.15.3 and the service runs as unprivileged user "openbazaar" instead of root.

--- a/dietpi/func/dietpi-set_swapfile
+++ b/dietpi/func/dietpi-set_swapfile
@@ -97,14 +97,15 @@
 		# zram
 		if [[ $SWAP_FS == 'zram' ]]; then
 
-			[[ -b '/dev/zram0' ]] || G_EXEC modprobe zram
+			[[ -b $SWAP_PATH ]] || G_EXEC modprobe zram
 			G_EXEC eval 'echo 1 > /sys/block/zram0/reset'
 			G_EXEC eval "echo '${SWAP_SIZE}M' > /sys/block/zram0/disksize"
+			G_EXEC chmod 0600 "$SWAP_PATH"
 			G_EXEC mkswap "$SWAP_PATH"
 			G_EXEC swapon "$SWAP_PATH"
 			# Make persistent, proceed with failure in case of R/O rootfs
 			G_EXEC_NOHALT=1 G_EXEC eval "echo 'zram' > /etc/modules-load.d/dietpi-zram-swap.conf" || return 1
-			G_EXEC_NOHALT=1 G_EXEC eval "echo 'SUBSYSTEM==\"block\", KERNEL==\"zram0\", ACTION==\"add\", ATTR{disksize}=\"${SWAP_SIZE}M\", RUN+=\"/sbin/mkswap /dev/zram0\", RUN+=\"/sbin/swapon /dev/zram0\"' > /etc/udev/rules.d/98-dietpi-zram-swap.rules" || return 1
+			G_EXEC_NOHALT=1 G_EXEC eval "echo 'SUBSYSTEM==\"block\", KERNEL==\"zram0\", ACTION==\"add\", ATTR{disksize}=\"${SWAP_SIZE}M\", RUN+=\"chmod 0600 /dev/zram0\", RUN+=\"/sbin/mkswap /dev/zram0\", RUN+=\"/sbin/swapon /dev/zram0\"' > /etc/udev/rules.d/98-dietpi-zram-swap.rules" || return 1
 			G_EXEC_NOHALT=1 G_EXEC eval "echo 'swappiness=50' > /etc/sysctl.d/98-dietpi-zram-swap.conf" || return 1
 			return 0
 
@@ -119,7 +120,7 @@
 		fi
 
 		# Harden permissions, allow to fail on filesystems without UNIX permission support
-		G_EXEC_NOHALT=1 G_EXEC chmod 600 "$SWAP_PATH" 
+		G_EXEC_NOHALT=1 G_EXEC chmod 0600 "$SWAP_PATH"
 		# Make persistent, proceed with failure in case of R/O rootfs
 		G_EXEC_NOHALT=1 G_EXEC eval "echo '$SWAP_PATH none swap sw' >> /etc/fstab" || return 1
 
@@ -142,7 +143,7 @@
 	Swap_Disable
 
 	# zram-swap
-	if [[ $SWAP_PATH == 'zram' ]]; then
+	if [[ $SWAP_PATH == 'zram' || $SWAP_PATH == 'zram0' || $SWAP_PATH == '/dev/zram0' ]]; then
 
 		(( $SWAP_SIZE == 1 )) && SWAP_SIZE=$(( $(free -m | mawk '/^Mem:/{print $2;exit}') / 2 )) # Auto size
 		SWAP_PATH='/dev/zram0' SWAP_FS='zram'

--- a/dietpi/func/dietpi-set_swapfile
+++ b/dietpi/func/dietpi-set_swapfile
@@ -41,13 +41,13 @@
 	# - Path: Store current saved (only absolute paths to exclude zram) and active paths for later use
 	SWAP_PATH_CURRENT=$(sed -n '/^[[:blank:]]*AUTO_SETUP_SWAPFILE_LOCATION=\//{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 	read -ra SWAP_FILES_ACTIVE < <(mawk '$2=="file" {print $1}' /proc/swaps)
-	if [[ $2 == '/'* || $2 == 'zram' ]]; then
+	if [[ $2 == '/'* || $2 == 'zram' || $2 == 'zram0' ]]; then
 
 		SWAP_PATH=$2
 
-	elif SWAP_PATH=$SWAP_PATH_CURRENT; [[ $SWAP_PATH != '/'* && $SWAP_PATH != 'zram' ]]; then
+	elif SWAP_PATH=$SWAP_PATH_CURRENT; [[ $SWAP_PATH != '/'* && $SWAP_PATH != 'zram' && $SWAP_PATH != 'zram0' ]]; then
 
-		SWAP_PATH=$(mawk '$2=="file" {print $1;exit}' /proc/swaps) && [[ $SWAP_PATH == '/'* || $SWAP_PATH == 'zram' ]] || SWAP_PATH='/var/swap'
+		SWAP_PATH=$(mawk '$2=="file" {print $1;exit}' /proc/swaps) && [[ $SWAP_PATH == '/'* || $SWAP_PATH == 'zram' || $SWAP_PATH == 'zram0' ]] || SWAP_PATH='/var/swap'
 
 	fi
 


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Set_swapfile | Harden zram-swap device permissions
+ DietPi-Set_swapfile | Be more tolerant to interpret "zram0" and "/dev/zram0" as zram-swap as well