### PR TITLE
General | Add support for F2FS and Btrfs root file systems

### DIFF
--- a/.meta/dietpi-imager
+++ b/.meta/dietpi-imager
@@ -12,7 +12,7 @@
 	# - Create new .img file from drive
 	#   or use an existing .img file
 	#   or use Clonezilla to generate a bootable installer ISO from drive for x86_64 systems
-	# - Minimises root partition and file system
+	# - Minimises root partition and filesystem
 	# - Hashes and 7z's the final image ready for release
 	#////////////////////////////////////
 
@@ -35,6 +35,7 @@
 	FP_SOURCE=
 	PART_TABLE_TYPE=
 	FP_ROOT_DEV=
+	ROOT_FS_TYPE=
 	CLONING_TOOL='dd'
 	OUTPUT_IMG_EXT='img'
 	OUTPUT_IMG_NAME='DietPi_RPi-ARMv6-Buster'
@@ -50,19 +51,30 @@
 
 	Menu_Source_Type()
 	{
+		main_menu_choice='Source type' # On cancel, keep this entry selected
+
 		G_WHIP_MENU_ARRAY=(
 			'Drive' ': The OS is stored on an attached drive.'
 			'Image' ': The OS is stored as an image file.'
 		)
 		G_WHIP_DEFAULT_ITEM=$SOURCE_TYPE
-		G_WHIP_MENU 'Please select how the input OS is stored:' && { Delete_Loopback; SOURCE_TYPE=$G_WHIP_RETURNED_VALUE FP_SOURCE_IMG='' FP_SOURCE='' FP_ROOT_DEV=''; }
+		G_WHIP_MENU 'Please select how the input OS is stored:' || return
+		Delete_Loopback
+		SOURCE_TYPE=$G_WHIP_RETURNED_VALUE
+		FP_SOURCE_IMG=
+		FP_SOURCE=
+		FP_ROOT_DEV=
+
+		Menu_Source_Path # Directly open this menu next
 	}
 
 	Menu_Source_Path()
 	{
+		main_menu_choice='Source path' # On cancel, keep this entry selected
+
 		if [[ $SOURCE_TYPE == 'Drive' ]]
 		then
-			# Detect drives with a partition table, containing a partition with ext4 file system, excluding the hosts root file system drive
+			# Detect drives with a partition table, containing a partition with ext4 filesystem, excluding the hosts root filesystem drive
 			mapfile -t G_WHIP_MENU_ARRAY < <(mawk -v root="$(lsblk -npo PKNAME "$G_ROOTFS_DEV")" '{if ( $1!=root && $2=="ext4" ) print $1"\n"$2}' < <(lsblk -rnpo PKNAME,FSTYPE) | sort -u)
 
 			if [[ ! ${G_WHIP_MENU_ARRAY[0]} ]]
@@ -80,9 +92,10 @@
 			G_WHIP_DEFAULT_ITEM=$FP_SOURCE
 			G_WHIP_MENU 'Please select the drive you wish to create the image from:
 \nNB: All mounted partitions of the selected drive will be unmounted.' || return
-			FP_SOURCE=$G_WHIP_RETURNED_VALUE FP_ROOT_DEV=''
+			FP_SOURCE=$G_WHIP_RETURNED_VALUE
+			FP_ROOT_DEV=
 
-			G_DIETPI-NOTIFY 2 "Unmounting all file systems below selected $FP_SOURCE ..."
+			G_DIETPI-NOTIFY 2 "Unmounting all filesystems below selected $FP_SOURCE ..."
 			local mountpoint
 			for i in "$FP_SOURCE"?*
 			do
@@ -95,7 +108,8 @@
 			[[ -f $fp_selected ]] && rm $fp_selected # Failsafe
 			/boot/dietpi/dietpi-explorer 1
 			[[ -f $fp_selected && $(<$fp_selected) ]] || { G_DIETPI-NOTIFY 1 'No image file selected, aborting...'; read -rp 'Press any key to return to menu...'; return; }
-			FP_SOURCE_IMG=$(<$fp_selected) FP_ROOT_DEV=''
+			FP_SOURCE_IMG=$(<$fp_selected)
+			FP_ROOT_DEV=
 			rm $fp_selected
 			[[ -f $FP_SOURCE_IMG ]] || { G_DIETPI-NOTIFY 1 "Selected image file ($FP_SOURCE_IMG) does not exist, aborting..."; read -rp 'Press any key to return to menu...'; return; }
 
@@ -108,10 +122,14 @@
 			G_EXEC_NOEXIT=1 G_EXEC partx -u "$FP_SOURCE" || return
 			G_DIETPI-NOTIFY 0 "Mounted the image ($FP_SOURCE_IMG) as loopback device: $FP_SOURCE"
 		fi
+
+		Menu_Source_RootFS # Directly open this menu next
 	}
 
 	Menu_Source_RootFS()
 	{
+		main_menu_choice='Source rootfs' # On cancel, keep this entry selected
+
 		# Detect partitions and list for selection
 		# Coders NB: read/mapfile cannot be easily used here since we need to parse multiple lines and split at newline AND space.
 		# shellcheck disable=SC2207
@@ -119,11 +137,16 @@
 		# Visually separate dev name and size and add FS type
 		for ((i=1;i<${#G_WHIP_MENU_ARRAY[@]};i+=2)); do G_WHIP_MENU_ARRAY[$i]=": $(lsblk -drno SIZE,FSTYPE "${G_WHIP_MENU_ARRAY[$i-1]}")"; done
 		G_WHIP_DEFAULT_ITEM=$FP_ROOT_DEV
-		G_WHIP_MENU 'Please select the OS root partition:' && FP_ROOT_DEV=$G_WHIP_RETURNED_VALUE
+		G_WHIP_MENU 'Please select the OS root partition:' || return
+		FP_ROOT_DEV=$G_WHIP_RETURNED_VALUE
+
+		Menu_Target_Type # Directly open this menu next
 	}
 
 	Menu_Target_Type()
 	{
+		main_menu_choice='Target type' # On cancel, keep this entry selected
+
 		G_WHIP_MENU_ARRAY=(
 			'dd'         ': Create an .img file to flash to target system drive directly.'
 			'Clonezilla' ': Create an installer .iso file to boot from removeable media. (x86_64 only!)'
@@ -136,12 +159,17 @@
  - Clonezilla: An installer ISO image is created which must be flashed to an external/USB/removeable drive.
 	Boot from the external drive will launch Clonezilla and allow you to install DietPi to any internal drive.
 	This is required e.g. for UEFI images.
-	NB: Only compatible with x86_64 systems!' && CLONING_TOOL=$G_WHIP_RETURNED_VALUE
+	NB: Only compatible with x86_64 systems!' || return
+		CLONING_TOOL=$G_WHIP_RETURNED_VALUE
 		[[ $CLONING_TOOL == 'dd' ]] && OUTPUT_IMG_EXT='img' || OUTPUT_IMG_EXT='iso'
+
+		Menu_Target_Name # Directly open this menu next
 	}
 
 	Menu_Target_Name()
 	{
+		main_menu_choice='Target Name' # On cancel, keep this entry selected
+
 		G_WHIP_DEFAULT_ITEM=$OUTPUT_IMG_NAME
 		G_WHIP_INPUTBOX 'Please enter a name for the new image:\n - DietPi_<device>-<arch>-<distro>\n - E.g.: DietPi_RPi-ARMv6-Buster' || return
 		OUTPUT_IMG_NAME=$G_WHIP_RETURNED_VALUE
@@ -154,6 +182,8 @@
 			G_WHIP_YESNO "[WARNING] $PWD/$OUTPUT_IMG_NAME.$OUTPUT_IMG_EXT already exists
 \nDo you want to overwrite or backup the existing file to $PWD/$OUTPUT_IMG_NAME.$OUTPUT_IMG_EXT.bak?" || mv "$OUTPUT_IMG_NAME.$OUTPUT_IMG_EXT"{,.bak}
 		fi
+
+		main_menu_choice='Mount' # Select this entry next
 	}
 
 	Menu_Main()
@@ -174,7 +204,6 @@
 		G_WHIP_DEFAULT_ITEM=$main_menu_choice
 		G_WHIP_BUTTON_CANCEL_TEXT='Exit'
 		G_WHIP_MENU 'Select input parameters and hit "Start" to continue image creation:' || exit 0
-		main_menu_choice=$G_WHIP_RETURNED_VALUE
 
 		case $G_WHIP_RETURNED_VALUE in
 			'Source type') Menu_Source_Type;;
@@ -184,6 +213,25 @@
 			'Target name') Menu_Target_Name;;
 			'Mount') [[ $MOUNT_IT == 'Off' ]] && MOUNT_IT='On' || MOUNT_IT='Off';;
 		esac
+	}
+
+	Run_fsck()
+	{
+		if [[ $ROOT_FS_TYPE == 'ext4' ]]
+		then
+			G_EXEC_OUTPUT=1 G_EXEC e2fsck -fp "$FP_ROOT_DEV"
+
+		elif [[ $ROOT_FS_TYPE == 'f2fs' ]]
+		then
+			G_EXEC_OUTPUT=1 G_EXEC fsck.f2fs -f "$FP_ROOT_DEV"
+
+		elif [[ $ROOT_FS_TYPE == 'btrfs' ]]
+		then
+			G_EXEC_OUTPUT=1 G_EXEC btrfs check --repair "$FP_ROOT_DEV"
+		else
+			G_DIETPI-NOTIFY 1 "Unsupported root filesystem type ($PART_TABLE_TYPE), aborting..."
+			exit 1
+		fi
 	}
 
 	Main(){
@@ -201,8 +249,8 @@
 		G_AG_CHECK_INSTALL_PREREQ parted zerofree p7zip $fdisk
 		unset -v fdisk
 
-		# Auto detect partition table type, failsafe detection of MBR to debug possibly other/unknown wording/partition table types
-		PART_TABLE_TYPE=$(sfdisk -l "$FP_SOURCE" | mawk '/^Disklabel type:/{print $3;exit}')
+		# Detect partition table type, failsafe detection of MBR to debug possibly other/unknown wording/partition table types
+		PART_TABLE_TYPE=$(lsblk -no PTTYPE "$FP_ROOT_DEV")
 		if [[ $PART_TABLE_TYPE == 'dos' ]]
 		then
 			G_DIETPI-NOTIFY 2 'MBR partition table detected'
@@ -221,7 +269,10 @@
 			exit 1
 		fi
 
-		G_EXEC_OUTPUT=1 G_EXEC e2fsck -fp "$FP_ROOT_DEV"
+		# Detect root filesystem type
+		ROOT_FS_TYPE=$(lsblk -no FSTYPE "$FP_ROOT_DEV")
+
+		Run_fsck
 
 		# Remount image for any required edits
 		G_EXEC mkdir -p $FP_MNT_TMP
@@ -248,34 +299,75 @@
 		G_EXEC rmdir $FP_MNT_TMP
 		G_EXEC partprobe "$FP_SOURCE" # Failsafe
 		G_EXEC partx -u "$FP_SOURCE" # Failsafe
-		G_EXEC_OUTPUT=1 G_EXEC e2fsck -fp "$FP_ROOT_DEV"
+		Run_fsck
 
-		# Shrink file system to minimum
-		# - Run multiple times until no change is done any more
-		G_DIETPI-NOTIFY 2 'Shrinking RootFS to minimum size...'
-		local out
-		FS_SIZE=0
-		while :
-		do
-			resize2fs -M "$FP_ROOT_DEV" 2>&1 | tee resize2fs_out
-			if out=$(grep -im1 'nothing to do!' resize2fs_out)
-			then
-				FS_SIZE=$(mawk '{print $5}' <<< "$out") # blocks
-				BLOCK_SIZE=${out%%k) *} BLOCK_SIZE=${BLOCK_SIZE##*\(} # KiB
-				# Re-add 4 MiB to be failsafe, was required on Raspbian Buster for successful boot
-				FS_SIZE=$(( $FS_SIZE + 4096/$BLOCK_SIZE )) # blocks
-				rm resize2fs_out
-				G_EXEC resize2fs "$FP_ROOT_DEV" $FS_SIZE
-				G_DIETPI-NOTIFY 0 "Reduced RootFS size to $(( $FS_SIZE * $BLOCK_SIZE / 1024 + 1 )) MiB"
-				FS_SIZE=$(( $FS_SIZE * $BLOCK_SIZE * 2 )) # blocks => 512 byte sectors
-				break
+		# Shrink filesystem to minimum
+		if [[ $ROOT_FS_TYPE == 'ext4' ]]
+		then
+			# Run multiple times until no change is done any more
+			G_DIETPI-NOTIFY 2 'Shrinking root filesystem to minimum size...'
+			local out
+			FS_SIZE=0
+			while :
+			do
+				resize2fs -M "$FP_ROOT_DEV" 2>&1 | tee resize2fs_out
+				if out=$(grep -im1 'nothing to do!' resize2fs_out)
+				then
+					FS_SIZE=$(mawk '{print $5}' <<< "$out") # blocks
+					BLOCK_SIZE=${out%%k) *} BLOCK_SIZE=${BLOCK_SIZE##*\(} # KiB
+					# Re-add 4 MiB to be failsafe, was required on Raspbian Buster for successful boot
+					FS_SIZE=$(( $FS_SIZE + 4096/$BLOCK_SIZE )) # blocks
+					rm resize2fs_out
+					G_EXEC resize2fs "$FP_ROOT_DEV" $FS_SIZE
+					G_DIETPI-NOTIFY 0 "Reduced RootFS size to $(( $FS_SIZE * $BLOCK_SIZE / 1024 + 1 )) MiB"
+					FS_SIZE=$(( $FS_SIZE * $BLOCK_SIZE * 2 )) # blocks => 512 byte sectors
+					break
 
-			elif out=$(grep -im1 'no such file or directory' resize2fs_out)
-			then
-				G_DIETPI-NOTIFY 1 'Partition not found, aborting...'
-				exit 1
-			fi
-		done
+				elif out=$(grep -im1 'no such file or directory' resize2fs_out)
+				then
+					G_DIETPI-NOTIFY 1 'Partition not found, aborting...'
+					exit 1
+				fi
+			done
+
+		elif [[ $ROOT_FS_TYPE == 'f2fs' && $(lsblk -rno FSUSE% "$FP_ROOT_DEV") =~ ^(9[5-9]|100)%$ ]]
+		then
+			# F2FS does not support shrinking: https://www.reddit.com/r/archlinux/comments/bpp77f/shrinking_a_f2fs_partition/
+			# Hence copy all data outside, remove and re-create a smaller filesytem, then copy them back in, as long as disk usage is not >=95% already.
+			local usage=$(lsblk -rnbo FSUSED "$FP_ROOT_DEV") # bytes
+			local sector_size=$(lsblk -rnbo LOG-SEC "$FP_ROOT_DEV") # bytes
+			FS_SIZE=$(( ( $usage + 4*1024**2 ) / $sector_size )) # bytes + 4 MiB buffer => sectors
+			G_DIETPI-NOTIFY 2 'Copying root filesystem content to temporary directory'
+			G_EXEC mkdir -p ${FP_MNT_TMP}{,_backup}
+			G_EXEC mount -o ro "$FP_ROOT_DEV" $FP_MNT_TMP
+			G_EXEC cp -a $FP_MNT_TMP/. ${FP_MNT_TMP}_backup/
+			G_EXEC umount $FP_MNT_TMP
+			G_DIETPI-NOTIFY 2 'Purging root filesystem'
+			G_EXEC dd if=/dev/zero of="$FP_ROOT_DEV" bs=4K count=10
+			G_DIETPI-NOTIFY 2 'Re-creating smaller root filesystem' # Probably sload.f2fs can replace this? https://manpages.debian.org/sload.f2fs
+			G_EXEC_OUTPUT=1 G_EXEC mkfs.f2fs -w "$sector_size" "$FP_ROOT_DEV" $FS_SIZE
+			G_DIETPI-NOTIFY 2 'Moving root filesystem content back'
+			G_EXEC mount "$FP_ROOT_DEV" $FP_MNT_TMP
+			G_EXEC cp -a ${FP_MNT_TMP}_backup/. $FP_MNT_TMP/
+			G_EXEC rm -R ${FP_MNT_TMP}_backup
+			sync
+			sleep 1 # Give the system 1 second to avoid "mount is busy"
+			G_EXEC umount $FP_MNT_TMP
+			G_EXEC rmdir $FP_MNT_TMP
+			G_EXEC partprobe "$FP_SOURCE" # Failsafe
+			G_EXEC partx -u "$FP_SOURCE" # Failsafe
+			Run_fsck
+			# Assure root filesystem size is in 512 byte sectors, as this is what sfdisk assmes
+			FS_SIZE=$(( $FS_SIZE * $sector_size / 512 ))
+		elif [[ $ROOT_FS_TYPE == 'btrfs' ]]
+		then
+			G_DIETPI-NOTIFY 2 'Shrinking root filesystem to minimum size...'
+			G_EXEC mkdir -p $FP_MNT_TMP
+			G_EXEC mount -o ro "$FP_ROOT_DEV" $FP_MNT_TMP
+			FS_SIZE=$(( $(btrfs inspect-internal min-dev-size $FP_MNT_TMP) + 4*1024**2 )) # bytes? + 4 MiB buffer
+			G_EXEC_OUTPUT=1 G_EXEC btrfs filesystem resize $FS_SIZE
+			FS_SIZE=$(( $FS_SIZE / 512 )) # bytes => 512 byte sectors
+		fi
 
 		# Only resize partition when new size would be less than current size
 		if (( $(</sys/class/block/"${FP_ROOT_DEV##*/}"/size) > $FS_SIZE ))
@@ -286,9 +378,12 @@
 			G_EXEC partx -u "$FP_SOURCE"
 		fi
 
-		G_DIETPI-NOTIFY 2 'Overriding root partition free space with zeros to purge removed data and allow further archive size reduction...'
-		G_EXEC_OUTPUT=1 G_EXEC zerofree -v "$FP_ROOT_DEV"
-		G_EXEC sync
+		if [[ $ROOT_FS_TYPE == 'ext4' ]]
+		then
+			G_DIETPI-NOTIFY 2 'Overriding root filesystem free space with zeros to purge removed data and allow further archive size reduction...'
+			G_EXEC_OUTPUT=1 G_EXEC zerofree -v "$FP_ROOT_DEV"
+			G_EXEC sync
+		fi
 
 		# Finished: Derive final image size from last partition end + failsafe buffer
 		G_EXEC partprobe "$FP_SOURCE"

--- a/.meta/dietpi-imager
+++ b/.meta/dietpi-imager
@@ -329,6 +329,8 @@
 					exit 1
 				fi
 			done
+			G_DIETPI-NOTIFY 2 'Overriding root filesystem free space with zeros to purge removed data and allow further archive size reduction...'
+			G_EXEC_OUTPUT=1 G_EXEC zerofree -v "$FP_ROOT_DEV"
 
 		elif [[ $ROOT_FS_TYPE == 'f2fs' && $(lsblk -rno FSUSE% "$FP_ROOT_DEV") =~ ^(9[5-9]|100)%$ ]]
 		then
@@ -350,13 +352,11 @@
 			G_EXEC mount "$FP_ROOT_DEV" $FP_MNT_TMP
 			G_EXEC cp -a ${FP_MNT_TMP}_backup/. $FP_MNT_TMP/
 			G_EXEC rm -R ${FP_MNT_TMP}_backup
+			G_EXEC fstrim $FP_MNT_TMP
 			sync
 			sleep 1 # Give the system 1 second to avoid "mount is busy"
 			G_EXEC umount $FP_MNT_TMP
 			G_EXEC rmdir $FP_MNT_TMP
-			G_EXEC partprobe "$FP_SOURCE" # Failsafe
-			G_EXEC partx -u "$FP_SOURCE" # Failsafe
-			Run_fsck
 			# Assure root filesystem size is in 512 byte sectors, as this is what sfdisk assmes
 			FS_SIZE=$(( $FS_SIZE * $sector_size / 512 ))
 		elif [[ $ROOT_FS_TYPE == 'btrfs' ]]
@@ -365,9 +365,19 @@
 			G_EXEC mkdir -p $FP_MNT_TMP
 			G_EXEC mount -o ro "$FP_ROOT_DEV" $FP_MNT_TMP
 			FS_SIZE=$(( $(btrfs inspect-internal min-dev-size $FP_MNT_TMP) + 4*1024**2 )) # bytes? + 4 MiB buffer
-			G_EXEC_OUTPUT=1 G_EXEC btrfs filesystem resize $FS_SIZE
+			G_EXEC_OUTPUT=1 G_EXEC btrfs filesystem resize $FS_SIZE $FP_MNT_TMP
+			G_EXEC fstrim $FP_MNT_TMP
+			sync
+			sleep 1 # Give the system 1 second to avoid "mount is busy"
+			G_EXEC umount $FP_MNT_TMP
+			G_EXEC rmdir $FP_MNT_TMP
 			FS_SIZE=$(( $FS_SIZE / 512 )) # bytes => 512 byte sectors
 		fi
+
+		G_EXEC sync
+		G_EXEC partprobe "$FP_SOURCE" # Failsafe
+		G_EXEC partx -u "$FP_SOURCE" # Failsafe
+		Run_fsck
 
 		# Only resize partition when new size would be less than current size
 		if (( $(</sys/class/block/"${FP_ROOT_DEV##*/}"/size) > $FS_SIZE ))
@@ -378,16 +388,7 @@
 			G_EXEC partx -u "$FP_SOURCE"
 		fi
 
-		if [[ $ROOT_FS_TYPE == 'ext4' ]]
-		then
-			G_DIETPI-NOTIFY 2 'Overriding root filesystem free space with zeros to purge removed data and allow further archive size reduction...'
-			G_EXEC_OUTPUT=1 G_EXEC zerofree -v "$FP_ROOT_DEV"
-			G_EXEC sync
-		fi
-
 		# Finished: Derive final image size from last partition end + failsafe buffer
-		G_EXEC partprobe "$FP_SOURCE"
-		G_EXEC partx -u "$FP_SOURCE"
 		IMAGE_SIZE=$(( ( $(sfdisk -qlo End "$FP_SOURCE" | tail -1) + 1 ) * 512 )) # 512 byte sectors => Byte
 		IMAGE_SIZE=$(( $IMAGE_SIZE + ( 512 * 256 ) )) # 64 byte for secondary GPT + safety net
 
@@ -556,11 +557,8 @@ _EOF_
 		# - gdisk will correct this
 		if [[ $PART_TABLE_TYPE == 'gpt' ]]
 		then
-			local loop=$(losetup -f)
-			G_EXEC losetup "$loop" "$OUTPUT_IMG_NAME.$OUTPUT_IMG_EXT"			
-			G_EXEC_DESC='Reapplying GPT partition backup table fix' G_EXEC_OUTPUT=1 G_EXEC sgdisk -e "$loop"
+			G_EXEC_DESC='Reapplying GPT partition backup table fix' G_EXEC_OUTPUT=1 G_EXEC sgdisk -e "$OUTPUT_IMG_NAME.$OUTPUT_IMG_EXT"
 			G_EXEC sync
-			G_EXEC losetup -d "$loop"
 		fi
 
 		# Generate hashes: MD5, SHA1, SHA256

--- a/.meta/dietpi-imager
+++ b/.meta/dietpi-imager
@@ -331,34 +331,36 @@
 			done
 			G_DIETPI-NOTIFY 2 'Overriding root filesystem free space with zeros to purge removed data and allow further archive size reduction...'
 			G_EXEC_OUTPUT=1 G_EXEC zerofree -v "$FP_ROOT_DEV"
+			G_EXEC sync
 
-		elif [[ $ROOT_FS_TYPE == 'f2fs' && $(lsblk -rno FSUSE% "$FP_ROOT_DEV") =~ ^(9[5-9]|100)%$ ]]
+		elif [[ $ROOT_FS_TYPE == 'f2fs' ]] #&& $(lsblk -rno FSUSE% "$FP_ROOT_DEV") =~ ^(9[5-9]|100)%$ ]]
 		then
 			# F2FS does not support shrinking: https://www.reddit.com/r/archlinux/comments/bpp77f/shrinking_a_f2fs_partition/
 			# Hence copy all data outside, remove and re-create a smaller filesytem, then copy them back in, as long as disk usage is not >=95% already.
-			local usage=$(lsblk -rnbo FSUSED "$FP_ROOT_DEV") # bytes
-			local sector_size=$(lsblk -rnbo LOG-SEC "$FP_ROOT_DEV") # bytes
-			FS_SIZE=$(( ( $usage + 4*1024**2 ) / $sector_size )) # bytes + 4 MiB buffer => sectors
-			G_DIETPI-NOTIFY 2 'Copying root filesystem content to temporary directory'
+			# The UUID changes and there is currently no way to change it back...
+			#local usage=$(lsblk -rnbo FSUSED "$FP_ROOT_DEV") # bytes
+			#local sector_size=$(lsblk -rnbo LOG-SEC "$FP_ROOT_DEV") # bytes
+			#FS_SIZE=$(( ( $usage + 4*1024**2 ) / $sector_size )) # bytes + 4 MiB buffer => sectors
+			#G_DIETPI-NOTIFY 2 'Copying root filesystem content to temporary directory'
 			G_EXEC mkdir -p ${FP_MNT_TMP}{,_backup}
 			G_EXEC mount -o ro "$FP_ROOT_DEV" $FP_MNT_TMP
-			G_EXEC cp -a $FP_MNT_TMP/. ${FP_MNT_TMP}_backup/
-			G_EXEC umount $FP_MNT_TMP
-			G_DIETPI-NOTIFY 2 'Purging root filesystem'
-			G_EXEC dd if=/dev/zero of="$FP_ROOT_DEV" bs=4K count=10
-			G_DIETPI-NOTIFY 2 'Re-creating smaller root filesystem' # Probably sload.f2fs can replace this? https://manpages.debian.org/sload.f2fs
-			G_EXEC_OUTPUT=1 G_EXEC mkfs.f2fs -w "$sector_size" "$FP_ROOT_DEV" $FS_SIZE
-			G_DIETPI-NOTIFY 2 'Moving root filesystem content back'
-			G_EXEC mount "$FP_ROOT_DEV" $FP_MNT_TMP
-			G_EXEC cp -a ${FP_MNT_TMP}_backup/. $FP_MNT_TMP/
-			G_EXEC rm -R ${FP_MNT_TMP}_backup
+			#G_EXEC cp -a $FP_MNT_TMP/. ${FP_MNT_TMP}_backup/
+			#G_EXEC umount $FP_MNT_TMP
+			#G_DIETPI-NOTIFY 2 'Purging root filesystem'
+			#G_EXEC dd if=/dev/zero of="$FP_ROOT_DEV" bs=4K count=10
+			#G_DIETPI-NOTIFY 2 'Re-creating smaller root filesystem' # Probably sload.f2fs can replace this? https://manpages.debian.org/sload.f2fs
+			#G_EXEC_OUTPUT=1 G_EXEC mkfs.f2fs -w "$sector_size" "$FP_ROOT_DEV" $FS_SIZE
+			#G_DIETPI-NOTIFY 2 'Moving root filesystem content back'
+			#G_EXEC mount "$FP_ROOT_DEV" $FP_MNT_TMP
+			#G_EXEC cp -a ${FP_MNT_TMP}_backup/. $FP_MNT_TMP/
+			#G_EXEC rm -R ${FP_MNT_TMP}_backup
 			G_EXEC fstrim $FP_MNT_TMP
-			sync
-			sleep 1 # Give the system 1 second to avoid "mount is busy"
+			G_EXEC sync
+			G_EXEC sleep 1 # Give the system 1 second to avoid "mount is busy"
 			G_EXEC umount $FP_MNT_TMP
 			G_EXEC rmdir $FP_MNT_TMP
 			# Assure root filesystem size is in 512 byte sectors, as this is what sfdisk assmes
-			FS_SIZE=$(( $FS_SIZE * $sector_size / 512 ))
+			#FS_SIZE=$(( $FS_SIZE * $sector_size / 512 ))
 		elif [[ $ROOT_FS_TYPE == 'btrfs' ]]
 		then
 			G_DIETPI-NOTIFY 2 'Shrinking root filesystem to minimum size...'
@@ -367,20 +369,17 @@
 			FS_SIZE=$(( $(btrfs inspect-internal min-dev-size $FP_MNT_TMP) + 4*1024**2 )) # bytes? + 4 MiB buffer
 			G_EXEC_OUTPUT=1 G_EXEC btrfs filesystem resize $FS_SIZE $FP_MNT_TMP
 			G_EXEC fstrim $FP_MNT_TMP
-			sync
-			sleep 1 # Give the system 1 second to avoid "mount is busy"
+			G_EXEC sync
+			G_EXEC sleep 1 # Give the system 1 second to avoid "mount is busy"
 			G_EXEC umount $FP_MNT_TMP
 			G_EXEC rmdir $FP_MNT_TMP
 			FS_SIZE=$(( $FS_SIZE / 512 )) # bytes => 512 byte sectors
 		fi
 
-		G_EXEC sync
-		G_EXEC partprobe "$FP_SOURCE" # Failsafe
-		G_EXEC partx -u "$FP_SOURCE" # Failsafe
 		Run_fsck
 
 		# Only resize partition when new size would be less than current size
-		if (( $(</sys/class/block/"${FP_ROOT_DEV##*/}"/size) > $FS_SIZE ))
+		if [[ $ROOT_FS_TYPE != 'f2fs' ]] && (( $(</sys/class/block/"${FP_ROOT_DEV##*/}"/size) > $FS_SIZE ))
 		then
 			G_DIETPI-NOTIFY 2 "Shrinking root partition to: $(( $FS_SIZE / 2048 + 1 )) MiB"
 			G_EXEC_OUTPUT=1 G_EXEC eval "sfdisk --no-reread --no-tell-kernel -fN${FP_ROOT_DEV: -1} '$FP_SOURCE' <<< ',$FS_SIZE'"

--- a/.meta/dietpi-imager
+++ b/.meta/dietpi-imager
@@ -365,7 +365,7 @@
 		then
 			G_DIETPI-NOTIFY 2 'Shrinking root filesystem to minimum size...'
 			G_EXEC mkdir -p $FP_MNT_TMP
-			G_EXEC mount -o ro "$FP_ROOT_DEV" $FP_MNT_TMP
+			G_EXEC mount "$FP_ROOT_DEV" $FP_MNT_TMP
 			FS_SIZE=$(( $(btrfs inspect-internal min-dev-size $FP_MNT_TMP) + 4*1024**2 )) # bytes? + 4 MiB buffer
 			G_EXEC_OUTPUT=1 G_EXEC btrfs filesystem resize $FS_SIZE $FP_MNT_TMP
 			G_EXEC fstrim $FP_MNT_TMP

--- a/.meta/dietpi-imager
+++ b/.meta/dietpi-imager
@@ -168,7 +168,7 @@
 
 	Menu_Target_Name()
 	{
-		main_menu_choice='Target Name' # On cancel, keep this entry selected
+		main_menu_choice='Target name' # On cancel, keep this entry selected
 
 		G_WHIP_DEFAULT_ITEM=$OUTPUT_IMG_NAME
 		G_WHIP_INPUTBOX 'Please enter a name for the new image:\n - DietPi_<device>-<arch>-<distro>\n - E.g.: DietPi_RPi-ARMv6-Buster' || return
@@ -212,6 +212,7 @@
 			'Target type') Menu_Target_Type;;
 			'Target name') Menu_Target_Name;;
 			'Mount') [[ $MOUNT_IT == 'Off' ]] && MOUNT_IT='On' || MOUNT_IT='Off';;
+			'Start') main_menu_choice='Start';;
 		esac
 	}
 
@@ -236,7 +237,8 @@
 
 	Main(){
 
-		local main_menu_choice='Source type'
+		local main_menu_choice
+		Menu_Source_Type
 		until [[ $main_menu_choice == 'Start' ]]
 		do
 			Menu_Main

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,12 +2,15 @@ v7.1
 (2021-03-XX)
 
 Changes:
+- DietPi-FS_partition_resize | Added support to automatically resize F2FS and Btrfs filesystems on first boot.
+- DietPi-Drive_Manager | Added support for resizing F2FS and Btrfs filesystems as well as format- and filesystem check & repair support for XFS filesystems.
 
 Fixes:
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 
 Known/Outstanding Issues:
+- DietPi-Drive_Manager | Fixed detection and visualisation of loop devices in menu.
 - DietPi-Config | Enabling WiFi + Ethernet adapters, both on different subnets, breaks WiFi connection in some cases: https://github.com/MichaIng/DietPi/issues/2103
 - DietPi-Software | MATE desktop: When logging in as root, desktop items and right-click context menu is missing: https://github.com/MichaIng/DietPi/issues/3160
 - DietPi-Software | Sonarr/Radarr/Mono: With current Mono version 6, import to a file system without UNIX permissions support (exFAT, FAT32/vfat, CIFS mounts and NTFS without "permissions" option) fails, regardless of user/umask mount options: https://github.com/MichaIng/DietPi/issues/3179

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -634,12 +634,13 @@ Currently installed: $G_DISTRO_NAME (ID: $G_DISTRO)"; then
 		G_EXEC mv "DietPi-$G_GITBRANCH/CHANGELOG.txt" /boot/dietpi-CHANGELOG.txt
 
 		# Reading version string for later use
-		G_DIETPI_VERSION_CORE=$(mawk 'NR==1' "DietPi-$G_GITBRANCH/dietpi/server_version-6")
-		G_DIETPI_VERSION_SUB=$(mawk 'NR==2' "DietPi-$G_GITBRANCH/dietpi/server_version-6")
-		G_DIETPI_VERSION_RC=$(mawk 'NR==3' "DietPi-$G_GITBRANCH/dietpi/server_version-6")
+		. "DietPi-$G_GITBRANCH/.update/version"
+		G_DIETPI_VERSION_CORE=$G_REMOTE_VERSION_CORE
+		G_DIETPI_VERSION_SUB=$G_REMOTE_VERSION_SUB
+		G_DIETPI_VERSION_RC=$G_REMOTE_VERSION_RC
 
-		# Remove server_version* / (pre-)patch_file (downloads fresh from dietpi-update)
-		rm "DietPi-$G_GITBRANCH/dietpi/server_version"*
+		# Remove server_version-6 / (pre-)patch_file (downloads fresh from dietpi-update)
+		rm "DietPi-$G_GITBRANCH/dietpi/server_version-6"
 		rm "DietPi-$G_GITBRANCH/dietpi/pre-patch_file"
 		rm "DietPi-$G_GITBRANCH/dietpi/patch_file"
 

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -775,14 +775,25 @@ Currently installed: $G_DISTRO_NAME (ID: $G_DISTRO)"; then
 		fi
 
 		# Install gdisk if root file system is on a GPT partition, used by DietPi-FS_partition_resize
-		[[ $(parted -s "$(lsblk -npo PKNAME "$(findmnt -no SOURCE /)")" print) == *'Partition Table: gpt'* ]] && aPACKAGES_REQUIRED_INSTALL+=('gdisk')
+		[[ $(lsblk -ndo PTTYPE "$(lsblk -npo PKNAME "$(findmnt -no SOURCE /)")") == 'gpt' ]] && aPACKAGES_REQUIRED_INSTALL+=('gdisk')
 
-		# Install required filesystem packages
-		if [[ $(blkid -s TYPE -o value) =~ (^|[[:space:]]|v)'fat' ]]; then
+		# Install file system tools required for file system resizing and fsck
+		while read -r line
+		do
+			if [[ $line == 'vfat' ]]
+			then
+				aPACKAGES_REQUIRED_INSTALL+=('dosfstools')
 
-			aPACKAGES_REQUIRED_INSTALL+=('dosfstools')		# DietPi-Drive_Manager + fat (boot) drive file system check and creation tools
+			elif [[ $line == 'f2fs' ]]
+			then
+				aPACKAGES_REQUIRED_INSTALL+=('f2fs-tools')
 
-		fi
+			elif [[ $line == 'btrfs' ]]
+			then
+				aPACKAGES_REQUIRED_INSTALL+=('btrfs-progs')
+			fi
+
+		done < <(lsblk -no FSTYPE | sort -u)
 
 		# Kernel/bootloader/firmware
 		# - We need to install those directly to allow G_AGA() autoremove possible older packages later: https://github.com/MichaIng/DietPi/issues/1285#issuecomment-354602594

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -828,11 +828,10 @@ Currently installed: $G_DISTRO_NAME (ID: $G_DISTRO)"; then
 
 			local apackages=(
 
-				'linux-dtb-'
-				'linux-u-'
 				'linux-image-'
-				"linux-$DISTRO_TARGET_NAME-"
-				'sunxi-tools'
+				'linux-dtb-'
+				'linux-u-boot-'
+				"linux-$DISTRO_TARGET_NAME-root-"
 
 			)
 
@@ -845,7 +844,7 @@ Currently installed: $G_DISTRO_NAME (ID: $G_DISTRO)"; then
 					aPACKAGES_REQUIRED_INSTALL+=("$line")
 					G_DIETPI-NOTIFY 2 "Armbian package detected and added: $line"
 
-				done <<< "$(dpkg-query -Wf '${Package}\n' | mawk -v pat="^$i" '$0~pat')"
+				done < <(dpkg-query -Wf '${Package}\n' | mawk -v pat="^$i" '$0~pat')
 
 			done
 			unset -v apackages

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -411,22 +411,22 @@ aDRIVE_ISPARTITIONTABLE ${aDRIVE_ISPARTITIONTABLE[$i]}
 	# $1=source
 	Return_Drive_Without_Partitions(){
 
-		# IDE/SATA/SCSI
-		if [[ $1 == /dev/[sh]d[a-z]* ]]; then
+		local drive=${1#/dev/}
 
-			local drive=${1#/dev/}
+		# IDE/SATA/SCSI
+		if [[ $1 == /dev/[sh]d[a-z][1-9] ]]; then
+
 			echo "${drive%[0-9]}"
 
-		# MMC/NVMe
-		elif [[ $1 == '/dev/mmcblk'* || $1 == '/dev/nvme'* ]]; then
+		# MMC/NVMe/loop
+		elif [[ $1 =~ ^/dev/(mmcblk|nvme[0-9]n|loop)[0-9]p[1-9]$ ]]; then
 
-			local drive=${1#/dev/}
 			echo "${drive%p[0-9]}"
 
-		# Network drive
+		# No partition table or unknown block device type
 		else
 
-			echo "$1"
+			echo "$drive"
 
 		fi
 

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -391,7 +391,6 @@ aDRIVE_ISPARTITIONTABLE ${aDRIVE_ISPARTITIONTABLE[$i]}
 		[[ $APT_CHECK == 0 && $need_ntfs$need_hfs$need_exfat ]] && G_AG_CHECK_INSTALL_PREREQ $need_ntfs $need_hfs $need_exfat && APT_CHECK=1
 
 		G_EXEC sync
-		G_EXEC mount -a
 
 	}
 
@@ -1461,8 +1460,8 @@ We recommend \"ext4\" as filesystem type for the RootFS."
 
 				fi
 
-				if (( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} )); then
-
+				if (( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} ))
+				then
 					G_WHIP_YESNO 'For safe check and repair, the drive needs to be unmounted.
 \nDo you want to continue with the drive being unmounted automatically?' || return 1
 
@@ -1472,8 +1471,7 @@ We recommend \"ext4\" as filesystem type for the RootFS."
 					(( $partition_contains_swapfile )) && G_EXEC swapoff -a
 
 					# Unmount drive
-					G_EXEC umount "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
-
+					G_EXEC umount "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
 				fi
 
 				# Do dry-run first for filesystems supporting it:
@@ -1486,8 +1484,8 @@ We recommend \"ext4\" as filesystem type for the RootFS."
 
 				fi
 
-				if G_WHIP_YESNO "Would you like to run an automated repair on the following drive now?\n       ${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}\n
-NB:
+				if G_WHIP_YESNO "Would you like to run an automated repair on the following drive now?\n${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}
+\nNB:
 - Automated repair steps potentially lead to data loss, which would have been able to recover by professional drive recovery services.
 - If the data is extremely important and you don't have any backup, you might want to hand the drive to a recovery service as is.
 - These services are usually very expensive, but might be able to recover more data than (after) this automated repair steps!"; then
@@ -1498,11 +1496,14 @@ NB:
 
 				fi
 
-				# Remount all drives
-				G_EXEC mount -a
+				if (( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} ))
+				then
+					# Remount drive
+					G_EXEC mount "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
 
-				# Re-enable swap
-				(( $partition_contains_swapfile )) && G_EXEC swapon -a
+					# Re-enable swap
+					(( $partition_contains_swapfile )) && G_EXEC swapon -a
+				fi
 
 			elif [[ $G_WHIP_RETURNED_VALUE == 'I/O Scheduler' ]]; then
 

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -508,15 +508,13 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 
 		elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == ext[2-4] ]]; then
 
-			(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} )) && G_EXEC_NOEXIT=1 G_EXEC umount "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
 			G_EXEC_NOEXIT=1 G_EXEC resize2fs "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
-			(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} )) && G_EXEC_NOEXIT=1 G_EXEC mount "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
 
 		elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'f2fs' ]]; then
 
-			(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} )) && G_EXEC_NOEXIT=1 G_EXEC umount "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
+			(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} && ! ${aDRIVE_ISREADONLY_CURRENTLY[$MENU_DRIVE_INDEX]} )) && G_EXEC_NOEXIT=1 G_EXEC mount -o remount,ro "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
 			G_EXEC_NOEXIT=1 G_EXEC resize.f2fs "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
-			(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} )) && G_EXEC_NOEXIT=1 G_EXEC mount "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
+			(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} && ! ${aDRIVE_ISREADONLY_CURRENTLY[$MENU_DRIVE_INDEX]} )) && G_EXEC_NOEXIT=1 G_EXEC mount -o remount,rw "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
 
 		elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'btrfs' ]]; then
 
@@ -1149,7 +1147,7 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 				G_WHIP_MENU_ARRAY+=('Check & Repair' ': Check and optionally repair filesystem')
 
 				# Resize
-				if [[ ${aDRIVE_ISREADONLY_CURRENTLY[$MENU_DRIVE_INDEX]} == 0 && ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} =~ ^(ext[2-4]|f2fs|btrfs)$ ]]; then
+				if [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} =~ ^(ext[2-4]|f2fs|btrfs)$ ]]; then
 
 					G_WHIP_MENU_ARRAY+=('Resize' ': Maximize the available filesystem size')
 

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -172,13 +172,13 @@ $swap_mounts
 
 			aDRIVE_SOURCE_DEVICE[$index]=$(Return_Drive_Without_Partitions "${aDRIVE_MOUNT_SOURCE[$index]}")
 			[[ ${aDRIVE_MOUNT_SOURCE[$index]} == /dev/${aDRIVE_SOURCE_DEVICE[$index]} ]] || aDRIVE_ISPARTITIONTABLE[$index]=1
-			aDRIVE_UUID[$index]=$(blkid -s UUID -o value "${aDRIVE_MOUNT_SOURCE[$index]}")
-			(( ${aDRIVE_ISPARTITIONTABLE[$index]} )) && aDRIVE_PART_UUID[$index]=$(blkid -s PARTUUID -o value "${aDRIVE_MOUNT_SOURCE[$index]}")
+			aDRIVE_UUID[$index]=$(findmnt -no UUID "${aDRIVE_MOUNT_TARGET[$index]}")
+			(( ${aDRIVE_ISPARTITIONTABLE[$index]} )) && aDRIVE_PART_UUID[$index]=$(findmnt -no PARTUUID "${aDRIVE_MOUNT_TARGET[$index]}")
 
 			# Physical?
 			if [[ -d '/sys/block/'${aDRIVE_SOURCE_DEVICE[$index]} ]]; then
 
-				aDRIVE_FSTYPE[$index]=$(blkid -s TYPE -o value "${aDRIVE_MOUNT_SOURCE[$index]}")
+				aDRIVE_FSTYPE[$index]=$(findmnt -no FSTYPE "${aDRIVE_MOUNT_TARGET[$index]}")
 				[[ ${aDRIVE_FSTYPE[$index]} ]] && aDRIVE_ISFILESYSTEM[$index]=1
 
 			# Networked
@@ -248,7 +248,7 @@ $swap_mounts
 				if [[ ${aDRIVE_MOUNT_TARGET[$index]} =~ ^/(boot(/efi)?)?$ ]]; then
 
 					# On RPi we need to use PARTUUID for Root/BootFS
-					(( $G_HW_MODEL < 10 )) && dev_entry="PARTUUID=${aDRIVE_PART_UUID[$index]}"
+					(( $G_HW_MODEL > 9 )) || dev_entry="PARTUUID=${aDRIVE_PART_UUID[$index]}"
 					[[ ${aDRIVE_MOUNT_TARGET[$index]} == '/' ]] && options+=' 0 1' || options+=' 0 2' # dump + fsck flag
 
 				else
@@ -267,20 +267,20 @@ $swap_mounts
 
 		done < <(df -a --output=source --exclude-type=tmpfs --exclude-type=ecryptfs --exclude-type=vboxsf --exclude-type=glusterfs | sed "\|^/dev/root$|c$G_ROOTFS_DEV" | mawk '/\// && !x[$0]++')
 
-		# Check blkid for unmounted drives, if drive is not mounted, add entry as disabled/commented mount
+		# Check blkid for unmounted filesystems
 		while read -r line
 		do
 
 			[[ $line ]] || continue
 
-			# Exclude drives already found
+			# Exclude drives already found (mounted)
 			for i in "${aDRIVE_MOUNT_SOURCE[@]}"
 			do
 				[[ $i == "$line"* ]] && continue 2
 			done
 
-			# Must have a valid UUID! (this excludes /dev/mmcblk0)
-			local uuid=$(blkid -s UUID -o value "$line")
+			# Failsafe: Must have a valid UUID! But blkid should print only drives with filesytems.
+			local uuid=$(lsblk -no UUID "$line")
 			[[ $uuid ]] || continue
 
 			G_DIETPI-NOTIFY 2 " - Detected unmounted drive: $line"
@@ -292,26 +292,20 @@ $swap_mounts
 			aDRIVE_MOUNT_TARGET[$index]="/mnt/${aDRIVE_UUID[$index]}"
 			aDRIVE_SOURCE_DEVICE[$index]=$(Return_Drive_Without_Partitions "${aDRIVE_MOUNT_SOURCE[$index]}")
 			[[ ${aDRIVE_MOUNT_SOURCE[$index]} == /dev/${aDRIVE_SOURCE_DEVICE[$index]} ]] || aDRIVE_ISPARTITIONTABLE[$index]=1
-			(( ${aDRIVE_ISPARTITIONTABLE[$index]} )) && aDRIVE_PART_UUID[$index]=$(blkid -s PARTUUID -o value "${aDRIVE_MOUNT_SOURCE[$index]}")
-			aDRIVE_FSTYPE[$index]=$(blkid -s TYPE -o value "${aDRIVE_MOUNT_SOURCE[$index]}")
+			(( ${aDRIVE_ISPARTITIONTABLE[$index]} )) && aDRIVE_PART_UUID[$index]=$(lsblk -no PARTUUID "${aDRIVE_MOUNT_SOURCE[$index]}")
+			aDRIVE_FSTYPE[$index]=$(lsblk -no FSTYPE "${aDRIVE_MOUNT_SOURCE[$index]}")
 			[[ ${aDRIVE_FSTYPE[$index]} ]] && aDRIVE_ISFILESYSTEM[$index]=1
-
-			# FS type: In case of unknown network drive, use "auto", to allow remove FS changes without breaking the fstab entry
-			local type=${aDRIVE_FSTYPE[$index]}
-			(( ${aDRIVE_ISNETWORKED[$index]} )) && type='auto'
-
-			echo "#UUID=${aDRIVE_UUID[$index]} ${aDRIVE_MOUNT_TARGET[$index]} ${type:-auto} noatime,lazytime,rw,nofail,noauto,x-systemd.automount" >> $fp_fstab_tmp
 
 		done < <(blkid -o device)
 
-		# Find unformated drives
+		# Find unformatted drives
 		# - Exclude mtdblock devices: https://github.com/MichaIng/DietPi/issues/2067#issuecomment-422400520
 		while read -r line
 		do
 
 			[[ $line ]] || continue
 
-			# Exclude drives already found
+			# Exclude drives already found (formatted)
 			for i in "${aDRIVE_SOURCE_DEVICE[@]}"
 			do
 				[[ $line == $i* ]] && continue 2
@@ -390,15 +384,14 @@ aDRIVE_ISPARTITIONTABLE ${aDRIVE_ISPARTITIONTABLE[$i]}
 		Update_Menu_Drive_Index
 
 		# Move new fstab in place and reload systemd generators
-		cp -a $fp_fstab_tmp /etc/fstab
-		systemctl daemon-reload
-		rm $fp_fstab_tmp
+		G_EXEC mv $fp_fstab_tmp /etc/fstab
+		G_EXEC systemctl daemon-reload
 
 		# Install required APT packages for FS R/W access
 		[[ $APT_CHECK == 0 && $need_ntfs$need_hfs$need_exfat ]] && G_AG_CHECK_INSTALL_PREREQ $need_ntfs $need_hfs $need_exfat && APT_CHECK=1
 
-		sync
-		mount -a
+		G_EXEC sync
+		G_EXEC mount -a
 
 	}
 
@@ -481,7 +474,7 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 		# Mount options
 		local aoptions=()
 		# - FS type specific options
-		local fs_type=$(blkid "$source" -s TYPE -o value)
+		local fs_type=$(lsblk -no FSTYPE "$source")
 		if [[ $fs_type == 'ntfs' ]]; then
 
 			aoptions=('-o' 'permissions')
@@ -514,16 +507,23 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 
 		if [[ ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} == '/' ]]; then
 
-			systemctl unmask dietpi-fs_partition_resize
 			G_EXEC systemctl enable dietpi-fs_partition_resize
-			G_WHIP_YESNO 'RootFS resize will occur on next reboot.\n\nWould you like to reboot the system now?' && reboot
+			G_WHIP_YESNO 'RootFS resize will occur on next reboot.\n\nWould you like to reboot the system now?' && reboot || return
 
-		else
+		elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == ext[2-4] ]]; then
 
-			G_EXEC_NOHALT=1 G_EXEC resize2fs "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
-			Init_Drives_and_Refresh
+			G_EXEC_NOEXIT=1 G_EXEC resize2fs "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
+
+		elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'f2fs' ]]; then
+
+			G_EXEC_NOEXIT=1 G_EXEC resize.f2fs "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
+
+		elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'btrfs' ]]; then
+
+			G_EXEC_NOEXIT=1 G_EXEC btrfs filesystem resize max "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
 
 		fi
+		Init_Drives_and_Refresh
 
 	}
 
@@ -563,18 +563,17 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 			else
 
 				# Umount and zero all partitions on device
+				# - Partition wipe must be done 1st, else UUIDs are still reported.
 				for i in "/dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}"?*
 				do
-
 					[[ -b $i ]] || continue
-					umount "$i"
+					findmnt "$i" > /dev/null && G_EXEC umount "$i"
 					G_DIETPI-NOTIFY 2 "Writing zeros to partition: $i"
-					G_EXEC dd if=/dev/zero of="$i" bs=4K count=10 # Partition wipe must be done 1st, else blkid still reports UUIDs etc
-
+					G_EXEC dd if=/dev/zero of="$i" bs=4K count=10
 				done
 
 				# Unmount whole drive in case of fs on drive without partition table
-				umount "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
+				findmnt "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}" > /dev/null && G_EXEC umount "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
 
 				# Clear partition table from device
 				G_DIETPI-NOTIFY 2 "Writing zeros to partition table: /dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}"
@@ -588,23 +587,20 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 				G_EXEC parted -s "/dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}" mklabel $parition_table_type
 				G_EXEC parted -s "/dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}" mkpart primary 0% 100%
 				partprobe "/dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}"
+				partx -u "/dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}"
 
 				sleep 1 # Due to systemd automount, wait for it
-				umount "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
+				findmnt "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}" > /dev/null && G_EXEC umount "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
 
 				# Generate new aDRIVE_MOUNT_SOURCE location to use
-				# - mmcblkXp1/nvmeXn1p1
-				aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]="/dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}p1"
-				# - h/sdX1
-				if [[ ${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]} == [sh]d[a-z]* ]]; then
-
+				# - hda1/sda1
+				if [[ ${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]} == [sh]d[a-z] ]]
+				then
 					aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]="/dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}1"
 
-				# - NanoPC-T4 + NVMe special: https://github.com/MichaIng/DietPi/issues/2102#issue-366001513
-				elif [[ $G_HW_MODEL == 68 && ${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]} == nvme* ]]; then
-
-					aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]="/dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}p6"
-
+				# - mmcblk0p1/nvme0n0p1
+				else
+					aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]="/dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}p1"
 				fi
 
 			fi
@@ -613,23 +609,23 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 			if (( $FORMAT_FILESYSTEM_TYPE == 0 )); then
 
 				# force
-				info_format_fs_type='EXT4'
+				info_format_fs_type='ext4'
 				G_EXEC mkfs.ext4 -F -m 0 "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
 				resize2fs "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
 
 			# Format NTFS
 			elif (( $FORMAT_FILESYSTEM_TYPE == 1 )); then
 
-				# fast format / no indexing / force
+				# -f: fast format | -I: no indexing | -F: force
 				info_format_fs_type='NTFS'
 				G_EXEC mkfs.ntfs -f -I -F "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
 
 			# Format FAT32
 			elif (( $FORMAT_FILESYSTEM_TYPE == 2 )); then
 
-				# Use 1 parition on whole device
+				# -I: Use 1 parition on whole device
 				info_format_fs_type='FAT'
-				G_EXEC mkfs.vfat -I "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
+				G_EXEC mkfs.fat -I "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
 
 			# Format HFS+
 			elif (( $FORMAT_FILESYSTEM_TYPE == 3 )); then
@@ -640,8 +636,8 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 			# Format btrfs
 			elif (( $FORMAT_FILESYSTEM_TYPE == 4 )); then
 
-				# force
-				info_format_fs_type='BTRFS'
+				# -f: force
+				info_format_fs_type='Btrfs'
 				G_EXEC mkfs.btrfs -f "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
 
 			# Format f2fs
@@ -656,6 +652,13 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 				info_format_fs_type='exFAT'
 				G_EXEC mkfs.exfat "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
 
+			# Format XFS
+			elif (( $FORMAT_FILESYSTEM_TYPE == 7 )); then
+
+				# -f: force
+				info_format_fs_type='XFS'
+				G_EXEC mkfs.xfs -f "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
+
 			fi
 
 			G_DIETPI-NOTIFY 0 "Created $info_format_fs_type filesystem: ${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
@@ -665,7 +668,7 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 			[[ -e ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} ]] && rm -R "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
 
 			# Automatically mount it
-			local new_uuid=$(blkid -s UUID -o value "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}")
+			local new_uuid=$(lsblk -no UUID "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}")
 			if ! Mount_Drive "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}" "/mnt/$new_uuid"; then
 
 				MENU_DRIVE_TARGET="/mnt/$new_uuid"
@@ -705,7 +708,7 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 
 		# Mount rootfs to tmp mountpoint to allow rsync
 		# - rsync "-x" option prevents copying mounts content, but it copies permissions of mountpoint dirs according to mount options instead of those of the dir on the parent fs.
-		# - Since mount permissions might not be wanted for the underlying file system dir, we copy from a temporary mountpoint to assure that underlying rootfs content matches 100%.
+		# - Since mount permissions might not be wanted for the underlying filesystem dir, we copy from a temporary mountpoint to assure that underlying rootfs content matches 100%.
 		G_EXEC mkdir -p /tmp/tmp_rootfs
 		G_EXEC mount "$G_ROOTFS_DEV" /tmp/tmp_rootfs
 
@@ -1133,7 +1136,7 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 				G_WHIP_MENU_ARRAY+=('Check & Repair' ': Check and optionally repair filesystem')
 
 				# Resize
-				if [[ ${aDRIVE_ISREADONLY_CURRENTLY[$MENU_DRIVE_INDEX]} == 0 && ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'ext4' ]]; then
+				if [[ ${aDRIVE_ISREADONLY_CURRENTLY[$MENU_DRIVE_INDEX]} == 0 && ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} =~ ^(ext[2-4]|f2fs|btrfs)$ ]]; then
 
 					G_WHIP_MENU_ARRAY+=('Resize' ': Maximize the available filesystem size')
 
@@ -1222,8 +1225,8 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 				local max=$(( $current_freespace - 2000 ))
 				if [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'btrfs' ]]; then
 
-					G_WHIP_MSG '[FAILED] The file system BTRFS does not support swap files.\n
-Please choose another drive or format this one with another file system, e.g. ext4.'
+					G_WHIP_MSG '[FAILED] The filesystem Btrfs does not support swap files.\n
+Please choose another drive or format this one with another filesystem, e.g. ext4.'
 
 				elif (( $max < $min )); then
 
@@ -1341,7 +1344,7 @@ We recommend \"ext4\" as filesystem type for the RootFS."
 
 					if G_WHIP_YESNO 'This process will move the root filesystem data to another location. This may increase R/W performance when using a USB drive over SDcard, however, there are some limitations:
 \n - The SD/eMMC card, which holds kernel and bootloader, is still required for the boot process. On RPi3, which supports full USB boot, instead it is recommended to flash the whole DietPi image to a USB drive and boot the system without SDcard.
-\n - Custom software installs might use info of the old root mount/filesystem, hence we recommend to move the root file system on fresh DietPi systems only.
+\n - Custom software installs might use info of the old root mount/filesystem, hence we recommend to move the root filesystem on fresh DietPi systems only.
 \n - An immediate reboot is done after the transfer has successfully finished to assure that fstab and cmdline cannot be reverted.
 \nDo you wish to continue?'; then
 
@@ -1386,8 +1389,8 @@ We recommend \"ext4\" as filesystem type for the RootFS."
 
 				if [[ ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} == '/' ]]; then
 
-					if G_WHIP_YESNO 'The root file system can only be checked on reboot.
-\nDo you want to force a file system check of root partition on next reboot?
+					if G_WHIP_YESNO 'The root filesystem can only be checked on reboot.
+\nDo you want to force a filesystem check of root partition on next reboot?
 \nNB: Logs can be found after reboot either via "journalctl -t systemd-fsck" or "cat /run/initramfs/fsck.log"'; then
 
 						> /forcefsck
@@ -1413,7 +1416,7 @@ We recommend \"ext4\" as filesystem type for the RootFS."
 
 				fi
 
-				if [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} =~ 'ext' ]]; then
+				if [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == ext[2-4] ]]; then
 
 					local fsck_dry='e2fsck -n -f'
 					local fsck_fix='e2fsck -y -f'
@@ -1453,15 +1456,21 @@ We recommend \"ext4\" as filesystem type for the RootFS."
 					local fsck_dry='btrfs check --readonly'
 					local fsck_fix='btrfs check --repair'
 
+				elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'xfs' ]]; then
+
+					G_AG_CHECK_INSTALL_PREREQ xfsprogs
+					local fsck_dry='xfs_repair -n'
+					local fsck_fix='xfs_repair'
+
 				else
 
-					G_WHIP_MSG "File system checks are currently not supported for '${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]}'. Aborting..."
+					G_WHIP_MSG "Filesystem checks are currently not supported for '${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]}'. Aborting..."
 					TARGETMENUID=1
 					return
 
 				fi
 
-				# Do dry-run first for file systems supporting it:
+				# Do dry-run first for filesystems supporting it:
 				if [[ $fsck_dry ]]; then
 
 					G_WHIP_MSG "The following drive will now be checked for errors:\n${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}\n\nNo repair will be completed during this process. An option to repair the drive, will be provided after the check."
@@ -1536,7 +1545,7 @@ Read more about I/O scheduling: https://wiki.archlinux.org/index.php/Improving_p
 		local format_mode_text='Drive'
 		(( $FORMAT_MODE )) && format_mode_text='Partition'
 
-		local format_type_text='EXT4'
+		local format_type_text='ext4'
 		if (( $FORMAT_FILESYSTEM_TYPE == 1 )); then
 
 			format_type_text='NTFS'
@@ -1551,7 +1560,7 @@ Read more about I/O scheduling: https://wiki.archlinux.org/index.php/Improving_p
 
 		elif (( $FORMAT_FILESYSTEM_TYPE == 4 )); then
 
-			format_type_text='BTRFS'
+			format_type_text='Btrfs'
 
 		elif (( $FORMAT_FILESYSTEM_TYPE == 5 )); then
 
@@ -1560,6 +1569,10 @@ Read more about I/O scheduling: https://wiki.archlinux.org/index.php/Improving_p
 		elif (( $FORMAT_FILESYSTEM_TYPE == 6 )); then
 
 			format_type_text='exFAT'
+
+		elif (( $FORMAT_FILESYSTEM_TYPE == 7 )); then
+
+			format_type_text='XFS'
 
 		fi
 
@@ -1613,19 +1626,22 @@ NB: If you are planning to dedicate the drive to this system, it is recommended 
 
 				G_WHIP_MENU_ARRAY=(
 
-					'0' ': EXT4   | Default (Recommended)'
+					'0' ': ext4   | Default (Recommended)'
 					'1' ': NTFS   | Windows (High CPU usage)'
 					'2' ': FAT32  | All OS (4GB filesize limit)'
-					'3' ': HFS+   | Mac OS X (Intel Mac default file system)'
-					'4' ': BTRFS  | Linux (Modern filesystem)'
+					'3' ': HFS+   | macOS (Apple default filesystem)'
+					'4' ': Btrfs  | Linux (Modern filesystem)'
 					'5' ': F2FS   | Linux (Flash filesystem)'
 					'6' ': exFAT  | Windows (Flash filesystem)'
+					'7' ': XFS    | Linux (Modern filesystem)'
 
 				)
 
 				G_WHIP_DEFAULT_ITEM=$FORMAT_FILESYSTEM_TYPE
-				if G_WHIP_MENU 'Please select a filesystem type for this format:\n\nEXT4:\nHighly recommended if you plan to use this drive solely on this system (dedicated drive).\n
-NTFS:\nRecommended if you plan to use this drive on a Windows system. High CPU usage during transfers.\n\nFull list of different filesystem types:\nhttps://dietpi.com/docs/dietpi_tools/#dietpi-drive-manager'; then
+				if G_WHIP_MENU 'Please select a filesystem type for this format:
+\next4:\nHighly recommended if you plan to use this drive solely on this system (dedicated drive).
+\nNTFS:\nRecommended if you plan to use this drive on a Windows system. High CPU usage during transfers.
+\nFull list of different filesystem types:\nhttps://dietpi.com/docs/dietpi_tools/#dietpi-drive-manager'; then
 
 					# Install FS pre-reqs
 					# - NTFS
@@ -1657,6 +1673,11 @@ NTFS:\nRecommended if you plan to use this drive on a Windows system. High CPU u
 					elif (( $G_WHIP_RETURNED_VALUE == 6 )); then
 
 						G_AG_CHECK_INSTALL_PREREQ exfat-utils exfat-fuse
+
+					# - XFS
+					elif (( $G_WHIP_RETURNED_VALUE == 7 )); then
+
+						G_AG_CHECK_INSTALL_PREREQ xfsprogs
 
 					fi
 

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -538,7 +538,7 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 		local i text_desc info_format_fs_type
 		local info_format_type_output='Drive format' # Used in complete message
 
-		# No partition table, force drive wipe
+		# Failsafe: No partition table, force drive wipe - actually done in parent menu already
 		(( ${aDRIVE_ISPARTITIONTABLE[$MENU_DRIVE_INDEX]} )) || FORMAT_MODE=0
 
 		if (( $FORMAT_MODE )); then
@@ -559,7 +559,7 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 				info_format_type_output='Single partition format'
 
 				# Unmount
-				umount "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
+				(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} )) && { Unmount_Drive "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}" || return 1; }
 
 				# Clear partition from device
 				G_DIETPI-NOTIFY 2 "Writing zeros to partition ${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
@@ -573,13 +573,14 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 				for i in "/dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}"?*
 				do
 					[[ -b $i ]] || continue
-					findmnt "$i" > /dev/null && G_EXEC umount "$i"
+					local target=$(findmnt -no TARGET "$i")
+					[[ $target ]] && { Unmount_Drive "$target"  || return 1; }
 					G_DIETPI-NOTIFY 2 "Writing zeros to partition: $i"
 					G_EXEC dd if=/dev/zero of="$i" bs=4K count=10
 				done
 
 				# Unmount whole drive in case of fs on drive without partition table
-				findmnt "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}" > /dev/null && G_EXEC umount "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
+				(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} )) && { Unmount_Drive "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}" || return 1; }
 
 				# Clear partition table from device
 				G_DIETPI-NOTIFY 2 "Writing zeros to partition table: /dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}"
@@ -919,7 +920,7 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 
 			elif [[ $G_WHIP_RETURNED_VALUE == 'Add network drive' ]]; then
 
-				TARGETMENUID=3
+				TARGETMENUID=3 # Add network drive menu
 
 			elif [[ $G_WHIP_RETURNED_VALUE == 'Idle Spindown' ]]; then
 
@@ -974,7 +975,7 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 			# Edit drive
 			elif [[ $G_WHIP_RETURNED_VALUE ]]; then
 
-				TARGETMENUID=1
+				TARGETMENUID=1 # Drive menu
 				MENU_DRIVE_TARGET=$G_WHIP_RETURNED_VALUE
 				Update_Menu_Drive_Index
 
@@ -1002,6 +1003,7 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 
 	}
 
+	# TARGETMENUID=1
 	Menu_Drive(){
 
 		G_WHIP_MENU_ARRAY=()
@@ -1216,7 +1218,7 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 \nNB: You can add additional network shares at a later date through the 'dietpi-drive_manager' main menu."; then
 
 						Unmount_Drive "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
-						TARGETMENUID=0
+						TARGETMENUID=0 # Main menu
 
 					fi
 
@@ -1318,14 +1320,9 @@ Please enter the desired percentage of reserved blocks, e.g. "0.05" for 0.05% or
 
 					Notification 1
 
-				# User must unmount partition on this drive, before we can format, this ensures a valid unmount check
-				elif (( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} )); then
-
-					G_WHIP_MSG "The partition (${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}) must be unmounted, before formatting is allowed.\n\nPlease use the option 'Unmount' on the next screen, then retry the 'Format' option."
-
 				else
 
-					TARGETMENUID=2
+					TARGETMENUID=2 # Format menu
 
 				fi
 
@@ -1361,12 +1358,10 @@ We recommend \"ext4\" as filesystem type for the RootFS."
 \n - Odroid: RootFS transfer supports ONLY EXT4 format\n\n - RPi: RootFS transfer supports EXT4, BTRFS and F2FS'
 
 						# NB: We dont enter main loop in this func
-						TARGETMENUID=2
+						TARGETMENUID=2 # Format menu
 						while (( $TARGETMENUID == 2 ))
 						do
-
 							Menu_Format
-
 						done
 
 						(( $FORMAT_COMPLETED )) && RootFS_Move
@@ -1406,21 +1401,6 @@ We recommend \"ext4\" as filesystem type for the RootFS."
 
 					fi
 					return
-
-				fi
-
-				if (( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} )); then
-
-					G_WHIP_YESNO 'For safe check and repair, the drive needs to be unmounted.
-\nDo you want to continue with the drive being unmounted automatically?' || { TARGETMENUID=1; return; }
-
-					(( $SERVICES_STOPPED )) || { /boot/dietpi/dietpi-services stop; SERVICES_STOPPED=1; }
-
-					# Disable swap
-					(( $partition_contains_swapfile )) && G_EXEC swapoff -a
-
-					# Unmount drive
-					G_EXEC umount "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
 
 				fi
 
@@ -1473,8 +1453,22 @@ We recommend \"ext4\" as filesystem type for the RootFS."
 				else
 
 					G_WHIP_MSG "Filesystem checks are currently not supported for '${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]}'. Aborting..."
-					TARGETMENUID=1
-					return
+					return 1
+
+				fi
+
+				if (( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} )); then
+
+					G_WHIP_YESNO 'For safe check and repair, the drive needs to be unmounted.
+\nDo you want to continue with the drive being unmounted automatically?' || return 1
+
+					(( $SERVICES_STOPPED )) || { /boot/dietpi/dietpi-services stop; SERVICES_STOPPED=1; }
+
+					# Disable swap
+					(( $partition_contains_swapfile )) && G_EXEC swapoff -a
+
+					# Unmount drive
+					G_EXEC umount "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
 
 				fi
 
@@ -1537,12 +1531,13 @@ Read more about I/O scheduling: https://wiki.archlinux.org/index.php/Improving_p
 
 		else
 
-			TARGETMENUID=0 # Exit
+			TARGETMENUID=0 # Main menu
 
 		fi
 
 	}
 
+	# TARGETMENUID=2
 	Menu_Format(){
 
 		FORMAT_COMPLETED=0
@@ -1610,8 +1605,7 @@ Read more about I/O scheduling: https://wiki.archlinux.org/index.php/Improving_p
 
 			if [[ $G_WHIP_RETURNED_VALUE == 'Partition Type' ]]; then
 
-				G_WHIP_BUTTON_OK_TEXT='MBR'
-				G_WHIP_BUTTON_CANCEL_TEXT='GPT'
+				G_WHIP_BUTTON_OK_TEXT='MBR' G_WHIP_BUTTON_CANCEL_TEXT='GPT'
 				G_WHIP_YESNO 'Would you like to use GPT or MBR parition table?\n - GPT is required for 2TB+ drives\n - MBR does NOT support 2TB+ drives\n\nIf unsure, select GPT (default)' && FORMAT_GPT=0 || FORMAT_GPT=1
 
 			elif [[ $G_WHIP_RETURNED_VALUE == 'Format Mode' ]]; then
@@ -1696,13 +1690,13 @@ NB: If you are planning to dedicate the drive to this system, it is recommended 
 			elif [[ $G_WHIP_RETURNED_VALUE == 'Format' ]]; then
 
 				Run_Format
-				TARGETMENUID=1
+				TARGETMENUID=1 # Drive menu
 
 			fi
 
 		else
 
-			TARGETMENUID=1
+			TARGETMENUID=1 # Drive menu
 
 		fi
 
@@ -1772,7 +1766,7 @@ NB: If you are planning to dedicate the drive to this system, it is recommended 
 
 				MENU_DRIVE_TARGET=$samba_fp_mount_target
 				Init_Drives_and_Refresh
-				TARGETMENUID=1
+				TARGETMENUID=1 # Drive menu
 
 				G_WHIP_MSG "Mount completed. The new mount can be accessed via:\n - $samba_fp_mount_target\n - CIFS vers=$i"
 				rm $fp_tmp
@@ -1834,7 +1828,7 @@ NB: If you are planning to dedicate the drive to this system, it is recommended 
 
 			MENU_DRIVE_TARGET=$nfs_fp_mount_target
 			Init_Drives_and_Refresh
-			TARGETMENUID=1
+			TARGETMENUID=1 # Drive menu
 
 			G_WHIP_MSG "Mount completed. The new mount can be accessed via:\n - $nfs_fp_mount_target"
 			rm $fp_tmp
@@ -1857,7 +1851,7 @@ NB: If you are planning to dedicate the drive to this system, it is recommended 
 
 				MENU_DRIVE_TARGET=$nfs_fp_mount_target
 				Init_Drives_and_Refresh
-				TARGETMENUID=1
+				TARGETMENUID=1 # Drive menu
 
 				G_WHIP_MSG "Mount completed. The new mount can be accessed via:\n - $nfs_fp_mount_target"
 				rm $fp_tmp
@@ -1875,6 +1869,7 @@ NB: If you are planning to dedicate the drive to this system, it is recommended 
 
 	}
 
+	# TARGETMENUID=3
 	Menu_Add_Network_Drive(){
 
 		G_WHIP_MENU_ARRAY=(

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -521,13 +521,17 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 
 		elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'btrfs' ]]; then
 
-			if (( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} ))
+			if (( ! ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} ))
 			then
-				G_EXEC_NOEXIT=1 G_EXEC btrfs filesystem resize max "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
-			else
-				G_WHIP_MSG 'Btrfs file systems need to be mounted to resize. Please mount the drive first, then retry.'
+				G_EXEC_NOEXIT=1 G_EXEC mkdir -p /tmp/temporary_f2fs_mountpoint
+				G_EXEC_NOEXIT=1 G_EXEC mount "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}" /tmp/temporary_f2fs_mountpoint
 			fi
-
+			G_EXEC_NOEXIT=1 G_EXEC btrfs filesystem resize max "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
+			if (( ! ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} ))
+			then
+				G_EXEC_NOEXIT=1 G_EXEC umount /tmp/temporary_f2fs_mountpoint
+				G_EXEC_NOEXIT=1 G_EXEC rmdir /tmp/temporary_f2fs_mountpoint
+			fi
 		fi
 		Init_Drives_and_Refresh
 

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -493,13 +493,10 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 
 		local target=$1
 
-		if G_EXEC_NOHALT=1 G_EXEC umount "$target"; then
-
-			sed -i "\#[[:blank:]]${target}[[:blank:]]#d" /etc/fstab # Only needed for networked drives currently...
-			G_EXEC_NOHALT=1 G_EXEC rmdir "$target"
-			Init_Drives_and_Refresh
-
-		fi
+		G_EXEC_NOEXIT=1 G_EXEC umount "$target" || return 1
+		sed -i "\#[[:blank:]]${target}[[:blank:]]#d" /etc/fstab # Only needed for networked drives currently...
+		G_EXEC_NOEXIT=1 G_EXEC rmdir "$target"
+		Init_Drives_and_Refresh
 
 	}
 

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -667,11 +667,13 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 
 			fi
 
+			G_EXEC sync # Sync to disk, as well to add a slight delay since XFS formatted file systems do not return a UUID (below) immediately
+
 			G_DIETPI-NOTIFY 0 "Created $info_format_fs_type filesystem: ${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
 			FORMAT_COMPLETED=1
 
 			# Remove old mount point
-			[[ -e ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} ]] && rm -R "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
+			[[ -e ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} ]] && G_EXEC_NOEXIT=1 G_EXEC rm -R "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
 
 			# Automatically mount it
 			local new_uuid=$(lsblk -no UUID "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}")

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -496,7 +496,7 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 		if G_EXEC_NOHALT=1 G_EXEC umount "$target"; then
 
 			sed -i "\#[[:blank:]]${target}[[:blank:]]#d" /etc/fstab # Only needed for networked drives currently...
-			rmdir "$target"
+			G_EXEC_NOHALT=1 G_EXEC rmdir "$target"
 			Init_Drives_and_Refresh
 
 		fi
@@ -512,15 +512,24 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 
 		elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == ext[2-4] ]]; then
 
+			(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} )) && G_EXEC_NOEXIT=1 G_EXEC umount "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
 			G_EXEC_NOEXIT=1 G_EXEC resize2fs "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
+			(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} )) && G_EXEC_NOEXIT=1 G_EXEC mount "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
 
 		elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'f2fs' ]]; then
 
+			(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} )) && G_EXEC_NOEXIT=1 G_EXEC umount "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
 			G_EXEC_NOEXIT=1 G_EXEC resize.f2fs "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
+			(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} )) && G_EXEC_NOEXIT=1 G_EXEC mount "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
 
 		elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'btrfs' ]]; then
 
-			G_EXEC_NOEXIT=1 G_EXEC btrfs filesystem resize max "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
+			if (( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} ))
+			then
+				G_EXEC_NOEXIT=1 G_EXEC btrfs filesystem resize max "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
+			else
+				G_WHIP_MSG 'Btrfs file systems need to be mounted to resize. Please mount the drive first, then retry.'
+			fi
 
 		fi
 		Init_Drives_and_Refresh
@@ -1076,11 +1085,11 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 								[[ $FP_SWAPFILE_CURRENT == '/var/swap' && ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} == '/' ]]; }; then
 
 								partition_contains_swapfile=1
-								G_WHIP_MENU_ARRAY+=('Swapfile' ": [X] | ${swapfile_size} MiB used on this drive, select to change size")
+								G_WHIP_MENU_ARRAY+=('Swap file' ": [X] | ${swapfile_size} MiB used on this drive, select to change size")
 
 							else
 
-								G_WHIP_MENU_ARRAY+=('Swapfile' ': [ ] | Select to transfer swapfile to this drive')
+								G_WHIP_MENU_ARRAY+=('Swap file' ': [ ] | Select to transfer swapfile to this drive')
 
 							fi
 
@@ -1218,7 +1227,7 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 
 				fi
 
-			elif [[ $G_WHIP_RETURNED_VALUE == 'Swapfile' ]]; then
+			elif [[ $G_WHIP_RETURNED_VALUE == 'Swap file' ]]; then
 
 				local min=0
 				local current_freespace=$(G_CHECK_FREESPACE "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}")
@@ -1235,9 +1244,9 @@ Please choose another drive or format this one with another filesystem, e.g. ext
 				else
 
 					G_WHIP_DEFAULT_ITEM=$swapfile_size
-					if G_WHIP_INPUTBOX "Please input a new value for swapfile size (MiB):
-\nSwapfile has a swapiness setting of 1, and, is used only to prevent out of memory errors.
-\n - Recommended value = 1 (auto)\n - 0 = Disable swapfile\n - 1 = Auto size swapfile (2GB - RAM = size)\n - 2 - $max = Manual size"; then
+					if G_WHIP_INPUTBOX "Please input a new value for swap file size (MiB):
+\nSwap file has a swapiness setting of 1, and, is used only to prevent out of memory errors.
+\n - Recommended value = 1 (auto)\n - 0 = Disable swap file\n - 1 = Auto size swap file (2GB - RAM = size)\n - 2 - $max = Manual size"; then
 
 						if G_CHECK_VALIDINT "$G_WHIP_RETURNED_VALUE" $min $max; then
 

--- a/rootfs/var/lib/dietpi/services/fs_partition_resize.sh
+++ b/rootfs/var/lib/dietpi/services/fs_partition_resize.sh
@@ -15,15 +15,15 @@
 	# - eMMC:	/dev/mmcblk[0-9]p[1-9]
 	# - NVMe:	/dev/nvme[0-9]n[0-9]p[1-9]
 	# - loop:	/dev/loop[0-9]p[1-9]
-	if [[ $ROOT_DEV =~ ^/dev/(mmcblk|nvme[0-9]n|loop)[0-9]p[1-9]$ ]]; then
-
-		ROOT_PART=${ROOT_DEV##*[0-9]p}	# /dev/mmcblk0p1 => 1
-		ROOT_DRIVE=${ROOT_DEV%p[1-9]}	# /dev/mmcblk0p1 => /dev/mmcblk0
-
-	elif [[ $ROOT_DEV =~ ^/dev/[sh]d[a-z][1-9]$ ]]; then
+	if [[ $ROOT_DEV == /dev/[sh]d[a-z][1-9] ]]; then
 
 		ROOT_PART=${ROOT_DEV: -1}	# /dev/sda1 => 1
 		ROOT_DRIVE=${ROOT_DEV%[1-9]}	# /dev/sda1 => /dev/sda
+
+	elif [[ $ROOT_DEV =~ ^/dev/(mmcblk|nvme[0-9]n|loop)[0-9]p[1-9]$ ]]; then
+
+		ROOT_PART=${ROOT_DEV##*[0-9]p}	# /dev/mmcblk0p1 => 1
+		ROOT_DRIVE=${ROOT_DEV%p[1-9]}	# /dev/mmcblk0p1 => /dev/mmcblk0
 
 	else
 

--- a/rootfs/var/lib/dietpi/services/fs_partition_resize.sh
+++ b/rootfs/var/lib/dietpi/services/fs_partition_resize.sh
@@ -36,7 +36,7 @@
 	sync
 
 	# GPT partition table: Move backup GPT data structures to the end of the disk
-	[[ $(lsblk -dno PTTYPE "$ROOT_DRIVE") != 'gpt' ]] || sgdisk -e "$ROOT_DRIVE"
+	[[ $(lsblk -ndo PTTYPE "$ROOT_DRIVE") != 'gpt' ]] || sgdisk -e "$ROOT_DRIVE"
 
 	# Maximise root partition size
 	sfdisk --no-reread --no-tell-kernel -fN"$ROOT_PART" "$ROOT_DRIVE" <<< ',+'
@@ -56,6 +56,10 @@
 	elif [[ $ROOT_FSTYPE == 'f2fs' ]]; then
 
 		resize.f2fs "$ROOT_DEV"
+
+	elif [[ $ROOT_FSTYPE == 'btrfs' ]]; then
+
+		btrfs filesystem resize max /
 
 	else
 

--- a/rootfs/var/lib/dietpi/services/fs_partition_resize.sh
+++ b/rootfs/var/lib/dietpi/services/fs_partition_resize.sh
@@ -55,7 +55,9 @@
 
 	elif [[ $ROOT_FSTYPE == 'f2fs' ]]; then
 
+		mount -o remount,ro /
 		resize.f2fs "$ROOT_DEV"
+		mount -o remount,rw /
 
 	elif [[ $ROOT_FSTYPE == 'btrfs' ]]; then
 

--- a/rootfs/var/lib/dietpi/services/fs_partition_resize.sh
+++ b/rootfs/var/lib/dietpi/services/fs_partition_resize.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 {
+	# Error out on command failures
+	set -e
+
 	# Disable this service
-	systemctl disable dietpi-fs_partition_resize
+	! systemctl is-enabled dietpi-fs_partition_resize > /dev/null || systemctl disable dietpi-fs_partition_resize
 
 	# Detect root device
 	ROOT_DEV=$(findmnt -no SOURCE /)
@@ -12,47 +15,54 @@
 	# - eMMC:	/dev/mmcblk[0-9]p[1-9]
 	# - NVMe:	/dev/nvme[0-9]n[0-9]p[1-9]
 	# - loop:	/dev/loop[0-9]p[1-9]
-	if [[ $ROOT_DEV =~ ^/dev/(mmcblk|nvme[0-9]n|loop)[0-9](p[1-9])?$ ]]; then
+	if [[ $ROOT_DEV =~ ^/dev/(mmcblk|nvme[0-9]n|loop)[0-9]p[1-9]$ ]]; then
 
 		ROOT_PART=${ROOT_DEV##*[0-9]p}	# /dev/mmcblk0p1 => 1
 		ROOT_DRIVE=${ROOT_DEV%p[1-9]}	# /dev/mmcblk0p1 => /dev/mmcblk0
 
-	elif [[ $ROOT_DEV =~ ^/dev/[sh]d[a-z][1-9]?$ ]]; then
+	elif [[ $ROOT_DEV =~ ^/dev/[sh]d[a-z][1-9]$ ]]; then
 
 		ROOT_PART=${ROOT_DEV: -1}	# /dev/sda1 => 1
 		ROOT_DRIVE=${ROOT_DEV%[1-9]}	# /dev/sda1 => /dev/sda
 
 	else
 
-		echo "[FAILED] Unsupported block device naming scheme ($ROOT_DEV). Aborting..."
+		echo "[FAILED] Unsupported root device naming scheme ($ROOT_DEV). Aborting..."
 		exit 1
 
 	fi
 
-	# Maximize root partition if drive contains a partition table
-	if [[ $ROOT_PART == [1-9] ]]; then
+	# Failsafe: Sync changes to disk before touching partitions
+	sync
 
-		# Failsafe: Sync changes to disk before touching partitions
-		sync
+	# GPT partition table: Move backup GPT data structures to the end of the disk
+	[[ $(lsblk -dno PTTYPE "$ROOT_DRIVE") != 'gpt' ]] || sgdisk -e "$ROOT_DRIVE"
 
-		# GPT partition table: Move backup GPT data structures to the end of the disk
-		sfdisk -l "$ROOT_DRIVE" | grep -q '^Disklabel type: gpt$' && sgdisk -e "$ROOT_DRIVE"
+	# Maximise root partition size
+	sfdisk --no-reread --no-tell-kernel -fN"$ROOT_PART" "$ROOT_DRIVE" <<< ',+'
 
-		# Maximize root partition size
-		sfdisk --no-reread --no-tell-kernel -fN"$ROOT_PART" "$ROOT_DRIVE" <<< ',+'
+	# Inform kernel about changed partition table, be failsafe by using two differet methods
+	partprobe "$ROOT_DRIVE"
+	partx -u "$ROOT_DRIVE"
 
-		# Inform kernel about changed partition table, be failsafe by using two differet methods
-		partprobe "$ROOT_DRIVE"
-		partx -u "$ROOT_DRIVE"
+	# Detect root file system type
+	ROOT_FSTYPE=$(findmnt -no FSTYPE /)
+
+	# Maximise root file system if type is supported
+	if [[ $ROOT_FSTYPE == ext[2-4] ]]; then
+
+		resize2fs "$ROOT_DEV"
+
+	elif [[ $ROOT_FSTYPE == 'f2fs' ]]; then
+
+		resize.f2fs "$ROOT_DEV"
 
 	else
 
-		echo "[ INFO ] The root file system ($ROOT_DEV) does not seem to be on a partition. Skipping partition resize..."
+		echo "[FAILED] Unsupported root file system type ($ROOT_FSTYPE). Aborting..."
+		exit 1
 
 	fi
-
-	# Maximize root file system
-	resize2fs "$ROOT_DEV"
 
 	exit 0
 }


### PR DESCRIPTION
+ DietPi-FS_partition_resize | Add support for F2FS file system expansion
+ DietPi-FS_partition_resize | Since all known systems require the root/boot file system to be as a partition on a partition table, do not support cases the it is not on a partition, but instead error out with "unsupported naming scheme". Even if there were cases where such was possible, it's better to create visible failure for now. If such cases were reported, we'd need to handle those gracefully at many other places in the code.
+ DietPi-FS_partition_resize | Use "set -e" to error our directly when any command fails. This requires to use either if-then-else or "a || b" for conditionals, so that the check itself does not error out the script.