### PR TITLE
DietPi-Software | O!MPD

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -41,6 +41,7 @@ Fixes:
 - DietPi-Software | IceCast: Resolved an issue where DarkIce fails to connect to IceCast by default, due to an invalid hostname in its config.
 - DietPi-Software | Koel: Resolved issues which caused a failing install, caused by changed archive directory names and changed Laravel dependencies.
 - DietPi-Software | myMPD: Resolved an issue where the service fails to start because of a renamed setting. Many thanks to @sofad for reporting this issue: https://github.com/MichaIng/DietPi/issues/4256
+- DietPi-Software | O!MPD: Resolved an issue where browsing the media directory from the web UI failed because of a missing slash in the local config file. Many thanks to @pinkdot for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=8904
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11680,7 +11680,7 @@ _EOF_
 \$cfg['mysqli_socket']               = '/run/mysqld/mysqld.sock';
 \$cfg['mysqli_auto_create_db']       = true;
 # Media dir
-\$cfg['media_dir']                   = '/mnt/dietpi_userdata/Music';
+\$cfg['media_dir']                   = '/mnt/dietpi_userdata/Music/';
 ?>
 _EOF_
 


### PR DESCRIPTION
There is an issue report on the forum about a missing `/` in `config.local.inc.php` configuration file

**Status**: Ready
- [x] adjust config file

**Reference**: https://dietpi.com/phpbb/viewtopic.php?t=8904

**Commit list/description**:
- DietPi-Software | O!MPD - adjust config file