### PR TITLE
DietPi-Software | rTorrent

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11072,10 +11072,11 @@ _EOF_
 				[[ -f '/etc/.rutorrent-htaccess' ]] || echo "root:rtorrent:$(echo -n "root:rtorrent:$GLOBAL_PW" | md5sum | mawk '{print $1}')" > /etc/.rutorrent-htaccess
 
 				# Add to /etc/lighttpd/lighttpd.conf
-				if ! grep -q '^#RUTORRENT_DIETPI' /etc/lighttpd/lighttpd.conf; then
+				if grep -q '^#RUTORRENT_DIETPI' /etc/lighttpd/lighttpd.conf; then
+					G_EXEC sed -i '/#RUTORRENT_DIETPI/,/#RUTORRENT_DIETPI/d' /etc/lighttpd/lighttpd.conf
+				fi
 
-					cat << '_EOF_' >> /etc/lighttpd/lighttpd.conf
-#RUTORRENT_DIETPI
+				cat << '_EOF_' > /etc/lighttpd/conf-available/98-dietpi-rtorrent.conf
 server.modules += ( "mod_fastcgi" )
 server.modules += ( "mod_scgi" )
 server.modules += ( "mod_auth" )
@@ -11106,9 +11107,8 @@ scgi.server = ( "/RPC2" =>
 $HTTP["url"] =~ "^/rutorrent/(conf|share)($|/)" {
 	url.access-deny = ("")
 }
-#RUTORRENT_DIETPI
 _EOF_
-				fi
+			G_EXEC lighty-enable-mod dietpi-rtorrent
 
 			# - Nginx
 			elif (( ${aSOFTWARE_INSTALL_STATE[85]} > 0 )); then
@@ -15157,7 +15157,15 @@ _EOF_
 			# - Authentication
 			[[ -f '/etc/.rutorrent-htaccess' ]] && rm /etc/.rutorrent-htaccess
 			# - Lighttpd
-			#Remove from #RUTORRENT_DIETPI to #RUTORRENT_DIETPI in /etc/lighttpd/lighttpd.conf
+			#Remove from #RUTORRENT_DIETPI to #RUTORRENT_DIETPI in /etc/lighttpd/lighttpd.conf if exist - pre DietPi 7.2
+			if grep -q '^#RUTORRENT_DIETPI' /etc/lighttpd/lighttpd.conf; then
+				G_EXEC sed -i '/#RUTORRENT_DIETPI/,/#RUTORRENT_DIETPI/d' /etc/lighttpd/lighttpd.conf
+			fi
+			#Remove rTorrent config from Lighttpd - since DietPi 7.2
+			if [[ -f '/etc/lighttpd/conf-available/98-dietpi-rtorrent.conf' ]]; then
+				G_EXEC lighty-disable-mod dietpi-rtorrent
+				G_EXEC rm /etc/lighttpd/conf-available/98-dietpi-rtorrent.conf
+			fi
 			# - Nginx
 			[[ -f '/etc/nginx/sites-dietpi/dietpi-rutorrent.conf' ]] && rm /etc/nginx/sites-dietpi/dietpi-rutorrent.conf
 			# - Apache2

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5904,19 +5904,19 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			# - Reinstall
 			if [[ -d '/var/www/rutorrent' ]]; then
 
-				# Move known original config files, if they exist already
-				[[ -f '/var/www/rutorrent/conf/config.php' ]] && G_EXEC mv ruTorrent-*/conf/config.php{,.example}
-				[[ -f '/var/www/rutorrent/conf/access.ini' ]] && G_EXEC mv ruTorrent-*/conf/access.ini{,.example}
-				[[ -f '/var/www/rutorrent/conf/plugins.ini' ]] && G_EXEC mv ruTorrent-*/conf/plugins.ini{,.example}
+				# Make new config files examples, if they exist in the old install already
+				[[ -f '/var/www/rutorrent/conf/config.php' ]] && G_EXEC mv "ruTorrent-${version#v}/conf/config.php"{,.example}
+				[[ -f '/var/www/rutorrent/conf/access.ini' ]] && G_EXEC mv "ruTorrent-${version#v}/conf/access.ini"{,.example}
+				[[ -f '/var/www/rutorrent/conf/plugins.ini' ]] && G_EXEC mv "ruTorrent-${version#v}/conf/plugins.ini"{,.example}
 
 				# Merge new install into old to preserve e.g. 3rd party plugins
-				G_EXEC cp -a ruTorrent-*/. /var/www/rutorrent/
-				G_EXEC rm -R ruTorrent-*
+				G_EXEC cp -a "ruTorrent-${version#v}/". /var/www/rutorrent/
+				G_EXEC rm -R "ruTorrent-${version#v}"
 
 			# - Fresh install
 			else
 
-				G_EXEC mv ruTorrent-* /var/www/rutorrent
+				G_EXEC mv "ruTorrent-${version#v}" /var/www/rutorrent
 
 			fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11071,10 +11071,8 @@ _EOF_
 
 				[[ -f '/etc/.rutorrent-htaccess' ]] || echo "root:rtorrent:$(echo -n "root:rtorrent:$GLOBAL_PW" | md5sum | mawk '{print $1}')" > /etc/.rutorrent-htaccess
 
-				# Add to /etc/lighttpd/lighttpd.conf
-				if grep -q '^#RUTORRENT_DIETPI' /etc/lighttpd/lighttpd.conf; then
-					G_EXEC sed -i '/#RUTORRENT_DIETPI/,/#RUTORRENT_DIETPI/d' /etc/lighttpd/lighttpd.conf
-				fi
+				# Pre-v7.2: Remove obsolete entries from /etc/lighttpd/lighttpd.conf
+				grep -q '^#RUTORRENT_DIETPI' /etc/lighttpd/lighttpd.conf && G_EXEC sed -i '/#RUTORRENT_DIETPI/,/#RUTORRENT_DIETPI/d' /etc/lighttpd/lighttpd.conf
 
 				cat << '_EOF_' > /etc/lighttpd/conf-available/98-dietpi-rtorrent.conf
 server.modules += ( "mod_fastcgi" )
@@ -11108,7 +11106,7 @@ $HTTP["url"] =~ "^/rutorrent/(conf|share)($|/)" {
 	url.access-deny = ("")
 }
 _EOF_
-			G_EXEC lighty-enable-mod dietpi-rtorrent
+				[[ -f '/etc/lighttpd/conf-enabled/98-dietpi-rtorrent.conf' ]] || G_EXEC lighty-enable-mod dietpi-rtorrent
 
 			# - Nginx
 			elif (( ${aSOFTWARE_INSTALL_STATE[85]} > 0 )); then
@@ -15157,15 +15155,13 @@ _EOF_
 			# - Authentication
 			[[ -f '/etc/.rutorrent-htaccess' ]] && rm /etc/.rutorrent-htaccess
 			# - Lighttpd
-			#Remove from #RUTORRENT_DIETPI to #RUTORRENT_DIETPI in /etc/lighttpd/lighttpd.conf if exist - pre DietPi 7.2
-			if grep -q '^#RUTORRENT_DIETPI' /etc/lighttpd/lighttpd.conf; then
-				G_EXEC sed -i '/#RUTORRENT_DIETPI/,/#RUTORRENT_DIETPI/d' /etc/lighttpd/lighttpd.conf
-			fi
-			#Remove rTorrent config from Lighttpd - since DietPi 7.2
-			if [[ -f '/etc/lighttpd/conf-available/98-dietpi-rtorrent.conf' ]]; then
-				G_EXEC lighty-disable-mod dietpi-rtorrent
-				G_EXEC rm /etc/lighttpd/conf-available/98-dietpi-rtorrent.conf
-			fi
+			# Pre-v7.2: Remove from #RUTORRENT_DIETPI to #RUTORRENT_DIETPI in /etc/lighttpd/lighttpd.conf if exist
+			[[ -f '/etc/lighttpd/lighttpd.conf' ]] && grep -q '^#RUTORRENT_DIETPI' /etc/lighttpd/lighttpd.conf && G_EXEC_NOEXIT=1 G_EXEC sed -i '/#RUTORRENT_DIETPI/,/#RUTORRENT_DIETPI/d' /etc/lighttpd/lighttpd.conf
+
+			# Remove rTorrent config from Lighttpd
+			[[ -f '/etc/lighttpd/conf-enabled/98-dietpi-rtorrent.conf' ]] && G_EXEC_NOEXIT=1 G_EXEC lighty-disable-mod dietpi-rtorrent
+			[[ -f '/etc/lighttpd/conf-available/98-dietpi-rtorrent.conf' ]] && G_EXEC_NOEXIT=1 G_EXEC rm /etc/lighttpd/conf-available/98-dietpi-rtorrent.conf
+
 			# - Nginx
 			[[ -f '/etc/nginx/sites-dietpi/dietpi-rutorrent.conf' ]] && rm /etc/nginx/sites-dietpi/dietpi-rutorrent.conf
 			# - Apache2


### PR DESCRIPTION
Switch rTorrent/Lighttpd to a new/own configuration file

**Status**: Ready

- [x] adjust `dietpi-software` to allow new rTorrent configuration file for `Lighttpd`
- [x] check new install
- [x] check uninstall new config
- [x] check reinstall and conversion from old to new configuration
- [x] check uninstall using old configuration

**Reference**: https://github.com/MichaIng/DietPi/issues/4330

**Commit list/description**:
- DietPi-Software | rTorrent - rework configuration for Lighttpd and enable own configuration file
- DietPi-Software | rTorrent - ensure on reinstall old configuration to be deleted and new configuration file to be used
- DietPi-Software | rTorrent - on uninstall respect old and new configuration file
- DietPi-Software | rTorrent - Fix failing reinstall by replacing wildcard asterisk with actual directory name, derived from version string, like we do in case of Box86: Actual version string is tag name minus leading "v".
