### PR TITLE
DietPi-Software | Nginx: correct typo on configuration section

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -25,6 +25,7 @@ Bug Fixes:
 - DietPi-Software | O!MPD: Resolved an issue where the URL check for youtube-dl failed.
 - DietPi-Software | Single File PHP Gallery: Resolved an issue where directory previews were not shown due to missing permissions. Many thanks to @tallbastard for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?p=28155#p28155
 - DietPi-Software | WebIOPi: Resolved an issue where the download and install failed.
+- DietPi-Software | Nginx: Resolved an issue where the amount of worker processes was not set to the amount of CPU threads as intended.
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7203,7 +7203,7 @@ _EOF_
 			G_EXEC sed -i "s#/run/php/php.*-fpm.sock#/run/php/$PHP_NAME-fpm.sock#g" /etc/nginx/nginx.conf
 
 			# CPU core count
-			G_EXEV sed -i "/worker_processes/c\worker_processes $G_HW_CPU_CORES;" /etc/nginx/nginx.conf
+			G_EXEC sed -i "/worker_processes/c\worker_processes $G_HW_CPU_CORES;" /etc/nginx/nginx.conf
 
 			# Default site
 			dps_index=$software_id Download_Install 'nginx.default' /etc/nginx/sites-available/default


### PR DESCRIPTION
During installation I discovered any issue/typo

`/boot/dietpi/dietpi-software: line 7137: G_EXEV: command not found`

**Status**: Ready
- [x] correct typo on configuration section

**Reference**: n/a

**Commit list/description**:
- DietPi-Software | Nginx: correct typo on configuration section
