### PR TITLE
DietPi-Software | WiringPi

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4357,6 +4357,8 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
+			
+			[[ -d '/usr/local/bin' ]] || G_EXEC mkdir -p /usr/local/bin
 
 			# RPi
 			if (( $G_HW_MODEL < 10 )); then


### PR DESCRIPTION
There is a need to check for `/usr/local/bin` before running installation of WiringPi as it is targeted directory to install the gpio binary.

**Status**: Ready
- [x] add check

**Reference**: https://dietpi.com/phpbb/viewtopic.php?f=11&t=8609

**Commit list/description**:
- DietPi-Software | WiringPi: add a check for availability of `/usr/local/bin`