### PR TITLE
DietPi-Software | Fix and enhance GitHub URL/version auto-detection

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,6 +26,7 @@ Fixes:
 - DietPi-Software | PaperMC: Resolved an issue where the install failed due to changed download URLs and stabilised service start and config creation by setting the Java heap size and allowing more time for the startup on smaller SBCs. Many thanks to @omavoss for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?p=30191#p30191
 - DietPi-Software | OpenTyrian: The install option has been disabled on x86_64, since the Debian package comes with a different file structure and it has been disabled on 64-bit RPi systems, since the binary has been compiled for armhf.
 - DietPi-Software | Domoticz: Resolved an issue where saving custom scripts and starting with a template did not work. Many thanks to @tec13 for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=8627
+- DietPi-Software | Resolved an issue where for ruTorrent, Koel and Bitwarden_RS the automatic newest version detection failed and instead a possibly older fallback was used. Many thanks to @kelvmod for reporting this issue: https://github.com/MichaIng/DietPi/issues/4105
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/4XXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3015,6 +3015,7 @@ _EOF_
 
 		fi
 
+		# shellcheck disable=SC2154
 		(( $no_check_url )) || G_CHECK_URL "$url"
 
 		G_EXEC cd /tmp/$G_PROGRAM_NAME # Failsafe

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2985,7 +2985,23 @@ _EOF_
 	# NB: This does not support installs that require user input (eg: a whiptail prompt for deb installs)
 	Download_Install(){
 
-		local url=${1:-$fallback_url}
+		# Verify input URL
+		if [[ $1 ]]
+		then
+			local url=$1
+
+		elif [[ $fallback_url ]]
+		then
+			G_DIETPI-NOTIFY 1 "Automatic latest ${aSOFTWARE_NAME[$software_id]} download URL detection failed."
+			G_DIETPI-NOTIFY 1 "\"$fallback_url\" will be used as fallback, but a newer version might be available."
+			G_DIETPI-NOTIFY 1 'Please report this at: https://github.com/MichaIng/DietPi/issues'
+			local url=$fallback_url
+
+		else
+			G_DIETPI-NOTIFY 1 "An empty download URL was passed during ${aSOFTWARE_NAME[$software_id]} install. Please report this at: https://github.com/MichaIng/DietPi/issues"
+			return 1
+		fi
+
 		local target=$2 # Target path
 		local file=${url##*/} # Grab file name from URL
 		local type=${file##*.} # Grab file type from file name to special handle deb|zip|tar(.gz|.bz2)|tgz|tbz2|7z
@@ -3514,16 +3530,14 @@ Package: openssl libssl*\nPin: origin packages.sury.org\nPin-Priority: -1' > /et
 
 			# Quick install: https://docs.phpmyadmin.net/en/latest/setup.html#quick-install
 			# - Get latest version name
-			INSTALL_URL_ADDRESS='https://api.github.com/repos/phpmyadmin/phpmyadmin/releases/latest'
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-			local version=$(curl -sf "$INSTALL_URL_ADDRESS" | grep -m1 '^[[:blank:]]*"name":' | cut -d \" -f 4)
-			local fallback_url='https://files.phpmyadmin.net/phpMyAdmin/5.0.4/phpMyAdmin-5.0.4-english.tar.gz'
+			local version=$(curl -sSfL 'https://api.github.com/repos/phpmyadmin/phpmyadmin/releases/latest' | mawk -F\" '/"name": /{print $4}')
+			[[ $version ]] || { version='5.0.4'; G_DIETPI-NOTIFY 1 "Automatic latest ${aSOFTWARE_NAME[$software_id]} version detection failed. Version \"$version\" will be installed as fallback, but a newer version might be available. Please report this at: https://github.com/MichaIng/DietPi/issues"; }
 			Download_Install "https://files.phpmyadmin.net/phpMyAdmin/$version/phpMyAdmin-$version-english.tar.gz"
 			# - Reinstall: Clean install but preserve existing config file
 			[[ -f '/var/www/phpmyadmin/config.inc.php' ]] && G_EXEC mv /var/www/phpmyadmin/config.inc.php phpMyAdmin-*-english/
 			G_EXEC rm -Rf /var/www/phpmyadmin # Include pre-v6.27 symlink: https://github.com/MichaIng/DietPi/issues/3304
 			# - Remove GUI setup: https://docs.phpmyadmin.net/en/latest/setup.html#securing-your-phpmyadmin-installation
-			rm -R phpMyAdmin-*-english/setup
+			G_EXEC_NOHALT=1 G_EXEC rm -R phpMyAdmin-*-english/setup
 			# - Move new instance in place
 			G_EXEC mv phpMyAdmin-*-english /var/www/phpmyadmin
 
@@ -4396,10 +4410,8 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-			INSTALL_URL_ADDRESS='https://api.github.com/repos/airsonic/airsonic/releases/latest'
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 			local fallback_url='https://github.com/airsonic/airsonic/releases/download/v10.6.2/airsonic.war'
-			no_check_url=1 Download_Install "$(curl -sSfL "$INSTALL_URL_ADDRESS" | mawk -F\" '/browser_download_url.*\.war"/{print $4}')" /mnt/dietpi_userdata/airsonic/airsonic.war
+			Download_Install "$(curl -sSfL 'https://api.github.com/repos/airsonic/airsonic/releases/latest' | mawk -F\" '/"browser_download_url": .*\/airsonic\.war"/{print $4}')" /mnt/dietpi_userdata/airsonic/airsonic.war
 
 		fi
 
@@ -4416,8 +4428,6 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-			INSTALL_URL_ADDRESS='https://api.github.com/repos/remoteit/installer/releases/latest'
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			# ARMv6/7
 			local arch='armhf'
@@ -4434,9 +4444,8 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 
 			fi
 
-			INSTALL_URL_ADDRESS=$(curl -sf "$INSTALL_URL_ADDRESS" | grep -m1 "browser_download_url.*connectd_.*_$arch\.deb" | cut -d \" -f 4)
 			local fallback_url="https://github.com/remoteit/installer/releases/download/v2.5.38/connectd_2.5.38_$arch.deb"
-			no_check_url=1 Download_Install "$INSTALL_URL_ADDRESS"
+			Download_Install "$(curl -sSfL 'https://api.github.com/repos/remoteit/installer/releases/latest' | grep "\"browser_download_url\": .*/connectd_[^\"/]*_$arch\.deb\"" | cut -d \" -f 4)"
 
 		fi
 
@@ -4538,18 +4547,11 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://api.github.com/repos/blynkkk/blynk-server/releases/latest'
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-
 			# On Stretch and ARMv6 (RPi 1/Zero) use Java 8, else most current
-			local java='[^a].' # Exclude "a" from jav[a]8 but allow "8" as this can be from version string
-			(( $G_DISTRO < 5 || G_HW_ARCH == 1 )) && java='java8'
-			INSTALL_URL_ADDRESS=$(curl -sf "$INSTALL_URL_ADDRESS" | grep -m1 "browser_download_url.*$java\.jar" | cut -d \" -f 4)
+			local fallback_url='https://github.com/blynkkk/blynk-server/releases/download/v0.41.15/server-0.41.15.jar' java=
+			(( $G_DISTRO < 5 || G_HW_ARCH == 1 )) && fallback_url='https://github.com/blynkkk/blynk-server/releases/download/v0.41.15/server-0.41.15-java8.jar' java='-java8'
 
-			local fallback_url='https://github.com/blynkkk/blynk-server/releases/download/v0.41.14/server-0.41.14.jar'
-			(( $G_DISTRO < 5 || G_HW_ARCH == 1 )) && fallback_url='https://github.com/blynkkk/blynk-server/releases/download/v0.41.14/server-0.41.14-java8.jar'
-
-			DEPS_LIST='python' no_check_url=1 Download_Install "$INSTALL_URL_ADDRESS" /mnt/dietpi_userdata/blynk/blynkserver.jar
+			DEPS_LIST='python' Download_Install "$(curl -sSfL 'https://api.github.com/repos/blynkkk/blynk-server/releases/latest' | grep "\"browser_download_url\": .*/server-[0-9.]*$java\.jar\"" | cut -d \" -f 4)" /mnt/dietpi_userdata/blynk/blynkserver.jar
 
 			# Install Blynk JS libary
 			npm i -g --unsafe-perm onoff
@@ -4584,7 +4586,7 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 			# Get latest version: No Bullseye packages available yet
 			local distro=$G_DISTRO_NAME
 			(( $G_DISTRO > 5 )) && distro='buster'
-			local package=$(curl -sSfL "$url/$distro/" | sed -n "/networkaudiod_.*_$arch.deb/{s/^[^\"]*\"//;s/\".*$//p}" | tail -1)
+			local package=$(curl -sSfL "$url/$distro/" | sed -n "/href=\"networkaudiod_[^\"]*_$arch.deb\"/{s/^[^\"]*\"//;s/\".*$//p}" | tail -1)
 
 			# Check final URL before applying debconf settings
 			G_CHECK_URL "$url/$distro/$package"
@@ -4852,12 +4854,8 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-
-			INSTALL_URL_ADDRESS='https://api.github.com/repos/gotson/komga/releases/latest'
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-
-			local fallback_url='https://github.com/gotson/komga/releases/download/v0.64.6/komga-0.64.6.jar'
-			no_check_url=1 Download_Install "$(curl -sf "$INSTALL_URL_ADDRESS" | mawk -F\" '/"browser_download_url": .*komga-[0-9.]*\.jar/{print $4;quit}')" /mnt/dietpi_userdata/komga/komga.jar
+			local fallback_url='https://github.com/gotson/komga/releases/download/v0.69.2/komga-0.69.2.jar'
+			Download_Install "$(curl -sSfL 'https://api.github.com/repos/gotson/komga/releases/latest' | mawk -F\" '/"browser_download_url": .*\/komga-[^"\/]*\.jar"/{print $4}')" /mnt/dietpi_userdata/komga/komga.jar
 
 		fi
 
@@ -5245,14 +5243,11 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://api.github.com/repos/sabre-io/Baikal/releases/latest'
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-
 			# APT deps: https://github.com/sabre-io/Baikal/wiki/Baïkal-dependencies
 			DEPS_LIST="$PHP_NAME-xml $PHP_NAME-mbstring $PHP_NAME-mysql"
 
-			local fallback_url='https://github.com/sabre-io/Baikal/releases/download/0.7.2/baikal-0.7.2.zip'
-			no_check_url=1 Download_Install "$(curl -sf "$INSTALL_URL_ADDRESS" | mawk -F\" '/"browser_download_url":/{print $4;exit}')"
+			local fallback_url='https://github.com/sabre-io/Baikal/releases/download/0.8.0/baikal-0.8.0.zip'
+			Download_Install "$(curl -sSfL 'https://api.github.com/repos/sabre-io/Baikal/releases/latest' | mawk -F\" '/"browser_download_url": .*\/baikal-[^"\/]*\.zip"/{print $4}')"
 
 			# Reinstall: https://sabre.io/baikal/upgrade/
 			if [[ -d '/var/www/baikal' ]]; then
@@ -5279,9 +5274,6 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://api.github.com/repos/MediaBrowser/Emby.Releases/releases/latest'
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-
 			# ARMv7
 			local arch='armhf'
 
@@ -5297,10 +5289,8 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			fi
 
-			local fallback_url="https://github.com/MediaBrowser/Emby.Releases/releases/download/4.5.3.0/emby-server-deb_4.5.3.0_$arch.deb"
-			no_check_url=1 Download_Install "$(curl -sf "$INSTALL_URL_ADDRESS" | grep -m1 "browser_download_url.*emby-server-deb_.*_$arch\.deb" | cut -d \" -f 4)"
-
-			unset -v arch
+			local fallback_url="https://github.com/MediaBrowser/Emby.Releases/releases/download/4.5.4.0/emby-server-deb_4.5.4.0_$arch.deb"
+			Download_Install "$(curl -sSfL 'https://api.github.com/repos/MediaBrowser/Emby.Releases/releases/latest' | grep "\"browser_download_url\": .*/emby-server-deb_[^\"/]*_$arch\.deb\"" | cut -d \" -f 4)"
 
 		fi
 
@@ -5421,9 +5411,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 				fi
 
 				local fallback_url="https://github.com/gogs/gogs/releases/download/v0.12.3/gogs_0.12.3_linux_$arch.tar.gz"
-				G_CHECK_URL 'https://api.github.com/repos/gogs/gogs/releases/latest'
-				INSTALL_URL_ADDRESS=$(curl -sf 'https://api.github.com/repos/gogs/gogs/releases/latest' | grep -m1 "browser_download_url.*linux_$arch.tar.gz" | cut -d \" -f 4)
-				local no_check_url=1 # G_CHECK_URL faces 403
+				INSTALL_URL_ADDRESS=$(curl -sSfL 'https://api.github.com/repos/gogs/gogs/releases/latest' | grep "\"browser_download_url\": .*/gogs_[^\"/]*_linux_$arch.tar.gz\"" | cut -d \" -f 4)
 
 			fi
 
@@ -5461,9 +5449,9 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			# Install ruTorrent: Web UI for rTorrent
 			# - Grab current version
-			INSTALL_URL_ADDRESS='https://api.github.com/repos/Novik/ruTorrent/releases/latest'
-			local version=$(curl -sSfL "$INSTALL_URL_ADDRESS" | mawk -F\" '/^[[:blank:]]*"tag_name":/{print $4;exit}')
-			Download_Install "https://github.com/Novik/ruTorrent/archive/${version:-v3.9}.tar.gz"
+			local version=$(curl -sSfL 'https://api.github.com/repos/Novik/ruTorrent/releases/latest' | mawk -F\" '/"tag_name": /{print $4}')
+			[[ $version ]] || { version='v3.10'; G_DIETPI-NOTIFY 1 "Automatic latest ruTorrent version detection failed. Version \"$version\" will be installed as fallback, but a newer version might be available. Please report this at: https://github.com/MichaIng/DietPi/issues"; }
+			Download_Install "https://github.com/Novik/ruTorrent/archive/$version.tar.gz"
 
 			# - Reinstall
 			if [[ -d '/var/www/rutorrent' ]]; then
@@ -5474,13 +5462,13 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 				G_BACKUP_FP /var/www/rutorrent/conf/plugins.ini
 
 				# Merge new install into old to preserve e.g. 3rd party plugins
-				cp -a ruTorrent-*/. /var/www/rutorrent/
-				rm -R ruTorrent-*
+				G_EXEC cp -a ruTorrent-*/. /var/www/rutorrent/
+				G_EXEC rm -R ruTorrent-*
 
 			# - Fresh install
 			else
 
-				mv ruTorrent-* /var/www/rutorrent
+				G_EXEC mv ruTorrent-* /var/www/rutorrent
 
 			fi
 
@@ -5547,10 +5535,6 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			else
 
-				# Get latest version from GitHub
-				INSTALL_URL_ADDRESS='https://api.github.com/repos/syncthing/syncthing/releases/latest'
-				G_CHECK_URL "$INSTALL_URL_ADDRESS"
-
 				# ARMv6/7
 				local arch='arm'
 
@@ -5566,9 +5550,9 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 				fi
 
-				local fallback_url="https://github.com/syncthing/syncthing/releases/download/v1.12.0/syncthing-linux-$arch-v1.12.0.tar.gz"
-				no_check_url=1 Download_Install "$(curl -sf "$INSTALL_URL_ADDRESS" | grep -m1 "browser_download_url.*linux-$arch-v[0-9.]*tar\.gz" | cut -d \" -f 4)"
-				mv syncthing-* /opt/syncthing
+				local fallback_url="https://github.com/syncthing/syncthing/releases/download/v1.13.1/syncthing-linux-$arch-v1.13.1.tar.gz"
+				Download_Install "$(curl -sSfL 'https://api.github.com/repos/syncthing/syncthing/releases/latest' | grep "\"browser_download_url\": .*/syncthing-linux-$arch-[^\"/]*\.tar\.gz\"" | cut -d \" -f 4)"
+				G_EXEC mv syncthing-* /opt/syncthing
 
 			fi
 
@@ -5734,9 +5718,9 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			DEPS_LIST='pkg-config libssl-dev'
 
 			# Download
-			INSTALL_URL_ADDRESS='https://api.github.com/repos/dani-garcia/bitwarden_rs/releases/latest'
-			local version=$(curl -sSfL "$INSTALL_URL_ADDRESS" | mawk -F\" '/^[[:blank:]]*"tag_name":/{print $4;exit}')
-			Download_Install "https://github.com/dani-garcia/bitwarden_rs/archive/${version:=1.17.0}.tar.gz"
+			local version=$(curl -sSfL 'https://api.github.com/repos/dani-garcia/bitwarden_rs/releases/latest' | mawk -F\" '/"tag_name": /{print $4}')
+			[[ $version ]] || { version='1.19.0'; G_DIETPI-NOTIFY 1 "Automatic latest ${aSOFTWARE_NAME[$software_id]} version detection failed. Version \"$version\" will be installed as fallback, but a newer version might be available. Please report this at: https://github.com/MichaIng/DietPi/issues"; }
+			Download_Install "https://github.com/dani-garcia/bitwarden_rs/archive/$version.tar.gz"
 
 			# Replace old instance on reinstall
 			[[ -d '/opt/bitwarden_rs' ]] && G_EXEC rm -R /opt/bitwarden_rs
@@ -5783,10 +5767,8 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			HOME='/root'
 
 			# Install web vault
-			INSTALL_URL_ADDRESS='https://api.github.com/repos/dani-garcia/bw_web_builds/releases/latest'
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-			local fallback_url='https://github.com/dani-garcia/bw_web_builds/releases/download/v2.17.1/bw_web_v2.17.1.tar.gz'
-			no_check_url=1 Download_Install "$(curl -sfL "$INSTALL_URL_ADDRESS" | mawk -F\" '/browser_download_url.*\.tar\.gz\"/{print $4;exit}')" /mnt/dietpi_userdata/bitwarden_rs
+			local fallback_url='https://github.com/dani-garcia/bw_web_builds/releases/download/v2.18.1b/bw_web_v2.18.1b.tar.gz'
+			Download_Install "$(curl -sSfL 'https://api.github.com/repos/dani-garcia/bw_web_builds/releases/latest' | mawk -F\" '/"browser_download_url": .*\/bw_web_[^"\/]*\.tar\.gz"/{print $4}')" /mnt/dietpi_userdata/bitwarden_rs
 
 		fi
 
@@ -5794,9 +5776,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-			INSTALL_URL_ADDRESS='https://github.com/Fornoth/spotify-connect-web/releases'
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-			no_check_url=1 Download_Install "$INSTALL_URL_ADDRESS/download/0.0.4-alpha/spotify-connect-web_0.0.4-alpha.tar.gz" /mnt/dietpi_userdata
+			Download_Install 'https://github.com/Fornoth/spotify-connect-web/releases/download/0.0.4-alpha/spotify-connect-web_0.0.4-alpha.tar.gz' /mnt/dietpi_userdata
 
 		fi
 
@@ -5827,9 +5807,8 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			DEPS_LIST="python libpng-dev $PHP_NAME-bcmath $PHP_NAME-json $PHP_NAME-mbstring $PHP_NAME-xml"
 
 			# Grab latest release
-			INSTALL_URL_ADDRESS='https://api.github.com/repos/koel/koel/releases/latest'
-			local version=$(curl -sSfL "$INSTALL_URL_ADDRESS" | mawk -F\" '/^[[:blank:]]*"tag_name":/{print $4;exit}')
-			Download_Install "https://github.com/koel/koel/archive/${version:-v4.4.0}.tar.gz"
+			local fallback_url='https://github.com/koel/koel/releases/download/v5.0.2/koel-v5.0.2.tar.gz'
+			Download_Install "$(curl -sSfL 'https://api.github.com/repos/koel/koel/releases/latest' | mawk -F\" '/"browser_download_url": .*\/koel-[^"\/]*\.tar\.gz"/{print $4}')"
 
 			# Reinstall: Clear previous install, but keep existing config file
 			if [[ -d '/mnt/dietpi_userdata/koel' ]]; then
@@ -5838,7 +5817,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 				G_EXEC rm -R /mnt/dietpi_userdata/koel
 
 			fi
-			mv koel-* /mnt/dietpi_userdata/koel
+			G_EXEC mv koel-* /mnt/dietpi_userdata/koel
 
 			# Download external assets manually, not included in download archive: https://github.com/koel/koel/tree/master/resources
 			# - NB: We pull master archive, but this might not match to Koel latest release. Requires testing, else we need to switch to git clone.
@@ -5930,35 +5909,32 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
  - If you need to reinstall (e.g. broken instance), please manually remove the install dir \"/opt/radarr\" and rerun \"dietpi-software reinstall $software_id\"."
 
 			else
-				INSTALL_URL_ADDRESS='https://api.github.com/repos/Radarr/Radarr/releases/latest'
-				G_CHECK_URL "$INSTALL_URL_ADDRESS"
-
 				# ARMv6
 				if (( $G_HW_ARCH == 1 ))
 				then
-					INSTALL_URL_ADDRESS=$(curl -sf "$INSTALL_URL_ADDRESS" | mawk -F\" '/browser_download_url.*linux\.tar\.gz/{print $4;exit}')
-					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v3.0.1.4259/Radarr.master.3.0.1.4259.linux.tar.gz'
+					INSTALL_URL_ADDRESS=$(curl -sSfL "$INSTALL_URL_ADDRESS" | mawk -F\" '/"browser_download_url": .*linux\.tar\.gz"/{print $4}')
+					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v3.0.2.4552/Radarr.master.3.0.2.4552.linux.tar.gz'
 
 				# ARMv7
 				elif (( $G_HW_ARCH == 2 ))
 				then
-					INSTALL_URL_ADDRESS=$(curl -sf "$INSTALL_URL_ADDRESS" | mawk -F\" '/browser_download_url.*linux-core-arm\.tar\.gz/{print $4;exit}')
-					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v3.0.1.4259/Radarr.master.3.0.1.4259.linux-core-arm.tar.gz'
+					INSTALL_URL_ADDRESS=$(curl -sSfL "$INSTALL_URL_ADDRESS" | mawk -F\" '/"browser_download_url": .*linux-core-arm\.tar\.gz"/{print $4}')
+					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v3.0.2.4552/Radarr.master.3.0.2.4552.linux-core-arm.tar.gz'
 
 				# ARMv8
 				elif (( $G_HW_ARCH == 3 ))
 				then
-					INSTALL_URL_ADDRESS=$(curl -sf "$INSTALL_URL_ADDRESS" | mawk -F\" '/browser_download_url.*linux-core-arm64\.tar\.gz/{print $4;exit}')
-					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v3.0.1.4259/Radarr.master.3.0.1.4259.linux-core-arm64.tar.gz'
+					INSTALL_URL_ADDRESS=$(curl -sSfL "$INSTALL_URL_ADDRESS" | mawk -F\" '/"browser_download_url": .*linux-core-arm64\.tar\.gz"/{print $4}')
+					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v3.0.2.4552/Radarr.master.3.0.2.4552.linux-core-arm64.tar.gz'
 
 				# x86_64
 				elif (( $G_HW_ARCH == 10 ))
 				then
-					INSTALL_URL_ADDRESS=$(curl -sf "$INSTALL_URL_ADDRESS" | mawk -F\" '/browser_download_url.*linux-core-x64\.tar\.gz/{print $4;exit}')
-					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v3.0.1.4259/Radarr.master.3.0.1.4259.linux-core-x64.tar.gz'
+					INSTALL_URL_ADDRESS=$(curl -sSfL "$INSTALL_URL_ADDRESS" | mawk -F\" '/"browser_download_url": .*linux-core-x64\.tar\.gz"/{print $4}')
+					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v3.0.2.4552/Radarr.master.3.0.2.4552.linux-core-x64.tar.gz'
 				fi
 
-				no_check_url=1 Download_Install "$INSTALL_URL_ADDRESS"
+				Download_Install "$INSTALL_URL_ADDRESS"
 				G_EXEC mv Radarr /opt/radarr
 			fi
 		fi
@@ -5977,13 +5953,8 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			else
 
-				INSTALL_URL_ADDRESS='https://api.github.com/repos/Lidarr/Lidarr/releases'
-				G_CHECK_URL "$INSTALL_URL_ADDRESS"
-				INSTALL_URL_ADDRESS=$(curl -sf "$INSTALL_URL_ADDRESS" | grep -m1 'browser_download_url.*linux\.tar\.gz' | cut -d \" -f 4)
 				local fallback_url='https://github.com/lidarr/Lidarr/releases/download/v0.7.2.1878/Lidarr.master.0.7.2.1878.linux.tar.gz'
-
-				DEPS_LIST='mediainfo'
-				no_check_url=1 Download_Install "$INSTALL_URL_ADDRESS" /opt
+				DEPS_LIST='mediainfo' Download_Install "$(curl -sSfL 'https://api.github.com/repos/Lidarr/Lidarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux\.tar\.gz"/{print $4}')" /opt
 
 			fi
 
@@ -6049,12 +6020,10 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			Banner_Installing
 
 			# Grab latest version download link
-			INSTALL_URL_ADDRESS='https://api.github.com/repos/Jackett/Jackett/releases/latest'
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			# - ARMv6: Requires Mono: https://github.com/Jackett/Jackett#installation-on-linux-armv6-or-below
-			INSTALL_URL_ADDRESS=$(curl -sf "$INSTALL_URL_ADDRESS" | grep -m1 'browser_download_url.*Jackett\.Binaries\.Mono\.tar\.gz' | cut -d \" -f 4)
-			local fallback_url='https://github.com/Jackett/Jackett/releases/download/v0.17.50/Jackett.Binaries.Mono.tar.gz'
+			INSTALL_URL_ADDRESS=$(curl -sSfL 'https://api.github.com/repos/Jackett/Jackett/releases/latest' | mawk -F\" '/"browser_download_url": .*\/Jackett\.Binaries\.Mono\.tar\.gz"/{print $4}')
+			local fallback_url='https://github.com/Jackett/Jackett/releases/download/v0.17.513/Jackett.Binaries.Mono.tar.gz'
 
 			# - ARMv7
 			if (( $G_HW_ARCH == 2 )); then
@@ -6094,18 +6063,17 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 				fi
 			fi
 
-			# Download: wget --spider/curl -IL return 403
-			no_check_url=1 Download_Install "$INSTALL_URL_ADDRESS" /opt
+			Download_Install "$INSTALL_URL_ADDRESS" /opt
 
 			# Move existing configs to unpacked install dir
-			[[ -d '/opt/jackett/Jackett' ]] && mv /opt/jackett/Jackett /opt/Jackett/
-			[[ -d '/opt/jackett/.mono' ]] && mv /opt/jackett/.mono /opt/Jackett/
+			[[ -d '/opt/jackett/Jackett' ]] && G_EXEC mv /opt/jackett/Jackett /opt/Jackett/
+			[[ -d '/opt/jackett/.mono' ]] && G_EXEC mv /opt/jackett/.mono /opt/Jackett/
 
 			# Remove existing install dir
-			[[ -d '/opt/jackett' ]] && rm -R /opt/jackett
+			[[ -d '/opt/jackett' ]] && G_EXEC rm -R /opt/jackett
 
 			# Move unpacked install dir in place
-			mv /opt/Jackett /opt/jackett
+			G_EXEC mv /opt/Jackett /opt/jackett
 
 		fi
 
@@ -6342,12 +6310,8 @@ If you want to update ${aSOFTWARE_NAME[$software_id]}, please use its internal u
 
 			Banner_Installing
 
-			# Grab latest version from GitHub
-			INSTALL_URL_ADDRESS='https://api.github.com/repos/go-gitea/gitea/releases/latest'
-			G_CHECK_URL "$INSTALL_URL_ADDRESS" # wget --spider fails on binary URL
-
 			# Binary + data dir
-			mkdir -p /mnt/dietpi_userdata/gitea/gitea-repositories
+			G_EXEC mkdir -p /mnt/dietpi_userdata/gitea/gitea-repositories
 
 			# ARMv6 + ARMv7 since as of v1.8 there are issues with ARMv7 binaries on Raspbian which are hence not provided anymore: https://github.com/MichaIng/DietPi/issues/2959 (Troubleshooting)
 			local arch='arm-6'
@@ -6364,10 +6328,8 @@ If you want to update ${aSOFTWARE_NAME[$software_id]}, please use its internal u
 
 			fi
 
-			INSTALL_URL_ADDRESS=$(curl -sf "$INSTALL_URL_ADDRESS" | grep -m1 "\"browser_download_url.*gitea-[0-9.]*-linux-$arch\"" | cut -d \" -f 4)
-			# - Fallback URL
-			[[ $INSTALL_URL_ADDRESS ]] || INSTALL_URL_ADDRESS="https://github.com/go-gitea/gitea/releases/download/v1.11.3/gitea-1.11.3-linux-$arch"
-			G_EXEC curl -sSfL "$INSTALL_URL_ADDRESS" -o /mnt/dietpi_userdata/gitea/gitea
+			local fallback_url="https://github.com/go-gitea/gitea/releases/download/v1.13.2/gitea-1.13.2-linux-$arch"
+			Download_Install "$(curl -sSfL 'https://api.github.com/repos/go-gitea/gitea/releases/latest' | grep "\"browser_download_url\": .*/gitea-[^\"/]*-linux-$arch\"" | cut -d \" -f 4)" /mnt/dietpi_userdata/gitea/gitea
 
 		fi
 
@@ -6554,8 +6516,8 @@ If you want to update ${aSOFTWARE_NAME[$software_id]}, please use its internal u
 			DEPS_LIST='cmake python3-minimal'
 
 			# Download
-			local version=$(curl -sSfL https://api.github.com/repos/ptitSeb/box86/tags | mawk '/"name": /{print $4;exit}')
-			[[ $version ]] || version='v0.2.0' # Fallback
+			local version=$(curl -sSfL 'https://api.github.com/repos/ptitSeb/box86/tags' | mawk -F\" '/"name": /{print $4;exit}')
+			[[ $version ]] || { version='v0.2.0'; G_DIETPI-NOTIFY 1 "Automatic latest ${aSOFTWARE_NAME[$software_id]} version detection failed. Version \"$version\" will be installed as fallback, but a newer version might be available. Please report this at: https://github.com/MichaIng/DietPi/issues"; }
 			Download_Install "https://github.com/ptitSeb/box86/archive/$version.tar.gz"
 
 			# Build
@@ -10238,10 +10200,8 @@ _EOF_
 
 				# Download latest easy-rsa from GitHub
 				G_DIETPI-NOTIFY 2 'Downloading latest easy-rsa for certificate and key generation...'
-				INSTALL_URL_ADDRESS='https://api.github.com/repos/OpenVPN/easy-rsa/releases/latest'
-				G_CHECK_URL "$INSTALL_URL_ADDRESS"
 				local fallback_url='https://github.com/OpenVPN/easy-rsa/releases/download/v3.0.8/EasyRSA-3.0.8.tgz'
-				no_check_url=1 Download_Install "$(curl -sf "$INSTALL_URL_ADDRESS" | grep -m1 '"browser_download_url.*EasyRSA-.*\.tgz' | cut -d \" -f 4)"
+				Download_Install "$(curl -sSfL 'https://api.github.com/repos/OpenVPN/easy-rsa/releases/latest' | mawk -F\" '/"browser_download_url": .*\/EasyRSA-[^"\/]*\.tgz"/{print $4}')"
 				[[ -d '/etc/openvpn/easy-rsa' ]] && rm -R /etc/openvpn/easy-rsa
 				G_EXEC mv EasyRSA-* /etc/openvpn/easy-rsa
 


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Software | Fix download GitHub URL/version detection for ruTorrent, Koel and Bitwarden_RS: mawk does not support "[[:blank:]]" syntax, hence the fallback URL was used in those cases.
+ DietPi-Software | Align automated GitHub download URL/version detection for all installs. Take into account that mawk is not able to handle "[[:blank:]]" syntax and variables, hence if this is required, "grep | cut" pipe needs to be used. Use "curl -sSfL" in all cases so that curl errors and server error responses are shown, for debugging purpose. mawk and grep are then not allowed to exit on first match, since this causes a curl 23 exit code and error message about a broken pipe before the response could have been written completely, when the match was not within the last buffer chunk. To compensate this, assure that a single match exists by being more specific about the expected regex, assure that a fallback is present and effective in every case.
**Once Stretch support is dropped, we could use `CURLOPT_BUFFERSIZE=524288` (introduced with curl v7.53 vs Stretch curl v7.52.1) to maximise the curl buffer chunks so that a GitHub API page fully fits inside and parsing can stop at first match. But being explicit about the URL has it's own benefits, in case of multiple matches we might want to review the two options and pick one explicitly.**
+ DietPi-Software | Whenever a download fallback URL or version string is used, print an error message, inform about the fallback but ask user to do a report as obviously we need to update the URL or regex.
+ DietPi-Software | "curl -IL" does not suffer from failing GitHub download URL checks, hence the workaround to check the API page only can be removed. Testet on all distros from Stretch to Bullseye.
+ DietPi-Software | Use G_EXEC more widely throughout the script, where applicable