### PR TITLE
Links in dietpi-software changed from phpBB to dietpi.com/docs

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -17094,30 +17094,26 @@ _EOF_
 Welcome to DietPi:
 ───────────────────────────────────────────────────────────────
 Use PageUp/Down or Arrow Up/Down to scroll this help screen.
-Press ESC, or TAB then enter to exit this help screen.\n
+Press ESC, or TAB then ENTER to exit this help screen.\n
 Easy to follow, step by step guides for installing DietPi:
-https://dietpi.com/docs/user-guide_installation/ resp. https://dietpi.com/docs/user-guide_overview/\n
+https://dietpi.com/docs/user-guide_installation/\n
 For a list of all installation options and their details:
-https://dietpi.com/software\n
+https://dietpi.com/docs/dietpi_optimised_software/\n
 ───────────────────────────────────────────────────────────────
-List of installed software and their URL links for online docs:
+List of installed software and their online documentation URLs:
 ───────────────────────────────────────────────────────────────\n'
 
 					# Installed software
 					for i in "${!aSOFTWARE_INSTALL_STATE[@]}"
 					do
 
-						if (( ${aSOFTWARE_INSTALL_STATE[i]} > 0 )) && [[ ${aSOFTWARE_ONLINEDOC_URL[$i]} ]]; then
-
-							string+="\n${aSOFTWARE_NAME[$i]}: ${aSOFTWARE_DESC[$i]}\n$FP_ONLINEDOC_URL${aSOFTWARE_ONLINEDOC_URL[$i]}\n"
-
-						fi
+						(( ${aSOFTWARE_INSTALL_STATE[i]} > 0 )) && [[ ${aSOFTWARE_ONLINEDOC_URL[$i]} ]] || continue
+						string+="\n${aSOFTWARE_NAME[$i]}: ${aSOFTWARE_DESC[$i]}\n$FP_ONLINEDOC_URL${aSOFTWARE_ONLINEDOC_URL[$i]}\n"
 
 					done
 
 					G_WHIP_SIZE_X_MAX=70
 					G_WHIP_MSG "$string"
-					unset string
 
 				;;
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -17106,10 +17106,9 @@ List of installed software and their online documentation URLs:
 					# Installed software
 					for i in "${!aSOFTWARE_INSTALL_STATE[@]}"
 					do
-
+						# shellcheck disable=SC2015
 						(( ${aSOFTWARE_INSTALL_STATE[i]} > 0 )) && [[ ${aSOFTWARE_ONLINEDOC_URL[$i]} ]] || continue
 						string+="\n${aSOFTWARE_NAME[$i]}: ${aSOFTWARE_DESC[$i]}\n$FP_ONLINEDOC_URL${aSOFTWARE_ONLINEDOC_URL[$i]}\n"
-
 					done
 
 					G_WHIP_SIZE_X_MAX=70

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -16553,7 +16553,7 @@ _EOF_
 			if (( ${aSOFTWARE_INSTALL_STATE[68]} == 1 )); then
 
 				G_WHIP_MSG 'Remot3.it requires you to create an online account, and, link it this device.
-\nOnce DietPi has completed your software installations, and rebooted, please follow the First Run tutorial link below:\nhttps://dietpi.com/phpbb/viewtopic.php?p=188#p188'
+\nOnce DietPi has completed your software installations, and rebooted, please follow the First Run tutorial link below:\nhttps://dietpi.com/docs/software/remote_desktop/#remot3it'
 
 			fi
 
@@ -16561,7 +16561,7 @@ _EOF_
 			if (( ${aSOFTWARE_INSTALL_STATE[92]} == 1 )); then
 
 				G_WHIP_MSG 'The DietPi installation of Certbot supports all offered web servers.\n\nOnce the installation has finished, you can setup your free SSL cert with:
- - DietPi-LetsEncrypt\n\nThis is a easy to use frontend for Certbot and allows integration into DietPi systems.\n\nMore information:\n - https://dietpi.com/phpbb/viewtopic.php?p=1062#p1062'
+ - DietPi-LetsEncrypt\n\nThis is a easy to use frontend for Certbot and allows integration into DietPi systems.\n\nMore information:\n - https://dietpi.com/docs/software/system_security/#lets-encrypt'
 
 			fi
 
@@ -16570,7 +16570,7 @@ _EOF_
 			if (( ${aSOFTWARE_INSTALL_STATE[67]} == 1 )); then
 
 				if G_WHIP_YESNO 'No-IP can be setup and configured by using DietPi-Config. Would you like to complete this now?\n\n - Once finished, exit DietPi-Config to resume setup.
-\n - More information:\nhttps://dietpi.com/phpbb/viewtopic.php?p=58#p58'; then
+\n - More information:\nhttps://dietpi.com/docs/software/advanced_networking/#no-ip'; then
 
 					# Write installed states to temp
 					Write_InstallFileList temp
@@ -16819,7 +16819,7 @@ _EOF_
 \n- None: Select this option if you do NOT require a method of accessing files and folders on this device, over a network.
 \n- ProFTPD (Recommended for RPi v1): Allows you to access/share files on this device efficiently with minimal cpu usage. Uses FTP protocol.
 \n- Samba (Recommended for RPi v2): Allows you to easily access/share files on this device, at the cost of higher cpu usage.
-\nMore info: https://dietpi.com/phpbb/viewtopic.php?p=19#p19'; then
+\nMore info: https://dietpi.com/docs/dietpi_tools/#quick-selections'; then
 
 						# Assign target index
 						if [[ $G_WHIP_RETURNED_VALUE == 'None' ]]; then
@@ -16932,7 +16932,7 @@ _EOF_
 
 					G_WHIP_BUTTON_CANCEL_TEXT='Back'
 					if G_WHIP_MENU 'Choose where to store your user data. User data includes software such as ownCloud data store, BitTorrent downloads etc.
-\nMore information on user data in DietPi:\n- https://dietpi.com/phpbb/viewtopic.php?p=2087
+\nMore information on user data in DietPi:\n- https://dietpi.com/docs/dietpi_tools/#quick-selections
 \n- DietPi-Drive_Manager: Launch DietPi-Drive_Manager to setup external drives, and, move user data to different locations.'; then
 
 						# DriveMan
@@ -17004,7 +17004,7 @@ _EOF_
 
 					G_WHIP_DEFAULT_ITEM=$index_webserver_text
 					G_WHIP_BUTTON_CANCEL_TEXT='Back'
-					if G_WHIP_MENU 'Please select a Webserver preference, more info https://dietpi.com/phpbb/viewtopic.php?p=1549#p1549:
+					if G_WHIP_MENU 'Please select a Webserver preference, more info https://dietpi.com/docs/dietpi_tools/#quick-selections:
 \n- Apache2: Feature-rich and popular. Recommended for beginners and users who are looking to follow Apache2 based guides.
 \n- Nginx: Lightweight alternative to Apache2. Nginx claims faster webserver performance compared to Apache2.
 \n- Lighttpd: Extremely lightweight and is generally considered to offer the \"best\" webserver performance for SBCs. Recommended for users who expect low webserver traffic.'; then
@@ -17096,7 +17096,7 @@ Welcome to DietPi:
 Use PageUp/Down or Arrow Up/Down to scroll this help screen.
 Press ESC, or TAB then enter to exit this help screen.\n
 Easy to follow, step by step guides for installing DietPi:
-https://dietpi.com/phpbb/viewtopic.php?f=8&t=9\n
+https://dietpi.com/docs/user-guide_installation/ resp. https://dietpi.com/docs/user-guide_overview/\n
 For a list of all installation options and their details:
 https://dietpi.com/software\n
 ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
**Status**: Ready
- [x] Links in dietpi-software.sh were changed from <https://dietpi.com/phpbb/> to <https://dietpi.com/docs/>.

@MichaIng:
Open point: The mechanism with "readonly FP_ONLINEDOC_URL='https://dietpi.com/phpbb/viewtopic.php?'" (see line 258 in dietpi-software.sh) need also to be changed to direct to dietpi.com/docs instead of phpBB.
