### PR TITLE
DietPi-Software | OctoPrint: Migrate to user-level Python instance

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5948,7 +5948,14 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 				pip='pip2'
 			fi
 
-			G_EXEC_OUTPUT=1 G_EXEC $pip install -U octoprint
+			# Pre-create user and its home directory to allow user-level Python instance
+			Create_User -G dialout,tty,video -d /mnt/dietpi_userdata/octoprint octoprint
+			G_EXEC mkdir -p /mnt/dietpi_userdata/octoprint
+			G_EXEC chown -R octoprint:octoprint /mnt/dietpi_userdata/octoprint
+
+			# Clear user-level pip cache before installing OctoPrint
+			[[ -d '/mnt/dietpi_userdata/octoprint/.cache' ]] && G_EXEC rm -R /mnt/dietpi_userdata/octoprint/.cache
+			G_EXEC_OUTPUT=1 G_EXEC $pip install -U --user octoprint
 			unset -v pip
 		fi
 
@@ -12367,14 +12374,8 @@ _EOF_
 		then
 			Banner_Configuration
 
-			# User: Grant serial and console devices (3D printer ports) and RPi vcgencmd
-			Create_User -G dialout,tty,video -d /mnt/dietpi_userdata/octoprint octoprint
-
-			# Data
-			G_EXEC mkdir -p /mnt/dietpi_userdata/octoprint
-
 			# Service: https://github.com/OctoPrint/OctoPrint/blob/master/scripts/octoprint.service
-			cat << _EOF_ > /etc/systemd/system/octoprint.service
+			cat << '_EOF_' > /etc/systemd/system/octoprint.service
 [Unit]
 Description=OctoPrint (DietPi)
 Documentation=https://docs.octoprint.org/
@@ -12384,29 +12385,16 @@ After=network-online.target dietpi-boot.service
 [Service]
 Environment="LC_ALL=C.UTF-8" "LANG=C.UTF-8"
 User=octoprint
-ExecStart=$(command -v octoprint) serve
+ExecStart=/mnt/dietpi_userdata/octoprint/.local/bin/octoprint serve
 
 [Install]
 WantedBy=multi-user.target
 _EOF_
 			# CLI alias
-			echo "alias octoprint='sudo -u octoprint octoprint'" > /etc/bashrc.d/dietpi-octoprint.sh
+			echo "alias octoprint='sudo -u octoprint /mnt/dietpi_userdata/octoprint/.local/bin/octoprint'" > /etc/bashrc.d/dietpi-octoprint.sh
 
-			# Permissions
-			G_EXEC chown -R octoprint:octoprint /mnt/dietpi_userdata/octoprint
-			local pip='pip3'
-			(( $G_DISTRO > 4 )) || pip='pip2'
-			echo "octoprint ALL=NOPASSWD: $(command -v systemctl) restart octoprint, $(command -v reboot), $(command -v poweroff), SETENV: $(command -v $pip)" > /etc/sudoers.d/octoprint
-
-			# Force global Python module installs/upgrades via shell sudo wrapper. $TESTBALLOON_OUTPUT needs to be passed which is used for OctoPrint pip check: https://github.com/OctoPrint/OctoPrint/blob/master/src/octoprint/util/pip.py#L408
-			# The implementation of localPipCommand allows a single absolut file path only, hence the little script: https://github.com/OctoPrint/OctoPrint/issues/3700
-			# - Stretch: "--preserve-env=list" does not yet exist in sudo 1.8.19, hence use "TESTBALLOON_OUTPUT=$TESTBALLOON_OUTPUT" to pass the variable, which is slightly less beautiful since it declares an empty variable as well.
-			echo -e "#!/bin/dash\nexec sudo TESTBALLOON_OUTPUT=\$TESTBALLOON_OUTPUT $(command -v $pip) \"\$@\"" > /mnt/dietpi_userdata/octoprint/$pip
-			G_EXEC chmod +x /mnt/dietpi_userdata/octoprint/$pip
-			G_EXEC sudo -u octoprint octoprint config set server.commands.localPipCommand /mnt/dietpi_userdata/octoprint/$pip
-			unset -v pip
-
-			# Apply service and system commands
+			# Apply service and system commands: Allow execution via specific sudoers config
+			echo "octoprint ALL=NOPASSWD: $(command -v systemctl) restart octoprint, $(command -v reboot), $(command -v poweroff)" > /etc/sudoers.d/octoprint
 			G_EXEC sudo -u octoprint octoprint config set server.commands.serverRestartCommand 'sudo systemctl restart octoprint'
 			G_EXEC sudo -u octoprint octoprint config set server.commands.systemRestartCommand 'sudo reboot'
 			G_EXEC sudo -u octoprint octoprint config set server.commands.systemShutdownCommand 'sudo poweroff'
@@ -14070,9 +14058,6 @@ _EOF_
 			# User
 			getent passwd octoprint > /dev/null && userdel octoprint
 			getent group octoprint > /dev/null && groupdel octoprint
-			# Uninstall via pip
-			command -v pip3 > /dev/null && pip3 uninstall -y OctoPrint
-			command -v pip2 > /dev/null && pip2 uninstall -y OctoPrint # Stretch + pre-v6.32
 			# Data
 			[[ -d '/mnt/dietpi_userdata/octoprint' ]] && rm -R /mnt/dietpi_userdata/octoprint
 			# CLI alias

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -13082,11 +13082,6 @@ _EOF_
 
 			gpu_memory=64
 
-		# DietPi-Cloudshell: Enable display output
-		elif (( ${aSOFTWARE_INSTALL_STATE[62]} != 1 )); then
-
-			gpu_enabled=0
-
 		fi
 
 		# RPi: Apply memory split

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5955,7 +5955,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			# Clear user-level pip cache before installing OctoPrint
 			[[ -d '/mnt/dietpi_userdata/octoprint/.cache' ]] && G_EXEC rm -R /mnt/dietpi_userdata/octoprint/.cache
-			G_EXEC_OUTPUT=1 G_EXEC $pip install -U --user octoprint
+			G_EXEC_OUTPUT=1 G_EXEC sudo -u octoprint $pip install -U --user octoprint
 			unset -v pip
 		fi
 
@@ -12378,7 +12378,7 @@ _EOF_
 			cat << '_EOF_' > /etc/systemd/system/octoprint.service
 [Unit]
 Description=OctoPrint (DietPi)
-Documentation=https://docs.octoprint.org/
+Documentation=https://dietpi.com/docs/software/printing/#octoprint
 Wants=network-online.target
 After=network-online.target dietpi-boot.service
 
@@ -12395,9 +12395,9 @@ _EOF_
 
 			# Apply service and system commands: Allow execution via specific sudoers config
 			echo "octoprint ALL=NOPASSWD: $(command -v systemctl) restart octoprint, $(command -v reboot), $(command -v poweroff)" > /etc/sudoers.d/octoprint
-			G_EXEC sudo -u octoprint octoprint config set server.commands.serverRestartCommand 'sudo systemctl restart octoprint'
-			G_EXEC sudo -u octoprint octoprint config set server.commands.systemRestartCommand 'sudo reboot'
-			G_EXEC sudo -u octoprint octoprint config set server.commands.systemShutdownCommand 'sudo poweroff'
+			G_EXEC sudo -u octoprint /mnt/dietpi_userdata/octoprint/.local/bin/octoprint config set server.commands.serverRestartCommand 'sudo systemctl restart octoprint'
+			G_EXEC sudo -u octoprint /mnt/dietpi_userdata/octoprint/.local/bin/octoprint config set server.commands.systemRestartCommand 'sudo reboot'
+			G_EXEC sudo -u octoprint /mnt/dietpi_userdata/octoprint/.local/bin/octoprint config set server.commands.systemShutdownCommand 'sudo poweroff'
 		fi
 
 		software_id=154 # Roon Server

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -2688,8 +2688,8 @@ _EOF_
 					G_EXEC mv /{root,mnt/dietpi_userdata/octoprint}/.octoprint
 				fi
 				[[ -d '/opt/octoprint' ]] && G_EXEC rm -Rf /opt/octoprint
-				command -v pip2 > /dev/null && pip2 uninstall octoprint 2> /dev/null
-				command -v pip3 > /dev/null && pip3 uninstall octoprint 2> /dev/null
+				command -v pip2 > /dev/null && pip2 uninstall -y octoprint 2> /dev/null
+				command -v pip3 > /dev/null && pip3 uninstall -y octoprint 2> /dev/null
 				echo 153 >> /var/tmp/dietpi/dietpi-update_reinstalls
 			fi
 			#-------------------------------------------------------------------------------

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -2681,7 +2681,12 @@ _EOF_
 			# OctoPrint reinstall to migrate to new PyPI-based install and apply permission fixes: https://github.com/MichaIng/DietPi/issues/3940
 			if [[ -f '/boot/dietpi/.installed' ]] && grep -q '^aSOFTWARE_INSTALL_STATE\[153\]=2' /boot/dietpi/.installed
 			then
-				G_DIETPI-NOTIFY 2 'Preparing OctoPrint reinstall to migrate to PyPI-based install and apply permission fixes'
+				G_WHIP_MSG '[ INFO ] Preparing OctoPrint reinstall
+\nThe internal updater of OctoPrint has changed, which does not work with the way OctoPrint was installed. We hence need to reinstall it to make the software updater, as well as plugin installs, functional.
+\nNote that you likely need to reinstall plugins. We are especially sorry for users where this was required just after the last DietPi update already, due to Python 2 => Python 3 migration.
+\nOctoPrint is now installed as service user local instance to:
+ - /mnt/dietpi_userdata/octoprint/.local/
+\nThe good news is that this is a long-term reliable method, so that we do not expect any further required changes.'
 				if [[ -d '/root/.octoprint' && ! -d '/mnt/dietpi_userdata/octoprint/.octoprint' ]]
 				then
 					G_EXEC mkdir -p /mnt/dietpi_userdata/octoprint

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -2682,17 +2682,14 @@ _EOF_
 			if [[ -f '/boot/dietpi/.installed' ]] && grep -q '^aSOFTWARE_INSTALL_STATE\[153\]=2' /boot/dietpi/.installed
 			then
 				G_DIETPI-NOTIFY 2 'Preparing OctoPrint reinstall to migrate to PyPI-based install and apply permission fixes'
-				if [[ -d '/mnt/dietpi_userdata/octoprint/.octoprint' ]]
+				if [[ -d '/root/.octoprint' && ! -d '/mnt/dietpi_userdata/octoprint/.octoprint' ]]
 				then
-					G_EXEC mv /mnt/dietpi_userdata{/octoprint,}/.octoprint
-
-				elif [[ -d '/root/.octoprint' ]]
-				then
-					G_EXEC mv /{root,mnt/dietpi_userdata}/.octoprint
+					G_EXEC mkdir -p /mnt/dietpi_userdata/octoprint
+					G_EXEC mv /{root,mnt/dietpi_userdata/octoprint}/.octoprint
 				fi
-				G_EXEC rm -Rf /{opt,mnt/dietpi_userdata}/octoprint
-				G_EXEC mkdir -p /mnt/dietpi_userdata/octoprint
-				[[ -d '/mnt/dietpi_userdata/.octoprint' ]] && G_EXEC mv /mnt/dietpi_userdata{,/octoprint}/.octoprint
+				[[ -d '/opt/octoprint' ]] && G_EXEC rm -Rf /opt/octoprint
+				command -v pip2 > /dev/null && pip2 uninstall octoprint 2> /dev/null
+				command -v pip3 > /dev/null && pip3 uninstall octoprint 2> /dev/null
 				echo 153 >> /var/tmp/dietpi/dietpi-update_reinstalls
 			fi
 			#-------------------------------------------------------------------------------

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -2688,7 +2688,13 @@ _EOF_
 					G_EXEC mv /{root,mnt/dietpi_userdata/octoprint}/.octoprint
 				fi
 				[[ -d '/opt/octoprint' ]] && G_EXEC rm -Rf /opt/octoprint
+				# Beta 6.34.0+1
+				[[ -f '/mnt/dietpi_userdata/octoprint/pip2' ]] && G_EXEC rm /mnt/dietpi_userdata/octoprint/pip2
+				[[ -f '/mnt/dietpi_userdata/octoprint/pip3' ]] && G_EXEC rm /mnt/dietpi_userdata/octoprint/pip3
+				[[ -f '/mnt/dietpi_userdata/octoprint/.octoprint/config.yaml' ]] && G_EXEC sed -i '/localPipCommand/d' /mnt/dietpi_userdata/octoprint/.octoprint/config.yaml
+				# shellcheck disable=SC2046
 				command -v pip2 > /dev/null && pip2 uninstall -y $(pip2 freeze | mawk '/[Oo]cto[Pp]rint/{print $1}') 2> /dev/null
+				# shellcheck disable=SC2046
 				command -v pip3 > /dev/null && pip3 uninstall -y $(pip3 freeze | mawk '/[Oo]cto[Pp]rint/{print $1}') 2> /dev/null
 				echo 153 >> /var/tmp/dietpi/dietpi-update_reinstalls
 			fi

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -2688,8 +2688,8 @@ _EOF_
 					G_EXEC mv /{root,mnt/dietpi_userdata/octoprint}/.octoprint
 				fi
 				[[ -d '/opt/octoprint' ]] && G_EXEC rm -Rf /opt/octoprint
-				command -v pip2 > /dev/null && pip2 uninstall -y octoprint 2> /dev/null
-				command -v pip3 > /dev/null && pip3 uninstall -y octoprint 2> /dev/null
+				command -v pip2 > /dev/null && pip2 uninstall -y $(pip2 freeze | mawk '/[Oo]cto[Pp]rint/{print $1}') 2> /dev/null
+				command -v pip3 > /dev/null && pip3 uninstall -y $(pip3 freeze | mawk '/[Oo]cto[Pp]rint/{print $1}') 2> /dev/null
 				echo 153 >> /var/tmp/dietpi/dietpi-update_reinstalls
 			fi
 			#-------------------------------------------------------------------------------


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Software | OctoPrint: Migrate to user-level Python instance