### PR TITLE
DietPi-Software | WebIOPi: RPi 3/4 support + Python 3

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,7 @@ Changes:
 - DietPi-Software | YaCy: New installs and reinstalls will now have the latest version detected and downloaded automatically. This enables an easy update method by simply reinstalling YaCy via "dietpi-software reinstall 133", independent of the DietPi version.
 - DietPi-Software | Remot3.it: After the install finished, it is now offered to do the interactive "connectd_installer" setup directly. Neither is a reboot required, nor does any service need to run to be registered. This is especially helpful for installs via "dietpi-software install 68", where the hint about this required setup was not shown before.
 - DietPi-Software | Sonarr: Support for and migration to v3 has been implemented. Existing installs won't be migrated automatically, run "dietpi-software reinstall 144" to upgrade your Sonarr to v3. On DietPi update, Sonarr v2 users will receive a related notification.
+- DietPi-Software | RPi.GPIO: This software option has been renamed to "Python 3 RPi.GPIO" to make clear that it is a Python package. In our efforts to migrate all software options to Python 3, only the Python 3 package is installed from now on. To install it for Python 2, one needs to run the following command manually form console: "apt install python-rpi.gpio"
 
 New Scripts:
 - DietPi-VPN | This new tool has been added, which allows you to establish VPN connections to known public VPN providers or connect via custom OpenVPN configuration file. It incorporates all features from the previous DietPi-NordVPN script and more (see changes above). 

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Links to hardware and software manufacturers, sources and build instructions use
 - [CUPS](https://github.com/OpenPrinting/cups)
 - [Go](https://github.com/golang/go)
 - [VSCodium](https://github.com/VSCodium/vscodium)
+- [WebIOPi](https://github.com/Freenove/WebIOPi)
 
 ---
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1255,8 +1255,8 @@ _EOF_
 		#--------------------------------------------------------------------------------
 		software_id=69
 
-		aSOFTWARE_NAME[$software_id]='Python RPi.GPIO'
-		aSOFTWARE_DESC[$software_id]='Control Raspberry Pi GPIO channels in Python'
+		aSOFTWARE_NAME[$software_id]='Python 3 RPi.GPIO'
+		aSOFTWARE_DESC[$software_id]='Control Raspberry Pi GPIO channels in Python 3'
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#rpigpio'
 		# RPi only
@@ -2140,15 +2140,6 @@ _EOF_
 
 		fi
 
-		# Software required by Google AIY
-		if (( ${aSOFTWARE_INSTALL_STATE[169]} == 1 )); then
-
-			aSOFTWARE_INSTALL_STATE[69]=1 # RPi.GPIO
-			G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[69]} will be installed"
-			#aSOFTWARE_INSTALL_STATE[130]=1 # Python 3, enabled in "Software that requires Python 3"
-
-		fi
-
 		# Software that requires Avahi-Daemon
 		# - Kodi (31)
 		# - Shairport-Sync (37)
@@ -2296,10 +2287,14 @@ _EOF_
 
 		fi
 
-		# Software that requires Python RPi.GPIO
+		# Software that requires Python 3 RPi.GPIO
 		# - WebIOPi (71)
+		# - Node-RED (122)
+		# - Google AIY (169)
 		software_id=69
-		if (( ${aSOFTWARE_INSTALL_STATE[71]} == 1 )); then
+		if (( $G_HW_MODEL < 10 )) && (( ${aSOFTWARE_INSTALL_STATE[71]} == 1 ||
+			${aSOFTWARE_INSTALL_STATE[122]} == 1 ||
+			${aSOFTWARE_INSTALL_STATE[169]} == 1 )); then
 
 			aSOFTWARE_INSTALL_STATE[$software_id]=1
 			G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[$software_id]} will be installed"
@@ -4841,11 +4836,11 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 
 		fi
 
-		software_id=69 # Python RPi.GPIO
+		software_id=69 # Python 3 RPi.GPIO
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-			G_AGI python{3,}-rpi.gpio
+			G_AGI python3-rpi.gpio
 
 		fi
 
@@ -4919,10 +4914,7 @@ ExecStart=/mnt/dietpi_userdata/node-red/node_modules/.bin/node-red -u /mnt/dietp
 WantedBy=multi-user.target
 _EOF_
 			# Pre-reqs
-			local apackages=('python3')
-			# - RPi: GPIO control for Node-RED
-			(( $G_HW_MODEL > 9 )) || apackages+=('python3-rpi.gpio')
-			G_AGI "${apackages[@]}"
+			G_AGI python3
 
 			# Install as local instance for "nodered" user
 			G_EXEC cd /mnt/dietpi_userdata/node-red
@@ -14734,11 +14726,11 @@ _EOF_
 
 		fi
 
-		software_id=69 # Python RPi.GPIO
+		software_id=69 # Python 3 RPi.GPIO
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			G_AGP python{3,}-rpi.gpio
+			G_AGP python3-rpi.gpio
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5031,6 +5031,16 @@ _EOF_
 			# Apply patch
 			G_EXEC_OUTPUT=1 G_EXEC patch -p1 -i webiopi-pi2bplus.patch
 
+			# Fix shutdown: https://github.com/Freenove/WebIOPi/pull/1
+			grep -q 'self\.shutdown()' python/webiopi/protocols/http.py || G_EXEC sed -i '/self\.server_close()/i\        self.shutdown()' python/webiopi/protocols/http.py
+
+			# Remove Google Analytics
+			if grep -q '_gaq' htdocs/webiopi.js
+			then
+				G_EXEC sed -i '/_gaq/d' htdocs/webiopi.js
+				G_EXEC sed -i '/\/\/ GA/,/head.appendChild(ga)/d' htdocs/webiopi.js
+			fi
+
 			# Install for Python 3 only
 			G_EXEC sed -i '/SEARCH="python python3"/c\SEARCH="python3"' setup.sh
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5048,6 +5048,25 @@ _EOF_
 			# On fresh installs, change port to 8002 to avoid conflict with IceCast
 			(( $reinstall )) || G_EXEC sed -i 's/^port = 8000$/port = 8002/' /etc/webiopi/config
 
+			# Service
+			Remove_SysV webiopi 1
+			cat << _EOF_ > /etc/systemd/system/webiopi.service 
+[Unit]
+Description=WebIOPi (DietPi)
+Wants=network-online.target
+After=network-online.target dietpi-boot.service
+
+[Service]
+SyslogIdentifier=WebIOPi
+ExecStart=$(which python3) -m webiopi -c /etc/webiopi/config
+
+# Hardening
+PrivateTmp=true
+ProtectHome=true
+
+[Install]
+WantedBy=multi-user.target
+_EOF_
 		fi
 
 		software_id=98 # HAProxy
@@ -14478,7 +14497,7 @@ _EOF_
 			if [[ -f '/etc/systemd/system/airsonic.service' ]]; then
 
 				systemctl disable --now airsonic
-				rm -R /etc/systemd/system/airsonic.service*
+				rm /etc/systemd/system/airsonic.service
 
 			fi
 			[[ -d '/etc/systemd/system/airsonic.service.d' ]] && rm -R /etc/systemd/system/airsonic.service.d
@@ -14509,6 +14528,12 @@ _EOF_
 				systemctl unmask webiopi
 				systemctl disable --now webiopi
 				rm /etc/init.d/webiopi
+
+			fi
+			if [[ -f '/etc/systemd/system/webiopi.service' ]]; then
+
+				systemctl disable --now webiopi
+				rm /etc/systemd/system/webiopi.service
 
 			fi
 			[[ -d '/etc/systemd/system/webiopi.service.d' ]] && rm -R /etc/systemd/system/webiopi.service.d

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5023,7 +5023,7 @@ _EOF_
 			local reinstall=0
 			[[ -f '/etc/webiopi/config' ]] && reinstall=1
 
-			DEPS_LIST='python3-dev python3-setuptools'
+			DEPS_LIST='python3-dev python3-setuptools patch'
 			Download_Install 'https://github.com/Freenove/WebIOPi/archive/refs/heads/master.tar.gz'
 
 			G_EXEC cd WebIOPi-master/WebIOPi-*

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5034,7 +5034,7 @@ _EOF_
 			DEPS_LIST='python3-dev'
 			Download_Install 'https://github.com/Freenove/WebIOPi/archive/refs/heads/master.tar.gz'
 
-			G_EXEC cd WebIOPi-master
+			G_EXEC cd WebIOPi-master/WebIOPi-*
 
 			# Install for Python 3 only
 			G_EXEC sed -i '/SEARCH="python python3"/c\SEARCH="python3"' setup.sh

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5023,7 +5023,7 @@ _EOF_
 			local reinstall=0
 			[[ -f '/etc/webiopi/config' ]] && reinstall=1
 
-			DEPS_LIST='python3-dev'
+			DEPS_LIST='python3-dev python3-setuptools'
 			Download_Install 'https://github.com/Freenove/WebIOPi/archive/refs/heads/master.tar.gz'
 
 			G_EXEC cd WebIOPi-master/WebIOPi-*

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5025,7 +5025,7 @@ _EOF_
 		software_id=71 # WebIOPi
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
-			Banner_Installing
+			Banner_Installing # https://github.com/Freenove/WebIOPi
 
 			# Check for reinstall
 			local reinstall=0
@@ -5035,6 +5035,9 @@ _EOF_
 			Download_Install 'https://github.com/Freenove/WebIOPi/archive/refs/heads/master.tar.gz'
 
 			G_EXEC cd WebIOPi-master/WebIOPi-*
+
+			# Apply patch
+			G_EXEC_OUTPUT=1 G_EXEC patch -p1 -i webiopi-pi2bplus.patch
 
 			# Install for Python 3 only
 			G_EXEC sed -i '/SEARCH="python python3"/c\SEARCH="python3"' setup.sh

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1285,8 +1285,8 @@ _EOF_
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#webiopi'
 		aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
-		# RPi1/2/Zero only
-		for ((i=3; i<=$MAX_G_HW_MODEL; i++))
+		# RPi only
+		for ((i=10; i<=$MAX_G_HW_MODEL; i++))
 		do
 			aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,$i]=0
 		done
@@ -5031,12 +5031,13 @@ _EOF_
 			local reinstall=0
 			[[ -f '/etc/webiopi/config' ]] && reinstall=1
 
-			DEPS_LIST='python-dev python-setuptools'
-			Download_Install 'https://sourceforge.net/projects/webiopi/files/WebIOPi-0.7.1.tar.gz/download' webiopi.tar.gz
-			G_EXEC tar xf webiopi.tar.gz
-			G_EXEC_NOHALT=1 G_EXEC rm webiopi.tar.gz
+			DEPS_LIST='python3-dev'
+			Download_Install 'https://github.com/Freenove/WebIOPi/archive/refs/heads/master.tar.gz'
 
-			G_EXEC cd WebIOPi-0.7.1
+			G_EXEC cd WebIOPi-master
+
+			# Install for Python 3 only
+			G_EXEC sed -i '/SEARCH="python python3"/c\SEARCH="python3"' setup.sh
 
 			# Skip Weaved install prompt
 			G_EXEC sed -i '/read response/c\response="n"' setup.sh
@@ -5047,7 +5048,7 @@ _EOF_
 			G_EXEC cd /tmp/$G_PROGRAM_NAME
 
 			# Cleanup
-			G_EXEC_NOHALT=1 G_EXEC rm -R WebIOPi-0.7.1
+			G_EXEC_NOHALT=1 G_EXEC rm -R WebIOPi-master
 
 			# On fresh installs, change port to 8002 to avoid conflict with IceCast
 			(( $reinstall )) || G_EXEC sed -i 's/^port = 8000$/port = 8002/' /etc/webiopi/config
@@ -14521,6 +14522,7 @@ _EOF_
 			[[ -f '/usr/bin/webiopi-passwd' ]] && rm /usr/bin/webiopi-passwd # Password generator
 			[[ -d '/etc/webiopi' ]] && rm -R /etc/webiopi # Config dir
 			[[ -d '/usr/share/webiopi' ]] && rm -R /usr/share/webiopi # HTML resources
+			rm -Rf /usr/local/lib/python*/dist-packages/WebIOPi* # Python packages
 
 		fi
 


### PR DESCRIPTION
**Status**: Ready

- [x] Buster
- [x] Stretch
- [x] Bullseye

**Reference**: https://dietpi.com/phpbb/viewtopic.php?t=8945

**Changelog**: https://github.com/MichaIng/DietPi/commit/8dd9cd5d81e148835d569a1f25fab37d2ceb2dd5

**Commit list/description**:
+ DietPi-Software | WebIOPi: Use newer fork to enable RPi 3 and RPi 4 support and make it a Python 3 only install. Remove the Python package(s) on uninstall as well.