### PR TITLE
DietPi-Software | Kodi

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,7 @@ Fixes:
 - DietPi-Software | rTorrent: Resolved an issue where v7.1 reinstalls failed. Many thanks to @Joulinar for fixing it.
 - DietPi-Software | Radarr: Resolved an issue where an older fallback version was installed, rather than the latest one. Many thanks to @Takerman for reporting this issue: https://github.com/MichaIng/DietPi/issues/4350
 - DietPi-Software | Node.js: Resolved an issue on ARMv6 where installing further modules via web interface failed, as an incompatible Node.js version was installed. The latest Node.js version is now installed via unofficial builds (see changes above). Many thanks to @torwan for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=8944
+- DietPi-Software | Kodi: Resolved an issue where an attempt was made during install to create a desktop entry, even if no desktop environment was installed. Many thanks to @sidgeg for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=8995
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9022,8 +9022,8 @@ _EOF_
 			[[ -f '/etc/default/kodi' ]] && G_CONFIG_INJECT 'USER=' 'USER=root' /etc/default/kodi
 
 			# Desktop entry
-			G_THREAD_START curl -sSfL "https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.conf/desktop/icons/kodi-icon.png" -o /var/lib/dietpi/dietpi-software/installed/desktop/icons/kodi-icon.png
-			G_THREAD_START curl -sSfL "https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.conf/desktop/apps/kodi.desktop" -o /usr/share/applications/kodi.desktop
+			[[ -d '/var/lib/dietpi/dietpi-software/installed/desktop/icons/' ]] && G_THREAD_START curl -sSfL "https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.conf/desktop/icons/kodi-icon.png" -o /var/lib/dietpi/dietpi-software/installed/desktop/icons/kodi-icon.png
+			[[ -d '/usr/share/applications/' ]] && G_THREAD_START curl -sSfL "https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.conf/desktop/apps/kodi.desktop" -o /usr/share/applications/kodi.desktop
 
 			# Copy udev rules, probably not needed for root, but we'll do it anyway
 			dps_index=$software_id Download_Install '99-dietpi-kodi.rules' /etc/udev/rules.d/99-dietpi-kodi.rules


### PR DESCRIPTION
At the moment download of Kodi desktop item will fail if no desktop was selected because the target desktop icon folder did not exist

**Status**: Ready
- [x] update `dietpi-software`

**Reference**: https://dietpi.com/phpbb/viewtopic.php?t=8995

**Commit list/description**:
- DietPi-Software | Kodi: check for the availability of the desktop icon folder before going to download the Kodi desktop icon