### PR TITLE
DietPi-LetsEncrypt | Lighttpd: Resolve lighty-*-mod errors

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Changes:
 Fixes:
 - Odroid XU4 | Resolved an issue where installs and possibly other tasks hang, because the device ran out of entropy. All Odroid XU4 system will have the unsupported hardware random generator daemon removed and the software HAVEGE daemon installed instead for entropy generation. Many thanks to @Speeedfire for reporting this issue: https://github.com/MichaIng/DietPi/issues/4318
 - DietPi-Banner | Resolved an issue where the MOTD was not updated via daily cron job, if the banner settings have not been changed yet, hence no config file exists. Since the MOTD is enabled by default, it needs to be updated as well if the config file does not exist. Many thanks to @gorby-pranata for helping us discovering this issue: https://github.com/MichaIng/DietPi/pull/4292#issuecomment-830787256
+- DietPi-LetsEncrypt | Resolved an issue with Lighttpd, where lighty-enable-mod or lighty-disable-mod failed, if the related config was already enabled or disabled, respectively. Many thanks to @staxfax for reporting this issue: https://github.com/MichaIng/DietPi/issues/4336
 - DietPi-Software | Python 3: Resolved an issue where installing pip on Stretch systems failed, due to a changed download URL. Many thanks to @tfmeier for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=8968
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX

--- a/dietpi/dietpi-letsencrypt
+++ b/dietpi/dietpi-letsencrypt
@@ -174,7 +174,7 @@ _EOF_
 			then
 				G_EXEC sed -i 's/, "Options" => "-SessionTicket"//' /etc/lighttpd/conf-available/50-dietpi-https.conf
 			fi
-			G_EXEC lighty-enable-mod dietpi-https
+			[[ -f '/etc/lighttpd/conf-enabled/50-dietpi-https.conf' ]] || G_EXEC lighty-enable-mod dietpi-https
 
 			# Redirect
 			if (( $LETSENCRYPT_REDIRECT )); then
@@ -191,11 +191,11 @@ $HTTP["scheme"] == "http" {
 	}
 }
 _EOF_
-				G_EXEC lighty-enable-mod dietpi-https_redirect
+				[[ -f '/etc/lighttpd/conf-enabled/98-dietpi-https_redirect.conf' ]] || G_EXEC lighty-enable-mod dietpi-https_redirect
 
 			elif [[ -f '/etc/lighttpd/conf-available/98-dietpi-https_redirect.conf' ]]; then
 
-				G_EXEC lighty-disable-mod dietpi-https_redirect
+				[[ -f '/etc/lighttpd/conf-enabled/98-dietpi-https_redirect.conf' ]] && G_EXEC lighty-disable-mod dietpi-https_redirect
 				G_EXEC rm /etc/lighttpd/conf-available/98-dietpi-https_redirect.conf
 
 			fi
@@ -208,11 +208,11 @@ $HTTP["scheme"] == "https" {
 	setenv.add-response-header = ( "Strict-Transport-Security" => "max-age=31536000; includeSubdomains" )
 }
 _EOF_
-				G_EXEC lighty-enable-mod dietpi-hsts
+				[[ -f '/etc/lighttpd/conf-enabled/98-dietpi-hsts.conf' ]] || G_EXEC lighty-enable-mod dietpi-hsts
 
 			elif [[ -f '/etc/lighttpd/conf-available/98-dietpi-hsts.conf' ]]; then
 
-				G_EXEC lighty-disable-mod dietpi-hsts
+				[[ -f '/etc/lighttpd/conf-enabled/98-dietpi-hsts.conf' ]] && G_EXEC lighty-disable-mod dietpi-hsts
 				G_EXEC rm /etc/lighttpd/conf-available/98-dietpi-hsts.conf
 
 			fi


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-LetsEncrypt | Do not try to enable/disable Lighttpd configs, when they are enabled/disabled already, as this will produce an error code (2)