### PR TITLE
DietPi-Software | Portainer enhancement

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12610,8 +12610,8 @@ _EOF_
 			# Check for existing portainer installation
 			if [[ -d '/mnt/dietpi_userdata/docker-data/volumes/portainer_data' ]]; then
 				G_DIETPI-NOTIFY 2 'Portainer detected, container will be dropped before reinstallation.'
-				G_EXEC docker rm "$(docker ps -a | mawk '/portainer\/portainer*/{print $1}')" --force
-				G_EXEC docker rmi "$(docker images -a | mawk '/portainer\/portainer*/{print $3}')"
+				G_EXEC docker rm "$(docker ps -a | mawk '/portainer\/portainer(-ce)?( |$)/{print $1}')" --force
+				G_EXEC docker rmi "$(docker images -a | mawk '/portainer\/portainer(-ce)?( |$)/{print $3}')"
 			else
 				# Create data directory
 				G_EXEC docker volume create portainer_data
@@ -15270,8 +15270,8 @@ _EOF_
 				G_EXEC systemctl restart docker
 
 				# Remove portainer container, image & volume
-				G_EXEC docker rm "$(docker ps -a | mawk '/portainer\/portainer*/{print $1}')" --force
-				G_EXEC docker rmi "$(docker images -a | mawk '/portainer\/portainer*/{print $3}')"
+				G_EXEC docker rm "$(docker ps -a | mawk '/portainer\/portainer(-ce)?( |$)/{print $1}')" --force
+				G_EXEC docker rmi "$(docker images -a | mawk '/portainer\/portainer(-ce)?( |$)/{print $3}')"
 				G_EXEC docker volume rm portainer_data
 			fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12610,8 +12610,8 @@ _EOF_
 			# Check for existing portainer installation
 			if [[ -d '/mnt/dietpi_userdata/docker-data/volumes/portainer_data' ]]; then
 				G_DIETPI-NOTIFY 2 'Portainer detected, container will be dropped before reinstallation.'
-				G_EXEC docker rm "$(docker ps -a | mawk '/portainer\/portainer-ce/{print $1}')" --force
-				G_EXEC docker rmi "$(docker images -a | mawk '/portainer\/portainer-ce/{print $3}')"
+				G_EXEC docker rm "$(docker ps -a | mawk '/portainer\/portainer*/{print $1}')" --force
+				G_EXEC docker rmi "$(docker images -a | mawk '/portainer\/portainer*/{print $3}')"
 			else
 				# Create data directory
 				G_EXEC docker volume create portainer_data
@@ -15270,8 +15270,8 @@ _EOF_
 				G_EXEC systemctl restart docker
 
 				# Remove portainer container, image & volume
-				G_EXEC docker rm "$(docker ps -a | mawk '/portainer\/portainer-ce/{print $1}')" --force
-				G_EXEC docker rmi "$(docker images -a | mawk '/portainer\/portainer-ce/{print $3}')"
+				G_EXEC docker rm "$(docker ps -a | mawk '/portainer\/portainer*/{print $1}')" --force
+				G_EXEC docker rmi "$(docker images -a | mawk '/portainer\/portainer*/{print $3}')"
 				G_EXEC docker volume rm portainer_data
 			fi
 


### PR DESCRIPTION
Portainer images using different names for 1.x and 2.0. Therefore we would need to use `wildcards` to detect all image version

**Status**:  Ready 
- [x] check re-installation and upgrade from 1.x to 2

**Reference**: https://github.com/MichaIng/DietPi-Docs/pull/301

**Commit list/description**:
- DietPi-Software | Portainer: ensure that all image version of Portainer are detected during installation or removal
