### PR TITLE
Choice of automatic login user appears too often

### DIFF
--- a/dietpi/dietpi-autostart
+++ b/dietpi/dietpi-autostart
@@ -103,7 +103,7 @@ _EOF_
 			G_EXEC_NOHALT=1 G_AG_CHECK_INSTALL_PREREQ dbus
 			G_EXEC_NOHALT=1 G_EXEC systemctl unmask systemd-logind
 
-			# Apply tweaks
+			# RPi tweaks
 			if (( $G_HW_MODEL < 10 )); then
 
 				G_CONFIG_INJECT 'boot_delay=' 'boot_delay=0' /boot/config.txt
@@ -114,15 +114,15 @@ _EOF_
 			fi
 
 		# - LightDM: Install only if startx (a desktop) is already installed. This is re-applied by dietpi-software after install automatically.
-		elif (( $ID_AUTOSTART == 16 )) && command -v startx > /dev/null; then
+		elif (( $ID_AUTOSTART == 16 )); then
 
+			command -v X > /dev/null || { G_WHIP_MSG '[FAILED] No X server has been found\n\nLightDM requires an X server. Please install a desktop or other X application first.'; return 1; }
 			G_AG_CHECK_INSTALL_PREREQ lightdm
 			# graphical.target Wants=display-manager.service
 			G_EXEC ln -sf /lib/systemd/system/lightdm.service /etc/systemd/system/display-manager.service
 
-		# - Enable autologin 
-		#   only for cases 7 (Local terminal - Automatic login) and 2 (Desktops - Automatic login)
-		elif ((( $ID_AUTOSTART == 7 )) || (( $ID_AUTOSTART == 2 ))); then
+		# - Enable autologin
+		elif (( $ID_AUTOSTART > 0 )); then
 
 			# Autologin user
 			local user=$(sed -n '/^[[:blank:]]*AUTO_SETUP_AUTOSTART_LOGIN_USER=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
@@ -256,7 +256,7 @@ This mode allows for a < 2.5 second boot on an RPi3, into Amiberry.\n\nIf you ex
 			elif [[ $ID_AUTOSTART == 14 && ! -f '/var/lib/dietpi/dietpi-autostart/custom.sh' ]]; then
 
 				G_EXEC mkdir -p /var/lib/dietpi/dietpi-autostart
-				cat << _EOF_ > /var/lib/dietpi/dietpi-autostart/custom.sh
+				cat << '_EOF_' > /var/lib/dietpi/dietpi-autostart/custom.sh
 #!/bin/bash
 #---Examples---
 
@@ -267,10 +267,9 @@ This mode allows for a < 2.5 second boot on an RPi3, into Amiberry.\n\nIf you ex
 #startx
 
 # Print Hello
-#echo "Hello"
+#echo 'Hello'
 
 #---Put your code below this line---
-
 _EOF_
 				G_WHIP_MSG 'A template script has been created:\n - /var/lib/dietpi/dietpi-autostart/custom.sh\n
 Please edit this file and enter the required commands you wish to launch. DietPi will then execute this script during boot.'

--- a/dietpi/dietpi-autostart
+++ b/dietpi/dietpi-autostart
@@ -120,8 +120,9 @@ _EOF_
 			# graphical.target Wants=display-manager.service
 			G_EXEC ln -sf /lib/systemd/system/lightdm.service /etc/systemd/system/display-manager.service
 
-		# - Enable autologin
-		elif (( $ID_AUTOSTART > 0 )); then
+		# - Enable autologin 
+		#   only for cases 7 (Local terminal - Automatic login) and 2 (Desktops - Automatic login)
+		elif ((( $ID_AUTOSTART == 7 )) || (( $ID_AUTOSTART == 2 ))); then
 
 			# Autologin user
 			local user=$(sed -n '/^[[:blank:]]*AUTO_SETUP_AUTOSTART_LOGIN_USER=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -35,43 +35,33 @@ Available commands:
 	# Filepath
 	#/////////////////////////////////////////////////////////////////////////////////////
 	readonly FP_INSTALLED_FILE='/boot/dietpi/.installed'
-	readonly FP_INSTALLED_FILE_TMP='.installed'
 
 	# Used to set user/personal data directories (e.g.: usbdrive)
 	FP_DIETPI_DEDICATED_USBDRIVE=
 
 	Write_InstallFileList(){
 
-		local fp_target=$FP_INSTALLED_FILE
-		local write_software_in_pending_state=0
-		if [[ $1 == 'temp' ]]; then
-
-			fp_target=$FP_INSTALLED_FILE_TMP
-			write_software_in_pending_state=1
-
-		fi
-
-		> $fp_target
+		> $FP_INSTALLED_FILE
 
 		# Save installed states
 		for i in "${!aSOFTWARE_NAME[@]}"
 		do
 
-			# Never save pending state for software (=1). Excluding temp saves.
-			if (( ${aSOFTWARE_INSTALL_STATE[$i]} == 1 && ! $write_software_in_pending_state )); then
+			# Never save pending state for software (=1).
+			if (( ${aSOFTWARE_INSTALL_STATE[$i]} == 1 )); then
 
-				echo "aSOFTWARE_INSTALL_STATE[$i]=0" >> $fp_target
+				echo "aSOFTWARE_INSTALL_STATE[$i]=0" >> $FP_INSTALLED_FILE
 
 			else
 
-				echo "aSOFTWARE_INSTALL_STATE[$i]=${aSOFTWARE_INSTALL_STATE[$i]}" >> $fp_target
+				echo "aSOFTWARE_INSTALL_STATE[$i]=${aSOFTWARE_INSTALL_STATE[$i]}" >> $FP_INSTALLED_FILE
 
 			fi
 
 		done
 
 		# Misc
-		cat << _EOF_ >> $fp_target
+		cat << _EOF_ >> $FP_INSTALLED_FILE
 
 # DietPi Choice System: SSH Server
 INDEX_SSHSERVER_CURRENT=$INDEX_SSHSERVER_CURRENT
@@ -97,11 +87,8 @@ _EOF_
 		# Load Software states
 		G_DIETPI-NOTIFY -2 'Reading database'
 
-		local fp_target=$FP_INSTALLED_FILE
-		[[ $1 == 'temp' ]] && fp_target=$FP_INSTALLED_FILE_TMP
-
 		# Load
-		[[ -f $fp_target ]] && . $fp_target
+		[[ -f $FP_INSTALLED_FILE ]] && . $FP_INSTALLED_FILE
 
 		# Always reset choice system during first run to defaults: https://github.com/MichaIng/DietPi/issues/1122
 		if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
@@ -15903,6 +15890,31 @@ _EOF_
 		# Apply GPU Memory Splits
 		Install_Apply_GPU_Settings
 
+		# No-IP configuration
+		(( ${aSOFTWARE_INSTALL_STATE[67]} == 1 )) && G_WHIP_YESNO 'No-IP can be setup and configured by using DietPi-Config. Would you like to complete this now?
+\n - Once finished, exit DietPi-Config to finish this install.
+\n - More information:\nhttps://dietpi.com/phpbb/viewtopic.php?p=58#p58' && /boot/dietpi/dietpi-config 16 1
+
+		# DietPi-AutoStart choice
+		if (( $G_DIETPI_INSTALL_STAGE == 2 )) && ((
+			${aSOFTWARE_INSTALL_STATE[23]} == 1 ||
+			${aSOFTWARE_INSTALL_STATE[24]} == 1 ||
+			${aSOFTWARE_INSTALL_STATE[25]} == 1 ||
+			${aSOFTWARE_INSTALL_STATE[26]} == 1 ||
+			${aSOFTWARE_INSTALL_STATE[31]} == 1 ||
+			${aSOFTWARE_INSTALL_STATE[51]} == 1 ||
+			${aSOFTWARE_INSTALL_STATE[108]} == 1 ||
+			${aSOFTWARE_INSTALL_STATE[112]} == 1 ||
+			${aSOFTWARE_INSTALL_STATE[119]} == 1 ||
+			${aSOFTWARE_INSTALL_STATE[155]} == 1 ||
+			${aSOFTWARE_INSTALL_STATE[173]} == 1 )); then
+
+			G_WHIP_YESNO 'Would you like to configure the DietPi-AutoStart option?
+\nThis will allow you to choose which program loads automatically, after the system has booted up, e.g.:
+ - Console\n - Desktop\n - Kodi' && /boot/dietpi/dietpi-autostart
+
+		fi
+
 		# Install finished, set all installed software to state 2 (installed)
 		# - Apply same states to Allo and Allo_update
 		(( ${aSOFTWARE_INSTALL_STATE[159]} == 1 || ${aSOFTWARE_INSTALL_STATE[160]} == 1 )) && { aSOFTWARE_INSTALL_STATE[159]=2; aSOFTWARE_INSTALL_STATE[160]=2; }
@@ -16565,26 +16577,6 @@ _EOF_
 
 			fi
 
-			# dietpi-config can be used to install/configure the following software. Ask user.
-			# - No-IP
-			if (( ${aSOFTWARE_INSTALL_STATE[67]} == 1 )); then
-
-				if G_WHIP_YESNO 'No-IP can be setup and configured by using DietPi-Config. Would you like to complete this now?\n\n - Once finished, exit DietPi-Config to resume setup.
-\n - More information:\nhttps://dietpi.com/phpbb/viewtopic.php?p=58#p58'; then
-
-					# Write installed states to temp
-					Write_InstallFileList temp
-
-					# Launch DietPi-config
-					/boot/dietpi/dietpi-config 16 1
-
-					# Read installed states from temp
-					Read_InstallFileList temp
-
-				fi
-
-			fi
-
 			# Home Assistant: Inform about long install/build time: https://github.com/MichaIng/DietPi/issues/2897
 			if (( ${aSOFTWARE_INSTALL_STATE[157]} == 1 )); then
 
@@ -16592,26 +16584,6 @@ _EOF_
 \nThe install process of Home Assistant within the virtual environment, especially the Python build, can take more than one hour, especially on slower SBCs like RPi Zero and similar.
 \nPlease be patient. Meanwhile you might want to participate the discussion about reducing (re)install times, by skipping Python rebuild or installing everything outside of the pyenv environment:
  - https://github.com/MichaIng/DietPi/issues/2374'
-
-			fi
-
-			# Boot Choices
-			if (( ${aSOFTWARE_INSTALL_STATE[23]} == 1 ||
-				${aSOFTWARE_INSTALL_STATE[24]} == 1 ||
-				${aSOFTWARE_INSTALL_STATE[25]} == 1 ||
-				${aSOFTWARE_INSTALL_STATE[26]} == 1 ||
-				${aSOFTWARE_INSTALL_STATE[31]} == 1 ||
-				${aSOFTWARE_INSTALL_STATE[51]} == 1 ||
-				${aSOFTWARE_INSTALL_STATE[108]} == 1 ||
-				${aSOFTWARE_INSTALL_STATE[112]} == 1 ||
-				${aSOFTWARE_INSTALL_STATE[119]} == 1 ||
-				${aSOFTWARE_INSTALL_STATE[155]} == 1 ||
-				${aSOFTWARE_INSTALL_STATE[173]} == 1 )); then
-
-				# Set Boot Order
-				G_WHIP_YESNO 'Would you like to configure the auto boot options for DietPi?
-\nThis will allow you to choose which program loads automatically, after the system has booted up, e.g.:
- - Console\n - Desktop\n - Kodi' && /boot/dietpi/dietpi-autostart
 
 			fi
 


### PR DESCRIPTION
The choice of the user for an automatic logic (with its dialog) appeared too often.  E.g. if you selected "LightDM login mask" the user name choice was displayed (what should not be the case).  
Now the choice is only done in cases of automatic login (dietpi-autologin options 7 and 2).

**Status**: Testing
- [x] Changed automatic login selection 

@MichaIng: Please check whether my changes are correct.
