### PR TITLE
DietPi-Software | Webmin: Add support for internal restart

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Fixes:
 - Odroid XU4 | Resolved an issue where installs and possibly other tasks hang, because the device ran out of entropy. All Odroid XU4 system will have the unsupported hardware random generator daemon removed and the software HAVEGE daemon installed instead for entropy generation. Many thanks to @Speeedfire for reporting this issue: https://github.com/MichaIng/DietPi/issues/4318
 - DietPi-Banner | Resolved an issue where the MOTD was not updated via daily cron job, if the banner settings have not been changed yet, hence no config file exists. Since the MOTD is enabled by default, it needs to be updated as well if the config file does not exist. Many thanks to @gorby-pranata for helping us discovering this issue: https://github.com/MichaIng/DietPi/pull/4292#issuecomment-830787256
 - DietPi-Software | Python 3: Resolved an issue where installing pip on Stretch systems failed, due to a changed download URL. Many thanks to @tfmeier for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=8968
+- DietPi-Software | Webmin: Resolved an issue where restarts from the web interface only stopped the service. Many thanks to @Burgess85 and @Keridos for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=8839, https://github.com/MichaIng/DietPi/pull/4331
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4637,12 +4637,17 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-			INSTALL_URL_ADDRESS='https://www.webmin.com/jcameron-key.asc'
+
+			# APT key
+			INSTALL_URL_ADDRESS='https://webmin.com/jcameron-key.asc'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 			G_EXEC eval "curl -sSLf '$INSTALL_URL_ADDRESS' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-webmin.gpg --yes"
-			echo 'deb https://download.webmin.com/download/repository/ sarge contrib' > /etc/apt/sources.list.d/webmin.list
 
+			# APT list
+			echo 'deb https://download.webmin.com/download/repository/ sarge contrib' > /etc/apt/sources.list.d/webmin.list
 			G_AGUP
+
+			# APT package
 			G_AGI webmin
 
 		fi
@@ -4936,10 +4941,12 @@ _EOF_
 			# Use official APT repository where available: https://repo.mosquitto.org/debian/pool/main/m/mosquitto/
 			if [[ $G_HW_ARCH != 3 && $G_DISTRO -le 5 ]]; then
 
+				# APT key
 				INSTALL_URL_ADDRESS='https://repo.mosquitto.org/debian/mosquitto-repo.gpg.key'
 				G_CHECK_URL "$INSTALL_URL_ADDRESS"
 				G_EXEC eval "curl -sSLf '$INSTALL_URL_ADDRESS' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-mosquitto.gpg --yes"
-				# The Bullseye suite does not yet exist: https://repo.mosquitto.org/debian/dists/
+
+				# APT list: The Bullseye suite does not yet exist: https://repo.mosquitto.org/debian/dists/
 				G_EXEC eval "echo 'deb https://repo.mosquitto.org/debian/ ${G_DISTRO_NAME/bullseye/buster} main' > /etc/apt/sources.list.d/dietpi-mosquitto.list"
 				G_AGUP
 
@@ -5217,14 +5224,16 @@ _EOF_
 
 			Banner_Installing
 
+			# APT key
 			INSTALL_URL_ADDRESS='https://repos.influxdata.com/influxdb.key'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-
 			G_EXEC eval "curl -sSLf '$INSTALL_URL_ADDRESS' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-influxdb.gpg --yes"
-			# Use Buster branch on Bullseye
+
+			# APT list: The Bullseye suite does not yet exist: https://repos.influxdata.com/debian/dists/
 			echo "deb https://repos.influxdata.com/debian/ ${G_DISTRO_NAME/bullseye/buster} stable" > /etc/apt/sources.list.d/influxdb.list
 			G_AGUP
 
+			# APT package
 			G_AGI influxdb
 
 		fi
@@ -5570,14 +5579,14 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			Banner_Installing
 
-			# Install APT repo key
+			# APT key
 			G_EXEC eval "curl -sSfL 'https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.gpg' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-vscodium.gpg --yes"
 
-			# Install APT repo list
+			# APT list
 			G_EXEC eval "echo 'deb https://paulcarroty.gitlab.io/vscodium-deb-rpm-repo/debs vscodium main' > /etc/apt/sources.list.d/dietpi-vscodium.list"
 			G_AGUP
 
-			# Install VSCodium
+			# APT package
 			# - gnome-keyring is the backend daemon for the Secrets API used to store credentials, required e.g. for the GitHub PR and issues extension.
 			G_AGI codium gnome-keyring
 
@@ -6710,14 +6719,14 @@ If you want to update ${aSOFTWARE_NAME[$software_id]}, please use its internal u
 			local distro='debian'
 			(( $G_HW_MODEL < 10 )) && (( $G_RASPBIAN )) && distro='raspbian'
 
-			# Install APT repo key
+			# APT key
 			G_EXEC eval "curl -sSfL 'https://download.docker.com/linux/$distro/gpg' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-docker.gpg --yes"
 
-			# Install APT repo list
-			G_EXEC eval "echo 'deb https://download.docker.com/linux/$distro/ ${G_DISTRO_NAME/bullseye/buster} stable' > /etc/apt/sources.list.d/docker.list"
+			# APT list
+			G_EXEC eval "echo 'deb https://download.docker.com/linux/$distro/ $G_DISTRO_NAME stable' > /etc/apt/sources.list.d/docker.list"
 			G_AGUP
 
-			# Install Docker
+			# APT package
 			G_AGI docker-ce
 
 		fi
@@ -6954,16 +6963,16 @@ If you want to update ${aSOFTWARE_NAME[$software_id]}, please use its internal u
 
 			Banner_Installing
 
-			# Install APT repo key
+			# APT repo key
 			INSTALL_URL_ADDRESS='https://repo.jellyfin.org/jellyfin_team.gpg.key'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 			G_EXEC eval "curl -sSfL '$INSTALL_URL_ADDRESS' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-jellyfin.gpg --yes"
 
-			# Install APT repo
+			# APT repo
 			echo "deb https://repo.jellyfin.org/debian/ $G_DISTRO_NAME main" > /etc/apt/sources.list.d/dietpi-jellyfin.list
 			G_AGUP
 
-			# Install Jellyfin + FFmpeg implementation
+			# APT packages: Jellyfin + FFmpeg implementation
 			G_AGI jellyfin jellyfin-ffmpeg
 
 		fi
@@ -9267,17 +9276,19 @@ _EOF_
 
 			Banner_Configuration
 
-			Remove_SysV webmin
-
 			# Service
+			Remove_SysV webmin
 			cat << '_EOF_' > /etc/systemd/system/webmin.service
 [Unit]
 Description=Webmin (DietPi)
+Documentation=https://doxfer.webmin.com/Webmin/Main_Page
 
 [Service]
 Type=forking
+GuessMainPID=no
 ExecStart=/etc/webmin/start
 ExecStop=/etc/webmin/stop
+ExecReload=/etc/webmin/reload
 
 [Install]
 WantedBy=multi-user.target

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9286,6 +9286,7 @@ Documentation=https://doxfer.webmin.com/Webmin/Main_Page
 [Service]
 Type=forking
 GuessMainPID=no
+SyslogIdentifier=Webmin
 ExecStart=/etc/webmin/start
 ExecStop=/etc/webmin/stop
 ExecReload=/etc/webmin/reload
@@ -13608,14 +13609,14 @@ _EOF_
 			Banner_Uninstalling
 			if [[ -f '/etc/systemd/system/webmin.service' ]]; then
 
-				systemctl disable --now webmin
-				rm -R /etc/systemd/system/webmin.service*
+				G_EXEC_NOEXIT=1 G_EXEC systemctl disable --now webmin
+				G_EXEC_NOEXIT=1 G_EXEC rm /etc/systemd/system/webmin.service
 
 			fi
-			[[ -d '/etc/systemd/system/webmin.service.d' ]] && rm -R /etc/systemd/system/webmin.service.d
+			[[ -d '/etc/systemd/system/webmin.service.d' ]] && G_EXEC_NOEXIT=1 G_EXEC rm -R /etc/systemd/system/webmin.service.d
 			G_AGP webmin
-			[[ -f '/etc/apt/sources.list.d/webmin.list' ]] && rm -v /etc/apt/sources.list.d/webmin.list
-			[[ -f '/etc/apt/trusted.gpg.d/dietpi-webmin.gpg' ]] && rm -v /etc/apt/trusted.gpg.d/dietpi-webmin.gpg
+			[[ -f '/etc/apt/sources.list.d/webmin.list' ]] && G_EXEC_NOEXIT=1 G_EXEC rm /etc/apt/sources.list.d/webmin.list
+			[[ -f '/etc/apt/trusted.gpg.d/dietpi-webmin.gpg' ]] && G_EXEC_NOEXIT=1 G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-webmin.gpg
 
 		fi
 


### PR DESCRIPTION
**Status**: Ready

**Testing**:
- [x] Stretch
- [x] Buster
- [x] Bullseye

**Commit list/description**:
+ DietPi-Software | Webmin: Add support for internal restart by not letting the systemd unit guessing the main process ID anymore. Webmin spawns a new process, if a settings change triggers a restart internally, which makes systemd kill the whole control group, as the original process, guessed as main process, is not running anymore. With this change, there is no main process and systemd will only see the service as "exited" when all processes of the control group are dead. This way no automatic restart loop is required.
+ DietPi-Software | Webmin: Enable service reload via new (?) reload executable
+ DietPi-Software | Docker: The official APT repository has now a Bullseye suite, hence use it
+ DietPi-Software | Align code and comments when 3rd party repositories are used