### PR TITLE
DietPi-Software | MineOS: Several updates

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Changes / Improvements / Optimisations:
 - DietPi-Software | OpenBazaar: Build is now done with the currently latest Go v1.15.3 and the service runs as unprivileged user "openbazaar" instead of root.
 - DietPi-Software | XRDP: Remote desktop connections can now be done with the "Xorg" method and hence don't require an active VNC server anymore. New installes will not pull TigerVNC as dependency and if only RDP is required, TigerVNC can be uninstalled.
 - DietPi-Software | Single File PHP Gallery: Updated new installs to latest v4.7.1. Run "dietpi-software reinstall 56" to upgrade your existing instance.
+- DietPi-Software | MineOS: A systemd service is now used to run the daemon in favour of the previous supervisor, the obsolete "mineos" user is not created anymore, Node.js v11 is used to build MineOS, obsolete dependencies have been removed and a reinstall will now perform a MineOS upgrade and the existing /etc/mineos.conf is not replaced anymore.
 
 Bug Fixes:
 - DietPi-Config | Resolved an issue on RPi where selecting the waveshare32 LCD panel installed an outdated device tree overlay, incompatible with the current Linux 5.4 kernel. Many thanks to @black00019 for reporting this issue: https://github.com/MichaIng/DietPi/issues/3881
@@ -28,6 +29,7 @@ Bug Fixes:
 - DietPi-Software | Single File PHP Gallery: Resolved an issue where directory previews were not shown due to missing permissions. Many thanks to @tallbastard for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?p=28155#p28155
 - DietPi-Software | WebIOPi: Resolved an issue where the download and install failed.
 - DietPi-Software | Nginx: Resolved an issue where the amount of worker processes was not set to the amount of CPU threads as intended.
+- DietPi-Software | MineOS: Resolved an issue where the Node.js downgrade an hence the web UI compiling failed. Many thanks to @CactiChameleon9 for reporting this issue: https://github.com/MichaIng/DietPi/issues/3901
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -146,7 +146,7 @@ Available services:
 			'firefox-sync'
 
 			# - Emulation/Gaming
-			'supervisor'
+			'mineos'
 			'nukkit'
 			'cuberite'
 			'papermc'

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1130,7 +1130,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		software_id=53
 
 		aSOFTWARE_NAME[$software_id]='MineOS'
-		aSOFTWARE_DESC[$software_id]='Minecraft servers with web interface (Node.js)'
+		aSOFTWARE_DESC[$software_id]='Minecraft servers with web interface (Java/Node.js)'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=5
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=2069#p2069'
@@ -10519,9 +10519,6 @@ _EOF_
 		then
 			Banner_Configuration
 
-			# Add underprivilged user for web access
-			getent passwd mineos > /dev/null || { G_EXEC useradd mineos; chpasswd <<< "mineos:$GLOBAL_PW"; }
-
 			# Config: Preserve existing
 			[[ -f '/etc/mineos.conf' ]] || G_EXEC cp /mnt/dietpi_userdata/mineos/minecraft/mineos.conf /etc/mineos.conf
 
@@ -10544,21 +10541,15 @@ Wants=network-online.target
 After=network-online.target dietpi-boot.service
 
 [Service]
-Type=forking
-PIDFile=/run/mineos.pid
 WorkingDirectory=/mnt/dietpi_userdata/mineos/minecraft
-Environment="SHELL=/bin/bash"
-ExecStart=$(command -v node) service.js start
-ExecStop=$(command -v node) service.js stop
-ExecReload=$(command -v node) service.js restart
-Restart=on-failure
+Environment="SHELL=/bin/bash" "HOME=/root"
+SyslogIdentifier=MineOS
+ExecStart=$(command -v node) webui.js
 KillMode=process
 
 [Install]
 WantedBy=multi-user.target
 _EOF_
-			# Permissions
-			G_EXEC chown -R mineos:mineos /mnt/dietpi_userdata/mineos /var/games/minecraft /etc/ssl/certs/mineos*
 		fi
 
 		software_id=49 # Gogs
@@ -14470,13 +14461,13 @@ _EOF_
 				systemctl disable --now mineos
 				rm -R /etc/systemd/system/mineos.service*
 			fi
-			[[ -d '/etc/systemd/system/cuberite.mineos.d' ]] && rm -R /etc/systemd/system/cuberite.service.d
-			getent passwd mineos > /dev/null && userdel mineos
-			getent group mineos > /dev/null && groupdel mineos
-			[[ -d '/home/mineos' ]] && rm -R /home/mineos
+			[[ -d '/etc/systemd/system/mineos.service.d' ]] && rm -R /etc/systemd/system/mineos.service.d
 			[[ -d '/mnt/dietpi_userdata/mineos' ]] && rm -R /mnt/dietpi_userdata/mineos
 			[[ -f '/etc/mineos.conf' ]] && rm /etc/mineos.conf
 			rm -Rf /var/games/minecraft /usr/local/bin/mineos # Symlinks
+			getent passwd mineos > /dev/null && userdel mineos # pre-v6.34
+			getent group mineos > /dev/null && groupdel mineos # pre-v6.34
+			[[ -d '/home/mineos' ]] && rm -R /home/mineos # pre-v6.34
 		fi
 
 		software_id=49 # Gogs
@@ -14490,6 +14481,7 @@ _EOF_
 				rm -R /etc/systemd/system/gogs.service*
 
 			fi
+			[[ -d '/etc/systemd/system/gogs.service.d' ]] && rm -R /etc/systemd/system/gogs.service.d
 
 			getent passwd gogs > /dev/null && userdel gogs
 			getent group gogs > /dev/null && groupdel gogs

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5151,7 +5151,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			# APT deps
-			G_AGI rdiff-backup rsync screen
+			G_AGI python rdiff-backup rsync screen
 
 			# Download/Update MineOS
 			G_EXEC mkdir -p /mnt/dietpi_userdata/mineos

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1120,7 +1120,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		software_id=52
 
 		aSOFTWARE_NAME[$software_id]='Cuberite'
-		aSOFTWARE_DESC[$software_id]='minecraft server with web interface (c++)'
+		aSOFTWARE_DESC[$software_id]='Minecraft server with web interface (C++)'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=5
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=2068#p2068'
@@ -1130,7 +1130,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		software_id=53
 
 		aSOFTWARE_NAME[$software_id]='MineOS'
-		aSOFTWARE_DESC[$software_id]='minecraft servers with web interface (java)'
+		aSOFTWARE_DESC[$software_id]='Minecraft servers with web interface (Node.js)'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=5
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=2069#p2069'
@@ -5143,21 +5143,22 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 		fi
 
 		software_id=53 # MineOS
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 ))
+		then
+			Banner_Installing # https://minecraft.codeemo.com/mineoswiki/index.php?title=MineOS-node_(apt-get)
 
 			INSTALL_URL_ADDRESS='https://github.com/hexparrot/mineos-node.git'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			# APT deps
-			G_AGI python3 rdiff-backup screen rsync
+			G_AGI rdiff-backup rsync screen
 
 			# Download/Update MineOS
 			G_EXEC mkdir -p /mnt/dietpi_userdata/mineos
 			G_EXEC cd /mnt/dietpi_userdata/mineos
 			if [[ -d 'minecraft' ]]
 			then
+				# https://minecraft.codeemo.com/mineoswiki/index.php?title=Updating_the_Webui
 				G_EXEC cd minecraft
 				if [[ -x 'update_webui.sh' ]]
 				then
@@ -5171,17 +5172,17 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 				G_EXEC cd minecraft
 			fi
 
+			# File modes
 			G_EXEC git config core.filemode false
 			G_EXEC chmod +x mineos_console.js webui.js update_webui.sh reset_webui.sh generate-sslcert.sh
 
-			# Install Node 11, as MineOS is currently not compatible with newer Node versions: https://github.com/MichaIng/DietPi/issues/1880
+			# Install Node 11, as MineOS is currently not compatible with newer Node versions: https://github.com/hexparrot/mineos-node/issues/374
 			G_EXEC_OUTPUT=1 G_EXEC npm i -g n
 			G_EXEC_OUTPUT=1 G_EXEC n 11
 
 			# Install MineOS
 			G_EXEC_OUTPUT=1 G_EXEC npm i
 			G_EXEC cd /tmp/$G_PROGRAM_NAME
-
 		fi
 
 		software_id=49 # Gogs
@@ -10514,16 +10515,15 @@ _EOF_
 		fi
 
 		software_id=53 # MineOS
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 ))
+		then
 			Banner_Configuration
 
 			# Add underprivilged user for web access
 			getent passwd mineos > /dev/null || { G_EXEC useradd mineos; chpasswd <<< "mineos:$GLOBAL_PW"; }
 
-			# Config
-			G_BACKUP_FP /etc/mineos.conf
-			G_EXEC cp /mnt/dietpi_userdata/mineos/minecraft/mineos.conf /etc/mineos.conf
+			# Config: Preserve existing
+			[[ -f '/etc/mineos.conf' ]] || G_EXEC cp /mnt/dietpi_userdata/mineos/minecraft/mineos.conf /etc/mineos.conf
 
 			# Create symlinks for console and userdata dir
 			G_EXEC ln -sf /mnt/dietpi_userdata/mineos/minecraft/mineos_console.js /usr/local/bin/mineos
@@ -10559,7 +10559,6 @@ WantedBy=multi-user.target
 _EOF_
 			# Permissions
 			G_EXEC chown -R mineos:mineos /mnt/dietpi_userdata/mineos /var/games/minecraft /etc/ssl/certs/mineos*
-
 		fi
 
 		software_id=49 # Gogs
@@ -14474,6 +14473,7 @@ _EOF_
 			[[ -d '/etc/systemd/system/cuberite.mineos.d' ]] && rm -R /etc/systemd/system/cuberite.service.d
 			getent passwd mineos > /dev/null && userdel mineos
 			getent group mineos > /dev/null && groupdel mineos
+			[[ -d '/home/mineos' ]] && rm -R /home/mineos
 			[[ -d '/mnt/dietpi_userdata/mineos' ]] && rm -R /mnt/dietpi_userdata/mineos
 			[[ -f '/etc/mineos.conf' ]] && rm /etc/mineos.conf
 			rm -Rf /var/games/minecraft /usr/local/bin/mineos # Symlinks

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5147,30 +5147,39 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			Banner_Installing
 
-			# Check folder is online
 			INSTALL_URL_ADDRESS='https://github.com/hexparrot/mineos-node.git'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
-			# Pre-reqs
-			G_AGI python python3 supervisor rdiff-backup screen rsync
+			# APT deps
+			G_AGI python3 rdiff-backup screen rsync
 
-			mkdir -p /mnt/dietpi_userdata/mineos
+			# Download/Update MineOS
+			G_EXEC mkdir -p /mnt/dietpi_userdata/mineos
 			G_EXEC cd /mnt/dietpi_userdata/mineos
-			git clone "$INSTALL_URL_ADDRESS" minecraft
+			if [[ -d 'minecraft' ]]
+			then
+				G_EXEC cd minecraft
+				if [[ -x 'update_webui.sh' ]]
+				then
+					G_EXEC_OUTPUT=1 G_EXEC ./update_webui.sh
+				else
+					G_EXEC_OUTPUT=1 G_EXEC git fetch
+					G_EXEC_OUTPUT=1 G_EXEC git merge origin/master
+				fi
+			else
+				G_EXEC_OUTPUT=1 G_EXEC git clone "$INSTALL_URL_ADDRESS" minecraft
+				G_EXEC cd minecraft
+			fi
 
-			G_EXEC cd minecraft
 			G_EXEC git config core.filemode false
-			chmod +x service.js mineos_console.js generate-sslcert.sh webui.js
+			G_EXEC chmod +x mineos_console.js webui.js update_webui.sh reset_webui.sh
 
-			# Install Node 8, as MineOS is currently not compatible with Node 10: https://github.com/MichaIng/DietPi/issues/1880
-			npm i -g --unsafe-perm n
-			# - On ARMv8 explicitly add arch info, since it is not recognized by "n": https://github.com/MichaIng/DietPi/issues/1880#issuecomment-464097174
-			local arch=
-			(( $G_HW_ARCH == 3 )) && arch='-a arm64'
-			n "$arch" 8
+			# Install Node 11, as MineOS is currently not compatible with newer Node versions: https://github.com/MichaIng/DietPi/issues/1880
+			G_EXEC_OUTPUT=1 G_EXEC npm i -g n
+			G_EXEC_OUTPUT=1 G_EXEC n 11
 
-			npm i --unsafe-perm
-
+			# Install MineOS
+			G_EXEC_OUTPUT=1 G_EXEC npm i
 			G_EXEC cd /tmp/$G_PROGRAM_NAME
 
 		fi
@@ -10509,46 +10518,47 @@ _EOF_
 
 			Banner_Configuration
 
-			# Add underprivilged user for web access | no longer works, could be a nodejs v8 issue?
+			# Add underprivilged user for web access
 			getent passwd mineos > /dev/null || { G_EXEC useradd mineos; chpasswd <<< "mineos:$GLOBAL_PW"; }
 
-			# Stop mineos from running while we config it. When we didn't do this, the program would constantly overwrite our symlink from (/var/games/minecraft).
-			#/boot/dietpi/dietpi-services stop # Already done after install step now
-			killall -w supervisord &> /dev/null
-			killall -w node &> /dev/null
-			killall -w nodejs &> /dev/null
-
-			# Create symlinks to userdata dir
-			mkdir -p /mnt/dietpi_userdata/mineos/minecraft
-			ln -sf /mnt/dietpi_userdata/mineos/minecraft/mineos_console.js /usr/local/bin/mineos
-
+			# Config
 			G_BACKUP_FP /etc/mineos.conf
-			cp /mnt/dietpi_userdata/mineos/minecraft/mineos.conf /etc/mineos.conf
+			G_EXEC cp /mnt/dietpi_userdata/mineos/minecraft/mineos.conf /etc/mineos.conf
 
-			rm -Rf /var/games/minecraft
-			mkdir -p /var/games /mnt/dietpi_userdata/mineos/serverdata
-			ln -s /mnt/dietpi_userdata/mineos/serverdata /var/games/minecraft
+			# Create symlinks for console and userdata dir
+			G_EXEC ln -sf /mnt/dietpi_userdata/mineos/minecraft/mineos_console.js /usr/local/bin/mineos
+			G_EXEC rm -Rf /var/games/minecraft
+			G_EXEC mkdir -p /var/games /mnt/dietpi_userdata/mineos/serverdata
+			G_EXEC ln -s /mnt/dietpi_userdata/mineos/serverdata /var/games/minecraft
 
 			# Setup SSL cert
 			G_EXEC cd /mnt/dietpi_userdata/mineos/minecraft
-			./generate-sslcert.sh
+			G_EXEC_OUTPUT=1 G_EXEC ./generate-sslcert.sh
 			G_EXEC cd /tmp/$G_PROGRAM_NAME
 
-			# Supervisor service
-			cat << '_EOF_' > /etc/supervisor/conf.d/mineos.conf
-[program:mineos]
-command=/usr/local/bin/node webui.js
-directory=/mnt/dietpi_userdata/mineos/minecraft
-environment=HOME=/mnt/dietpi_userdata/mineos
-user=root
-autostart=true
-autorestart=true
-redirect_stderr=true
-_EOF_
-			supervisorctl reload
+			# Service
+			cat << _EOF_ > /etc/systemd/system/mineos.service
+[Unit]
+Description=MineOS (DietPi)
+Wants=network-online.target
+After=network-online.target dietpi-boot.service
 
+[Service]
+Type=forking
+PIDFile=/run/mineos.pid
+WorkingDirectory=/mnt/dietpi_userdata/mineos/minecraft
+Environment="SHELL=/bin/bash"
+ExecStart=$(command -v node) service.js start
+ExecStop=$(command -v node) service.js stop
+ExecReload=$(command -v node) service.js restart
+Restart=on-failure
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target
+_EOF_
 			# Permissions
-			chown -R mineos:dietpi /mnt/dietpi_userdata/mineos /var/games/minecraft /etc/ssl/certs/mineos*
+			G_EXEC chown -R mineos:mineos /mnt/dietpi_userdata/mineos /var/games/minecraft /etc/ssl/certs/mineos*
 
 		fi
 
@@ -14453,20 +14463,20 @@ _EOF_
 		fi
 
 		software_id=53 # MineOS
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
-
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 ))
+		then
 			Banner_Uninstalling
-			rm -R /mnt/dietpi_userdata/mineos
-			rm -R /var/games/minecraft
-
-			rm /etc/supervisor/conf.d/mineos.conf
-			supervisorctl reload
-
-			rm /usr/local/bin/mineos
-
+			if [[ -f '/etc/systemd/system/mineos.service' ]]
+			then
+				systemctl disable --now mineos
+				rm -R /etc/systemd/system/mineos.service*
+			fi
+			[[ -d '/etc/systemd/system/cuberite.mineos.d' ]] && rm -R /etc/systemd/system/cuberite.service.d
 			getent passwd mineos > /dev/null && userdel mineos
 			getent group mineos > /dev/null && groupdel mineos
-
+			[[ -d '/mnt/dietpi_userdata/mineos' ]] && rm -R /mnt/dietpi_userdata/mineos
+			[[ -f '/etc/mineos.conf' ]] && rm /etc/mineos.conf
+			rm -Rf /var/games/minecraft /usr/local/bin/mineos # Symlinks
 		fi
 
 		software_id=49 # Gogs

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5172,7 +5172,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			fi
 
 			G_EXEC git config core.filemode false
-			G_EXEC chmod +x mineos_console.js webui.js update_webui.sh reset_webui.sh
+			G_EXEC chmod +x mineos_console.js webui.js update_webui.sh reset_webui.sh generate-sslcert.sh
 
 			# Install Node 11, as MineOS is currently not compatible with newer Node versions: https://github.com/MichaIng/DietPi/issues/1880
 			G_EXEC_OUTPUT=1 G_EXEC npm i -g n

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5177,11 +5177,11 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			G_EXEC chmod +x mineos_console.js webui.js update_webui.sh reset_webui.sh generate-sslcert.sh
 
 			# Install Node 11, as MineOS is currently not compatible with newer Node versions: https://github.com/hexparrot/mineos-node/issues/374
-			G_EXEC_OUTPUT=1 G_EXEC npm i -g n
+			G_EXEC_OUTPUT=1 G_EXEC npm i -g --unsafe-perm n
 			G_EXEC_OUTPUT=1 G_EXEC n 11
 
 			# Install MineOS
-			G_EXEC_OUTPUT=1 G_EXEC npm i
+			G_EXEC_OUTPUT=1 G_EXEC npm i --unsafe-perm
 			G_EXEC cd /tmp/$G_PROGRAM_NAME
 		fi
 
@@ -13131,7 +13131,7 @@ _EOF_
 
 			fi
 			[[ -d '/etc/systemd/system/node-red.service.d' ]] && rm -R /etc/systemd/system/node-red.service.d
-			npm r -g node-red
+			npm r -g --unsafe-perm node-red
 			getent passwd nodered > /dev/null && userdel nodered
 			getent group nodered > /dev/null && groupdel nodered
 			[[ -f '/etc/sudoers.d/nodered' ]] && rm /etc/sudoers.d/nodered
@@ -15291,7 +15291,7 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			npm r -g n yarn npm
+			npm r -g --unsafe-perm n yarn npm
 
 			# Old install via repo
 			G_AGP nodejs

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -2586,7 +2586,7 @@ opcache.max_accelerated_files=10000\nopcache.memory_consumption=128\nopcache.sav
 			#-------------------------------------------------------------------------------
 			# Mosquitto reinstall: https://github.com/MichaIng/DietPi/issues/3042
 			# Amiberry v3.3
-			(( $G_DIETPI_INSTALL_STAGE == 2 )) && echo 108 123 >> /var/tmp/dietpi/dietpi-update_reinstalls
+			echo 108 123 >> /var/tmp/dietpi/dietpi-update_reinstalls
 			#-------------------------------------------------------------------------------
 			# Cuberite: https://github.com/MichaIng/DietPi/issues/3664
 			if (( $G_DIETPI_INSTALL_STAGE == 2 )) && grep -q '^aSOFTWARE_INSTALL_STATE\[52\]=2' /boot/dietpi/.installed && [[ ! -d '/mnt/dietpi_userdata/cuberite' ]]; then
@@ -2659,6 +2659,9 @@ _EOF_
 				[[ $gpu_mem_current ]] || gpu_mem_current=64 # default value
 				(( $gpu_mem_current < 32 )) && /boot/dietpi/func/dietpi-set_hardware gpumemsplit $gpu_mem_current
 			fi
+			#-------------------------------------------------------------------------------
+			# MineOS reinstall to migrate from supervisor to systemd unit: https://github.com/MichaIng/DietPi/pull/3904
+			[[ -f '/etc/systemd/system/mineos.service' ]] && echo 53 >> /var/tmp/dietpi/dietpi-update_reinstalls
 			#-------------------------------------------------------------------------------
 			# Last subversion patch completed
 			# - Apply reinstalls


### PR DESCRIPTION
**Status**: Ready

**Testing**:
- [x] VM Buster
- [x] VM Stretch
- [x] VM Bullseye
- [x] RPi
- [x] ARMv8

**Commit list/description**:
+ DietPi-Software | MineOS: Fix Node 8 install and remove obsolete npm and "n" options
+ DietPi-Software | MineOS: Use latest compatible Node v11
+ DietPi-Software | MineOS: Switch form supervisor to systemd unit
+ DietPi-Software | MineOS: Remove Python 3 from dependencies, as this was required for the Python-based implementation only, while this is a Node.js-based one.
+ DietPi-Software | MineOS: Do not create obsolete "mineos" user anymore