### PR TITLE
DietPi-Software | Docker Compose: Fix install on ARMv8 + Stretch

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Fixes:
 - DietPi-LetsEncrypt | Resolved an issue with Lighttpd, where lighty-enable-mod or lighty-disable-mod failed, if the related config was already enabled or disabled, respectively. Many thanks to @staxfax for reporting this issue: https://github.com/MichaIng/DietPi/issues/4336
 - DietPi-Software | Python 3: Resolved an issue where installing pip on Stretch systems failed, due to a changed download URL. Many thanks to @tfmeier for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=8968
 - DietPi-Software | Webmin: Resolved an issue where restarts from the web interface only stopped the service. Many thanks to @Burgess85 and @Keridos for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=8839, https://github.com/MichaIng/DietPi/pull/4331
+- DietPi-Software | Docker Compose: Resolved an issue on ARMv8 Debian Stretch systems, where the install failed because of missing development headers. Many thanks to @tfmeier for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?p=34293#p34293
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6737,7 +6737,9 @@ If you want to update ${aSOFTWARE_NAME[$software_id]}, please use its internal u
 			Banner_Installing
 
 			# Python build dependencies for aarch64
-			(( $G_HW_ARCH == 3 )) && G_AGI make gcc
+			# - libffi-dev additionally required on Stretch: https://dietpi.com/phpbb/viewtopic.php?p=34293#p34293
+			(( $G_HW_ARCH == 3 && $G_DISTRO < 5 )) && local ffi='libffi-dev' || local ffi=
+			(( $G_HW_ARCH == 3 )) && G_AGI make gcc $ffi
 
 			G_EXEC_OUTPUT=1 G_EXEC pip3 install docker-compose
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6738,8 +6738,10 @@ If you want to update ${aSOFTWARE_NAME[$software_id]}, please use its internal u
 
 			# Python build dependencies for aarch64
 			# - libffi-dev additionally required on Stretch: https://dietpi.com/phpbb/viewtopic.php?p=34293#p34293
-			(( $G_HW_ARCH == 3 && $G_DISTRO < 5 )) && local ffi='libffi-dev' || local ffi=
-			(( $G_HW_ARCH == 3 )) && G_AGI make gcc $ffi
+			local apackages=('make' 'gcc')
+			(( $G_DISTRO < 5 )) && apackages+=('libffi-dev')
+			(( $G_HW_ARCH == 3 )) && G_AGI "${apackages[@]}"
+			unset -v apackages
 
 			G_EXEC_OUTPUT=1 G_EXEC pip3 install docker-compose
 


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Software | Docker Compose: Add libffi-dev on ARMv8 + Stretch, required for cffi module compilation on ARMv8: https://dietpi.com/phpbb/viewtopic.php?p=34293#p34293