### PR TITLE
DietPi-Software | Bitwarden_RS: Adding meta info

### DIFF
--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -199,13 +199,13 @@
 	aSOFTWARE_NAME[23]='LXDE'
 	aSOFTWARE_NAME[24]='MATE'
 	aSOFTWARE_NAME[25]='Xfce'
-	aSOFTWARE_NAME[26]='GNUStep'
+	aSOFTWARE_NAME[26]='GNUstep'
 	aSOFTWARE_NAME[27]='TightVNC Server'
 	aSOFTWARE_NAME[28]='TigerVNC Server'
 	aSOFTWARE_NAME[29]='XRDP'
 	aSOFTWARE_NAME[30]='NoMachine'
 	aSOFTWARE_NAME[31]='Kodi'
-	aSOFTWARE_NAME[32]='YMPD'
+	aSOFTWARE_NAME[32]='ympd'
 	aSOFTWARE_NAME[33]='Airsonic'
 	aSOFTWARE_NAME[34]='Subsonic'
 	aSOFTWARE_NAME[35]='Logitech Media Server'
@@ -230,7 +230,7 @@
 	aSOFTWARE_NAME[54]='phpBB'
 	aSOFTWARE_NAME[55]='Wordpress'
 	aSOFTWARE_NAME[56]='Image Gallery'
-	aSOFTWARE_NAME[57]='BaiKal'
+	aSOFTWARE_NAME[57]='Baïkal'
 	aSOFTWARE_NAME[58]='OpenBazaar'
 	aSOFTWARE_NAME[59]='RPi Cam Control'
 	aSOFTWARE_NAME[60]='WiFi Hotspot'
@@ -268,7 +268,7 @@
 	aSOFTWARE_NAME[92]='Certbot'
 	aSOFTWARE_NAME[93]='Pi-hole'
 	aSOFTWARE_NAME[94]='ProFTPD'
-	aSOFTWARE_NAME[95]='vsFTPD'
+	aSOFTWARE_NAME[95]='vsftpd'
 	aSOFTWARE_NAME[96]='Samba Server'
 	aSOFTWARE_NAME[97]='OpenVPN'
 	aSOFTWARE_NAME[98]='HAProxy'
@@ -399,7 +399,7 @@
 	done
 	aSOFTWARE_NAME6_23[173]='LXQt'
 	aSOFTWARE_NAME6_23[174]='GIMP'
-	aSOFTWARE_NAME6_23[175]='XFCE Power Manager'
+	aSOFTWARE_NAME6_23[175]='Xfce Power Manager'
 
 	# v6.24 + v6.25
 	aSOFTWARE_NAME6_24=()
@@ -491,8 +491,9 @@
 	aSOFTWARE_NAME6_34[134]='134' # Tonido
 	aSOFTWARE_NAME6_34[137]='137' # CloudPrint
 	aSOFTWARE_NAME6_34[181]='PaperMC'
-	# shellcheck disable=SC2034
 	aSOFTWARE_NAME6_34[182]='Unbound'
+	# shellcheck disable=SC2034
+	aSOFTWARE_NAME6_34[183]='Bitwarden_RS'
 
 	Main(){
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,5 @@
 v6.34
-(XX/11/20)
+(XX/12/20)
 
 Changes / Improvements / Optimisations:
 - DietPi-Globals | In DietPi scripts, the PATH variable is now overwritten with the Debian/bash system default to assure that no broken or manipulated PATH can be passed via e.g. "su" or "sudo -E". This means that overrides must be placed in /usr/local/(s)bin now, which as well was the only save location for system-wide overrides before. Many thanks to @tandy-1000 for reporting a related issue: https://github.com/MichaIng/DietPi/issues/3873
@@ -9,6 +9,7 @@ Changes / Improvements / Optimisations:
 - DietPi-Config | Audio Options: Added an option to switch between direct audio output and automatic software conversions, for channels, format and rate via ALSA "plug" plugin. This may be required to play any raw wav file regardless of sound card capabilities and without defining supported values manually. Having automated software conversions enabled matches the Debian ALSA defaults but may increase CPU usage and decrease sound quality.
 - DietPi-Software | PaperMC: Highly optimised Minecraft server, written in Java, extensible via plugins, now available for install. Many thanks to @ravenclaw900 for implementing this software option: https://github.com/MichaIng/DietPi/pull/3828
 - DietPi-Software | Unbound: Validating, recursive, caching DNS resolver, now available for install and integrate with Pi-hole. Many thanks to @ravenclaw900 for implementing this software option: https://github.com/MichaIng/DietPi/pull/3872
+- DietPi-Software | Bitwarden_RS: An unofficial Bitwarden password manager server with web UI, written in Rust, now available for install. Many thanks to @CactiChameleon9 for implementing this software option: https://github.com/MichaIng/DietPi/issues/3724
 - DietPi-Software | Tonido: This software option has been removed, since it is not developed anymore fore three years, no sources have been found and the latest binaries require ancient library versions which fail to be easily installed on currently supported Debian versions.
 - DietPi-Software | CloudPrint: This software option has been removed, since the Google Cloud Print service will be shut down at the end of 2020 and we don't want to offer software options which will work for at most two months. Please migrate to another printing solution in time. Already installed CloudPrint instances will remain installed and the system service remains functional until the end of the year. With the first DietPi release in 2021 we will remove service handling and offer the package removal during the update process. Further information can be found here: https://www.google.com/cloudprint/learn/ 
 - DietPi-Software | OpenBazaar: Build is now done with the currently latest Go v1.15.3 and the service runs as unprivileged user "openbazaar" instead of root.

--- a/README.md
+++ b/README.md
@@ -275,6 +275,9 @@ Links to hardware and software manufacturers, sources and build instructions use
 - [Komga](https://github.com/gotson/komga)
 - [HTPC Manager](https://github.com/HTPC-Manager/HTPC-Manager)
 - [Bazarr](https://github.com/morpheus65535/bazarr)
+- [PaperMC](https://github.com/PaperMC/Paper)
+- [Unbound](https://github.com/NLnetLabs/unbound)
+- [Bitwarden_RS](https://github.com/dani-garcia/bitwarden_rs)
 
 ---
 


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ CHANGELOG | Bitwarden_RS: An unofficial Bitwarden password manager server with web UI, written in Rust, now available for install
+ README | Add newly added software source code links
+ DietPi-Survey_report | Add support for Bitwarden_RS and apply some software name spelling fixes