### PR TITLE
DietPi-Software | WiringPi: Migrate to new RPi Git branch

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,8 @@ v7.2
 (2021-05-29)
 
 Changes:
+- DietPi-Software | WiringPi: On RPi, a new updated fork of the deprecated original project is now used, which enables support for RPi 4/400 and CM4: https://github.com/WiringPi/WiringPi
+- DietPi-Software | WiringPi: On new installs and reinstalls, the source/examples directory is now installed to /mnt/dietpi_userdata/WiringPi instead of /root/wiringPi, to enable general access to non-root users.
 
 Fixes:
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4869,6 +4869,7 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 			[[ -d '/usr/local/bin' ]] || G_EXEC mkdir -p /usr/local/bin # Failsafe, not pre-created currently: https://github.com/WiringPi/WiringPi/blob/master/gpio/Makefile
 			G_EXEC cd WiringPi-master
 			G_EXEC_OUTPUT=1 G_EXEC ./build
+			G_EXEC strip --remove-section=.comment --remove-section=.note /usr/local/bin/gpio
 			G_EXEC cd /tmp/$G_PROGRAM_NAME
 
 			# Move source dir to disk, as it contains additional examples to compile

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1342,8 +1342,8 @@ _EOF_
 		#------------------
 		software_id=166
 
-		aSOFTWARE_NAME[$software_id]='PI-SPC'
-		aSOFTWARE_DESC[$software_id]='audiophonics pi-spc power control module'
+		aSOFTWARE_NAME[$software_id]='Audiophonics PI-SPC'
+		aSOFTWARE_DESC[$software_id]='Raspberry Pi power management module'
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#audiophonics-pi-spc'
 		# RPi only
@@ -2105,7 +2105,7 @@ _EOF_
 		fi
 
 		# Software that requires WiringPi
-		# - Audiophonics Pi-SPC (166)
+		# - Audiophonics PI-SPC (166)
 		software_id=70
 		if (( ${aSOFTWARE_INSTALL_STATE[166]} == 1 )); then
 
@@ -4853,31 +4853,24 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 
 			Banner_Installing
 
-			[[ -d '/usr/local/bin' ]] || G_EXEC mkdir -p /usr/local/bin
-
 			# RPi
 			if (( $G_HW_MODEL < 10 )); then
 
-				# https://git.drogon.net/?p=wiringPi;a=shortlog;h=refs/heads/master snapshot
-				Download_Install 'https://dietpi.com/downloads/binaries/all/wiringPi-8d188fa.tar.gz'
+				Download_Install 'https://github.com/WiringPi/WiringPi/archive/master.tar.gz'
 
 			# Odroids
 			elif (( $G_HW_MODEL < 20 )); then
 
 				Download_Install 'https://github.com/hardkernel/wiringPi/archive/master.tar.gz'
+				G_EXEC mv {w,W}iringPi-master
 
 			fi
 
-			mv WiringBP* wiringPi &> /dev/null # BPi
-			mv wiringPi* wiringPi &> /dev/null # eg: RPi, wiringPi-HEAD-8d188fa
-
-			G_EXEC cd wiringPi
-			G_EXEC chmod +x build
+			[[ -d '/usr/local/bin' ]] || G_EXEC mkdir -p /usr/local/bin # Failsafe, not pre-created currently: https://github.com/WiringPi/WiringPi/blob/master/gpio/Makefile
+			G_EXEC cd WiringPi-master
 			G_EXEC_OUTPUT=1 G_EXEC ./build
 			G_EXEC cd /tmp/$G_PROGRAM_NAME
-
-			G_EXEC rm -Rf /root/wiringPi
-			G_EXEC mv wiringPi /root/
+			G_EXEC_NOEXIT=1 G_EXEC rm -R WiringPi-master
 
 		fi
 
@@ -6825,7 +6818,7 @@ If you want to update ${aSOFTWARE_NAME[$software_id]}, please use its internal u
 
 		fi
 
-		software_id=166 # Audiophonics Pi-SPC
+		software_id=166 # Audiophonics PI-SPC
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -12888,21 +12881,18 @@ WantedBy=multi-user.target
 _EOF_
 		fi
 
-		software_id=166 # Audiophonics Pi-SPC
+		software_id=166 # Audiophonics PI-SPC
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
 
 			G_EXEC mkdir -p /var/lib/dietpi/dietpi-software/installed/pi-spc
-
 			cat << '_EOF_' > /var/lib/dietpi/dietpi-software/installed/pi-spc/sds.sh
-#!/bin/bash
-# DietPi version
-PATH+=':/root/wiringPi/gpio'
+#!/bin/dash
 
-TICKRATE=0.25
+TICKRATE='0.25'
 
-echo 'Audiophonics Shutdown script starting...
+echo 'Audiophonics PI-SPC: Shutdown script starting...
 Asserting pins :
 ShutDown : GPIO17=in, Low
 BootOK   : GPIO22=out, High
@@ -12915,29 +12905,20 @@ gpio -g write 17 0
 gpio -g mode 22 out
 gpio -g write 22 1
 
-while :
+until [ $(gpio -g read 17) == 1 ]
 do
-
-	if (( $(gpio -g read 17) == 1 )); then
-
-		G_DIETPI-NOTIFY 0 'Audiophonics Pi-SPC: Power off requested. Shutting down system.'
-		sudo poweroff
-		#sudo shutdown -h -P now
-		break
-
-	fi
-
 	sleep $TICKRATE
-
 done
 
+echo 'Audiophonics PI-SPC: Power off requested. Shutting down system.'
+poweroff
 exit 0
 _EOF_
 			G_EXEC chmod +x /var/lib/dietpi/dietpi-software/installed/pi-spc/sds.sh
 
 			cat << '_EOF_' > /etc/systemd/system/pi-spc.service
 [Unit]
-Description=Audiophonics Pi-SPC (DietPi)
+Description=Audiophonics PI-SPC (DietPi)
 
 [Service]
 StandardOutput=tty
@@ -14782,11 +14763,19 @@ _EOF_
 
 		fi
 
-		software_id=70
+		software_id=70 # WiringPi
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			rm -Rf /root/wiringPi*
+			# Library
+			G_EXEC_NOEXIT=1 G_EXEC rm -f /usr/local/lib/libwiring.*
+			# Device library
+			G_EXEC_NOEXIT=1 G_EXEC rm -f /usr/local/lib/libwiringDev.*
+			# GPIO utility
+			[[ -f '/usr/local/bin/gpio' ]] && G_EXEC_NOEXIT=1 G_EXEC rm /usr/local/bin/gpio
+			[[ -f '/usr/local/share/man/man1/gpio.1' ]] && G_EXEC_NOEXIT=1 G_EXEC rm /usr/local/share/man/man1/gpio.1
+			# Pre-v7.2: Source files
+			[[ -d '/root/wiringPi' ]] && G_EXEC_NOEXIT=1 G_EXEC rm -R /root/wiringPi
 
 		fi
 
@@ -15286,18 +15275,18 @@ _EOF_
 
 		fi
 
-		software_id=166
+		software_id=166 # Audiophonics PI-SPC
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
 			if [[ -f '/etc/systemd/system/pi-spc.service' ]]; then
 
 				systemctl disable --now pi-spc
-				rm -R /etc/systemd/system/pi-spc.service*
+				rm /etc/systemd/system/pi-spc.service
 
 			fi
 			[[ -d '/etc/systemd/system/pi-spc.service.d' ]] && rm -R /etc/systemd/system/pi-spc.service.d
-			rm -R /var/lib/dietpi/dietpi-software/installed/pi-spc
+			[[ -d '/var/lib/dietpi/dietpi-software/installed/pi-spc' ]] && rm -R /var/lib/dietpi/dietpi-software/installed/pi-spc
 
 			sed -i '/^[[:blank:]]*dtoverlay=gpio-shutdown/d' /boot/config.txt
 			sed -i '/^[[:blank:]]*dtoverlay=gpio-poweroff/d' /boot/config.txt

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4870,7 +4870,11 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 			G_EXEC cd WiringPi-master
 			G_EXEC_OUTPUT=1 G_EXEC ./build
 			G_EXEC cd /tmp/$G_PROGRAM_NAME
-			G_EXEC_NOEXIT=1 G_EXEC rm -R WiringPi-master
+
+			# Move source dir to disk, as it contains additional examples to compile
+			[[ -d '/root/wiringPi' ]] && G_EXEC_NOEXIT=1 G_EXEC rm -R /root/wiringPi # Pre-v7.2
+			[[ -d '/mnt/dietpi_userdata/WiringPi' ]] && G_EXEC rm -R /mnt/dietpi_userdata/WiringPi
+			G_EXEC mv WiringPi-master /mnt/dietpi_userdata/WiringPi
 
 		fi
 
@@ -14767,15 +14771,30 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			# Library
-			G_EXEC_NOEXIT=1 G_EXEC rm -f /usr/local/lib/libwiring.*
-			# Device library
-			G_EXEC_NOEXIT=1 G_EXEC rm -f /usr/local/lib/libwiringDev.*
+			if [[ -d '/mnt/dietpi_userdata/WiringPi' ]]
+			then
+				G_EXEC cd /mnt/dietpi_userdata/WiringPi
+				G_EXEC_NOEXIT=1 G_EXEC ./build uninstall
+				G_EXEC cd /tmp/$G_PROGRAM_NAME
+				G_EXEC_NOEXIT=1 G_EXEC rm -R /mnt/dietpi_userdata/WiringPi
+			fi
+			# Pre-v7.2
+			if [[ -d '/root/wiringPi' ]]
+			then
+				G_EXEC cd /root/wiringPi
+				G_EXEC_NOEXIT=1 G_EXEC ./build uninstall
+				G_EXEC cd /tmp/$G_PROGRAM_NAME
+				G_EXEC_NOEXIT=1 G_EXEC rm -R /root/wiringPi
+			fi
 			# GPIO utility
 			[[ -f '/usr/local/bin/gpio' ]] && G_EXEC_NOEXIT=1 G_EXEC rm /usr/local/bin/gpio
 			[[ -f '/usr/local/share/man/man1/gpio.1' ]] && G_EXEC_NOEXIT=1 G_EXEC rm /usr/local/share/man/man1/gpio.1
-			# Pre-v7.2: Source files
-			[[ -d '/root/wiringPi' ]] && G_EXEC_NOEXIT=1 G_EXEC rm -R /root/wiringPi
+			# Library
+			G_EXEC_NOEXIT=1 G_EXEC rm -f /usr/local/lib/libwiringPi.*
+			# Device library
+			G_EXEC_NOEXIT=1 G_EXEC rm -f /usr/local/lib/libwiringPiDev.*
+			# Headers
+			G_EXEC_NOEXIT=1 G_EXEC rm -f /usr/local/include/wiringPi*.h
 
 		fi
 


### PR DESCRIPTION
**Status**: Ready

**Testing**:
- [x] Stretch
- [x] Buster
- [x] Bullseye

**Commit list/description**:
+ DietPi-Software | WiringPi: Migrate to new RPi Git branch
+ DietPi-Software | WiringPi: No not keep source files, but uninstall installed binaries and libraries as well
+ DietPi-Software | Audiophonics Pi-SPC: Rename install option and simplify shutdown script