### PR TITLE
DietPi-Update | Add ability to update APT packages

### DIFF
--- a/dietpi.txt
+++ b/dietpi.txt
@@ -165,7 +165,7 @@ CONFIG_CHECK_CONNECTION_IP=9.9.9.9
 # - Domain to ping when checking DNS resolver. Default: dns9.quad9.net (Quad9 DNS domain)
 CONFIG_CHECK_DNS_DOMAIN=dns9.quad9.net
 
-# Check for Updates: 0=do nothing | 1=check for updates (DietPi and apt) | 2=check for updates and auto-update apt | 3=auto-update apt and DietPi
+# Check for Updates: 0=do nothing | 1=check for updates (DietPi and apt) | 2=check for updates and auto-update apt
 # - https://github.com/MichaIng/DietPi/issues/2622
 CONFIG_CHECK_UPDATES=1
 

--- a/dietpi.txt
+++ b/dietpi.txt
@@ -3,8 +3,7 @@
 # - Do not remove uncommented lines, as the items are scraped by DietPi programs, on demand.
 
 #------------------------------------------------------------------------------------------------------
-# D I E T - P I
-# DietPi-Automation settings, applied on first boot of DietPi only, ONCE!
+##### DietPi-Automation settings, applied on first boot of DietPi only, ONCE! #####
 #------------------------------------------------------------------------------------------------------
 # By setting this to "1" you accept the DietPi GPLv2 license and skip the related interactive dialog.
 # - Full license text: /boot/dietpi-LICENSE.txt
@@ -20,7 +19,7 @@ AUTO_SETUP_KEYBOARD_LAYOUT=gb
 # Timezone eg: "Europe/London" / "America/New_York" | Full list (TZ*): https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 AUTO_SETUP_TIMEZONE=Europe/London
 
-##### Networking Options #####
+##### Network Options #####
 # Enable Ethernet or WiFi adapter: 1=enable | 0=disable
 # - If both Ethernet and WiFi are enabled, WiFi will take priority and Ethernet will be disabled.
 # - If using WiFi, please edit dietpi-wifi.txt to pre-enter credentials.
@@ -112,16 +111,14 @@ AUTO_SETUP_GLOBAL_PASSWORD=dietpi
 #AUTO_SETUP_INSTALL_SOFTWARE_ID=23
 
 #------------------------------------------------------------------------------------------------------
-# D I E T - P I
-# Misc DietPi program settings
+##### Misc DietPi program settings #####
 #------------------------------------------------------------------------------------------------------
 # DietPi-Survey: 1=opt in | 0=opt out | -1=ask on first call
 # - https://dietpi.com/phpbb/viewtopic.php?p=34#p34
 SURVEY_OPTED_IN=-1
 
 #------------------------------------------------------------------------------------------------------
-# D I E T - P I
-# DietPi-Config settings
+##### DietPi-Config settings #####
 #------------------------------------------------------------------------------------------------------
 # CPU Governor: powersave | conservative | ondemand | performance
 CONFIG_CPU_GOVERNOR=ondemand
@@ -165,9 +162,11 @@ CONFIG_CHECK_CONNECTION_IP=9.9.9.9
 # - Domain to ping when checking DNS resolver. Default: dns9.quad9.net (Quad9 DNS domain)
 CONFIG_CHECK_DNS_DOMAIN=dns9.quad9.net
 
-# Check for Updates: 0=do nothing | 1=check for updates (DietPi and apt) | 2=check for updates and auto-update apt
-# - https://github.com/MichaIng/DietPi/issues/2622
-CONFIG_CHECK_UPDATES=1
+# Daily check for DietPi updates: 0=disable | 1=enable
+CONFIG_CHECK_DIETPI_UPDATES=1
+
+# Daily check or apply for APT updates: 0=disable | 1=check only | 2=check and apply
+CONFIG_CHECK_APT_UPDATES=1
 
 # Network time sync: 0=disabled | 1=boot only | 2=boot + daily | 3=boot + hourly | 4=Daemon + Drift
 CONFIG_NTP_MODE=2
@@ -175,7 +174,7 @@ CONFIG_NTP_MODE=2
 # Serial Console: Set to 0 if you do not require serial console.
 CONFIG_SERIAL_CONSOLE_ENABLE=1
 
-# Soundcard
+# Sound card
 CONFIG_SOUNDCARD=none
 
 # LCD Panel addon
@@ -190,7 +189,7 @@ CONFIG_PREFER_IPV4=1
 
 # APT mirrors which are applied to /etc/apt/sources.list | Values here will also be applied during 1st run setup
 # - Raspbian: https://www.raspbian.org/RaspbianMirrors
-CONFIG_APT_RASPBIAN_MIRROR=http://raspbian.raspberrypi.org/raspbian
+CONFIG_APT_RASPBIAN_MIRROR=http://raspbian.raspberrypi.org/raspbian/
 # - Debian: https://www.debian.org/mirror/official#list
 CONFIG_APT_DEBIAN_MIRROR=https://deb.debian.org/debian/
 
@@ -200,11 +199,10 @@ CONFIG_APT_DEBIAN_MIRROR=https://deb.debian.org/debian/
 CONFIG_NTP_MIRROR=debian.pool.ntp.org
 
 #------------------------------------------------------------------------------------------------------
-# D I E T - P I
-# DietPi-Software settings
+##### DietPi-Software settings #####
 #------------------------------------------------------------------------------------------------------
 # Enter your EmonCMS.org write API key here. It will be applied automatically during EmonPi/Hub install.
-# - Eg: SOFTWARE_EMONHUB_APIKEY=b4dfmk2o203mmxx93a
+# - E.g.: SOFTWARE_EMONHUB_APIKEY=b4dfmk2o203mmxx93a
 SOFTWARE_EMONHUB_APIKEY=
 
 # VNC Server
@@ -235,7 +233,7 @@ SOFTWARE_XORG_DPI=96
 # Chromium
 SOFTWARE_CHROMIUM_RES_X=1280
 SOFTWARE_CHROMIUM_RES_Y=720
-SOFTWARE_CHROMIUM_AUTOSTART_URL=https://dietpi.com
+SOFTWARE_CHROMIUM_AUTOSTART_URL=https://dietpi.com/
 
 # Home Assistant
 # - Optional Python build dependencies and modules, possibly required for certain HA components
@@ -245,13 +243,11 @@ SOFTWARE_HOMEASSISTANT_APT_DEPS=
 SOFTWARE_HOMEASSISTANT_PIP_DEPS=
 
 #------------------------------------------------------------------------------------------------------
-# D I E T - P I
-# Dev settings
+##### Dev settings #####
 #------------------------------------------------------------------------------------------------------
 DEV_GITBRANCH=master
 DEV_GITOWNER=MichaIng
 
 #------------------------------------------------------------------------------------------------------
-# D I E T - P I
-# Settings, automatically added by dietpi-update
+##### Settings, automatically added by dietpi-update #####
 #------------------------------------------------------------------------------------------------------

--- a/dietpi.txt
+++ b/dietpi.txt
@@ -165,8 +165,9 @@ CONFIG_CHECK_CONNECTION_IP=9.9.9.9
 # - Domain to ping when checking DNS resolver. Default: dns9.quad9.net (Quad9 DNS domain)
 CONFIG_CHECK_DNS_DOMAIN=dns9.quad9.net
 
-# DietPi checks for updates: Allows DietPi to check for updates on a daily basis and boot using a less 1 KiB file download.
-CONFIG_CHECK_DIETPI_UPDATES=1
+# Check for Updates: 0=do nothing | 1=check for updates (DietPi and apt) | 2=check for updates and auto-update apt | 3=auto-update apt and DietPi
+# - https://github.com/MichaIng/DietPi/issues/2622
+CONFIG_CHECK_UPDATES=1
 
 # Network time sync: 0=disabled | 1=boot only | 2=boot + daily | 3=boot + hourly | 4=Daemon + Drift
 CONFIG_NTP_MODE=2

--- a/dietpi.txt
+++ b/dietpi.txt
@@ -163,9 +163,11 @@ CONFIG_CHECK_CONNECTION_IP=9.9.9.9
 CONFIG_CHECK_DNS_DOMAIN=dns9.quad9.net
 
 # Daily check for DietPi updates: 0=disable | 1=enable
+# - Checks are done by downloading a file of only 7 bytes.
 CONFIG_CHECK_DIETPI_UPDATES=1
 
-# Daily check or apply for APT updates: 0=disable | 1=check only | 2=check and apply
+# Daily check for APT package updates: 0=disable | 1=check only | 2=check and upgrade automatically
+# - Upgrade logs can be found at: /var/tmp/dietpi/logs/dietpi-update_apt.log
 CONFIG_CHECK_APT_UPDATES=1
 
 # Network time sync: 0=disabled | 1=boot only | 2=boot + daily | 3=boot + hourly | 4=Daemon + Drift

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1851,6 +1851,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=3469#p3469'
 		aSOFTWARE_REQUIRES_USERINPUT[$software_id]=1
 		aSOFTWARE_REQUIRES_GIT[$software_id]=1
+		aSOFTWARE_RECOMMENDS_AUTOMATED_UPGRADES[$software_id]=1
 		#------------------
 		software_id=171
 
@@ -2643,6 +2644,17 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 				aSOFTWARE_INSTALL_STATE[$software_id]=1
 				G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[$software_id]} will be installed"
 
+			fi
+
+			#-------------------------------------------------------------------------
+			# Pre-req other
+			if (( ${aSOFTWARE_RECOMMENDS_AUTOMATED_UPGRADES[$i]:=0})); then
+				G_WHIP_BUTTON_OK_TEXT='YES'
+				G_WHIP_BUTTON_CANCEL_TEXT='NO'
+				if G_WHIP_YESNO "Would you like to enable automated upgrades for APT packages?  This is recommended for ${aSOFTWARE_NAME[$software_id]}."
+				then
+					G_CONFIG_INJECT 'CONFIG_CHECK_UPDATES=' 'CONFIG_CHECK_UPDATES=2' /boot/dietpi.txt
+				fi
 			fi
 
 		done
@@ -4728,6 +4740,8 @@ _EOF_
 			G_EXEC chmod +x install.bash
 			G_DIETPI-NOTIFY 2 'Preventing reboot from within PiVPN installer'
 			G_EXEC sed -i '/shutdown[[:space:]]/d' install.bash
+			G_DIETPI-NOTIFY 2 'Preventing install of unattended-upgrades'
+			G_EXEC sed -i "s/[[:blank:]]*UNATTUPG=[[:digit:]]/UNATTUPG=0/" install.bash
 
 			# APT deps
 			G_AGI dnsutils net-tools bsdmainutils # https://github.com/pivpn/pivpn/blob/master/auto_install/install.sh#L43

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2651,7 +2651,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 			if (( ${aSOFTWARE_RECOMMENDS_AUTOMATED_UPGRADES[$i]:=0})); then
 				G_WHIP_BUTTON_OK_TEXT='YES'
 				G_WHIP_BUTTON_CANCEL_TEXT='NO'
-				if G_WHIP_YESNO "Would you like to enable automated upgrades for APT packages?  This is recommended for ${aSOFTWARE_NAME[$software_id]}."
+				if G_WHIP_YESNO "Would you like to enable automated upgrades for APT packages?  This is recommended for ${aSOFTWARE_NAME[$i]}."
 				then
 					G_CONFIG_INJECT 'CONFIG_CHECK_UPDATES=' 'CONFIG_CHECK_UPDATES=2' /boot/dietpi.txt
 				fi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4744,7 +4744,7 @@ _EOF_
 			G_EXEC sed -i "s/[[:blank:]]*UNATTUPG=[[:digit:]]/UNATTUPG=0/" install.bash
 
 			# APT deps
-			G_AGI dnsutils net-tools bsdmainutils # https://github.com/pivpn/pivpn/blob/master/auto_install/install.sh#L43
+			G_AGI dnsutils net-tools bsdmainutils iptables-persistent # https://github.com/pivpn/pivpn/blob/master/auto_install/install.sh#L43
 
 			G_EXEC_OUTPUT=1 G_EXEC_NOEXIT=1 G_EXEC ./install.bash || aSOFTWARE_INSTALL_STATE[$software_id]=0
 			G_EXEC_NOHALT=1 G_EXEC rm install.bash

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2650,7 +2650,8 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 			if (( ${aSOFTWARE_RECOMMENDS_AUTOMATED_UPGRADES[$i]:=0} )) && ! grep -q '^[[:blank:]]*CONFIG_CHECK_APT_UPDATES=2' /boot/dietpi.txt
 			then
 				G_WHIP_BUTTON_OK_TEXT='YES' G_WHIP_BUTTON_CANCEL_TEXT='NO'
-				if G_WHIP_YESNO "Would you like to enable automated upgrades for APT packages? This is recommended for ${aSOFTWARE_NAME[$i]}."
+				if G_WHIP_YESNO "Would you like to enable automated daily upgrades for APT packages?\n\nThis is recommended for ${aSOFTWARE_NAME[$i]}.
+\nDaily APT upgrade logs can be found at: /var/tmp/dietpi/logs/dietpi-update_apt.log"
 				then
 					G_CONFIG_INJECT 'CONFIG_CHECK_APT_UPDATES=' 'CONFIG_CHECK_APT_UPDATES=2' /boot/dietpi.txt
 				fi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2646,14 +2646,13 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 
 			fi
 
-			#-------------------------------------------------------------------------
-			# Pre-req other
-			if (( ${aSOFTWARE_RECOMMENDS_AUTOMATED_UPGRADES[$i]:=0})); then
-				G_WHIP_BUTTON_OK_TEXT='YES'
-				G_WHIP_BUTTON_CANCEL_TEXT='NO'
-				if G_WHIP_YESNO "Would you like to enable automated upgrades for APT packages?  This is recommended for ${aSOFTWARE_NAME[$i]}."
+			# Software that recommends automated APT upgrades
+			if (( ${aSOFTWARE_RECOMMENDS_AUTOMATED_UPGRADES[$i]:=0} )) && ! grep -q '^[[:blank:]]*CONFIG_CHECK_APT_UPDATES=2' /boot/dietpi.txt
+			then
+				G_WHIP_BUTTON_OK_TEXT='YES' G_WHIP_BUTTON_CANCEL_TEXT='NO'
+				if G_WHIP_YESNO "Would you like to enable automated upgrades for APT packages? This is recommended for ${aSOFTWARE_NAME[$i]}."
 				then
-					G_CONFIG_INJECT 'CONFIG_CHECK_UPDATES=' 'CONFIG_CHECK_UPDATES=2' /boot/dietpi.txt
+					G_CONFIG_INJECT 'CONFIG_CHECK_APT_UPDATES=' 'CONFIG_CHECK_APT_UPDATES=2' /boot/dietpi.txt
 				fi
 			fi
 
@@ -4741,10 +4740,10 @@ _EOF_
 			G_DIETPI-NOTIFY 2 'Preventing reboot from within PiVPN installer'
 			G_EXEC sed -i '/shutdown[[:space:]]/d' install.bash
 			G_DIETPI-NOTIFY 2 'Preventing install of unattended-upgrades'
-			G_EXEC sed -i "s/[[:blank:]]*UNATTUPG=[[:digit:]]/UNATTUPG=0/" install.bash
+			G_EXEC sed -i 's/^[[:blank:]]*UNATTUPG=[[:digit:]]/UNATTUPG=0/' install.bash
 
 			# APT deps
-			G_AGI dnsutils net-tools bsdmainutils iptables-persistent # https://github.com/pivpn/pivpn/blob/master/auto_install/install.sh#L43
+			G_AGI dnsutils net-tools bsdmainutils iptables-persistent # https://github.com/pivpn/pivpn/blob/master/auto_install/install.sh#L40
 
 			G_EXEC_OUTPUT=1 G_EXEC_NOEXIT=1 G_EXEC ./install.bash || aSOFTWARE_INSTALL_STATE[$software_id]=0
 			G_EXEC_NOHALT=1 G_EXEC rm install.bash

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -191,7 +191,7 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 
 			apt-get dist-upgrade -s --quiet=2 | grep -c ^Inst > /run/dietpi/.package_update
 
-			if [[ $mode == 2 || $mode == 3 || $INPUT == 1 ]]; then
+			if [[ $mode == 2 || $mode == 3 || $INPUT != 2 ]]; then
 				G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Upgrading APT packages'
 				G_AGUP
 				G_AGUG

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -197,7 +197,8 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 				G_AGUG
 			fi
 
-			if [[ $mode == 3 ]]; then
+			if [[ $mode == 3 || $INPUT == 1 ]]; then
+				G_AGUG
 				INPUT=1
 			fi
 		fi

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -202,7 +202,7 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 			fi
 
 			# Update APT packages
-			if [[ $mode == 2 || $INPUT != 2 ]]; then
+			if [[ $INPUT != 2 ]]; then
 				G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Upgrading APT packages'
 				G_AGUP
 				G_AGUG

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -191,7 +191,7 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 
 			fi
 
-			echo "$(apt-get dist-upgrade -s --quiet=2 | grep -c ^Inst)" > /run/dietpi/.package_update
+			$(apt-get dist-upgrade -s --quiet=2 | grep -c ^Inst) > /run/dietpi/.package_update
 
 			if (( $mode == 2 )); then
 				G_AGUG

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -155,7 +155,7 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 
 		local mode=$(grep -oP '(?<=CONFIG_CHECK_UPDATES=)[0-3]' /boot/dietpi.txt)
 
-		if [[ $mode != 0 || $INPUT == 1 ]]; then
+		if [[ $mode != 0 || $INPUT != 2 ]]; then
 
 			# Update requires new image
 			if (( $DIETPIUPDATE_VERSION_CORE < $COREVERSION_SERVER )); then

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -157,7 +157,7 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 
 		G_AGUP
 
-		if (( ! $mode == 0 )) || (( $INPUT == 1 )); then
+		if (( $mode != 0 )) || (( $INPUT == 1 )); then
 
 			# Update requires new image
 			if (( $DIETPIUPDATE_VERSION_CORE < $COREVERSION_SERVER )); then

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -189,8 +189,6 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 
 			fi
 
-			apt-get dist-upgrade -s --quiet=2 | grep -c ^Inst > /run/dietpi/.package_update
-
 			if [[ $mode == 2 || $mode == 3 || $INPUT != 2 ]]; then
 				G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Upgrading APT packages'
 				G_AGUP
@@ -200,6 +198,8 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 			if [[ $mode == 3 ]]; then
 				INPUT=1
 			fi
+
+			apt-get upgrade -s --quiet=2 | grep -c ^Inst > /run/dietpi/.package_update
 		fi
 
 		G_DIETPI-NOTIFY 2 "$INFO_CURRENT_VERSION"

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -197,7 +197,7 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 				G_AGUG
 			fi
 
-			if [[ $mode == 3 || $INPUT == 1 ]]; then
+			if [[ $mode == 3 ]]; then
 				G_AGUG
 				INPUT=1
 			fi

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -177,14 +177,16 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 				G_DIETPI-NOTIFY 0 'Update available:'
 
 				# Apply pre-patches
-				G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Applying pre-patches'
-				G_EXEC_DESC='Downloading pre-patch file' G_EXEC curl -sSfL "${aURL_MIRROR_PREPATCH[$URL_MIRROR_INDEX]}" -o pre-patch_file
-				G_EXEC_DESC='Applying execute permission' G_EXEC chmod +x pre-patch_file
-				if ! ./pre-patch_file $G_DIETPI_VERSION_SUB; then
-					G_DIETPI-NOTIFY 1 "An error occured during pre-patch $?. Please check the above log or $FP_LOG for errors, and rerun \"dietpi-update\" after the cause has been solved."
-					exit 1
+				if [[ $INPUT != 2 ]]; then
+					G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Applying pre-patches'
+					G_EXEC_DESC='Downloading pre-patch file' G_EXEC curl -sSfL "${aURL_MIRROR_PREPATCH[$URL_MIRROR_INDEX]}" -o pre-patch_file
+					G_EXEC_DESC='Applying execute permission' G_EXEC chmod +x pre-patch_file
+					if ! ./pre-patch_file $G_DIETPI_VERSION_SUB; then
+						G_DIETPI-NOTIFY 1 "An error occured during pre-patch $?. Please check the above log or $FP_LOG for errors, and rerun \"dietpi-update\" after the cause has been solved."
+						exit 1
+					fi
+					G_DIETPI-NOTIFY 0 'Successfully applied pre-patches'
 				fi
-				G_DIETPI-NOTIFY 0 'Successfully applied pre-patches'
 
 			# No update required
 			else

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -153,7 +153,7 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 
 	Check_Update_Available(){
 
-		local mode=$(grep -oP '(?<=CONFIG_CHECK_UPDATES=)[0-3]' /boot/dietpi.txt)
+		local mode=$(grep -oP '(?<=CONFIG_CHECK_UPDATES=)[0-2]' /boot/dietpi.txt)
 
 		if [[ $mode != 0 || $INPUT != 2 ]]; then
 
@@ -189,14 +189,11 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 
 			fi
 
-			if [[ $mode == 2 || $mode == 3 || $INPUT != 2 ]]; then
+			# Update APT packages
+			if [[ $mode == 2 || $INPUT != 2 ]]; then
 				G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Upgrading APT packages'
 				G_AGUP
 				G_AGUG
-			fi
-
-			if [[ $mode == 3 ]]; then
-				INPUT=1
 			fi
 
 			apt-get upgrade -s --quiet=2 | grep -c ^Inst > /run/dietpi/.package_update

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -191,16 +191,13 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 
 			apt-get dist-upgrade -s --quiet=2 | grep -c ^Inst > /run/dietpi/.package_update
 
-			if [[ $mode == 2 || $INPUT == 1 ]]; then
+			if [[ $mode == 2 || $mode == 3 || $INPUT == 1 ]]; then
 				G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Upgrading APT packages'
 				G_AGUP
 				G_AGUG
 			fi
 
 			if [[ $mode == 3 ]]; then
-				G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Upgrading APT packages'
-				G_AGUP
-				G_AGUG
 				INPUT=1
 			fi
 		fi

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -157,7 +157,7 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 
 		G_AGUP
 
-		if (( $mode != 0 || $INPUT == 1 )); then
+		if [[ $mode != 0 || $INPUT == 1 ]]; then
 
 			# Update requires new image
 			if (( $DIETPIUPDATE_VERSION_CORE < $COREVERSION_SERVER )); then

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -153,36 +153,53 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 
 	Check_Update_Available(){
 
-		# Update requires new image
-		if (( $DIETPIUPDATE_VERSION_CORE < $COREVERSION_SERVER )); then
+		local mode = $(grep -Eo '(?<=CONFIG_CHECK_UPDATES=)[0-3]' /boot/dietpi.txt)
 
-			# Write "-1" to flag file for DietPi-Banner to show info about required new image
-			echo '-1' > /run/dietpi/.update_available
+		G_AGUP
 
-			G_DIETPI-NOTIFY 1 'The installed version of DietPi is now obsolete and cannot be updated.
-Please download the latest DietPi image from: https://dietpi.com/#download'
+		if (( ! $mode == 0 )) || (( $INPUT == 1 )); then
 
-		# Update available
-		elif (( $G_DIETPI_VERSION_SUB < $SUBVERSION_SERVER || ( $G_DIETPI_VERSION_SUB == $SUBVERSION_SERVER && $G_DIETPI_VERSION_RC < $RCVERSION_SERVER ) )); then
+			# Update requires new image
+			if (( $DIETPIUPDATE_VERSION_CORE < $COREVERSION_SERVER )); then
 
-			UPDATE_AVAILABLE=1
+				# Write "-1" to flag file for DietPi-Banner to show info about required new image
+				echo '-1' > /run/dietpi/.update_available
 
-			# Write available update version to flag file
-			echo "$COREVERSION_SERVER.$SUBVERSION_SERVER.$RCVERSION_SERVER" > /run/dietpi/.update_available
+				G_DIETPI-NOTIFY 1 'The installed version of DietPi is now obsolete and cannot be updated.
+	Please download the latest DietPi image from: https://dietpi.com/#download'
 
-			G_DIETPI-NOTIFY 0 'Update available:'
+			# Update available
+			elif (( $G_DIETPI_VERSION_SUB < $SUBVERSION_SERVER || ( $G_DIETPI_VERSION_SUB == $SUBVERSION_SERVER && $G_DIETPI_VERSION_RC < $RCVERSION_SERVER ) )); then
 
-		# No update required
-		else
+				UPDATE_AVAILABLE=1
 
-			# Mark 1st run update as completed
-			Apply_1st_Run_Update_Success
+				# Write available update version to flag file
+				echo "$COREVERSION_SERVER.$SUBVERSION_SERVER.$RCVERSION_SERVER" > /run/dietpi/.update_available
 
-			# Remove flag file
-			[[ -f '/run/dietpi/.update_available' ]] && rm /run/dietpi/.update_available
+				G_DIETPI-NOTIFY 0 'Update available:'
 
-			G_DIETPI-NOTIFY 0 'No update required, your DietPi installation is already up to date:'
+			# No update required
+			else
 
+				# Mark 1st run update as completed
+				Apply_1st_Run_Update_Success
+
+				# Remove flag file
+				[[ -f '/run/dietpi/.update_available' ]] && rm /run/dietpi/.update_available
+
+				G_DIETPI-NOTIFY 0 'No update required, your DietPi installation is already up to date:'
+
+			fi
+
+			echo "$(apt-get dist-upgrade -s --quiet=2 | grep ^Inst | wc -l)" > /run/dietpi/.package_update
+
+			if (( $mode == 2 )); then
+				G_AGUG
+			fi
+
+			if (( $mode == 3 )); then
+				INPUT = 1
+			fi
 		fi
 
 		G_DIETPI-NOTIFY 2 "$INFO_CURRENT_VERSION"

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -439,8 +439,8 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 	# Check for APT updates and in case store result to /run/dietpi/.apt_updates for use by DietPi-Banner
 	mode=$(sed -n '/^[[:blank:]]*CONFIG_CHECK_APT_UPDATES=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 	[[ -f '/run/dietpi/.apt_updates' ]] && rm /run/dietpi/.apt_updates
-	[[ $mode != 0 ]] && G_AGUP && count=$(apt -qq list --upgradeable | wc -l) && (( $count )) && echo "$count" > /run/dietpi/.apt_updates
-	[[ $mode == 2 ]] && (( $count )) && G_AGUG &> >(tee /var/tmp/dietpi/logs/dietpi-upgrade_apt.log)
+	[[ $mode != 0 ]] && G_EXEC_NOHALT=1 G_AGUP && count=$(apt -qq list --upgradeable 2> /dev/null | wc -l) && (( $count )) && echo "$count" > /run/dietpi/.apt_updates
+	[[ $mode == 2 ]] && (( $count )) && G_EXEC_NOHALT=1 G_AGUG &> >(tee /var/tmp/dietpi/logs/dietpi-upgrade_apt.log)
 	#----------------------------------------------------------------
 	exit 0
 	#----------------------------------------------------------------

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -192,11 +192,13 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 			apt-get dist-upgrade -s --quiet=2 | grep -c ^Inst > /run/dietpi/.package_update
 
 			if [[ $mode == 2 || $INPUT == 1 ]]; then
+				G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Upgrading APT packages'
 				G_AGUP
 				G_AGUG
 			fi
 
 			if [[ $mode == 3 ]]; then
+				G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Upgrading APT packages'
 				G_AGUP
 				G_AGUG
 				INPUT=1
@@ -233,10 +235,6 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 
 		fi
 		G_DIETPI-NOTIFY 0 'Successfully applied pre-patches'
-
-		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Upgrading APT packages'
-		G_AGUP
-		G_AGUG
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Installing new DietPi code'
 		G_EXEC_DESC='Downloading update archive' G_EXEC curl -sSfL "${aURL_MIRROR_ARCHIVE[$URL_MIRROR_INDEX]}" -o update.tar.gz

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -153,7 +153,7 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 
 	Check_Update_Available(){
 
-		local mode = $(grep -Eo '(?<=CONFIG_CHECK_UPDATES=)[0-3]' /boot/dietpi.txt)
+		local mode=$(grep -Eo '(?<=CONFIG_CHECK_UPDATES=)[0-3]' /boot/dietpi.txt)
 
 		G_AGUP
 
@@ -191,14 +191,14 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 
 			fi
 
-			echo "$(apt-get dist-upgrade -s --quiet=2 | grep ^Inst | wc -l)" > /run/dietpi/.package_update
+			echo "$(apt-get dist-upgrade -s --quiet=2 | grep -c ^Inst)" > /run/dietpi/.package_update
 
 			if (( $mode == 2 )); then
 				G_AGUG
 			fi
 
 			if (( $mode == 3 )); then
-				INPUT = 1
+				INPUT=1
 			fi
 		fi
 

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -191,7 +191,7 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 
 			fi
 
-			echo "$(apt-get dist-upgrade -s --quiet=2 | grep -c ^Inst)" > /run/dietpi/.package_update
+			apt-get dist-upgrade -s --quiet=2 | grep -c ^Inst > /run/dietpi/.package_update
 
 			if (( $mode == 2 )); then
 				G_AGUG

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -156,7 +156,7 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 			echo '-1' > /run/dietpi/.update_available
 
 			G_DIETPI-NOTIFY 1 'The installed version of DietPi is now obsolete and cannot be updated.
-	Please download the latest DietPi image from: https://dietpi.com/#download'
+Please download the latest DietPi image from: https://dietpi.com/#download'
 
 		# Update available
 		elif (( $G_DIETPI_VERSION_SUB < $SUBVERSION_SERVER || ( $G_DIETPI_VERSION_SUB == $SUBVERSION_SERVER && $G_DIETPI_VERSION_RC < $RCVERSION_SERVER ) )); then

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -191,7 +191,7 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 
 			fi
 
-			$(apt-get dist-upgrade -s --quiet=2 | grep -c ^Inst) > /run/dietpi/.package_update
+			echo "$(apt-get dist-upgrade -s --quiet=2 | grep -c ^Inst)" > /run/dietpi/.package_update
 
 			if (( $mode == 2 )); then
 				G_AGUG

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -153,7 +153,7 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 
 	Check_Update_Available(){
 
-		local mode=$(grep -Eo '(?<=CONFIG_CHECK_UPDATES=)[0-3]' /boot/dietpi.txt)
+		local mode=$(grep -oP '(?<=CONFIG_CHECK_UPDATES=)[0-3]' /boot/dietpi.txt)
 
 		if [[ $mode != 0 || $INPUT == 1 ]]; then
 

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -191,11 +191,13 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 
 			apt-get dist-upgrade -s --quiet=2 | grep -c ^Inst > /run/dietpi/.package_update
 
-			if [[ $mode == 2 ]]; then
+			if [[ $mode == 2 || $INPUT == 1 ]]; then
+				G_AGUP
 				G_AGUG
 			fi
 
 			if [[ $mode == 3 ]]; then
+				G_AGUP
 				G_AGUG
 				INPUT=1
 			fi

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -157,7 +157,7 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 
 		G_AGUP
 
-		if (( $mode != 0 )) || (( $INPUT == 1 )); then
+		if (( $mode != 0 || $INPUT == 1 )); then
 
 			# Update requires new image
 			if (( $DIETPIUPDATE_VERSION_CORE < $COREVERSION_SERVER )); then

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -155,8 +155,6 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 
 		local mode=$(grep -Eo '(?<=CONFIG_CHECK_UPDATES=)[0-3]' /boot/dietpi.txt)
 
-		G_AGUP
-
 		if [[ $mode != 0 || $INPUT == 1 ]]; then
 
 			# Update requires new image

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -176,6 +176,16 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 
 				G_DIETPI-NOTIFY 0 'Update available:'
 
+				# Apply pre-patches
+				G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Applying pre-patches'
+				G_EXEC_DESC='Downloading pre-patch file' G_EXEC curl -sSfL "${aURL_MIRROR_PREPATCH[$URL_MIRROR_INDEX]}" -o pre-patch_file
+				G_EXEC_DESC='Applying execute permission' G_EXEC chmod +x pre-patch_file
+				if ! ./pre-patch_file $G_DIETPI_VERSION_SUB; then
+					G_DIETPI-NOTIFY 1 "An error occured during pre-patch $?. Please check the above log or $FP_LOG for errors, and rerun \"dietpi-update\" after the cause has been solved."
+					exit 1
+				fi
+				G_DIETPI-NOTIFY 0 'Successfully applied pre-patches'
+
 			# No update required
 			else
 
@@ -197,6 +207,7 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 			fi
 
 			apt-get upgrade -s --quiet=2 | grep -c ^Inst > /run/dietpi/.package_update
+
 		fi
 
 		G_DIETPI-NOTIFY 2 "$INFO_CURRENT_VERSION"
@@ -218,17 +229,6 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 			G_DIETPI-NOTIFY 2 "RC update: Subversion intentionally reduced to \e[33m\"$G_DIETPI_VERSION_SUB\"\e[90m to reapply the last update"
 
 		fi
-
-		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Applying pre-patches'
-		G_EXEC_DESC='Downloading pre-patch file' G_EXEC curl -sSfL "${aURL_MIRROR_PREPATCH[$URL_MIRROR_INDEX]}" -o pre-patch_file
-		G_EXEC_DESC='Applying execute permission' G_EXEC chmod +x pre-patch_file
-		if ! ./pre-patch_file $G_DIETPI_VERSION_SUB; then
-
-			G_DIETPI-NOTIFY 1 "An error occured during pre-patch $?. Please check the above log or $FP_LOG for errors, and rerun \"dietpi-update\" after the cause has been solved."
-			exit 1
-
-		fi
-		G_DIETPI-NOTIFY 0 'Successfully applied pre-patches'
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Installing new DietPi code'
 		G_EXEC_DESC='Downloading update archive' G_EXEC curl -sSfL "${aURL_MIRROR_ARCHIVE[$URL_MIRROR_INDEX]}" -o update.tar.gz

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -15,15 +15,17 @@
 	# - Uses patch_file for incremental patching after APT calls and DietPi code update
 	#
 	# Usage:
-	# - dietpi-update	= Check for updates and in case open interactive menu
-	# - dietpi-update 1	= Check for updates and in case apply noninteractively
-	# - dietpi-update 2	= Check for updates only and in case store result to /run/dietpi/.update_available to be used by DietPi-Banner
+	# - dietpi-update	= Check for update and in case open interactive menu
+	# - dietpi-update 1	= Check for update and in case apply noninteractively
+	# - dietpi-update 2	= Check for update only and in case store result to /run/dietpi/.update_available to be used by DietPi-Banner
+	#			  Else, if CONFIG_CHECK_APT_UPDATES is set, check for APT updates and store results to /run/dietpi/.apt_updates
+	#			  If CONFIG_CHECK_APT_UPDATES=2 is set, apply APT upgrades automatically.
 	# - dietpi-update -1	= Like "1" but internally reduce subversion by 1 to reapply the last update, e.g. to apply latest dev branch changes
 	#////////////////////////////////////
 
 	# Import DietPi-Globals --------------------------------------------------------------
 	. /boot/dietpi/func/dietpi-globals
-	G_PROGRAM_NAME='DietPi-Update'
+	readonly G_PROGRAM_NAME='DietPi-Update'
 	G_CHECK_ROOT_USER
 	G_CHECK_ROOTFS_RW
 	G_INIT
@@ -42,9 +44,6 @@
 	readonly DIETPIUPDATE_VERSION_CORE=6 # Version of dietpi-update / set server_version-6 line one to value++ and obsolete previous dietpi-update scripts
 
 	CHANGELOG_DOWNLOADED=0 # Prevent redownload of changelog if already done in this session
-	SERVER_ONLINE=0
-	UPDATE_AVAILABLE=0
-	RUN_UPDATE=0
 
 	GITOWNER_TARGET=$(sed -n '/^[[:blank:]]*DEV_GITOWNER=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 	GITOWNER_TARGET=${GITOWNER_TARGET:-MichaIng}
@@ -118,11 +117,10 @@
 					disable_error=1 G_CHECK_VALIDINT "$SUBVERSION_SERVER" &&
 					disable_error=1 G_CHECK_VALIDINT "$RCVERSION_SERVER"; then
 
-					SERVER_ONLINE=1
 					G_DIETPI-NOTIFY 0 "Using update server: ${aURL_MIRROR_SERVERVERSION[$i]}"
 					URL_MIRROR_INDEX=$i
 					INFO_VERSIONS_UPDATE
-					break
+					return 0
 
 				else
 
@@ -139,88 +137,61 @@
 		done
 
 		# No valid update server response
-		if (( ! $SERVER_ONLINE )); then
-
-			G_DIETPI-NOTIFY 1 'Unable to access any update server. Please check your network connection, then rerun dietpi-update.
+		G_DIETPI-NOTIFY 1 'Unable to access any update server. Please check your network connection, then rerun dietpi-update.
 If this error persists, please report at: https://github.com/MichaIng/DietPi/issues'
-			exit 1
-
-		fi
+		return 1
 
 	}
 
 	Apply_1st_Run_Update_Success(){ [[ $G_DIETPI_INSTALL_STAGE == [12] ]] || echo 1 > /boot/dietpi/.install_stage; }
 
-	Check_Update_Available(){
+	Check_DietPi_Update(){
 
-		local mode=$(grep -oP '(?<=CONFIG_CHECK_UPDATES=)[0-2]' /boot/dietpi.txt)
+		local result=1
 
-		if [[ $mode != 0 || $INPUT != 2 ]]; then
+		# Update requires new image
+		if (( $DIETPIUPDATE_VERSION_CORE < $COREVERSION_SERVER )); then
 
-			# Update requires new image
-			if (( $DIETPIUPDATE_VERSION_CORE < $COREVERSION_SERVER )); then
+			# Write "-1" to flag file for DietPi-Banner to show info about required new image
+			echo '-1' > /run/dietpi/.update_available
 
-				# Write "-1" to flag file for DietPi-Banner to show info about required new image
-				echo '-1' > /run/dietpi/.update_available
-
-				G_DIETPI-NOTIFY 1 'The installed version of DietPi is now obsolete and cannot be updated.
+			G_DIETPI-NOTIFY 1 'The installed version of DietPi is now obsolete and cannot be updated.
 	Please download the latest DietPi image from: https://dietpi.com/#download'
 
-			# Update available
-			elif (( $G_DIETPI_VERSION_SUB < $SUBVERSION_SERVER || ( $G_DIETPI_VERSION_SUB == $SUBVERSION_SERVER && $G_DIETPI_VERSION_RC < $RCVERSION_SERVER ) )); then
+		# Update available
+		elif (( $G_DIETPI_VERSION_SUB < $SUBVERSION_SERVER || ( $G_DIETPI_VERSION_SUB == $SUBVERSION_SERVER && $G_DIETPI_VERSION_RC < $RCVERSION_SERVER ) )); then
 
-				UPDATE_AVAILABLE=1
+			result=0
 
-				# Write available update version to flag file
-				echo "$COREVERSION_SERVER.$SUBVERSION_SERVER.$RCVERSION_SERVER" > /run/dietpi/.update_available
+			# Write available update version to flag file
+			echo "$COREVERSION_SERVER.$SUBVERSION_SERVER.$RCVERSION_SERVER" > /run/dietpi/.update_available
 
-				G_DIETPI-NOTIFY 0 'Update available:'
+			G_DIETPI-NOTIFY 0 'Update available:'
 
-				# Apply pre-patches
-				if [[ $INPUT != 2 ]]; then
-					G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Applying pre-patches'
-					G_EXEC_DESC='Downloading pre-patch file' G_EXEC curl -sSfL "${aURL_MIRROR_PREPATCH[$URL_MIRROR_INDEX]}" -o pre-patch_file
-					G_EXEC_DESC='Applying execute permission' G_EXEC chmod +x pre-patch_file
-					if ! ./pre-patch_file $G_DIETPI_VERSION_SUB; then
-						G_DIETPI-NOTIFY 1 "An error occured during pre-patch $?. Please check the above log or $FP_LOG for errors, and rerun \"dietpi-update\" after the cause has been solved."
-						exit 1
-					fi
-					G_DIETPI-NOTIFY 0 'Successfully applied pre-patches'
-				fi
+		# No update required
+		else
 
-			# No update required
-			else
+			# Mark 1st run update as completed
+			Apply_1st_Run_Update_Success
 
-				# Mark 1st run update as completed
-				Apply_1st_Run_Update_Success
+			# Remove flag file
+			[[ -f '/run/dietpi/.update_available' ]] && rm /run/dietpi/.update_available
 
-				# Remove flag file
-				[[ -f '/run/dietpi/.update_available' ]] && rm /run/dietpi/.update_available
-
-				G_DIETPI-NOTIFY 0 'No update required, your DietPi installation is already up to date:'
-
-			fi
-
-			# Update APT packages
-			if [[ $INPUT != 2 ]]; then
-				G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Upgrading APT packages'
-				G_AGUP
-				G_AGUG
-			fi
-
-			apt-get upgrade -s --quiet=2 | grep -c ^Inst > /run/dietpi/.package_update
+			G_DIETPI-NOTIFY 0 'No update required, your DietPi installation is already up to date:'
 
 		fi
 
 		G_DIETPI-NOTIFY 2 "$INFO_CURRENT_VERSION"
 		G_DIETPI-NOTIFY 2 "$INFO_SERVER_VERSION"
 
+		return $result
+
 	}
 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Update DietPi
 	#/////////////////////////////////////////////////////////////////////////////////////
-	Run_Update(){
+	Run_DietPi_Update(){
 
 		# RC-only update: Reapply last subversion patches
 		if (( $G_DIETPI_VERSION_SUB == $SUBVERSION_SERVER )); then
@@ -231,6 +202,21 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 			G_DIETPI-NOTIFY 2 "RC update: Subversion intentionally reduced to \e[33m\"$G_DIETPI_VERSION_SUB\"\e[90m to reapply the last update"
 
 		fi
+
+		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Applying pre-patches'
+		G_EXEC_DESC='Downloading pre-patch file' G_EXEC curl -sSfL "${aURL_MIRROR_PREPATCH[$URL_MIRROR_INDEX]}" -o pre-patch_file
+		G_EXEC_DESC='Applying execute permission' G_EXEC chmod +x pre-patch_file
+		if ! ./pre-patch_file $G_DIETPI_VERSION_SUB; then
+
+			G_DIETPI-NOTIFY 1 "An error occured during pre-patch $?. Please check the above log or $FP_LOG for errors, and rerun \"dietpi-update\" after the cause has been solved."
+			exit 1
+
+		fi
+		G_DIETPI-NOTIFY 0 'Successfully applied pre-patches'
+
+		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Upgrading APT packages'
+		G_AGUP
+		G_AGUG
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Installing new DietPi code'
 		G_EXEC_DESC='Downloading update archive' G_EXEC curl -sSfL "${aURL_MIRROR_ARCHIVE[$URL_MIRROR_INDEX]}" -o update.tar.gz
@@ -350,17 +336,12 @@ Please select 'Update' option to apply the update."; then
 				if [[ $G_WHIP_RETURNED_VALUE == 'Update' ]]; then
 
 					G_WHIP_SIZE_X_MAX=80
-					if G_WHIP_YESNO ">----------------------------------Notice----------------------------------<
+					G_WHIP_YESNO ">----------------------------------Notice----------------------------------<
 - A benefit of DietPi is: We use standard Linux (Debian) configurations and commands.
 - A potential downside is: We can't possibly accommodate or predict all modification to Linux configurations files by the end user, outside of DietPi programs, during updates.\n
 Although we test the updates thoroughly, if you have made any custom changes to Linux configuration files outside of the DietPi programs, an update may trigger a potential issue.
 >--------------------------------------------------------------------------<\n
-Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SERVER.$RCVERSION_SERVER?"; then
-
-						RUN_UPDATE=1
-						return
-
-					fi
+Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SERVER.$RCVERSION_SERVER?" && return 0
 
 				elif [[ $G_WHIP_RETURNED_VALUE == 'Changelog' ]]; then
 
@@ -374,7 +355,7 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 
 			else
 
-				return # Exit
+				return 1 # Exit
 
 			fi
 
@@ -389,7 +370,7 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 	G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Checking for available DietPi update'
 	#----------------------------------------------------------------
 	# Select mirror and download server version info
-	Get_Server_Version
+	Get_Server_Version || exit 1
 	#----------------------------------------------------------------
 	# If requested, reduce current subversion by 1 to reapply last update
 	if (( $INPUT == -1 )); then
@@ -402,11 +383,9 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 
 	fi
 	#----------------------------------------------------------------
-	# Check for update and in case store result to /run/dietpi/.update_available for use by DietPi-Banner
-	Check_Update_Available
-	#----------------------------------------------------------------
-	# Update available and no check-only chosen
-	if (( $UPDATE_AVAILABLE && $INPUT != 2 )); then
+	# Check for DietPi update and in case store result to /run/dietpi/.update_available for use by DietPi-Banner
+	# Run update if no check-only input
+	if Check_DietPi_Update && (( $INPUT != 2 )); then
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Checking for update pre-requirements'
 
@@ -416,13 +395,9 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 		# Check for sufficient free space
 		G_CHECK_FREESPACE / 100 || exit 1
 
-		# Noninteractive update or ask user
-		# shellcheck disable=SC2015
-		(( $INPUT == 1 )) && RUN_UPDATE=1 || Menu_Update
-
 		#----------------------------------------------------------------
-		# Run Update
-		if (( $RUN_UPDATE )); then
+		# Noninteractive update or ask user
+		if (( $INPUT == 1 )) || Menu_Update; then
 
 			# Disable powersaving on main screen
 			setterm -blank 0 -powersave off 2> /dev/null
@@ -430,9 +405,9 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 			# Stop Services
 			/boot/dietpi/dietpi-services stop
 
-			# Run_Update: https://github.com/MichaIng/DietPi/issues/1877#issuecomment-403866204
+			# Run_DietPi_Update: https://github.com/MichaIng/DietPi/issues/1877#issuecomment-403866204
 			# - Log to file by redirecting to subshell instead of piping, else G_EXEC cannot exit the script via "kill -INT $$": https://github.com/MichaIng/DietPi/issues/3127
-			Run_Update &> >(tee $FP_LOG); wait $!
+			Run_DietPi_Update &> >(tee $FP_LOG); wait $!
 
 			# Mark 1st run update as completed
 			Apply_1st_Run_Update_Success
@@ -454,12 +429,18 @@ Do you wish to continue and update DietPi to v$COREVERSION_SERVER.$SUBVERSION_SE
 			(( $G_DIETPI_INSTALL_STAGE == 2 )) && /boot/dietpi/dietpi-services restart
 
 		fi
-
 		#----------------------------------------------------------------
 		# Desktop run, exit key prompt
 		pgrep 'lxsession' > /dev/null && read -rp 'Press any key to exit DietPi-Update...'
+		exit 0
 
 	fi
+
+	# Check for APT updates and in case store result to /run/dietpi/.apt_updates for use by DietPi-Banner
+	mode=$(sed -n '/^[[:blank:]]*CONFIG_CHECK_APT_UPDATES=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+	[[ -f '/run/dietpi/.apt_updates' ]] && rm /run/dietpi/.apt_updates
+	[[ $mode != 0 ]] && G_AGUP && count=$(apt -qq list --upgradeable | wc -l) && (( $count )) && echo "$count" > /run/dietpi/.apt_updates
+	[[ $mode == 2 ]] && (( $count )) && G_AGUG &> >(tee /var/tmp/dietpi/logs/dietpi-upgrade_apt.log)
 	#----------------------------------------------------------------
 	exit 0
 	#----------------------------------------------------------------

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -193,11 +193,11 @@ If this error persists, please report at: https://github.com/MichaIng/DietPi/iss
 
 			apt-get dist-upgrade -s --quiet=2 | grep -c ^Inst > /run/dietpi/.package_update
 
-			if (( $mode == 2 )); then
+			if [[ $mode == 2 ]]; then
 				G_AGUG
 			fi
 
-			if (( $mode == 3 )); then
+			if [[ $mode == 3 ]]; then
 				INPUT=1
 			fi
 		fi

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -95,7 +95,7 @@
 	Obtain_Package_Updates(){
 
 		[[ -f '/run/dietpi/.package_update' ]] || return
-		UPDATE_AVAILABLE_VERSION=$(</run/dietpi/.package_update)
+		PACKAGE_NUMBER=$(</run/dietpi/.package_update)
 
 	}
 

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -146,7 +146,7 @@
 		Obtain_Package_Updates
 		if [[ $PACKAGE_NUMBER != 0 ]]; then
 
-			echo -e "$GREEN_BULLET There are $PACKAGE_NUMBER package updates avalible. Update with (sudo) apt-get upgrade"
+			echo -e "$GREEN_BULLET There are $PACKAGE_NUMBER package updates avalible. Please run dietpi-update."
 
 		fi
 

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -95,7 +95,7 @@
 	Check_APT_Updates(){
 
 		[[ -f '/run/dietpi/.apt_updates' ]] || return 1
-		PACKAGE_COUNT=$(</run/dietpi/.package_update)
+		PACKAGE_COUNT=$(</run/dietpi/.apt_updates)
 		return 0
 
 	}

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -91,6 +91,14 @@
 
 	}
 
+	PACKAGE_NUMBER=0
+	Obtain_Package_Updates(){
+
+		[[ -f '/run/dietpi/.package_update' ]] || return
+		UPDATE_AVAILABLE_VERSION=$(</run/dietpi/.package_update)
+
+	}
+
 	Save(){
 
 		# Custom entry description
@@ -132,6 +140,13 @@
 
 			local locale_current=$(sed -n '/^[[:blank:]]*AUTO_SETUP_LOCALE=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			local text_update_available_date=$(LC_ALL=${locale_current:-C.UTF-8} date +"%R - %a %x")
+
+		fi
+
+		Obtain_Package_Updates
+		if [[ ! PACKAGE_NUMBER == 0 ]]; then
+
+			echo -e "$GREEN_BULLET There are $PACKAGE_NUMBER package updates avalible. Update with apt-get upgrade"
 
 		fi
 

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -185,7 +185,7 @@ $GREEN_LINE"
 			Obtain_Package_Updates
 			if [[ $PACKAGE_NUMBER != 0 ]]; then
 
-				echo -e " $GREEN_BULLET There are $PACKAGE_NUMBER package updates avalible. Please run dietpi-update."
+				echo -e " $GREEN_BULLET There are $PACKAGE_NUMBER package updates avalible. Please run (sudo) apt-get upgrade."
 
 			fi
 

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -139,7 +139,7 @@
 		# APT update available?
 		elif Check_APT_Updates; then
 
-			local text_update_available_date="$PACKAGE_COUNT APT updates available"
+			local text_update_available_date="${aCOLOUR[3]}$PACKAGE_COUNT APT updates available"
 
 		else
 

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -181,6 +181,7 @@ $GREEN_LINE"
 			fi
 
 		else
+			# Package Updates Avalible?
 			Obtain_Package_Updates
 			if [[ $PACKAGE_NUMBER != 0 ]]; then
 

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -144,7 +144,7 @@
 		fi
 
 		Obtain_Package_Updates
-		if [[ ! $PACKAGE_NUMBER == 0 ]]; then
+		if [[ $PACKAGE_NUMBER != 0 ]]; then
 
 			echo -e "$GREEN_BULLET There are $PACKAGE_NUMBER package updates avalible. Update with apt-get upgrade"
 

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -187,7 +187,7 @@ $GREEN_LINE"
 
 		# APT updates available?
 		elif (( $PACKAGE_COUNT )); then
-			
+
 			echo -e " $GREEN_BULLET $PACKAGE_COUNT APT packages can be upgraded, run (sudo) \"apt upgrade\" or \"apt full-upgrade\"."
 
 		fi

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -143,13 +143,6 @@
 
 		fi
 
-		Obtain_Package_Updates
-		if [[ $PACKAGE_NUMBER != 0 ]]; then
-
-			echo -e "$GREEN_BULLET There are $PACKAGE_NUMBER package updates avalible. Please run dietpi-update."
-
-		fi
-
 		echo -e "$GREEN_LINE
  ${aCOLOUR[1]}DietPi v$DIETPI_VERSION$COLOUR_RESET $GREEN_SEPARATOR $text_update_available_date$COLOUR_RESET
 $GREEN_LINE"
@@ -184,6 +177,14 @@ $GREEN_LINE"
 			else
 
 				echo -e " ${aCOLOUR[1]}dietpi-update$COLOUR_RESET   $GREEN_SEPARATOR ${aCOLOUR[3]}Run now to update DietPi from v$DIETPI_VERSION to v$UPDATE_AVAILABLE_VERSION.$COLOUR_RESET\n"
+
+			fi
+
+		else
+			Obtain_Package_Updates
+			if [[ $PACKAGE_NUMBER != 0 ]]; then
+
+				echo -e " $GREEN_BULLET There are $PACKAGE_NUMBER package updates avalible. Please run dietpi-update."
 
 			fi
 

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -80,22 +80,23 @@
 	DIETPI_VERSION="$G_DIETPI_VERSION_CORE.$G_DIETPI_VERSION_SUB.$G_DIETPI_VERSION_RC"
 	[[ $G_GITBRANCH == 'master' ]] || DIETPI_VERSION+=" ($G_GITBRANCH)"
 
-	# Update available?
-	UPDATE_AVAILABLE=0
-	UPDATE_AVAILABLE_VERSION= # -1 = image required, other value = latest version
-	Obtain_Update_Available(){
+	# DietPi update available?
+	AVAILABLE_UPDATE= # -1 = image required, other value = latest version
+	Check_DietPi_Update(){
 
-		[[ -f '/run/dietpi/.update_available' ]] || return
-		UPDATE_AVAILABLE=1
-		UPDATE_AVAILABLE_VERSION=$(</run/dietpi/.update_available)
+		[[ -f '/run/dietpi/.update_available' ]] || return 1
+		AVAILABLE_UPDATE=$(</run/dietpi/.update_available)
+		return 0
 
 	}
 
-	PACKAGE_NUMBER=0
-	Obtain_Package_Updates(){
+	# APT updates available?
+	PACKAGE_COUNT=0
+	Check_APT_Updates(){
 
-		[[ -f '/run/dietpi/.package_update' ]] || return
-		PACKAGE_NUMBER=$(</run/dietpi/.package_update)
+		[[ -f '/run/dietpi/.apt_updates' ]] || return 1
+		PACKAGE_COUNT=$(</run/dietpi/.package_update)
+		return 0
 
 	}
 
@@ -122,11 +123,10 @@
 
 	Print_Header(){
 
-		# Update Available?
-		Obtain_Update_Available
-		if (( $UPDATE_AVAILABLE )); then
+		# DietPi update available?
+		if Check_DietPi_Update; then
 
-			if [[ $UPDATE_AVAILABLE_VERSION == '-1' ]]; then
+			if [[ $AVAILABLE_UPDATE == '-1' ]]; then
 
 				local text_update_available_date="${aCOLOUR[3]}Image available"
 
@@ -136,10 +136,15 @@
 
 			fi
 
+		# APT update available?
+		elif Check_APT_Updates; then
+
+			local text_update_available_date="$PACKAGE_COUNT APT updates available"
+
 		else
 
-			local locale_current=$(sed -n '/^[[:blank:]]*AUTO_SETUP_LOCALE=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-			local text_update_available_date=$(LC_ALL=${locale_current:-C.UTF-8} date +"%R - %a %x")
+			local locale=$(sed -n '/^[[:blank:]]*AUTO_SETUP_LOCALE=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+			local text_update_available_date=$(LC_ALL=${locale:-C.UTF-8} date +"%R - %a %x")
 
 		fi
 
@@ -167,27 +172,23 @@ $GREEN_LINE"
 
 		echo -e " DietPi Hosting  : Powered by https://myvirtualserver.com$COLOUR_RESET\n"
 
-		# Update available?
-		if (( $UPDATE_AVAILABLE )); then
+		# DietPi update available?
+		if (( $AVAILABLE_UPDATE )); then
 
-			if [[ $UPDATE_AVAILABLE_VERSION == '-1' ]]; then
+			if [[ $AVAILABLE_UPDATE == '-1' ]]; then
 
 				echo -e " ${aCOLOUR[3]}Updated DietPi image is available, please download it:$COLOUR_RESET\n https://dietpi.com/#download\n"
 
 			else
 
-				echo -e " ${aCOLOUR[1]}dietpi-update$COLOUR_RESET   $GREEN_SEPARATOR ${aCOLOUR[3]}Run now to update DietPi from v$DIETPI_VERSION to v$UPDATE_AVAILABLE_VERSION.$COLOUR_RESET\n"
+				echo -e " ${aCOLOUR[1]}dietpi-update$COLOUR_RESET   $GREEN_SEPARATOR ${aCOLOUR[3]}Run now to update DietPi from v$DIETPI_VERSION to v$AVAILABLE_UPDATE.$COLOUR_RESET\n"
 
 			fi
 
-		else
-			# Package Updates Avalible?
-			Obtain_Package_Updates
-			if [[ $PACKAGE_NUMBER != 0 ]]; then
-
-				echo -e " $GREEN_BULLET There are $PACKAGE_NUMBER package updates avalible. Please run (sudo) apt-get upgrade."
-
-			fi
+		# APT updates available?
+		elif (( $PACKAGE_COUNT )); then
+			
+			echo -e " $GREEN_BULLET $PACKAGE_COUNT APT packages can be upgraded, run (sudo) \"apt upgrade\" or \"apt full-upgrade\"."
 
 		fi
 

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -144,7 +144,7 @@
 		fi
 
 		Obtain_Package_Updates
-		if [[ ! PACKAGE_NUMBER == 0 ]]; then
+		if [[ ! $PACKAGE_NUMBER == 0 ]]; then
 
 			echo -e "$GREEN_BULLET There are $PACKAGE_NUMBER package updates avalible. Update with apt-get upgrade"
 

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -146,7 +146,7 @@
 		Obtain_Package_Updates
 		if [[ $PACKAGE_NUMBER != 0 ]]; then
 
-			echo -e "$GREEN_BULLET There are $PACKAGE_NUMBER package updates avalible. Update with apt-get upgrade"
+			echo -e "$GREEN_BULLET There are $PACKAGE_NUMBER package updates avalible. Update with (sudo) apt-get upgrade"
 
 		fi
 

--- a/rootfs/etc/apt/apt.conf.d/97dietpi
+++ b/rootfs/etc/apt/apt.conf.d/97dietpi
@@ -27,4 +27,4 @@ Acquire::IndexTargets::deb-src::Sources::KeepCompressedAs "xz";
 DPkg::options:: "--force-confdef,confold";
 
 # Remove package flag file
-DPKg::Options:: "--post-invoke=[ $DPKG_HOOK_ACTION = 'unpack' ] && [ -f '/run/dietpi/.apt_updates' ] && rm /run/dietpi/.apt_updates || :";
+DPkg::Options:: "--post-invoke=[ $DPKG_HOOK_ACTION = 'unpack' ] && [ -f '/run/dietpi/.apt_updates' ] && rm /run/dietpi/.apt_updates || :";

--- a/rootfs/etc/apt/apt.conf.d/97dietpi
+++ b/rootfs/etc/apt/apt.conf.d/97dietpi
@@ -27,4 +27,4 @@ Acquire::IndexTargets::deb-src::Sources::KeepCompressedAs "xz";
 DPkg::options:: "--force-confdef,confold";
 
 # Remove package flag file
-DPkg::Post-Invoke {"/bin/rm -f /run/dietpi/.package_update";};
+DPkg::Post-Invoke:: "[ \"$DPKG_HOOK_ACTION\" = 'install' ] && [ -f '/run/dietpi/.apt_updates' ] && rm /run/dietpi/.apt_update";

--- a/rootfs/etc/apt/apt.conf.d/97dietpi
+++ b/rootfs/etc/apt/apt.conf.d/97dietpi
@@ -27,4 +27,4 @@ Acquire::IndexTargets::deb-src::Sources::KeepCompressedAs "xz";
 DPkg::options:: "--force-confdef,confold";
 
 # Remove package flag file
-DPkg::Post-Invoke:: "[ \"$DPKG_HOOK_ACTION\" = 'install' ] && [ -f '/run/dietpi/.apt_updates' ] && rm /run/dietpi/.apt_update";
+DPKg::Options:: "--post-invoke=[ $DPKG_HOOK_ACTION = 'unpack' ] && [ -f '/run/dietpi/.apt_updates' ] && rm /run/dietpi/.apt_updates || :";

--- a/rootfs/etc/apt/apt.conf.d/97dietpi
+++ b/rootfs/etc/apt/apt.conf.d/97dietpi
@@ -25,3 +25,6 @@ Acquire::IndexTargets::deb-src::Sources::KeepCompressedAs "xz";
 
 # Preserve modified and missing DEB package config files
 DPkg::options:: "--force-confdef,confold";
+
+# Remove package flag file
+DPkg::Post-Invoke {"/bin/rm -f /run/dietpi/.package_update";};

--- a/rootfs/etc/apt/apt.conf.d/97dietpi
+++ b/rootfs/etc/apt/apt.conf.d/97dietpi
@@ -27,4 +27,4 @@ Acquire::IndexTargets::deb-src::Sources::KeepCompressedAs "xz";
 DPkg::options:: "--force-confdef,confold";
 
 # Remove package flag file
-DPkg::Options:: "--post-invoke=[ $DPKG_HOOK_ACTION = 'unpack' ] && [ -f '/run/dietpi/.apt_updates' ] && rm /run/dietpi/.apt_updates || :";
+DPkg::Pre-Install-Pkgs:: "read -r dummy && [ -f '/run/dietpi/.apt_updates' ] && rm /run/dietpi/.apt_updates || :";

--- a/rootfs/etc/cron.daily/dietpi
+++ b/rootfs/etc/cron.daily/dietpi
@@ -23,8 +23,8 @@
 	else
 		mode=$(sed -n '/^[[:blank:]]*CONFIG_CHECK_APT_UPDATES=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 		[[ -f '/run/dietpi/.apt_updates' ]] && rm /run/dietpi/.apt_updates
-		[[ $mode != 0 ]] && G_AGUP && count=$(apt -qq list --upgradeable | wc -l) && (( $count )) && echo "$count" > /run/dietpi/.apt_updates
-		[[ $mode == 2 ]] && (( $count )) && G_AGUG &> /var/tmp/dietpi/logs/dietpi-upgrade_apt.log
+		[[ $mode != 0 ]] && apt-get -qq update && count=$(apt -qq list --upgradeable 2> /dev/null | wc -l) && (( $count )) && echo "$count" > /run/dietpi/.apt_updates
+		[[ $mode == 2 ]] && (( $count )) && apt-get -qq upgrade &> /var/tmp/dietpi/logs/dietpi-upgrade_apt.log
 	fi
 	#----------------------------------------------------------------
 	# Refresh DietPi MOTD

--- a/rootfs/etc/cron.daily/dietpi
+++ b/rootfs/etc/cron.daily/dietpi
@@ -21,7 +21,7 @@
 	then
 		/boot/dietpi/dietpi-update 2
 	else
-		mode=$(sed -n '/^[[:blank:]]*CONFIG_CHECK_DIETPI_UPDATES=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+		mode=$(sed -n '/^[[:blank:]]*CONFIG_CHECK_APT_UPDATES=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 		[[ -f '/run/dietpi/.apt_updates' ]] && rm /run/dietpi/.apt_updates
 		[[ $mode == [12] ]] && G_AGUP && count=$(apt -qq list --upgradeable | wc -l) && (( $count )) && echo "$count" > /run/dietpi/.apt_updates
 		[[ $mode == 2 ]] && (( $count )) && G_AGUG &> /var/tmp/dietpi/logs/dietpi-upgrade_apt.log

--- a/rootfs/etc/cron.daily/dietpi
+++ b/rootfs/etc/cron.daily/dietpi
@@ -17,7 +17,7 @@
 	grep -q '^[[:blank:]]*CONFIG_NTP_MODE=2' /boot/dietpi.txt && /boot/dietpi/func/run_ntpd 1
 	#----------------------------------------------------------------
 	# Check for DietPi updates
-	grep -q '^[[:blank:]]*CONFIG_CHECK_UPDATES=[1-3]' /boot/dietpi.txt && /boot/dietpi/dietpi-update 2
+	grep -q '^[[:blank:]]*CONFIG_CHECK_UPDATES=[1-2]' /boot/dietpi.txt && /boot/dietpi/dietpi-update 2
 	#----------------------------------------------------------------
 	# Refresh DietPi MOTD
 	if [[ -f '/boot/dietpi/.dietpi-banner' ]] && grep -q '^[[:blank:]]*aENABLED\[12\]=1' /boot/dietpi/.dietpi-banner; then

--- a/rootfs/etc/cron.daily/dietpi
+++ b/rootfs/etc/cron.daily/dietpi
@@ -23,7 +23,7 @@
 	else
 		mode=$(sed -n '/^[[:blank:]]*CONFIG_CHECK_APT_UPDATES=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 		[[ -f '/run/dietpi/.apt_updates' ]] && rm /run/dietpi/.apt_updates
-		[[ $mode == [12] ]] && G_AGUP && count=$(apt -qq list --upgradeable | wc -l) && (( $count )) && echo "$count" > /run/dietpi/.apt_updates
+		[[ $mode != 0 ]] && G_AGUP && count=$(apt -qq list --upgradeable | wc -l) && (( $count )) && echo "$count" > /run/dietpi/.apt_updates
 		[[ $mode == 2 ]] && (( $count )) && G_AGUG &> /var/tmp/dietpi/logs/dietpi-upgrade_apt.log
 	fi
 	#----------------------------------------------------------------

--- a/rootfs/etc/cron.daily/dietpi
+++ b/rootfs/etc/cron.daily/dietpi
@@ -16,21 +16,27 @@
 	# Sync system time if mode 2 (daily) is detected
 	grep -q '^[[:blank:]]*CONFIG_NTP_MODE=2' /boot/dietpi.txt && /boot/dietpi/func/run_ntpd 1
 	#----------------------------------------------------------------
-	# Check for DietPi updates
-	grep -q '^[[:blank:]]*CONFIG_CHECK_UPDATES=[1-2]' /boot/dietpi.txt && /boot/dietpi/dietpi-update 2
+	# Check for DietPi and/or updates
+	if grep -q '^[[:blank:]]*CONFIG_CHECK_DIETPI_UPDATES=1' /boot/dietpi.txt
+	then
+		/boot/dietpi/dietpi-update 2
+	else
+		mode=$(sed -n '/^[[:blank:]]*CONFIG_CHECK_DIETPI_UPDATES=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+		[[ -f '/run/dietpi/.apt_updates' ]] && rm /run/dietpi/.apt_updates
+		[[ $mode == [12] ]] && G_AGUP && count=$(apt -qq list --upgradeable | wc -l) && (( $count )) && echo $count > /run/dietpi/.apt_updates
+		[[ $mode == 2 ]] && (( $count )) && G_AGUG &> /var/tmp/dietpi/logs/dietpi-upgrade_apt.log && rm /run/dietpi/.apt_updates
+	fi
 	#----------------------------------------------------------------
 	# Refresh DietPi MOTD
-	if [[ -f '/boot/dietpi/.dietpi-banner' ]] && grep -q '^[[:blank:]]*aENABLED\[12\]=1' /boot/dietpi/.dietpi-banner; then
-
+	if [[ -f '/boot/dietpi/.dietpi-banner' ]] && grep -q '^[[:blank:]]*aENABLED\[12\]=1' /boot/dietpi/.dietpi-banner
+	then
 		curl -sSfL https://dietpi.com/motd > /run/dietpi/.dietpi_motd
-
 	fi
 	#----------------------------------------------------------------
 	# DietPi-Sync daily
-	if [[ -f '/boot/dietpi/.dietpi-sync_settings' ]] && grep -q '^[[:blank:]]*SYNC_CRONDAILY=1' /boot/dietpi/.dietpi-sync_settings; then
-
+	if [[ -f '/boot/dietpi/.dietpi-sync_settings' ]] && grep -q '^[[:blank:]]*SYNC_CRONDAILY=1' /boot/dietpi/.dietpi-sync_settings
+	then
 		/boot/dietpi/dietpi-sync 1
-
 	fi
 	#----------------------------------------------------------------
 	exit

--- a/rootfs/etc/cron.daily/dietpi
+++ b/rootfs/etc/cron.daily/dietpi
@@ -17,7 +17,7 @@
 	grep -q '^[[:blank:]]*CONFIG_NTP_MODE=2' /boot/dietpi.txt && /boot/dietpi/func/run_ntpd 1
 	#----------------------------------------------------------------
 	# Check for DietPi updates
-	grep -q '^[[:blank:]]*CONFIG_CHECK_DIETPI_UPDATES=1' /boot/dietpi.txt && /boot/dietpi/dietpi-update 2
+	grep -q '^[[:blank:]]*CONFIG_CHECK_UPDATES=[1-3]' /boot/dietpi.txt && /boot/dietpi/dietpi-update 2
 	#----------------------------------------------------------------
 	# Refresh DietPi MOTD
 	if [[ -f '/boot/dietpi/.dietpi-banner' ]] && grep -q '^[[:blank:]]*aENABLED\[12\]=1' /boot/dietpi/.dietpi-banner; then

--- a/rootfs/etc/cron.daily/dietpi
+++ b/rootfs/etc/cron.daily/dietpi
@@ -23,8 +23,8 @@
 	else
 		mode=$(sed -n '/^[[:blank:]]*CONFIG_CHECK_DIETPI_UPDATES=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 		[[ -f '/run/dietpi/.apt_updates' ]] && rm /run/dietpi/.apt_updates
-		[[ $mode == [12] ]] && G_AGUP && count=$(apt -qq list --upgradeable | wc -l) && (( $count )) && echo $count > /run/dietpi/.apt_updates
-		[[ $mode == 2 ]] && (( $count )) && G_AGUG &> /var/tmp/dietpi/logs/dietpi-upgrade_apt.log && rm /run/dietpi/.apt_updates
+		[[ $mode == [12] ]] && G_AGUP && count=$(apt -qq list --upgradeable | wc -l) && (( $count )) && echo "$count" > /run/dietpi/.apt_updates
+		[[ $mode == 2 ]] && (( $count )) && G_AGUG &> /var/tmp/dietpi/logs/dietpi-upgrade_apt.log
 	fi
 	#----------------------------------------------------------------
 	# Refresh DietPi MOTD


### PR DESCRIPTION
**Status**: Ready
- [x] Test on VM
- [x] Test on RPi
- [x] Figure out how to have it detect package updates more often than the daily `cron`
- [x] When logging in, it shows up as `You have  package updates available...`

**Commit list/description**:
<!--
- DietPi-Config | Add "Fan control" option to "Performance Options"
![Screenshot](https://xxx.github.com/images/xxx.png)
- DietPi-Config | Add "Fan control" support for Odroid C2
- DietPi-Config | Syntax fix
-->
- DietPi-Update | Add ability to update apt packages and DietPi
- DietPi-Update | CodeFactor Fixes
- DietPi-Update | CodeFactor notice fix
- DietPi-Update | Switch back to echo
- DietPi-Update | Switch to !=
- DietPi-Update | Use (( on if statement
- DietPi-Update | CodeFactor fix
- DietPi-Update | Use [[
- DietPi-Update | Switch to [[ on other if statements
- DietPi-Update | Add more conditions
- DietPi-Update | Remove extra G_AGUG
- DietPi-Update | Remove G_AGUP
- DietPi-Update | Switch to grep -oP
- DietPi-Banner | Switch to != for package number
- DietPi-Banner | Change variable to PACKAGE_NUMBER
- DietPi-Update | Update APT packages when INPUT = 1
- DietPi-Update | Move G_DIETPI-NOTIFY
- DietPi-Update | Simplify if statement
- DietPi-Banner | Add sudo into update message
- DietPi-Banner | Switch to asking for DietPi-Update
- DietPi-Update | Switch from == 1 to != 2
- DietPi-Update | Move package update checking to end
- DietPi-Update | Change to INPUT != 2
- DietPi-Update | Fixes
- DietPi-Update | Remove package flag file
- DietPi-Update | Add pre-patches
- DietPi-Update | Apply pre-patches only if actually running the update
- DietPi-Software | Add automated upgrades into dietpi-software
- DietPi-Software | Show the right name
- DietPi-Software | Auto-install iptables-persistent
- DietPi-Update | Only update APT packages when running dietpi-update manually