### PR TITLE
DietPi-Software | Node.js: Use unofficial builds on ARMv6

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,7 @@ Fixes:
 - DietPi-Software | rTorrent: Resolved an issue where pre-v7.1 reinstalls with Lighttpd did not update the webserver configuration to provide the new RPC socket proxy. Many thanks to @bbsixzz for reporting this issue: https://github.com/MichaIng/DietPi/issues/4330
 - DietPi-Software | rTorrent: Resolved an issue where v7.1 reinstalls failed. Many thanks to @Joulinar for fixing it.
 - DietPi-Software | Radarr: Resolved an issue where an older fallback version was installed, rather than the latest one. Many thanks to @Takerman for reporting this issue: https://github.com/MichaIng/DietPi/issues/4350
+- DietPi-Software | Node.js: Resolved an issue on ARMv6 where installing further modules via web interface failed, as an incompatible Node.js version was installed. The latest Node.js version is now installed via unofficial builds (see changes above). Many thanks to @torwan for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=8944
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ v7.2
 Changes:
 - DietPi-Software | WiringPi: On RPi, a new updated fork of the deprecated original project is now used, which enables support for RPi 4/400 and CM4: https://github.com/WiringPi/WiringPi
 - DietPi-Software | WiringPi: On new installs and reinstalls, the source/examples directory is now installed to /mnt/dietpi_userdata/WiringPi instead of /root/wiringPi, to enable general access to non-root users.
+- DietPi-Software | Node.js: On ARMv6, new Node.js versions are now installed via unofficial builds. Official builds are provided up to Node v11 only. Many thanks to @ollliegits for adding support for this builds to our Node.js installer fork: https://github.com/MichaIng/nodejs-linux-installer/pull/2
 
 Fixes:
 - Odroid XU4 | Resolved an issue where installs and possibly other tasks hang, because the device ran out of entropy. All Odroid XU4 system will have the unsupported hardware random generator daemon removed and the software HAVEGE daemon installed instead for entropy generation. Many thanks to @Speeedfire for reporting this issue: https://github.com/MichaIng/DietPi/issues/4318
@@ -13,6 +14,8 @@ Fixes:
 - DietPi-Software | Python 3: Resolved an issue where installing pip on Stretch systems failed, due to a changed download URL. Many thanks to @tfmeier for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=8968
 - DietPi-Software | Webmin: Resolved an issue where restarts from the web interface only stopped the service. Many thanks to @Burgess85 and @Keridos for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=8839, https://github.com/MichaIng/DietPi/pull/4331
 - DietPi-Software | Docker Compose: Resolved an issue on ARMv8 Debian Stretch systems, where the install failed because of missing development headers. Many thanks to @tfmeier for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?p=34293#p34293
+- DietPi-Software | rTorrent: Resolved an issue where pre-v7.1 reinstalls with Lighttpd did not update the webserver configuration to provide the new RPC socket proxy. Many thanks to @bbsixzz for reporting this issue: https://github.com/MichaIng/DietPi/issues/4330
+- DietPi-Software | rTorrent: Resolved an issue where v7.1 reinstalls failed. Many thanks to @Joulinar for fixing it.
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3455,7 +3455,6 @@ _EOF_
 			# Download installer
 			Download_Install 'https://raw.githubusercontent.com/MichaIng/nodejs-linux-installer/master/node-install.sh'
 			G_EXEC chmod +x node-install.sh
-			G_EXEC mkdir -p /usr/local # failsafe
 
 			# ARMv6: Use unofficial builds to get the latest version: https://github.com/MichaIng/nodejs-linux-installer/pull/2
 			local unofficial=

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3449,16 +3449,19 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://raw.githubusercontent.com/MichaIng/nodejs-linux-installer/master/node-install.sh'
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-			G_EXEC curl -sSfLO "$INSTALL_URL_ADDRESS"
+			# Deps: https://github.com/MichaIng/DietPi/issues/3614
+			DEPS_LIST='libatomic1'
+
+			# Download installer
+			Download_Install 'https://raw.githubusercontent.com/ollliegits/nodejs-linux-installer/add-armv6-unofficials/node-install.sh'
 			G_EXEC chmod +x node-install.sh
 			G_EXEC mkdir -p /usr/local # failsafe
-			G_EXEC_OUTPUT=1 G_EXEC ./node-install.sh
-			G_EXEC_NOHALT=1 G_EXEC rm node-install.sh
 
-			# Deps: https://github.com/MichaIng/DietPi/issues/3614
-			G_AGI libatomic1
+			# ARMv6: Use unofficial builds to get the latest version: https://github.com/MichaIng/nodejs-linux-installer/pull/2
+			local unofficial=
+			(( $G_HW_ARCH == 1 )) && unofficial='-u'
+			G_EXEC_OUTPUT=1 G_EXEC ./node-install.sh $unofficial
+			G_EXEC_NOHALT=1 G_EXEC rm node-install.sh
 
 		fi
 
@@ -15980,7 +15983,7 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			npm r -g --unsafe-perm n yarn npm
+			command -v npm > /dev/null && npm r -g --unsafe-perm n yarn npm
 
 			# Old install via repo
 			G_AGP nodejs

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3453,7 +3453,7 @@ _EOF_
 			DEPS_LIST='libatomic1'
 
 			# Download installer
-			Download_Install 'https://raw.githubusercontent.com/ollliegits/nodejs-linux-installer/add-armv6-unofficials/node-install.sh'
+			Download_Install 'https://raw.githubusercontent.com/MichaIng/nodejs-linux-installer/master/node-install.sh'
 			G_EXEC chmod +x node-install.sh
 			G_EXEC mkdir -p /usr/local # failsafe
 


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Software | Node.js: Use unofficial builds on ARMv6 which includes newer versions for rare architectures, e.g.: https://unofficial-builds.nodejs.org/download/release/v16.1.0/

This likely solves issues with Node-RED: https://dietpi.com/phpbb/viewtopic.php?p=34205#p34205