### PR TITLE
Dietpi-Software | Fail2Ban: Fix drop-in config directory pre-creation

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4557,13 +4557,13 @@ action = %(banaction)s[blocktype=blackhole]
 # See "filter.d/sshd.conf" for details.
 #mode = normal
 _EOF_
+			G_AGI python3-systemd fail2ban
+
 			# Log to systemd by default
 			local logtarget='SYSOUT'
 			(( $G_DISTRO < 5 )) && logtarget='SYSLOG'
 			echo -e "[Definition]\nlogtarget = $logtarget" > /etc/fail2ban/fail2ban.d/97_dietpi.conf
 			unset -v logtarget
-
-			G_AGI python3-systemd fail2ban
 
 			# Remove obsolete sysvinit service and traces
 			rm -f /etc/{init.d,default}/fail2ban

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4535,7 +4535,7 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 			Banner_Installing
 
 			# Create jail.conf (backend = systemd) first, to prevent APT failure due to missing /var/log/auth.log: https://github.com/MichaIng/DietPi/issues/475#issuecomment-310873879
-			mkdir -p /etc/fail2ban/fail2ban.conf.d
+			G_EXEC mkdir -p /etc/fail2ban/fail2ban.d
 			[[ -f '/etc/fail2ban/jail.conf' ]] || cat << '_EOF_' > /etc/fail2ban/jail.conf
 [DEFAULT]
 enabled = true
@@ -4557,13 +4557,13 @@ action = %(banaction)s[blocktype=blackhole]
 # See "filter.d/sshd.conf" for details.
 #mode = normal
 _EOF_
-			G_AGI python3-systemd fail2ban
-
 			# Log to systemd by default
 			local logtarget='SYSOUT'
 			(( $G_DISTRO < 5 )) && logtarget='SYSLOG'
 			echo -e "[Definition]\nlogtarget = $logtarget" > /etc/fail2ban/fail2ban.d/97_dietpi.conf
 			unset -v logtarget
+
+			G_AGI python3-systemd fail2ban
 
 			# Remove obsolete sysvinit service and traces
 			rm -f /etc/{init.d,default}/fail2ban


### PR DESCRIPTION
**Status**: Ready | 
- [x] update `dietpi-software`
- [x] tested on RPI3B+

**Reference**: on current installation you will see an error messages passing by

```
[ SUB1 ] DietPi-Software > Installing Fail2Ban: prevents brute-force attacks with ip ban
/boot/dietpi/dietpi-software: line 4529: /etc/fail2ban/fail2ban.d/97_dietpi.conf: No such file or directory
[ INFO ] DietPi-Software | APT install for: python3-systemd fail2ban, please wait...
```

**Commit list/description**:
- DietPi-Software | change order of activities. Install Fail2Ban first before creating any config files
