### PR TITLE
DietPi-Software | Migrate documentation URLs

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -251,8 +251,6 @@ _EOF_
 	INDEX_WEBSERVER_CURRENT=-2
 	INDEX_WEBSERVER_TARGET=-2
 
-	readonly FP_ONLINEDOC_URL='https://dietpi.com/phpbb/viewtopic.php?'
-
 	# Available for (need to match highest value in dietpi-obtain_hw_model)
 	readonly MAX_G_HW_MODEL=73
 	readonly MAX_G_HW_ARCH=10
@@ -800,7 +798,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='bittorrent server with web interface (c)'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=46#p46'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#transmission'
 		#------------------
 		software_id=45
 
@@ -808,7 +806,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='bittorrent server with web interface (python)'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=61#p61'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#deluge'
 		#------------------
 		software_id=46
 
@@ -824,7 +822,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='bittorrent server with rutorrent web interface'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=2603#p2603'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#rtorrent'
 		aSOFTWARE_REQUIRES_WEBSERVER[$software_id]=1
 		aSOFTWARE_REQUIRES_PHP[$software_id]=1
 		#------------------
@@ -834,7 +832,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Automatic Video Library Manager for TV Shows'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=3327#p3327'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#medusa'
 		# - Stretch: Python 3 > 3.5 only: https://github.com/pymedusa/Medusa#dependencies
 		aSOFTWARE_AVAIL_G_DISTRO[$software_id,4]=0
 		#------------------
@@ -844,7 +842,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='download manager with web interface'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=6177#p6177'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#arias'
 		aSOFTWARE_REQUIRES_WEBSERVER[$software_id]=1
 		aSOFTWARE_REQUIRES_PHP[$software_id]=1
 		aSOFTWARE_REQUIRES_SQLITE[$software_id]=1
@@ -855,7 +853,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='nzb download manager'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=6747#p6747'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#sabnzbd'
 		# Pre-compiling required on ARM
 		(( $G_HW_ARCH > 9 )) || aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
 		#------------------
@@ -865,7 +863,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='automatically download movies'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=7212#p7212'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#couchpotato'
 		aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
 		aSOFTWARE_REQUIRES_GIT[$software_id]=1
 		# Python 2 only, hence not supported on Bullseye
@@ -877,7 +875,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='automatically download TV shows'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=7455#p7455'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#sonarr'
 		aSOFTWARE_REQUIRES_SQLITE[$software_id]=1
 		#------------------
 		software_id=145
@@ -886,7 +884,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='automatically download movies'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=7457#p7457'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#radarr'
 		aSOFTWARE_REQUIRES_SQLITE[$software_id]=1
 		#------------------
 		software_id=106
@@ -895,7 +893,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='automatically download music'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=13580#p13580'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#lidarr'
 		aSOFTWARE_REQUIRES_SQLITE[$software_id]=1
 		#------------------
 		software_id=180
@@ -904,7 +902,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='automatically download subtitles'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=27577#p27577'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#bazarr'
 		aSOFTWARE_REQUIRES_GIT[$software_id]=1
 		# FFmpeg required on ARM, x86_64 binaries are shipped with the Bazarr repo: https://github.com/morpheus65535/bazarr/tree/master/bin/Linux
 		# build-essential required on ARM to assure all required Python modules build successfully: https://github.com/MichaIng/DietPi/pull/3796#issuecomment-706768323
@@ -918,7 +916,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='API support for your torrent trackers'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=7503#p7503'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#jackett'
 		#------------------
 		software_id=149
 
@@ -926,7 +924,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='nzb download manager'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=7575#p7575'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#nzbget'
 		#------------------
 		software_id=155
 
@@ -934,7 +932,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='manage your HTPC from anywhere'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=8043#p8043'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#htpc-manager'
 		aSOFTWARE_REQUIRES_GIT[$software_id]=1
 		aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
 
@@ -946,7 +944,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='File sync, sharing and collaboration platform'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=47#p47'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#owncloud'
 		aSOFTWARE_REQUIRES_WEBSERVER[$software_id]=1
 		aSOFTWARE_REQUIRES_PHP[$software_id]=1
 		aSOFTWARE_REQUIRES_MYSQL[$software_id]=1
@@ -957,7 +955,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='File sync, sharing and collaboration platform'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=3026#p3026'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#nextcloud'
 		aSOFTWARE_REQUIRES_WEBSERVER[$software_id]=1
 		aSOFTWARE_REQUIRES_PHP[$software_id]=1
 		aSOFTWARE_REQUIRES_MYSQL[$software_id]=1
@@ -968,7 +966,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Video calls with configured coTURN server'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=15227#p15227'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#nextcloud-talk'
 		# Currently requires manual domain and coTURN server port input.
 		# - To resolve: Default port 5349 could be used, but reliable method to get external domain/static IP is required.
 		aSOFTWARE_REQUIRES_USERINPUT[$software_id]=1
@@ -979,7 +977,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='feature-rich backup and sync server'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1064#p1064'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#pydio'
 		aSOFTWARE_REQUIRES_WEBSERVER[$software_id]=1
 		aSOFTWARE_REQUIRES_PHP[$software_id]=1
 		aSOFTWARE_REQUIRES_MYSQL[$software_id]=1
@@ -990,7 +988,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='full system backup server'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=65#p65'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#urbackup'
 		# - ARMv6
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
 		#------------------
@@ -1000,7 +998,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='personal github server with web interface'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=2187#p2187'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#gogs'
 		aSOFTWARE_REQUIRES_GIT[$software_id]=1
 		aSOFTWARE_REQUIRES_MYSQL[$software_id]=1
 		#------------------
@@ -1010,7 +1008,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='backup and sync server with web interface'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=2363#p2363'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#syncthing'
 		#------------------
 		software_id=158
 
@@ -1018,7 +1016,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='S3 compatible distributed object server'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=9121#p9121'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#minio'
 		#------------------
 		software_id=161
 
@@ -1026,6 +1024,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Lightweight WebDAV cloud (eg: dropbox) with a CMS'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#fuguhub'
 		# - ARMv8
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,3]=0
 		#------------------
@@ -1035,7 +1034,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Git with a cup of tea'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=9863#p9863'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#gitea'
 		aSOFTWARE_REQUIRES_GIT[$software_id]=1
 		aSOFTWARE_REQUIRES_MYSQL[$software_id]=1
 		#------------------
@@ -1045,7 +1044,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Sync bookmarks, tabs, history & passwords'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=24713#p24713'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#firefox-sync-server'
 		aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
 		aSOFTWARE_REQUIRES_SQLITE[$software_id]=1
 		# - Bullseye: python(2)-virtualenv not available (yet): https://packages.debian.org/python-virtualenv
@@ -1057,7 +1056,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Unofficial Bitwarden password manager server written in Rust'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=28903#p28903'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#bitwarden_rs'
 		aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
 		aSOFTWARE_REQUIRES_SQLITE[$software_id]=1
 
@@ -1069,7 +1068,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Optimised Amiga emulator for ARM-based SoCs'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=5
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=64#p64'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/gaming/#amiberry'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		# RPi only
 		for ((i=10; i<=$MAX_G_HW_MODEL; i++))
@@ -1087,7 +1086,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='a classic retro game, addictive'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=5
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=45#p45'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/gaming/#opentyrian'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		aSOFTWARE_REQUIRES_XSERVERXORG[$software_id]=1
 		# RPi only
@@ -1104,7 +1103,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Descent 1/2'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=5
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=2963#p2963'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/gaming/#dxx-rebirth'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		# RPi only
 		for ((i=10; i<=$MAX_G_HW_MODEL; i++))
@@ -1118,7 +1117,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Minecraft server with web interface (C++)'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=5
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=2068#p2068'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/gaming/#cuberite'
 		# - ARMv8
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,3]=0
 		#------------------
@@ -1128,7 +1127,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Minecraft servers with web interface (Java/Node.js)'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=5
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=2069#p2069'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/gaming/#mineos'
 		aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
 		aSOFTWARE_REQUIRES_GIT[$software_id]=1
 		aSOFTWARE_REQUIRES_JAVA_JRE_JDK[$software_id]=1
@@ -1140,7 +1139,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Valve gaming platform client'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=5
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=8016#p8016'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/gaming/#steam'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		aSOFTWARE_REQUIRES_XSERVERXORG[$software_id]=1
 		aSOFTWARE_REQUIRES_DESKTOP[$software_id]=1
@@ -1154,7 +1153,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='A nuclear-powered server for Minecraft Pocket Edition'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=5
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=10675#p10675'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/gaming/#nukkit'
 		aSOFTWARE_REQUIRES_JAVA_JRE_JDK[$software_id]=1
 		#------------------
 		software_id=181
@@ -1163,7 +1162,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Highly optimised Minecraft server with plugins, written in Java'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=5
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=28177#p28177'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/gaming/#papermc'
 		aSOFTWARE_REQUIRES_JAVA_JRE_JDK[$software_id]=1
 		aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
 		aSOFTWARE_REQUIRES_USERINPUT[$software_id]=1
@@ -1175,7 +1174,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='x86 userspace emulation'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=5
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=0#p0'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/gaming/#box86'
 		aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
 		# Only works on ARMv7
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
@@ -1190,7 +1189,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='bulletin board forum software'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=6
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=51#p51'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/social/#phpbb'
 		aSOFTWARE_REQUIRES_WEBSERVER[$software_id]=1
 		aSOFTWARE_REQUIRES_PHP[$software_id]=1
 		aSOFTWARE_REQUIRES_MYSQL[$software_id]=1
@@ -1201,7 +1200,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='website blog and publishing platform'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=6
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=395#p395'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/social/#wordpress'
 		aSOFTWARE_REQUIRES_WEBSERVER[$software_id]=1
 		aSOFTWARE_REQUIRES_PHP[$software_id]=1
 		aSOFTWARE_REQUIRES_MYSQL[$software_id]=1
@@ -1212,7 +1211,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='self-hosted RSS feed aggregator'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=6
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=13918#p13918'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/social/#freshrss'
 		aSOFTWARE_REQUIRES_WEBSERVER[$software_id]=1
 		aSOFTWARE_REQUIRES_PHP[$software_id]=1
 		aSOFTWARE_REQUIRES_MYSQL[$software_id]=1
@@ -1223,7 +1222,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='website to host and browse your images'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=6
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=480#p480'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/social/#single-file-php-gallery'
 		aSOFTWARE_REQUIRES_WEBSERVER[$software_id]=1
 		aSOFTWARE_REQUIRES_PHP[$software_id]=1
 		#------------------
@@ -1233,7 +1232,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='lightweight caldav + carddav server'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=6
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1502#p1502'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/social/#baikal'
 		aSOFTWARE_REQUIRES_WEBSERVER[$software_id]=1
 		aSOFTWARE_REQUIRES_PHP[$software_id]=1
 		aSOFTWARE_REQUIRES_MYSQL[$software_id]=1
@@ -1244,7 +1243,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='decentralised peer to peer bitcoin market'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=6
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1796#p1796'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/social/#openbazaar'
 		aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
 		aSOFTWARE_REQUIRES_GIT[$software_id]=1
 		aSOFTWARE_REQUIRES_USERINPUT[$software_id]=1
@@ -1255,7 +1254,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='decentralised open source search engine'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=6
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=6202#p6202'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/social/#yacy'
 		aSOFTWARE_REQUIRES_JAVA_JRE_JDK[$software_id]=1
 
 		# Camera & Surveillance
@@ -1266,7 +1265,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='web interface & controls for your rpi camera'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=7
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=48#p48'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/camera/#rpi-cam-control'
 		aSOFTWARE_REQUIRES_WEBSERVER[$software_id]=1
 		aSOFTWARE_REQUIRES_PHP[$software_id]=1
 		# RPi only
@@ -1281,7 +1280,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='web interface & surveillance for your camera'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=7
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=6610#p6610'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/camera/#motioneye'
  		aSOFTWARE_REQUIRES_FFMPEG[$software_id]=1
 		aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
 		# Python 2 only, hence not supported on Bullseye
@@ -1295,7 +1294,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='web interface system stats'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=8
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=108#p108'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/system_stats/#linuxdash'
 		aSOFTWARE_REQUIRES_WEBSERVER[$software_id]=1
 		aSOFTWARE_REQUIRES_PHP[$software_id]=1
 		#------------------
@@ -1305,7 +1304,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='web interface system stats'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=8
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=451#p451'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/system_stats/#phpsysinfo'
 		aSOFTWARE_REQUIRES_WEBSERVER[$software_id]=1
 		aSOFTWARE_REQUIRES_PHP[$software_id]=1
 		#------------------
@@ -1315,7 +1314,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='real-time performance monitoring'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=8
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1611#p1611'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/system_stats/#netdata'
 		# Node.js only required for our custom v1.11 package for Stretch ARMv6 RPi
 		(( $G_HW_ARCH == 1 && $G_DISTRO < 5 )) && aSOFTWARE_REQUIRES_NODEJS[$software_id]=1
 		#------------------
@@ -1325,7 +1324,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='web interface system stats'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=8
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1503#p1503'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/system_stats/#rpi-monitor'
 		# RPi only
 		for ((i=10; i<=$MAX_G_HW_MODEL; i++))
 		do
@@ -1338,7 +1337,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='web interface system management'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=8
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=3047#p3047'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/system_stats/#webmin'
 		#------------------
 		software_id=162
 
@@ -1346,7 +1345,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Build, ship, and run distributed applications'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=8
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=9120#p9120'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/programming/#docker'
 		# - Bullseye: https://download.docker.com/linux/debian/dists/
 		aSOFTWARE_AVAIL_G_DISTRO[$software_id,6]=0
 		#------------------
@@ -1356,7 +1355,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Simplifies container management in Docker (standalone host)'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=8
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=29377#p29377'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/programming/#portainer'
 		# - Bullseye
 		aSOFTWARE_AVAIL_G_DISTRO[$software_id,6]=0
 		#------------------
@@ -1366,7 +1365,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Tool to defining and run multi-container Docker applications'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=8
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=xxx#pxxx'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/programming/#docker-compose'
 		# - Bullseye: https://download.docker.com/linux/debian/dists/
 		aSOFTWARE_AVAIL_G_DISTRO[$software_id,6]=0
 
@@ -1378,7 +1377,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='(Weaved) access your device over the internet'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=9
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=188#p188'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/remote_desktop/#remot3it'
 		#------------------
 		software_id=138
 
@@ -1386,7 +1385,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='server: share USB devices over the network'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=9
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=6709#p6709'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/remote_desktop/#virtualhere'
 
 		# Hardware Projects
 		#--------------------------------------------------------------------------------
@@ -1396,7 +1395,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='gpio interface library for rpi (python)'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1065#p1065'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#rpigpio'
 		# RPi only
 		for ((i=10; i<=$MAX_G_HW_MODEL; i++))
 		do
@@ -1409,7 +1408,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='gpio interface library (c)'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1066#p1066'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#wiringpi'
 		aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
 		# RPi + Odroids only
 		for ((i=20; i<=$MAX_G_HW_MODEL; i++))
@@ -1425,7 +1424,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='web interface to control rpi.gpio'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=189#p189'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#webiopi'
 		aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
 		# RPi1/2/Zero only
 		for ((i=3; i<=$MAX_G_HW_MODEL; i++))
@@ -1451,7 +1450,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='pisupply ups'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=10740#p10740'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#pijuice'
 		# RPi only
 		for ((i=10; i<=$MAX_G_HW_MODEL; i++))
 		do
@@ -1464,7 +1463,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='tool for wiring devices, APIs and online services'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=4292#p4292'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#node-red'
 		aSOFTWARE_REQUIRES_NODEJS[$software_id]=1
 		aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
 		#------------------
@@ -1474,7 +1473,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='MQTT messaging broker'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=4293#p4293'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#mosquitto'
 		#------------------
 		software_id=131
 
@@ -1482,7 +1481,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='msg controller for blynk mobile app and sbcs'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=5901#p5901'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#blynk-server'
 		aSOFTWARE_REQUIRES_JAVA_JRE_JDK[$software_id]=1
 		aSOFTWARE_REQUIRES_NODEJS[$software_id]=1
 		aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
@@ -1493,7 +1492,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='audiophonics pi-spc power control module'
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
 		aSOFTWARE_TYPE[$software_id]=0
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=9359#p9359'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#audiophonics-pi-spc'
 		# RPi only
 		for ((i=10; i<=$MAX_G_HW_MODEL; i++))
 		do
@@ -1506,7 +1505,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='voice kit'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=9486#p9486'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#google-aiy'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
  		aSOFTWARE_REQUIRES_GIT[$software_id]=1
 		# RPi only
@@ -1521,7 +1520,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Open Source Voice Assistant'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=18562#p18562'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#mycroft-ai'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
  		aSOFTWARE_REQUIRES_GIT[$software_id]=1
 		aSOFTWARE_REQUIRES_USERINPUT[$software_id]=1
@@ -1532,7 +1531,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='time-series database'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=12523#p12523'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#influxdb'
 		#------------------
 		software_id=77
 
@@ -1540,7 +1539,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='platform for analytics and monitoring'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=12524#p12524'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#grafana'
 
 		# System Security
 		#--------------------------------------------------------------------------------
@@ -1550,7 +1549,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='prevents brute-force attacks with ip ban'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=11
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=452#p452'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/system_security/#fail2ban'
 
 		# Webserver Stacks
 		#--------------------------------------------------------------------------------
@@ -1560,7 +1559,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='apache2  | sqlite  | php'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=12
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=52#p52'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/webserver_stack/#lasp-web-stack'
 		#------------------
 		software_id=76
 
@@ -1568,7 +1567,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='apache2  | mariadb | php'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=12
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=52#p52'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/webserver_stack/#lamp-web-stack'
 		#------------------
 		software_id=78
 
@@ -1576,7 +1575,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='nginx    | sqlite  | php'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=12
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=53#p53'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/webserver_stack/#lesp-web-stack'
 		#------------------
 		software_id=79
 
@@ -1584,7 +1583,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='nginx    | mariadb | php'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=12
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=53#p53'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/webserver_stack/#lemp-web-stack'
 		#------------------
 		software_id=81
 
@@ -1592,7 +1591,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='lighttpd | sqlite  | php'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=12
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1335#p1335'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/webserver_stack/#llsp-web-stack'
 		#------------------
 		software_id=82
 
@@ -1600,7 +1599,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='lighttpd | mariadb | php'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=12
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1335#p1335'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/webserver_stack/#llmp-web-stack'
 		#------------------
 		software_id=83
 
@@ -1608,7 +1607,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='webserver'
 		aSOFTWARE_TYPE[$software_id]=-1
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=12
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=52#p52'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/webserver_stack/#apache2'
 		aSOFTWARE_REQUIRES_PHP[$software_id]=1
 		#------------------
 		software_id=84
@@ -1617,7 +1616,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='webserver'
 		aSOFTWARE_TYPE[$software_id]=-1
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=12
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1335#p1335'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/webserver_stack/#lighttpd'
 		aSOFTWARE_REQUIRES_PHP[$software_id]=1
 		#------------------
 		software_id=85
@@ -1626,7 +1625,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='webserver'
 		aSOFTWARE_TYPE[$software_id]=-1
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=12
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=53#p53'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/webserver_stack/#nginx'
 		aSOFTWARE_REQUIRES_PHP[$software_id]=1
 		#------------------
 		software_id=87
@@ -1635,7 +1634,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='database'
 		aSOFTWARE_TYPE[$software_id]=-1
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=12
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1335#p1335'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/webserver_stack/#sqlite'
 		#------------------
 		software_id=88
 
@@ -1643,7 +1642,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='database'
 		aSOFTWARE_TYPE[$software_id]=-1
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=12
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1335#p1335'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/webserver_stack/#mariadb'
 		#------------------
 		software_id=89
 
@@ -1651,7 +1650,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Hypertext Preprocessor for dynamic web content'
 		aSOFTWARE_TYPE[$software_id]=-1
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=12
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1335#p1335'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/webserver_stack/#php'
 		#------------------
 		software_id=90
 
@@ -1659,7 +1658,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='optional mysql admin tools'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=12
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=54#p54'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/webserver_stack/#phpmyadmin'
 		aSOFTWARE_REQUIRES_WEBSERVER[$software_id]=1
 		aSOFTWARE_REQUIRES_MYSQL[$software_id]=1
 		aSOFTWARE_REQUIRES_PHP[$software_id]=1
@@ -1670,6 +1669,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='optional non-sql database store'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=12
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/webserver_stack/#redis'
 		#------------------
 		software_id=92
 
@@ -1677,7 +1677,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]="Obtain and renew Let's Encrypt SSL certs for HTTPS"
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=12
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1062#p1062'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/system_security/#lets-encrypt'
 		#------------------
 		software_id=125
 
@@ -1685,7 +1685,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='apache tomcat server'
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=12
 		aSOFTWARE_TYPE[$software_id]=0
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=4316#p4316'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/webserver_stack/#tomcat'
 		aSOFTWARE_REQUIRES_JAVA_JRE_JDK[$software_id]=1
 		# - non-Raspbian Buster: https://packages.debian.org/tomcat8
 		(( $G_HW_MODEL > 9 )) || (( ! $G_RASPBIAN )) && aSOFTWARE_AVAIL_G_DISTRO[$software_id,5]=0 aSOFTWARE_AVAIL_G_DISTRO[$software_id,6]=0
@@ -1698,7 +1698,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='block adverts for any device on your network'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=13
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=174#p174'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/dns_servers/#pi-hole'
 		aSOFTWARE_REQUIRES_GIT[$software_id]=1
 		aSOFTWARE_REQUIRES_WEBSERVER[$software_id]=1
 		aSOFTWARE_REQUIRES_PHP[$software_id]=1
@@ -1711,7 +1711,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='validating, recursive, caching DNS resolver'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=13
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=28779#p28779'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/dns_servers/#unbound'
 
 		# File Servers
 		#--------------------------------------------------------------------------------
@@ -1721,7 +1721,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='lightweight ftp server'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=14
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=55#p55'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/file_servers/#proftpd'
 		#------------------
 		software_id=95
 
@@ -1729,7 +1729,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='alternative ftp server'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=14
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=2820#p2820'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/file_servers/#vsftpd'
 		#------------------
 		software_id=96
 
@@ -1737,7 +1737,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='feature-rich file server'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=14
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=56#p56'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/file_servers/#samba'
 		#------------------
 		software_id=109
 
@@ -1745,7 +1745,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='network file system server'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=14
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=2821#p2821'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/file_servers/#nfs'
 
 		# VPN
 		#--------------------------------------------------------------------------------
@@ -1755,7 +1755,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='vpn server'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=15
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=613#p613'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/vpn/#openvpn'
 		#------------------
 		software_id=172
 
@@ -1763,7 +1763,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='an extremely simple yet fast and modern VPN'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=15
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=16308#p16308'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/vpn/#wireguard'
 		# Required to ask for public domain/IP and desired VPN server port
 		aSOFTWARE_REQUIRES_USERINPUT[$software_id]=1
 		# RPi/Odroids/x86_64 only
@@ -1790,7 +1790,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='openvpn/wireguard server install & management tool'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=15
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=3469#p3469'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/vpn/#pivpn'
 		aSOFTWARE_REQUIRES_USERINPUT[$software_id]=1
 		aSOFTWARE_REQUIRES_GIT[$software_id]=1
 		aSOFTWARE_RECOMMENDS_AUTOMATED_UPGRADES[$software_id]=1
@@ -1801,7 +1801,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='vpn client with connection gui'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=15
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p15975#p15975'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/vpn/#dietpi-nordvpn'
 
 		# Advanced Networking
 		#--------------------------------------------------------------------------------
@@ -1811,7 +1811,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='turn your device into a wifi hotspot'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=16
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1207#p1207'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/advanced_networking/#wifi-hotspot'
 		#------------------
 		software_id=61
 
@@ -1819,7 +1819,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='optional: route hotspot traffic through tor'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=16
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1529#p1529'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/advanced_networking/#tor-hotspot'
 		#------------------
 		software_id=67
 
@@ -1827,7 +1827,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Dynamic DNS update client'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=16
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=58#p58'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/advanced_networking/#no-ip'
 		#------------------
 		software_id=98
 
@@ -1835,7 +1835,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='high performance tcp/http load balancer'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=16
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=221#p221'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/advanced_networking/#haproxy'
 		aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
 		#------------------
 		software_id=184
@@ -1844,7 +1844,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='add a node to the Tor network'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=16
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=29381#p29381'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/advanced_networking/#tor-relay'
 		aSOFTWARE_RECOMMENDS_AUTOMATED_UPGRADES[$software_id]=1
 		aSOFTWARE_REQUIRES_USERINPUT[$software_id]=1
 
@@ -1856,7 +1856,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='energy usage addon board with web interface'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=17
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1525#p1525'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/home_automation/#emonpi'
 		# RPi only
 		for ((i=10; i<=$MAX_G_HW_MODEL; i++))
 		do
@@ -1871,7 +1871,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='open-source home automation platform'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=17
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=70#p70'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/home_automation/#home-assistant'
 		#------------------
 		software_id=140
 
@@ -1879,7 +1879,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='open-source home automation platform'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=17
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=23065#p23065'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/home_automation/#domoticz'
 		#------------------
 		software_id=27
 
@@ -1887,7 +1887,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Website to manage ESP8266 devices flashed with Tasmota'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=17
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=20584#p20584'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/home_automation/#tasmoadmin'
 		aSOFTWARE_REQUIRES_WEBSERVER[$software_id]=1
 		aSOFTWARE_REQUIRES_PHP[$software_id]=1
 
@@ -1899,7 +1899,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='web interface for controlling 3d printers'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=18
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=7958#p7958'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/printing/#octoprint'
 		aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
 
 		# Computational Science
@@ -1910,7 +1910,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='distributed disease research project'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=19
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=13704#p13704'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/computational_science/#foldinghome'
 		# - ARMv6 - ARMv7
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,2]=0
@@ -1967,21 +1967,21 @@ _EOF_
 		software_id=5
 
 		aSOFTWARE_NAME[$software_id]='ALSA'
-		aSOFTWARE_DESC[$software_id]='linux sound system'
+		aSOFTWARE_DESC[$software_id]='Advanced Linux Sound Architecture'
 		aSOFTWARE_TYPE[$software_id]=1
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
 		#------------------
 		software_id=6
 
-		aSOFTWARE_NAME[$software_id]='Xserver'
-		aSOFTWARE_DESC[$software_id]='linux display system'
+		aSOFTWARE_NAME[$software_id]='X.Org X Server'
+		aSOFTWARE_DESC[$software_id]='aka X11 - X Window System implementation'
 		aSOFTWARE_TYPE[$software_id]=1
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
 		#------------------
 		software_id=151
 
 		aSOFTWARE_NAME[$software_id]='Nvidia'
-		aSOFTWARE_DESC[$software_id]='display driver'
+		aSOFTWARE_DESC[$software_id]='Proprietary display driver for Nvidia graphics cards'
 		aSOFTWARE_TYPE[$software_id]=1
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
 		aSOFTWARE_REQUIRES_XSERVERXORG[$software_id]=1
@@ -1997,21 +1997,21 @@ _EOF_
 		software_id=7
 
 		aSOFTWARE_NAME[$software_id]='FFmpeg'
-		aSOFTWARE_DESC[$software_id]='audio & visual libary'
+		aSOFTWARE_DESC[$software_id]='Audio & video codec libary and programs'
 		aSOFTWARE_TYPE[$software_id]=1
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
 		#------------------
 		software_id=8
 
 		aSOFTWARE_NAME[$software_id]='Java'
-		aSOFTWARE_DESC[$software_id]='OpenJDK + JRE libary'
+		aSOFTWARE_DESC[$software_id]='OpenJDK runtime environment and development kit'
 		aSOFTWARE_TYPE[$software_id]=1
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
 		#------------------
 		software_id=9
 
 		aSOFTWARE_NAME[$software_id]='Node.js'
-		aSOFTWARE_DESC[$software_id]='javascript runtime'
+		aSOFTWARE_DESC[$software_id]='JavaScript runtime environment'
 		aSOFTWARE_TYPE[$software_id]=1
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
 		#------------------
@@ -2032,7 +2032,7 @@ _EOF_
 		software_id=126
 
 		aSOFTWARE_NAME[$software_id]='LibSSL1.0.0'
-		aSOFTWARE_DESC[$software_id]='backwards compatibility (stretch, buster, bullseye)'
+		aSOFTWARE_DESC[$software_id]='for backwards compatibility on Stretch, Buster and Bullseye'
 		aSOFTWARE_TYPE[$software_id]=1
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
 
@@ -2092,14 +2092,14 @@ _EOF_
 		software_id=16
 
 		aSOFTWARE_NAME[$software_id]='Build-Essentials'
-		aSOFTWARE_DESC[$software_id]='common packages for compile'
+		aSOFTWARE_DESC[$software_id]='common packages for compiling'
 		aSOFTWARE_TYPE[$software_id]=1
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=6
 		#------------------
 		software_id=17
 
 		aSOFTWARE_NAME[$software_id]='Git Client'
-		aSOFTWARE_DESC[$software_id]='git clone etc'
+		aSOFTWARE_DESC[$software_id]='Clone and manage Git repositories locally'
 		aSOFTWARE_TYPE[$software_id]=1
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=6
 		#------------------
@@ -2155,7 +2155,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='cross-platform, free rss reader'
 		aSOFTWARE_TYPE[$software_id]=1
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=8
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=2075#p2075'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/desktop/#quiterss'
 		aSOFTWARE_REQUIRES_DESKTOP[$software_id]=1
 
 		#--------------------------------------------------------------------------------
@@ -2167,7 +2167,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='rotates log files'
 		aSOFTWARE_TYPE[$software_id]=-1
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=0
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=68#p68'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/log_system/#full-logging'
 		#------------------
 		software_id=102
 
@@ -2175,7 +2175,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='system logging'
 		aSOFTWARE_TYPE[$software_id]=-1
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=0
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=68#p68'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/log_system/#full-logging'
 		#------------------
 		software_id=103
 
@@ -2183,7 +2183,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='minimal, optimised logging'
 		aSOFTWARE_TYPE[$software_id]=-1
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=0
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=68#p68'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/log_system/#dietpi-ramlog'
 
 		#--------------------------------------------------------------------------------
 		# SSH Servers (hidden)
@@ -2194,7 +2194,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Lightweight SSH server'
 		aSOFTWARE_TYPE[$software_id]=-1
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=0
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=62#p62'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/ssh/#dropbear'
 		#------------------
 		software_id=105
 
@@ -2202,7 +2202,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Feature-rich SSH server with SFTP and SCP support'
 		aSOFTWARE_TYPE[$software_id]=-1
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=0
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=63#p63'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/ssh/#openssh'
 
 		#--------------------------------------------------------------------------------
 		# Init install state for defined software
@@ -16343,7 +16343,7 @@ _EOF_
 				fi
 
 				# - Online docs
-				[[ ${aSOFTWARE_ONLINEDOC_URL[$i]} ]] && string+=" | \e[90m$FP_ONLINEDOC_URL${aSOFTWARE_ONLINEDOC_URL[$i]}\e[0m"
+				[[ ${aSOFTWARE_ONLINEDOC_URL[$i]} ]] && string+=" | \e[90m${aSOFTWARE_ONLINEDOC_URL[$i]}\e[0m"
 
 				# - Convert string to lowercase
 				echo -e "${string,,}"
@@ -17253,9 +17253,8 @@ List of installed software and their online documentation URLs:
 					# Installed software
 					for i in "${!aSOFTWARE_INSTALL_STATE[@]}"
 					do
-						# shellcheck disable=SC2015
-						(( ${aSOFTWARE_INSTALL_STATE[i]} > 0 )) && [[ ${aSOFTWARE_ONLINEDOC_URL[$i]} ]] || continue
-						string+="\n${aSOFTWARE_NAME[$i]}: ${aSOFTWARE_DESC[$i]}\n$FP_ONLINEDOC_URL${aSOFTWARE_ONLINEDOC_URL[$i]}\n"
+						[[ ${aSOFTWARE_INSTALL_STATE[i]} -gt 0 && ${aSOFTWARE_ONLINEDOC_URL[$i]} ]] || continue
+						string+="\n${aSOFTWARE_NAME[$i]}: ${aSOFTWARE_DESC[$i]}\n${aSOFTWARE_ONLINEDOC_URL[$i]}\n"
 					done
 
 					G_WHIP_SIZE_X_MAX=70

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -328,7 +328,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='ultra lightweight desktop'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=0
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=42#p42'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/desktop/#lxde'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		aSOFTWARE_REQUIRES_XSERVERXORG[$software_id]=1
 		#------------------
@@ -338,7 +338,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='lightweight desktop'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=0
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=17712#p17712'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/desktop/#lxqt'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		aSOFTWARE_REQUIRES_XSERVERXORG[$software_id]=1
 		#------------------
@@ -348,7 +348,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='desktop enviroment'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=0
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=2073#p2073'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/desktop/#mate'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		aSOFTWARE_REQUIRES_XSERVERXORG[$software_id]=1
 		#------------------
@@ -358,7 +358,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='lightweight desktop'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=0
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=2203#p2203'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/desktop/#xfce'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		aSOFTWARE_REQUIRES_XSERVERXORG[$software_id]=1
 		#------------------
@@ -368,7 +368,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='lightweight desktop based on OpenStep'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=0
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=2072#p2072'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/desktop/#gnustep'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		aSOFTWARE_REQUIRES_XSERVERXORG[$software_id]=1
 		#------------------
@@ -378,7 +378,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='web browser for desktop or autostart'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=0
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=3011#p3011'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/desktop/#chromium'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		aSOFTWARE_REQUIRES_XSERVERXORG[$software_id]=1
 		#------------------
@@ -388,15 +388,16 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='mspaint on steroids'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=0
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=17713#p17713'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/desktop/#gimp'
 		aSOFTWARE_REQUIRES_XSERVERXORG[$software_id]=1
 		#------------------
  		software_id=175
 
- 		aSOFTWARE_NAME[$software_id]='Xfce4 Power'
- 		aSOFTWARE_DESC[$software_id]='power manager with brightness (recommended for LXDE/LXQt)'
+ 		aSOFTWARE_NAME[$software_id]='Xfce Power Manager'
+ 		aSOFTWARE_DESC[$software_id]='power manager with brightness control (recommended for LXDE/LXQt)'
  		aSOFTWARE_TYPE[$software_id]=0
  		aSOFTWARE_CATEGORY_INDEX[$software_id]=0
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/desktop/#xfce-power-manager'
  		aSOFTWARE_REQUIRES_XSERVERXORG[$software_id]=1
 
 		# Remote Desktop
@@ -407,7 +408,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='desktop for remote connection'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=1
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=408#p408'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/remote_desktop/#tigervnc-server'
 		aSOFTWARE_REQUIRES_DESKTOP[$software_id]=1
 		#------------------
 		software_id=29
@@ -416,7 +417,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='remote desktop protocol (rdp) server'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=1
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=2074#p2074'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/remote_desktop/#xrdp'
 		aSOFTWARE_REQUIRES_DESKTOP[$software_id]=1
 		#------------------
 		software_id=30
@@ -425,7 +426,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='multi-platform server and client access'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=1
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=2071#p2071'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/remote_desktop/#nomachine'
 		aSOFTWARE_REQUIRES_DESKTOP[$software_id]=1
 		#------------------
 		software_id=120
@@ -434,7 +435,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='desktop for remote connection'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=1
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=4149#p4149'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/remote_desktop/#realvnc-server'
 		aSOFTWARE_REQUIRES_DESKTOP[$software_id]=1
 		# RPi only (archive.raspberrypi.org repo, libraspberrypi dependency, license)
 		for ((i=10; i<=$MAX_G_HW_MODEL; i++))
@@ -450,7 +451,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='the media centre for linux'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=43#p43'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#kodi'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		# Odroid N2+C4 have not GPU support for Xserver, hence it's not required for Kodi
 		[[ $G_HW_MODEL == 1[56] ]] || aSOFTWARE_REQUIRES_XSERVERXORG[$software_id]=1
@@ -475,7 +476,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='lightweight web interface music player for mpd'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=50#p50'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#ympd'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		#------------------
 		software_id=148
@@ -484,7 +485,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='fork of ympd with improved features'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=13978#p13978'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#mympd'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
 		#------------------
@@ -494,7 +495,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='optional: console audio vis for mpd'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=3928#p3928'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#cava'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		#------------------
 		software_id=33
@@ -503,7 +504,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='web interface media streaming server'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=11280#p11280'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#airsonic'
 		aSOFTWARE_REQUIRES_JAVA_JRE_JDK[$software_id]=1
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		aSOFTWARE_REQUIRES_FFMPEG[$software_id]=1
@@ -514,7 +515,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='web interface media streaming server'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=213#p213'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#subsonic'
 		aSOFTWARE_REQUIRES_JAVA_JRE_JDK[$software_id]=1
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		aSOFTWARE_REQUIRES_FFMPEG[$software_id]=1
@@ -528,7 +529,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='aka LMS, Squeezebox Server, SqueezeCenter, SlimServer'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1009#p1009'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#logitech-media-server'
 		#------------------
 		software_id=36
 
@@ -545,7 +546,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='airplay audio player with multiroom sync'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1221#p1221'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#shairport-sync'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		#------------------
 		software_id=39
@@ -554,7 +555,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='(MiniDLNA) media streaming server (dlna, upnp)'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=49#p49'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#readymedia'
 		#------------------
 		software_id=40
 
@@ -562,7 +563,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='web interface media streaming server'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=554#p554'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#ampache'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		aSOFTWARE_REQUIRES_GIT[$software_id]=1
 		aSOFTWARE_REQUIRES_FFMPEG[$software_id]=1
@@ -572,11 +573,11 @@ _EOF_
 		#------------------
 		software_id=41
 
-		aSOFTWARE_NAME[$software_id]='Emby Server'
+		aSOFTWARE_NAME[$software_id]='Emby'
 		aSOFTWARE_DESC[$software_id]='web interface media streaming server'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1789#p1789'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#emby'
 		# - ARMv6: https://github.com/MichaIng/DietPi/issues/534#issuecomment-416405968
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
 		#------------------
@@ -586,7 +587,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='web interface media streaming server'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1949#p1949'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#plex-media-server'
 		# - ARMv6: https://github.com/MichaIng/DietPi/issues/648
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
 		#------------------
@@ -596,7 +597,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='mumble voip server'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1691#p1691'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#murmur'
 		#------------------
 		software_id=118
 
@@ -613,7 +614,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Turns device into Roon capable audio player'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=4153#p4153'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#roon-bridge'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		# - ARMv6
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
@@ -624,7 +625,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='signalyst network audio adaptor (naa)'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=4294#p4294'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#naa-daemon'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		#------------------
 		software_id=128
@@ -641,7 +642,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='feature-rich, web interface audio player for mpd'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=5171#p5171'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#ompd'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		aSOFTWARE_REQUIRES_WEBSERVER[$software_id]=1
 		aSOFTWARE_REQUIRES_PHP[$software_id]=1
@@ -653,7 +654,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Shoutcast streaming server (+DarkIce)'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=6526#p6526'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#icecast'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		# - VM
 		aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,20]=0
@@ -664,7 +665,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='web interface for spotify premium'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=7013#p7013'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#spotify-connect-web'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		# ARMv7 only
 		for ((i=1; i<=$MAX_G_HW_ARCH; i++))
@@ -679,7 +680,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='web interface audio streamer'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=7305#p7305'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#koel'
 		aSOFTWARE_REQUIRES_PHP[$software_id]=1
  		aSOFTWARE_REQUIRES_MYSQL[$software_id]=1
 		aSOFTWARE_REQUIRES_NODEJS[$software_id]=1
@@ -694,7 +695,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='monitoring and tracking tool for Plex'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=7463#p7463'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#tautulli'
  		aSOFTWARE_REQUIRES_GIT[$software_id]=1
 		#------------------
 		software_id=154
@@ -703,7 +704,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Roon capable audio player and core'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=7966#p7966'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#roon-server'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		aSOFTWARE_REQUIRES_FFMPEG[$software_id]=1
 		# x86_64 only
@@ -719,7 +720,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='web interface'
 		aSOFTWARE_TYPE[$software_id]=-1
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='t=2317'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/phpbb/viewtopic.php?t=2317'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		aSOFTWARE_REQUIRES_WEBSERVER[$software_id]=1
 		aSOFTWARE_REQUIRES_PHP[$software_id]=1
@@ -738,7 +739,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Resource efficient UPnP/DLNA renderer'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=9012#p9012'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#gmediarender'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		#------------------
 		software_id=167
@@ -747,7 +748,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='spotify connect client'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=9368#p9368'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#raspotify'
 		aSOFTWARE_REQUIRES_ALSA[$software_id]=1
 		# - ARMv8 - x86_64
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,3]=0
@@ -759,7 +760,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='free home server for your comics and ebooks library'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=12969#p12969'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#ubooquity'
 		aSOFTWARE_REQUIRES_JAVA_JRE_JDK[$software_id]=1
 		#------------------
 		software_id=179
@@ -768,7 +769,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Free and open source comics/mangas media server with web UI'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=26858#p26858'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#komga'
 		aSOFTWARE_REQUIRES_JAVA_JRE_JDK[$software_id]=1
 		#------------------
 		software_id=86
@@ -777,7 +778,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='Manage extensions from within Roon'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=13160#p13160'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#roon-extension-manager'
 		aSOFTWARE_REQUIRES_GIT[$software_id]=1
 		aSOFTWARE_REQUIRES_NODEJS[$software_id]=1
 		#------------------
@@ -787,7 +788,7 @@ _EOF_
 		aSOFTWARE_DESC[$software_id]='FOSS web interface media streaming server'
 		aSOFTWARE_TYPE[$software_id]=0
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=26255#p26255'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#jellyfin'
 		# - ARMv6: https://github.com/jellyfin/jellyfin/issues/5011
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
 


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Software | Migrate documentation URLs shown by dietpi-software to our new documentation site and add a few missing URLs: https://dietpi.com/docs/
+ DietPi-Software | Xfce Power Manager: Rename it so that it matches how the name is shown within its GUI
+ DietPi-Software | X.Org X Server: Rename it to include the actual implementation we install
+ DietPi-Software | Rephrase or extend a few software descriptions, which were a bit short or nor precise