### PR TITLE
DietPi-Software | vaultwarden: Rename from Bitwarden_RS

### DIFF
--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -473,7 +473,7 @@ shopt -s extglob
 	unset -v 'aSOFTWARE_NAME6_34[137]' # CloudPrint
 	aSOFTWARE_NAME6_34[181]='PaperMC'
 	aSOFTWARE_NAME6_34[182]='Unbound'
-	aSOFTWARE_NAME6_34[183]='Bitwarden_RS'
+	aSOFTWARE_NAME6_34[183]='vaultwarden'
 	aSOFTWARE_NAME6_34[184]='Tor Relay'
 	aSOFTWARE_NAME6_34[185]='Portainer'
 

--- a/.update/patches
+++ b/.update/patches
@@ -97,20 +97,28 @@ fi
 # v7.2: Rename Bitwarden_RS into vaultwarden: https://github.com/MichaIng/DietPi/issues/4325
 if [[ -d '/mnt/dietpi_userdata/bitwarden_rs' ]]
 then
-	G_DIETPI-NOTIFY 2 "vaultwarden will be reinstalled now."
-	systemctl disable --now bitwarden_rs
-	# Rename Bitwarden_RS directories into vaultwarden due to project name change
-	G_EXEC mv /mnt/dietpi_userdata/{bitwarden_rs,vaultwarden}
-	G_EXEC mv /mnt/dietpi_userdata/vaultwarden/{bitwarden_rs,vaultwarden}.env
-	G_CONFIG_INJECT 'DATA_FOLDER=' 'DATA_FOLDER=/mnt/dietpi_userdata/vaultwarden' /mnt/dietpi_userdata/vaultwarden/vaultwarden.env
+	G_DIETPI-NOTIFY 2 'vaultwarden will be reinstalled now.'
 	# Remove Bitwarden_RS service
-	[[ -f '/etc/systemd/system/bitwarden_rs.service' ]] && rm -R /etc/systemd/system/bitwarden_rs.service*
-	[[ -d '/etc/systemd/system/bitwarden_rs.service.d' ]] && rm -R /etc/systemd/system/bitwarden_rs.service.d
+	if [[ -f '/etc/systemd/system/bitwarden_rs.service' ]]
+	then
+		G_EXEC systemctl disable --now bitwarden_rs
+		G_EXEC rm /etc/systemd/system/bitwarden_rs.service
+	fi
+	[[ -d '/etc/systemd/system/bitwarden_rs.service.d' ]] && G_EXEC rm -R /etc/systemd/system/bitwarden_rs.service.d
 	# Remove Bitwarden_RS user and group
-	getent passwd bitwarden_rs > /dev/null && userdel bitwarden_rs
-	getent group bitwarden_rs > /dev/null && groupdel bitwarden_rs
+	getent passwd bitwarden_rs > /dev/null && G_EXEC userdel bitwarden_rs
+	getent group bitwarden_rs > /dev/null && G_EXEC groupdel bitwarden_rs
+	# Remove Bitwarden_RS install directory
+	[[ -d '/opt/bitwarden_rs' ]] && G_EXEC rm -R /opt/bitwarden_rs
+	# Update and rename Bitwarden_RS config file
+	if [[ -f '/mnt/dietpi_userdata/bitwarden_rs/bitwarden_rs.env' ]]
+	then
+		G_CONFIG_INJECT 'DATA_FOLDER=' 'DATA_FOLDER=/mnt/dietpi_userdata/vaultwarden' /mnt/dietpi_userdata/bitwarden_rs/bitwarden_rs.env
+		G_EXEC mv /mnt/dietpi_userdata/bitwarden_rs/{bitwarden_rs,vaultwarden}.env
+	fi
+	G_EXEC mv /mnt/dietpi_userdata/{bitwarden_rs,vaultwarden}
 	# Start vaultwarden reinstallation
-	G_EXEC_OUTPUT=1 G_EXEC /boot/dietpi/dietpi-software reinstall 183
+	/boot/dietpi/dietpi-software reinstall 183 || exit 1
 fi
 
 exit 0

--- a/.update/patches
+++ b/.update/patches
@@ -108,7 +108,7 @@ then
 	getent passwd bitwarden_rs > /dev/null && userdel bitwarden_rs
 	getent group bitwarden_rs > /dev/null && groupdel bitwarden_rs
 	# Start vaultwarden reinstallation
-	G_EXEC /boot/dietpi/dietpi-software reinstall 183
+	G_EXEC_OUTPUT=1 G_EXEC /boot/dietpi/dietpi-software reinstall 183
 fi
 
 exit 0

--- a/.update/patches
+++ b/.update/patches
@@ -102,6 +102,7 @@ then
 	# Rename Bitwarden_RS directories into vaultwarden due to project name change
 	G_EXEC mv /mnt/dietpi_userdata/{bitwarden_rs,vaultwarden}
 	G_EXEC mv /mnt/dietpi_userdata/vaultwarden/{bitwarden_rs,vaultwarden}.env
+	G_CONFIG_INJECT 'DATA_FOLDER=' 'DATA_FOLDER=/mnt/dietpi_userdata/vaultwarden' /mnt/dietpi_userdata/vaultwarden/vaultwarden.env
 	# Remove Bitwarden_RS service
 	[[ -f '/etc/systemd/system/bitwarden_rs.service' ]] && rm -R /etc/systemd/system/bitwarden_rs.service*
 	[[ -d '/etc/systemd/system/bitwarden_rs.service.d' ]] && rm -R /etc/systemd/system/bitwarden_rs.service.d

--- a/.update/patches
+++ b/.update/patches
@@ -94,5 +94,22 @@ then
 	dpkg-query -s haveged &> /dev/null || G_AGI haveged
 fi
 
+# v7.2: Rename Bitwarden_RS into vaultwarden: https://github.com/MichaIng/DietPi/issues/4325
+if [[ -d '/mnt/dietpi_userdata/bitwarden_rs' ]]
+then
+	systemctl disable --now bitwarden_rs
+	# Rename Bitwarden_RS directories into vaultwarden due to project name change
+	G_EXEC mv /mnt/dietpi_userdata/{bitwarden_rs,vaultwarden}
+	G_EXEC mv /mnt/dietpi_userdata/vaultwarden/{bitwarden_rs,vaultwarden}.env
+	# Remove Bitwarden_RS service
+	[[ -f '/etc/systemd/system/bitwarden_rs.service' ]] && rm -R /etc/systemd/system/bitwarden_rs.service*
+	[[ -d '/etc/systemd/system/bitwarden_rs.service.d' ]] && rm -R /etc/systemd/system/bitwarden_rs.service.d
+	# Remove Bitwarden_RS user and group
+	getent passwd bitwarden_rs > /dev/null && userdel bitwarden_rs
+	getent group bitwarden_rs > /dev/null && groupdel bitwarden_rs
+	# Start vaultwarden reinstallation
+	G_EXEC /boot/dietpi/dietpi-software reinstall 183
+fi
+
 exit 0
 }

--- a/.update/patches
+++ b/.update/patches
@@ -118,7 +118,9 @@ then
 	fi
 	G_EXEC mv /mnt/dietpi_userdata/{bitwarden_rs,vaultwarden}
 	# Start vaultwarden reinstallation
-	/boot/dietpi/dietpi-software reinstall 183 || exit 1
+	/boot/dietpi/dietpi-software reinstall 183 || G_WHIP_MSG '[WARNING] The vaultwarden (re)install failed.
+\nHowever, all required dietpi-update migration steps have been done and it will hence finish.
+\nRepeat the reinstall manually to bring up your new vaultwarden instance, when you find time: "dietpi-software reinstall 183"'
 fi
 
 exit 0

--- a/.update/patches
+++ b/.update/patches
@@ -97,6 +97,7 @@ fi
 # v7.2: Rename Bitwarden_RS into vaultwarden: https://github.com/MichaIng/DietPi/issues/4325
 if [[ -d '/mnt/dietpi_userdata/bitwarden_rs' ]]
 then
+	G_DIETPI-NOTIFY 2 "vaultwarden will be reinstalled now."
 	systemctl disable --now bitwarden_rs
 	# Rename Bitwarden_RS directories into vaultwarden due to project name change
 	G_EXEC mv /mnt/dietpi_userdata/{bitwarden_rs,vaultwarden}

--- a/.update/pre-patches
+++ b/.update/pre-patches
@@ -40,7 +40,7 @@ then
 	if G_WHIP_YESNO '[ INFO ] Bitwarden_RS detected
 \nDue to user confusion and to avoid any possible trademark/brand issues with the official Bitwarden server, Bitwarden_RS has been renamed to vaultwarden by its author: https://github.com/dani-garcia/vaultwarden/discussions/1642
 \nTo be able to continue providing support for vaultwarden, DietPi-Update will force a re-installation. This process can take 30 minutes up to several hours, especially on slower SBCs like RPi Zero and similar, like it was on the initial Bitwarden_RS install you did.
-\nContinue DietPi-Update now, if you are ok with the re-installation of vaultwarden and grab yourself a coffee or tee. If not, you are ok to cancel the update process and return later.
+\nContinue DietPi-Update now, if you are ok with the re-installation of vaultwarden and grab yourself a coffee or tea. If not, you are ok to cancel the update process and return later.
 \nNB: All your passwords, data and config will be preserved by the re-installation process.'
 	then
 		G_DIETPI-NOTIFY 2 'vaultwarden will be reinstalled during DietPi-Update incremental patches.'

--- a/.update/pre-patches
+++ b/.update/pre-patches
@@ -37,7 +37,10 @@ if [[ -d '/mnt/dietpi_userdata/bitwarden_rs' ]]
 then
 	G_WHIP_BUTTON_OK_TEXT='Continue'
 	G_WHIP_BUTTON_CANCEL_TEXT='Cancel'
-	if G_WHIP_YESNO 'Bitwarden_RS detected'
+	if G_WHIP_YESNO '[ INFO ] Bitwarden_RS detected
+\nDue to user confusion and to avoid any possible trademark/brand issues with the official Bitwarden server, Bitwarden_RS is going to be renamed to vaultwarden. https://github.com/dani-garcia/vaultwarden/discussions/1642
+\nTo be able to continue provide support for vaultwarden, DietPi-Update will force a re-installation. This process can take 30 minutes up to 2 hour, especially on slower SBCs like RPi Zero and similar.
+\nContinue DietPi-Update now, if you are ok with the re-installation of vaultwarden. If not, you are ok to cancel the update process and return later.'
 	then
 		G_DIETPI-NOTIFY 2 "vaultwarden will be reinstalled during DietPi-Update."
 	else

--- a/.update/pre-patches
+++ b/.update/pre-patches
@@ -32,5 +32,19 @@ then
 	G_EXEC curl -sSfL 'https://packages.sury.org/php/apt.gpg' -o /etc/apt/trusted.gpg.d/dietpi-php.gpg
 fi
 
+# v7.2: Rename Bitwarden_RS into vaultwarden: https://github.com/MichaIng/DietPi/issues/4325
+if [[ -d '/mnt/dietpi_userdata/bitwarden_rs' ]]
+then
+	G_WHIP_BUTTON_OK_TEXT='Continue'
+	G_WHIP_BUTTON_CANCEL_TEXT='Cancel'
+	if G_WHIP_YESNO 'Bitwarden_RS detected'
+	then
+		G_DIETPI-NOTIFY 2 "vaultwarden will be reinstalled during DietPi-Update."
+	else
+		G_DIETPI-NOTIFY 2 "DietPi-Update aborted by user."
+		exit 1
+	fi
+fi
+
 exit 0
 }

--- a/.update/pre-patches
+++ b/.update/pre-patches
@@ -42,7 +42,7 @@ then
 \nTo be able to continue providing support for vaultwarden, DietPi-Update will force a re-installation. This process can take 30 minutes up to several hours, especially on slower SBCs like RPi Zero and similar, like it was on the initial Bitwarden_RS install you did.
 \nContinue DietPi-Update now, if you are ok with the re-installation of vaultwarden and grab yourself a coffee or tee. If not, you are ok to cancel the update process and return later.'
 	then
-		G_DIETPI-NOTIFY 2 'vaultwarden will be reinstalled during DietPi-Update during incremental patches.'
+		G_DIETPI-NOTIFY 2 'vaultwarden will be reinstalled during DietPi-Update incremental patches.'
 	else
 		G_DIETPI-NOTIFY 2 'DietPi-Update aborted by user.'
 		exit 1

--- a/.update/pre-patches
+++ b/.update/pre-patches
@@ -38,13 +38,13 @@ then
 	G_WHIP_BUTTON_OK_TEXT='Continue'
 	G_WHIP_BUTTON_CANCEL_TEXT='Cancel'
 	if G_WHIP_YESNO '[ INFO ] Bitwarden_RS detected
-\nDue to user confusion and to avoid any possible trademark/brand issues with the official Bitwarden server, Bitwarden_RS is going to be renamed to vaultwarden. https://github.com/dani-garcia/vaultwarden/discussions/1642
-\nTo be able to continue provide support for vaultwarden, DietPi-Update will force a re-installation. This process can take 30 minutes up to 2 hour, especially on slower SBCs like RPi Zero and similar.
-\nContinue DietPi-Update now, if you are ok with the re-installation of vaultwarden. If not, you are ok to cancel the update process and return later.'
+\nDue to user confusion and to avoid any possible trademark/brand issues with the official Bitwarden server, Bitwarden_RS has been renamed to vaultwarden by its author: https://github.com/dani-garcia/vaultwarden/discussions/1642
+\nTo be able to continue providing support for vaultwarden, DietPi-Update will force a re-installation. This process can take 30 minutes up to several hours, especially on slower SBCs like RPi Zero and similar, like it was on the initial Bitwarden_RS install you did.
+\nContinue DietPi-Update now, if you are ok with the re-installation of vaultwarden and grab yourself a coffee or tee. If not, you are ok to cancel the update process and return later.'
 	then
-		G_DIETPI-NOTIFY 2 "vaultwarden will be reinstalled during DietPi-Update."
+		G_DIETPI-NOTIFY 2 'vaultwarden will be reinstalled during DietPi-Update during incremental patches.'
 	else
-		G_DIETPI-NOTIFY 2 "DietPi-Update aborted by user."
+		G_DIETPI-NOTIFY 2 'DietPi-Update aborted by user.'
 		exit 1
 	fi
 fi

--- a/.update/pre-patches
+++ b/.update/pre-patches
@@ -40,7 +40,8 @@ then
 	if G_WHIP_YESNO '[ INFO ] Bitwarden_RS detected
 \nDue to user confusion and to avoid any possible trademark/brand issues with the official Bitwarden server, Bitwarden_RS has been renamed to vaultwarden by its author: https://github.com/dani-garcia/vaultwarden/discussions/1642
 \nTo be able to continue providing support for vaultwarden, DietPi-Update will force a re-installation. This process can take 30 minutes up to several hours, especially on slower SBCs like RPi Zero and similar, like it was on the initial Bitwarden_RS install you did.
-\nContinue DietPi-Update now, if you are ok with the re-installation of vaultwarden and grab yourself a coffee or tee. If not, you are ok to cancel the update process and return later.'
+\nContinue DietPi-Update now, if you are ok with the re-installation of vaultwarden and grab yourself a coffee or tee. If not, you are ok to cancel the update process and return later.
+\nNB: All your passwords, data and config will be preserved by the re-installation process.'
 	then
 		G_DIETPI-NOTIFY 2 'vaultwarden will be reinstalled during DietPi-Update incremental patches.'
 	else

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-<h1 align="center"><img src="https://raw.githubusercontent.com/MichaIng/DietPi-Website/master/images/dietpi-logo_180x180.png" alt="DietPi Logo"></h1>
+<h1 align="center"><img src="https://raw.githubusercontent.com/MichaIng/DietPi-Website/master/images/dietpi-logo_180x180.png" alt="DietPi logo" width="180" height="180" loading="lazy"></h1>
 <p align="center">
 	<b>Lightweight justice for your single-board computer!</b>
 	<br><br>
 	optimised • simplified • for everyone
 	<br><br>
-	<a href="https://dietpi.com/">Website</a> • <a href="https://dietpi.com/docs/">Documentation</a> • <a href="https://dietpi.com/#download">View all supported platforms</a> • <a href="https://dietpi.com/phpbb/">Forum</a>
+	<a href="https://dietpi.com/" target="_blank" rel="noopener">Website</a> • <a href="https://dietpi.com/docs/" target="_blank" rel="noopener">Documentation</a> • <a href="https://dietpi.com/#download" target="_blank" rel="noopener">View all supported platforms</a> • <a href="https://dietpi.com/phpbb/" target="_blank" rel="noopener">Forum</a>
 </p>
 <hr>
 <p align="center">
-	<strong>Ready to run</strong> optimised software choices with <a href="https://dietpi.com/dietpi-software.html"><strong>dietpi-software</strong></a>
+	<strong>Ready to run</strong> optimised software choices with <a href="https://dietpi.com/dietpi-software.html" target="_blank" rel="noopener"><strong>dietpi-software</strong></a>
 	<br>Feature-rich configuration tool for your device with <strong>dietpi-config</strong>.
 </p>
 <hr>
@@ -19,7 +19,7 @@ DietPi is an extremely lightweight Debian-based OS. It is highly optimised for m
 
 The **dietpi programs** use lightweight whiptail menus. You'll spend more time enjoying DietPi and applications you need and less time staring at the command line.
 
-Use `dietpi-software` to quick and easy install **Ready to Run** & **Optimised** applications for your system. DietPi will do all the necessary configurations, including starting the services. Few highlights: [Desktop Environments](https://dietpi.com/docs/dietpi_optimised_software/#desktops), [Remote Desktop access](https://dietpi.com/docs/dietpi_optimised_software/#remote-desktop-remote-access), [Media Systems and Players](https://dietpi.com/docs/dietpi_optimised_software/#media-systems), [BitTorrent & Downloading](https://dietpi.com/docs/dietpi_optimised_software/#bittorrent-download-tools), [Cloud and Backup](https://dietpi.com/docs/dietpi_optimised_software/#cloud-backup-systems), [Gaming](https://dietpi.com/docs/dietpi_optimised_software/#gaming-emulation), [Social & Search](https://dietpi.com/docs/dietpi_optimised_software/#social-search), [Camera & Surveillance](https://dietpi.com/docs/dietpi_optimised_software/#camera-surveillance), [Networking](https://dietpi.com/docs/dietpi_optimised_software/#advanced-networking), [System Stats & Management](https://dietpi.com/docs/dietpi_optimised_software/#system-stats-management), [Home Automation](https://dietpi.com/docs/dietpi_optimised_software/#home-automation), [Hardware & Voice Projects](https://dietpi.com/docs/dietpi_optimised_software/#hardware-projects), [web server stacks](https://dietpi.com/docs/dietpi_optimised_software/#web-development), [DNS Servers / Pi-hole](https://dietpi.com/docs/dietpi_optimised_software/#dns-servers), [File Servers](https://dietpi.com/docs/dietpi_optimised_software/#file-servers), [Cloud printing & Print 3D](https://dietpi.com/docs/dietpi_optimised_software/#printing-server) and much more.
+Use `dietpi-software` to quick and easy install **Ready to Run** & **Optimised** applications for your system. DietPi will do all the necessary configurations, including starting the services. Few highlights: [Desktop Environments](https://dietpi.com/docs/software/desktop/), [Remote Desktop Access](https://dietpi.com/docs/software/remote_desktop/), [Media Systems & Players](https://dietpi.com/docs/software/media/), [BitTorrent & Downloading](https://dietpi.com/docs/software/bittorrent/), [Cloud & Backup](https://dietpi.com/docs/software/cloud/), [Gaming & Emulation](https://dietpi.com/docs/software/gaming/), [Social & Search](https://dietpi.com/docs/software/social/), [Camera & Surveillance](https://dietpi.com/docs/software/camera/), [Networking](https://dietpi.com/docs/software/advanced_networking/), [System Stats & Management](https://dietpi.com/docs/software/system_stats/), [Home Automation](https://dietpi.com/docs/software/home_automation/), [Hardware & Voice Projects](https://dietpi.com/docs/software/hardware_projects/), [Webserver Stacks](https://dietpi.com/docs/software/webserver_stack/), [DNS Servers / Pi-hole](https://dietpi.com/docs/software/dns_servers/), [File Servers](https://dietpi.com/docs/software/file_servers/), [Printing](https://dietpi.com/docs/software/printing/) and much more.
 
 Use `dietpi-services` to control which installed software has higher or lower priority levels (nice, affinity, policy scheduler).
 
@@ -279,7 +279,7 @@ Links to hardware and software manufacturers, sources and build instructions use
 - [Bazarr](https://github.com/morpheus65535/bazarr)
 - [PaperMC](https://github.com/PaperMC/Paper)
 - [Unbound](https://github.com/NLnetLabs/unbound)
-- [Bitwarden_RS](https://github.com/dani-garcia/bitwarden_rs)
+- [vaultwarden](https://github.com/dani-garcia/vaultwarden)
 - [Docker](https://github.com/docker/docker-ce)
 - [Portainer](https://github.com/portainer/portainer)
 - [Tor](https://gitlab.torproject.org/tpo/core/tor)
@@ -296,9 +296,7 @@ Links to hardware and software manufacturers, sources and build instructions use
 
 ---
 
-<html>
-	<p align="center">
-		<img src="https://www.myvirtualserver.com/images/myvirtualserver_logo.png" alt="myVirtualserver Logo" width="200">
-		<br>DietPi's web hosting is powered by <a href="https://www.myvirtualserver.com">myVirtualserver</a>.
-	</p>
-</html>
+<p align="center">
+	<img src="https://www.myvirtualserver.com/images/myvirtualserver_logo.png" alt="myVirtualserver logo" width="200" height="44" loading="lazy">
+	<br>DietPi's web hosting is powered by <a href="https://www.myvirtualserver.com" target="_blank" rel="noopener">myVirtualserver</a>.
+</p>

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -144,7 +144,7 @@ Available services:
 			'gogs'
 			'gitea'
 			'firefox-sync'
-			'bitwarden_rs'
+			'vaultwarden'
 
 			# - Emulation/Gaming
 			'mineos'

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6175,8 +6175,6 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			[[ $version ]] || { version='1.21.0'; G_DIETPI-NOTIFY 1 "Automatic latest ${aSOFTWARE_NAME[$software_id]} version detection failed. Version \"$version\" will be installed as fallback, but a newer version might be available. Please report this at: https://github.com/MichaIng/DietPi/issues"; }
 			Download_Install "https://github.com/dani-garcia/vaultwarden/archive/$version.tar.gz"
 
-			# Replace old instance on reinstall - before project was renamed
-			[[ -d '/opt/bitwarden_rs' ]] && G_EXEC rm -R /opt/bitwarden_rs
 			# Replace old instance on reinstall using new project name
 			[[ -d '/opt/vaultwarden' ]] && G_EXEC rm -R /opt/vaultwarden
 			G_EXEC mv "vaultwarden-$version" /opt/vaultwarden
@@ -11939,24 +11937,7 @@ _EOF_
 			# User
 			Create_User -d /mnt/dietpi_userdata/vaultwarden vaultwarden
 
-			if [[ -d '/mnt/dietpi_userdata/bitwarden_rs' ]]
-			then
-				# Rename old Bitwarden_RS due to project name change
-				G_EXEC mv /mnt/dietpi_userdata/{bitwarden_rs,vaultwarden}
-				G_EXEC mv /mnt/dietpi_userdata/vaultwarden/{bitwarden_rs,vaultwarden}.env
-				
-				if [[ -f '/etc/systemd/system/bitwarden_rs.service' ]]; then
-					rm -R /etc/systemd/system/bitwarden_rs.service*
-				fi
-				[[ -d '/etc/systemd/system/bitwarden_rs.service.d' ]] && rm -R /etc/systemd/system/bitwarden_rs.service.d
-
-				getent passwd bitwarden_rs > /dev/null && userdel bitwarden_rs
-				getent group bitwarden_rs > /dev/null && groupdel bitwarden_rs
-				
-			elif [[ ! -d '/mnt/dietpi_userdata/vaultwarden' ]]
-			then
-				G_EXEC mkdir -p /mnt/dietpi_userdata/vaultwarden
-			fi
+			if [[ ! -d '/mnt/dietpi_userdata/vaultwarden' ]] && G_EXEC mkdir -p /mnt/dietpi_userdata/vaultwarden
 
 			# Config: Preserve old
 			if [[ ! -f '/mnt/dietpi_userdata/vaultwarden/vaultwarden.env' ]]
@@ -11979,7 +11960,7 @@ _EOF_
 			# Service: https://github.com/dani-garcia/vaultwarden/wiki/Setup-as-a-systemd-service
 			cat << '_EOF_' > /etc/systemd/system/vaultwarden.service
 [Unit]
-Description=Bitwarden Server (Rust Edition)
+Description=vaultwarden Server (Rust Edition)
 Documentation=https://github.com/dani-garcia/vaultwarden
 
 After=dietpi-boot.service network.target
@@ -13955,22 +13936,6 @@ _EOF_
 
 			Banner_Uninstalling
 
-			# Uninstall Bitwarden_RS - old project name
-			if [[ -f '/etc/systemd/system/bitwarden_rs.service' ]]; then
-
-				systemctl disable --now bitwarden_rs
-				rm -R /etc/systemd/system/bitwarden_rs.service*
-
-			fi
-			[[ -d '/etc/systemd/system/bitwarden_rs.service.d' ]] && rm -R /etc/systemd/system/bitwarden_rs.service.d
-
-			getent passwd bitwarden_rs > /dev/null && userdel bitwarden_rs
-			getent group bitwarden_rs > /dev/null && groupdel bitwarden_rs
-
-			[[ -d '/opt/bitwarden_rs' ]] && rm -R /opt/bitwarden_rs
-			[[ -d '/mnt/dietpi_userdata/bitwarden_rs' ]] && rm -R /mnt/dietpi_userdata/bitwarden_rs
-
-			# Uninstall Vaultwarden
 			if [[ -f '/etc/systemd/system/vaultwarden.service' ]]; then
 
 				systemctl disable --now vaultwarden

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -953,7 +953,7 @@ _EOF_
 		#------------------
 		software_id=183
 
-		aSOFTWARE_NAME[$software_id]='Vaultwarden'
+		aSOFTWARE_NAME[$software_id]='vaultwarden'
 		aSOFTWARE_DESC[$software_id]='Unofficial Bitwarden password manager server written in Rust'
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#vaultwarden'
@@ -6162,7 +6162,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 		fi
 
-		software_id=183 # Vaultwarden
+		software_id=183 # vaultwarden
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -11931,7 +11931,7 @@ _EOF_
 
 		fi
 
-		software_id=183 # Vaultwarden
+		software_id=183 # vaultwarden
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -11939,18 +11939,29 @@ _EOF_
 			# User
 			Create_User -d /mnt/dietpi_userdata/vaultwarden vaultwarden
 
-			# Data and config dir
-			G_EXEC mkdir -p /mnt/dietpi_userdata/vaultwarden
+			if [[ -d '/mnt/dietpi_userdata/bitwarden_rs' ]]
+			then
+				# Rename old Bitwarden_RS due to project name change
+				G_EXEC mv /mnt/dietpi_userdata/{bitwarden_rs,vaultwarden}
+				G_EXEC mv /mnt/dietpi_userdata/vaultwarden/{bitwarden_rs,vaultwarden}.env
+				
+				if [[ -f '/etc/systemd/system/bitwarden_rs.service' ]]; then
+					rm -R /etc/systemd/system/bitwarden_rs.service*
+				fi
+				[[ -d '/etc/systemd/system/bitwarden_rs.service.d' ]] && rm -R /etc/systemd/system/bitwarden_rs.service.d
 
-			# Config: Rename old Bitwarden_RS due to project name change
-			if [[ -d '/mnt/dietpi_userdata/bitwarden_rs' ]]; then
-				G_EXEC mv /mnt/dietpi_userdata/bitwarden_rs /mnt/dietpi_userdata/vaultwarden
+				getent passwd bitwarden_rs > /dev/null && userdel bitwarden_rs
+				getent group bitwarden_rs > /dev/null && groupdel bitwarden_rs
+				
+			elif [[ ! -d '/mnt/dietpi_userdata/vaultwarden' ]]
+			then
+				G_EXEC mkdir -p /mnt/dietpi_userdata/vaultwarden
 			fi
 
 			# Config: Preserve old
 			if [[ ! -f '/mnt/dietpi_userdata/vaultwarden/vaultwarden.env' ]]
 			then
-				G_EXEC cp /opt/vaultwarden/.env.template /mnt/dietpi_userdata/vaultwarden/vaultwarden_rs.env
+				G_EXEC cp /opt/vaultwarden/.env.template /mnt/dietpi_userdata/vaultwarden/vaultwarden.env
 				G_CONFIG_INJECT 'DATA_FOLDER=' 'DATA_FOLDER=/mnt/dietpi_userdata/vaultwarden' /mnt/dietpi_userdata/vaultwarden/vaultwarden.env
 				# Create TLS certificate for web vault: Currently only RSA is supported. Add SAN with local IP and hostname, required for the client to accept the connection.
 				G_EXEC_OUTPUT=1 G_EXEC openssl req -reqexts SAN -subj '/CN=DietPi Vaultwarden' -config <(cat /etc/ssl/openssl.cnf <(echo -ne "[SAN]\nsubjectAltName=DNS:$(</etc/hostname),IP:$(mawk 'NR==4' /run/dietpi/.network)\nbasicConstraints=CA:TRUE,pathlen:0"))\
@@ -13939,7 +13950,7 @@ _EOF_
 
 		fi
 
-		software_id=183 # Vaultwarden
+		software_id=183 # vaultwarden
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -953,10 +953,10 @@ _EOF_
 		#------------------
 		software_id=183
 
-		aSOFTWARE_NAME[$software_id]='Bitwarden_RS'
+		aSOFTWARE_NAME[$software_id]='Vaultwarden'
 		aSOFTWARE_DESC[$software_id]='Unofficial Bitwarden password manager server written in Rust'
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#bitwarden_rs'
+		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#vaultwarden'
 		aSOFTWARE_REQUIRES_BUILDESSENTIAL[$software_id]=1
 		aSOFTWARE_REQUIRES_SQLITE[$software_id]=1
 
@@ -6162,28 +6162,30 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 		fi
 
-		software_id=183 # Bitwarden_RS
+		software_id=183 # Vaultwarden
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
 
-			# Dependencies: https://github.com/dani-garcia/bitwarden_rs/wiki/Building-binary#dependencies
+			# Dependencies: https://github.com/dani-garcia/vaultwarden/wiki/Building-binary#dependencies
 			DEPS_LIST='pkg-config libssl-dev'
 
 			# Download
-			local version=$(curl -sSfL 'https://api.github.com/repos/dani-garcia/bitwarden_rs/releases/latest' | mawk -F\" '/"tag_name": /{print $4}')
-			[[ $version ]] || { version='1.19.0'; G_DIETPI-NOTIFY 1 "Automatic latest ${aSOFTWARE_NAME[$software_id]} version detection failed. Version \"$version\" will be installed as fallback, but a newer version might be available. Please report this at: https://github.com/MichaIng/DietPi/issues"; }
-			Download_Install "https://github.com/dani-garcia/bitwarden_rs/archive/$version.tar.gz"
+			local version=$(curl -sSfL 'https://api.github.com/repos/dani-garcia/vaultwarden/releases/latest' | mawk -F\" '/"tag_name": /{print $4}')
+			[[ $version ]] || { version='1.21.0'; G_DIETPI-NOTIFY 1 "Automatic latest ${aSOFTWARE_NAME[$software_id]} version detection failed. Version \"$version\" will be installed as fallback, but a newer version might be available. Please report this at: https://github.com/MichaIng/DietPi/issues"; }
+			Download_Install "https://github.com/dani-garcia/vaultwarden/archive/$version.tar.gz"
 
-			# Replace old instance on reinstall
+			# Replace old instance on reinstall - before project was renamed
 			[[ -d '/opt/bitwarden_rs' ]] && G_EXEC rm -R /opt/bitwarden_rs
-			G_EXEC mv "bitwarden_rs-$version" /opt/bitwarden_rs
+			# Replace old instance on reinstall using new project name
+			[[ -d '/opt/vaultwarden' ]] && G_EXEC rm -R /opt/vaultwarden
+			G_EXEC mv "vaultwarden-$version" /opt/vaultwarden
 
 			# Assure 2 GiB overall memory (-100 MiB to avoid tiny swap space) is available and limit concurrent cargo build jobs to 2 if less than 3 GiB memory is available.
 			local jobs=
 			if (( $RAM_TOTAL < 1948 ))
 			then
-				G_DIETPI-NOTIFY 2 'Bitwaden_RS build requires at least 2 GiB memory. We will now increase your swap size to satisfy this requirement.'
+				G_DIETPI-NOTIFY 2 'Vaultwarden build requires at least 2 GiB memory. We will now increase your swap size to satisfy this requirement.'
 				/boot/dietpi/func/dietpi-set_swapfile 1
 				(( $G_HW_CPU_CORES > 2 )) && jobs=2
 
@@ -6209,7 +6211,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			G_EXEC . .cargo/env
 
 			# Build
-			G_EXEC cd /opt/bitwarden_rs
+			G_EXEC cd /opt/vaultwarden
 			G_EXEC_OUTPUT=1 G_EXEC cargo build ${jobs:+-j $jobs} --features sqlite --release
 			G_EXEC cd /tmp/$G_PROGRAM_NAME
 
@@ -6220,8 +6222,8 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			HOME='/root'
 
 			# Install web vault
-			local fallback_url='https://github.com/dani-garcia/bw_web_builds/releases/download/v2.18.1b/bw_web_v2.18.1b.tar.gz'
-			Download_Install "$(curl -sSfL 'https://api.github.com/repos/dani-garcia/bw_web_builds/releases/latest' | mawk -F\" '/"browser_download_url": .*\/bw_web_[^"\/]*\.tar\.gz"/{print $4}')" /mnt/dietpi_userdata/bitwarden_rs
+			local fallback_url='https://github.com/dani-garcia/bw_web_builds/releases/download/v2.19.0d/bw_web_v2.19.0d.tar.gz'
+			Download_Install "$(curl -sSfL 'https://api.github.com/repos/dani-garcia/bw_web_builds/releases/latest' | mawk -F\" '/"browser_download_url": .*\/bw_web_[^"\/]*\.tar\.gz"/{print $4}')" /mnt/dietpi_userdata/vaultwarden
 
 		fi
 
@@ -11929,40 +11931,45 @@ _EOF_
 
 		fi
 
-		software_id=183 # Bitwarden_RS
+		software_id=183 # Vaultwarden
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
 
 			# User
-			Create_User -d /mnt/dietpi_userdata/bitwarden_rs bitwarden_rs
+			Create_User -d /mnt/dietpi_userdata/vaultwarden vaultwarden
 
 			# Data and config dir
-			G_EXEC mkdir -p /mnt/dietpi_userdata/bitwarden_rs
+			G_EXEC mkdir -p /mnt/dietpi_userdata/vaultwarden
+
+			# Config: Rename old Bitwarden_RS due to project name change
+			if [[ -d '/mnt/dietpi_userdata/bitwarden_rs' ]]; then
+				G_EXEC mv /mnt/dietpi_userdata/bitwarden_rs /mnt/dietpi_userdata/vaultwarden
+			fi
 
 			# Config: Preserve old
-			if [[ ! -f '/mnt/dietpi_userdata/bitwarden_rs/bitwarden_rs.env' ]]
+			if [[ ! -f '/mnt/dietpi_userdata/vaultwarden/vaultwarden.env' ]]
 			then
-				G_EXEC cp /opt/bitwarden_rs/.env.template /mnt/dietpi_userdata/bitwarden_rs/bitwarden_rs.env
-				G_CONFIG_INJECT 'DATA_FOLDER=' 'DATA_FOLDER=/mnt/dietpi_userdata/bitwarden_rs' /mnt/dietpi_userdata/bitwarden_rs/bitwarden_rs.env
+				G_EXEC cp /opt/vaultwarden/.env.template /mnt/dietpi_userdata/vaultwarden/vaultwarden_rs.env
+				G_CONFIG_INJECT 'DATA_FOLDER=' 'DATA_FOLDER=/mnt/dietpi_userdata/vaultwarden' /mnt/dietpi_userdata/vaultwarden/vaultwarden.env
 				# Create TLS certificate for web vault: Currently only RSA is supported. Add SAN with local IP and hostname, required for the client to accept the connection.
-				G_EXEC_OUTPUT=1 G_EXEC openssl req -reqexts SAN -subj '/CN=DietPi Bitwarden_RS' -config <(cat /etc/ssl/openssl.cnf <(echo -ne "[SAN]\nsubjectAltName=DNS:$(</etc/hostname),IP:$(mawk 'NR==4' /run/dietpi/.network)\nbasicConstraints=CA:TRUE,pathlen:0"))\
-					-x509 -days 7200 -sha256 -extensions SAN -out /mnt/dietpi_userdata/bitwarden_rs/cert.pem\
-					-newkey rsa:4096 -nodes -keyout /mnt/dietpi_userdata/bitwarden_rs/privkey.pem
-				G_CONFIG_INJECT 'ROCKET_TLS=' 'ROCKET_TLS={certs="./cert.pem",key="./privkey.pem"}' /mnt/dietpi_userdata/bitwarden_rs/bitwarden_rs.env
-				G_CONFIG_INJECT 'ROCKET_PORT=' 'ROCKET_PORT=8001' /mnt/dietpi_userdata/bitwarden_rs/bitwarden_rs.env # Avoid port conflict with IceCast
-				G_CONFIG_INJECT 'WEB_VAULT_ENABLED=' 'WEB_VAULT_ENABLED=true' /mnt/dietpi_userdata/bitwarden_rs/bitwarden_rs.env
+				G_EXEC_OUTPUT=1 G_EXEC openssl req -reqexts SAN -subj '/CN=DietPi Vaultwarden' -config <(cat /etc/ssl/openssl.cnf <(echo -ne "[SAN]\nsubjectAltName=DNS:$(</etc/hostname),IP:$(mawk 'NR==4' /run/dietpi/.network)\nbasicConstraints=CA:TRUE,pathlen:0"))\
+					-x509 -days 7200 -sha256 -extensions SAN -out /mnt/dietpi_userdata/vaultwarden/cert.pem\
+					-newkey rsa:4096 -nodes -keyout /mnt/dietpi_userdata/vaultwarden/privkey.pem
+				G_CONFIG_INJECT 'ROCKET_TLS=' 'ROCKET_TLS={certs="./cert.pem",key="./privkey.pem"}' /mnt/dietpi_userdata/vaultwarden/vaultwarden.env
+				G_CONFIG_INJECT 'ROCKET_PORT=' 'ROCKET_PORT=8001' /mnt/dietpi_userdata/vaultwarden/vaultwarden.env # Avoid port conflict with IceCast
+				G_CONFIG_INJECT 'WEB_VAULT_ENABLED=' 'WEB_VAULT_ENABLED=true' /mnt/dietpi_userdata/vaultwarden/vaultwarden.env
 			fi
 
 			# Permissions
-			G_EXEC chown -R bitwarden_rs:bitwarden_rs /mnt/dietpi_userdata/bitwarden_rs
-			G_EXEC chmod +x /opt/bitwarden_rs/target/release/bitwarden_rs
+			G_EXEC chown -R vaultwarden:vaultwarden /mnt/dietpi_userdata/vaultwarden
+			G_EXEC chmod +x /opt/vaultwarden/target/release/vaultwarden
 
-			# Service: https://github.com/dani-garcia/bitwarden_rs/wiki/Setup-as-a-systemd-service
-			cat << '_EOF_' > /etc/systemd/system/bitwarden_rs.service
+			# Service: https://github.com/dani-garcia/vaultwarden/wiki/Setup-as-a-systemd-service
+			cat << '_EOF_' > /etc/systemd/system/vaultwarden.service
 [Unit]
 Description=Bitwarden Server (Rust Edition)
-Documentation=https://github.com/dani-garcia/bitwarden_rs
+Documentation=https://github.com/dani-garcia/vaultwarden
 
 After=dietpi-boot.service network.target
 
@@ -11974,24 +11981,24 @@ StartLimitBurst=5
 # Server sometimes fails to start on startup, this should fix it
 Restart=on-failure
 RestartSec=5s
-# The user bitwarden_rs is run under. the working directory (see below) should allow write and read access to this user
-User=bitwarden_rs
+# The user vaultwarden is run under. the working directory (see below) should allow write and read access to this user
+User=vaultwarden
 # The location of the .env file for configuration
-EnvironmentFile=/mnt/dietpi_userdata/bitwarden_rs/bitwarden_rs.env
+EnvironmentFile=/mnt/dietpi_userdata/vaultwarden/vaultwarden.env
 # The location of the compiled binary
-ExecStart=/opt/bitwarden_rs/target/release/bitwarden_rs
+ExecStart=/opt/vaultwarden/target/release/vaultwarden
 # Set reasonable connection and process limits
 LimitNOFILE=1048576
 LimitNPROC=64
-# Isolate bitwarden_rs from the rest of the system
+# Isolate vaultwarden from the rest of the system
 PrivateTmp=true
 PrivateDevices=true
 ProtectHome=true
 ProtectSystem=strict
 # Only allow writes to the following directory and set it to the working directory (user and password data are stored here)
-WorkingDirectory=/mnt/dietpi_userdata/bitwarden_rs
-ReadWritePaths=/mnt/dietpi_userdata/bitwarden_rs
-# Allow bitwarden_rs to bind ports in the range of 0-1024
+WorkingDirectory=/mnt/dietpi_userdata/vaultwarden
+ReadWritePaths=/mnt/dietpi_userdata/vaultwarden
+# Allow vaultwarden to bind ports in the range of 0-1024
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 [Install]
@@ -13932,11 +13939,12 @@ _EOF_
 
 		fi
 
-		software_id=183 # Bitwarden_RS
+		software_id=183 # Vaultwarden
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
 
+			# Uninstall Bitwarden_RS - old project name
 			if [[ -f '/etc/systemd/system/bitwarden_rs.service' ]]; then
 
 				systemctl disable --now bitwarden_rs
@@ -13950,6 +13958,21 @@ _EOF_
 
 			[[ -d '/opt/bitwarden_rs' ]] && rm -R /opt/bitwarden_rs
 			[[ -d '/mnt/dietpi_userdata/bitwarden_rs' ]] && rm -R /mnt/dietpi_userdata/bitwarden_rs
+
+			# Uninstall Vaultwarden
+			if [[ -f '/etc/systemd/system/vaultwarden.service' ]]; then
+
+				systemctl disable --now vaultwarden
+				rm -R /etc/systemd/system/vaultwarden.service*
+
+			fi
+			[[ -d '/etc/systemd/system/vaultwarden.service.d' ]] && rm -R /etc/systemd/system/vaultwarden.service.d
+
+			getent passwd vaultwarden > /dev/null && userdel vaultwarden
+			getent group vaultwarden > /dev/null && groupdel vaultwarden
+
+			[[ -d '/opt/vaultwarden' ]] && rm -R /opt/vaultwarden
+			[[ -d '/mnt/dietpi_userdata/vaultwarden' ]] && rm -R /mnt/dietpi_userdata/vaultwarden
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11937,7 +11937,7 @@ _EOF_
 			# User
 			Create_User -d /mnt/dietpi_userdata/vaultwarden vaultwarden
 
-			if [[ ! -d '/mnt/dietpi_userdata/vaultwarden' ]] && G_EXEC mkdir -p /mnt/dietpi_userdata/vaultwarden
+			[[ ! -d '/mnt/dietpi_userdata/vaultwarden' ]] && G_EXEC mkdir -p /mnt/dietpi_userdata/vaultwarden
 
 			# Config: Preserve old
 			if [[ ! -f '/mnt/dietpi_userdata/vaultwarden/vaultwarden.env' ]]


### PR DESCRIPTION
Project has been renamed to avoid legal issues with the original Bitwarden software https://github.com/dani-garcia/vaultwarden/discussions/1642

**Status**: Testing
- [x] test `vaultwarden` install
- [x] test `vaultwarden` reinstall
- [x] test `vaultwarden` uninstall
- [x] test migration during `dietpi-update`

**Reference**: https://github.com/MichaIng/DietPi/issues/4325

**Commit list/description**:
- DietPi-Software | vaultwarden: project has been renamed to avoid legal issues with the original Bitwarden software
- DietPi-Software | vaultwarden: use lower case on application name
- DietPi-Software | vaultwarden: adjust reinstall to ensure transition from Bitwarden_RS to vaultwarden
- DietPi-Services | vaultwarden: rename service from bitwarden_rs to vaultwarden DietPi-Patches | vaultwarden: add Bitwarden_RS migartion into vaultwarden
- DietPi-Pre-Patches | vaultwarden: add detection for Bitwarden_RS and inform user about long run time
- DietPi-Software | vaultwarden: remove Bitwarden_RS  migration code as it has been moved into DietPi-Patches
- DietPi-Patches | vaultwarden: show output of vaultwarden reinstall
- DietPi-Patches | vaultwarden: add users notification
- DietPi-Patches | vaultwarden: modify data directory setting inside vaultwarden.env
- DietPi-Pre-Patches | vaultwarden:  adjust user notification