### PR TITLE
DietPi-Software | Domoticz

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6723,8 +6723,8 @@ exec sudo -u $ha_user dash -c '$ha_pyenv_activation; exec pip3 install -U homeas
 		fi
 
 		software_id=181 # PaperMC
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 ))
-		then
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+		
 			Banner_Installing
 
 			# Make sure user agrees to the EULA
@@ -6749,6 +6749,8 @@ exec sudo -u $ha_user dash -c '$ha_pyenv_activation; exec pip3 install -U homeas
 
 		software_id=140 # Domoticz
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+		
+			Banner_Installing
 
 			# APT deps
 			DEPS_LIST='libusb-0.1 libcurl3-gnutls'
@@ -12715,6 +12717,9 @@ _EOF_
 
 			# Permissions
 			chown -R domoticz:domoticz /opt/domoticz /mnt/dietpi_userdata/domoticz
+			
+			# Move script directoty to userdata location
+			G_EXEC cp -a /opt/domoticz/scripts /mnt/dietpi_userdata/domoticz/
 
 			# Service
 			cat << '_EOF_' > /etc/systemd/system/domoticz.service

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11297,7 +11297,7 @@ _EOF_
 			# - Deprecated commands:
 			#	https://github.com/rakshasa/rtorrent/wiki/rTorrent-0.9-Comprehensive-Command-list-(WIP)
 			#	https://github.com/rakshasa/rtorrent/blob/master/doc/scripts/update_commands_0.9.sed
-			mkdir -p /mnt/dietpi_userdata/rtorrent
+			G_EXEC mkdir -p /mnt/dietpi_userdata/rtorrent
 			[[ -f '/mnt/dietpi_userdata/rtorrent/.rtorrent.rc' ]] || cat << _EOF_ > /mnt/dietpi_userdata/rtorrent/.rtorrent.rc
 ### Miscellaneous settings
 #system.daemon.set = true
@@ -12692,13 +12692,15 @@ _EOF_
 		software_id=140 # Domoticz: https://www.domoticz.com/wiki/Linux
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
+			Banner_Configuration
+
 			# Data dir
-			mkdir -p /mnt/dietpi_userdata/domoticz
+			G_EXEC mkdir -p /mnt/dietpi_userdata/domoticz
 
 			# Config file
 			if [[ ! -f '/mnt/dietpi_userdata/domoticz/domoticz.conf' ]]; then
 
-				cp /opt/domoticz/scripts/domoticz.conf /mnt/dietpi_userdata/domoticz/domoticz.conf
+				G_EXEC cp /opt/domoticz/scripts/domoticz.conf /mnt/dietpi_userdata/domoticz/domoticz.conf
 				G_CONFIG_INJECT 'http_port=' 'http_port=8124' /mnt/dietpi_userdata/domoticz/domoticz.conf
 				G_CONFIG_INJECT 'ssl_port=' 'ssl_port=8424' /mnt/dietpi_userdata/domoticz/domoticz.conf
 				G_CONFIG_INJECT 'ssl_cert=' 'ssl_cert=/opt/domoticz/server_cert.pem' /mnt/dietpi_userdata/domoticz/domoticz.conf
@@ -12716,9 +12718,9 @@ _EOF_
 			Create_User -G dialout -d /mnt/dietpi_userdata/domoticz domoticz
 
 			# Permissions
-			chown -R domoticz:domoticz /opt/domoticz /mnt/dietpi_userdata/domoticz
+			G_EXEC chown -R domoticz:domoticz /opt/domoticz /mnt/dietpi_userdata/domoticz
 			
-			# Move script directoty to userdata location
+			# Copy scripts directory to data dir: https://dietpi.com/phpbb/viewtopic.php?t=8627
 			G_EXEC cp -a /opt/domoticz/scripts /mnt/dietpi_userdata/domoticz/
 
 			# Service
@@ -12726,7 +12728,7 @@ _EOF_
 [Unit]
 Description=Domoticz (DietPi)
 Wants=network-online.target
-After=network-online.target
+After=network-online.target dietpi-boot.service
 
 [Service]
 User=domoticz
@@ -15320,6 +15322,7 @@ _EOF_
 				rm -R /etc/systemd/system/domoticz.service*
 
 			fi
+			[[ -d '/etc/systemd/system/domoticz.service.d' ]] && rm -R /etc/systemd/system/domoticz.service.d
 			getent passwd domoticz > /dev/null && userdel domoticz
 			getent group domoticz > /dev/null && groupdel domoticz
 			[[ -d '/opt/domoticz' ]] && rm -R /opt/domoticz
@@ -15331,13 +15334,14 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			# Remove systemd unit
+			# Remove service
 			if [[ -f '/etc/systemd/system/gitea.service' ]]; then
 
 				systemctl disable --now gitea
 				rm -R /etc/systemd/system/gitea.service*
 
 			fi
+			[[ -d '/etc/systemd/system/gitea.service.d' ]] && rm -R /etc/systemd/system/gitea.service.d
 
 			# Delete data
 			[[ -d '/mnt/dietpi_userdata/gitea' ]] && rm -R /mnt/dietpi_userdata/gitea
@@ -15360,6 +15364,7 @@ _EOF_
 				rm -R /etc/systemd/system/pi-spc.service*
 
 			fi
+			[[ -d '/etc/systemd/system/pi-spc.service.d' ]] && rm -R /etc/systemd/system/pi-spc.service.d
 			rm -R /var/lib/dietpi/dietpi-software/installed/pi-spc
 
 			sed -i '/^[[:blank:]]*dtoverlay=gpio-shutdown/d' /boot/config.txt


### PR DESCRIPTION
Script directory needs to be moved to userdata location, otherwise it is not possible to save customer scripts as well as templates are missing

**Status**: Ready 

- [x] update `dietpi-software`

**Reference**: https://dietpi.com/forum/t/domoticz-cannot-save-scripts/4945

**Commit list/description**:
- DietPi-Software | Domoticz - Move script directoty to userdata location
