### PR TITLE
DietPi-Software | Add Box86 and Docker Compose meta info

### DIFF
--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -464,7 +464,7 @@
 	do
 		aSOFTWARE_NAME6_34[$i]=${aSOFTWARE_NAME6_33[$i]}
 	done
-	aSOFTWARE_NAME6_34[134]='62' # DietPi-CloudShell
+	aSOFTWARE_NAME6_34[62]='62' # DietPi-CloudShell
 	aSOFTWARE_NAME6_34[134]='134' # Tonido
 	aSOFTWARE_NAME6_34[137]='137' # CloudPrint
 	aSOFTWARE_NAME6_34[181]='PaperMC'
@@ -477,9 +477,11 @@
 	aSOFTWARE_NAME6_35=()
 	for i in "${!aSOFTWARE_NAME6_34[@]}"
 	do
-		# shellcheck disable=SC2034
 		aSOFTWARE_NAME6_35[$i]=${aSOFTWARE_NAME6_34[$i]}
 	done
+	aSOFTWARE_NAME6_35[62]='Box86'
+	# shellcheck disable=SC2034
+	aSOFTWARE_NAME6_35[134]='Docker Compose'
 
 	Main(){
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,9 @@ Changes:
 - DietPi-Software | Unbound: On new installs, by default access is now granted to all private IPv4 and IPv6 address ranges instead of to the 192.168.0.0/16 subnet only, which includes VPNs, containers and cases of multiple local networks the server is attached to.
 
 New Software:
+- DietPi-Software | Docker Compose: A tool to define and run multi-container Docker applications can now be installed through our software selection. Docker will be pulled in as dependency automatically.
+- DietPi-Software | Box86: An x86 wrapper/emulator for ARMv7 systems is now available for install. Thanks to it's ability to wrap ARMv7 shared system libraries to be used with i386 binaries, often no additional libraries need to be installed. Thanks to binfmt, it will be invoked automatically when an i386 binary is executed.
+- DietPi-Software | Steam: By automatically pulling in Box86 as dependency, Steam can now be installed on ARMv7 boards. It won't run perfectly stable yet and has limited features and game support, but we're optimistic that further improvements will address this in the future. Check out our documentation about it: https://dietpi.com/docs/software/gaming/#steam
 
 Fixes:
 - DietPi-Set_swapfile | Resolve an issue where "zram"/"zram0" dietpi.txt path entries were dropped, when running the script without input arguments. This especially broke applying zram-swap on first boot. Many thanks to @Dr0bac for reporting this issue: https://github.com/MichaIng/DietPi/issues/4002
@@ -16,6 +19,7 @@ Fixes:
 - DietPi-Software | WiFi Hotspot: Resolved an issue where the install on Armbian-based images with RTL8188C* WiFi chip failed. Many thanks to @smogan71 for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=8523
 - DietPi-Software | Medusa: This software option has been disabled on Stretch systems, since it now requires Python >=3.6, which is not available in the Debian Stretch repository. If you run Medusa on a Stretch system, it will continue to work, but updating will either not be possible or break it. Many thanks to @aermak for reporting this issue: https://github.com/MichaIng/DietPi/issues/3991
 - DietPi-Software | WiringPi: Resolved an issue where the install failed, if the /usr/local/bin directory was not present. Many thanks to @bruz for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=8609
+- DietPi-Software | PaperMC: Resolved an issue where the install failed due to changed download URLs and stabilised service start and config creation by setting the Java heap size and allowing more time for the startup on smaller SBCs. Many thanks to @omavoss for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?p=30191#p30191
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/4XXX
 

--- a/README.md
+++ b/README.md
@@ -288,6 +288,9 @@ Links to hardware and software manufacturers, sources and build instructions use
 - [Docker](https://github.com/docker/docker-ce)
 - [Portainer](https://github.com/portainer/portainer)
 - [Tor](https://gitlab.torproject.org/tpo/core/tor)
+- [Docker Compose](https://github.com/docker/compose)
+- [Box86](https://github.com/ptitSeb/box86)
+- [Steam](https://steamcommunity.com/)
 
 ---
 


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Survey_report | Add Box86 and Docker Compose recognition
+ CHANGELOG | Add Docker Compose, Box86 and Steam on ARM software implementation notes and PaperMC fixes
+ README | Add Docker Compose, Box86 and Steam repo/community URLs