### PR TITLE
Beta v7.1.2

### DIFF
--- a/.conf/dps_182/unbound.conf
+++ b/.conf/dps_182/unbound.conf
@@ -49,7 +49,7 @@ server:
 	do-ip6: yes
 	prefer-ip6: no
 
-	# DNS root server information file. Updated monthly via cronjob
+	# DNS root server information file. Updated monthly via cron job: /etc/cron.monthly/dietpi-unbound
 	root-hints: "/var/lib/unbound/root.hints"
 
 	# Maximum number of queries per second

--- a/.conf/dpv/protonvpn.template
+++ b/.conf/dpv/protonvpn.template
@@ -26,12 +26,7 @@
 client
 dev tun
 proto $PROTOCOL
-
-remote $VPN_SERVER 443
-remote $VPN_SERVER 80
 remote $VPN_SERVER 1194
-remote $VPN_SERVER 5060
-remote $VPN_SERVER 4569
 
 remote-random
 resolv-retry infinite

--- a/.update/patches
+++ b/.update/patches
@@ -62,7 +62,7 @@ fi
 [[ -d '/usr/local/go' ]] && ! grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[188\]=2' /boot/dietpi/.installed && grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[58\]=2' /boot/dietpi/.installed && G_CONFIG_INJECT 'aSOFTWARE_INSTALL_STATE\[188\]=' 'aSOFTWARE_INSTALL_STATE[188]=2' /boot/dietpi/.installed
 
 # v7.1: Interactively inform user about possible No-IP => DietPi-DDNS migration
-[[ -f '/boot/dietpi/.installed' ]] && grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[67)\]=2' /boot/dietpi/.installed && G_WHIP_MSG '[ INFO ] No-IP client installation found
+[[ -f '/boot/dietpi/.installed' ]] && grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[67\]=2' /boot/dietpi/.installed && G_WHIP_MSG '[ INFO ] No-IP client installation found
 \nThe No-IP client install option has been replaced by our new DietPi-DDNS tool. The No-IP client remains functional on your system but we recommend a migration to our new tool.
 \nSimply run "dietpi-ddns" from console, select "No-IP" as provider, enter domain and credentials, then select "Apply". The old No-IP client and service will be removed automatically as last step, once a final DDNS update test succeeded.'
 
@@ -83,6 +83,9 @@ rm -f /mnt/dietpi_userdata/{{sonarr,radarr}/nzbdrone.db-{shm,wal},lidarr/lidarr.
 
 # v7.1: On 64-bit RPi systems, remove the obsolete foreign architecture armhf
 [[ $G_HW_MODEL -le 9 && $G_HW_ARCH == 3 && $(dpkg --print-architecture) == 'arm64' ]] && G_EXEC dpkg --remove-architecture 'armhf'
+
+# v7.1: Plex Media Server: Fix secure remote access via app.plex.tv did not work if Unbound with DNS rebinding protection is installed: https://dietpi.com/phpbb/viewtopic.php?t=8896
+[[ -f '/boot/dietpi/.installed' ]] && grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[42\]=2' /boot/dietpi/.installed && grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[182\]=2' /boot/dietpi/.installed && echo -e 'server:\n\tprivate-domain: "plex.direct"' > /etc/unbound/unbound.conf.d/dietpi-plex.conf
 
 exit 0
 }

--- a/.update/version
+++ b/.update/version
@@ -1,7 +1,7 @@
 # Available DietPi version
 G_REMOTE_VERSION_CORE=7
 G_REMOTE_VERSION_SUB=1
-G_REMOTE_VERSION_RC=1
+G_REMOTE_VERSION_RC=2
 # Minimum DietPi version to allow update
 G_MIN_VERSION_CORE=6
 G_MIN_VERSION_SUB=0

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -63,7 +63,8 @@ Fixes:
 - DietPi-Software | Kodi: Worked around an issue on 64-bit RPi systems, where the wrong Kodi package is tried to be installed, causing an APT failure. Many thanks to @mmnpkf for reporting this issue: https://github.com/MichaIng/DietPi/issues/4194
 - DietPi-Software | Chromium: Worked around an issue on 64-bit RPi systems, where the install failed, as The Raspberry Pi repository does not ship a 64-bit build yet. The Chromium package from the Debian repository is now installed instead.
 - DietPi-Software | Sonarr/Radarr: Having both now installed as v3 or later, resolves a long outstanding issue, where importing downloads to filesystems without native UNIX permissions support, including Samba/CIFS mounts, failed.
-- DietPi-Software | WebIOPi: Resolved an issue where the GPIO pins could not be toggled via web interface by moving to a newer fork of this project. This additionally enabled us to run it with Python 3 and enable it on RPi 3 and RPi 4 models. Many thanks to @torwan for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=8945 
+- DietPi-Software | WebIOPi: Resolved an issue where the GPIO pins could not be toggled via web interface by moving to a newer fork of this project. This additionally enabled us to run it with Python 3 and enable it on RPi 3 and RPi 4 models. Many thanks to @torwan for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=8945
+- DietPi-Software | Plex Media Server: Resolved an issue where secure remote access via app.plex.tv did not work if Unbound with DNS rebinding protection is installed. Many thanks to @danmo117 for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=8896
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/4305
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -62,6 +62,7 @@ Fixes:
 - DietPi-Software | Kodi: Worked around an issue on 64-bit RPi systems, where the wrong Kodi package is tried to be installed, causing an APT failure. Many thanks to @mmnpkf for reporting this issue: https://github.com/MichaIng/DietPi/issues/4194
 - DietPi-Software | Chromium: Worked around an issue on 64-bit RPi systems, where the install failed, as The Raspberry Pi repository does not ship a 64-bit build yet. The Chromium package from the Debian repository is now installed instead.
 - DietPi-Software | Sonarr/Radarr: Having both now installed as v3 or later, resolves a long outstanding issue, where importing downloads to filesystems without native UNIX permissions support, including Samba/CIFS mounts, failed.
+- DietPi-Software | WebIOPi: Resolved an issue where the GPIO pins could not be toggled via web interface by moving to a newer fork of this project. This additionally enabled us to run it with Python 3 and enable it on RPi 3 and RPi 4 models. Many thanks to @torwan for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=8945 
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/4305
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -49,6 +49,7 @@ Fixes:
 - DietPi-Config | Resolved an issue on Sparky SBC, where selecting the generic USB DAC sound card option failed, due to invalid amixer calls. Many thanks to @Balmoral86 for reporting this issue: https://github.com/MichaIng/DietPi/issues/4249
 - DietPi-Drive_Manager | Fixed detection and visualisation of loop devices in menu.
 - DietPi-Set_userdata | When dietpi_userdata was moved to another drive, the intended dietpi:dietpi ownership was not applied to the target directory as intended. This is required by some software titles, like Syncthing and file servers, to permit the creation of files and directories. Many thanks to @redschumi for reporting this issue: https://github.com/MichaIng/DietPi/issues/4228
+- DietPi-Config | Worked around an issue in RPi, where selecting a sound card ended with an error prompt in certain circumstances. Many thanks to @sturbs for reporting this issue: https://github.com/MichaIng/DietPi/issues/4306
 - DietPi-Software | Resolved an issue where the "uninstall" command did not work and the "reinstall" did not show the intended backup prompt. Many thanks to @Zeuskk for reporting this v7.0 regression: https://dietpi.com/phpbb/viewtopic.php?t=8729
 - DietPi-Software | Resolved an issue where directory permissions could be wrong because of 7zr overriding the default umask. This lead e.g. to 403 browser error on a fresh Single File PHP Gallery install. Many thanks to @Alexgolshtein for reporting this issue: https://github.com/MichaIng/DietPi/issues/4251
 - DietPi-Software | X.Org X Server: Resolved an issue on RPi where the X server start failed when the KMS device tree overlay was not enabled. Many thanks to @xthedakmanx for reporting this issue: https://github.com/MichaIng/DietPi/issues/4175
@@ -62,7 +63,7 @@ Fixes:
 - DietPi-Software | Chromium: Worked around an issue on 64-bit RPi systems, where the install failed, as The Raspberry Pi repository does not ship a 64-bit build yet. The Chromium package from the Debian repository is now installed instead.
 - DietPi-Software | Sonarr/Radarr: Having both now installed as v3 or later, resolves a long outstanding issue, where importing downloads to filesystems without native UNIX permissions support, including Samba/CIFS mounts, failed.
 
-As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
+As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/4305
 
 Known/Outstanding Issues:
 - DietPi-Config | Enabling WiFi + Ethernet adapters, both on different subnets, breaks WiFi connection in some cases: https://github.com/MichaIng/DietPi/issues/2103

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,7 @@ Changes:
 - DietPi-Software | YaCy: New installs and reinstalls will now have the latest version detected and downloaded automatically. This enables an easy update method by simply reinstalling YaCy via "dietpi-software reinstall 133", independent of the DietPi version.
 - DietPi-Software | Remot3.it: After the install finished, it is now offered to do the interactive "connectd_installer" setup directly. Neither is a reboot required, nor does any service need to run to be registered. This is especially helpful for installs via "dietpi-software install 68", where the hint about this required setup was not shown before.
 - DietPi-Software | Sonarr: Support for and migration to v3 has been implemented. Existing installs won't be migrated automatically, run "dietpi-software reinstall 144" to upgrade your Sonarr to v3. On DietPi update, Sonarr v2 users will receive a related notification.
+- DietPi-Software | RPi.GPIO: This software option has been renamed to "Python 3 RPi.GPIO" to make clear that it is a Python package. In our efforts to migrate all software options to Python 3, only the Python 3 package is installed from now on. To install it for Python 2, one needs to run the following command manually form console: "apt install python-rpi.gpio"
 
 New Scripts:
 - DietPi-VPN | This new tool has been added, which allows you to establish VPN connections to known public VPN providers or connect via custom OpenVPN configuration file. It incorporates all features from the previous DietPi-NordVPN script and more (see changes above). 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -65,6 +65,7 @@ Fixes:
 - DietPi-Software | Sonarr/Radarr: Having both now installed as v3 or later, resolves a long outstanding issue, where importing downloads to filesystems without native UNIX permissions support, including Samba/CIFS mounts, failed.
 - DietPi-Software | WebIOPi: Resolved an issue where the GPIO pins could not be toggled via web interface by moving to a newer fork of this project. This additionally enabled us to run it with Python 3 and enable it on RPi 3 and RPi 4 models. Many thanks to @torwan for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=8945
 - DietPi-Software | Plex Media Server: Resolved an issue where secure remote access via app.plex.tv did not work if Unbound with DNS rebinding protection is installed. Many thanks to @danmo117 for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=8896
+- DietPi-Software | MATE: Resolved an issue where DietPi menu and desktop shortcuts could not be started, as the MATE terminal emulator is not compatible with the "start in console" flag of desktop shortcuts. xterm is now installed together with MATE, to replace the default terminal emulator. Many thanks to @maya95 for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=8949
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/4305
 

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -23,7 +23,7 @@
 	# - PREIMAGE_INFO='Some GNU/Linux'
 	# - HW_MODEL=0				(must match one of the supported IDs below)
 	# - WIFI_REQUIRED=0			[01]
-	# - DISTRO_TARGET=5			[456] (Buster: 5, Bullseye: 6)
+	# - DISTRO_TARGET=5			[56] (Buster: 5, Bullseye: 6)
 	#------------------------------------------------------------------------------------------------
 
 	# Core globals

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Links to hardware and software manufacturers, sources and build instructions use
 - [CUPS](https://github.com/OpenPrinting/cups)
 - [Go](https://github.com/golang/go)
 - [VSCodium](https://github.com/VSCodium/vscodium)
+- [WebIOPi](https://github.com/Freenove/WebIOPi)
 
 ---
 

--- a/dietpi/dietpi-ddns
+++ b/dietpi/dietpi-ddns
@@ -24,8 +24,13 @@ Available options:
   -t <timespan>		Duration between DDNS updates in minutes (optional, defaults to 10)
 Available providers:
   <custom>		Full URL to update against a custom DDNS provider
-  DuckDNS		Read more: https://www.duckdns.org/about.jsp
-  No-IP			Read more: https://www.noip.com/about
+          		Use the "-u" and "-p" options if HTTP authentication is required.
+  DuckDNS 		Read more: https://www.duckdns.org/about.jsp
+          		Use the "-d" and "-p" options to set domains and account token.
+  No-IP    		Read more: https://www.noip.com/about
+           		Use the "-d", "-u" and "-p" options to set domains, username and password.
+  Dynu     		Read more: https://www.dynu.com/DynamicDNS
+          		Use the "-d" and "-p" options to set domains and account password.
 '
 
 # Load DietPi-Globals

--- a/dietpi/dietpi-ddns
+++ b/dietpi/dietpi-ddns
@@ -160,7 +160,7 @@ Apply()
 	local result
 	if ! result=$(curl -sSfL ${http_auth:+ -u "$USERNAME:$PASSWORD"} "$url" 2>&1) ||
 		[[ $PROVIDER == 'DuckDNS' && $result == 'KO' ]] ||
-		[[ $PROVIDER == 'Dynu' && $result != 'good*' && $result != 'nochg*' ]]
+		[[ $PROVIDER == 'Dynu' && $result != 'good'* && $result != 'nochg'* ]]
 	then
 		G_DIETPI-NOTIFY 1 "DDNS update test failed, please check your input${result:+:\n$result}"
 		STATUS="DDNS update test failed, please check your input${result:+:\n$result}"

--- a/dietpi/dietpi-letsencrypt
+++ b/dietpi/dietpi-letsencrypt
@@ -169,7 +169,7 @@ _EOF_
 				G_EXEC sed -i '2d' /etc/lighttpd/conf-available/50-dietpi-https.conf
 				G_EXEC sed -i '/ssl.openssl.ssl-conf-cmd/c\\tssl.use-sslv2 = "disable"\n\tssl.use-sslv3 = "disable"' /etc/lighttpd/conf-available/50-dietpi-https.conf
 
-			# Bullseye: Keep session tickets enabled, which is save since Lighttpd v1.4.56: https://github.com/MichaIng/DietPi/issues/4294#issuecomment-826802056
+			# Bullseye: Keep session tickets enabled, which is safe since Lighttpd v1.4.56: https://github.com/MichaIng/DietPi/issues/4294#issuecomment-826802056
 			elif (( $G_DISTRO > 5 ))
 			then
 				G_EXEC sed -i 's/, "Options" => "-SessionTicket"//' /etc/lighttpd/conf-available/50-dietpi-https.conf

--- a/dietpi/dietpi-letsencrypt
+++ b/dietpi/dietpi-letsencrypt
@@ -168,6 +168,11 @@ _EOF_
 			then
 				G_EXEC sed -i '2d' /etc/lighttpd/conf-available/50-dietpi-https.conf
 				G_EXEC sed -i '/ssl.openssl.ssl-conf-cmd/c\\tssl.use-sslv2 = "disable"\n\tssl.use-sslv3 = "disable"' /etc/lighttpd/conf-available/50-dietpi-https.conf
+
+			# Bullseye: Keep session tickets enabled, which is save since Lighttpd v1.4.56: https://github.com/MichaIng/DietPi/issues/4294#issuecomment-826802056
+			elif (( $G_DISTRO > 5 ))
+			then
+				G_EXEC sed -i 's/, "Options" => "-SessionTicket"//' /etc/lighttpd/conf-available/50-dietpi-https.conf
 			fi
 			G_EXEC lighty-enable-mod dietpi-https
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1255,8 +1255,8 @@ _EOF_
 		#--------------------------------------------------------------------------------
 		software_id=69
 
-		aSOFTWARE_NAME[$software_id]='Python RPi.GPIO'
-		aSOFTWARE_DESC[$software_id]='Control Raspberry Pi GPIO channels in Python'
+		aSOFTWARE_NAME[$software_id]='Python 3 RPi.GPIO'
+		aSOFTWARE_DESC[$software_id]='Control Raspberry Pi GPIO channels in Python 3'
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#rpigpio'
 		# RPi only
@@ -1285,8 +1285,8 @@ _EOF_
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#webiopi'
 		aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
-		# RPi1/2/Zero only
-		for ((i=3; i<=$MAX_G_HW_MODEL; i++))
+		# RPi only
+		for ((i=10; i<=$MAX_G_HW_MODEL; i++))
 		do
 			aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,$i]=0
 		done
@@ -2140,15 +2140,6 @@ _EOF_
 
 		fi
 
-		# Software required by Google AIY
-		if (( ${aSOFTWARE_INSTALL_STATE[169]} == 1 )); then
-
-			aSOFTWARE_INSTALL_STATE[69]=1 # RPi.GPIO
-			G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[69]} will be installed"
-			#aSOFTWARE_INSTALL_STATE[130]=1 # Python 3, enabled in "Software that requires Python 3"
-
-		fi
-
 		# Software that requires Avahi-Daemon
 		# - Kodi (31)
 		# - Shairport-Sync (37)
@@ -2296,10 +2287,14 @@ _EOF_
 
 		fi
 
-		# Software that requires Python RPi.GPIO
+		# Software that requires Python 3 RPi.GPIO
 		# - WebIOPi (71)
+		# - Node-RED (122)
+		# - Google AIY (169)
 		software_id=69
-		if (( ${aSOFTWARE_INSTALL_STATE[71]} == 1 )); then
+		if (( $G_HW_MODEL < 10 )) && (( ${aSOFTWARE_INSTALL_STATE[71]} == 1 ||
+			${aSOFTWARE_INSTALL_STATE[122]} == 1 ||
+			${aSOFTWARE_INSTALL_STATE[169]} == 1 )); then
 
 			aSOFTWARE_INSTALL_STATE[$software_id]=1
 			G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[$software_id]} will be installed"
@@ -4841,11 +4836,11 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 
 		fi
 
-		software_id=69 # Python RPi.GPIO
+		software_id=69 # Python 3 RPi.GPIO
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-			G_AGI python{3,}-rpi.gpio
+			G_AGI python3-rpi.gpio
 
 		fi
 
@@ -4919,10 +4914,7 @@ ExecStart=/mnt/dietpi_userdata/node-red/node_modules/.bin/node-red -u /mnt/dietp
 WantedBy=multi-user.target
 _EOF_
 			# Pre-reqs
-			local apackages=('python3')
-			# - RPi: GPIO control for Node-RED
-			(( $G_HW_MODEL > 9 )) || apackages+=('python3-rpi.gpio')
-			G_AGI "${apackages[@]}"
+			G_AGI python3
 
 			# Install as local instance for "nodered" user
 			G_EXEC cd /mnt/dietpi_userdata/node-red
@@ -5025,18 +5017,32 @@ _EOF_
 		software_id=71 # WebIOPi
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
-			Banner_Installing
+			Banner_Installing # https://github.com/Freenove/WebIOPi
 
 			# Check for reinstall
 			local reinstall=0
 			[[ -f '/etc/webiopi/config' ]] && reinstall=1
 
-			DEPS_LIST='python-dev python-setuptools'
-			Download_Install 'https://sourceforge.net/projects/webiopi/files/WebIOPi-0.7.1.tar.gz/download' webiopi.tar.gz
-			G_EXEC tar xf webiopi.tar.gz
-			G_EXEC_NOHALT=1 G_EXEC rm webiopi.tar.gz
+			DEPS_LIST='python3-dev python3-setuptools patch'
+			Download_Install 'https://github.com/Freenove/WebIOPi/archive/refs/heads/master.tar.gz'
 
-			G_EXEC cd WebIOPi-0.7.1
+			G_EXEC cd WebIOPi-master/WebIOPi-*
+
+			# Apply patch
+			G_EXEC_OUTPUT=1 G_EXEC patch -p1 -i webiopi-pi2bplus.patch
+
+			# Fix shutdown: https://github.com/Freenove/WebIOPi/pull/1
+			grep -q 'self\.shutdown()' python/webiopi/protocols/http.py || G_EXEC sed -i '/self\.server_close()/i\        self.shutdown()' python/webiopi/protocols/http.py
+
+			# Remove Google Analytics
+			if grep -q '_gaq' htdocs/webiopi.js
+			then
+				G_EXEC sed -i '/_gaq/d' htdocs/webiopi.js
+				G_EXEC sed -i '/\/\/ GA/,/head.appendChild(ga)/d' htdocs/webiopi.js
+			fi
+
+			# Install for Python 3 only
+			G_EXEC sed -i '/SEARCH="python python3"/c\SEARCH="python3"' setup.sh
 
 			# Skip Weaved install prompt
 			G_EXEC sed -i '/read response/c\response="n"' setup.sh
@@ -5047,11 +5053,30 @@ _EOF_
 			G_EXEC cd /tmp/$G_PROGRAM_NAME
 
 			# Cleanup
-			G_EXEC_NOHALT=1 G_EXEC rm -R WebIOPi-0.7.1
+			G_EXEC_NOHALT=1 G_EXEC rm -R WebIOPi-master
 
 			# On fresh installs, change port to 8002 to avoid conflict with IceCast
 			(( $reinstall )) || G_EXEC sed -i 's/^port = 8000$/port = 8002/' /etc/webiopi/config
 
+			# Service
+			Remove_SysV webiopi 1
+			cat << _EOF_ > /etc/systemd/system/webiopi.service 
+[Unit]
+Description=WebIOPi (DietPi)
+Wants=network-online.target
+After=network-online.target dietpi-boot.service
+
+[Service]
+SyslogIdentifier=WebIOPi
+ExecStart=$(which python3) -m webiopi -c /etc/webiopi/config
+
+# Hardening
+PrivateTmp=true
+ProtectHome=true
+
+[Install]
+WantedBy=multi-user.target
+_EOF_
 		fi
 
 		software_id=98 # HAProxy
@@ -14482,7 +14507,7 @@ _EOF_
 			if [[ -f '/etc/systemd/system/airsonic.service' ]]; then
 
 				systemctl disable --now airsonic
-				rm -R /etc/systemd/system/airsonic.service*
+				rm /etc/systemd/system/airsonic.service
 
 			fi
 			[[ -d '/etc/systemd/system/airsonic.service.d' ]] && rm -R /etc/systemd/system/airsonic.service.d
@@ -14515,12 +14540,19 @@ _EOF_
 				rm /etc/init.d/webiopi
 
 			fi
+			if [[ -f '/etc/systemd/system/webiopi.service' ]]; then
+
+				systemctl disable --now webiopi
+				rm /etc/systemd/system/webiopi.service
+
+			fi
 			[[ -d '/etc/systemd/system/webiopi.service.d' ]] && rm -R /etc/systemd/system/webiopi.service.d
 			update-rc.d -f webiopi remove
 			[[ -f '/usr/bin/webiopi' ]] && rm /usr/bin/webiopi # Executable
 			[[ -f '/usr/bin/webiopi-passwd' ]] && rm /usr/bin/webiopi-passwd # Password generator
 			[[ -d '/etc/webiopi' ]] && rm -R /etc/webiopi # Config dir
 			[[ -d '/usr/share/webiopi' ]] && rm -R /usr/share/webiopi # HTML resources
+			rm -Rf /usr/local/lib/python*/dist-packages/WebIOPi* # Python packages
 
 		fi
 
@@ -14729,11 +14761,11 @@ _EOF_
 
 		fi
 
-		software_id=69 # Python RPi.GPIO
+		software_id=69 # Python 3 RPi.GPIO
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			G_AGP python{3,}-rpi.gpio
+			G_AGP python3-rpi.gpio
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1255,8 +1255,8 @@ _EOF_
 		#--------------------------------------------------------------------------------
 		software_id=69
 
-		aSOFTWARE_NAME[$software_id]='RPi.GPIO'
-		aSOFTWARE_DESC[$software_id]='gpio interface library for rpi (python)'
+		aSOFTWARE_NAME[$software_id]='Python RPi.GPIO'
+		aSOFTWARE_DESC[$software_id]='Control Raspberry Pi GPIO channels in Python'
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#rpigpio'
 		# RPi only
@@ -1268,7 +1268,7 @@ _EOF_
 		software_id=70
 
 		aSOFTWARE_NAME[$software_id]='WiringPi'
-		aSOFTWARE_DESC[$software_id]='gpio interface library (c)'
+		aSOFTWARE_DESC[$software_id]='GPIO interface library (C)'
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#wiringpi'
 		aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
@@ -1281,7 +1281,7 @@ _EOF_
 		software_id=71
 
 		aSOFTWARE_NAME[$software_id]='WebIOPi'
-		aSOFTWARE_DESC[$software_id]='web interface to control rpi.gpio'
+		aSOFTWARE_DESC[$software_id]='Web interface to control RPi GPIO channels'
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#webiopi'
 		aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
@@ -2290,6 +2290,16 @@ _EOF_
 		software_id=62
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} < 2 && $G_HW_ARCH == 2 &&
 			${aSOFTWARE_INSTALL_STATE[156]} == 1 )); then
+
+			aSOFTWARE_INSTALL_STATE[$software_id]=1
+			G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[$software_id]} will be installed"
+
+		fi
+
+		# Software that requires Python RPi.GPIO
+		# - WebIOPi (71)
+		software_id=69
+		if (( ${aSOFTWARE_INSTALL_STATE[71]} == 1 )); then
 
 			aSOFTWARE_INSTALL_STATE[$software_id]=1
 			G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[$software_id]} will be installed"
@@ -4831,14 +4841,11 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 
 		fi
 
-		# WebIOPi requires RPi GPIO
-		(( ${aSOFTWARE_INSTALL_STATE[71]} == 1 )) && aSOFTWARE_INSTALL_STATE[69]=1
-
-		software_id=69 # RPi GPIO
+		software_id=69 # Python RPi.GPIO
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-			G_AGI python-rpi.gpio python3-rpi.gpio
+			G_AGI python{3,}-rpi.gpio
 
 		fi
 
@@ -14722,11 +14729,11 @@ _EOF_
 
 		fi
 
-		software_id=69
+		software_id=69 # Python RPi.GPIO
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			G_AGP python-rpi.gpio python3-rpi.gpio
+			G_AGP python{3,}-rpi.gpio
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4926,7 +4926,7 @@ _EOF_
 
 			# Install as local instance for "nodered" user
 			G_EXEC cd /mnt/dietpi_userdata/node-red
-			G_EXEC_OUTPUT=1 G_EXEC sudo -u nodered npm i node-red
+			G_EXEC_OUTPUT=1 G_EXEC sudo -u nodered npm i --no-audit node-red
 			G_EXEC cd /tmp/$G_PROGRAM_NAME
 
 			# CLI alias
@@ -4967,8 +4967,8 @@ _EOF_
 			DEPS_LIST='python' Download_Install "$(curl -sSfL 'https://api.github.com/repos/blynkkk/blynk-server/releases/latest' | mawk -F\" "/\"browser_download_url\": .*\/server-[0-9.]*$java\.jar\"/{print \$4}")" /mnt/dietpi_userdata/blynk/blynkserver.jar
 
 			# Install Blynk JS libary
-			npm i -g --unsafe-perm onoff
-			npm i -g --unsafe-perm blynk-library
+			G_EXEC_OUTPUT=1 G_EXEC npm i -g --unsafe-perm --no-audit onoff
+			G_EXEC_OUTPUT=1 G_EXEC npm i -g --unsafe-perm --no-audit blynk-library
 
 		fi
 
@@ -5798,11 +5798,11 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			G_EXEC chmod +x mineos_console.js webui.js update_webui.sh reset_webui.sh generate-sslcert.sh
 
 			# Install Node 11, as MineOS is currently not compatible with newer Node versions: https://github.com/hexparrot/mineos-node/issues/374
-			G_EXEC_OUTPUT=1 G_EXEC npm i -g --unsafe-perm n
+			G_EXEC_OUTPUT=1 G_EXEC npm i -g --unsafe-perm --no-audit n
 			G_EXEC_OUTPUT=1 G_EXEC n 11
 
 			# Install MineOS
-			G_EXEC_OUTPUT=1 G_EXEC npm i --unsafe-perm
+			G_EXEC_OUTPUT=1 G_EXEC npm i --unsafe-perm --no-audit
 			G_EXEC cd /tmp/$G_PROGRAM_NAME
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4753,6 +4753,9 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 					G_EXEC sed -i '/^[[:blank:]]*PIHOLE_DNS_2=/d' /etc/pihole/setupVars.conf
 				fi
 			fi
+
+			# Plex Media Server: Fix secure remote access: https://dietpi.com/phpbb/viewtopic.php?t=8896
+			(( ${aSOFTWARE_INSTALL_STATE[42]} > 0 )) && echo -e 'server:\n\tprivate-domain: "plex.direct"' > /etc/unbound/unbound.conf.d/dietpi-plex.conf
 		fi
 
 		software_id=93 # Pi-hole
@@ -10789,6 +10792,9 @@ location = /.well-known/caldav {
 			G_EXEC mkdir -p /etc/systemd/system/plexmediaserver.service.d
 			echo -e '[Service]\nGroup=' > /etc/systemd/system/plexmediaserver.service.d/dietpi-group.conf
 
+			# Unbound: Fix secure remote access: https://dietpi.com/phpbb/viewtopic.php?t=8896
+			(( ${aSOFTWARE_INSTALL_STATE[182]} == 2 )) && echo -e 'server:\n\tprivate-domain: "plex.direct"' > /etc/unbound/unbound.conf.d/dietpi-plex.conf
+
 			Download_Test_Media
 
 		fi
@@ -15018,7 +15024,7 @@ _EOF_
 			fi
 			[[ -d '/var/lib/plexmediaserver' ]] && rm -R /var/lib/plexmediaserver # Left over from purging package, still...
 			[[ -d '/etc/systemd/system/plexmediaserver.service.d' ]] && rm -R /etc/systemd/system/plexmediaserver.service.d
-
+			[[ -f '/etc/unbound/unbound.conf.d/dietpi-plex.conf' ]] && rm /etc/unbound/unbound.conf.d/dietpi-plex.conf
 		fi
 
 		software_id=52 # Cuberite

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3599,7 +3599,8 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-			G_AGI mate-desktop-environment-core mate-media upower firefox-esr
+			# Add xterm, as the mate-terminal is not compatible with desktop console shortcuts: https://github.com/MichaIng/DietPi/issues/3160#issuecomment-828305136
+			G_AGI mate-desktop-environment-core mate-media upower firefox-esr xterm
 
 		fi
 

--- a/dietpi/dietpi-vpn
+++ b/dietpi/dietpi-vpn
@@ -357,8 +357,8 @@ _EOF_
 -A OUTPUT -d 192.168.0.0/16 -j ACCEPT
 -A OUTPUT -d 172.16.0.0/12 -j ACCEPT
 -A OUTPUT -d 10.0.0.0/8 -j ACCEPT
--A OUTPUT -d $VPN_SERVER -p tcp -m multiport --dports 80,443,1194,4569,5060 -j ACCEPT
--A OUTPUT -d $VPN_SERVER -p udp -m multiport --dports 80,443,1194,4569,5060 -j ACCEPT
+-A OUTPUT -d $VPN_SERVER -p tcp --dport 1194 -j ACCEPT
+-A OUTPUT -d $VPN_SERVER -p udp --dport 1194 -j ACCEPT
 -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 COMMIT
 _EOF_

--- a/dietpi/func/create_mysql_db
+++ b/dietpi/func/create_mysql_db
@@ -15,16 +15,16 @@
 
 	# Import DietPi-Globals --------------------------------------------------------------
 	. /boot/dietpi/func/dietpi-globals
-	G_PROGRAM_NAME='DietPi-Create_MySQL_DB'
+	readonly G_PROGRAM_NAME='DietPi-Create_MySQL_DB'
 	G_CHECK_ROOT_USER
 	G_INIT
 	# Import DietPi-Globals --------------------------------------------------------------
 
 	# Grab input
-	DATABASE_NAME=$1
-	DATABASE_USER=$2
-	DATABASE_PW=$3
-	MESSAGE="Creating MariaDB database $DATABASE_NAME for user $DATABASE_USER"
+	readonly DATABASE_NAME=$1
+	readonly DATABASE_USER=$2
+	readonly DATABASE_PW=$3
+	readonly MESSAGE="Creating MariaDB database $DATABASE_NAME for user $DATABASE_USER"
 
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Main Loop
@@ -43,9 +43,10 @@
 	grant_privileges="grant all privileges on \`$DATABASE_NAME\`.* to \`$DATABASE_USER\`@localhost identified by '$DATABASE_PW';flush privileges"
 	[[ $DATABASE_USER != 'root' ]] || grant_privileges=
 	mysql -e "create database \`$DATABASE_NAME\`;$grant_privileges"
+	exit_code=$?
 
 	#-----------------------------------------------------------------------------------
-	G_DIETPI-NOTIFY -1 $? "$MESSAGE"
-	exit $?
+	G_DIETPI-NOTIFY -1 $exit_code "$MESSAGE"
+	exit $exit_code
 	#-----------------------------------------------------------------------------------
 }

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -26,7 +26,7 @@
 	# - Allow cuncurrent banner prints but a single menu call only
 	if [[ $1 == 2 ]]; then
 
-		G_PROGRAM_NAME='DietPi-Banner'
+		readonly G_PROGRAM_NAME='DietPi-Banner'
 		G_CHECK_ROOT_USER # Required to store settings
 		G_INIT
 
@@ -61,9 +61,9 @@
 	# Set defaults: Disable CPU temp by default in VMs
 	if (( $G_HW_MODEL == 20 ))
 	then
-		aENABLED=(1 0 1 0 0 1 0 0 0 0 0 1 1 0)
-	else
 		aENABLED=(1 0 0 0 0 1 0 1 0 0 0 1 1 0)
+	else
+		aENABLED=(1 0 1 0 0 1 0 0 0 0 0 1 1 0)
 	fi
 
 	COLOUR_RESET='\e[0m'
@@ -120,9 +120,7 @@
 
 		for i in "${!aCOLOUR[@]}"
 		do
-
 			echo "aCOLOUR[$i]='${aCOLOUR[$i]}'" >> $FP_SAVEFILE
-
 		done
 
 	}
@@ -242,11 +240,9 @@ $GREEN_LINE"
 		G_WHIP_CHECKLIST_ARRAY=()
 		for i in "${!aDESCRIPTION[@]}"
 		do
-
 			local state='off'
 			(( ${aENABLED[$i]:=0} == 1 )) && state='on'
 			G_WHIP_CHECKLIST_ARRAY+=("$i" "${aDESCRIPTION[$i]}" "$state")
-
 		done
 
 		if G_WHIP_CHECKLIST "Please (de)select options via spacebar to be shown in the $G_PROGRAM_NAME:"; then
@@ -260,7 +256,6 @@ $GREEN_LINE"
 
 			for i in $G_WHIP_RETURNED_VALUE
 			do
-
 				aENABLED[$i]=1
 				# Custom entry
 				if (( $i == 10 )); then
@@ -283,7 +278,6 @@ NB: It is executed as bash script, so it needs to be in bash compatible syntax.
 					[[ -f $FP_CUSTOM ]] || aENABLED[10]=0
 
 				fi
-
 			done
 
 			Save

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -66,7 +66,7 @@
 	# - Assign defaults/code version as fallback
 	[[ $G_DIETPI_VERSION_CORE ]] || G_DIETPI_VERSION_CORE=7
 	[[ $G_DIETPI_VERSION_SUB ]] || G_DIETPI_VERSION_SUB=1
-	[[ $G_DIETPI_VERSION_RC ]] || G_DIETPI_VERSION_RC=1
+	[[ $G_DIETPI_VERSION_RC ]] || G_DIETPI_VERSION_RC=2
 	[[ $G_GITBRANCH ]] || G_GITBRANCH='master'
 	[[ $G_GITOWNER ]] || G_GITOWNER='MichaIng'
 	# - Save current version and Git branch
@@ -220,9 +220,7 @@ $(ps f -eo pid,user,tty,cmd | grep -i '[d]ietpi')" && continue
 			[[ $1 == 1 && $G_PROGRAM_NAME ]] && output_string+="$grey$G_PROGRAM_NAME |$reset "
 			for ((i=$1; i<${#ainput_string[@]}; i++))
 			do
-
 				output_string+=${ainput_string[$i]}
-
 			done
 			echo -ne "$output_string$reset"
 
@@ -516,7 +514,6 @@ $grey─────────────────────────
 			# Split line by "\n" newline escape sequences, the only one which is interpreted by whiptail, in a strict way: "\\n" still creates a newline, hence the sequence cannot be escaped!
 			while [[ $line == *'\n'* ]]
 			do
-
 				# Grab first line
 				split=${line%%\\n*}
 				# Add required line + additional lines due to automated line breaks, if text exceeds internal box
@@ -525,7 +522,6 @@ $grey─────────────────────────
 				(( $whip_lines_text > $WHIP_SIZE_Y )) && return 1
 				# Cut away handled line from string
 				line=${line#*\\n}
-
 			done
 
 			# Process remaining line
@@ -564,27 +560,21 @@ $grey─────────────────────────
 			local i character_count_max=0
 			for (( i=1; i<${#G_WHIP_MENU_ARRAY[@]}; i+=2 ))
 			do
-
 				(( ${#G_WHIP_MENU_ARRAY[$i]} > $character_count_max )) && character_count_max=${#G_WHIP_MENU_ARRAY[$i]}
-
 			done
 			((character_count_max--)) # -1 for additional ●
 
 			# - Now add the additional required lines
 			for (( i=1; i<${#G_WHIP_MENU_ARRAY[@]}; i+=2 ))
 			do
-
 				[[ ${G_WHIP_MENU_ARRAY[$i]} == '●'* ]] || continue
 
 				while (( ${#G_WHIP_MENU_ARRAY[$i]} < $character_count_max ))
 				do
-
 					G_WHIP_MENU_ARRAY[$i]+='─'
-
 				done
 
 				G_WHIP_MENU_ARRAY[$i]+='●'
-
 			done
 
 		# - G_WHIP_CHECKLIST
@@ -598,9 +588,7 @@ $grey─────────────────────────
 			local i character_count_max=0
 			for (( i=1; i<${#G_WHIP_CHECKLIST_ARRAY[@]}; i+=3 ))
 			do
-
 				(( ${#G_WHIP_CHECKLIST_ARRAY[$i]} > $character_count_max )) && character_count_max=${#G_WHIP_CHECKLIST_ARRAY[$i]}
-
 			done
 			((character_count_max--)) # -1 for additional ●
 
@@ -612,9 +600,7 @@ $grey─────────────────────────
 
 				while (( ${#G_WHIP_CHECKLIST_ARRAY[$i]} < $character_count_max ))
 				do
-
 					G_WHIP_CHECKLIST_ARRAY[$i]+='─'
-
 				done
 
 				G_WHIP_CHECKLIST_ARRAY[$i]+='●'
@@ -753,13 +739,11 @@ $grey─────────────────────────
 			local WHIP_ERROR WHIP_BACKTITLE WHIP_SCROLLTEXT WHIP_SIZE_X WHIP_SIZE_Y WHIP_MESSAGE=$*
 			while :
 			do
-
 				G_WHIP_INIT
 				G_WHIP_RETURNED_VALUE=$(whiptail ${G_PROGRAM_NAME:+--title "$G_PROGRAM_NAME"} --backtitle "$WHIP_BACKTITLE" --inputbox "$WHIP_ERROR$WHIP_MESSAGE" --ok-button "$G_WHIP_BUTTON_OK_TEXT" --cancel-button "$G_WHIP_BUTTON_CANCEL_TEXT" $WHIP_SCROLLTEXT "$WHIP_SIZE_Y" "$WHIP_SIZE_X" "$G_WHIP_DEFAULT_ITEM" 3>&1 1>&2 2>&3-; echo $? > /tmp/.G_WHIP_INPUTBOX_RESULT)
 				result=$(</tmp/.G_WHIP_INPUTBOX_RESULT); rm -f /tmp/.G_WHIP_INPUTBOX_RESULT
 				[[ $result == 0 && -z $G_WHIP_RETURNED_VALUE ]] && { WHIP_ERROR='[FAILED] An input value was not entered, please try again...\n\n'; continue; }
 				break
-
 			done
 
 		fi
@@ -783,7 +767,6 @@ $grey─────────────────────────
 			local WHIP_ERROR WHIP_BACKTITLE WHIP_SCROLLTEXT WHIP_SIZE_X WHIP_SIZE_Y WHIP_MESSAGE=$*
 			while :
 			do
-
 				G_WHIP_INIT
 				local password_0=$(whiptail ${G_PROGRAM_NAME:+--title "$G_PROGRAM_NAME"} --backtitle "$WHIP_BACKTITLE" --passwordbox "$WHIP_ERROR$WHIP_MESSAGE" --ok-button "$G_WHIP_BUTTON_OK_TEXT" --nocancel $WHIP_SCROLLTEXT "$WHIP_SIZE_Y" "$WHIP_SIZE_X" 3>&1 1>&2 2>&3-)
 				[[ $password_0 ]] || { WHIP_ERROR='[FAILED] No password entered, please try again...\n\n'; continue; }
@@ -792,7 +775,6 @@ $grey─────────────────────────
 				result=$password_0
 				return_value=0
 				break
-
 			done
 
 		fi
@@ -870,7 +852,6 @@ $grey─────────────────────────
 		# Enter retry loop
 		while :
 		do
-
 			declare -F G_EXEC_PRE_FUNC &> /dev/null && G_EXEC_PRE_FUNC
 
 			# Execute command, store output to $fp_log file and store exit code to $exit_code variable
@@ -1048,7 +1029,6 @@ $log_content" || break # Exit error handler menu loop on cancel
 
 			fi
 			break
-
 		done
 
 		# Do not exit originating script if $G_EXEC_NOEXIT=1 or $G_EXEC_NOHALT=1 is given
@@ -1217,7 +1197,6 @@ $log_content" || break # Exit error handler menu loop on cancel
 
 		while :
 		do
-
 			if ! mkdir -p "$input"; then
 
 				G_WHIP_MSG "Error creating directory $input, unable to check filesystem permissions"
@@ -1258,7 +1237,6 @@ $log_content" || break # Exit error handler menu loop on cancel
 			# Else ok
 			exit_code=0
 			break
-
 		done
 
 		[[ -f $fp_target ]] && rm -f "$fp_target"
@@ -1422,11 +1400,9 @@ $log_content" || break # Exit error handler menu loop on cancel
 
 		for i in "$@"
 		do
-
 			dpkg-query -s "$i" &> /dev/null && continue
 			G_DIETPI-NOTIFY 2 "Flagged for install: \e[33m$i"
 			apackages+=("$i")
-
 		done
 
 		if [[ ${apackages[0]} ]]; then
@@ -1557,7 +1533,6 @@ $log_content" || break # Exit error handler menu loop on cancel
 		# ps: inaccurate but fast
 		while read -r line # Aside reasing raw, -r removes leading and trailing white spaces each line
 		do
-
 			line=${line/.} # Remove decimal dot
 			((usage+=${line#0})) # Remove leading zero, if present, then sum up
 
@@ -1615,11 +1590,7 @@ $log_content" || break # Exit error handler menu loop on cancel
 	# Usage = if G_CHECK_VALIDINT input; then
 	G_CHECK_VALIDINT(){
 
-		local return_value=1
-		local input=$1
-		local min=$2
-		local max=$3
-		[[ $disable_error == 1 ]] || local disable_error=0
+		local input=$1 min=$2 max=$3 return_value=1
 
 		if [[ $input =~ ^-?[0-9]+$ ]]; then
 
@@ -1633,7 +1604,7 @@ $log_content" || break # Exit error handler menu loop on cancel
 
 							return_value=0
 
-						elif (( ! $disable_error )); then
+						elif [[ $disable_error != 1 ]]; then
 
 							G_WHIP_MSG "Input value \"$input\" is higher than allowed \"$max\". No changes applied."
 
@@ -1645,7 +1616,7 @@ $log_content" || break # Exit error handler menu loop on cancel
 
 					fi
 
-				elif (( ! $disable_error )); then
+				elif [[ $disable_error != 1 ]]; then
 
 					G_WHIP_MSG "Input value \"$input\" is lower than allowed \"$min\". No changes applied."
 
@@ -1657,7 +1628,7 @@ $log_content" || break # Exit error handler menu loop on cancel
 
 			fi
 
-		elif (( ! $disable_error )); then
+		elif [[ $disable_error != 1 ]]; then
 
 			G_WHIP_MSG "Invalid input value \"$input\". No changes applied."
 
@@ -1735,9 +1706,7 @@ $log_content" || break # Exit error handler menu loop on cancel
 			local index=0
 			while [[ -e ${fp_backup_target}_$index ]]
 			do
-
 				((index++))
-
 			done
 
 			local notify_code=1
@@ -1795,21 +1764,17 @@ $log_content" || break # Exit error handler menu loop on cancel
 		# Wait until all theads finished
 		while :
 		do
-
 			for i in "${!G_THREAD_COMMAND[@]}"
 			do
-
 				[[ -f /tmp/.G_THREAD_EXITCODE_$i && $(<"/tmp/.G_THREAD_EXITCODE_$i") == '-1337' ]] || continue
 				# Print what we are waiting for, update processing message if thread changed since last loop
 				[[ $waiting_for == "$i" ]] || G_DIETPI-NOTIFY -2 "G_THREAD_WAIT_$i | ${G_THREAD_COMMAND[$i]}"
 				waiting_for=$i
 				sleep 1
 				continue 2
-
 			done
 
 			break
-
 		done
 
 		G_DIETPI-NOTIFY 0 'G_THREAD: All threads finished'
@@ -1817,7 +1782,6 @@ $log_content" || break # Exit error handler menu loop on cancel
 		# Check all thread's exit codes for issues
 		for i in "${!G_THREAD_COMMAND[@]}"
 		do
-
 			if [[ -r /tmp/.G_THREAD_EXITCODE_$i ]]; then
 
 				exit_code=$(<"/tmp/.G_THREAD_EXITCODE_$i")
@@ -1828,7 +1792,6 @@ $log_content" || break # Exit error handler menu loop on cancel
 				G_DIETPI-NOTIFY 2 "DEBUG: /tmp/.G_THREAD_EXITCODE_$i does not exist or is not readable"
 
 			fi
-
 		done
 
 		rm -f /tmp/.G_THREAD*

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -68,7 +68,7 @@ $FP_SCRIPT	rpi-eeprom
 		ARMBIAN=0
 		FP_UENV='/tmp/uEnv.txt'
 		for i in /boot/u{e,E}nv.txt; do [[ -f $i ]] && FP_UENV=$i && break; done
-		unset i
+		unset -v i
 
 	fi
 
@@ -126,7 +126,7 @@ $FP_SCRIPT	rpi-eeprom
 			# Comment extended start setting
 			G_EXEC sed -i '/^[[:blank:]]*start_x=/c\#start_x=1' /boot/config.txt
 
-			# Add modules blacklist, which are otherwise loaded by default since kernel 4.19
+			# Add modules blacklist, which are otherwise loaded by default since kernel 4.19/5.10
 			echo -e 'blacklist bcm2835_codec\nblacklist bcm2835_v4l2\nblacklist bcm2835_isp' > /etc/modprobe.d/dietpi-disable_rpi_camera.conf
 
 		else
@@ -148,32 +148,31 @@ $FP_SCRIPT	rpi-eeprom
 
 			G_CONFIG_INJECT 'program_usb_boot_mode=' 'program_usb_boot_mode=1' /boot/config.txt
 
-			cat << _EOF_ > /etc/systemd/system/dietpi-rm_program_usb_boot_mode.service
+			cat << '_EOF_' > /etc/systemd/system/dietpi-rm_program_usb_boot_mode.service
 [Unit]
 Description=DietPi-rm_program_usb_boot_mode.service
-After=dietpi-boot.service
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStartPre=$(command -v sed) -i '/^[[:blank:]]*program_usb_boot_mode=/d' /boot/config.txt
-ExecStartPre=$(command -v systemctl) disable dietpi-rm_program_usb_boot_mode
-ExecStart=$(command -v rm) /etc/systemd/system/dietpi-rm_program_usb_boot_mode.service
+ExecStartPre=/bin/sed -i '/^[[:blank:]]*program_usb_boot_mode=/d' /boot/config.txt
+ExecStartPre=/bin/systemctl disable dietpi-rm_program_usb_boot_mode
+ExecStart=/bin/rm /etc/systemd/system/dietpi-rm_program_usb_boot_mode.service
 
 [Install]
 WantedBy=multi-user.target
 _EOF_
-			systemctl daemon-reload
-			systemctl enable dietpi-rm_program_usb_boot_mode
+			G_EXEC systemctl daemon-reload
+			G_EXEC systemctl enable dietpi-rm_program_usb_boot_mode
 
 		elif [[ $INPUT_DEVICE_VALUE == 'disable' ]]; then
 
-			sed -i '/^[[:blank:]]*program_usb_boot_mode=/d' /boot/config.txt
+			G_EXEC sed -i '/^[[:blank:]]*program_usb_boot_mode=/d' /boot/config.txt
 
 			if [[ -f '/etc/systemd/system/dietpi-rm_program_usb_boot_mode.service' ]]; then
 
-				systemctl disable dietpi-rm_program_usb_boot_mode
-				rm /etc/systemd/system/dietpi-rm_program_usb_boot_mode.service
+				G_EXEC systemctl disable --now dietpi-rm_program_usb_boot_mode
+				G_EXEC rm /etc/systemd/system/dietpi-rm_program_usb_boot_mode.service
 
 			fi
 
@@ -192,15 +191,15 @@ _EOF_
 
 		(( $G_HW_MODEL == 4 )) || { Unsupported_Input_Name; return 1; } # Exit path for non-RPi4
 
-		# Install required APT package, be failsafe and install/upgrade VC firmware and bootloader as well
+		# Install required APT package
 		G_AGUP
-		G_AGI rpi-eeprom libraspberrypi-bin raspberrypi-bootloader
+		G_AGI rpi-eeprom
 
 		# Update/flash new bootloader and VL805 USB firmware to EEPROM
 		rpi-eeprom-update -a
 
-		# Required? Enable update service to run on every boot
-		systemctl enable rpi-eeprom-update
+		# Failsafe
+		G_EXEC systemctl enable rpi-eeprom-update
 
 	}
 
@@ -275,7 +274,7 @@ _EOF_
 				# - Disable HDMI hotplug detection, which requires it to be generally responsive/active
 				G_CONFIG_INJECT 'hdmi_ignore_hotplug=' 'hdmi_ignore_hotplug=1' /boot/config.txt
 				# - Disable SDTV on RPi4
-				sed -i '/^[[:blank:]]*enable_tvout=/c\#enable_tvout=0' /boot/config.txt
+				G_EXEC sed -i '/^[[:blank:]]*enable_tvout=/c\#enable_tvout=0' /boot/config.txt
 
 			# Odroid C2
 			elif (( $G_HW_MODEL == 12 )); then
@@ -295,13 +294,13 @@ _EOF_
 			# RPi
 			if (( $G_HW_MODEL < 10 )); then
 
-				sed -i '/^[[:blank:]]*framebuffer_width=/c\#framebuffer_width=16' /boot/config.txt
-				sed -i '/^[[:blank:]]*framebuffer_height=/c\#framebuffer_height=16' /boot/config.txt
-				sed -i '/^[[:blank:]]*max_framebuffer_width=/c\#max_framebuffer_width=16' /boot/config.txt
-				sed -i '/^[[:blank:]]*max_framebuffer_height=/c\#max_framebuffer_height=16' /boot/config.txt
-				sed -i '/^[[:blank:]]*hdmi_blanking=/c\#hdmi_blanking=0' /boot/config.txt
-				sed -i '/^[[:blank:]]*hdmi_ignore_hotplug=/c\#hdmi_ignore_hotplug=0' /boot/config.txt
-				sed -i '/^[[:blank:]]*enable_tvout=/c\#enable_tvout=0' /boot/config.txt
+				G_EXEC sed -i '/^[[:blank:]]*framebuffer_width=/c\#framebuffer_width=16' /boot/config.txt
+				G_EXEC sed -i '/^[[:blank:]]*framebuffer_height=/c\#framebuffer_height=16' /boot/config.txt
+				G_EXEC sed -i '/^[[:blank:]]*max_framebuffer_width=/c\#max_framebuffer_width=16' /boot/config.txt
+				G_EXEC sed -i '/^[[:blank:]]*max_framebuffer_height=/c\#max_framebuffer_height=16' /boot/config.txt
+				G_EXEC sed -i '/^[[:blank:]]*hdmi_blanking=/c\#hdmi_blanking=0' /boot/config.txt
+				G_EXEC sed -i '/^[[:blank:]]*hdmi_ignore_hotplug=/c\#hdmi_ignore_hotplug=0' /boot/config.txt
+				G_EXEC sed -i '/^[[:blank:]]*enable_tvout=/c\#enable_tvout=0' /boot/config.txt
 
 			# Odroid C2
 			elif (( $G_HW_MODEL == 12 )); then
@@ -336,18 +335,24 @@ _EOF_
 
 			if [[ -f '/etc/systemd/system/justboom-ir-mpd.service' ]]; then
 
-				systemctl disable --now justboom-ir-mpd
-				rm -R /etc/systemd/system/justboom-ir-mpd.service*
+				G_EXEC systemctl disable --now justboom-ir-mpd
+				G_EXEC rm /etc/systemd/system/justboom-ir-mpd.service
 
 			fi
+			[[ -d '/etc/systemd/system/justboom-ir-mpd.service.d' ]] && G_EXEC rm -R /etc/systemd/system/justboom-ir-mpd.service.d
 
-			sed -i '/^[[:blank:]]*dtoverlay=gpio-ir/d' /boot/config.txt
+			G_EXEC sed -i '/^[[:blank:]]*dtoverlay=gpio-ir/d' /boot/config.txt
 
 		# Disable Odroids
-		elif (( $G_HW_MODEL < 20 )) && [[ -f '/etc/systemd/system/odroid-remote.service' ]]; then
+		elif (( $G_HW_MODEL < 20 )); then
 
-			systemctl disable --now odroid-remote
-			rm -R /etc/systemd/system/odroid-remote.service*
+			if [[ -f '/etc/systemd/system/odroid-remote.service' ]]; then
+
+				G_EXEC systemctl disable --now odroid-remote
+				G_EXEC rm /etc/systemd/system/odroid-remote.service
+
+			fi
+			[[ -d '/etc/systemd/system/odroid-remote.service.d' ]] && G_EXEC rm -R /etc/systemd/system/odroid-remote.service.d
 
 		fi
 
@@ -382,12 +387,8 @@ _EOF_
 
 			fi
 
-			# All
-			# - systemd
-			systemctl enable lircd
-
-			# - Lircd conf for Odroid Remote
-			cat << _EOF_ > /etc/lirc/lircd.conf
+			# Config
+			cat << '_EOF_' > /etc/lirc/lircd.conf
 begin remote
 
   name lircd.conf
@@ -423,6 +424,8 @@ begin remote
 
 end remote
 _EOF_
+			# Service
+			G_EXEC systemctl enable --now lircd
 
 		elif [[ $INPUT_DEVICE_VALUE == 'justboom_ir_remote' ]]; then
 
@@ -432,7 +435,8 @@ _EOF_
 
 			G_CONFIG_INJECT 'dtoverlay=gpio-ir' 'dtoverlay=gpio-ir,gpio_pin=25' /boot/config.txt
 
-			cat << _EOF_ > /etc/lirc/hardware.conf
+			# Config
+			cat << '_EOF_' > /etc/lirc/hardware.conf
 LIRCD_ARGS="--uinput"
 LOAD_MODULES=true
 DRIVER="default"
@@ -441,8 +445,7 @@ MODULES="lirc_rpi"
 LIRCD_CONF=""
 LIRCMD_CONF=""
 _EOF_
-
-			cat << _EOF_ > /etc/lirc/lircd.conf
+			cat << '_EOF_' > /etc/lirc/lircd.conf
 begin remote
 
   name  lircd.conf
@@ -481,11 +484,10 @@ begin remote
 
 end remote
 _EOF_
-
 			# MPD control
 			G_AG_CHECK_INSTALL_PREREQ mpc
 
-			cat << _EOF_ > /root/.lircrc
+			cat << '_EOF_' > /root/.lircrc
 begin
 prog = irexec
 button = KEY_ENTER
@@ -532,7 +534,6 @@ button = KEY_MENU
 config = mpc repeat off
 end
 _EOF_
-
 			# Service
 			cat << _EOF_ > /etc/systemd/system/justboom-ir-mpd.service
 [Unit]
@@ -545,8 +546,8 @@ ExecStart=$(command -v irexec)
 [Install]
 WantedBy=default.target
 _EOF_
-			systemctl daemon-reload
-			systemctl enable --now justboom-ir-mpd
+			G_EXEC systemctl daemon-reload
+			G_EXEC systemctl enable --now justboom-ir-mpd
 
 		elif [[ $INPUT_DEVICE_VALUE != 'none' ]]; then
 
@@ -579,17 +580,18 @@ ExecStart=$(command -v ethtool) -s $iface speed $speed_mbit duplex full autoneg 
 [Install]
 WantedBy=ifup@$iface.service
 _EOF_
-			systemctl daemon-reload
-			systemctl enable --now ethtool_force_speed
+			G_EXEC systemctl daemon-reload
+			G_EXEC systemctl enable --now ethtool_force_speed
 
 		elif [[ $INPUT_DEVICE_VALUE == 'disable' ]]; then # 0 is converted to "disable"
 
 			if [[ -f '/etc/systemd/system/ethtool_force_speed.service' ]]; then
 
-				systemctl disable --now ethtool_force_speed
-				rm -R /etc/systemd/system/ethtool_force_speed.service*
+				G_EXEC systemctl disable --now ethtool_force_speed
+				G_EXEC rm /etc/systemd/system/ethtool_force_speed.service
 
 			fi
+			[[ -d '/etc/systemd/system/ethtool_force_speed.service.d' ]] && G_EXEC rm -R /etc/systemd/system/ethtool_force_speed.service.d
 
 		else
 
@@ -606,8 +608,8 @@ _EOF_
 
 		(( $G_HW_MODEL > 9 )) && { Unsupported_Input_Name; return 1; } # Exit path for non-RPi
 
-		# Always remove previous vc4 overlay entry
-		sed -i '/^[[:blank:]]*dtoverlay=vc4-/d' /boot/config.txt
+		# Always remove previous VC4 overlay entry
+		G_EXEC sed -i '/^[[:blank:]]*dtoverlay=vc4-/d' /boot/config.txt
 
 		if [[ $INPUT_DEVICE_VALUE == 'vc4-kms-v3d' || $INPUT_DEVICE_VALUE == 'vc4-kms-v3d-pi4' || $INPUT_DEVICE_VALUE == 'vc4-fkms-v3d' ]]; then
 
@@ -621,10 +623,6 @@ _EOF_
 			G_AG_CHECK_INSTALL_PREREQ libgl1-mesa-dri libgles2 $libegl1 mesa-utils
 
 			G_CONFIG_INJECT "dtoverlay=$INPUT_DEVICE_VALUE" "dtoverlay=$INPUT_DEVICE_VALUE" /boot/config.txt
-
-			# Set 1080p by default
-			G_CONFIG_INJECT 'framebuffer_width=' 'framebuffer_width=1920' /boot/config.txt
-			G_CONFIG_INJECT 'framebuffer_height=' 'framebuffer_height=1080' /boot/config.txt
 
 		elif [[ $INPUT_DEVICE_VALUE != 'disable' ]]; then
 
@@ -988,9 +986,10 @@ _EOF_
 		if [[ -f '/etc/systemd/system/odroid-lcd35.service' ]]; then
 
 			G_EXEC systemctl disable --now odroid-lcd35
-			G_EXEC rm -R /etc/systemd/system/odroid-lcd35.service*
+			G_EXEC rm /etc/systemd/system/odroid-lcd35.service
 
 		fi
+		[[ -d '/etc/systemd/system/odroid-lcd35.service.d' ]] && G_EXEC rm -R /etc/systemd/system/odroid-lcd35.service.d
 		[[ -f '/etc/X11/xorg.conf.d/99-odroid-lcd35.conf' ]] && G_EXEC rm /etc/X11/xorg.conf.d/99-odroid-lcd35.conf
 
 	}
@@ -1250,12 +1249,10 @@ Do you want to continue and disable the serial login console?' || return 1
 		local i
 		for i in /etc/sysctl{,.d/*}.conf
 		do
-
 			[[ $i != '/etc/sysctl.d/dietpi-disable_ipv6.conf' && -f $i ]] || continue
 			grep -q '^[[:blank:]]*net.ipv6.conf.[^[:blank:]]*.disable_ipv6[[:blank:]]*=' "$i" || continue
 			i=$(readlink -f $i) # https://github.com/MichaIng/DietPi/issues/3003#issuecomment-669464255
 			sed -i 's/^[[:blank:]]*net.ipv6.conf.[^[:blank:]]*.disable_ipv6[[:blank:]]*=/#&/' "$i"
-
 		done
 
 	}
@@ -1291,10 +1288,8 @@ Do you want to continue and disable the serial login console?' || return 1
 		local i
 		for i in /etc/apt/apt.conf.d/*
 		do
-
 			[[ ! -f $i || $i == *'99-dietpi-force-ipv4' ]] && continue
 			sed -i 's/^[[:blank:]]*Acquire::ForceIPv[46][[:blank:]]*=/#&/' "$i"
-
 		done
 
 	}
@@ -1356,10 +1351,8 @@ Do you want to continue and disable the serial login console?' || return 1
 			# cfg80211 last
 			for ((i=$(( ${#aWIFI_MODULES[@]} - 1 )); i>=0; i--))
 			do
-
 				echo "blacklist ${aWIFI_MODULES[$i]}" >> /etc/modprobe.d/dietpi-disable_wifi.conf
 				modprobe -rf "${aWIFI_MODULES[$i]}" 2> /dev/null
-
 			done
 
 			if G_WHIP_YESNO 'Would you like to purge all WiFi related APT packages?
@@ -1394,9 +1387,7 @@ _EOF_
 			# cfg80211 first
 			for i in "${aWIFI_MODULES[@]}"
 			do
-
 				modprobe "$i" 2> /dev/null
-
 			done
 
 			# Delay to allow modules + WPA2-Enterprise being fully loaded and avoid device not found error
@@ -1539,10 +1530,8 @@ Do you want to continue and DISABLE Bluetooth now?' || return 1
 				# ttyFIQ[0-9]: https://github.com/MichaIng/DietPi/issues/1829#issuecomment-398302497
 				for i in /dev/tty{S,AMA,SAC}[0-9]
 				do
-
 					[[ -e $i ]] || continue
 					INPUT_ADDITIONAL=${i/\/dev\/} Serial_Main
-
 				done
 
 				# On RPi enable primary UART device
@@ -1606,20 +1595,16 @@ Do you want to continue and DISABLE Bluetooth now?' || return 1
 				# ttyFIQ[0-9]: https://github.com/MichaIng/DietPi/issues/1829#issuecomment-398302497
 				for i in /dev/tty{S,AMA,SAC}[0-9]
 				do
-
 					[[ -e $i ]] || continue
 					INPUT_ADDITIONAL=${i/\/dev\/} Serial_Main
-
 				done
 
 				# Cleanup: Disable for left non-existent devices
 				for i in /etc/systemd/system/getty.target.wants/serial-getty@*
 				do
-
 					[[ -e $i ]] || continue
 					i=${i%.service}
 					INPUT_ADDITIONAL=${i##*@} Serial_Main
-
 				done
 
 				# On RPi disable primary UART device
@@ -1658,7 +1643,7 @@ Do you want to continue and DISABLE Bluetooth now?' || return 1
 		# - Remove stored amixer state
 		[[ -f '/var/lib/alsa/asound.state' ]] && G_EXEC rm /var/lib/alsa/asound.state
 
-		# - Reset active amixer state
+		# - Reset active amixer state ("-g" option has been added upstream: https://github.com/alsa-project/alsa-utils/issues/75)
 		[[ $INPUT_DEVICE_VALUE != 'none' && -f '/proc/asound/cards' && $(</proc/asound/cards) ]] && alsactl init
 
 		# HW specific
@@ -1735,7 +1720,7 @@ Do you want to continue and DISABLE Bluetooth now?' || return 1
 		if [[ -f '/etc/systemd/system/odroid-hifishield2.service' ]]; then
 
 			systemctl disable --now odroid-hifishield2
-			rm -R /etc/systemd/system/odroid-hifishield2.service*
+			rm /etc/systemd/system/odroid-hifishield2.service
 
 		fi
 		[[ -d '/etc/systemd/system/odroid-hifishield2.service.d' ]] && rm -R /etc/systemd/system/odroid-hifishield2.service.d
@@ -2181,6 +2166,8 @@ _EOF_
 		fi
 
 		# Store control states once to assure they are not lost on ungraceful shutdown
+		# - On RPi, this can fail, fake success for now until we find time to further investigate the when and why: https://github.com/MichaIng/DietPi/issues/4306
+		(( $G_HW_MODEL > 9 )) || G_EXEC_NOFAIL=1
 		G_EXEC alsactl -g store
 
 		# Buster: Avoid alsa-state.service start if its config file does not exist: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=932209

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -108,7 +108,7 @@ $FP_SCRIPT	passwords		NULL=Prompt user to change DietPi related passwords | X=op
 				local components='main'
 				(( $G_DISTRO < 5 )) && components+=' ui'
 				# Bullseye is not yet available, revert to Buster
-				echo "deb https://archive.raspberrypi.org/debian/ ${G_DISTRO_NAME/bullseye/buster} $components" > /etc/apt/sources.list.d/raspi.list
+				echo "deb https://archive.raspberrypi.org/debian/ $G_DISTRO_NAME $components" > /etc/apt/sources.list.d/raspi.list
 
 			fi
 


### PR DESCRIPTION
### Beta v7.1.2
_(2021-04-28)_

#### Changes since v7.1.1
- DietPi-Software | RPi.GPIO: This software option has been renamed to "Python 3 RPi.GPIO" to make clear that it is a Python package. In our efforts to migrate all software options to Python 3, only the Python 3 package is installed from now on. To install it for Python 2, one needs to run the following command manually form console: "apt install python-rpi.gpio"

#### Fixes since v7.1.1
- DietPi-Config | Worked around an issue in RPi, where selecting a sound card ended with an error prompt in certain circumstances. Many thanks to @sturbs for reporting this issue: https://github.com/MichaIng/DietPi/issues/4306
- DietPi-Software | WebIOPi: Resolved an issue where the GPIO pins could not be toggled via web interface by moving to a newer fork of this project. This additionally enabled us to run it with Python 3 and enable it on RPi 3 and RPi 4 models. Many thanks to `@torwan` for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=8945
- DietPi-Software | Plex Media Server: Resolved an issue where secure remote access via app.plex.tv did not work if Unbound with DNS rebinding protection is installed. Many thanks to `@danmo117` for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=8896
- DietPi-Software | MATE: Resolved an issue where DietPi menu and desktop shortcuts could not be started, as the MATE terminal emulator is not compatible with the "start in console" flag of desktop shortcuts. xterm is now installed together with MATE, to replace the default terminal emulator. Many thanks to `@maya95` for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=8949