### PR TITLE
DietPi-Software | Python3

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ v7.2
 Changes:
 
 Fixes:
+- DietPi-Software | Python 3: Resolved an issue where installing pip on Stretch systems failed, due to a changed download URL. Many thanks to @tfmeier for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=8968
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3469,8 +3469,8 @@ _EOF_
 			[[ $G_HW_ARCH != [12] || -f '/etc/pip.conf' ]] || G_EXEC eval "echo -e '[global]\nextra-index-url=https://www.piwheels.org/simple/' > /etc/pip.conf"
 
 			# Perform pip3 installation
-			INSTALL_URL_ADDRESS='https://bootstrap.pypa.io/get-pip.py'
-			(( $G_DISTRO > 4 )) || INSTALL_URL_ADDRESS='https://bootstrap.pypa.io/3.5/get-pip.py' # https://pip.pypa.io/en/stable/news/#id1
+			INSTALL_URL_ADDRESS='https://bootstrap.pypa.io/pip/get-pip.py'
+			(( $G_DISTRO > 4 )) || INSTALL_URL_ADDRESS='https://bootstrap.pypa.io/pip/3.5/get-pip.py' # https://pip.pypa.io/en/stable/news/#id1
 			DEPS_LIST='python3-dev' Download_Install "$INSTALL_URL_ADDRESS"
 			G_EXEC_OUTPUT=1 G_EXEC python3 ./get-pip.py
 			G_EXEC_NOHALT=1 G_EXEC rm get-pip.py


### PR DESCRIPTION
Looks like there was/is a change to download `get-pip.py` on older Debian version. At least on Stretch this is failing atm as content inside `get-pip.py` change into a message. 

```
#!/usr/bin/env python
from __future__ import print_function
import sys
import textwrap

message = """
Hi there!

The URL you are using to fetch this script has changed, and this one will no
longer work. Please use get-pip.py from the following URL instead:

    https://bootstrap.pypa.io/pip/3.5/get-pip.py

Sorry if this change causes any inconvenience for you!

We don't have a good mechanism to make more gradual changes here, and this
renaming is a part of an effort to make it easier to us to update these
scripts, when there's a pip release. It's also essential for improving how we
handle the `get-pip.py` scripts, when pip drops support for a Python minor
version.

There are no more renames/URL changes planned, and we don't expect that a need
would arise to do this again in the near future.

Thanks for understanding!

- Pradyun, on behalf of the volunteers who maintain pip.
"""

print(message, file=sys.stderr)
sys.exit(1)
```

Even if Buster is still working, I adjusted the URL as well. 

**Status**: Ready
- [x] Update Pip3 install

**Reference**: https://dietpi.com/phpbb/viewtopic.php?f=9&t=8968

**Commit list/description**:
- DietPi-Software | Python3 - update download URL to reflect recent changes
