### PR TITLE
DietPi-Software | O!MPD: Update download URL

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,7 @@ Bug Fixes:
 - DietPi-Software | Medusa: Resolved an issue where Medusa failed to start after install. Many thanks to @Luan7805 for reporting this issue: https://github.com/MichaIng/DietPi/issues/3842
 - DietPi-Software | Webservers: Resolved an issue where reinstall failed if /var/www/html did not exist.
 - DietPi-Software | Lighttpd: Resolved an issue where (re)install failed if the fastcgi or fastcgi-php module was enabled already.
+- DietPi-Software | O!MPD: Resolved an issue where the URL check for youtube-dl failed.
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4118,9 +4118,9 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 			# Enable YouTube and Tidal support: youtube-dl is available in Stretch+ repo only or as standalone binary: https://github.com/ytdl-org/youtube-dl#installation
 			mkdir -p /usr/local/bin
 			# - "wget --spider" and "curl -IL" fail with 403 Forbidden
-			INSTALL_URL_ADDRESS='https://yt-dl.org/downloads/latest'
+			INSTALL_URL_ADDRESS='https://yt-dl.org/downloads/latest/youtube-dl'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-			G_THREAD_START curl -sSfL "$INSTALL_URL_ADDRESS/youtube-dl" -o /usr/local/bin/youtube-dl
+			G_THREAD_START curl -sSfL "$INSTALL_URL_ADDRESS" -o /usr/local/bin/youtube-dl
 			DEPS_LIST='python-requests'
 
 			Download_Install 'https://github.com/ArturSierzant/OMPD/archive/master.tar.gz' /var/www

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4115,25 +4115,22 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 
 			Banner_Installing
 
-			# Enable YouTube and Tidal support: youtube-dl is available in Stretch+ repo only or as standalone binary: https://github.com/ytdl-org/youtube-dl#installation
-			mkdir -p /usr/local/bin
-			# - "wget --spider" and "curl -IL" fail with 403 Forbidden
-			INSTALL_URL_ADDRESS='https://yt-dl.org/downloads/latest/youtube-dl'
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-			G_THREAD_START curl -sSfL "$INSTALL_URL_ADDRESS" -o /usr/local/bin/youtube-dl
+			# Enable YouTube and Tidal support: youtube-dl is available as standalone binary: https://yt-dl.org/download.html
+			G_EXEC mkdir -p /usr/local/bin
+			G_THREAD_START curl -sSfL 'https://yt-dl.org/downloads/latest/youtube-dl' -o /usr/local/bin/youtube-dl
 			DEPS_LIST='python-requests'
 
 			Download_Install 'https://github.com/ArturSierzant/OMPD/archive/master.tar.gz' /var/www
 			# Replace existing installs but preserve local config override
 			if [[ -d '/var/www/ompd' ]]; then
 
-				[[ -f '/var/www/ompd/include/config.local.inc.php' ]] && mv /var/www/ompd/include/config.local.inc.php /var/www/OMPD*/include/
-				rm -R /var/www/ompd
+				[[ -f '/var/www/ompd/include/config.local.inc.php' ]] && G_EXEC mv /var/www/ompd/include/config.local.inc.php /var/www/OMPD-master/include/
+				G_EXEC rm -R /var/www/ompd
 
 			fi
-			mv /var/www/OMPD* /var/www/ompd
+			G_EXEC mv /var/www/OMPD-master /var/www/ompd
 
-			chmod +x /usr/local/bin/youtube-dl
+			G_EXEC chmod +x /usr/local/bin/youtube-dl
 
 		fi
 


### PR DESCRIPTION
@MichaIng 

Main web site for O!MPD as been taken down due to copyright violations. Therefore we get `HTTP 451` while checking the URL

`HTTP request sent, awaiting response... 451 Unavailable for Legal Reasons `

However direct download is still working. Therefore it's needed to check against the download file instead of main web site.

**Status**: Ready
- [x] update download URL

**Reference**: 
- https://dietpi.com/phpbb/viewtopic.php?f=11&t=8242
- https://youtube-dl.org/
- https://github.com/github/dmca/blob/master/2020/10/2020-10-23-RIAA.md

**Commit list/description**:
- DietPi-Software | O!MPD: Update download URL as main web site has been taken down
