### PR TITLE
DietPi-Software | Radarr

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6365,31 +6365,29 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
  - If you need to reinstall (e.g. broken instance), please manually remove the install dir \"/opt/radarr\" and rerun \"dietpi-software reinstall $software_id\"."
 
 			else
-				INSTALL_URL_ADDRESS='https://api.github.com/repos/Radarr/Radarr/releases/latest'
-				G_CHECK_URL "$INSTALL_URL_ADDRESS"
 				# ARMv6
 				if (( $G_HW_ARCH == 1 ))
 				then
-					INSTALL_URL_ADDRESS=$(curl -sSfL "$INSTALL_URL_ADDRESS" | mawk -F\" '/"browser_download_url": .*linux\.tar\.gz"/{print $4}')
-					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v3.0.2.4552/Radarr.master.3.0.2.4552.linux.tar.gz'
+					INSTALL_URL_ADDRESS=$(curl -sSfL 'https://api.github.com/repos/Radarr/Radarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux\.tar\.gz"/{print $4}')
+					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v3.1.1.4954/Radarr.master.3.1.1.4954.linux.tar.gz'
 
 				# ARMv7
 				elif (( $G_HW_ARCH == 2 ))
 				then
-					INSTALL_URL_ADDRESS=$(curl -sSfL "$INSTALL_URL_ADDRESS" | mawk -F\" '/"browser_download_url": .*linux-core-arm\.tar\.gz"/{print $4}')
-					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v3.0.2.4552/Radarr.master.3.0.2.4552.linux-core-arm.tar.gz'
+					INSTALL_URL_ADDRESS=$(curl -sSfL 'https://api.github.com/repos/Radarr/Radarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux-core-arm\.tar\.gz"/{print $4}')
+					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v3.1.1.4954/Radarr.master.3.1.1.4954.linux-core-arm.tar.gz'
 
 				# ARMv8
 				elif (( $G_HW_ARCH == 3 ))
 				then
-					INSTALL_URL_ADDRESS=$(curl -sSfL "$INSTALL_URL_ADDRESS" | mawk -F\" '/"browser_download_url": .*linux-core-arm64\.tar\.gz"/{print $4}')
-					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v3.0.2.4552/Radarr.master.3.0.2.4552.linux-core-arm64.tar.gz'
+					INSTALL_URL_ADDRESS=$(curl -sSfL 'https://api.github.com/repos/Radarr/Radarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux-core-arm64\.tar\.gz"/{print $4}')
+					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v3.1.1.4954/Radarr.master.3.1.1.4954.linux-core-arm64.tar.gz'
 
 				# x86_64
 				elif (( $G_HW_ARCH == 10 ))
 				then
-					INSTALL_URL_ADDRESS=$(curl -sSfL "$INSTALL_URL_ADDRESS" | mawk -F\" '/"browser_download_url": .*linux-core-x64\.tar\.gz"/{print $4}')
-					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v3.0.2.4552/Radarr.master.3.0.2.4552.linux-core-x64.tar.gz'
+					INSTALL_URL_ADDRESS=$(curl -sSfL 'https://api.github.com/repos/Radarr/Radarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux-core-x64\.tar\.gz"/{print $4}')
+					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v3.1.1.4954/Radarr.master.3.1.1.4954.linux-core-x64.tar.gz'
 				fi
 
 				Download_Install "$INSTALL_URL_ADDRESS"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6365,6 +6365,8 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
  - If you need to reinstall (e.g. broken instance), please manually remove the install dir \"/opt/radarr\" and rerun \"dietpi-software reinstall $software_id\"."
 
 			else
+				INSTALL_URL_ADDRESS='https://api.github.com/repos/Radarr/Radarr/releases/latest'
+				G_CHECK_URL "$INSTALL_URL_ADDRESS"
 				# ARMv6
 				if (( $G_HW_ARCH == 1 ))
 				then


### PR DESCRIPTION
At the moment `INSTALL_URL_ADDRESS` variable missing on Radarr installation. Therefore, installation is falling back to backup URL

**EDIT**
found it https://github.com/MichaIng/DietPi/pull/4106/commits/73a73ddd60df6251319391ee6e5fc249283e05f6#

**Status**: Ready
- [x] update `dietpi-software`

**Reference**: https://github.com/MichaIng/DietPi/issues/4350

**Commit list/description**:
- DietPi-Software | Radarr: INSTALL_URL_ADDRESS variable missing. Therefore, installation is currently falling back to backup URL
