### PR TITLE
DietPi-CloudShell | Fix and simplify obtaining Pi-hole stats

### DIFF
--- a/dietpi/dietpi-cloudshell
+++ b/dietpi/dietpi-cloudshell
@@ -696,11 +696,13 @@
 		# Exit if connection fails
 		>&3 || return 3
 
-		# Get last blocked domain
-		echo '>recentBlocked' >&3
-		PIHOLE_LAST_DOMAIN_BLOCKED=$(<&3)
+		# Ask FTL for last blocked domain and to quit when finished
+		echo '>recentBlocked >quit' >&3
+		# Read last blocked domain, allowing 1 second timeout
+		read -r -t 1 PIHOLE_LAST_DOMAIN_BLOCKED <&3
 
-		# Ask FTL for stats and to quit when finished
+		# Re-establish connection, then ask FTL for stats and to quit when finished
+		exec 3<>"/dev/tcp/127.0.0.1/$port"
 		echo '>stats >quit' >&3
 
 		# Read output, allowing 1 second timeout per line, exit on empty string when connection is closed
@@ -725,7 +727,7 @@
 		exec 3<&-
 
 		# Calculate percentage of blocked queries and convert to graph
-		Percent_To_Graph $(( $PIHOLE_TOTAL_ADS * 100 / $PIHOLE_QUERY_COUNT ))
+		Percent_To_Graph $(( $PIHOLE_QUERY_COUNT ? $PIHOLE_TOTAL_ADS * 100 / $PIHOLE_QUERY_COUNT : 0 ))
 		PIHOLE_PERCENT_ADS=$C_PERCENT_GRAPH
 
 	}
@@ -1020,7 +1022,7 @@
 		local first_line=" $BANNER_PRINT"
 
 		# Update data, print warning if it fails
-		Obtain_PIHOLE || first_line="${aCOLOUR[1]}$C_REVERSE Updating data failed!    "
+		Obtain_PIHOLE || first_line="${aCOLOUR[1]}$C_REVERSE Updating data failed! ($?)"
 
 		# Clear screen
 		clear
@@ -1100,7 +1102,7 @@ _EOF_
 		#--------------------------------------------------------------------------------
 		# Check and disable scenes if software is not installed:
 		# - 8 Pi-hole
-		[[ -f '/etc/pihole/gravity.list' ]] || aEnabledScenes[8]=0
+		command -v pihole-FTL > /dev/null || aEnabledScenes[8]=0
 		# - 9 Tor Relay
 		command -v tor > /dev/null && command -v nyx > /dev/null || aEnabledScenes[9]=0
 

--- a/dietpi/dietpi-cloudshell
+++ b/dietpi/dietpi-cloudshell
@@ -682,19 +682,19 @@
 		# - https://docs.pi-hole.net/ftldns/telnet-api/
 
 		# Exit if Pi-hole FTL is not running
-		[[ -f '/run/pihole-FTL.port' ]] || return 1
+		[[ -f '/run/pihole-FTL.port' ]] || { first_line="${aCOLOUR[1]}$C_REVERSE Pi-hole not yet started  "; return; }
 
 		# Get FTL port
 		local port=$(</run/pihole-FTL.port)
 
 		# Exit if no valid integer contained
-		(( $port )) || return 2
+		(( $port )) || { first_line="${aCOLOUR[1]}$C_REVERSE Pi-hole has stopped      "; return; }
 
 		# Establish connection / Create file descriptors
      		exec 3<>"/dev/tcp/127.0.0.1/$port"
 
 		# Exit if connection fails
-		>&3 || return 3
+		>&3 || { first_line="${aCOLOUR[1]}$C_REVERSE Pi-hole connection failed"; return; }
 
 		# Ask FTL for last blocked domain and to quit when finished
 		echo '>recentBlocked >quit' >&3
@@ -1019,10 +1019,9 @@
 	# Pi-hole
 	Update_Scene_8(){
 
+		# Update data, replace first output line with error message in case of failure
 		local first_line=" $BANNER_PRINT"
-
-		# Update data, print warning if it fails
-		Obtain_PIHOLE || first_line="${aCOLOUR[1]}$C_REVERSE Updating data failed! ($?)"
+		Obtain_PIHOLE
 
 		# Clear screen
 		clear

--- a/dietpi/dietpi-cloudshell
+++ b/dietpi/dietpi-cloudshell
@@ -690,20 +690,21 @@
 		# Exit if no valid integer contained
 		(( $port )) || return 2
 
-		# Exit if connector foes not exist
-		[[ -e /dev/tcp/127.0.0.1/$port ]] || return 3
-
 		# Establish connection / Create file descriptors
      		exec 3<>"/dev/tcp/127.0.0.1/$port"
 
 		# Exit if connection fails
-		>&3 || return 4
+		>&3 || return 3
+
+		# Get last blocked domain
+		echo '>recentBlocked' >&3
+		PIHOLE_LAST_DOMAIN_BLOCKED=$(<&3)
 
 		# Ask FTL for stats and to quit when finished
-		echo '>stats >recentBlocked >quit' >&3
+		echo '>stats >quit' >&3
 
 		# Read output, allowing 1 second timeout per line, exit on empty string when connection is closed
-		while read -r -t 1 line <&3 && [[ $line || -t 3 ]]
+		while read -r -t 1 line && [[ $line || -t 3 ]]
 		do
 			if [[ $line == 'domains_being_blocked '* ]]
 			then
@@ -716,13 +717,8 @@
 			elif [[ $line == 'ads_blocked_today '* ]]
 			then
 				PIHOLE_TOTAL_ADS=${line#* }
-
-			# If the line does not contain a free space, it's the last blocked domain
-			elif [[ $line != *' '* ]]
-			then
-				PIHOLE_LAST_DOMAIN_BLOCKED=$line
 			fi
-		done
+		done <&3
 
 		# Close connection / Remove file descriptors
 		exec 3>&-

--- a/dietpi/dietpi-cloudshell
+++ b/dietpi/dietpi-cloudshell
@@ -24,13 +24,13 @@
 	G_INIT
 	# Import DietPi-Globals --------------------------------------------------------------
 
-	# Grab Input (valid interger)
-	disable_error=1 G_CHECK_VALIDINT "$1" && INPUT=$1 || INPUT=0
+	# Grab valid input
+	[[ $1 == [12] ]] && INPUT=$1 || INPUT=0
 
 	# Version
-	readonly DIETPI_CLOUDSHELL_VERSION=10
+	readonly DIETPI_CLOUDSHELL_VERSION=11
 
-	# /tmp/.* files used throughout this script.
+	# Temporary file used throughout the script
 	readonly FP_TMP='.tmp'
 
 	BLANK_SCREEN_ACTIVE=0
@@ -38,7 +38,7 @@
 	BLANK_SCREEN_TIME_HOUR_START=0
 	BLANK_SCREEN_TIME_HOUR_END=0
 
-	# This will only work if dietpi-cloudshell was started by autostart (login script), as the setterm power options can only be applied when the command originates from the same terminal (no redirects).
+	# This will only work if dietpi-cloudshell was started via dietpi-autostart/dietpi-login, as the setterm power options can only be applied when the command originates from the same terminal without redirects.
 	RUN_BLANK_SCREEN_AT_SPECIFIC_TIME(){
 
 		local current_hour=$(date +%-H)
@@ -272,7 +272,7 @@
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Obtain Stat Data
 	#/////////////////////////////////////////////////////////////////////////////////////
-	TEMPERATURE_CONVERSION_VALUE=0
+	TEMPERATURE_CONVERSION_VALUE=
 	Obtain_Temperature_Conversion(){
 
 		if (( $TEMPERATURE_OUTPUT_TYPE == 0 )); then
@@ -288,41 +288,14 @@
 
 	}
 
-	DATE_TIME=0
+	DATE_TIME=
 	Obtain_DATE_TIME(){ DATE_TIME=$(date +"%a %x - %R"); }
 
-	UPTIME=0
+	UPTIME=
 	Obtain_UPTIME(){
 
-		local fSeconds=$(mawk '{print $1}' /proc/uptime)
-
-		local seconds=${fSeconds%.*}
-		local minutes=0
-		local hours=0
-		local days=0
-
-		while (( $seconds >= 60 )); do
-
-			((minutes++))
-			seconds=$(( $seconds - 60 ))
-
-		done
-
-		while (( $minutes >= 60 )); do
-
-			((hours++))
-			minutes=$(( $minutes - 60 ))
-
-		done
-
-		while (( $hours >= 24 )); do
-
-			((days++))
-			hours=$(( $hours - 24 ))
-
-		done
-
-		UPTIME="Uptime: $days Day, $hours Hour"
+		local seconds=$(mawk -F\. '{print $1}' /proc/uptime)
+		UPTIME="Uptime: $(( $seconds / 86400 )) Day, $(( $seconds % 86400 / 3600)) Hour"
 
 	}
 
@@ -428,9 +401,9 @@
 
 		# df will endless hang when NFS server is down: https://github.com/MichaIng/DietPi/issues/395
 		# - So lets run it as another thread so we can kill it if it hangs.
-		local df_failed=0
-		rm $FP_TMP
-		df -Ph > $FP_TMP &
+		local df_failed=0 pid
+		[[ -f $FP_TMP ]] && rm $FP_TMP
+		df -Ph > $FP_TMP & pid=$!
 
 		# - Wait X seconds before terminating the df thread
 		local max_seconds=4
@@ -443,13 +416,9 @@
 
 				G_DIETPI-NOTIFY 1 'DF failed, unable to obtain drive data'
 				sleep 2
-
-				killall -w df
-
+				kill $pid
 				df_failed=1
-
 				echo -e "$(date) | df failed to respond" >> /var/log/dietpi-cloudshell.log
-
 				break
 
 			else
@@ -700,54 +669,68 @@
 
 	}
 
-	# PI-HOLE STATS!
+	# Pi-hole stats
 	PIHOLE_QUERY_COUNT=0
 	PIHOLE_TOTAL_ADS=0
-	PIHOLE_PERCENT_ADS=0
+	PIHOLE_PERCENT_ADS=
 	PIHOLE_TOTAL_DOMAINS=0
-	PIHOLE_LAST_DOMAIN_BLOCKED=0
+	PIHOLE_LAST_DOMAIN_BLOCKED=
 	Obtain_PIHOLE(){
 
-		local pihole_log_file='/var/log/pihole.log'
+		# Pi-hole FTL API:
+		# - https://github.com/pi-hole/pi-hole/blob/development/advanced/Scripts/chronometer.sh
+		# - https://docs.pi-hole.net/ftldns/telnet-api/
 
-		# Lets pull the total number of blocked domains only once during 1st run, its quite cpu intensive.
-		if (( $PIHOLE_TOTAL_DOMAINS == 0 )); then
+		# Exit if Pi-hole FTL is not running
+		[[ -f '/run/pihole-FTL.port' ]] || return 1
 
-			if [[ -f '/etc/pihole/gravity.list' ]]; then
+		# Get FTL port
+		local port=$(</run/pihole-FTL.port)
 
-				PIHOLE_TOTAL_DOMAINS=$(wc -l /etc/pihole/gravity.list | mawk '{print $1}')
+		# Exit if no valid integer contained
+		(( $port )) || return 2
 
-			else
+		# Exit if connector foes not exist
+		[[ -e /dev/tcp/127.0.0.1/$port ]] || return 3
 
-				PIHOLE_TOTAL_DOMAINS='Not Installed'
+		# Establish connection / Create file descriptors
+     		exec 3<>"/dev/tcp/127.0.0.1/$port"
 
+		# Exit if connection fails
+		>&3 || return 4
+
+		# Ask FTL for stats and to quit when finished
+		echo '>stats >recentBlocked >quit' >&3
+
+		# Read output, allowing 1 second timeout per line, exit on empty string when connection is closed
+		while read -r -t 1 line <&3 && [[ $line || -t 3 ]]
+		do
+			if [[ $line == 'domains_being_blocked '* ]]
+			then
+				PIHOLE_TOTAL_DOMAINS=${line#* }
+
+			elif [[ $line == 'dns_queries_today '* ]]
+			then
+				PIHOLE_QUERY_COUNT=${line#* }
+
+			elif [[ $line == 'ads_blocked_today '* ]]
+			then
+				PIHOLE_TOTAL_ADS=${line#* }
+
+			# If the line does not contain a free space, it's the last blocked domain
+			elif [[ $line != *' '* ]]
+			then
+				PIHOLE_LAST_DOMAIN_BLOCKED=$line
 			fi
+		done
 
-		fi
+		# Close connection / Remove file descriptors
+		exec 3>&-
+		exec 3<&-
 
-		local today=$(date +'%b %e')
-
-		PIHOLE_QUERY_COUNT=$(grep "$today" $pihole_log_file | mawk '/query/{print $7}' | wc -l)
-		# Prevent / 0 on percentage
-		(( $PIHOLE_QUERY_COUNT > 0 )) || PIHOLE_QUERY_COUNT=1
-
-		PIHOLE_TOTAL_ADS=$(grep "$today" $pihole_log_file | mawk '/\/etc\/pihole\/gravity.list/{print $7}' | wc -l)
-		PIHOLE_PERCENT_ADS=$(echo | mawk "{print $PIHOLE_TOTAL_ADS / $PIHOLE_QUERY_COUNT * 100}")
-
-		# Convert to interger and graph it
-		Percent_To_Graph "$PIHOLE_PERCENT_ADS"
+		# Calculate percentage of blocked queries and convert to graph
+		Percent_To_Graph $(( $PIHOLE_TOTAL_ADS * 100 / $PIHOLE_QUERY_COUNT ))
 		PIHOLE_PERCENT_ADS=$C_PERCENT_GRAPH
-
-		# Get last blocked domain
-		if (( $PIHOLE_TOTAL_ADS == 0 )); then
-
-			PIHOLE_LAST_DOMAIN_BLOCKED='None'
-
-		else
-
-			PIHOLE_LAST_DOMAIN_BLOCKED=$(tac /var/log/pihole.log | mawk '/gravity.list/{print $6;exit}' | cut -c 1-24 )
-
-		fi
 
 	}
 
@@ -1038,14 +1021,16 @@
 	# Pi-hole
 	Update_Scene_8(){
 
-		# Update data
-		Obtain_PIHOLE
+		local first_line=" $BANNER_PRINT"
+
+		# Update data, print warning if it fails
+		Obtain_PIHOLE || first_line="${aCOLOUR[1]}$C_REVERSE Updating data failed!    "
 
 		# Clear screen
 		clear
 
 		# Banner
-		echo -e "$C_RESET $BANNER_PRINT"
+		echo -e "$C_RESET$first_line"
 		echo -e "$C_RESET${aCOLOUR[$USER_COLOUR_INDEX]}$C_REVERSE Pi-hole stats (TODAY):   "
 		echo -e "$C_RESET${aCOLOUR[$USER_COLOUR_INDEX]} Ads Blocked: $C_RESET$PIHOLE_TOTAL_ADS"
 		echo -e "$C_RESET${aCOLOUR[$USER_COLOUR_INDEX]} DNS Queries: $C_RESET$PIHOLE_QUERY_COUNT"


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-CloudShell | Fix and simplify obtaining Pi-hole stats, by asking FTL via it's TCP port API directly, instead of querying any logs or database files manually. This matches the method how Pi-hole's Chronometer and PADD are doing it: https://github.com/pi-hole/pi-hole/blob/development/advanced/Scripts/chronometer.sh, https://docs.pi-hole.net/ftldns/telnet-api/
+ DietPi-CloudShell | Massively simplify uptime estimation: Instead of looping through each minute, then each hour, then each day, calculate hours and days in a single step
+ DietPi-CloudShell | When obtaining drive data hangs, do not killall df executions but be more specific by storing the PID and killing the exact process only
+ DietPi-CloudShell | Do not initialise variables with "0" when they are not aimed to be integers