### PR TITLE
DietPi-Software | Docker-Compose

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1347,6 +1347,16 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=29377#p29377'
 		# - Bullseye
 		aSOFTWARE_AVAIL_G_DISTRO[$software_id,6]=0
+		#------------------
+		software_id=187
+
+		aSOFTWARE_NAME[$software_id]='Docker Compose'
+		aSOFTWARE_DESC[$software_id]='Tool to defining and run multi-container Docker applications'
+		aSOFTWARE_TYPE[$software_id]=0
+		aSOFTWARE_CATEGORY_INDEX[$software_id]=8
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=xxx#pxxx'
+		# - Bullseye: https://download.docker.com/linux/debian/dists/
+		aSOFTWARE_AVAIL_G_DISTRO[$software_id,6]=0
 
 		# Remote Access
 		#--------------------------------------------------------------------------------

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2248,8 +2248,10 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 
 		# Docker
 		# - Portainer (185)
+		# - Docker Compose (187)
 		software_id=162
-		if ((${aSOFTWARE_INSTALL_STATE[185]} == 1 && ${aSOFTWARE_INSTALL_STATE[$software_id]} < 1 ))
+		if ((${aSOFTWARE_INSTALL_STATE[185]} == 1 && ${aSOFTWARE_INSTALL_STATE[$software_id]} < 1 ||
+			${aSOFTWARE_INSTALL_STATE[187]} == 1 && ${aSOFTWARE_INSTALL_STATE[$software_id]} < 1 ))
 		then
 			aSOFTWARE_INSTALL_STATE[$software_id]=1
 			G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[$software_id]} will be installed"
@@ -2391,13 +2393,15 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		# - HTPC Manager (155)
 		# - Google AIY (169)
 		# - Bazarr (180)
+		# - Docker Compose
 		software_id=130
 		if (( ( ${aSOFTWARE_INSTALL_STATE[118]} == 1 && $G_DISTRO > 4 ) ||
 			${aSOFTWARE_INSTALL_STATE[139]} == 1 ||
 		      ( ${aSOFTWARE_INSTALL_STATE[153]} == 1 && $G_DISTRO > 4 ) ||
 			${aSOFTWARE_INSTALL_STATE[155]} == 1 ||
 			${aSOFTWARE_INSTALL_STATE[169]} == 1 ||
-			${aSOFTWARE_INSTALL_STATE[180]} == 1 )); then
+			${aSOFTWARE_INSTALL_STATE[180]} == 1 ||
+			${aSOFTWARE_INSTALL_STATE[187]} == 1 )); then
 
 			aSOFTWARE_INSTALL_STATE[$software_id]=1
 			G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[$software_id]} will be installed"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2250,8 +2250,9 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		# - Portainer (185)
 		# - Docker Compose (134)
 		software_id=162
-		if ((${aSOFTWARE_INSTALL_STATE[185]} == 1 && ${aSOFTWARE_INSTALL_STATE[$software_id]} < 1 ||
-			${aSOFTWARE_INSTALL_STATE[134]} == 1 && ${aSOFTWARE_INSTALL_STATE[$software_id]} < 1 ))
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} < 1 )) &&
+		   (( ${aSOFTWARE_INSTALL_STATE[185]} == 1 ||
+		      ${aSOFTWARE_INSTALL_STATE[134]} == 1 ))
 		then
 			aSOFTWARE_INSTALL_STATE[$software_id]=1
 			G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[$software_id]} will be installed"
@@ -2393,7 +2394,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		# - HTPC Manager (155)
 		# - Google AIY (169)
 		# - Bazarr (180)
-		# - Docker Compose
+		# - Docker Compose (134)
 		software_id=130
 		if (( ( ${aSOFTWARE_INSTALL_STATE[118]} == 1 && $G_DISTRO > 4 ) ||
 			${aSOFTWARE_INSTALL_STATE[139]} == 1 ||
@@ -6090,12 +6091,12 @@ If you want to update ${aSOFTWARE_NAME[$software_id]}, please use its internal u
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-			
+
 			# Python build dependencies for aarch64
 			(( $G_HW_ARCH == 3 )) && G_AGI make gcc
 
 			G_EXEC_OUTPUT=1 G_EXEC pip3 install docker-compose
-			
+
 		fi
 
 		software_id=161 # FuguHub
@@ -6996,18 +6997,10 @@ exec sudo -u $ha_user dash -c '$ha_pyenv_activation; exec pip3 install -U homeas
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-			# create piwheels config file for ARMv6 and ARMv7
-			if (( $G_HW_ARCH == 1 || $G_HW_ARCH == 2 )); then
-			 
-				if ! [[ -f '/etc/pip.conf' ]]; then				
-				
-					echo '[global]
-extra-index-url=https://www.piwheels.org/simple
-' > /etc/pip.conf
 
-				fi			
-			fi
-			
+			# Create piwheels config file for ARMv6 and ARMv7
+			[[ $G_HW_ARCH != [12] || -f '/etc/pip.conf' ]] || G_EXEC eval "echo -e '[global]\nextra-index-url=https://www.piwheels.org/simple/' > /etc/pip.conf"
+
 			# Perform pip3 installation
 			INSTALL_URL_ADDRESS='https://bootstrap.pypa.io/get-pip.py'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
@@ -7015,6 +7008,7 @@ extra-index-url=https://www.piwheels.org/simple
 			G_EXEC curl -sSfL "$INSTALL_URL_ADDRESS" -o get-pip.py
 			G_EXEC_OUTPUT=1 G_EXEC python3 ./get-pip.py
 			G_EXEC_NOHALT=1 G_EXEC rm get-pip.py
+
 		fi
 
 		software_id=150 # Mono runtime
@@ -15295,24 +15289,26 @@ _EOF_
 			fi
 
 		fi
-		
+
 		software_id=134 # Docker Compose
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			
-			G_EXEC_OUTPUT=1 G_EXEC pip3 uninstall -y docker-compose
-			
+			G_EXEC_NOEXIT=1 G_EXEC_OUTPUT=1 G_EXEC pip3 uninstall -y docker-compose
+
 		fi
 
-		software_id=164
+		software_id=164 # Nukkit
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			# Remove Service file
-			[[ -f '/etc/systemd/system/nukkit.service' ]] && rm /etc/systemd/system/nukkit.service
+			if [[ -f '/etc/systemd/system/nukkit.service' ]]; then
 
-			# Remove nukkit java file/folder
+				systemctl disable --now nukkit
+				rm -R /etc/systemd/system/nukkit.service*
+
+			fi
+			[[ -d '/etc/systemd/system/nukkit.service.d' ]] && rm -R /etc/systemd/system/nukkit.service.d
 			[[ -e '/usr/local/bin/nukkit' ]] && rm -R /usr/local/bin/nukkit
 
 		fi
@@ -15807,8 +15803,6 @@ _EOF_
 			Banner_Uninstalling
 			pip3 uninstall -y pip
 			G_AGP python3-pip # Pre-v6.32
-			
-			# Remove piwheels config file
 			[[ -f '/etc/pip.conf' ]] && rm /etc/pip.conf
 
 		fi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1348,7 +1348,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 		# - Bullseye
 		aSOFTWARE_AVAIL_G_DISTRO[$software_id,6]=0
 		#------------------
-		software_id=187
+		software_id=134
 
 		aSOFTWARE_NAME[$software_id]='Docker Compose'
 		aSOFTWARE_DESC[$software_id]='Tool to defining and run multi-container Docker applications'
@@ -2248,10 +2248,10 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 
 		# Docker
 		# - Portainer (185)
-		# - Docker Compose (187)
+		# - Docker Compose (134)
 		software_id=162
 		if ((${aSOFTWARE_INSTALL_STATE[185]} == 1 && ${aSOFTWARE_INSTALL_STATE[$software_id]} < 1 ||
-			${aSOFTWARE_INSTALL_STATE[187]} == 1 && ${aSOFTWARE_INSTALL_STATE[$software_id]} < 1 ))
+			${aSOFTWARE_INSTALL_STATE[134]} == 1 && ${aSOFTWARE_INSTALL_STATE[$software_id]} < 1 ))
 		then
 			aSOFTWARE_INSTALL_STATE[$software_id]=1
 			G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[$software_id]} will be installed"
@@ -2401,7 +2401,7 @@ DietPi-Software will decrypt and use it for software installs. You can change it
 			${aSOFTWARE_INSTALL_STATE[155]} == 1 ||
 			${aSOFTWARE_INSTALL_STATE[169]} == 1 ||
 			${aSOFTWARE_INSTALL_STATE[180]} == 1 ||
-			${aSOFTWARE_INSTALL_STATE[187]} == 1 )); then
+			${aSOFTWARE_INSTALL_STATE[134]} == 1 )); then
 
 			aSOFTWARE_INSTALL_STATE[$software_id]=1
 			G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[$software_id]} will be installed"
@@ -6086,7 +6086,7 @@ If you want to update ${aSOFTWARE_NAME[$software_id]}, please use its internal u
 
 		fi
 		
-		software_id=187 # Docker Compose
+		software_id=134 # Docker Compose
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -6996,13 +6996,6 @@ exec sudo -u $ha_user dash -c '$ha_pyenv_activation; exec pip3 install -U homeas
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-			INSTALL_URL_ADDRESS='https://bootstrap.pypa.io/get-pip.py'
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-			G_AGI python3-dev
-			G_EXEC curl -sSfL "$INSTALL_URL_ADDRESS" -o get-pip.py
-			G_EXEC_OUTPUT=1 G_EXEC python3 ./get-pip.py
-			G_EXEC_NOHALT=1 G_EXEC rm get-pip.py
-			
 			# create piwheels config file for ARMv6 and ARMv7
 			if (( $G_HW_ARCH == 1 || $G_HW_ARCH == 2 )); then
 			 
@@ -7014,6 +7007,14 @@ extra-index-url=https://www.piwheels.org/simple
 
 				fi			
 			fi
+			
+			# Perform pip3 installation
+			INSTALL_URL_ADDRESS='https://bootstrap.pypa.io/get-pip.py'
+			G_CHECK_URL "$INSTALL_URL_ADDRESS"
+			G_AGI python3-dev
+			G_EXEC curl -sSfL "$INSTALL_URL_ADDRESS" -o get-pip.py
+			G_EXEC_OUTPUT=1 G_EXEC python3 ./get-pip.py
+			G_EXEC_NOHALT=1 G_EXEC rm get-pip.py
 		fi
 
 		software_id=150 # Mono runtime
@@ -15295,7 +15296,7 @@ _EOF_
 
 		fi
 		
-		software_id=187 # Docker Compose
+		software_id=134 # Docker Compose
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6092,7 +6092,7 @@ If you want to update ${aSOFTWARE_NAME[$software_id]}, please use its internal u
 			Banner_Installing
 			
 			# Python build dependencies for aarch64
-			(( $G_HW_ARCH == 3 )) && G_AGI make gcc libffi-dev libssl-dev
+			(( $G_HW_ARCH == 3 )) && G_AGI make gcc
 
 			G_EXEC_OUTPUT=1 G_EXEC pip3 install docker-compose
 			

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5736,7 +5736,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 					INSTALL_URL_ADDRESS=$(curl -sf "$INSTALL_URL_ADDRESS" | mawk -F\" '/browser_download_url.*linux\.tar\.gz/{print $4;exit}')
 					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v3.0.1.4259/Radarr.master.3.0.1.4259.linux.tar.gz'
 
-				# ARMv/
+				# ARMv7
 				elif (( $G_HW_ARCH == 2 ))
 				then
 					INSTALL_URL_ADDRESS=$(curl -sf "$INSTALL_URL_ADDRESS" | mawk -F\" '/browser_download_url.*linux-core-arm\.tar\.gz/{print $4;exit}')
@@ -6084,6 +6084,18 @@ If you want to update ${aSOFTWARE_NAME[$software_id]}, please use its internal u
 			G_EXEC_DESC='Running Docker installer' G_EXEC_OUTPUT=1 G_EXEC ./DockerInstall.sh
 			G_EXEC_NOFAIL=1 G_EXEC rm DockerInstall.sh
 
+		fi
+		
+		software_id=187 # Docker Compose
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			
+			# Python build dependencies for aarch64
+			(( $G_HW_ARCH == 3 )) && G_AGI make gcc libffi-dev libssl-dev
+
+			G_EXEC_OUTPUT=1 G_EXEC pip3 install docker-compose
+			
 		fi
 
 		software_id=161 # FuguHub
@@ -6990,7 +7002,18 @@ exec sudo -u $ha_user dash -c '$ha_pyenv_activation; exec pip3 install -U homeas
 			G_EXEC curl -sSfL "$INSTALL_URL_ADDRESS" -o get-pip.py
 			G_EXEC_OUTPUT=1 G_EXEC python3 ./get-pip.py
 			G_EXEC_NOHALT=1 G_EXEC rm get-pip.py
+			
+			# create piwheels config file for ARMv6 and ARMv7
+			if (( $G_HW_ARCH == 1 || $G_HW_ARCH == 2 )); then
+			 
+				if ! [[ -f '/etc/pip.conf' ]]; then				
+				
+					echo '[global]
+extra-index-url=https://www.piwheels.org/simple
+' > /etc/pip.conf
 
+				fi			
+			fi
 		fi
 
 		software_id=150 # Mono runtime
@@ -15271,6 +15294,15 @@ _EOF_
 			fi
 
 		fi
+		
+		software_id=187 # Docker Compose
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
+
+			Banner_Uninstalling
+			
+			G_EXEC_OUTPUT=1 G_EXEC pip3 uninstall -y docker-compose
+			
+		fi
 
 		software_id=164
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
@@ -15774,6 +15806,9 @@ _EOF_
 			Banner_Uninstalling
 			pip3 uninstall -y pip
 			G_AGP python3-pip # Pre-v6.32
+			
+			# Remove piwheels config file
+			[[ -f '/etc/pip.conf' ]] && rm /etc/pip.conf
 
 		fi
 


### PR DESCRIPTION
**Status**: Testing
- [x] implementation
- [x] testing

**Reference**: https://github.com/MichaIng/DietPi/issues/3078

**Commit list/description**:
- DietPi-Software | Docker-Compose: reserve Software ID 187, get ready for further implementation.
- DietPi-Software | Docker-Compose:  Add dependency for Docker and Python (pip)
- DietPi-Software | Docker-Compose: add install and removal process
- DietPi-Software | Python (pip): enable `pipweels` as additional pip repository for ARMv6 and ARMv7
- DietPi-Software | Docker-Compose: removed dependency `libffi-dev` and `libssl-dev` for aarch64/arm64. It is not required for building docker-compose
- DietPi-Software | Python (pip): move `pipweels` installation on top, to be setup first
- DietPi-Software | Docker-Compose: change software ID from 187 to 134