### PR TITLE
DietPi-Software | Part 1: Merge "Linux" software and "DietPi" software functions

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3160,7 +3160,7 @@ _EOF_
 	}
 
 	# Run marked software installs
-	Install_Dietpi_Software(){
+	Install_Software(){
 
 		local software_id
 
@@ -6771,546 +6771,6 @@ exec sudo -u $ha_user dash -c '$ha_pyenv_activation; exec pip3 install -U homeas
 
 	}
 
-	Install_Linux_Software(){
-
-		local software_id
-
-		software_id=5 # ALSA
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			# Get chosen soundcard
-			local soundcard=$(sed -n '/^[[:blank:]]*CONFIG_SOUNDCARD=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-			soundcard=${soundcard:-none}
-
-			# Enable defaults, if set to "none"
-			if [[ $soundcard == 'none' ]]; then
-
-				# RPi: Onboard auto, Others: default
-				(( $G_HW_MODEL < 10 )) && soundcard='rpi-bcm2835-auto' || soundcard='default'
-
-			fi
-
-			# Apply: Installs "alsa-utils"
-			/boot/dietpi/func/dietpi-set_hardware soundcard "$soundcard"
-
-		fi
-
-		software_id=126 # LibSSL1.0.0
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			# On Stretch and above, libssl1.0.0 is no longer available: https://github.com/MichaIng/DietPi/issues/1299
-			# - Our packages are from Debian/Raspbian Jessie, which require multiarch-support: https://packages.debian.org/libssl1.0.0
-			# - On Bullseye, multiarch-support is not available, use from Buster instead: https://packages.debian.org/multiarch-support
-			# shellcheck disable=SC2015
-			(( $G_DISTRO < 6 )) && DEPS_LIST='multiarch-support' || Download_Install "https://dietpi.com/downloads/binaries/all/multiarch-support_$G_HW_ARCH_NAME.deb"
-			Download_Install "https://dietpi.com/downloads/binaries/all/libssl1.0.0_$G_HW_ARCH_NAME.deb"
-
-		fi
-
-		software_id=6 # X.Org X server
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			# Generic X server + Mesa OpenGL libraries and utilities
-			DEPS_LIST='xserver-xorg-core xserver-xorg-input-libinput xinit dbus-x11 xfonts-base x11-xserver-utils x11-utils libgl1-mesa-dri mesa-utils mesa-utils-extra'
-
-			# On RPi, add fbdev display driver, as modesetting requires the full- or fake KMS driver overlay being enabled, so that /dev/dri/card0 exists.
-			(( $G_HW_MODEL > 9 )) || DEPS_LIST+=' xserver-xorg-video-fbdev'
-
-			# On VM, add VMware display driver, which offers slightly better performance. VirtualBox can emulate it as well, which es even the nowadays recommended default.
-			(( $G_HW_MODEL == 20 )) && DEPS_LIST+=' xserver-xorg-video-vmware'
-
-			# Disable DPMS and screen blanking
-			dps_index=$software_id Download_Install '98-dietpi-disable_dpms.conf' /etc/X11/xorg.conf.d/98-dietpi-disable_dpms.conf
-
-			# RK3399
-			if (( $G_HW_CPUID == 3 )); then
-
-				# Buster: Mali-T864 driver by RockChip: https://github.com/rockchip-linux/rk-rootfs-build/tree/master/packages/arm64
-				if (( $G_DISTRO < 6 )); then
-
-					Download_Install 'https://dietpi.com/downloads/binaries/rk3399/libmali.deb'
-					G_EXEC cd /usr/lib/aarch64-linux-gnu
-					ln -sf libMali.so libEGL.so.1.1.0
-					ln -sf libMali.so libEGL.so
-					ln -sf libMali.so libEGL.so.1.0.0
-					ln -sf libMali.so libEGL.so.1.4
-					ln -sf libMali.so libEGL.so.1
-					ln -sf libMali.so libGLESv2.so
-					ln -sf libMali.so libGLESv2.so.2.0
-					ln -sf libMali.so libGLESv2.so.2.0.0
-					ln -sf libMali.so libGLESv1_CM.so
-					ln -sf libMali.so libGLESv1_CM.so.1
-					ln -sf libMali.so libGLESv1_CM.so.1.1
-					G_EXEC cd /tmp/$G_PROGRAM_NAME
-
-					# X.org config
-					G_BACKUP_FP /etc/X11/xorg.conf
-					dps_index=$software_id Download_Install 'xorg_rk3399.conf' /etc/X11/xorg.conf
-
-				# Bullseye: Use Mesa drivers provided by Debian repo
-				else
-
-					G_AGI libegl1 libgles2
-
-				fi
-
-			# Odroid C2: https://dietpi.com/meveric/pool/main/s/setup-odroid/
-			elif (( $G_HW_MODEL == 12 )); then
-
-				DEPS_LIST='mali450-odroid xf86-video-fbturbo-odroid libump-odroid'
-				G_BACKUP_FP /etc/X11/xorg.conf
-				dps_index=$software_id Download_Install 'xorg_c2.conf' /etc/X11/xorg.conf
-
-			# Odroid XU4: https://dietpi.com/meveric/pool/main/s/setup-odroid/
-			elif (( $G_HW_MODEL == 11 )); then
-
-				# xf86-video-armsoc-odroid creates an xorg.conf
-				G_AGI firmware-samsung malit628-odroid xf86-video-armsoc-odroid
-
-			# PINE A64
-			elif (( $G_HW_MODEL == 40 )); then
-
-				Download_Install 'https://dietpi.com/downloads/binaries/all/libump_1-1_arm64.deb'
-				G_EXEC mv /usr/local/lib/libUMP* /usr/lib/
-				Download_Install 'https://dietpi.com/downloads/binaries/all/xf86-video-fbturbo_1-1_arm64.deb'
-				G_BACKUP_FP /etc/X11/xorg.conf
-				dps_index=$software_id Download_Install 'xorg_pine64.conf' /etc/X11/xorg.conf
-
-			# ASUS TB
-			elif (( $G_HW_MODEL == 52 )); then
-
-				# Buster: Mali-T760 driver by RockChip: https://github.com/rockchip-linux/rk-rootfs-build/tree/master/packages/armhf
-				if (( $G_DISTRO < 6 )); then
-
-					Download_Install 'https://dietpi.com/downloads/binaries/asus/libmali.deb'
-					G_EXEC cd /usr/lib/arm-linux-gnueabihf
-					ln -sf libMali.so libEGL.so.1.1.0
-					ln -sf libMali.so libEGL.so
-					ln -sf libMali.so libEGL.so.1.0.0
-					ln -sf libMali.so libEGL.so.1.4
-					ln -sf libMali.so libEGL.so.1
-					ln -sf libMali.so libGLESv2.so
-					ln -sf libMali.so libGLESv2.so.2.0
-					ln -sf libMali.so libGLESv2.so.2.0.0
-					ln -sf libMali.so libGLESv1_CM.so
-					ln -sf libMali.so libGLESv1_CM.so.1
-					ln -sf libMali.so libGLESv1_CM.so.1.1
-					G_EXEC cd /tmp/$G_PROGRAM_NAME
-
-					# X.org config
-					G_BACKUP_FP /etc/X11/xorg.conf
-					dps_index=$software_id Download_Install 'xorg_asustb.conf' /etc/X11/xorg.conf
-
-				# Bullseye: Use Mesa drivers provided by Debian repo
-				else
-
-					G_AGI libegl1 libgles2
-
-				fi
-
-			fi
-
-		fi
-
-		software_id=151 # Nvidia driver
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI nvidia-driver
-
-		fi
-
-		software_id=152 # Avahi-Daemon
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI avahi-daemon
-
-		fi
-
-		software_id=16 # Build essentials
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI build-essential automake
-
-		fi
-
-		software_id=100 # PiJuice
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI pijuice-base
-
-		fi
-
-		software_id=17 # Git Client
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI git
-
-		fi
-
-		software_id=4 # Vifm
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI vifm
-
-		fi
-
-		software_id=20
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI vim
-
-		fi
-
-		software_id=21
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI vim-tiny
-
-		fi
-
-		software_id=127 # Neovim
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI neovim
-
-		fi
-
-		software_id=18
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI emacs
-
-		fi
-
-		software_id=12
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI iperf
-
-		fi
-
-		software_id=3 # MC
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI mc
-
-		fi
-
-		software_id=19
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI jed
-
-		fi
-
-		software_id=10
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI iftop
-
-		fi
-
-		software_id=11
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI iptraf
-
-		fi
-
-		software_id=13
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI mtr-tiny
-
-		fi
-
-		software_id=14
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI nload
-
-		fi
-
-		software_id=15
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI tcpdump
-
-		fi
-
-		software_id=0 # OpenSSH Client
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI openssh-client
-
-		fi
-
-		software_id=1 # Samba Client
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			# Remove Information file
-			[[ -f '/mnt/samba/readme.txt' ]] && G_EXEC rm /mnt/samba/readme.txt
-
-			G_AGI smbclient cifs-utils
-
-		fi
-
-		software_id=110 # NFS Client
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			# Remove information file
-			[[ -f '/mnt/nfs_client/readme.txt' ]] && G_EXEC rm /mnt/nfs_client/readme.txt
-
-			# "netbase" is needed for mounting NFSv3: https://github.com/MichaIng/DietPi/issues/1898#issuecomment-406247814
-			G_AGI nfs-common netbase
-
-		fi
-
-		software_id=104 # Dropbear
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			# Mark target SSH server choice, if not selected via menu or first run setup
-			INDEX_SSHSERVER_TARGET=-1
-
-			# Stop OpenSSH service to unbind port 22
-			systemctl -q is-active ssh && G_EXEC systemctl stop ssh
-
-			# On Stretch + Buster Dropbear packages have been split, install "dropbear-run" only, to have active service, but skip "dropbear-initramfs"
-			# On Bullseye+ "dropbear-run" has become a transitional dummy package for "dropbear" which does not include "dropbear-initramfs" anymore.
-			if (( $G_DISTRO > 5 )); then
-
-				G_AGI dropbear
-
-			else
-
-				G_AGI dropbear-run
-
-			fi
-
-			# Enable Dropbear daemon
-			G_CONFIG_INJECT 'NO_START=' 'NO_START=0' /etc/default/dropbear
-
-			# Failsafe: Enable Dropbear service
-			G_EXEC systemctl enable dropbear
-			aSTART_SERVICES+=('dropbear')
-
-			# Mark OpenSSH for uninstall and update choice system
-			dpkg-query -s 'openssh-server' &> /dev/null && aSOFTWARE_INSTALL_STATE[105]=-1 && UNINSTALL_REQUIRED=1
-			INDEX_SSHSERVER_CURRENT=-1
-
-		fi
-
-		software_id=105 # OpenSSH Server
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			# Mark target SSH server choice, if not selected via menu or first run setup
-			INDEX_SSHSERVER_TARGET=-2
-
-			# Stop Dropbear service to unbind port 22
-			systemctl -q is-active dropbear && G_EXEC systemctl stop dropbear
-
-			# SSH server package pulls client as dependency. Mark client hence as installed and mark it explicitly so that it is not autoremoved with the server but must be marked for uninstall instead.
-			G_AGI openssh-server openssh-client
-			aSOFTWARE_INSTALL_STATE[0]=2
-
-			# Allow root login
-			G_CONFIG_INJECT 'PermitRootLogin[[:blank:]]' 'PermitRootLogin yes' /etc/ssh/sshd_config
-
-			# Reload SSH server now so root users can login during setup.
-			systemctl reload ssh
-
-			# Failsafe: Enable OpenSSH service
-			G_EXEC systemctl enable ssh
-			aSTART_SERVICES+=('ssh')
-
-			# Mark Dropbear for uninstall and update choice system
-			grep -q '^dropbear[^[:blank:]]*[[:blank:]]' <<< "$(dpkg --get-selections)" && aSOFTWARE_INSTALL_STATE[104]=-1 && UNINSTALL_REQUIRED=1
-			INDEX_SSHSERVER_CURRENT=-2
-
-		fi
-
-		software_id=103 # DietPi-RAMlog
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			# Install persistent tmpfs
-			local tmpfs_max_size=$(sed -n '/^[[:blank:]]*AUTO_SETUP_RAMLOG_MAXSIZE=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-			sed -i '/[[:blank:]]\/var\/log[[:blank:]]/d' /etc/fstab
-			echo "tmpfs /var/log tmpfs size=${tmpfs_max_size:-50}M,noatime,lazytime,nodev,nosuid,mode=1777" >> /etc/fstab
-
-			# Enable DietPi-RAMdisk
-			G_EXEC systemctl enable dietpi-ramlog
-
-			# To assure a cleaned mountpoint we need to start RAMlog now
-			local acommand=('/boot/dietpi/func/dietpi-ramlog' '1')
-			systemctl is-active dietpi-ramlog > /dev/null && acommand=('systemctl' 'stop' 'dietpi-ramlog')
-			G_EXEC_DESC='Storing /var/log metadata to disk' G_EXEC "${acommand[@]}"
-			unset -v acommand
-			findmnt /var/log > /dev/null && G_EXEC_DESC='Unmounting /var/log' G_EXEC_NOHALT=1 G_EXEC umount -R /var/log
-			G_EXEC_DESC='Cleaning /var/log mountpoint' G_EXEC rm -Rf /var/log/{,.??,.[^.]}*
-			G_EXEC_DESC='Mounting tmpfs to /var/log' G_EXEC mount /var/log
-			G_EXEC_DESC='Restoring metadata to /var/log tmpfs' G_EXEC systemctl start dietpi-ramlog
-
-		fi
-
-		software_id=101 # Logrotate
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI logrotate
-
-		fi
-
-		software_id=102 # Rsyslog
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			# Workaround for dpkg failure on 1st install if service is already running but APT not installed: https://github.com/MichaIng/DietPi/pull/2277/#issuecomment-441460925
-			systemctl stop rsyslog 2> /dev/null
-			G_AGI rsyslog
-			G_EXEC systemctl enable --now rsyslog
-
-		fi
-
-		software_id=7 # FFmpeg
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI ffmpeg
-
-		fi
-
-		software_id=8 # Java
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			# On Stretch and ARMv6 (RPi 1/Zero) use Java 8, else most current
-			# Stretch does not ship Java 11 yet, ARMv6 is not Java 11 compatible, but luckily Raspbian ships Java 8 even on Bullseye: https://github.com/MichaIng/DietPi/issues/3182
-			local version=11
-			(( $G_DISTRO < 5 || G_HW_ARCH == 1 )) && version=8
-
-			# Allow two attempts as workaround for ARM install issue: https://github.com/MichaIng/DietPi/issues/2524
-			G_EXEC_RETRIES=1 G_AGI ca-certificates-java openjdk-$version-jre-headless openjdk-$version-jdk-headless
-
-		fi
-
-		software_id=9 # Node.js
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			INSTALL_URL_ADDRESS='https://raw.githubusercontent.com/MichaIng/nodejs-linux-installer/master/node-install.sh'
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-			G_EXEC curl -sSfLO "$INSTALL_URL_ADDRESS"
-			G_EXEC chmod +x node-install.sh
-			G_EXEC mkdir -p /usr/local # failsafe
-			G_EXEC_OUTPUT=1 G_EXEC ./node-install.sh
-			G_EXEC_NOHALT=1 G_EXEC rm node-install.sh
-
-			# Deps: https://github.com/MichaIng/DietPi/issues/3614
-			G_AGI libatomic1
-
-		fi
-
-		software_id=130 # Python 3 pip
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			# Create piwheels config file for ARMv6 and ARMv7
-			[[ $G_HW_ARCH != [12] || -f '/etc/pip.conf' ]] || G_EXEC eval "echo -e '[global]\nextra-index-url=https://www.piwheels.org/simple/' > /etc/pip.conf"
-
-			# Perform pip3 installation
-			INSTALL_URL_ADDRESS='https://bootstrap.pypa.io/get-pip.py'
-			(( $G_DISTRO > 4 )) || INSTALL_URL_ADDRESS='https://bootstrap.pypa.io/3.5/get-pip.py' # https://pip.pypa.io/en/stable/news/#id1
-			DEPS_LIST='python3-dev' Download_Install "$INSTALL_URL_ADDRESS"
-			G_EXEC_OUTPUT=1 G_EXEC python3 ./get-pip.py
-			G_EXEC_NOHALT=1 G_EXEC rm get-pip.py
-
-		fi
-
-		software_id=150 # Mono runtime
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing # https://www.mono-project.com/download/stable/#download-lin-debian
-
-			apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-
-			# On RPi use separate Raspbian repo: https://github.com/MichaIng/DietPi/issues/1023
-			# Use Buster branch on Bullseye
-			if (( $G_HW_MODEL < 10 )) && (( $G_RASPBIAN )); then
-
-				echo "deb https://download.mono-project.com/repo/debian/ raspbian${G_DISTRO_NAME/bullseye/buster} main" > /etc/apt/sources.list.d/mono-xamarin.list
-
-			else
-
-				echo "deb https://download.mono-project.com/repo/debian/ ${G_DISTRO_NAME/bullseye/buster} main" > /etc/apt/sources.list.d/mono-xamarin.list
-
-			fi
-
-			G_AGUP
-			G_AGI mono-runtime mono-complete
-
-			rm -f /tmp/mono* # https://github.com/MichaIng/DietPi/issues/1877#issuecomment-403856446
-
-		fi
-
-		software_id=170 # UnRAR
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			# On Raspbian, only "unrar-free" is available in repos, but does not support all rar formats, thus we use "unrar" [non-free] from Debian repo: http://raspbian.raspberrypi.org/raspbian/pool/non-free/u/unrar-nonfree/
-			if (( $G_HW_MODEL < 10 )) && (( $G_RASPBIAN )); then
-
-				Download_Install "https://dietpi.com/downloads/binaries/rpi/unrar-armhf-$G_DISTRO_NAME.deb"
-
-			else
-
-				G_AGI unrar
-
-			fi
-
-		fi
-
-	}
-
 	Apply_SSHServer_Choices(){
 
 		# Work out which SSH server needs installing from IDs (if any)
@@ -7421,14 +6881,8 @@ exec sudo -u $ha_user dash -c '$ha_pyenv_activation; exec pip3 install -U homeas
 
 	}
 
-	Apply_Webserver_Preference()
-	{
-		# Update current webserver index
-		INDEX_WEBSERVER_CURRENT=$INDEX_WEBSERVER_TARGET
-	}
-
 	# Configure marked software titles
-	Install_Apply_Configs(){
+	Configure_Software(){
 
 		local software_id
 
@@ -8852,11 +8306,9 @@ ExtORPort auto
 _EOF_
 				G_EXEC mkdir -p /etc/systemd/system/tor@.service.d
 				G_EXEC eval "echo -e '[Service]\nNoNewPrivileges=no' > /etc/systemd/system/tor@.service.d/dietpi-relay.conf"
-				G_EXEC systemctl daemon-reload
 
 			elif [[ $G_WHIP_RETURNED_VALUE == 'Guard/Middle' ]]
 			then
-
 				cat << _EOF_ > /etc/tor/torrc
 ORPort $orport
 ExitRelay 0
@@ -13387,6 +12839,540 @@ _EOF_
 		# NB: systemctl daemon-reload is executed at the end of this function
 		local software_id
 
+		software_id=5 # ALSA
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			# Get chosen soundcard
+			local soundcard=$(sed -n '/^[[:blank:]]*CONFIG_SOUNDCARD=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+			soundcard=${soundcard:-none}
+
+			# Enable defaults, if set to "none"
+			if [[ $soundcard == 'none' ]]; then
+
+				# RPi: Onboard auto, Others: default
+				(( $G_HW_MODEL < 10 )) && soundcard='rpi-bcm2835-auto' || soundcard='default'
+
+			fi
+
+			# Apply: Installs "alsa-utils"
+			/boot/dietpi/func/dietpi-set_hardware soundcard "$soundcard"
+
+		fi
+
+		software_id=126 # LibSSL1.0.0
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			# On Stretch and above, libssl1.0.0 is no longer available: https://github.com/MichaIng/DietPi/issues/1299
+			# - Our packages are from Debian/Raspbian Jessie, which require multiarch-support: https://packages.debian.org/libssl1.0.0
+			# - On Bullseye, multiarch-support is not available, use from Buster instead: https://packages.debian.org/multiarch-support
+			# shellcheck disable=SC2015
+			(( $G_DISTRO < 6 )) && DEPS_LIST='multiarch-support' || Download_Install "https://dietpi.com/downloads/binaries/all/multiarch-support_$G_HW_ARCH_NAME.deb"
+			Download_Install "https://dietpi.com/downloads/binaries/all/libssl1.0.0_$G_HW_ARCH_NAME.deb"
+
+		fi
+
+		software_id=6 # X.Org X server
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			# Generic X server + Mesa OpenGL libraries and utilities
+			DEPS_LIST='xserver-xorg-core xserver-xorg-input-libinput xinit dbus-x11 xfonts-base x11-xserver-utils x11-utils libgl1-mesa-dri mesa-utils mesa-utils-extra'
+
+			# On RPi, add fbdev display driver, as modesetting requires the full- or fake KMS driver overlay being enabled, so that /dev/dri/card0 exists.
+			(( $G_HW_MODEL > 9 )) || DEPS_LIST+=' xserver-xorg-video-fbdev'
+
+			# On VM, add VMware display driver, which offers slightly better performance. VirtualBox can emulate it as well, which es even the nowadays recommended default.
+			(( $G_HW_MODEL == 20 )) && DEPS_LIST+=' xserver-xorg-video-vmware'
+
+			# Disable DPMS and screen blanking
+			dps_index=$software_id Download_Install '98-dietpi-disable_dpms.conf' /etc/X11/xorg.conf.d/98-dietpi-disable_dpms.conf
+
+			# RK3399
+			if (( $G_HW_CPUID == 3 )); then
+
+				# Buster: Mali-T864 driver by RockChip: https://github.com/rockchip-linux/rk-rootfs-build/tree/master/packages/arm64
+				if (( $G_DISTRO < 6 )); then
+
+					Download_Install 'https://dietpi.com/downloads/binaries/rk3399/libmali.deb'
+					G_EXEC cd /usr/lib/aarch64-linux-gnu
+					ln -sf libMali.so libEGL.so.1.1.0
+					ln -sf libMali.so libEGL.so
+					ln -sf libMali.so libEGL.so.1.0.0
+					ln -sf libMali.so libEGL.so.1.4
+					ln -sf libMali.so libEGL.so.1
+					ln -sf libMali.so libGLESv2.so
+					ln -sf libMali.so libGLESv2.so.2.0
+					ln -sf libMali.so libGLESv2.so.2.0.0
+					ln -sf libMali.so libGLESv1_CM.so
+					ln -sf libMali.so libGLESv1_CM.so.1
+					ln -sf libMali.so libGLESv1_CM.so.1.1
+					G_EXEC cd /tmp/$G_PROGRAM_NAME
+
+					# X.org config
+					G_BACKUP_FP /etc/X11/xorg.conf
+					dps_index=$software_id Download_Install 'xorg_rk3399.conf' /etc/X11/xorg.conf
+
+				# Bullseye: Use Mesa drivers provided by Debian repo
+				else
+
+					G_AGI libegl1 libgles2
+
+				fi
+
+			# Odroid C2: https://dietpi.com/meveric/pool/main/s/setup-odroid/
+			elif (( $G_HW_MODEL == 12 )); then
+
+				DEPS_LIST='mali450-odroid xf86-video-fbturbo-odroid libump-odroid'
+				G_BACKUP_FP /etc/X11/xorg.conf
+				dps_index=$software_id Download_Install 'xorg_c2.conf' /etc/X11/xorg.conf
+
+			# Odroid XU4: https://dietpi.com/meveric/pool/main/s/setup-odroid/
+			elif (( $G_HW_MODEL == 11 )); then
+
+				# xf86-video-armsoc-odroid creates an xorg.conf
+				G_AGI firmware-samsung malit628-odroid xf86-video-armsoc-odroid
+
+			# PINE A64
+			elif (( $G_HW_MODEL == 40 )); then
+
+				Download_Install 'https://dietpi.com/downloads/binaries/all/libump_1-1_arm64.deb'
+				G_EXEC mv /usr/local/lib/libUMP* /usr/lib/
+				Download_Install 'https://dietpi.com/downloads/binaries/all/xf86-video-fbturbo_1-1_arm64.deb'
+				G_BACKUP_FP /etc/X11/xorg.conf
+				dps_index=$software_id Download_Install 'xorg_pine64.conf' /etc/X11/xorg.conf
+
+			# ASUS TB
+			elif (( $G_HW_MODEL == 52 )); then
+
+				# Buster: Mali-T760 driver by RockChip: https://github.com/rockchip-linux/rk-rootfs-build/tree/master/packages/armhf
+				if (( $G_DISTRO < 6 )); then
+
+					Download_Install 'https://dietpi.com/downloads/binaries/asus/libmali.deb'
+					G_EXEC cd /usr/lib/arm-linux-gnueabihf
+					ln -sf libMali.so libEGL.so.1.1.0
+					ln -sf libMali.so libEGL.so
+					ln -sf libMali.so libEGL.so.1.0.0
+					ln -sf libMali.so libEGL.so.1.4
+					ln -sf libMali.so libEGL.so.1
+					ln -sf libMali.so libGLESv2.so
+					ln -sf libMali.so libGLESv2.so.2.0
+					ln -sf libMali.so libGLESv2.so.2.0.0
+					ln -sf libMali.so libGLESv1_CM.so
+					ln -sf libMali.so libGLESv1_CM.so.1
+					ln -sf libMali.so libGLESv1_CM.so.1.1
+					G_EXEC cd /tmp/$G_PROGRAM_NAME
+
+					# X.org config
+					G_BACKUP_FP /etc/X11/xorg.conf
+					dps_index=$software_id Download_Install 'xorg_asustb.conf' /etc/X11/xorg.conf
+
+				# Bullseye: Use Mesa drivers provided by Debian repo
+				else
+
+					G_AGI libegl1 libgles2
+
+				fi
+
+			fi
+
+		fi
+
+		software_id=151 # Nvidia driver
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI nvidia-driver
+
+		fi
+
+		software_id=152 # Avahi-Daemon
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI avahi-daemon
+
+		fi
+
+		software_id=16 # Build essentials
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI build-essential automake
+
+		fi
+
+		software_id=100 # PiJuice
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI pijuice-base
+
+		fi
+
+		software_id=17 # Git Client
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI git
+
+		fi
+
+		software_id=4 # Vifm
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI vifm
+
+		fi
+
+		software_id=20
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI vim
+
+		fi
+
+		software_id=21
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI vim-tiny
+
+		fi
+
+		software_id=127 # Neovim
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI neovim
+
+		fi
+
+		software_id=18
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI emacs
+
+		fi
+
+		software_id=12
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI iperf
+
+		fi
+
+		software_id=3 # MC
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI mc
+
+		fi
+
+		software_id=19
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI jed
+
+		fi
+
+		software_id=10
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI iftop
+
+		fi
+
+		software_id=11
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI iptraf
+
+		fi
+
+		software_id=13
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI mtr-tiny
+
+		fi
+
+		software_id=14
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI nload
+
+		fi
+
+		software_id=15
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI tcpdump
+
+		fi
+
+		software_id=0 # OpenSSH Client
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI openssh-client
+
+		fi
+
+		software_id=1 # Samba Client
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			# Remove Information file
+			[[ -f '/mnt/samba/readme.txt' ]] && G_EXEC rm /mnt/samba/readme.txt
+
+			G_AGI smbclient cifs-utils
+
+		fi
+
+		software_id=110 # NFS Client
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			# Remove information file
+			[[ -f '/mnt/nfs_client/readme.txt' ]] && G_EXEC rm /mnt/nfs_client/readme.txt
+
+			# "netbase" is needed for mounting NFSv3: https://github.com/MichaIng/DietPi/issues/1898#issuecomment-406247814
+			G_AGI nfs-common netbase
+
+		fi
+
+		software_id=104 # Dropbear
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			# Mark target SSH server choice, if not selected via menu or first run setup
+			INDEX_SSHSERVER_TARGET=-1
+
+			# Stop OpenSSH service to unbind port 22
+			systemctl -q is-active ssh && G_EXEC systemctl stop ssh
+
+			# On Stretch + Buster Dropbear packages have been split, install "dropbear-run" only, to have active service, but skip "dropbear-initramfs"
+			# On Bullseye+ "dropbear-run" has become a transitional dummy package for "dropbear" which does not include "dropbear-initramfs" anymore.
+			if (( $G_DISTRO > 5 )); then
+
+				G_AGI dropbear
+
+			else
+
+				G_AGI dropbear-run
+
+			fi
+
+			# Enable Dropbear daemon
+			G_CONFIG_INJECT 'NO_START=' 'NO_START=0' /etc/default/dropbear
+
+			# Failsafe: Enable Dropbear service
+			G_EXEC systemctl enable dropbear
+			aSTART_SERVICES+=('dropbear')
+
+			# Mark OpenSSH for uninstall and update choice system
+			dpkg-query -s 'openssh-server' &> /dev/null && aSOFTWARE_INSTALL_STATE[105]=-1 && UNINSTALL_REQUIRED=1
+			INDEX_SSHSERVER_CURRENT=-1
+
+		fi
+
+		software_id=105 # OpenSSH Server
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			# Mark target SSH server choice, if not selected via menu or first run setup
+			INDEX_SSHSERVER_TARGET=-2
+
+			# Stop Dropbear service to unbind port 22
+			systemctl -q is-active dropbear && G_EXEC systemctl stop dropbear
+
+			# SSH server package pulls client as dependency. Mark client hence as installed and mark it explicitly so that it is not autoremoved with the server but must be marked for uninstall instead.
+			G_AGI openssh-server openssh-client
+			aSOFTWARE_INSTALL_STATE[0]=2
+
+			# Allow root login
+			G_CONFIG_INJECT 'PermitRootLogin[[:blank:]]' 'PermitRootLogin yes' /etc/ssh/sshd_config
+
+			# Reload SSH server now so root users can login during setup.
+			systemctl reload ssh
+
+			# Failsafe: Enable OpenSSH service
+			G_EXEC systemctl enable ssh
+			aSTART_SERVICES+=('ssh')
+
+			# Mark Dropbear for uninstall and update choice system
+			grep -q '^dropbear[^[:blank:]]*[[:blank:]]' <<< "$(dpkg --get-selections)" && aSOFTWARE_INSTALL_STATE[104]=-1 && UNINSTALL_REQUIRED=1
+			INDEX_SSHSERVER_CURRENT=-2
+
+		fi
+
+		software_id=103 # DietPi-RAMlog
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			# Install persistent tmpfs
+			local tmpfs_max_size=$(sed -n '/^[[:blank:]]*AUTO_SETUP_RAMLOG_MAXSIZE=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+			sed -i '/[[:blank:]]\/var\/log[[:blank:]]/d' /etc/fstab
+			echo "tmpfs /var/log tmpfs size=${tmpfs_max_size:-50}M,noatime,lazytime,nodev,nosuid,mode=1777" >> /etc/fstab
+
+			# Enable DietPi-RAMdisk
+			G_EXEC systemctl enable dietpi-ramlog
+
+			# To assure a cleaned mountpoint we need to start RAMlog now
+			local acommand=('/boot/dietpi/func/dietpi-ramlog' '1')
+			systemctl is-active dietpi-ramlog > /dev/null && acommand=('systemctl' 'stop' 'dietpi-ramlog')
+			G_EXEC_DESC='Storing /var/log metadata to disk' G_EXEC "${acommand[@]}"
+			unset -v acommand
+			findmnt /var/log > /dev/null && G_EXEC_DESC='Unmounting /var/log' G_EXEC_NOHALT=1 G_EXEC umount -R /var/log
+			G_EXEC_DESC='Cleaning /var/log mountpoint' G_EXEC rm -Rf /var/log/{,.??,.[^.]}*
+			G_EXEC_DESC='Mounting tmpfs to /var/log' G_EXEC mount /var/log
+			G_EXEC_DESC='Restoring metadata to /var/log tmpfs' G_EXEC systemctl start dietpi-ramlog
+
+		fi
+
+		software_id=101 # Logrotate
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI logrotate
+
+		fi
+
+		software_id=102 # Rsyslog
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			# Workaround for dpkg failure on 1st install if service is already running but APT not installed: https://github.com/MichaIng/DietPi/pull/2277/#issuecomment-441460925
+			systemctl stop rsyslog 2> /dev/null
+			G_AGI rsyslog
+			G_EXEC systemctl enable --now rsyslog
+
+		fi
+
+		software_id=7 # FFmpeg
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI ffmpeg
+
+		fi
+
+		software_id=8 # Java
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			# On Stretch and ARMv6 (RPi 1/Zero) use Java 8, else most current
+			# Stretch does not ship Java 11 yet, ARMv6 is not Java 11 compatible, but luckily Raspbian ships Java 8 even on Bullseye: https://github.com/MichaIng/DietPi/issues/3182
+			local version=11
+			(( $G_DISTRO < 5 || G_HW_ARCH == 1 )) && version=8
+
+			# Allow two attempts as workaround for ARM install issue: https://github.com/MichaIng/DietPi/issues/2524
+			G_EXEC_RETRIES=1 G_AGI ca-certificates-java openjdk-$version-jre-headless openjdk-$version-jdk-headless
+
+		fi
+
+		software_id=9 # Node.js
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			INSTALL_URL_ADDRESS='https://raw.githubusercontent.com/MichaIng/nodejs-linux-installer/master/node-install.sh'
+			G_CHECK_URL "$INSTALL_URL_ADDRESS"
+			G_EXEC curl -sSfLO "$INSTALL_URL_ADDRESS"
+			G_EXEC chmod +x node-install.sh
+			G_EXEC mkdir -p /usr/local # failsafe
+			G_EXEC_OUTPUT=1 G_EXEC ./node-install.sh
+			G_EXEC_NOHALT=1 G_EXEC rm node-install.sh
+
+			# Deps: https://github.com/MichaIng/DietPi/issues/3614
+			G_AGI libatomic1
+
+		fi
+
+		software_id=130 # Python 3 pip
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			# Create piwheels config file for ARMv6 and ARMv7
+			[[ $G_HW_ARCH != [12] || -f '/etc/pip.conf' ]] || G_EXEC eval "echo -e '[global]\nextra-index-url=https://www.piwheels.org/simple/' > /etc/pip.conf"
+
+			# Perform pip3 installation
+			INSTALL_URL_ADDRESS='https://bootstrap.pypa.io/get-pip.py'
+			(( $G_DISTRO > 4 )) || INSTALL_URL_ADDRESS='https://bootstrap.pypa.io/3.5/get-pip.py' # https://pip.pypa.io/en/stable/news/#id1
+			DEPS_LIST='python3-dev' Download_Install "$INSTALL_URL_ADDRESS"
+			G_EXEC_OUTPUT=1 G_EXEC python3 ./get-pip.py
+			G_EXEC_NOHALT=1 G_EXEC rm get-pip.py
+
+		fi
+
+		software_id=150 # Mono runtime
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing # https://www.mono-project.com/download/stable/#download-lin-debian
+
+			apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+
+			# On RPi use separate Raspbian repo: https://github.com/MichaIng/DietPi/issues/1023
+			# Use Buster branch on Bullseye
+			if (( $G_HW_MODEL < 10 )) && (( $G_RASPBIAN )); then
+
+				echo "deb https://download.mono-project.com/repo/debian/ raspbian${G_DISTRO_NAME/bullseye/buster} main" > /etc/apt/sources.list.d/mono-xamarin.list
+
+			else
+
+				echo "deb https://download.mono-project.com/repo/debian/ ${G_DISTRO_NAME/bullseye/buster} main" > /etc/apt/sources.list.d/mono-xamarin.list
+
+			fi
+
+			G_AGUP
+			G_AGI mono-runtime mono-complete
+
+			rm -f /tmp/mono* # https://github.com/MichaIng/DietPi/issues/1877#issuecomment-403856446
+
+		fi
+
+		software_id=170 # UnRAR
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			# On Raspbian, only "unrar-free" is available in repos, but does not support all rar formats, thus we use "unrar" [non-free] from Debian repo: http://raspbian.raspberrypi.org/raspbian/pool/non-free/u/unrar-nonfree/
+			if (( $G_HW_MODEL < 10 )) && (( $G_RASPBIAN )); then
+
+				Download_Install "https://dietpi.com/downloads/binaries/rpi/unrar-armhf-$G_DISTRO_NAME.deb"
+
+			else
+
+				G_AGI unrar
+
+			fi
+
+		fi
+
 		software_id=23 # LXDE
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
@@ -16194,27 +16180,26 @@ _EOF_
 		Apply_Logging_Choices
 
 		# Apply DietPi preference systems
-		Apply_Webserver_Preference
+		INDEX_WEBSERVER_CURRENT=$INDEX_WEBSERVER_TARGET
 
-		# Update required software that needs to be installed
+		# Mark dependencies for install
 		Install_Flag_Prereq_Software
 
 		# Read GLOBAL_PW
 		Update_Global_Pw
 
-		# Install Linux Software
-		Install_Linux_Software
+		# Install software
+		Install_Software
 
-		# Install DietPi Optimised Software
-		/boot/dietpi/dietpi-services stop
-		Install_Dietpi_Software
-
-		# Apply Uninstall script, if required by e.g. DietPi choice system
+		# Uninstall software, if required by e.g. DietPi choice system
 		(( $UNINSTALL_REQUIRED )) && Uninstall_Software
 
-		# Apply DietPi configurations and optimisations
+		# Configure software, stop services of newly installed APT packages to reduce memory usage during config steps
 		/boot/dietpi/dietpi-services stop
-		Install_Apply_Configs
+		Configure_Software
+
+		# Reload systemd units
+		G_EXEC systemctl daemon-reload
 
 		# Disable services so DietPi-Services can take control (DietPi will start all services from dietpi-postboot.service)
 		/boot/dietpi/dietpi-services dietpi_controlled
@@ -16227,7 +16212,7 @@ _EOF_
 \n - Once finished, exit DietPi-Config to finish this install.
 \n - More information:\nhttps://dietpi.com/phpbb/viewtopic.php?p=58#p58' && /boot/dietpi/dietpi-config 16 1
 
-		# DietPi-AutoStart choice
+		# Offer to change DietPi-AutoStart option
 		if (( $G_DIETPI_INSTALL_STAGE == 2 )) && ((
 			${aSOFTWARE_INSTALL_STATE[23]} == 1 ||
 			${aSOFTWARE_INSTALL_STATE[24]} == 1 ||
@@ -16249,12 +16234,10 @@ _EOF_
 
 		# Install finished, set all installed software to state 2 (installed)
 		# - Apply same states to Allo and Allo_update
-		(( ${aSOFTWARE_INSTALL_STATE[159]} == 1 || ${aSOFTWARE_INSTALL_STATE[160]} == 1 )) && { aSOFTWARE_INSTALL_STATE[159]=2; aSOFTWARE_INSTALL_STATE[160]=2; }
+		(( ${aSOFTWARE_INSTALL_STATE[159]} == 1 || ${aSOFTWARE_INSTALL_STATE[160]} == 1 )) && { aSOFTWARE_INSTALL_STATE[159]=2 aSOFTWARE_INSTALL_STATE[160]=2; }
 		for i in "${!aSOFTWARE_NAME[@]}"
-		do
-
+		
 			(( ${aSOFTWARE_INSTALL_STATE[$i]} == 1 )) && aSOFTWARE_INSTALL_STATE[$i]=2
-
 		done
 
 		# Write to .install File
@@ -16280,16 +16263,16 @@ _EOF_
 
 			fi
 
-			# Custom 1st run Script (Local file)
+			# Custom 1st run script (local file)
 			if [[ -f '/boot/Automation_Custom_Script.sh' ]]; then
 
-				G_EXEC cp /boot/Automation_Custom_Script.sh /root/AUTO_CustomScript.sh
+				G_EXEC_NOEXIT=1 G_EXEC cp /boot/Automation_Custom_Script.sh /root/AUTO_CustomScript.sh
 
-			# Custom 1st run Script (Online file)
+			# Custom 1st run script (online file)
 			elif [[ $AUTOINSTALL_CUSTOMSCRIPTURL != '0' ]]; then
 
 				G_CHECK_URL "$AUTOINSTALL_CUSTOMSCRIPTURL"
-				G_EXEC curl -sSfL "$AUTOINSTALL_CUSTOMSCRIPTURL" -o /root/AUTO_CustomScript.sh
+				G_EXEC_NOEXIT=1 G_EXEC curl -sSfL "$AUTOINSTALL_CUSTOMSCRIPTURL" -o /root/AUTO_CustomScript.sh
 
 			fi
 
@@ -16298,7 +16281,7 @@ _EOF_
 				local fp_log='/var/tmp/dietpi/logs/dietpi-automation_custom_script.log'
 
 				G_DIETPI-NOTIFY 2 'Running custom script, please wait...'
-				G_EXEC chmod +x /root/AUTO_CustomScript.sh
+				G_EXEC_NOEXIT=1 G_EXEC chmod +x /root/AUTO_CustomScript.sh
 				/root/AUTO_CustomScript.sh 2>&1 | tee $fp_log
 				if (( ${PIPESTATUS[0]} )); then
 
@@ -16310,11 +16293,11 @@ _EOF_
 
 				fi
 
-				G_EXEC rm /root/AUTO_CustomScript.sh
+				G_EXEC_NOEXIT=1 G_EXEC rm /root/AUTO_CustomScript.sh
 
 			fi
 
-			# Apply AutoStart
+			# Apply AutoStart choice
 			/boot/dietpi/dietpi-autostart "$AUTOINSTALL_AUTOSTARTTARGET"
 
 			# Set Install Stage to Finished
@@ -17402,8 +17385,8 @@ We allow it to take up to 30 minutes, it's process can be followed, please be pa
 
 								# Inform user
 								G_WHIP_MSG "Webserver Preference Changed:\n\n$G_WHIP_RETURNED_VALUE has been selected as your webserver preference.
-\nWhen you select any software for install that requires a webserver, DietPi will automatically install your prefered choice ($G_WHIP_RETURNED_VALUE)."
-								# NB: INDEX_WEBSERVER_CURRENT=$INDEX_WEBSERVER_TARGET | is applied during installation with func Apply_Webserver_Preference().
+\nWhen you select any software for install that requires a webserver, DietPi will automatically install your preferred choice ($G_WHIP_RETURNED_VALUE)."
+								# NB: INDEX_WEBSERVER_CURRENT=$INDEX_WEBSERVER_TARGET | is applied during installation with func Run_Installations().
 
 							fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5011,7 +5011,7 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-			
+
 			[[ -d '/usr/local/bin' ]] || G_EXEC mkdir -p /usr/local/bin
 
 			# RPi
@@ -5052,7 +5052,7 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing # Pre-configure user and data directory to allow a local service user install
-			
+
 			# Data dir
 			G_EXEC mkdir -p /mnt/dietpi_userdata/node-red
 
@@ -6709,14 +6709,14 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			G_EXEC_OUTPUT=1 G_EXEC sudo -u octoprint $pip install -U --no-cache-dir --user octoprint
 			unset -v pip
 		fi
-		
+
 		software_id=187 # CUPS
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 			Banner_Installing
-			
+
 			# Download base configuration if it does not exist yet
 			[[ -f '/etc/cups/cupsd.conf' ]] || dps_index=$software_id Download_Install 'cupsd.conf' /etc/cups/cupsd.conf
-				
+
 			G_AGI cups
 		fi
 
@@ -6830,7 +6830,7 @@ If you want to update ${aSOFTWARE_NAME[$software_id]}, please use its internal u
 			G_AGI docker-ce
 
 		fi
-		
+
 		software_id=134 # Docker Compose
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
@@ -7266,7 +7266,7 @@ exec sudo -u $ha_user dash -c '$ha_pyenv_activation; exec pip3 install -U homeas
 
 		software_id=181 # PaperMC
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-		
+
 			Banner_Installing
 
 			# Make sure user agrees to the EULA
@@ -7291,7 +7291,7 @@ exec sudo -u $ha_user dash -c '$ha_pyenv_activation; exec pip3 install -U homeas
 
 		software_id=140 # Domoticz
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-		
+
 			Banner_Installing
 
 			# APT deps
@@ -7430,7 +7430,7 @@ exec sudo -u $ha_user dash -c '$ha_pyenv_activation; exec pip3 install -U homeas
 			G_THREAD_START curl -sSfL "https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.conf/desktop/lxde/lxde-rc.xml" -o /etc/xdg/openbox/LXDE/rc.xml
 			G_THREAD_START curl -sSfL "https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.conf/desktop/lxde/pcmanfm.conf" -o /etc/xdg/pcmanfm/LXDE/pcmanfm.conf
 			G_THREAD_START curl -sSfL "https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.conf/desktop/lxde/panel" -o /etc/xdg/lxpanel/LXDE/panels/panel
-			
+
 			# Remove LXRandR menu item (monitor configuration tool as we set res in dietpi-config)
 			[[ -f '/usr/share/applications/lxrandr.desktop' ]] && G_EXEC rm /usr/share/applications/lxrandr.desktop
 
@@ -7460,7 +7460,7 @@ exec sudo -u $ha_user dash -c '$ha_pyenv_activation; exec pip3 install -U homeas
 			Banner_Configuration
 
 			Create_Desktop_Shared_Items
-			
+
 			# Odroid C2, define default pulseaudio sink: https://github.com/MichaIng/DietPi/issues/415
 			[[ $G_HW_MODEL == 12 && -f '/etc/pulse/default.pa' ]] && G_CONFIG_INJECT 'set-default-sink[[:blank:]]' 'set-default-sink alsa_output.platform-odroid_hdmi.37.analog-stereo' /etc/pulse/default.pa
 
@@ -7473,7 +7473,7 @@ exec sudo -u $ha_user dash -c '$ha_pyenv_activation; exec pip3 install -U homeas
 
 			# Configs
 			Download_Install "https://github.com/$G_GITOWNER/DietPi/raw/$G_GITBRANCH/.conf/desktop/lxqt/lxqt-$G_DISTRO_NAME.7z" /etc/xdg/
-			
+
 			# Disable trash
 			# - Skip on Buster since trash seems to be implemented differently: https://github.com/MichaIng/DietPi/issues/1918#issuecomment-488085982
 			(( $G_DISTRO < 5 )) && G_CONFIG_INJECT 'use_trash=' 'use_trash=0' /etc/xdg/libfm/libfm.conf
@@ -10188,7 +10188,7 @@ _EOF_
 				G_CONFIG_INJECT 'transcode_cmd[[:blank:]]=' 'transcode_cmd = "ffmpeg"' /var/www/ampache/config/ampache.cfg.php
 
 			fi
-			
+
 			# Permissions: Ampache can automatically migrate old configs to the new config file
 			G_EXEC chown www-data /var/www/ampache/config/ampache.cfg.php
 
@@ -12760,7 +12760,7 @@ _EOF_
 
 			# Permissions
 			G_EXEC chown -R domoticz:domoticz /opt/domoticz /mnt/dietpi_userdata/domoticz
-			
+
 			# Copy scripts directory to data dir: https://dietpi.com/phpbb/viewtopic.php?t=8627
 			G_EXEC cp -a /opt/domoticz/scripts /mnt/dietpi_userdata/domoticz/
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3164,6 +3164,540 @@ _EOF_
 
 		local software_id
 
+		software_id=5 # ALSA
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			# Get chosen soundcard
+			local soundcard=$(sed -n '/^[[:blank:]]*CONFIG_SOUNDCARD=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+			soundcard=${soundcard:-none}
+
+			# Enable defaults, if set to "none"
+			if [[ $soundcard == 'none' ]]; then
+
+				# RPi: Onboard auto, Others: default
+				(( $G_HW_MODEL < 10 )) && soundcard='rpi-bcm2835-auto' || soundcard='default'
+
+			fi
+
+			# Apply: Installs "alsa-utils"
+			/boot/dietpi/func/dietpi-set_hardware soundcard "$soundcard"
+
+		fi
+
+		software_id=126 # LibSSL1.0.0
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			# On Stretch and above, libssl1.0.0 is no longer available: https://github.com/MichaIng/DietPi/issues/1299
+			# - Our packages are from Debian/Raspbian Jessie, which require multiarch-support: https://packages.debian.org/libssl1.0.0
+			# - On Bullseye, multiarch-support is not available, use from Buster instead: https://packages.debian.org/multiarch-support
+			# shellcheck disable=SC2015
+			(( $G_DISTRO < 6 )) && DEPS_LIST='multiarch-support' || Download_Install "https://dietpi.com/downloads/binaries/all/multiarch-support_$G_HW_ARCH_NAME.deb"
+			Download_Install "https://dietpi.com/downloads/binaries/all/libssl1.0.0_$G_HW_ARCH_NAME.deb"
+
+		fi
+
+		software_id=6 # X.Org X server
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			# Generic X server + Mesa OpenGL libraries and utilities
+			DEPS_LIST='xserver-xorg-core xserver-xorg-input-libinput xinit dbus-x11 xfonts-base x11-xserver-utils x11-utils libgl1-mesa-dri mesa-utils mesa-utils-extra'
+
+			# On RPi, add fbdev display driver, as modesetting requires the full- or fake KMS driver overlay being enabled, so that /dev/dri/card0 exists.
+			(( $G_HW_MODEL > 9 )) || DEPS_LIST+=' xserver-xorg-video-fbdev'
+
+			# On VM, add VMware display driver, which offers slightly better performance. VirtualBox can emulate it as well, which es even the nowadays recommended default.
+			(( $G_HW_MODEL == 20 )) && DEPS_LIST+=' xserver-xorg-video-vmware'
+
+			# Disable DPMS and screen blanking
+			dps_index=$software_id Download_Install '98-dietpi-disable_dpms.conf' /etc/X11/xorg.conf.d/98-dietpi-disable_dpms.conf
+
+			# RK3399
+			if (( $G_HW_CPUID == 3 )); then
+
+				# Buster: Mali-T864 driver by RockChip: https://github.com/rockchip-linux/rk-rootfs-build/tree/master/packages/arm64
+				if (( $G_DISTRO < 6 )); then
+
+					Download_Install 'https://dietpi.com/downloads/binaries/rk3399/libmali.deb'
+					G_EXEC cd /usr/lib/aarch64-linux-gnu
+					ln -sf libMali.so libEGL.so.1.1.0
+					ln -sf libMali.so libEGL.so
+					ln -sf libMali.so libEGL.so.1.0.0
+					ln -sf libMali.so libEGL.so.1.4
+					ln -sf libMali.so libEGL.so.1
+					ln -sf libMali.so libGLESv2.so
+					ln -sf libMali.so libGLESv2.so.2.0
+					ln -sf libMali.so libGLESv2.so.2.0.0
+					ln -sf libMali.so libGLESv1_CM.so
+					ln -sf libMali.so libGLESv1_CM.so.1
+					ln -sf libMali.so libGLESv1_CM.so.1.1
+					G_EXEC cd /tmp/$G_PROGRAM_NAME
+
+					# X.org config
+					G_BACKUP_FP /etc/X11/xorg.conf
+					dps_index=$software_id Download_Install 'xorg_rk3399.conf' /etc/X11/xorg.conf
+
+				# Bullseye: Use Mesa drivers provided by Debian repo
+				else
+
+					G_AGI libegl1 libgles2
+
+				fi
+
+			# Odroid C2: https://dietpi.com/meveric/pool/main/s/setup-odroid/
+			elif (( $G_HW_MODEL == 12 )); then
+
+				DEPS_LIST='mali450-odroid xf86-video-fbturbo-odroid libump-odroid'
+				G_BACKUP_FP /etc/X11/xorg.conf
+				dps_index=$software_id Download_Install 'xorg_c2.conf' /etc/X11/xorg.conf
+
+			# Odroid XU4: https://dietpi.com/meveric/pool/main/s/setup-odroid/
+			elif (( $G_HW_MODEL == 11 )); then
+
+				# xf86-video-armsoc-odroid creates an xorg.conf
+				G_AGI firmware-samsung malit628-odroid xf86-video-armsoc-odroid
+
+			# PINE A64
+			elif (( $G_HW_MODEL == 40 )); then
+
+				Download_Install 'https://dietpi.com/downloads/binaries/all/libump_1-1_arm64.deb'
+				G_EXEC mv /usr/local/lib/libUMP* /usr/lib/
+				Download_Install 'https://dietpi.com/downloads/binaries/all/xf86-video-fbturbo_1-1_arm64.deb'
+				G_BACKUP_FP /etc/X11/xorg.conf
+				dps_index=$software_id Download_Install 'xorg_pine64.conf' /etc/X11/xorg.conf
+
+			# ASUS TB
+			elif (( $G_HW_MODEL == 52 )); then
+
+				# Buster: Mali-T760 driver by RockChip: https://github.com/rockchip-linux/rk-rootfs-build/tree/master/packages/armhf
+				if (( $G_DISTRO < 6 )); then
+
+					Download_Install 'https://dietpi.com/downloads/binaries/asus/libmali.deb'
+					G_EXEC cd /usr/lib/arm-linux-gnueabihf
+					ln -sf libMali.so libEGL.so.1.1.0
+					ln -sf libMali.so libEGL.so
+					ln -sf libMali.so libEGL.so.1.0.0
+					ln -sf libMali.so libEGL.so.1.4
+					ln -sf libMali.so libEGL.so.1
+					ln -sf libMali.so libGLESv2.so
+					ln -sf libMali.so libGLESv2.so.2.0
+					ln -sf libMali.so libGLESv2.so.2.0.0
+					ln -sf libMali.so libGLESv1_CM.so
+					ln -sf libMali.so libGLESv1_CM.so.1
+					ln -sf libMali.so libGLESv1_CM.so.1.1
+					G_EXEC cd /tmp/$G_PROGRAM_NAME
+
+					# X.org config
+					G_BACKUP_FP /etc/X11/xorg.conf
+					dps_index=$software_id Download_Install 'xorg_asustb.conf' /etc/X11/xorg.conf
+
+				# Bullseye: Use Mesa drivers provided by Debian repo
+				else
+
+					G_AGI libegl1 libgles2
+
+				fi
+
+			fi
+
+		fi
+
+		software_id=151 # Nvidia driver
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI nvidia-driver
+
+		fi
+
+		software_id=152 # Avahi-Daemon
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI avahi-daemon
+
+		fi
+
+		software_id=16 # Build essentials
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI build-essential automake
+
+		fi
+
+		software_id=100 # PiJuice
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI pijuice-base
+
+		fi
+
+		software_id=17 # Git Client
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI git
+
+		fi
+
+		software_id=4 # Vifm
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI vifm
+
+		fi
+
+		software_id=20
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI vim
+
+		fi
+
+		software_id=21
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI vim-tiny
+
+		fi
+
+		software_id=127 # Neovim
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI neovim
+
+		fi
+
+		software_id=18
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI emacs
+
+		fi
+
+		software_id=12
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI iperf
+
+		fi
+
+		software_id=3 # MC
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI mc
+
+		fi
+
+		software_id=19
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI jed
+
+		fi
+
+		software_id=10
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI iftop
+
+		fi
+
+		software_id=11
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI iptraf
+
+		fi
+
+		software_id=13
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI mtr-tiny
+
+		fi
+
+		software_id=14
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI nload
+
+		fi
+
+		software_id=15
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI tcpdump
+
+		fi
+
+		software_id=0 # OpenSSH Client
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI openssh-client
+
+		fi
+
+		software_id=1 # Samba Client
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			# Remove Information file
+			[[ -f '/mnt/samba/readme.txt' ]] && G_EXEC rm /mnt/samba/readme.txt
+
+			G_AGI smbclient cifs-utils
+
+		fi
+
+		software_id=110 # NFS Client
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			# Remove information file
+			[[ -f '/mnt/nfs_client/readme.txt' ]] && G_EXEC rm /mnt/nfs_client/readme.txt
+
+			# "netbase" is needed for mounting NFSv3: https://github.com/MichaIng/DietPi/issues/1898#issuecomment-406247814
+			G_AGI nfs-common netbase
+
+		fi
+
+		software_id=104 # Dropbear
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			# Mark target SSH server choice, if not selected via menu or first run setup
+			INDEX_SSHSERVER_TARGET=-1
+
+			# Stop OpenSSH service to unbind port 22
+			systemctl -q is-active ssh && G_EXEC systemctl stop ssh
+
+			# On Stretch + Buster Dropbear packages have been split, install "dropbear-run" only, to have active service, but skip "dropbear-initramfs"
+			# On Bullseye+ "dropbear-run" has become a transitional dummy package for "dropbear" which does not include "dropbear-initramfs" anymore.
+			if (( $G_DISTRO > 5 )); then
+
+				G_AGI dropbear
+
+			else
+
+				G_AGI dropbear-run
+
+			fi
+
+			# Enable Dropbear daemon
+			G_CONFIG_INJECT 'NO_START=' 'NO_START=0' /etc/default/dropbear
+
+			# Failsafe: Enable Dropbear service
+			G_EXEC systemctl enable dropbear
+			aSTART_SERVICES+=('dropbear')
+
+			# Mark OpenSSH for uninstall and update choice system
+			dpkg-query -s 'openssh-server' &> /dev/null && aSOFTWARE_INSTALL_STATE[105]=-1 && UNINSTALL_REQUIRED=1
+			INDEX_SSHSERVER_CURRENT=-1
+
+		fi
+
+		software_id=105 # OpenSSH Server
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			# Mark target SSH server choice, if not selected via menu or first run setup
+			INDEX_SSHSERVER_TARGET=-2
+
+			# Stop Dropbear service to unbind port 22
+			systemctl -q is-active dropbear && G_EXEC systemctl stop dropbear
+
+			# SSH server package pulls client as dependency. Mark client hence as installed and mark it explicitly so that it is not autoremoved with the server but must be marked for uninstall instead.
+			G_AGI openssh-server openssh-client
+			aSOFTWARE_INSTALL_STATE[0]=2
+
+			# Allow root login
+			G_CONFIG_INJECT 'PermitRootLogin[[:blank:]]' 'PermitRootLogin yes' /etc/ssh/sshd_config
+
+			# Reload SSH server now so root users can login during setup.
+			systemctl reload ssh
+
+			# Failsafe: Enable OpenSSH service
+			G_EXEC systemctl enable ssh
+			aSTART_SERVICES+=('ssh')
+
+			# Mark Dropbear for uninstall and update choice system
+			grep -q '^dropbear[^[:blank:]]*[[:blank:]]' <<< "$(dpkg --get-selections)" && aSOFTWARE_INSTALL_STATE[104]=-1 && UNINSTALL_REQUIRED=1
+			INDEX_SSHSERVER_CURRENT=-2
+
+		fi
+
+		software_id=103 # DietPi-RAMlog
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			# Install persistent tmpfs
+			local tmpfs_max_size=$(sed -n '/^[[:blank:]]*AUTO_SETUP_RAMLOG_MAXSIZE=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+			sed -i '/[[:blank:]]\/var\/log[[:blank:]]/d' /etc/fstab
+			echo "tmpfs /var/log tmpfs size=${tmpfs_max_size:-50}M,noatime,lazytime,nodev,nosuid,mode=1777" >> /etc/fstab
+
+			# Enable DietPi-RAMdisk
+			G_EXEC systemctl enable dietpi-ramlog
+
+			# To assure a cleaned mountpoint we need to start RAMlog now
+			local acommand=('/boot/dietpi/func/dietpi-ramlog' '1')
+			systemctl is-active dietpi-ramlog > /dev/null && acommand=('systemctl' 'stop' 'dietpi-ramlog')
+			G_EXEC_DESC='Storing /var/log metadata to disk' G_EXEC "${acommand[@]}"
+			unset -v acommand
+			findmnt /var/log > /dev/null && G_EXEC_DESC='Unmounting /var/log' G_EXEC_NOHALT=1 G_EXEC umount -R /var/log
+			G_EXEC_DESC='Cleaning /var/log mountpoint' G_EXEC rm -Rf /var/log/{,.??,.[^.]}*
+			G_EXEC_DESC='Mounting tmpfs to /var/log' G_EXEC mount /var/log
+			G_EXEC_DESC='Restoring metadata to /var/log tmpfs' G_EXEC systemctl start dietpi-ramlog
+
+		fi
+
+		software_id=101 # Logrotate
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI logrotate
+
+		fi
+
+		software_id=102 # Rsyslog
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			# Workaround for dpkg failure on 1st install if service is already running but APT not installed: https://github.com/MichaIng/DietPi/pull/2277/#issuecomment-441460925
+			systemctl stop rsyslog 2> /dev/null
+			G_AGI rsyslog
+			G_EXEC systemctl enable --now rsyslog
+
+		fi
+
+		software_id=7 # FFmpeg
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+			G_AGI ffmpeg
+
+		fi
+
+		software_id=8 # Java
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			# On Stretch and ARMv6 (RPi 1/Zero) use Java 8, else most current
+			# Stretch does not ship Java 11 yet, ARMv6 is not Java 11 compatible, but luckily Raspbian ships Java 8 even on Bullseye: https://github.com/MichaIng/DietPi/issues/3182
+			local version=11
+			(( $G_DISTRO < 5 || G_HW_ARCH == 1 )) && version=8
+
+			# Allow two attempts as workaround for ARM install issue: https://github.com/MichaIng/DietPi/issues/2524
+			G_EXEC_RETRIES=1 G_AGI ca-certificates-java openjdk-$version-jre-headless openjdk-$version-jdk-headless
+
+		fi
+
+		software_id=9 # Node.js
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			INSTALL_URL_ADDRESS='https://raw.githubusercontent.com/MichaIng/nodejs-linux-installer/master/node-install.sh'
+			G_CHECK_URL "$INSTALL_URL_ADDRESS"
+			G_EXEC curl -sSfLO "$INSTALL_URL_ADDRESS"
+			G_EXEC chmod +x node-install.sh
+			G_EXEC mkdir -p /usr/local # failsafe
+			G_EXEC_OUTPUT=1 G_EXEC ./node-install.sh
+			G_EXEC_NOHALT=1 G_EXEC rm node-install.sh
+
+			# Deps: https://github.com/MichaIng/DietPi/issues/3614
+			G_AGI libatomic1
+
+		fi
+
+		software_id=130 # Python 3 pip
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			# Create piwheels config file for ARMv6 and ARMv7
+			[[ $G_HW_ARCH != [12] || -f '/etc/pip.conf' ]] || G_EXEC eval "echo -e '[global]\nextra-index-url=https://www.piwheels.org/simple/' > /etc/pip.conf"
+
+			# Perform pip3 installation
+			INSTALL_URL_ADDRESS='https://bootstrap.pypa.io/get-pip.py'
+			(( $G_DISTRO > 4 )) || INSTALL_URL_ADDRESS='https://bootstrap.pypa.io/3.5/get-pip.py' # https://pip.pypa.io/en/stable/news/#id1
+			DEPS_LIST='python3-dev' Download_Install "$INSTALL_URL_ADDRESS"
+			G_EXEC_OUTPUT=1 G_EXEC python3 ./get-pip.py
+			G_EXEC_NOHALT=1 G_EXEC rm get-pip.py
+
+		fi
+
+		software_id=150 # Mono runtime
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing # https://www.mono-project.com/download/stable/#download-lin-debian
+
+			apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+
+			# On RPi use separate Raspbian repo: https://github.com/MichaIng/DietPi/issues/1023
+			# Use Buster branch on Bullseye
+			if (( $G_HW_MODEL < 10 )) && (( $G_RASPBIAN )); then
+
+				echo "deb https://download.mono-project.com/repo/debian/ raspbian${G_DISTRO_NAME/bullseye/buster} main" > /etc/apt/sources.list.d/mono-xamarin.list
+
+			else
+
+				echo "deb https://download.mono-project.com/repo/debian/ ${G_DISTRO_NAME/bullseye/buster} main" > /etc/apt/sources.list.d/mono-xamarin.list
+
+			fi
+
+			G_AGUP
+			G_AGI mono-runtime mono-complete
+
+			rm -f /tmp/mono* # https://github.com/MichaIng/DietPi/issues/1877#issuecomment-403856446
+
+		fi
+
+		software_id=170 # UnRAR
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			# On Raspbian, only "unrar-free" is available in repos, but does not support all rar formats, thus we use "unrar" [non-free] from Debian repo: http://raspbian.raspberrypi.org/raspbian/pool/non-free/u/unrar-nonfree/
+			if (( $G_HW_MODEL < 10 )) && (( $G_RASPBIAN )); then
+
+				Download_Install "https://dietpi.com/downloads/binaries/rpi/unrar-armhf-$G_DISTRO_NAME.deb"
+
+			else
+
+				G_AGI unrar
+
+			fi
+
+		fi
+
 		software_id=23 # LXDE
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
@@ -12839,540 +13373,6 @@ _EOF_
 		# NB: systemctl daemon-reload is executed at the end of this function
 		local software_id
 
-		software_id=5 # ALSA
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			# Get chosen soundcard
-			local soundcard=$(sed -n '/^[[:blank:]]*CONFIG_SOUNDCARD=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-			soundcard=${soundcard:-none}
-
-			# Enable defaults, if set to "none"
-			if [[ $soundcard == 'none' ]]; then
-
-				# RPi: Onboard auto, Others: default
-				(( $G_HW_MODEL < 10 )) && soundcard='rpi-bcm2835-auto' || soundcard='default'
-
-			fi
-
-			# Apply: Installs "alsa-utils"
-			/boot/dietpi/func/dietpi-set_hardware soundcard "$soundcard"
-
-		fi
-
-		software_id=126 # LibSSL1.0.0
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			# On Stretch and above, libssl1.0.0 is no longer available: https://github.com/MichaIng/DietPi/issues/1299
-			# - Our packages are from Debian/Raspbian Jessie, which require multiarch-support: https://packages.debian.org/libssl1.0.0
-			# - On Bullseye, multiarch-support is not available, use from Buster instead: https://packages.debian.org/multiarch-support
-			# shellcheck disable=SC2015
-			(( $G_DISTRO < 6 )) && DEPS_LIST='multiarch-support' || Download_Install "https://dietpi.com/downloads/binaries/all/multiarch-support_$G_HW_ARCH_NAME.deb"
-			Download_Install "https://dietpi.com/downloads/binaries/all/libssl1.0.0_$G_HW_ARCH_NAME.deb"
-
-		fi
-
-		software_id=6 # X.Org X server
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			# Generic X server + Mesa OpenGL libraries and utilities
-			DEPS_LIST='xserver-xorg-core xserver-xorg-input-libinput xinit dbus-x11 xfonts-base x11-xserver-utils x11-utils libgl1-mesa-dri mesa-utils mesa-utils-extra'
-
-			# On RPi, add fbdev display driver, as modesetting requires the full- or fake KMS driver overlay being enabled, so that /dev/dri/card0 exists.
-			(( $G_HW_MODEL > 9 )) || DEPS_LIST+=' xserver-xorg-video-fbdev'
-
-			# On VM, add VMware display driver, which offers slightly better performance. VirtualBox can emulate it as well, which es even the nowadays recommended default.
-			(( $G_HW_MODEL == 20 )) && DEPS_LIST+=' xserver-xorg-video-vmware'
-
-			# Disable DPMS and screen blanking
-			dps_index=$software_id Download_Install '98-dietpi-disable_dpms.conf' /etc/X11/xorg.conf.d/98-dietpi-disable_dpms.conf
-
-			# RK3399
-			if (( $G_HW_CPUID == 3 )); then
-
-				# Buster: Mali-T864 driver by RockChip: https://github.com/rockchip-linux/rk-rootfs-build/tree/master/packages/arm64
-				if (( $G_DISTRO < 6 )); then
-
-					Download_Install 'https://dietpi.com/downloads/binaries/rk3399/libmali.deb'
-					G_EXEC cd /usr/lib/aarch64-linux-gnu
-					ln -sf libMali.so libEGL.so.1.1.0
-					ln -sf libMali.so libEGL.so
-					ln -sf libMali.so libEGL.so.1.0.0
-					ln -sf libMali.so libEGL.so.1.4
-					ln -sf libMali.so libEGL.so.1
-					ln -sf libMali.so libGLESv2.so
-					ln -sf libMali.so libGLESv2.so.2.0
-					ln -sf libMali.so libGLESv2.so.2.0.0
-					ln -sf libMali.so libGLESv1_CM.so
-					ln -sf libMali.so libGLESv1_CM.so.1
-					ln -sf libMali.so libGLESv1_CM.so.1.1
-					G_EXEC cd /tmp/$G_PROGRAM_NAME
-
-					# X.org config
-					G_BACKUP_FP /etc/X11/xorg.conf
-					dps_index=$software_id Download_Install 'xorg_rk3399.conf' /etc/X11/xorg.conf
-
-				# Bullseye: Use Mesa drivers provided by Debian repo
-				else
-
-					G_AGI libegl1 libgles2
-
-				fi
-
-			# Odroid C2: https://dietpi.com/meveric/pool/main/s/setup-odroid/
-			elif (( $G_HW_MODEL == 12 )); then
-
-				DEPS_LIST='mali450-odroid xf86-video-fbturbo-odroid libump-odroid'
-				G_BACKUP_FP /etc/X11/xorg.conf
-				dps_index=$software_id Download_Install 'xorg_c2.conf' /etc/X11/xorg.conf
-
-			# Odroid XU4: https://dietpi.com/meveric/pool/main/s/setup-odroid/
-			elif (( $G_HW_MODEL == 11 )); then
-
-				# xf86-video-armsoc-odroid creates an xorg.conf
-				G_AGI firmware-samsung malit628-odroid xf86-video-armsoc-odroid
-
-			# PINE A64
-			elif (( $G_HW_MODEL == 40 )); then
-
-				Download_Install 'https://dietpi.com/downloads/binaries/all/libump_1-1_arm64.deb'
-				G_EXEC mv /usr/local/lib/libUMP* /usr/lib/
-				Download_Install 'https://dietpi.com/downloads/binaries/all/xf86-video-fbturbo_1-1_arm64.deb'
-				G_BACKUP_FP /etc/X11/xorg.conf
-				dps_index=$software_id Download_Install 'xorg_pine64.conf' /etc/X11/xorg.conf
-
-			# ASUS TB
-			elif (( $G_HW_MODEL == 52 )); then
-
-				# Buster: Mali-T760 driver by RockChip: https://github.com/rockchip-linux/rk-rootfs-build/tree/master/packages/armhf
-				if (( $G_DISTRO < 6 )); then
-
-					Download_Install 'https://dietpi.com/downloads/binaries/asus/libmali.deb'
-					G_EXEC cd /usr/lib/arm-linux-gnueabihf
-					ln -sf libMali.so libEGL.so.1.1.0
-					ln -sf libMali.so libEGL.so
-					ln -sf libMali.so libEGL.so.1.0.0
-					ln -sf libMali.so libEGL.so.1.4
-					ln -sf libMali.so libEGL.so.1
-					ln -sf libMali.so libGLESv2.so
-					ln -sf libMali.so libGLESv2.so.2.0
-					ln -sf libMali.so libGLESv2.so.2.0.0
-					ln -sf libMali.so libGLESv1_CM.so
-					ln -sf libMali.so libGLESv1_CM.so.1
-					ln -sf libMali.so libGLESv1_CM.so.1.1
-					G_EXEC cd /tmp/$G_PROGRAM_NAME
-
-					# X.org config
-					G_BACKUP_FP /etc/X11/xorg.conf
-					dps_index=$software_id Download_Install 'xorg_asustb.conf' /etc/X11/xorg.conf
-
-				# Bullseye: Use Mesa drivers provided by Debian repo
-				else
-
-					G_AGI libegl1 libgles2
-
-				fi
-
-			fi
-
-		fi
-
-		software_id=151 # Nvidia driver
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI nvidia-driver
-
-		fi
-
-		software_id=152 # Avahi-Daemon
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI avahi-daemon
-
-		fi
-
-		software_id=16 # Build essentials
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI build-essential automake
-
-		fi
-
-		software_id=100 # PiJuice
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI pijuice-base
-
-		fi
-
-		software_id=17 # Git Client
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI git
-
-		fi
-
-		software_id=4 # Vifm
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI vifm
-
-		fi
-
-		software_id=20
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI vim
-
-		fi
-
-		software_id=21
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI vim-tiny
-
-		fi
-
-		software_id=127 # Neovim
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI neovim
-
-		fi
-
-		software_id=18
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI emacs
-
-		fi
-
-		software_id=12
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI iperf
-
-		fi
-
-		software_id=3 # MC
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI mc
-
-		fi
-
-		software_id=19
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI jed
-
-		fi
-
-		software_id=10
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI iftop
-
-		fi
-
-		software_id=11
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI iptraf
-
-		fi
-
-		software_id=13
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI mtr-tiny
-
-		fi
-
-		software_id=14
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI nload
-
-		fi
-
-		software_id=15
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI tcpdump
-
-		fi
-
-		software_id=0 # OpenSSH Client
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI openssh-client
-
-		fi
-
-		software_id=1 # Samba Client
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			# Remove Information file
-			[[ -f '/mnt/samba/readme.txt' ]] && G_EXEC rm /mnt/samba/readme.txt
-
-			G_AGI smbclient cifs-utils
-
-		fi
-
-		software_id=110 # NFS Client
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			# Remove information file
-			[[ -f '/mnt/nfs_client/readme.txt' ]] && G_EXEC rm /mnt/nfs_client/readme.txt
-
-			# "netbase" is needed for mounting NFSv3: https://github.com/MichaIng/DietPi/issues/1898#issuecomment-406247814
-			G_AGI nfs-common netbase
-
-		fi
-
-		software_id=104 # Dropbear
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			# Mark target SSH server choice, if not selected via menu or first run setup
-			INDEX_SSHSERVER_TARGET=-1
-
-			# Stop OpenSSH service to unbind port 22
-			systemctl -q is-active ssh && G_EXEC systemctl stop ssh
-
-			# On Stretch + Buster Dropbear packages have been split, install "dropbear-run" only, to have active service, but skip "dropbear-initramfs"
-			# On Bullseye+ "dropbear-run" has become a transitional dummy package for "dropbear" which does not include "dropbear-initramfs" anymore.
-			if (( $G_DISTRO > 5 )); then
-
-				G_AGI dropbear
-
-			else
-
-				G_AGI dropbear-run
-
-			fi
-
-			# Enable Dropbear daemon
-			G_CONFIG_INJECT 'NO_START=' 'NO_START=0' /etc/default/dropbear
-
-			# Failsafe: Enable Dropbear service
-			G_EXEC systemctl enable dropbear
-			aSTART_SERVICES+=('dropbear')
-
-			# Mark OpenSSH for uninstall and update choice system
-			dpkg-query -s 'openssh-server' &> /dev/null && aSOFTWARE_INSTALL_STATE[105]=-1 && UNINSTALL_REQUIRED=1
-			INDEX_SSHSERVER_CURRENT=-1
-
-		fi
-
-		software_id=105 # OpenSSH Server
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			# Mark target SSH server choice, if not selected via menu or first run setup
-			INDEX_SSHSERVER_TARGET=-2
-
-			# Stop Dropbear service to unbind port 22
-			systemctl -q is-active dropbear && G_EXEC systemctl stop dropbear
-
-			# SSH server package pulls client as dependency. Mark client hence as installed and mark it explicitly so that it is not autoremoved with the server but must be marked for uninstall instead.
-			G_AGI openssh-server openssh-client
-			aSOFTWARE_INSTALL_STATE[0]=2
-
-			# Allow root login
-			G_CONFIG_INJECT 'PermitRootLogin[[:blank:]]' 'PermitRootLogin yes' /etc/ssh/sshd_config
-
-			# Reload SSH server now so root users can login during setup.
-			systemctl reload ssh
-
-			# Failsafe: Enable OpenSSH service
-			G_EXEC systemctl enable ssh
-			aSTART_SERVICES+=('ssh')
-
-			# Mark Dropbear for uninstall and update choice system
-			grep -q '^dropbear[^[:blank:]]*[[:blank:]]' <<< "$(dpkg --get-selections)" && aSOFTWARE_INSTALL_STATE[104]=-1 && UNINSTALL_REQUIRED=1
-			INDEX_SSHSERVER_CURRENT=-2
-
-		fi
-
-		software_id=103 # DietPi-RAMlog
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			# Install persistent tmpfs
-			local tmpfs_max_size=$(sed -n '/^[[:blank:]]*AUTO_SETUP_RAMLOG_MAXSIZE=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-			sed -i '/[[:blank:]]\/var\/log[[:blank:]]/d' /etc/fstab
-			echo "tmpfs /var/log tmpfs size=${tmpfs_max_size:-50}M,noatime,lazytime,nodev,nosuid,mode=1777" >> /etc/fstab
-
-			# Enable DietPi-RAMdisk
-			G_EXEC systemctl enable dietpi-ramlog
-
-			# To assure a cleaned mountpoint we need to start RAMlog now
-			local acommand=('/boot/dietpi/func/dietpi-ramlog' '1')
-			systemctl is-active dietpi-ramlog > /dev/null && acommand=('systemctl' 'stop' 'dietpi-ramlog')
-			G_EXEC_DESC='Storing /var/log metadata to disk' G_EXEC "${acommand[@]}"
-			unset -v acommand
-			findmnt /var/log > /dev/null && G_EXEC_DESC='Unmounting /var/log' G_EXEC_NOHALT=1 G_EXEC umount -R /var/log
-			G_EXEC_DESC='Cleaning /var/log mountpoint' G_EXEC rm -Rf /var/log/{,.??,.[^.]}*
-			G_EXEC_DESC='Mounting tmpfs to /var/log' G_EXEC mount /var/log
-			G_EXEC_DESC='Restoring metadata to /var/log tmpfs' G_EXEC systemctl start dietpi-ramlog
-
-		fi
-
-		software_id=101 # Logrotate
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI logrotate
-
-		fi
-
-		software_id=102 # Rsyslog
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			# Workaround for dpkg failure on 1st install if service is already running but APT not installed: https://github.com/MichaIng/DietPi/pull/2277/#issuecomment-441460925
-			systemctl stop rsyslog 2> /dev/null
-			G_AGI rsyslog
-			G_EXEC systemctl enable --now rsyslog
-
-		fi
-
-		software_id=7 # FFmpeg
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI ffmpeg
-
-		fi
-
-		software_id=8 # Java
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			# On Stretch and ARMv6 (RPi 1/Zero) use Java 8, else most current
-			# Stretch does not ship Java 11 yet, ARMv6 is not Java 11 compatible, but luckily Raspbian ships Java 8 even on Bullseye: https://github.com/MichaIng/DietPi/issues/3182
-			local version=11
-			(( $G_DISTRO < 5 || G_HW_ARCH == 1 )) && version=8
-
-			# Allow two attempts as workaround for ARM install issue: https://github.com/MichaIng/DietPi/issues/2524
-			G_EXEC_RETRIES=1 G_AGI ca-certificates-java openjdk-$version-jre-headless openjdk-$version-jdk-headless
-
-		fi
-
-		software_id=9 # Node.js
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			INSTALL_URL_ADDRESS='https://raw.githubusercontent.com/MichaIng/nodejs-linux-installer/master/node-install.sh'
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-			G_EXEC curl -sSfLO "$INSTALL_URL_ADDRESS"
-			G_EXEC chmod +x node-install.sh
-			G_EXEC mkdir -p /usr/local # failsafe
-			G_EXEC_OUTPUT=1 G_EXEC ./node-install.sh
-			G_EXEC_NOHALT=1 G_EXEC rm node-install.sh
-
-			# Deps: https://github.com/MichaIng/DietPi/issues/3614
-			G_AGI libatomic1
-
-		fi
-
-		software_id=130 # Python 3 pip
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			# Create piwheels config file for ARMv6 and ARMv7
-			[[ $G_HW_ARCH != [12] || -f '/etc/pip.conf' ]] || G_EXEC eval "echo -e '[global]\nextra-index-url=https://www.piwheels.org/simple/' > /etc/pip.conf"
-
-			# Perform pip3 installation
-			INSTALL_URL_ADDRESS='https://bootstrap.pypa.io/get-pip.py'
-			(( $G_DISTRO > 4 )) || INSTALL_URL_ADDRESS='https://bootstrap.pypa.io/3.5/get-pip.py' # https://pip.pypa.io/en/stable/news/#id1
-			DEPS_LIST='python3-dev' Download_Install "$INSTALL_URL_ADDRESS"
-			G_EXEC_OUTPUT=1 G_EXEC python3 ./get-pip.py
-			G_EXEC_NOHALT=1 G_EXEC rm get-pip.py
-
-		fi
-
-		software_id=150 # Mono runtime
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing # https://www.mono-project.com/download/stable/#download-lin-debian
-
-			apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-
-			# On RPi use separate Raspbian repo: https://github.com/MichaIng/DietPi/issues/1023
-			# Use Buster branch on Bullseye
-			if (( $G_HW_MODEL < 10 )) && (( $G_RASPBIAN )); then
-
-				echo "deb https://download.mono-project.com/repo/debian/ raspbian${G_DISTRO_NAME/bullseye/buster} main" > /etc/apt/sources.list.d/mono-xamarin.list
-
-			else
-
-				echo "deb https://download.mono-project.com/repo/debian/ ${G_DISTRO_NAME/bullseye/buster} main" > /etc/apt/sources.list.d/mono-xamarin.list
-
-			fi
-
-			G_AGUP
-			G_AGI mono-runtime mono-complete
-
-			rm -f /tmp/mono* # https://github.com/MichaIng/DietPi/issues/1877#issuecomment-403856446
-
-		fi
-
-		software_id=170 # UnRAR
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			# On Raspbian, only "unrar-free" is available in repos, but does not support all rar formats, thus we use "unrar" [non-free] from Debian repo: http://raspbian.raspberrypi.org/raspbian/pool/non-free/u/unrar-nonfree/
-			if (( $G_HW_MODEL < 10 )) && (( $G_RASPBIAN )); then
-
-				Download_Install "https://dietpi.com/downloads/binaries/rpi/unrar-armhf-$G_DISTRO_NAME.deb"
-
-			else
-
-				G_AGI unrar
-
-			fi
-
-		fi
-
 		software_id=23 # LXDE
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
@@ -16236,7 +16236,7 @@ _EOF_
 		# - Apply same states to Allo and Allo_update
 		(( ${aSOFTWARE_INSTALL_STATE[159]} == 1 || ${aSOFTWARE_INSTALL_STATE[160]} == 1 )) && { aSOFTWARE_INSTALL_STATE[159]=2 aSOFTWARE_INSTALL_STATE[160]=2; }
 		for i in "${!aSOFTWARE_NAME[@]}"
-		
+		do
 			(( ${aSOFTWARE_INSTALL_STATE[$i]} == 1 )) && aSOFTWARE_INSTALL_STATE[$i]=2
 		done
 


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Software | Part 1: Merge "Linux" software and "DietPi" software functions
+ DietPi-Software | Allow custom first boot script download + exec bit + removal to fail without failing the whole first run setup. This is consistent with the fact that we allow the script execution itself to fail, which we cannot control anyway.
+ DietPi-Software | Reload systemd units after installs, before e.g. restarting them, remove reload right within Tor Relay config block, where it is generally not required
+ DietPi-Software | Remove too simple Apply_Webserver_Preference function