### PR TITLE
DietPi-Software | Refactoring

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,9 @@ Changes:
 New Software:
 - Firefox | The Mozilla browser has now become an independent software option with the ID 67 (see changes above). 
 
+Removed Software:
+- LibSSL1.0.0 | This old library was kept for backwards-compatibility with old binaries but is not required anymore for any binary installed by DietPi-Software. It has hence been removed from the software list.
+
 Fixes:
 - Odroid XU4 | Resolved an issue where installs and possibly other tasks hang, because the device ran out of entropy. All Odroid XU4 system will have the unsupported hardware random generator daemon removed and the software HAVEGE daemon installed instead for entropy generation. Many thanks to @Speeedfire for reporting this issue: https://github.com/MichaIng/DietPi/issues/4318
 - DietPi-Banner | Resolved an issue where the MOTD was not updated via daily cron job, if the banner settings have not been changed yet, hence no config file exists. Since the MOTD is enabled by default, it needs to be updated as well if the config file does not exist. Many thanks to @gorby-pranata for helping us discovering this issue: https://github.com/MichaIng/DietPi/pull/4292#issuecomment-830787256

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -15857,6 +15857,8 @@ This requires an account at: https://remote.it/
 	# Setup steps prior to installs and network check
 	DietPi-Automation_Pre(){
 
+		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Applying initial first run setup steps'
+
 		# Get settings
 		AUTOINSTALL_ENABLED=$(sed -n '/^[[:blank:]]*AUTO_SETUP_AUTOMATED=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 		AUTOINSTALL_AUTOSTARTTARGET=$(sed -n '/^[[:blank:]]*AUTO_SETUP_AUTOSTART_TARGET_INDEX=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
@@ -16039,6 +16041,8 @@ This requires an account at: https://remote.it/
 		INDEX_DESKTOP_TARGET=$AUTOINSTALL_DESKTOPINDEX
 		INDEX_BROWSER_TARGET=$AUTOINSTALL_BROWSERINDEX
 
+		G_DIETPI-NOTIFY 0 'Applied initial first run setup steps'
+
 		# Automated installs
 		(( $AUTOINSTALL_ENABLED > 0 )) || return 0
 
@@ -16061,6 +16065,8 @@ This requires an account at: https://remote.it/
 
 	# Setup steps after installs with network assured
 	DietPi-Automation_Post(){
+
+		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Applying final first run setup steps'
 
 		# Remove fake-hwclock, if real hwclock is available
 		# REMOVED: "hwclock" succeeds if an RTC connector is available but no battery attached (or empty), hence we cannot guarantee correct RTC time on boot by only testing "hwclock".
@@ -16116,9 +16122,11 @@ This requires an account at: https://remote.it/
 		# Apply AutoStart choice
 		/boot/dietpi/dietpi-autostart "$AUTOINSTALL_AUTOSTARTTARGET"
 
-		# Set Install Stage to Finished
+		# Set install stage to finished
 		G_DIETPI_INSTALL_STAGE=2
 		echo $G_DIETPI_INSTALL_STAGE > /boot/dietpi/.install_stage
+
+		G_DIETPI-NOTIFY 0 'Applied final first run setup steps'
 
 	}
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -32,12 +32,9 @@ Available commands:
 	# Import DietPi-Globals ---------------------------------------------------------------
 
 	#/////////////////////////////////////////////////////////////////////////////////////
-	# Filepath
+	# Install state file
 	#/////////////////////////////////////////////////////////////////////////////////////
 	readonly FP_INSTALLED_FILE='/boot/dietpi/.installed'
-
-	# Used to set user/personal data directories (e.g.: usbdrive)
-	FP_DIETPI_DEDICATED_USBDRIVE=
 
 	Write_InstallFileList(){
 
@@ -51,7 +48,8 @@ Available commands:
 
 				install_states+="aSOFTWARE_INSTALL_STATE[$i]=2
 "
-			else
+			# Store DietPi-RAMlog and Dropbear uninstalled state as well, as it is initialised as installed matching our image defaults
+			elif (( $i == 103 || $i == 104 )); then
 
 				install_states+="aSOFTWARE_INSTALL_STATE[$i]=0
 "
@@ -90,34 +88,10 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 	Read_InstallFileList(){
 
-		# Load Software states
 		G_DIETPI-NOTIFY -2 'Reading database'
 
 		# Load
 		[[ -f $FP_INSTALLED_FILE ]] && . $FP_INSTALLED_FILE
-
-		# Always reset choice system during first run to defaults: https://github.com/MichaIng/DietPi/issues/1122
-		if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
-
-			INDEX_SSHSERVER_CURRENT=-1
-			INDEX_SSHSERVER_TARGET=-1
-
-			INDEX_FILESERVER_CURRENT=0
-			INDEX_FILESERVER_TARGET=0
-
-			INDEX_LOGGING_CURRENT=-1
-			INDEX_LOGGING_TARGET=-1
-
-			INDEX_WEBSERVER_CURRENT=-2
-			INDEX_WEBSERVER_TARGET=-2
-
-			INDEX_DESKTOP_CURRENT=0
-			INDEX_DESKTOP_TARGET=0
-
-			INDEX_BROWSER_CURRENT=-1
-			INDEX_BROWSER_TARGET=-1
-
-		fi
 
 		G_DIETPI-NOTIFY 0 'Reading database'
 
@@ -205,8 +179,6 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 	DEPS_LIST=
 
 	# Special installation vars
-	USER_EMONHUB_APIKEY_COMPLETED=0
-	USER_EMONHUB_APIKEY_CURRENT=0
 	WIFIHOTSPOT_RTL8188C_DEVICE=0
 	WIFIHOTSPOT_RTL8188C_PACKAGE=0
 	WIREGUARD_BUILTIN=0 # Is the WireGuard kernel module natively shipped by the kernel package?
@@ -221,41 +193,31 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 	fi
 
-	USBDRIVE=0
-
-	# Choices Made?
+	# Choices made?
 	INSTALL_SOFTWARE_CHOICESMADE=0
 
-	# DietPi Choice System: SSH Server
-	# NB: Update Read_InstallFileList with defaults
+	# DietPi Choice System
+	# - SSH Server
 	INSTALL_SSHSERVER_CHOICESMADE=0
 	INDEX_SSHSERVER_CURRENT=-1
 	INDEX_SSHSERVER_TARGET=-1
-
-	# DietPi Choice System: Fileserver
-	# NB: Update Read_InstallFileList with defaults
+	# - Fileserver
 	INSTALL_FILESERVER_CHOICESMADE=0
 	INDEX_FILESERVER_CURRENT=0
 	INDEX_FILESERVER_TARGET=0
-
-	# DietPi Choice System: Logging
-	# NB: Update Read_InstallFileList with defaults
+	# - Logging
 	INSTALL_LOGGING_CHOICESMADE=0
 	INDEX_LOGGING_CURRENT=-1
 	INDEX_LOGGING_TARGET=-1
 
-	# DietPi Preference System: Webserver
-	# NB: Update Read_InstallFileList with defaults
+	# DietPi Preference System
+	# - Webserver
 	INDEX_WEBSERVER_CURRENT=-2
 	INDEX_WEBSERVER_TARGET=-2
-
-	# DietPi Preference System: Desktop
-	# NB: Update Read_InstallFileList with defaults
+	# - Desktop
 	INDEX_DESKTOP_CURRENT=0
 	INDEX_DESKTOP_TARGET=0
-
-	# DietPi Preference System: Browser
-	# NB: Update Read_InstallFileList with defaults
+	# - Browser
 	INDEX_BROWSER_CURRENT=-1
 	INDEX_BROWSER_TARGET=-1
 
@@ -3087,9 +3049,9 @@ _EOF_
 			Banner_Installing
 
 			# Install persistent tmpfs
-			local tmpfs_max_size=$(sed -n '/^[[:blank:]]*AUTO_SETUP_RAMLOG_MAXSIZE=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+			local var_log_size=$(sed -n '/^[[:blank:]]*AUTO_SETUP_RAMLOG_MAXSIZE=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			sed -i '/[[:blank:]]\/var\/log[[:blank:]]/d' /etc/fstab
-			echo "tmpfs /var/log tmpfs size=${tmpfs_max_size:-50}M,noatime,lazytime,nodev,nosuid,mode=1777" >> /etc/fstab
+			echo "tmpfs /var/log tmpfs size=${var_log_size:-50}M,noatime,lazytime,nodev,nosuid,mode=1777" >> /etc/fstab
 
 			# Enable DietPi-RAMdisk
 			G_EXEC systemctl enable dietpi-ramlog
@@ -7102,9 +7064,6 @@ exec sudo -u $ha_user dash -c '$ha_pyenv_activation; exec pip3 install -U homeas
 
 		fi
 
-		# Reinstall DietPi-RAMlog on firstrun installs, if enabled, to apply AUTO_SETUP_RAMLOG_MAXSIZE
-		(( $G_DIETPI_INSTALL_STAGE == 1 && ${aSOFTWARE_INSTALL_STATE[103]} == 2 )) && aSOFTWARE_INSTALL_STATE[103]=1
-
 	}
 
 	# Configure marked software titles
@@ -10424,11 +10383,11 @@ _EOF_
 			/usr/share/rpimonitor/scripts/updatePackagesStatus.pl
 
 			# USB drive stats implimentation by Rich
-			if (( $USBDRIVE )); then
+			if findmnt -S /dev/sda1 > /dev/null; then
 
 				sed -i '\/include=\/etc\/rpimonitor\/template\/sdcard.conf/a include=\/etc\/rpimonitor\/template\/usb_hdd.conf' /etc/rpimonitor/data.conf
 
-				cat << _EOF_ > /etc/rpimonitor/template/usb_hdd.conf
+				cat << '_EOF_' > /etc/rpimonitor/template/usb_hdd.conf
 ########################################################################
 # Extract USB HDD (sda1) information
 #  Page: 1
@@ -10439,12 +10398,12 @@ _EOF_
 static.10.name=usbhdd_total
 static.10.source=df -t ext4
 static.10.regexp=sda1\s+(\d+)
-static.10.postprocess=\$1/1024
+static.10.postprocess=$1/1024
 
 dynamic.14.name=usbhdd_used
 dynamic.14.source=df -t ext4
 dynamic.14.regexp=sda1\s+\d+\s+(\d+)
-dynamic.14.postprocess=\$1/1024
+dynamic.14.postprocess=$1/1024
 dynamic.14.rrd=GAUGE
 
 web.status.1.content.9.name=USB HDD
@@ -13020,17 +12979,6 @@ _EOF_
  - Current: $current_gpu_mem MiB\n - Recommended: $gpu_memory MiB\n\nWould you like DietPi to apply the recommended GPU memory split?\n\nIf unsure, select 'Ok'." || return
 
 		/boot/dietpi/func/dietpi-set_hardware gpumemsplit $gpu_memory
-
-	}
-
-	Check_USB_Drive_Installed(){
-
-		USBDRIVE=0
-
-		FP_DIETPI_DEDICATED_USBDRIVE=$(df -P | mawk '/^\/dev\/sda1/{print $6;exit}')
-
-		# Only enable if mounted
-		[[ $FP_DIETPI_DEDICATED_USBDRIVE ]] && df -P | grep -qi "$FP_DIETPI_DEDICATED_USBDRIVE" && USBDRIVE=1
 
 	}
 
@@ -16084,18 +16032,21 @@ This requires an account at: https://remote.it/
 		AUTOINSTALL_CUSTOMSCRIPTURL=$(sed -n '/^[[:blank:]]*AUTO_SETUP_CUSTOM_SCRIPT_EXEC=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 		AUTOINSTALL_TIMESYNCMODE=$(sed -n '/^[[:blank:]]*CONFIG_NTP_MODE=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 		AUTOINSTALL_RESTORE=$(sed -n '/^[[:blank:]]*AUTO_SETUP_BACKUP_RESTORE=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+		AUTOINSTALL_RAMLOG_SIZE=$(sed -n '/^[[:blank:]]*AUTO_SETUP_RAMLOG_MAXSIZE=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+
 		# Else set defaults
 		[[ $AUTOINSTALL_ENABLED ]] || AUTOINSTALL_ENABLED=0
 		[[ $AUTOINSTALL_AUTOSTARTTARGET ]] || AUTOINSTALL_AUTOSTARTTARGET=0
-		[[ $AUTOINSTALL_SSHINDEX ]] || AUTOINSTALL_SSHINDEX=0
+		[[ $AUTOINSTALL_SSHINDEX ]] || AUTOINSTALL_SSHINDEX=-1
 		[[ $AUTOINSTALL_FILESERVERINDEX ]] || AUTOINSTALL_FILESERVERINDEX=0
-		[[ $AUTOINSTALL_LOGGINGINDEX ]] || AUTOINSTALL_LOGGINGINDEX=0
+		[[ $AUTOINSTALL_LOGGINGINDEX ]] || AUTOINSTALL_LOGGINGINDEX=-1
 		[[ $AUTOINSTALL_WEBSERVERINDEX ]] || AUTOINSTALL_WEBSERVERINDEX=-2
 		[[ $AUTOINSTALL_DESKTOPINDEX ]] || AUTOINSTALL_DESKTOPINDEX=0
 		[[ $AUTOINSTALL_BROWSERINDEX ]] || AUTOINSTALL_BROWSERINDEX=-1
 		[[ $AUTOINSTALL_CUSTOMSCRIPTURL ]] || AUTOINSTALL_CUSTOMSCRIPTURL=0
 		[[ $AUTOINSTALL_TIMESYNCMODE ]] || AUTOINSTALL_TIMESYNCMODE=2
 		[[ $AUTOINSTALL_RESTORE ]] || AUTOINSTALL_RESTORE=0
+		[[ $AUTOINSTALL_RAMLOG_SIZE ]] || AUTOINSTALL_RAMLOG_SIZE=50
 
 	}
 
@@ -16128,6 +16079,10 @@ This requires an account at: https://remote.it/
 		INDEX_WEBSERVER_TARGET=$AUTOINSTALL_WEBSERVERINDEX
 		INDEX_DESKTOP_TARGET=$AUTOINSTALL_DESKTOPINDEX
 		INDEX_BROWSER_TARGET=$AUTOINSTALL_BROWSERINDEX
+
+		# Apply RAMlog size
+		sed -i "\|[[:blank:]]/var/log[[:blank:]]|c\tmpfs /var/log tmpfs size=${AUTOINSTALL_RAMLOG_SIZE}M,noatime,lazytime,nodev,nosuid,mode=1777" /etc/fstab
+		findmnt /var/log > /dev/null && G_EXEC mount -o remount /var/log
 
 		# Set time sync mode
 		/boot/dietpi/func/dietpi-set_software ntpd-mode $AUTOINSTALL_TIMESYNCMODE
@@ -16395,7 +16350,7 @@ This requires an account at: https://remote.it/
 
 		if (( $display_software_menu )); then
 
-			G_WHIP_SIZE_X_MAX=95 # Assure this is enough to show full software descriptions + scroll bar
+			G_WHIP_SIZE_X_MAX=93 # Assure this is enough to show full software descriptions + scroll bar
 			G_WHIP_BUTTON_CANCEL_TEXT='Back'
 			G_WHIP_CHECKLIST "Please use the spacebar to select the software you wish to install.\n - Software and usage details: https://dietpi.com/docs/software/
  - NB: Pressing 'ESC' or selecting 'Back' will clear all changed selections"
@@ -16413,7 +16368,7 @@ This requires an account at: https://remote.it/
 			done
 
 			#-----------------------------------------------------------------------------
-			# Install Info/Warnings
+			# Install info/warnings/inputs
 
 			# DietPi-Drive_Manager can be used to setup Samba/NFS shares with ease!
 			if (( ${aSOFTWARE_INSTALL_STATE[1]} == 1 || ${aSOFTWARE_INSTALL_STATE[110]} == 1 )); then
@@ -16449,7 +16404,7 @@ We allow it to take up to 30 minutes, it's process can be followed, please be pa
 				if G_WHIP_YESNO "Gogs requires OpenSSH server to function.\n\nIf you continue, OpenSSH will be selected for install on your system. OpenSSH will also replace Dropbear (if currently installed).
 \nWould you like to continue with the Gogs installation?"; then
 
-					# - Use SSH target index to ensure Dropbear gets removed if installed.
+					# Use SSH target index to ensure Dropbear gets removed if installed.
 					INDEX_SSHSERVER_TARGET=-2
 
 				else
@@ -16464,48 +16419,41 @@ We allow it to take up to 30 minutes, it's process can be followed, please be pa
 			for i in 75 76 78 79 81 82
 			do
 				# Please let DietPi install them for you...
-				if (( ${aSOFTWARE_INSTALL_STATE[$i]} == 1 )); then
+				(( ${aSOFTWARE_INSTALL_STATE[$i]} == 1 )) || continue
 
-					G_WHIP_MSG 'DietPi will automatically install a webserver stack (based on your Webserver Preference) when any software that requires a webserver is selected for installation (eg: ownCloud, Pi-hole etc).
+				G_WHIP_MSG 'DietPi will automatically install a webserver stack (based on your Webserver Preference) when any software that requires a webserver is selected for installation (eg: ownCloud, Pi-hole etc).
 \nIt is highly recommended that you allow DietPi to do this for you, ensuring compatibility and stability across DietPi installed programs.\n\nPlease only select a webserver stack if you specifically require it, and, no other webserver stack is installed.
 \nTLDR: You do NOT need to select a webserver stack for installation with DietPi. Its all automatic.'
-					break
 
-				fi
+				break
 			done
 
-			# RPi Cam Interface - warn user of locking out camera: https://github.com/MichaIng/DietPi/issues/249
-			if (( ${aSOFTWARE_INSTALL_STATE[59]} == 1 )); then
-
-				G_WHIP_MSG 'RPi Cam Control Interface will automatically start and activate the camera during boot. This will prevent other programs (like raspistill) from using the camera.
+			# RPi Cam Interface: Warn user of locking out camera: https://github.com/MichaIng/DietPi/issues/249
+			(( ${aSOFTWARE_INSTALL_STATE[59]} == 1 )) && G_WHIP_MSG 'RPi Cam Control Interface will automatically start and activate the camera during boot. This will prevent other programs (like raspistill) from using the camera.
 \nYou can free up the camera by selecting "Stop Camera" from the web interface:\n - http://myip/rpicam'
 
-			fi
-
-			# EmonHUB/EmonPi
+			# emonHub
 			if (( ${aSOFTWARE_INSTALL_STATE[99]} == 1 )); then
 
-				# Enter API KEY
 				# Grab key from dietpi.txt
-				USER_EMONHUB_APIKEY_CURRENT=$(sed -n '/^[[:blank:]]*SOFTWARE_EMONHUB_APIKEY=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+				local apikey=$(sed -n '/^[[:blank:]]*SOFTWARE_EMONHUB_APIKEY=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 
-				while (( $USER_EMONHUB_APIKEY_COMPLETED == 0 ))
+				# Offer to enter if it has not yet been done
+				[[ $apikey ]] || while :
 				do
-					if G_WHIP_INPUTBOX "EmonHUB/EmonPi:\n\nPlease enter the \"Write API KEY\":\n - Visit https://emoncms.org to register an account and login.
- - Select \"Setup\" from the top right of screen, then select \"My Account\"\n - Enter the \"Write API Key\" into the box below."; then
+					G_WHIP_DEFAULT_ITEM=$apikey G_WHIP_BUTTON_CANCEL_TEXT='Skip'
+					G_WHIP_INPUTBOX 'Please enter your emonHub "Write API key":
+- Visit https://emoncms.org/ to register an account and login.
+- Select "Setup" from the top right of screen, then select "My Account".
+- Enter the "Write API key" into the box below.
+\nNB: You may skip this when using a local emonCMS instance or none at all.' || break
 
-						USER_EMONHUB_APIKEY_CURRENT=$G_WHIP_RETURNED_VALUE
+					apikey=$G_WHIP_RETURNED_VALUE
+					G_WHIP_YESNO "The following \"Write API key\" will be applied during installation:\n$apikey\n\nIs this key correct?" || continue
 
-						if G_WHIP_YESNO "The following \"Write API KEY\" will be applied during installation:\n$USER_EMONHUB_APIKEY_CURRENT\n\nIs this key correct?"; then
-
-							# Update dietpi.txt so the value will be applied during installation.
-							sed -i "/^[[:blank:]]*SOFTWARE_EMONHUB_APIKEY=/c\SOFTWARE_EMONHUB_APIKEY=$USER_EMONHUB_APIKEY_CURRENT" /boot/dietpi.txt
-
-							USER_EMONHUB_APIKEY_COMPLETED=1
-
-						fi
-
-					fi
+					# Update dietpi.txt so the value will be applied during installation.
+					sed -i "/^[[:blank:]]*SOFTWARE_EMONHUB_APIKEY=/c\SOFTWARE_EMONHUB_APIKEY=$apikey" /boot/dietpi.txt
+					break
 				done
 
 			fi
@@ -16589,28 +16537,17 @@ We allow it to take up to 30 minutes, it's process can be followed, please be pa
 			fi
 
 			# Let's Encrypt
-			if (( ${aSOFTWARE_INSTALL_STATE[92]} == 1 )); then
-
-				G_WHIP_MSG 'The DietPi installation of Certbot supports all offered web servers.\n\nOnce the installation has finished, you can setup your free SSL cert with:
+			(( ${aSOFTWARE_INSTALL_STATE[92]} == 1 )) && G_WHIP_MSG 'The DietPi installation of Certbot supports all offered web servers.\n\nOnce the installation has finished, you can setup your free SSL cert with:
  - DietPi-LetsEncrypt\n\nThis is a easy to use frontend for Certbot and allows integration into DietPi systems.\n\nMore information:\n - https://dietpi.com/docs/software/system_security/#lets-encrypt'
 
-			fi
-
 			# Box86 warning
-			if (( ${aSOFTWARE_INSTALL_STATE[156]} == 1 && $G_HW_ARCH == 2 ))
-			then
-				G_WHIP_MSG 'WARNING: The piece of software you are about to install is meant for the x86 platform.\n\nBox86 will be used to run it on ARM, however there may be performance and compatibility issues.'
-			fi
+			(( ${aSOFTWARE_INSTALL_STATE[156]} == 1 && $G_HW_ARCH == 2 )) && G_WHIP_MSG 'WARNING: The piece of software you are about to install is meant for the x86 platform.\n\nBox86 will be used to run it on ARM, however there may be performance and compatibility issues.'
 
 			# Home Assistant: Inform about long install/build time: https://github.com/MichaIng/DietPi/issues/2897
-			if (( ${aSOFTWARE_INSTALL_STATE[157]} == 1 )); then
-
-				G_WHIP_MSG '[ INFO ] Home Assistant: Grab yourself a coffee
+			(( ${aSOFTWARE_INSTALL_STATE[157]} == 1 )) && G_WHIP_MSG '[ INFO ] Home Assistant: Grab yourself a coffee
 \nThe install process of Home Assistant within the virtual environment, especially the Python build, can take more than one hour, especially on slower SBCs like RPi Zero and similar.
 \nPlease be patient. Meanwhile you might want to participate the discussion about reducing (re)install times, by skipping Python rebuild or installing everything outside of the pyenv environment:
  - https://github.com/MichaIng/DietPi/issues/2374'
-
-			fi
 
 		fi
 
@@ -16702,9 +16639,6 @@ We allow it to take up to 30 minutes, it's process can be followed, please be pa
 
 		fi
 
-		# Check status of USB drive
-		Check_USB_Drive_Installed
-
 		# Get real userdata location
 		local user_data_location_current=$(readlink -f /mnt/dietpi_userdata)
 
@@ -16713,7 +16647,7 @@ We allow it to take up to 30 minutes, it's process can be followed, please be pa
 
 			user_data_location_description="SD/eMMC | $user_data_location_current"
 
-		elif [[ $user_data_location_current == "$FP_DIETPI_DEDICATED_USBDRIVE" ]]; then
+		elif [[ $user_data_location_current == "$(findmnt -Ufnro TARGET -S /dev/sda1)" ]]; then
 
 			user_data_location_description="USB Drive | $user_data_location_current"
 
@@ -17248,12 +17182,10 @@ List of installed software and their online documentation URLs:
 		local i software_available_for_uninstall=0
 		for i in "${!aSOFTWARE_INSTALL_STATE[@]}"
 		do
-			if (( ${aSOFTWARE_INSTALL_STATE[$i]} == 2 )); then
+			(( ${aSOFTWARE_INSTALL_STATE[$i]} == 2 )) || continue
 
-				G_WHIP_CHECKLIST_ARRAY+=("$i" "${aSOFTWARE_NAME[$i]}: ${aSOFTWARE_DESC[$i]}" 'off')
-				software_available_for_uninstall=1
-
-			fi
+			G_WHIP_CHECKLIST_ARRAY+=("$i" "${aSOFTWARE_NAME[$i]}: ${aSOFTWARE_DESC[$i]}" 'off')
+			software_available_for_uninstall=1
 		done
 
 		# No software installed

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -179,8 +179,6 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 	DEPS_LIST=
 
 	# Special installation vars
-	WIFIHOTSPOT_RTL8188C_DEVICE=0
-	WIFIHOTSPOT_RTL8188C_PACKAGE=0
 	WIREGUARD_BUILTIN=0 # Is the WireGuard kernel module natively shipped by the kernel package?
 
 	# PHP version specific directories, APT package-, module- and command names
@@ -288,41 +286,41 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='LXDE'
 		aSOFTWARE_DESC[$software_id]='ultra lightweight desktop'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=0
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/desktop/#lxde'
-		aSOFTWARE_REQUIRES[$software_id]='5 6 browser'
+		aSOFTWARE_CATX[$software_id]=0
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/desktop/#lxde'
+		aSOFTWARE_DEPS[$software_id]='5 6 browser'
 		#------------------
 		software_id=173
 
 		aSOFTWARE_NAME[$software_id]='LXQt'
 		aSOFTWARE_DESC[$software_id]='lightweight desktop'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=0
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/desktop/#lxqt'
-		aSOFTWARE_REQUIRES[$software_id]='5 6 browser'
+		aSOFTWARE_CATX[$software_id]=0
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/desktop/#lxqt'
+		aSOFTWARE_DEPS[$software_id]='5 6 browser'
 		#------------------
 		software_id=24
 
 		aSOFTWARE_NAME[$software_id]='MATE'
 		aSOFTWARE_DESC[$software_id]='desktop enviroment'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=0
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/desktop/#mate'
-		aSOFTWARE_REQUIRES[$software_id]='5 6 browser'
+		aSOFTWARE_CATX[$software_id]=0
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/desktop/#mate'
+		aSOFTWARE_DEPS[$software_id]='5 6 browser'
 		#------------------
 		software_id=25
 
 		aSOFTWARE_NAME[$software_id]='Xfce'
 		aSOFTWARE_DESC[$software_id]='lightweight desktop'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=0
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/desktop/#xfce'
-		aSOFTWARE_REQUIRES[$software_id]='5 6 browser'
+		aSOFTWARE_CATX[$software_id]=0
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/desktop/#xfce'
+		aSOFTWARE_DEPS[$software_id]='5 6 browser'
 		#------------------
 		software_id=26
 
 		aSOFTWARE_NAME[$software_id]='GNUstep'
 		aSOFTWARE_DESC[$software_id]='lightweight desktop based on OpenStep'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=0
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/desktop/#gnustep'
-		aSOFTWARE_REQUIRES[$software_id]='5 6 browser'
+		aSOFTWARE_CATX[$software_id]=0
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/desktop/#gnustep'
+		aSOFTWARE_DEPS[$software_id]='5 6 browser'
 
 		# Remote Desktop
 		#--------------------------------------------------------------------------------
@@ -330,33 +328,33 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='TigerVNC Server'
 		aSOFTWARE_DESC[$software_id]='desktop for remote connection'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=1
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/remote_desktop/#tigervnc-server'
-		aSOFTWARE_REQUIRES[$software_id]='desktop'
+		aSOFTWARE_CATX[$software_id]=1
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/remote_desktop/#tigervnc-server'
+		aSOFTWARE_DEPS[$software_id]='desktop'
 		#------------------
 		software_id=29
 
 		aSOFTWARE_NAME[$software_id]='XRDP'
 		aSOFTWARE_DESC[$software_id]='remote desktop protocol (rdp) server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=1
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/remote_desktop/#xrdp'
-		aSOFTWARE_REQUIRES[$software_id]='desktop'
+		aSOFTWARE_CATX[$software_id]=1
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/remote_desktop/#xrdp'
+		aSOFTWARE_DEPS[$software_id]='desktop'
 		#------------------
 		software_id=30
 
 		aSOFTWARE_NAME[$software_id]='NoMachine'
 		aSOFTWARE_DESC[$software_id]='multi-platform server and client access'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=1
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/remote_desktop/#nomachine'
-		aSOFTWARE_REQUIRES[$software_id]='desktop'
+		aSOFTWARE_CATX[$software_id]=1
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/remote_desktop/#nomachine'
+		aSOFTWARE_DEPS[$software_id]='desktop'
 		#------------------
 		software_id=120
 
 		aSOFTWARE_NAME[$software_id]='RealVNC Server'
 		aSOFTWARE_DESC[$software_id]='desktop for remote connection'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=1
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/remote_desktop/#realvnc-server'
-		aSOFTWARE_REQUIRES[$software_id]='desktop'
+		aSOFTWARE_CATX[$software_id]=1
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/remote_desktop/#realvnc-server'
+		aSOFTWARE_DEPS[$software_id]='desktop'
 		# RPi only (archive.raspberrypi.org repo, libraspberrypi dependency, license)
 		for ((i=10; i<=$MAX_G_HW_MODEL; i++))
 		do
@@ -369,11 +367,11 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Kodi'
 		aSOFTWARE_DESC[$software_id]='the media centre for linux'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#kodi'
-		aSOFTWARE_REQUIRES[$software_id]='5 152'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#kodi'
+		aSOFTWARE_DEPS[$software_id]='5 152'
 		# Odroid N2+C4 have not GPU support for X server, hence it's not required for Kodi
-		[[ $G_HW_MODEL == 1[56] ]] || aSOFTWARE_REQUIRES[$software_id]+=' 6'
+		[[ $G_HW_MODEL == 1[56] ]] || aSOFTWARE_DEPS[$software_id]+=' 6'
 		# Only RPi + Odroid + x86_64
 		for ((i=22; i<=$MAX_G_HW_MODEL; i++))
 		do
@@ -393,41 +391,41 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='ympd'
 		aSOFTWARE_DESC[$software_id]='lightweight web interface music player for mpd'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#ympd'
-		aSOFTWARE_REQUIRES[$software_id]='5 128'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#ympd'
+		aSOFTWARE_DEPS[$software_id]='5 128'
 		#------------------
 		software_id=148
 
 		aSOFTWARE_NAME[$software_id]='myMPD'
 		aSOFTWARE_DESC[$software_id]='fork of ympd with improved features'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#mympd'
-		aSOFTWARE_REQUIRES[$software_id]='5 16 128'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#mympd'
+		aSOFTWARE_DEPS[$software_id]='5 16 128'
 		#------------------
 		software_id=119
 
 		aSOFTWARE_NAME[$software_id]='CAVA'
 		aSOFTWARE_DESC[$software_id]='optional: console audio vis for mpd'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#cava'
-		aSOFTWARE_REQUIRES[$software_id]='5 128'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#cava'
+		aSOFTWARE_DEPS[$software_id]='5 128'
 		#------------------
 		software_id=33
 
 		aSOFTWARE_NAME[$software_id]='Airsonic'
 		aSOFTWARE_DESC[$software_id]='web interface media streaming server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#airsonic'
-		aSOFTWARE_REQUIRES[$software_id]='5 7 8'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#airsonic'
+		aSOFTWARE_DEPS[$software_id]='5 7 8'
 		#------------------
 		software_id=34
 
 		aSOFTWARE_NAME[$software_id]='Subsonic'
 		aSOFTWARE_DESC[$software_id]='web interface media streaming server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#subsonic'
-		aSOFTWARE_REQUIRES[$software_id]='5 7 8'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#subsonic'
+		aSOFTWARE_DEPS[$software_id]='5 7 8'
 		# - Buster: https://github.com/MichaIng/DietPi/issues/2787
 		aSOFTWARE_AVAIL_G_DISTRO[$software_id,5]=0
 		aSOFTWARE_AVAIL_G_DISTRO[$software_id,6]=0
@@ -436,46 +434,46 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Logitech Media Server'
 		aSOFTWARE_DESC[$software_id]='aka SlimServer, SqueezeCenter, Squeezebox Server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#logitech-media-server'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#logitech-media-server'
 		#------------------
 		software_id=36
 
 		aSOFTWARE_NAME[$software_id]='Squeezelite'
 		aSOFTWARE_DESC[$software_id]='audio player for lms & squeezebox'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=1009#p1009'
-		aSOFTWARE_REQUIRES[$software_id]='5'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='p=1009#p1009'
+		aSOFTWARE_DEPS[$software_id]='5'
 		#------------------
 		software_id=37
 
 		aSOFTWARE_NAME[$software_id]='Shairport Sync'
 		aSOFTWARE_DESC[$software_id]='airplay audio player with multiroom sync'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#shairport-sync'
-		aSOFTWARE_REQUIRES[$software_id]='5 152'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#shairport-sync'
+		aSOFTWARE_DEPS[$software_id]='5 152'
 		#------------------
 		software_id=39
 
 		aSOFTWARE_NAME[$software_id]='ReadyMedia'
 		aSOFTWARE_DESC[$software_id]='(MiniDLNA) media streaming server (dlna, upnp)'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#readymedia'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#readymedia'
 		#------------------
 		software_id=40
 
 		aSOFTWARE_NAME[$software_id]='Ampache'
 		aSOFTWARE_DESC[$software_id]='web interface media streaming server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#ampache'
-		aSOFTWARE_REQUIRES[$software_id]='5 7 88 89 webserver'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#ampache'
+		aSOFTWARE_DEPS[$software_id]='5 7 88 89 webserver'
 		#------------------
 		software_id=41
 
 		aSOFTWARE_NAME[$software_id]='Emby'
 		aSOFTWARE_DESC[$software_id]='web interface media streaming server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#emby'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#emby'
 		# - ARMv6: https://github.com/MichaIng/DietPi/issues/534#issuecomment-416405968
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
 		#------------------
@@ -483,8 +481,8 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Plex Media Server'
 		aSOFTWARE_DESC[$software_id]='web interface media streaming server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#plex-media-server'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#plex-media-server'
 		# - ARMv6: https://github.com/MichaIng/DietPi/issues/648
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
 		#------------------
@@ -492,25 +490,25 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Murmur'
 		aSOFTWARE_DESC[$software_id]='mumble voip server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#murmur'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#murmur'
 		#------------------
 		software_id=118
 
 		aSOFTWARE_NAME[$software_id]='Mopidy'
 		aSOFTWARE_DESC[$software_id]='web interface music & radio player'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=3611#p3611'
-		aSOFTWARE_REQUIRES[$software_id]='5'
-		(( $G_DISTRO > 4 )) && aSOFTWARE_REQUIRES[$software_id]+=' 130'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='p=3611#p3611'
+		aSOFTWARE_DEPS[$software_id]='5'
+		(( $G_DISTRO > 4 )) && aSOFTWARE_DEPS[$software_id]+=' 130'
 		#------------------
 		software_id=121
 
 		aSOFTWARE_NAME[$software_id]='Roon Bridge'
 		aSOFTWARE_DESC[$software_id]='Turns device into Roon capable audio player'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#roon-bridge'
-		aSOFTWARE_REQUIRES[$software_id]='5'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#roon-bridge'
+		aSOFTWARE_DEPS[$software_id]='5'
 		# - ARMv6
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
 		#------------------
@@ -518,40 +516,40 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='NAA daemon'
 		aSOFTWARE_DESC[$software_id]='signalyst network audio adaptor (naa)'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#naa-daemon'
-		aSOFTWARE_REQUIRES[$software_id]='5'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#naa-daemon'
+		aSOFTWARE_DEPS[$software_id]='5'
 		#------------------
 		software_id=128
 
 		aSOFTWARE_NAME[$software_id]='MPD'
 		aSOFTWARE_DESC[$software_id]='music player daemon'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_REQUIRES[$software_id]='5 152'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DEPS[$software_id]='5 152'
 		#------------------
 		software_id=129
 
 		aSOFTWARE_NAME[$software_id]='O!MPD'
 		aSOFTWARE_DESC[$software_id]='feature-rich, web interface audio player for mpd'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#ompd'
-		aSOFTWARE_REQUIRES[$software_id]='5 88 89 128 webserver'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#ompd'
+		aSOFTWARE_DEPS[$software_id]='5 88 89 128 webserver'
 		#------------------
 		software_id=135
 
 		aSOFTWARE_NAME[$software_id]='IceCast'
 		aSOFTWARE_DESC[$software_id]='Shoutcast streaming server (+DarkIce)'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#icecast'
-		aSOFTWARE_REQUIRES[$software_id]='5'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#icecast'
+		aSOFTWARE_DEPS[$software_id]='5'
 		#------------------
 		software_id=141
 
 		aSOFTWARE_NAME[$software_id]='Spotify Connect Web'
 		aSOFTWARE_DESC[$software_id]='web interface for spotify premium'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#spotify-connect-web'
-		aSOFTWARE_REQUIRES[$software_id]='5'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#spotify-connect-web'
+		aSOFTWARE_DEPS[$software_id]='5'
 		# ARMv7 only
 		for ((i=1; i<=$MAX_G_HW_ARCH; i++))
 		do
@@ -563,25 +561,25 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Koel'
 		aSOFTWARE_DESC[$software_id]='web interface audio streamer'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#koel'
-		aSOFTWARE_REQUIRES[$software_id]='7 88 89'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#koel'
+		aSOFTWARE_DEPS[$software_id]='7 88 89'
 		#------------------
 		software_id=146
 
 		aSOFTWARE_NAME[$software_id]='Tautulli'
 		aSOFTWARE_DESC[$software_id]='monitoring and tracking tool for Plex'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#tautulli'
- 		aSOFTWARE_REQUIRES[$software_id]='17'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#tautulli'
+ 		aSOFTWARE_DEPS[$software_id]='17'
 		#------------------
 		software_id=154
 
 		aSOFTWARE_NAME[$software_id]='Roon Server'
 		aSOFTWARE_DESC[$software_id]='Roon capable audio player and core'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#roon-server'
-		aSOFTWARE_REQUIRES[$software_id]='5 7'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#roon-server'
+		aSOFTWARE_DEPS[$software_id]='5 7'
 		# x86_64 only
 		for ((i=1; i<=$MAX_G_HW_ARCH; i++))
 		do
@@ -593,31 +591,31 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Allo'
 		aSOFTWARE_DESC[$software_id]='web interface'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=-1
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/phpbb/viewtopic.php?t=2317'
-		aSOFTWARE_REQUIRES[$software_id]='5 36 37 65 88 89 96 121 124 128 129 152 163 webserver'
+		aSOFTWARE_CATX[$software_id]=-1
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/phpbb/viewtopic.php?t=2317'
+		aSOFTWARE_DEPS[$software_id]='5 36 37 65 88 89 96 121 124 128 129 152 163 webserver'
 		#------------------
 		software_id=160
 
 		aSOFTWARE_NAME[$software_id]='Allo_update'
 		aSOFTWARE_DESC[$software_id]='quick reinstall/update web only'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=-1
+		aSOFTWARE_CATX[$software_id]=-1
 		#------------------
 		software_id=163
 
 		aSOFTWARE_NAME[$software_id]='GMediaRender'
 		aSOFTWARE_DESC[$software_id]='Resource efficient UPnP/DLNA renderer'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#gmediarender'
-		aSOFTWARE_REQUIRES[$software_id]='5 152'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#gmediarender'
+		aSOFTWARE_DEPS[$software_id]='5 152'
 		#------------------
 		software_id=167
 
 		aSOFTWARE_NAME[$software_id]='Raspotify'
 		aSOFTWARE_DESC[$software_id]='spotify connect client'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#raspotify'
-		aSOFTWARE_REQUIRES[$software_id]='5'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#raspotify'
+		aSOFTWARE_DEPS[$software_id]='5'
 		# - ARMv8 - x86_64
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,3]=0
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,10]=0
@@ -626,32 +624,32 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Ubooquity'
 		aSOFTWARE_DESC[$software_id]='free home server for your comics and ebooks library'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#ubooquity'
-		aSOFTWARE_REQUIRES[$software_id]='8'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#ubooquity'
+		aSOFTWARE_DEPS[$software_id]='8'
 		#------------------
 		software_id=179
 
 		aSOFTWARE_NAME[$software_id]='Komga'
 		aSOFTWARE_DESC[$software_id]='Free and open source comics/mangas media server with web UI'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#komga'
-		aSOFTWARE_REQUIRES[$software_id]='8'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#komga'
+		aSOFTWARE_DEPS[$software_id]='8'
 		#------------------
 		software_id=86
 
 		aSOFTWARE_NAME[$software_id]='Roon Extension Manager'
 		aSOFTWARE_DESC[$software_id]='Manage extensions from within Roon'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#roon-extension-manager'
-		aSOFTWARE_REQUIRES[$software_id]='9 17'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#roon-extension-manager'
+		aSOFTWARE_DEPS[$software_id]='9 17'
 		#------------------
 		software_id=178
 
 		aSOFTWARE_NAME[$software_id]='Jellyfin'
 		aSOFTWARE_DESC[$software_id]='FOSS web interface media streaming server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=2
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/media/#jellyfin'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#jellyfin'
 		# - ARMv6: https://github.com/jellyfin/jellyfin/issues/5011
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
 
@@ -661,38 +659,38 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Transmission'
 		aSOFTWARE_DESC[$software_id]='bittorrent server with web interface (c)'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#transmission'
+		aSOFTWARE_CATX[$software_id]=3
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/bittorrent/#transmission'
 		#------------------
 		software_id=45
 
 		aSOFTWARE_NAME[$software_id]='Deluge'
 		aSOFTWARE_DESC[$software_id]='bittorrent server with web interface (python)'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#deluge'
+		aSOFTWARE_CATX[$software_id]=3
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/bittorrent/#deluge'
 		#------------------
 		software_id=46
 
 		aSOFTWARE_NAME[$software_id]='qBittorrent'
 		aSOFTWARE_DESC[$software_id]='bittorrent server with web interface (c++)'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='p=2272#p2272'
+		aSOFTWARE_CATX[$software_id]=3
+		aSOFTWARE_DOCS[$software_id]='p=2272#p2272'
 		#------------------
 		software_id=107
 
 		aSOFTWARE_NAME[$software_id]='rTorrent'
 		aSOFTWARE_DESC[$software_id]='bittorrent server with rutorrent web interface'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#rtorrent'
-		aSOFTWARE_REQUIRES[$software_id]='89 170 webserver'
+		aSOFTWARE_CATX[$software_id]=3
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/bittorrent/#rtorrent'
+		aSOFTWARE_DEPS[$software_id]='89 170 webserver'
 		#------------------
 		software_id=116
 
 		aSOFTWARE_NAME[$software_id]='Medusa'
 		aSOFTWARE_DESC[$software_id]='Automatic Video Library Manager for TV Shows'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#medusa'
-		aSOFTWARE_REQUIRES[$software_id]='170'
+		aSOFTWARE_CATX[$software_id]=3
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/bittorrent/#medusa'
+		aSOFTWARE_DEPS[$software_id]='170'
 		# - Stretch: Python 3 > 3.5 only: https://github.com/pymedusa/Medusa#dependencies
 		aSOFTWARE_AVAIL_G_DISTRO[$software_id,4]=0
 		#------------------
@@ -700,27 +698,27 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Aria2'
 		aSOFTWARE_DESC[$software_id]='download manager with web interface'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#arias'
-		aSOFTWARE_REQUIRES[$software_id]='87 89 webserver'
+		aSOFTWARE_CATX[$software_id]=3
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/bittorrent/#arias'
+		aSOFTWARE_DEPS[$software_id]='87 89 webserver'
 		#------------------
 		software_id=139
 
 		aSOFTWARE_NAME[$software_id]='SABnzbd'
 		aSOFTWARE_DESC[$software_id]='nzb download manager'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#sabnzbd'
-		aSOFTWARE_REQUIRES[$software_id]='130 170'
+		aSOFTWARE_CATX[$software_id]=3
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/bittorrent/#sabnzbd'
+		aSOFTWARE_DEPS[$software_id]='130 170'
 		# Pre-compiling required on ARM
-		(( $G_HW_ARCH > 9 )) || aSOFTWARE_REQUIRES[$software_id]+=' 16'
+		(( $G_HW_ARCH > 9 )) || aSOFTWARE_DEPS[$software_id]+=' 16'
 		#------------------
 		software_id=142
 
 		aSOFTWARE_NAME[$software_id]='CouchPotato'
 		aSOFTWARE_DESC[$software_id]='automatically download movies'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#couchpotato'
-		aSOFTWARE_REQUIRES[$software_id]='16 17'
+		aSOFTWARE_CATX[$software_id]=3
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/bittorrent/#couchpotato'
+		aSOFTWARE_DEPS[$software_id]='16 17'
 		# Python 2 only, hence not supported on Bullseye
 		aSOFTWARE_AVAIL_G_DISTRO[$software_id,6]=0
 		#------------------
@@ -728,38 +726,38 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Sonarr'
 		aSOFTWARE_DESC[$software_id]='automatically download TV shows'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#sonarr'
-		aSOFTWARE_REQUIRES[$software_id]='87 150'
+		aSOFTWARE_CATX[$software_id]=3
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/bittorrent/#sonarr'
+		aSOFTWARE_DEPS[$software_id]='87 150'
 		#------------------
 		software_id=145
 
 		aSOFTWARE_NAME[$software_id]='Radarr'
 		aSOFTWARE_DESC[$software_id]='automatically download movies'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#radarr'
-		aSOFTWARE_REQUIRES[$software_id]='87'
-		(( $G_HW_ARCH == 1 )) && aSOFTWARE_REQUIRES[$software_id]+=' 150'
+		aSOFTWARE_CATX[$software_id]=3
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/bittorrent/#radarr'
+		aSOFTWARE_DEPS[$software_id]='87'
+		(( $G_HW_ARCH == 1 )) && aSOFTWARE_DEPS[$software_id]+=' 150'
 		#------------------
 		software_id=106
 
 		aSOFTWARE_NAME[$software_id]='Lidarr'
 		aSOFTWARE_DESC[$software_id]='automatically download music'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#lidarr'
-		aSOFTWARE_REQUIRES[$software_id]='87 150'
+		aSOFTWARE_CATX[$software_id]=3
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/bittorrent/#lidarr'
+		aSOFTWARE_DEPS[$software_id]='87 150'
 		#------------------
 		software_id=180
 
 		aSOFTWARE_NAME[$software_id]='Bazarr'
 		aSOFTWARE_DESC[$software_id]='automatically download subtitles'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#bazarr'
-		aSOFTWARE_REQUIRES[$software_id]='17 130'
+		aSOFTWARE_CATX[$software_id]=3
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/bittorrent/#bazarr'
+		aSOFTWARE_DEPS[$software_id]='17 130'
 		# FFmpeg required on ARM, x86_64 binaries are shipped with the Bazarr repo: https://github.com/morpheus65535/bazarr/tree/master/bin/Linux
 		# build-essential required on ARM to assure all required Python modules build successfully: https://github.com/MichaIng/DietPi/pull/3796#issuecomment-706768323
-		(( $G_HW_MODEL == 10 )) || aSOFTWARE_REQUIRES[$software_id]+=' 7 16'
-		(( $G_HW_ARCH < 3 )) && aSOFTWARE_REQUIRES[$software_id]+=' 170'
+		(( $G_HW_MODEL == 10 )) || aSOFTWARE_DEPS[$software_id]+=' 7 16'
+		(( $G_HW_ARCH < 3 )) && aSOFTWARE_DEPS[$software_id]+=' 170'
 		# - Stretch due to Python >= 3.7.0 requirement
 		aSOFTWARE_AVAIL_G_DISTRO[$software_id,4]=0
 		#------------------
@@ -767,24 +765,24 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Jackett'
 		aSOFTWARE_DESC[$software_id]='API support for your torrent trackers'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#jackett'
-		(( $G_HW_ARCH == 1 )) && aSOFTWARE_REQUIRES[$software_id]='150'
+		aSOFTWARE_CATX[$software_id]=3
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/bittorrent/#jackett'
+		(( $G_HW_ARCH == 1 )) && aSOFTWARE_DEPS[$software_id]='150'
 		#------------------
 		software_id=149
 
 		aSOFTWARE_NAME[$software_id]='NZBGet'
 		aSOFTWARE_DESC[$software_id]='nzb download manager'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#nzbget'
+		aSOFTWARE_CATX[$software_id]=3
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/bittorrent/#nzbget'
 		#------------------
 		software_id=155
 
 		aSOFTWARE_NAME[$software_id]='HTPC Manager'
 		aSOFTWARE_DESC[$software_id]='manage your HTPC from anywhere'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=3
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/bittorrent/#htpc-manager'
-		aSOFTWARE_REQUIRES[$software_id]='16 17 130'
+		aSOFTWARE_CATX[$software_id]=3
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/bittorrent/#htpc-manager'
+		aSOFTWARE_DEPS[$software_id]='16 17 130'
 
 		# Cloud & Backup
 		#--------------------------------------------------------------------------------
@@ -792,25 +790,25 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='ownCloud'
 		aSOFTWARE_DESC[$software_id]='File sync, sharing and collaboration platform'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#owncloud'
-		aSOFTWARE_REQUIRES[$software_id]='88 89 91 webserver'
+		aSOFTWARE_CATX[$software_id]=4
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/cloud/#owncloud'
+		aSOFTWARE_DEPS[$software_id]='88 89 91 webserver'
 		#------------------
 		software_id=114
 
 		aSOFTWARE_NAME[$software_id]='Nextcloud'
 		aSOFTWARE_DESC[$software_id]='File sync, sharing and collaboration platform'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#nextcloud'
-		aSOFTWARE_REQUIRES[$software_id]='88 89 91 webserver'
+		aSOFTWARE_CATX[$software_id]=4
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/cloud/#nextcloud'
+		aSOFTWARE_DEPS[$software_id]='88 89 91 webserver'
 		#------------------
 		software_id=168
 
 		aSOFTWARE_NAME[$software_id]='Nextcloud Talk'
 		aSOFTWARE_DESC[$software_id]='Video calls with configured coTURN server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#nextcloud-talk'
-		aSOFTWARE_REQUIRES[$software_id]='114'
+		aSOFTWARE_CATX[$software_id]=4
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/cloud/#nextcloud-talk'
+		aSOFTWARE_DEPS[$software_id]='114'
 		# Currently requires manual domain and coTURN server port input.
 		# - To resolve: Default port 5349 could be used, but reliable method to get external domain/static IP is required.
 		aSOFTWARE_REQUIRES_USERINPUT[$software_id]=1
@@ -819,16 +817,16 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Pydio'
 		aSOFTWARE_DESC[$software_id]='feature-rich backup and sync server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#pydio'
-		aSOFTWARE_REQUIRES[$software_id]='88 89 webserver'
+		aSOFTWARE_CATX[$software_id]=4
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/cloud/#pydio'
+		aSOFTWARE_DEPS[$software_id]='88 89 webserver'
 		#------------------
 		software_id=111
 
 		aSOFTWARE_NAME[$software_id]='UrBackup Server'
 		aSOFTWARE_DESC[$software_id]='full system backup server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#urbackup'
+		aSOFTWARE_CATX[$software_id]=4
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/cloud/#urbackup'
 		# - ARMv6
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
 		#------------------
@@ -836,30 +834,30 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Gogs'
 		aSOFTWARE_DESC[$software_id]='personal github server with web interface'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#gogs'
-		aSOFTWARE_REQUIRES[$software_id]='17 88'
+		aSOFTWARE_CATX[$software_id]=4
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/cloud/#gogs'
+		aSOFTWARE_DEPS[$software_id]='17 88'
 		#------------------
 		software_id=50
 
 		aSOFTWARE_NAME[$software_id]='Syncthing'
 		aSOFTWARE_DESC[$software_id]='backup and sync server with web interface'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#syncthing'
+		aSOFTWARE_CATX[$software_id]=4
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/cloud/#syncthing'
 		#------------------
 		software_id=158
 
 		aSOFTWARE_NAME[$software_id]='MinIO'
 		aSOFTWARE_DESC[$software_id]='S3 compatible distributed object server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#minio'
+		aSOFTWARE_CATX[$software_id]=4
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/cloud/#minio'
 		#------------------
 		software_id=161
 
 		aSOFTWARE_NAME[$software_id]='FuguHub'
 		aSOFTWARE_DESC[$software_id]='Lightweight WebDAV cloud (eg: dropbox) with a CMS'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#fuguhub'
+		aSOFTWARE_CATX[$software_id]=4
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/cloud/#fuguhub'
 		# - ARMv8
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,3]=0
 		#------------------
@@ -867,17 +865,17 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Gitea'
 		aSOFTWARE_DESC[$software_id]='Git with a cup of tea'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#gitea'
-		aSOFTWARE_REQUIRES[$software_id]='17 88'
+		aSOFTWARE_CATX[$software_id]=4
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/cloud/#gitea'
+		aSOFTWARE_DEPS[$software_id]='17 88'
 		#------------------
 		software_id=177
 
 		aSOFTWARE_NAME[$software_id]='Firefox Sync Server'
 		aSOFTWARE_DESC[$software_id]='Sync bookmarks, tabs, history & passwords'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#firefox-sync-server'
-		aSOFTWARE_REQUIRES[$software_id]='16 87'
+		aSOFTWARE_CATX[$software_id]=4
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/cloud/#firefox-sync-server'
+		aSOFTWARE_DEPS[$software_id]='16 87'
 		# Python 2 only, hence not supported on Bullseye
 		aSOFTWARE_AVAIL_G_DISTRO[$software_id,6]=0
 		#------------------
@@ -885,9 +883,9 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='vaultwarden'
 		aSOFTWARE_DESC[$software_id]='Unofficial Bitwarden password manager server written in Rust'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#vaultwarden'
-		aSOFTWARE_REQUIRES[$software_id]='16 87'
+		aSOFTWARE_CATX[$software_id]=4
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/cloud/#vaultwarden'
+		aSOFTWARE_DEPS[$software_id]='16 87'
 
 		# Gaming & Emulation
 		#--------------------------------------------------------------------------------
@@ -895,9 +893,9 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Amiberry'
 		aSOFTWARE_DESC[$software_id]='Optimised Amiga emulator for ARM-based SoCs'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=5
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/gaming/#amiberry'
-		aSOFTWARE_REQUIRES[$software_id]='5'
+		aSOFTWARE_CATX[$software_id]=5
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/gaming/#amiberry'
+		aSOFTWARE_DEPS[$software_id]='5'
 		# RPi only
 		for ((i=10; i<=$MAX_G_HW_MODEL; i++))
 		do
@@ -912,9 +910,9 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='OpenTyrian'
 		aSOFTWARE_DESC[$software_id]='a classic retro game, addictive'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=5
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/gaming/#opentyrian'
-		aSOFTWARE_REQUIRES[$software_id]='5 6'
+		aSOFTWARE_CATX[$software_id]=5
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/gaming/#opentyrian'
+		aSOFTWARE_DEPS[$software_id]='5 6'
 		# RPi only
 		for ((i=10; i<=$MAX_G_HW_MODEL; i++))
 		do
@@ -927,9 +925,9 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='DXX-Rebirth'
 		aSOFTWARE_DESC[$software_id]='Descent 1/2'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=5
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/gaming/#dxx-rebirth'
-		aSOFTWARE_REQUIRES[$software_id]='5'
+		aSOFTWARE_CATX[$software_id]=5
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/gaming/#dxx-rebirth'
+		aSOFTWARE_DEPS[$software_id]='5'
 		# RPi only
 		for ((i=10; i<=$MAX_G_HW_MODEL; i++))
 		do
@@ -940,8 +938,8 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Cuberite'
 		aSOFTWARE_DESC[$software_id]='Minecraft server with web interface (C++)'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=5
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/gaming/#cuberite'
+		aSOFTWARE_CATX[$software_id]=5
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/gaming/#cuberite'
 		# - ARMv8
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,3]=0
 		#------------------
@@ -949,19 +947,19 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='MineOS'
 		aSOFTWARE_DESC[$software_id]='Minecraft servers with web interface (Java/Node.js)'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=5
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/gaming/#mineos'
-		aSOFTWARE_REQUIRES[$software_id]='8 9 16 17'
+		aSOFTWARE_CATX[$software_id]=5
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/gaming/#mineos'
+		aSOFTWARE_DEPS[$software_id]='8 9 16 17'
 		#------------------
 		software_id=156
 
 		aSOFTWARE_NAME[$software_id]='Steam'
 		aSOFTWARE_DESC[$software_id]='Valve gaming platform client'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=5
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/gaming/#steam'
-		aSOFTWARE_REQUIRES[$software_id]='5 6 desktop'
+		aSOFTWARE_CATX[$software_id]=5
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/gaming/#steam'
+		aSOFTWARE_DEPS[$software_id]='5 6 desktop'
 		# Box86 required on ARM
-		(( $G_HW_ARCH == 2 )) && aSOFTWARE_REQUIRES[$software_id]+=' 62'
+		(( $G_HW_ARCH == 2 )) && aSOFTWARE_DEPS[$software_id]+=' 62'
 		# x86_64 and ARMv7 only
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,3]=0
@@ -970,17 +968,17 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Nukkit'
 		aSOFTWARE_DESC[$software_id]='A nuclear-powered server for Minecraft Pocket Edition'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=5
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/gaming/#nukkit'
-		aSOFTWARE_REQUIRES[$software_id]='8'
+		aSOFTWARE_CATX[$software_id]=5
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/gaming/#nukkit'
+		aSOFTWARE_DEPS[$software_id]='8'
 		#------------------
 		software_id=181
 
 		aSOFTWARE_NAME[$software_id]='PaperMC'
 		aSOFTWARE_DESC[$software_id]='Highly optimised Minecraft server with plugins, written in Java'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=5
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/gaming/#papermc'
-		aSOFTWARE_REQUIRES[$software_id]='8 9'
+		aSOFTWARE_CATX[$software_id]=5
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/gaming/#papermc'
+		aSOFTWARE_DEPS[$software_id]='8 9'
 		aSOFTWARE_REQUIRES_USERINPUT[$software_id]=1
 
 		#------------------
@@ -988,9 +986,9 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Box86'
 		aSOFTWARE_DESC[$software_id]='x86 userspace emulation'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=5
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/gaming/#box86'
-		aSOFTWARE_REQUIRES[$software_id]='16'
+		aSOFTWARE_CATX[$software_id]=5
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/gaming/#box86'
+		aSOFTWARE_DEPS[$software_id]='16'
 		# Only works on ARMv7
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,3]=0
@@ -1002,50 +1000,50 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='phpBB'
 		aSOFTWARE_DESC[$software_id]='bulletin board forum software'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=6
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/social/#phpbb'
-		aSOFTWARE_REQUIRES[$software_id]='88 89 webserver'
+		aSOFTWARE_CATX[$software_id]=6
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/social/#phpbb'
+		aSOFTWARE_DEPS[$software_id]='88 89 webserver'
 		#------------------
 		software_id=55
 
 		aSOFTWARE_NAME[$software_id]='Wordpress'
 		aSOFTWARE_DESC[$software_id]='website blog and publishing platform'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=6
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/social/#wordpress'
-		aSOFTWARE_REQUIRES[$software_id]='88 89 webserver'
+		aSOFTWARE_CATX[$software_id]=6
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/social/#wordpress'
+		aSOFTWARE_DEPS[$software_id]='88 89 webserver'
 		#------------------
 		software_id=38
 
 		aSOFTWARE_NAME[$software_id]='FreshRSS'
 		aSOFTWARE_DESC[$software_id]='self-hosted RSS feed aggregator'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=6
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/social/#freshrss'
-		aSOFTWARE_REQUIRES[$software_id]='88 89 webserver'
+		aSOFTWARE_CATX[$software_id]=6
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/social/#freshrss'
+		aSOFTWARE_DEPS[$software_id]='88 89 webserver'
 		#------------------
 		software_id=56
 
 		aSOFTWARE_NAME[$software_id]='Single File PHP Gallery'
 		aSOFTWARE_DESC[$software_id]='website to host and browse your images'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=6
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/social/#single-file-php-gallery'
-		aSOFTWARE_REQUIRES[$software_id]='89 webserver'
+		aSOFTWARE_CATX[$software_id]=6
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/social/#single-file-php-gallery'
+		aSOFTWARE_DEPS[$software_id]='89 webserver'
 		#------------------
 		software_id=57
 
 		aSOFTWARE_NAME[$software_id]='Baïkal'
 		aSOFTWARE_DESC[$software_id]='lightweight caldav + carddav server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=6
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/social/#baikal'
-		aSOFTWARE_REQUIRES[$software_id]='88 89 webserver'
+		aSOFTWARE_CATX[$software_id]=6
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/social/#baikal'
+		aSOFTWARE_DEPS[$software_id]='88 89 webserver'
 		#------------------
 		software_id=58
 
 		aSOFTWARE_NAME[$software_id]='OpenBazaar'
 		aSOFTWARE_DESC[$software_id]='decentralised peer to peer bitcoin market'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=6
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/social/#openbazaar'
-		aSOFTWARE_REQUIRES[$software_id]='188'
-		(( $G_HW_ARCH == 10 )) || aSOFTWARE_REQUIRES[$software_id]+=' 16'
+		aSOFTWARE_CATX[$software_id]=6
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/social/#openbazaar'
+		aSOFTWARE_DEPS[$software_id]='188'
+		(( $G_HW_ARCH == 10 )) || aSOFTWARE_DEPS[$software_id]+=' 16'
 		aSOFTWARE_REQUIRES_USERINPUT[$software_id]=1
 
 		# Camera & Surveillance
@@ -1054,9 +1052,9 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='RPi Cam Control'
 		aSOFTWARE_DESC[$software_id]='Web interface & controls for your RPi camera'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=7
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/camera/#rpi-cam-control'
-		aSOFTWARE_REQUIRES[$software_id]='89 webserver'
+		aSOFTWARE_CATX[$software_id]=7
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/camera/#rpi-cam-control'
+		aSOFTWARE_DEPS[$software_id]='89 webserver'
 		# RPi only
 		for ((i=10; i<=$MAX_G_HW_MODEL; i++))
 		do
@@ -1069,9 +1067,9 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='MotionEye'
 		aSOFTWARE_DESC[$software_id]='Web interface & surveillance for your camera'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=7
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/camera/#motioneye'
- 		aSOFTWARE_REQUIRES[$software_id]='7 16'
+		aSOFTWARE_CATX[$software_id]=7
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/camera/#motioneye'
+ 		aSOFTWARE_DEPS[$software_id]='7 16'
 		# Python 2 only, hence not supported on Bullseye
 		aSOFTWARE_AVAIL_G_DISTRO[$software_id,6]=0
 		#------------------
@@ -1079,8 +1077,8 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='mjpg-streamer'
 		aSOFTWARE_DESC[$software_id]='Simple camera streaming tool with HTML plugin'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=7
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/camera/#mjpg-streamer'
+		aSOFTWARE_CATX[$software_id]=7
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/camera/#mjpg-streamer'
 
 		# System Stats & Management
 		#--------------------------------------------------------------------------------
@@ -1088,33 +1086,33 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='LinuxDash'
 		aSOFTWARE_DESC[$software_id]='web interface system stats'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=8
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/system_stats/#linuxdash'
-		aSOFTWARE_REQUIRES[$software_id]='89 webserver'
+		aSOFTWARE_CATX[$software_id]=8
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/system_stats/#linuxdash'
+		aSOFTWARE_DEPS[$software_id]='89 webserver'
 		#------------------
 		software_id=64
 
 		aSOFTWARE_NAME[$software_id]='phpSysInfo'
 		aSOFTWARE_DESC[$software_id]='web interface system stats'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=8
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/system_stats/#phpsysinfo'
-		aSOFTWARE_REQUIRES[$software_id]='89 webserver'
+		aSOFTWARE_CATX[$software_id]=8
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/system_stats/#phpsysinfo'
+		aSOFTWARE_DEPS[$software_id]='89 webserver'
 		#------------------
 		software_id=65
 
 		aSOFTWARE_NAME[$software_id]='Netdata'
 		aSOFTWARE_DESC[$software_id]='real-time performance monitoring'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=8
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/system_stats/#netdata'
+		aSOFTWARE_CATX[$software_id]=8
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/system_stats/#netdata'
 		# Node.js only required for our custom v1.11 package for Stretch ARMv6 RPi
-		(( $G_HW_ARCH == 1 && $G_DISTRO < 5 )) && aSOFTWARE_REQUIRES[$software_id]='9'
+		(( $G_HW_ARCH == 1 && $G_DISTRO < 5 )) && aSOFTWARE_DEPS[$software_id]='9'
 		#------------------
 		software_id=66
 
 		aSOFTWARE_NAME[$software_id]='RPi-Monitor'
 		aSOFTWARE_DESC[$software_id]='web interface system stats'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=8
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/system_stats/#rpi-monitor'
+		aSOFTWARE_CATX[$software_id]=8
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/system_stats/#rpi-monitor'
 		# RPi only
 		for ((i=10; i<=$MAX_G_HW_MODEL; i++))
 		do
@@ -1125,31 +1123,31 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Webmin'
 		aSOFTWARE_DESC[$software_id]='web interface system management'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=8
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/system_stats/#webmin'
+		aSOFTWARE_CATX[$software_id]=8
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/system_stats/#webmin'
 		#------------------
 		software_id=162
 
 		aSOFTWARE_NAME[$software_id]='Docker'
 		aSOFTWARE_DESC[$software_id]='Build, ship, and run distributed applications'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=8
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/programming/#docker'
+		aSOFTWARE_CATX[$software_id]=8
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/programming/#docker'
 		#------------------
 		software_id=185
 
 		aSOFTWARE_NAME[$software_id]='Portainer'
 		aSOFTWARE_DESC[$software_id]='Simplifies container management in Docker (standalone host)'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=8
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/programming/#portainer'
-		aSOFTWARE_REQUIRES[$software_id]='162'
+		aSOFTWARE_CATX[$software_id]=8
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/programming/#portainer'
+		aSOFTWARE_DEPS[$software_id]='162'
 		#------------------
 		software_id=134
 
 		aSOFTWARE_NAME[$software_id]='Docker Compose'
 		aSOFTWARE_DESC[$software_id]='Manage multi-container Docker applications'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=8
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/programming/#docker-compose'
-		aSOFTWARE_REQUIRES[$software_id]='130 162'
+		aSOFTWARE_CATX[$software_id]=8
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/programming/#docker-compose'
+		aSOFTWARE_DEPS[$software_id]='130 162'
 
 		# Remote Access
 		#--------------------------------------------------------------------------------
@@ -1157,16 +1155,16 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Remot3.it'
 		aSOFTWARE_DESC[$software_id]='(aka Weaved) access your device over the internet'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=9
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/remote_desktop/#remot3it'
+		aSOFTWARE_CATX[$software_id]=9
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/remote_desktop/#remot3it'
 		#------------------
 		software_id=138
 
 		aSOFTWARE_NAME[$software_id]='VirtualHere'
 		aSOFTWARE_DESC[$software_id]='server: share USB devices over the network'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=9
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/remote_desktop/#virtualhere'
-		aSOFTWARE_REQUIRES[$software_id]='152'
+		aSOFTWARE_CATX[$software_id]=9
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/remote_desktop/#virtualhere'
+		aSOFTWARE_DEPS[$software_id]='152'
 
 		# Hardware Projects
 		#--------------------------------------------------------------------------------
@@ -1174,8 +1172,8 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Python 3 RPi.GPIO'
 		aSOFTWARE_DESC[$software_id]='Control Raspberry Pi GPIO channels in Python 3'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#rpigpio'
+		aSOFTWARE_CATX[$software_id]=10
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/hardware_projects/#rpigpio'
 		# RPi only
 		for ((i=10; i<=$MAX_G_HW_MODEL; i++))
 		do
@@ -1186,9 +1184,9 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='WiringPi'
 		aSOFTWARE_DESC[$software_id]='GPIO interface library (C)'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#wiringpi'
-		aSOFTWARE_REQUIRES[$software_id]='16'
+		aSOFTWARE_CATX[$software_id]=10
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/hardware_projects/#wiringpi'
+		aSOFTWARE_DEPS[$software_id]='16'
 		# RPi + Odroids only
 		for ((i=20; i<=$MAX_G_HW_MODEL; i++))
 		do
@@ -1202,9 +1200,9 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='WebIOPi'
 		aSOFTWARE_DESC[$software_id]='Web interface to control RPi GPIO channels'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#webiopi'
-		aSOFTWARE_REQUIRES[$software_id]='16 69'
+		aSOFTWARE_CATX[$software_id]=10
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/hardware_projects/#webiopi'
+		aSOFTWARE_DEPS[$software_id]='16 69'
 		# RPi only
 		for ((i=10; i<=$MAX_G_HW_MODEL; i++))
 		do
@@ -1215,7 +1213,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='I2C'
 		aSOFTWARE_DESC[$software_id]='enables support for i2c based hardware'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
+		aSOFTWARE_CATX[$software_id]=10
 		# RPi only
 		for ((i=10; i<=$MAX_G_HW_MODEL; i++))
 		do
@@ -1226,9 +1224,9 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='PiJuice'
 		aSOFTWARE_DESC[$software_id]='pisupply ups'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#pijuice'
-		aSOFTWARE_REQUIRES[$software_id]='72'
+		aSOFTWARE_CATX[$software_id]=10
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/hardware_projects/#pijuice'
+		aSOFTWARE_DEPS[$software_id]='72'
 		# RPi only
 		for ((i=10; i<=$MAX_G_HW_MODEL; i++))
 		do
@@ -1239,32 +1237,32 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Node-RED'
 		aSOFTWARE_DESC[$software_id]='tool for wiring devices, APIs and online services'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#node-red'
-		aSOFTWARE_REQUIRES[$software_id]='9 16 69'
+		aSOFTWARE_CATX[$software_id]=10
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/hardware_projects/#node-red'
+		aSOFTWARE_DEPS[$software_id]='9 16 69'
 		#------------------
 		software_id=123
 
 		aSOFTWARE_NAME[$software_id]='Mosquitto'
 		aSOFTWARE_DESC[$software_id]='MQTT messaging broker'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#mosquitto'
+		aSOFTWARE_CATX[$software_id]=10
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/hardware_projects/#mosquitto'
 		#------------------
 		software_id=131
 
 		aSOFTWARE_NAME[$software_id]='Blynk Server'
 		aSOFTWARE_DESC[$software_id]='msg controller for blynk mobile app and sbcs'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#blynk-server'
-		aSOFTWARE_REQUIRES[$software_id]='8 9 16'
+		aSOFTWARE_CATX[$software_id]=10
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/hardware_projects/#blynk-server'
+		aSOFTWARE_DEPS[$software_id]='8 9 16'
 		#------------------
 		software_id=166
 
 		aSOFTWARE_NAME[$software_id]='Audiophonics PI-SPC'
 		aSOFTWARE_DESC[$software_id]='Raspberry Pi power management module'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#audiophonics-pi-spc'
-		aSOFTWARE_REQUIRES[$software_id]='70'
+		aSOFTWARE_CATX[$software_id]=10
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/hardware_projects/#audiophonics-pi-spc'
+		aSOFTWARE_DEPS[$software_id]='70'
 		# RPi only
 		for ((i=10; i<=$MAX_G_HW_MODEL; i++))
 		do
@@ -1275,9 +1273,9 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Google AIY'
 		aSOFTWARE_DESC[$software_id]='voice kit'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#google-aiy'
-		aSOFTWARE_REQUIRES[$software_id]='5 17 69 130'
+		aSOFTWARE_CATX[$software_id]=10
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/hardware_projects/#google-aiy'
+		aSOFTWARE_DEPS[$software_id]='5 17 69 130'
 		# RPi only
 		for ((i=10; i<=$MAX_G_HW_MODEL; i++))
 		do
@@ -1288,17 +1286,17 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Mycroft AI'
 		aSOFTWARE_DESC[$software_id]='Open Source Voice Assistant'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#mycroft-ai'
-		aSOFTWARE_REQUIRES[$software_id]='5 17'
+		aSOFTWARE_CATX[$software_id]=10
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/hardware_projects/#mycroft-ai'
+		aSOFTWARE_DEPS[$software_id]='5 17'
 		aSOFTWARE_REQUIRES_USERINPUT[$software_id]=1
 		#------------------
 		software_id=77
 
 		aSOFTWARE_NAME[$software_id]='Grafana'
 		aSOFTWARE_DESC[$software_id]='platform for analytics and monitoring'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=10
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/hardware_projects/#grafana'
+		aSOFTWARE_CATX[$software_id]=10
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/hardware_projects/#grafana'
 
 		# System Security
 		#--------------------------------------------------------------------------------
@@ -1306,8 +1304,8 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Fail2Ban'
 		aSOFTWARE_DESC[$software_id]='prevents brute-force attacks with ip ban'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=11
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/system_security/#fail2ban'
+		aSOFTWARE_CATX[$software_id]=11
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/system_security/#fail2ban'
 
 		# Webserver Stacks
 		#--------------------------------------------------------------------------------
@@ -1315,95 +1313,95 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='LASP'
 		aSOFTWARE_DESC[$software_id]='Apache2  | SQLite  | PHP'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=12
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/webserver_stack/#lasp-web-stack'
-		aSOFTWARE_REQUIRES[$software_id]='83 87 89'
+		aSOFTWARE_CATX[$software_id]=12
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/webserver_stack/#lasp-web-stack'
+		aSOFTWARE_DEPS[$software_id]='83 87 89'
 		#------------------
 		software_id=76
 
 		aSOFTWARE_NAME[$software_id]='LAMP'
 		aSOFTWARE_DESC[$software_id]='Apache2  | MariaDB | PHP'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=12
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/webserver_stack/#lamp-web-stack'
-		aSOFTWARE_REQUIRES[$software_id]='83 88 89'
+		aSOFTWARE_CATX[$software_id]=12
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/webserver_stack/#lamp-web-stack'
+		aSOFTWARE_DEPS[$software_id]='83 88 89'
 		#------------------
 		software_id=78
 
 		aSOFTWARE_NAME[$software_id]='LESP'
 		aSOFTWARE_DESC[$software_id]='Nginx    | SQLite  | PHP'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=12
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/webserver_stack/#lesp-web-stack'
-		aSOFTWARE_REQUIRES[$software_id]='85 87 89'
+		aSOFTWARE_CATX[$software_id]=12
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/webserver_stack/#lesp-web-stack'
+		aSOFTWARE_DEPS[$software_id]='85 87 89'
 		#------------------
 		software_id=79
 
 		aSOFTWARE_NAME[$software_id]='LEMP'
 		aSOFTWARE_DESC[$software_id]='Nginx    | MariaDB | PHP'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=12
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/webserver_stack/#lemp-web-stack'
-		aSOFTWARE_REQUIRES[$software_id]='85 88 89'
+		aSOFTWARE_CATX[$software_id]=12
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/webserver_stack/#lemp-web-stack'
+		aSOFTWARE_DEPS[$software_id]='85 88 89'
 		#------------------
 		software_id=81
 
 		aSOFTWARE_NAME[$software_id]='LLSP'
 		aSOFTWARE_DESC[$software_id]='Lighttpd | SQLite  | PHP'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=12
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/webserver_stack/#llsp-web-stack'
-		aSOFTWARE_REQUIRES[$software_id]='84 87 89'
+		aSOFTWARE_CATX[$software_id]=12
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/webserver_stack/#llsp-web-stack'
+		aSOFTWARE_DEPS[$software_id]='84 87 89'
 		#------------------
 		software_id=82
 
 		aSOFTWARE_NAME[$software_id]='LLMP'
 		aSOFTWARE_DESC[$software_id]='Lighttpd | MariaDB | PHP'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=12
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/webserver_stack/#llmp-web-stack'
-		aSOFTWARE_REQUIRES[$software_id]='84 88 89'
+		aSOFTWARE_CATX[$software_id]=12
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/webserver_stack/#llmp-web-stack'
+		aSOFTWARE_DEPS[$software_id]='84 88 89'
 		#------------------
 		software_id=83
 
 		aSOFTWARE_NAME[$software_id]='Apache2'
 		aSOFTWARE_DESC[$software_id]='Popular webserver'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=-1
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/webserver_stack/#apache2'
-		aSOFTWARE_REQUIRES[$software_id]='89'
+		aSOFTWARE_CATX[$software_id]=-1
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/webserver_stack/#apache2'
+		aSOFTWARE_DEPS[$software_id]='89'
 		#------------------
 		software_id=84
 
 		aSOFTWARE_NAME[$software_id]='Lighttpd'
 		aSOFTWARE_DESC[$software_id]='Extremely lightweight webserver'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=-1
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/webserver_stack/#lighttpd'
-		aSOFTWARE_REQUIRES[$software_id]='89'
+		aSOFTWARE_CATX[$software_id]=-1
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/webserver_stack/#lighttpd'
+		aSOFTWARE_DEPS[$software_id]='89'
 		#------------------
 		software_id=85
 
 		aSOFTWARE_NAME[$software_id]='Nginx'
 		aSOFTWARE_DESC[$software_id]='Lightweight webserver'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=-1
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/webserver_stack/#nginx'
-		aSOFTWARE_REQUIRES[$software_id]='89'
+		aSOFTWARE_CATX[$software_id]=-1
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/webserver_stack/#nginx'
+		aSOFTWARE_DEPS[$software_id]='89'
 		#------------------
 		software_id=89
 
 		aSOFTWARE_NAME[$software_id]='PHP'
 		aSOFTWARE_DESC[$software_id]='Hypertext Preprocessor for dynamic web content'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=-1
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/webserver_stack/#php'
+		aSOFTWARE_CATX[$software_id]=-1
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/webserver_stack/#php'
 		#------------------
 		software_id=92
 
 		aSOFTWARE_NAME[$software_id]='Certbot'
 		aSOFTWARE_DESC[$software_id]="Obtain and renew Let's Encrypt SSL certs for HTTPS"
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=12
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/system_security/#lets-encrypt'
+		aSOFTWARE_CATX[$software_id]=12
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/system_security/#lets-encrypt'
 		#------------------
 		software_id=125
 
 		aSOFTWARE_NAME[$software_id]='Tomcat8'
 		aSOFTWARE_DESC[$software_id]='apache tomcat server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=12
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/webserver_stack/#tomcat'
-		aSOFTWARE_REQUIRES[$software_id]='8'
+		aSOFTWARE_CATX[$software_id]=12
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/webserver_stack/#tomcat'
+		aSOFTWARE_DEPS[$software_id]='8'
 		# - non-Raspbian Buster: https://packages.debian.org/tomcat8
 		(( $G_HW_MODEL > 9 )) || (( ! $G_RASPBIAN )) && aSOFTWARE_AVAIL_G_DISTRO[$software_id,5]=0 aSOFTWARE_AVAIL_G_DISTRO[$software_id,6]=0
 
@@ -1413,17 +1411,17 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Pi-hole'
 		aSOFTWARE_DESC[$software_id]='block adverts for any device on your network'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=13
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/dns_servers/#pi-hole'
-		aSOFTWARE_REQUIRES[$software_id]='17 87 89 webserver'
+		aSOFTWARE_CATX[$software_id]=13
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/dns_servers/#pi-hole'
+		aSOFTWARE_DEPS[$software_id]='17 87 89 webserver'
 		aSOFTWARE_REQUIRES_USERINPUT[$software_id]=1
 		#------------------
 		software_id=182
 
 		aSOFTWARE_NAME[$software_id]='Unbound'
 		aSOFTWARE_DESC[$software_id]='validating, recursive, caching DNS resolver'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=13
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/dns_servers/#unbound'
+		aSOFTWARE_CATX[$software_id]=13
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/dns_servers/#unbound'
 
 		# File Servers
 		#--------------------------------------------------------------------------------
@@ -1431,29 +1429,29 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='ProFTPD'
 		aSOFTWARE_DESC[$software_id]='Efficient, lightweight FTP server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=14
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/file_servers/#proftpd'
+		aSOFTWARE_CATX[$software_id]=14
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/file_servers/#proftpd'
 		#------------------
 		software_id=95
 
 		aSOFTWARE_NAME[$software_id]='vsftpd'
 		aSOFTWARE_DESC[$software_id]='Alternative FTP server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=14
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/file_servers/#vsftpd'
+		aSOFTWARE_CATX[$software_id]=14
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/file_servers/#vsftpd'
 		#------------------
 		software_id=96
 
 		aSOFTWARE_NAME[$software_id]='Samba Server'
 		aSOFTWARE_DESC[$software_id]='Feature-rich SMB/CIFS server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=14
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/file_servers/#samba'
+		aSOFTWARE_CATX[$software_id]=14
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/file_servers/#samba'
 		#------------------
 		software_id=109
 
 		aSOFTWARE_NAME[$software_id]='NFS Server'
 		aSOFTWARE_DESC[$software_id]='Network File System server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=14
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/file_servers/#nfs'
+		aSOFTWARE_CATX[$software_id]=14
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/file_servers/#nfs'
 
 		# VPN Servers
 		#--------------------------------------------------------------------------------
@@ -1461,15 +1459,15 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='OpenVPN'
 		aSOFTWARE_DESC[$software_id]='vpn server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=15
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/vpn/#openvpn'
+		aSOFTWARE_CATX[$software_id]=15
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/vpn/#openvpn'
 		#------------------
 		software_id=172
 
 		aSOFTWARE_NAME[$software_id]='WireGuard'
 		aSOFTWARE_DESC[$software_id]='an extremely simple yet fast and modern VPN'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=15
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/vpn/#wireguard'
+		aSOFTWARE_CATX[$software_id]=15
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/vpn/#wireguard'
 		# Required to ask for public domain/IP and desired VPN server port
 		aSOFTWARE_REQUIRES_USERINPUT[$software_id]=1
 		# RPi/Odroids/x86_64 only
@@ -1494,9 +1492,9 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='PiVPN'
 		aSOFTWARE_DESC[$software_id]='openvpn/wireguard server install & management tool'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=15
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/vpn/#pivpn'
-		aSOFTWARE_REQUIRES[$software_id]='17'
+		aSOFTWARE_CATX[$software_id]=15
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/vpn/#pivpn'
+		aSOFTWARE_DEPS[$software_id]='17'
 		aSOFTWARE_REQUIRES_USERINPUT[$software_id]=1
 		aSOFTWARE_RECOMMENDS_AUTOMATED_UPGRADES[$software_id]=1
 
@@ -1506,24 +1504,24 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='WiFi Hotspot'
 		aSOFTWARE_DESC[$software_id]='turn your device into a wifi hotspot'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=16
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/advanced_networking/#wifi-hotspot'
+		aSOFTWARE_CATX[$software_id]=16
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/advanced_networking/#wifi-hotspot'
 		#------------------
 		software_id=61
 
 		aSOFTWARE_NAME[$software_id]='Tor Hotspot'
 		aSOFTWARE_DESC[$software_id]='optional: route hotspot traffic through tor'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=16
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/advanced_networking/#tor-hotspot'
-		aSOFTWARE_REQUIRES[$software_id]='60'
+		aSOFTWARE_CATX[$software_id]=16
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/advanced_networking/#tor-hotspot'
+		aSOFTWARE_DEPS[$software_id]='60'
 		#------------------
 		software_id=98
 
 		aSOFTWARE_NAME[$software_id]='HAProxy'
 		aSOFTWARE_DESC[$software_id]='high performance tcp/http load balancer'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=16
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/advanced_networking/#haproxy'
-		aSOFTWARE_REQUIRES[$software_id]='16'
+		aSOFTWARE_CATX[$software_id]=16
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/advanced_networking/#haproxy'
+		aSOFTWARE_DEPS[$software_id]='16'
 
 		# Home Automation
 		#--------------------------------------------------------------------------------
@@ -1531,9 +1529,9 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='emonHub'
 		aSOFTWARE_DESC[$software_id]='Data collector for the emonPi energy monitor addon board'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=17
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/home_automation/#emonpi'
-		aSOFTWARE_REQUIRES[$software_id]='69 130'
+		aSOFTWARE_CATX[$software_id]=17
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/home_automation/#emonpi'
+		aSOFTWARE_DEPS[$software_id]='69 130'
 		# RPi only
 		for ((i=10; i<=$MAX_G_HW_MODEL; i++))
 		do
@@ -1544,23 +1542,23 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Home Assistant'
 		aSOFTWARE_DESC[$software_id]='open-source home automation platform'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=17
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/home_automation/#home-assistant'
+		aSOFTWARE_CATX[$software_id]=17
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/home_automation/#home-assistant'
 		#------------------
 		software_id=140
 
 		aSOFTWARE_NAME[$software_id]='Domoticz'
 		aSOFTWARE_DESC[$software_id]='open-source home automation platform'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=17
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/home_automation/#domoticz'
+		aSOFTWARE_CATX[$software_id]=17
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/home_automation/#domoticz'
 		#------------------
 		software_id=27
 
 		aSOFTWARE_NAME[$software_id]='TasmoAdmin'
 		aSOFTWARE_DESC[$software_id]='Website to manage ESP8266 devices flashed with Tasmota'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=17
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/home_automation/#tasmoadmin'
-		aSOFTWARE_REQUIRES[$software_id]='89 webserver'
+		aSOFTWARE_CATX[$software_id]=17
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/home_automation/#tasmoadmin'
+		aSOFTWARE_DEPS[$software_id]='89 webserver'
 
 		# Printing
 		#--------------------------------------------------------------------------------
@@ -1568,18 +1566,18 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='OctoPrint'
 		aSOFTWARE_DESC[$software_id]='web interface for controlling 3d printers'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=18
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/printing/#octoprint'
-		(( $G_HW_ARCH < 3 && $G_DISTRO > 4 )) || aSOFTWARE_REQUIRES[$software_id]='16'
-		(( $G_DISTRO > 4 )) && aSOFTWARE_REQUIRES[$software_id]+=' 130'
+		aSOFTWARE_CATX[$software_id]=18
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/printing/#octoprint'
+		(( $G_HW_ARCH < 3 && $G_DISTRO > 4 )) || aSOFTWARE_DEPS[$software_id]='16'
+		(( $G_DISTRO > 4 )) && aSOFTWARE_DEPS[$software_id]+=' 130'
 		#------------------
 		software_id=187
 
 		aSOFTWARE_NAME[$software_id]='CUPS'
 		aSOFTWARE_DESC[$software_id]='common UNIX printing system'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=18
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/printing/#cups'
-		aSOFTWARE_REQUIRES[$software_id]='152'
+		aSOFTWARE_CATX[$software_id]=18
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/printing/#cups'
+		aSOFTWARE_DEPS[$software_id]='152'
 
 		# Distributed Projects
 		#--------------------------------------------------------------------------------
@@ -1587,8 +1585,8 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Folding@Home'
 		aSOFTWARE_DESC[$software_id]='distributed disease research project'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=19
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/distributed_projects/#foldinghome'
+		aSOFTWARE_CATX[$software_id]=19
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/distributed_projects/#foldinghome'
 		# - ARMv6 - ARMv7
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,2]=0
@@ -1597,16 +1595,16 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='YaCy'
 		aSOFTWARE_DESC[$software_id]='decentralised open source search engine'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=19
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/distributed_projects/#yacy'
-		aSOFTWARE_REQUIRES[$software_id]='8'
+		aSOFTWARE_CATX[$software_id]=19
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/distributed_projects/#yacy'
+		aSOFTWARE_DEPS[$software_id]='8'
 		#------------------
 		software_id=184
 
 		aSOFTWARE_NAME[$software_id]='Tor Relay'
 		aSOFTWARE_DESC[$software_id]='add a node to the Tor network'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=19
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/distributed_projects/#tor-relay'
+		aSOFTWARE_CATX[$software_id]=19
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/distributed_projects/#tor-relay'
 		aSOFTWARE_REQUIRES_USERINPUT[$software_id]=1
 		aSOFTWARE_RECOMMENDS_AUTOMATED_UPGRADES[$software_id]=1
 		#------------------
@@ -1614,8 +1612,8 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='IPFS Node'
 		aSOFTWARE_DESC[$software_id]='contribute to a decentralized internet'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=19
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/distributed_projects/#ipfs-node'
+		aSOFTWARE_CATX[$software_id]=19
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/distributed_projects/#ipfs-node'
 
 		# SSH Clients
 		#--------------------------------------------------------------------------------
@@ -1623,7 +1621,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='OpenSSH Client'
 		aSOFTWARE_DESC[$software_id]='Feature-rich SSH, SFTP and SCP client'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=20
+		aSOFTWARE_CATX[$software_id]=20
 
 		# File Server Clients
 		#--------------------------------------------------------------------------------
@@ -1631,15 +1629,15 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Samba Client'
 		aSOFTWARE_DESC[$software_id]='access SMB/CIFS/Samba network shares'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=21
-		aSOFTWARE_ONLINEDOC_URL[$software_id]=' dietpi-drive_manager > Add network drive'
+		aSOFTWARE_CATX[$software_id]=21
+		aSOFTWARE_DOCS[$software_id]=' dietpi-drive_manager > Add network drive'
 		#------------------
 		software_id=110
 
 		aSOFTWARE_NAME[$software_id]='NFS Client'
 		aSOFTWARE_DESC[$software_id]='network file system client'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=21
-		aSOFTWARE_ONLINEDOC_URL[$software_id]=' dietpi-drive_manager > Add network drive'
+		aSOFTWARE_CATX[$software_id]=21
+		aSOFTWARE_DOCS[$software_id]=' dietpi-drive_manager > Add network drive'
 
 		# File Managers
 		#--------------------------------------------------------------------------------
@@ -1647,13 +1645,13 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='MC'
 		aSOFTWARE_DESC[$software_id]='midnight commander, powerful file manager'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=22
+		aSOFTWARE_CATX[$software_id]=22
 		#------------------
 		software_id=4
 
 		aSOFTWARE_NAME[$software_id]='ViFM'
 		aSOFTWARE_DESC[$software_id]='file manager with vi bindings'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=22
+		aSOFTWARE_CATX[$software_id]=22
 
 		# System
 		#--------------------------------------------------------------------------------
@@ -1661,26 +1659,26 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='ALSA'
 		aSOFTWARE_DESC[$software_id]='Advanced Linux Sound Architecture'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=23
+		aSOFTWARE_CATX[$software_id]=23
 		#------------------
 		software_id=7
 
 		aSOFTWARE_NAME[$software_id]='FFmpeg'
 		aSOFTWARE_DESC[$software_id]='Audio & video codec libary and programs'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=23
+		aSOFTWARE_CATX[$software_id]=23
 		#------------------
 		software_id=6
 
 		aSOFTWARE_NAME[$software_id]='X.Org X Server'
 		aSOFTWARE_DESC[$software_id]='aka X11 - X Window System implementation'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=23
+		aSOFTWARE_CATX[$software_id]=23
 		#------------------
 		software_id=151
 
 		aSOFTWARE_NAME[$software_id]='Nvidia'
 		aSOFTWARE_DESC[$software_id]='Proprietary display driver for Nvidia graphics cards'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=23
-		aSOFTWARE_REQUIRES[$software_id]='6'
+		aSOFTWARE_CATX[$software_id]=23
+		aSOFTWARE_DEPS[$software_id]='6'
 		# Native PC only
 		for ((i=0; i<=$MAX_G_HW_MODEL; i++))
 		do
@@ -1688,17 +1686,11 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		done
 		aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,21]=1
 		#------------------
-		software_id=126
-
-		aSOFTWARE_NAME[$software_id]='LibSSL1.0.0'
-		aSOFTWARE_DESC[$software_id]='for backwards compatibility on Stretch, Buster and Bullseye'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=23
-		#------------------
 		software_id=170
 
 		aSOFTWARE_NAME[$software_id]='UnRAR'
 		aSOFTWARE_DESC[$software_id]='unarchiver for .rar files'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=23
+		aSOFTWARE_CATX[$software_id]=23
 
 		# Databases & Data Stores
 		#--------------------------------------------------------------------------------
@@ -1706,37 +1698,37 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='SQLite'
 		aSOFTWARE_DESC[$software_id]='Persistent single-file database system'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=24
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/databases/#sqlite'
+		aSOFTWARE_CATX[$software_id]=24
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/databases/#sqlite'
 		#------------------
 		software_id=88
 
 		aSOFTWARE_NAME[$software_id]='MariaDB'
 		aSOFTWARE_DESC[$software_id]='Persistent cached file-per-table database server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=24
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/databases/#mariadb'
+		aSOFTWARE_CATX[$software_id]=24
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/databases/#mariadb'
 		#------------------
 		software_id=90
 
 		aSOFTWARE_NAME[$software_id]='phpMyAdmin'
 		aSOFTWARE_DESC[$software_id]='Optional MariaDB web interface admin tools'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=24
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/databases/#phpmyadmin'
-		aSOFTWARE_REQUIRES[$software_id]='88 89 webserver'
+		aSOFTWARE_CATX[$software_id]=24
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/databases/#phpmyadmin'
+		aSOFTWARE_DEPS[$software_id]='88 89 webserver'
 		#------------------
 		software_id=91
 
 		aSOFTWARE_NAME[$software_id]='Redis'
 		aSOFTWARE_DESC[$software_id]='Volatile in-memory non-SQL database server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=24
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/databases/#redis'
+		aSOFTWARE_CATX[$software_id]=24
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/databases/#redis'
 		#------------------
 		software_id=74
 
 		aSOFTWARE_NAME[$software_id]='InfluxDB'
 		aSOFTWARE_DESC[$software_id]='Persistent time-series database server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=24
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/databases/#influxdb'
+		aSOFTWARE_CATX[$software_id]=24
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/databases/#influxdb'
 
 		# Network Tools
 		#--------------------------------------------------------------------------------
@@ -1744,43 +1736,43 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='iftop'
 		aSOFTWARE_DESC[$software_id]='displays bandwidth usage information'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=25
+		aSOFTWARE_CATX[$software_id]=25
 		#------------------
 		software_id=11
 
 		aSOFTWARE_NAME[$software_id]='IPTraf'
 		aSOFTWARE_DESC[$software_id]='interactive colorful ip lan monitor'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=25
+		aSOFTWARE_CATX[$software_id]=25
 		#------------------
 		software_id=12
 
 		aSOFTWARE_NAME[$software_id]='Iperf'
 		aSOFTWARE_DESC[$software_id]='internet protocol bandwidth measuring tool'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=25
+		aSOFTWARE_CATX[$software_id]=25
 		#------------------
 		software_id=13
 
 		aSOFTWARE_NAME[$software_id]='MTR-Tiny'
 		aSOFTWARE_DESC[$software_id]='full screen ncurses traceroute tool'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=25
+		aSOFTWARE_CATX[$software_id]=25
 		#------------------
 		software_id=14
 
 		aSOFTWARE_NAME[$software_id]='nLoad'
 		aSOFTWARE_DESC[$software_id]='realtime console network usage monitor'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=25
+		aSOFTWARE_CATX[$software_id]=25
 		#------------------
 		software_id=15
 
 		aSOFTWARE_NAME[$software_id]='tcpdump'
 		aSOFTWARE_DESC[$software_id]='command-line network traffic analyzer'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=25
+		aSOFTWARE_CATX[$software_id]=25
 		#------------------
 		software_id=152
 
 		aSOFTWARE_NAME[$software_id]='Avahi-Daemon'
 		aSOFTWARE_DESC[$software_id]='hostname broadcast (mac, pc bonjour)'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=25
+		aSOFTWARE_CATX[$software_id]=25
 
 		# Development & Programming
 		#--------------------------------------------------------------------------------
@@ -1788,52 +1780,52 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Build-Essential'
 		aSOFTWARE_DESC[$software_id]='GNU C/C++ compiler, development libraries and headers'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=26
+		aSOFTWARE_CATX[$software_id]=26
 		#------------------
 		software_id=17
 
 		aSOFTWARE_NAME[$software_id]='Git'
 		aSOFTWARE_DESC[$software_id]='Clone and manage Git repositories locally'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=26
+		aSOFTWARE_CATX[$software_id]=26
 		#------------------
 		software_id=130
 
 		aSOFTWARE_NAME[$software_id]='Python 3'
 		aSOFTWARE_DESC[$software_id]='Runtime system, pip package installer and development headers'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=26
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/programming/#python-3'
+		aSOFTWARE_CATX[$software_id]=26
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/programming/#python-3'
 		#------------------
 		software_id=189
 
 		aSOFTWARE_NAME[$software_id]='VSCodium'
 		aSOFTWARE_DESC[$software_id]='FLOSS version of MS VSCode'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=26
-		aSOFTWARE_REQUIRES[$software_id]='6 17'
+		aSOFTWARE_CATX[$software_id]=26
+		aSOFTWARE_DEPS[$software_id]='6 17'
 		#------------------
 		software_id=188
 
 		aSOFTWARE_NAME[$software_id]='Go'
 		aSOFTWARE_DESC[$software_id]='Runtime environment and package installer'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=26
-		aSOFTWARE_REQUIRES[$software_id]='17'
+		aSOFTWARE_CATX[$software_id]=26
+		aSOFTWARE_DEPS[$software_id]='17'
 		#------------------
 		software_id=8
 
 		aSOFTWARE_NAME[$software_id]='Java'
 		aSOFTWARE_DESC[$software_id]='OpenJDK runtime environment and development kit'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=26
+		aSOFTWARE_CATX[$software_id]=26
 		#------------------
 		software_id=9
 
 		aSOFTWARE_NAME[$software_id]='Node.js'
 		aSOFTWARE_DESC[$software_id]='JavaScript runtime environment'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=26
+		aSOFTWARE_CATX[$software_id]=26
 		#------------------
 		software_id=150
 
 		aSOFTWARE_NAME[$software_id]='Mono'
 		aSOFTWARE_DESC[$software_id]='runtime libraries and repo'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=26
+		aSOFTWARE_CATX[$software_id]=26
 
 		# Text Editors
 		#--------------------------------------------------------------------------------
@@ -1841,31 +1833,31 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Emacs'
 		aSOFTWARE_DESC[$software_id]='gnu emacs editor'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=27
+		aSOFTWARE_CATX[$software_id]=27
 		#------------------
 		software_id=19
 
 		aSOFTWARE_NAME[$software_id]='Jed'
 		aSOFTWARE_DESC[$software_id]='editor for programmers'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=27
+		aSOFTWARE_CATX[$software_id]=27
 		#------------------
 		software_id=20
 
 		aSOFTWARE_NAME[$software_id]='Vim'
 		aSOFTWARE_DESC[$software_id]='vi enhanced text editor'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=27
+		aSOFTWARE_CATX[$software_id]=27
 		#------------------
 		software_id=21
 
 		aSOFTWARE_NAME[$software_id]='Vim-Tiny'
 		aSOFTWARE_DESC[$software_id]='compact release of vim'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=27
+		aSOFTWARE_CATX[$software_id]=27
 		#------------------
 		software_id=127
 
 		aSOFTWARE_NAME[$software_id]='Neovim'
 		aSOFTWARE_DESC[$software_id]='heavily refactored vim fork'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=27
+		aSOFTWARE_CATX[$software_id]=27
 
 		# Desktop Utilities
 		#--------------------------------------------------------------------------------
@@ -1873,41 +1865,41 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='QuiteRSS'
 		aSOFTWARE_DESC[$software_id]='cross-platform, free rss reader'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=28
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/desktop/#quiterss'
-		aSOFTWARE_REQUIRES[$software_id]='6'
+		aSOFTWARE_CATX[$software_id]=28
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/desktop/#quiterss'
+		aSOFTWARE_DEPS[$software_id]='6'
 		#------------------
 		software_id=113
 
 		aSOFTWARE_NAME[$software_id]='Chromium'
 		aSOFTWARE_DESC[$software_id]='web browser for desktop or autostart'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=28
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/desktop/#chromium'
-		aSOFTWARE_REQUIRES[$software_id]='5 6'
+		aSOFTWARE_CATX[$software_id]=28
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/desktop/#chromium'
+		aSOFTWARE_DEPS[$software_id]='5 6'
 		#------------------
 		software_id=67
 
 		aSOFTWARE_NAME[$software_id]='Firefox'
 		aSOFTWARE_DESC[$software_id]='web browser for desktop'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=28
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/desktop/#firefox'
-		aSOFTWARE_REQUIRES[$software_id]='5 6'
+		aSOFTWARE_CATX[$software_id]=28
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/desktop/#firefox'
+		aSOFTWARE_DEPS[$software_id]='5 6'
 		#------------------
 		software_id=174
 
 		aSOFTWARE_NAME[$software_id]='GIMP'
 		aSOFTWARE_DESC[$software_id]='mspaint on steroids'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=28
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/desktop/#gimp'
-		aSOFTWARE_REQUIRES[$software_id]='6'
+		aSOFTWARE_CATX[$software_id]=28
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/desktop/#gimp'
+		aSOFTWARE_DEPS[$software_id]='6'
 		#------------------
  		software_id=175
 
  		aSOFTWARE_NAME[$software_id]='Xfce Power Manager'
  		aSOFTWARE_DESC[$software_id]='with brightness control, recommended for LXDE/LXQt'
- 		aSOFTWARE_CATEGORY_INDEX[$software_id]=28
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/desktop/#xfce-power-manager'
- 		aSOFTWARE_REQUIRES[$software_id]='6'
+ 		aSOFTWARE_CATX[$software_id]=28
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/desktop/#xfce-power-manager'
+ 		aSOFTWARE_DEPS[$software_id]='6'
 
 		#--------------------------------------------------------------------------------
 		# Logging Systems (hidden)
@@ -1916,22 +1908,22 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Logrotate'
 		aSOFTWARE_DESC[$software_id]='rotates log files'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=-1
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/log_system/#full-logging'
+		aSOFTWARE_CATX[$software_id]=-1
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/log_system/#full-logging'
 		#------------------
 		software_id=102
 
 		aSOFTWARE_NAME[$software_id]='Rsyslog'
 		aSOFTWARE_DESC[$software_id]='system logging'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=-1
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/log_system/#full-logging'
+		aSOFTWARE_CATX[$software_id]=-1
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/log_system/#full-logging'
 		#------------------
 		software_id=103
 
 		aSOFTWARE_NAME[$software_id]='DietPi-RAMlog'
 		aSOFTWARE_DESC[$software_id]='minimal, optimised logging'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=-1
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/log_system/#dietpi-ramlog'
+		aSOFTWARE_CATX[$software_id]=-1
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/log_system/#dietpi-ramlog'
 
 		#--------------------------------------------------------------------------------
 		# SSH Servers (hidden)
@@ -1940,15 +1932,15 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		aSOFTWARE_NAME[$software_id]='Dropbear'
 		aSOFTWARE_DESC[$software_id]='Lightweight SSH server'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=-1
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/ssh/#dropbear'
+		aSOFTWARE_CATX[$software_id]=-1
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/ssh/#dropbear'
 		#------------------
 		software_id=105
 
 		aSOFTWARE_NAME[$software_id]='OpenSSH Server'
 		aSOFTWARE_DESC[$software_id]='Feature-rich SSH server with SFTP and SCP support'
-		aSOFTWARE_CATEGORY_INDEX[$software_id]=-1
-		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/ssh/#openssh'
+		aSOFTWARE_CATX[$software_id]=-1
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/ssh/#openssh'
 
 		#--------------------------------------------------------------------------------
 		# Init install state for defined software
@@ -1993,7 +1985,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		# Loop through dependencies
 		local j
-		for j in ${aSOFTWARE_REQUIRES[$1]}
+		for j in ${aSOFTWARE_DEPS[$1]}
 		do
 			# Resolve webserver dependency based on install state and user preference
 			if [[ $j == 'webserver' ]]
@@ -2130,30 +2122,6 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		then
 			aSOFTWARE_INSTALL_STATE[$software_id]=1
 			G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[$software_id]} will be installed"
-		fi
-
-		# Software that requires LibSSL1.0.0
-		# - WiFi Hotspot (60, our custom compiled RTL8188C* binaries only)
-		#	Check for RTL8188C* device, which requires a different driver: https://github.com/pritambaral/hostapd-rtl871xdrv#why
-		#	ARM-only, since we have no x86 binaries
-		#	Exclude RPi, since compatible binaries are shipped with archive.raspberrypi.org
-		if (( ${aSOFTWARE_INSTALL_STATE[60]} == 1 )) && lsusb | grep -qi 'RTL8188C'; then
-
-			WIFIHOTSPOT_RTL8188C_DEVICE=1
-			# Some repos (e.g. ARMbian) provide special packages
-			apt-cache dumpavail | grep -qE '^P(ackage|rovides):.* hostapd-realtek(,|$)' && WIFIHOTSPOT_RTL8188C_PACKAGE=1
-
-		fi
-		# - Domoticz (140): https://github.com/MichaIng/DietPi/issues/129#issuecomment-596255110
-		# - Jackett (147)
-		software_id=126
-		if (( ( ${aSOFTWARE_INSTALL_STATE[60]} == 1 && $WIFIHOTSPOT_RTL8188C_DEVICE && ! $WIFIHOTSPOT_RTL8188C_PACKAGE && $G_HW_MODEL > 9 && $G_HW_ARCH < 4 ) ||
-			${aSOFTWARE_INSTALL_STATE[140]} == 1 ||
-			${aSOFTWARE_INSTALL_STATE[147]} == 1 )); then
-
-			aSOFTWARE_INSTALL_STATE[$software_id]=1
-			G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[$software_id]} will be installed"
-
 		fi
 
 		# Flag for software that recommends automated APT upgrades
@@ -2674,20 +2642,6 @@ _EOF_
 
 			# Apply: Installs "alsa-utils"
 			/boot/dietpi/func/dietpi-set_hardware soundcard "$soundcard"
-
-		fi
-
-		software_id=126 # LibSSL1.0.0
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-
-			# On Stretch and above, libssl1.0.0 is no longer available: https://github.com/MichaIng/DietPi/issues/1299
-			# - Our packages are from Debian/Raspbian Jessie, which require multiarch-support: https://packages.debian.org/libssl1.0.0
-			# - On Bullseye, multiarch-support is not available, use from Buster instead: https://packages.debian.org/multiarch-support
-			# shellcheck disable=SC2015
-			(( $G_DISTRO < 6 )) && DEPS_LIST='multiarch-support' || Download_Install "https://dietpi.com/downloads/binaries/all/multiarch-support_$G_HW_ARCH_NAME.deb"
-			Download_Install "https://dietpi.com/downloads/binaries/all/libssl1.0.0_$G_HW_ARCH_NAME.deb"
 
 		fi
 
@@ -5230,57 +5184,12 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			Banner_Installing
 
-			DEPS_LIST='hostapd isc-dhcp-server iptables libnl-3-200'
+			local packages=('hostapd' 'isc-dhcp-server' 'iptables' 'libnl-3-200')
 
 			# RTL8188C* device and special Realtek hostapd package available
-			if (( $WIFIHOTSPOT_RTL8188C_DEVICE && $WIFIHOTSPOT_RTL8188C_PACKAGE )); then
+			lsusb | grep -qi 'RTL8188C' && apt-cache dumpavail | grep -qE '^P(ackage|rovides):.* hostapd-realtek(,|$)' && packages[0]='hostapd-realtek'
 
-				# shellcheck disable=SC2086
-				G_AGI ${DEPS_LIST/hostapd/hostapd-realtek}
-
-			# RTL8188C* without special Realtek hostapd package: On non-RPi ARM, install our binaries with "rtl1871xdrv" driver. On RPi, a RTL8188C*-compatible hostapd package is shipped.
-			elif (( $WIFIHOTSPOT_RTL8188C_DEVICE && $G_HW_MODEL > 9 && $G_HW_ARCH < 4 )); then
-
-				Download_Install 'https://dietpi.com/downloads/binaries/all/hostapd_2.5_all.zip'
-
-				# Which binary to install
-				local filename_hostapd{,_cli}
-
-				# ARMv6
-				if (( $G_HW_ARCH == 1 )); then
-
-					filename_hostapd='hostapd-rtl8188c-armv6'
-					filename_hostapd_cli='hostapd_cli-armv6'
-
-				# ARMv7
-				elif (( $G_HW_ARCH == 2 )); then
-
-					filename_hostapd='hostapd-rtl8188c-armv7'
-					filename_hostapd_cli='hostapd_cli-armv7'
-
-				# ARMv8
-				elif (( $G_HW_ARCH == 3 )); then
-
-					filename_hostapd='hostapd-rtl8188c-arm64'
-					filename_hostapd_cli='hostapd_cli-arm64'
-
-				fi
-
-				G_EXEC mv "$filename_hostapd" /usr/sbin/hostapd
-				G_EXEC mv "$filename_hostapd_cli" /usr/sbin/hostapd_cli
-				G_EXEC chmod +x /usr/sbin/hostapd{,_cli}
-
-				G_EXEC rm hostapd*
-
-			# Else install the default package.
-			# NB: Debian Stretch ships an older version then our own compiled binaries, but many device/firmware repos (RPi, Meveric, Armbian) ship newer ones even for Stretch, thus we should not overwrite them anymore.
-			else
-
-				# shellcheck disable=SC2086
-				G_AGI $DEPS_LIST
-
-			fi
-			DEPS_LIST=
+			G_AGI "${packages[@]}"
 
 			# Enable WiFi modules
 			/boot/dietpi/func/dietpi-set_hardware wifimodules enable
@@ -10205,9 +10114,8 @@ wpa_key_mgmt=WPA-PSK
 wpa_pairwise=TKIP
 rsn_pairwise=CCMP
 _EOF_
-			# Check for RTL8188C* device, use the patched driver with compiled binary: https://github.com/pritambaral/hostapd-rtl871xdrv#why
-			# - Stay with default driver on RPi, where the issue seems to have been resolved differently and "rtl871xdrv" is not supported: https://github.com/MichaIng/DietPi/issues/2531#issuecomment-650810121
-			(( $WIFIHOTSPOT_RTL8188C_DEVICE && $G_HW_MODEL > 9 && $G_HW_ARCH < 4 || $WIFIHOTSPOT_RTL8188C_PACKAGE )) && G_CONFIG_INJECT 'driver=' 'driver=rtl871xdrv' /etc/hostapd/hostapd.conf
+			# Use "rtl871xdrv" driver when special package has been installed
+			dpkg-query -s hostapd-realtek &> /dev/null && G_CONFIG_INJECT 'driver=' 'driver=rtl871xdrv' /etc/hostapd/hostapd.conf
 
 			# Enable access point config
 			echo "DAEMON_CONF=\"/etc/hostapd/hostapd.conf\"" > /etc/default/hostapd
@@ -13482,15 +13390,6 @@ _EOF_
 
 		fi
 
-		software_id=126 # LibSSL1.0.0
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
-
-			Banner_Uninstalling
-			# shellcheck disable=SC2046
-			apt-mark auto $(dpkg --get-selections libssl1.0.0 multiarch-support 2> /dev/null | mawk '{print $1}') 2> /dev/null
-
-		fi
-
 		software_id=129 # O!MPD
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
@@ -15859,7 +15758,7 @@ _EOF_
 		G_AGUP
 
 		# Full package upgrade on first run installs: https://github.com/MichaIng/DietPi/issues/3098
-		(( $G_DIETPI_INSTALL_STAGE == 1 )) && G_AGDUG
+		(( $G_DIETPI_INSTALL_STAGE == 2 )) || G_AGDUG
 
 		# Unmark software installs for automated installs, if user input is required
 		Unmark_Unattended
@@ -15950,75 +15849,13 @@ This requires an account at: https://remote.it/
 		# Write to .install File
 		Write_InstallFileList
 
-		# DietPi-Automation
-		if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
-
-			# Remove fake-hwclock, if real hwclock is available
-			# REMOVED: "hwclock" succeeds if an RTC connector is available but no battery attached (or empty), hence we cannot guarantee correct RTC time on boot by only testing "hwclock".
-			#hwclock &> /dev/null && G_AGP fake-hwclock
-
-			# x86_64 microcode updates, skip on VM
-			if (( $G_HW_ARCH == 10 && $G_HW_MODEL != 20 )); then
-
-				grep -qi 'vendor_id.*intel' /proc/cpuinfo && G_AGI intel-microcode
-				grep -qi 'vendor_id.*amd' /proc/cpuinfo && G_AGI amd64-microcode
-
-			# RPi4 EEPROM update: https://github.com/MichaIng/DietPi/issues/3217
-			elif (( $G_HW_MODEL == 4 )); then
-
-				/boot/dietpi/func/dietpi-set_hardware rpi-eeprom
-
-			fi
-
-			# Custom 1st run script (local file)
-			if [[ -f '/boot/Automation_Custom_Script.sh' ]]; then
-
-				G_EXEC_NOEXIT=1 G_EXEC cp /boot/Automation_Custom_Script.sh /root/AUTO_CustomScript.sh
-
-			# Custom 1st run script (online file)
-			elif [[ $AUTOINSTALL_CUSTOMSCRIPTURL != '0' ]]; then
-
-				G_CHECK_URL "$AUTOINSTALL_CUSTOMSCRIPTURL"
-				G_EXEC_NOEXIT=1 G_EXEC curl -sSfL "$AUTOINSTALL_CUSTOMSCRIPTURL" -o /root/AUTO_CustomScript.sh
-
-			fi
-
-			if [[ -f '/root/AUTO_CustomScript.sh' ]]; then
-
-				local fp_log='/var/tmp/dietpi/logs/dietpi-automation_custom_script.log'
-
-				G_DIETPI-NOTIFY 2 'Running custom script, please wait...'
-				G_EXEC_NOEXIT=1 G_EXEC chmod +x /root/AUTO_CustomScript.sh
-				/root/AUTO_CustomScript.sh 2>&1 | tee $fp_log
-				if (( ${PIPESTATUS[0]} )); then
-
-					G_DIETPI-NOTIFY 0 "Custom script: $fp_log"
-
-				else
-
-					G_DIETPI-NOTIFY 1 "Custom script: $fp_log"
-
-				fi
-
-				G_EXEC_NOEXIT=1 G_EXEC rm /root/AUTO_CustomScript.sh
-
-			fi
-
-			# Apply AutoStart choice
-			/boot/dietpi/dietpi-autostart "$AUTOINSTALL_AUTOSTARTTARGET"
-
-			# Set Install Stage to Finished
-			G_DIETPI_INSTALL_STAGE=2
-			echo $G_DIETPI_INSTALL_STAGE > /boot/dietpi/.install_stage
-
-		fi
-
 	}
 
 	#/////////////////////////////////////////////////////////////////////////////////////
-	# First Run / Automation functions Vars (eg: on a fresh install)
+	# First Run / Automation function
 	#/////////////////////////////////////////////////////////////////////////////////////
-	FirstRun_Automation_Init(){
+	# Setup steps prior to installs and network check
+	DietPi-Automation_Pre(){
 
 		# Get settings
 		AUTOINSTALL_ENABLED=$(sed -n '/^[[:blank:]]*AUTO_SETUP_AUTOMATED=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
@@ -16048,37 +15885,144 @@ This requires an account at: https://remote.it/
 		[[ $AUTOINSTALL_RESTORE ]] || AUTOINSTALL_RESTORE=0
 		[[ $AUTOINSTALL_RAMLOG_SIZE ]] || AUTOINSTALL_RAMLOG_SIZE=50
 
-	}
+		# Restore DietPi-Backup
+		if (( $AUTOINSTALL_RESTORE )); then
 
-	FirstRun_Automation_Set(){
+			# Reboot only when backup restore succeeded
+			restore_succeeded=0
 
-		# Automated install
-		if (( $AUTOINSTALL_ENABLED > 0 )); then
-
-			G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Running automated installation'
-
-			TARGETMENUID=-1 # Skip menu loop
-			GOSTARTINSTALL=1 # Set install start flag
-
-			# Find all software entries of AUTO_SETUP_INSTALL_SOFTWARE_ID= in dietpi.txt. Then set to state 1 for installation.
-			while read -r software_id
+			G_DIETPI-NOTIFY 2 'DietPi-Backup restore selected, scanning and mounting attached drives...'
+			i=0
+			while read -r line
 			do
-				# Flag for installation
-				[[ ${aSOFTWARE_NAME[$software_id]} ]] || continue
-				aSOFTWARE_INSTALL_STATE[$software_id]=1
-				G_DIETPI-NOTIFY 2 "Automation: ${aSOFTWARE_NAME[$software_id]}. Flagged for installation."
+				# Mount drives to temporary mount points
+				mkdir -p "/mnt/dietpi-backup$i" && mount "$line" "/mnt/dietpi-backup$i"
+				((i++))
 
-			done <<< "$(grep '^[[:blank:]]*AUTO_SETUP_INSTALL_SOFTWARE_ID=' /boot/dietpi.txt | mawk '{print $1}' | sed 's/[^0-9]*//g')"
+			done < <(lsblk -rnpo NAME,UUID,MOUNTPOINT | mawk '$2 && ! $3 {print $1}')
+
+			G_DIETPI-NOTIFY 2 'Searching all drives for DietPi-Backup instances...'
+			mapfile -t alist < <(find /mnt -type f -name '.dietpi-backup_stats')
+
+			# Interactive restore
+			if [[ $AUTOINSTALL_RESTORE == 1 ]]; then
+
+				# Do we have any results?
+				if [[ ${alist[0]} ]]; then
+
+					# Create List for Whiptail
+					G_WHIP_MENU_ARRAY=()
+					for i in "${alist[@]}"
+					do
+						last_backup_date=$(sed -n '/ompleted/s/^.*: //p' "$i" | tail -1) # Date of last backup for this backup
+						backup_directory=${i%/.dietpi-backup_stats} # Backup directory (minus the backup file), that we can use for target backup directory.
+						G_WHIP_MENU_ARRAY+=("$backup_directory" ": $last_backup_date")
+					done
+
+					export G_DIETPI_SERVICES_DISABLE=1
+					G_WHIP_MENU 'Please select a previous backup to restore:' && /boot/dietpi/dietpi-backup -1 "$G_WHIP_RETURNED_VALUE" && restore_succeeded=1
+					unset -v G_DIETPI_SERVICES_DISABLE
+
+				else
+
+					G_WHIP_MSG 'No previous backups were found in /mnt/*. Install will continue like normal.'
+
+				fi
+
+			# Non-interactive restore
+			elif [[ $AUTOINSTALL_RESTORE == 2 ]]; then
+
+				# Do we have any results?
+				if [[ ${alist[0]} ]]; then
+
+					# Restore first found backup
+					export G_DIETPI_SERVICES_DISABLE=1
+					/boot/dietpi/dietpi-backup -1 "${alist[0]%/.dietpi-backup_stats}" && restore_succeeded=1
+					unset -v G_DIETPI_SERVICES_DISABLE
+
+				else
+
+					G_DIETPI-NOTIFY 1 'DietPi-Backup auto-restore was selected but no backup has been found in /mnt/*. Install will continue like normal.'
+
+				fi
+
+				# Downgrade dietpi.txt option
+				G_CONFIG_INJECT 'AUTO_SETUP_BACKUP_RESTORE=' 'AUTO_SETUP_BACKUP_RESTORE=1' /boot/dietpi.txt
+
+			fi
+
+			# Remove mounted drives and mount points
+			findmnt /mnt/dietpi-backup[0-9]* > /dev/null && umount /mnt/dietpi-backup[0-9]*
+			[[ -d '/mnt/dietpi-backup0' ]] && rmdir /mnt/dietpi-backup[0-9]*
+
+			# Reboot on successful restore
+			if (( $restore_succeeded )); then
+
+				G_DIETPI-NOTIFY 2 'The system will now reboot into the restored system'
+				sync # Failsafe
+				sleep 3
+				reboot
+
+			fi
 
 		fi
 
-		# Further Automated options. (Applied regardless of AUTOINSTALL_ENABLED)
-		INDEX_SSHSERVER_TARGET=$AUTOINSTALL_SSHINDEX
-		INDEX_FILESERVER_TARGET=$AUTOINSTALL_FILESERVERINDEX
-		INDEX_LOGGING_TARGET=$AUTOINSTALL_LOGGINGINDEX
-		INDEX_WEBSERVER_TARGET=$AUTOINSTALL_WEBSERVERINDEX
-		INDEX_DESKTOP_TARGET=$AUTOINSTALL_DESKTOPINDEX
-		INDEX_BROWSER_TARGET=$AUTOINSTALL_BROWSERINDEX
+		# Global PW
+		# - Automation, apply as per dietpi.txt
+		if (( $AUTOINSTALL_ENABLED )); then
+
+			Update_Global_Pw
+			# Set again to apply for UNIX users as well
+			/boot/dietpi/func/dietpi-set_software passwords "$GLOBAL_PW"
+
+		# - Prompt change global password and login passwords for root and dietpi users
+		else
+
+			/boot/dietpi/func/dietpi-set_software passwords
+
+		fi
+
+		# Disable serial? Must stay enabled for the following:
+		# - XU4: HC1/HC2 fail to boot into kernel without: https://github.com/MichaIng/DietPi/issues/2038#issuecomment-416089875
+		# - ROCKPro64: Fails to boot into kernel without
+		# - NanoPi NEO Air: Required for end users/debugging/setting up WiFi without automation
+		local keep_serial0=1
+		if grep -q '^[[:blank:]]*CONFIG_SERIAL_CONSOLE_ENABLE=1' /boot/dietpi.txt &&
+			(( $G_HW_MODEL != 11 && $G_HW_MODEL != 42 && $G_HW_MODEL != 64 )) &&
+			G_WHIP_YESNO 'Serial console is currently enabled, would you like to disable it?\n - Disabling serial console will reduce memory consumption slightly\n - If you are unsure on what serial console is, it is safe to disable it'; then
+
+			/boot/dietpi/func/dietpi-set_hardware serialconsole disable
+			keep_serial0=0
+
+		fi
+
+		# RPi: Convert "serial0" to its actual symlink target
+		if (( $G_HW_MODEL < 10 )); then
+
+			if [[ $keep_serial0 == 1 && -L '/dev/serial0' ]]; then
+
+				local tty=$(readlink -f /dev/serial0); tty=${tty#/dev/}
+				if [[ $(</boot/cmdline.txt) == *'serial0'* ]]; then
+
+					# shellcheck disable=2015
+					[[ $(</boot/cmdline.txt) == *"$tty"* ]] && sed -i "s/[[:blank:]]*console=${tty}[^\"[:blank:]]*//" /boot/cmdline.txt || sed -i "s/serial0/$tty/" /boot/cmdline.txt
+
+				fi
+				if [[ -f '/etc/systemd/system/getty.target.wants/serial-getty@serial0.service' ]]; then
+
+					systemctl disable serial-getty@serial0
+					systemctl enable "serial-getty@$tty"
+
+				fi
+
+			else
+
+				/boot/dietpi/func/dietpi-set_hardware serialconsole disable serial0
+
+			fi
+
+		fi
+		unset -v keep_serial0 tty
 
 		# Apply RAMlog size
 		sed -i "\|[[:blank:]]/var/log[[:blank:]]|c\tmpfs /var/log tmpfs size=${AUTOINSTALL_RAMLOG_SIZE}M,noatime,lazytime,nodev,nosuid,mode=1777" /etc/fstab
@@ -16086,6 +16030,95 @@ This requires an account at: https://remote.it/
 
 		# Set time sync mode
 		/boot/dietpi/func/dietpi-set_software ntpd-mode $AUTOINSTALL_TIMESYNCMODE
+
+		# Apply choice and preference system settings
+		INDEX_SSHSERVER_TARGET=$AUTOINSTALL_SSHINDEX
+		INDEX_FILESERVER_TARGET=$AUTOINSTALL_FILESERVERINDEX
+		INDEX_LOGGING_TARGET=$AUTOINSTALL_LOGGINGINDEX
+		INDEX_WEBSERVER_TARGET=$AUTOINSTALL_WEBSERVERINDEX
+		INDEX_DESKTOP_TARGET=$AUTOINSTALL_DESKTOPINDEX
+		INDEX_BROWSER_TARGET=$AUTOINSTALL_BROWSERINDEX
+
+		# Automated installs
+		(( $AUTOINSTALL_ENABLED > 0 )) || return 0
+
+		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Running automated installation'
+
+		TARGETMENUID=-1 # Skip menu loop
+		GOSTARTINSTALL=1 # Set install start flag
+
+		# Find all software entries of AUTO_SETUP_INSTALL_SOFTWARE_ID= in dietpi.txt. Then set to state 1 for installation.
+		while read -r software_id
+		do
+			# Flag for installation
+			[[ ${aSOFTWARE_NAME[$software_id]} ]] || continue
+			aSOFTWARE_INSTALL_STATE[$software_id]=1
+			G_DIETPI-NOTIFY 2 "Automation: ${aSOFTWARE_NAME[$software_id]}. Flagged for installation."
+
+		done <<< "$(grep '^[[:blank:]]*AUTO_SETUP_INSTALL_SOFTWARE_ID=' /boot/dietpi.txt | mawk '{print $1}' | sed 's/[^0-9]*//g')"
+
+	}
+
+	# Setup steps after installs with network assured
+	DietPi-Automation_Post(){
+
+		# Remove fake-hwclock, if real hwclock is available
+		# REMOVED: "hwclock" succeeds if an RTC connector is available but no battery attached (or empty), hence we cannot guarantee correct RTC time on boot by only testing "hwclock".
+		#hwclock &> /dev/null && G_AGP fake-hwclock
+
+		# x86_64 microcode updates, skip on VM
+		if (( $G_HW_ARCH == 10 && $G_HW_MODEL != 20 )); then
+
+			grep -qi 'vendor_id.*intel' /proc/cpuinfo && G_AGI intel-microcode
+			grep -qi 'vendor_id.*amd' /proc/cpuinfo && G_AGI amd64-microcode
+
+		# RPi4 EEPROM update: https://github.com/MichaIng/DietPi/issues/3217
+		elif (( $G_HW_MODEL == 4 )); then
+
+			/boot/dietpi/func/dietpi-set_hardware rpi-eeprom
+
+		fi
+
+		# Custom 1st run script (local file)
+		if [[ -f '/boot/Automation_Custom_Script.sh' ]]; then
+
+			G_EXEC_NOEXIT=1 G_EXEC cp /boot/Automation_Custom_Script.sh /root/AUTO_CustomScript.sh
+
+		# Custom 1st run script (online file)
+		elif [[ $AUTOINSTALL_CUSTOMSCRIPTURL != '0' ]]; then
+
+			G_CHECK_URL "$AUTOINSTALL_CUSTOMSCRIPTURL"
+			G_EXEC_NOEXIT=1 G_EXEC curl -sSfL "$AUTOINSTALL_CUSTOMSCRIPTURL" -o /root/AUTO_CustomScript.sh
+
+		fi
+
+		if [[ -f '/root/AUTO_CustomScript.sh' ]]; then
+
+			local fp_log='/var/tmp/dietpi/logs/dietpi-automation_custom_script.log'
+
+			G_DIETPI-NOTIFY 2 'Running custom script, please wait...'
+			G_EXEC_NOEXIT=1 G_EXEC chmod +x /root/AUTO_CustomScript.sh
+			/root/AUTO_CustomScript.sh 2>&1 | tee $fp_log
+			if (( ${PIPESTATUS[0]} )); then
+
+				G_DIETPI-NOTIFY 0 "Custom script: $fp_log"
+
+			else
+
+				G_DIETPI-NOTIFY 1 "Custom script: $fp_log"
+
+			fi
+
+			G_EXEC_NOEXIT=1 G_EXEC rm /root/AUTO_CustomScript.sh
+
+		fi
+
+		# Apply AutoStart choice
+		/boot/dietpi/dietpi-autostart "$AUTOINSTALL_AUTOSTARTTARGET"
+
+		# Set Install Stage to Finished
+		G_DIETPI_INSTALL_STAGE=2
+		echo $G_DIETPI_INSTALL_STAGE > /boot/dietpi/.install_stage
 
 	}
 
@@ -16216,7 +16249,7 @@ This requires an account at: https://remote.it/
 				(( ${aSOFTWARE_INSTALL_STATE[$i]} == 2 )) && string="\e[32m$string"
 
 				# Append dependencies
-				for j in ${aSOFTWARE_REQUIRES[$i]}
+				for j in ${aSOFTWARE_DEPS[$i]}
 				do
 					# Add software name or raw meta dependencies to string
 					[[ $j == *[^0-9]* ]] && string+=" +$j" || string+=" +${aSOFTWARE_NAME[$j]}"
@@ -16240,7 +16273,7 @@ This requires an account at: https://remote.it/
 				fi
 
 				# Append online docs if available
-				[[ ${aSOFTWARE_ONLINEDOC_URL[$i]} ]] && string+=" | \e[90m${aSOFTWARE_ONLINEDOC_URL[$i]}\e[0m"
+				[[ ${aSOFTWARE_DOCS[$i]} ]] && string+=" | \e[90m${aSOFTWARE_DOCS[$i]}\e[0m"
 
 				echo -e "$string"
 			done
@@ -16324,10 +16357,10 @@ This requires an account at: https://remote.it/
 				G_WHIP_CHECKLIST_ARRAY+=('' "${aSOFTWARE_CATEGORIES[$i]}" 'off')
 
 				# Loop through software title category IDs
-				for j in "${!aSOFTWARE_CATEGORY_INDEX[@]}"
+				for j in "${!aSOFTWARE_CATX[@]}"
 				do
 					# Check if this software's category matches the current category
-					(( ${aSOFTWARE_CATEGORY_INDEX[$j]} == $i )) || continue
+					(( ${aSOFTWARE_CATX[$j]} == $i )) || continue
 
 					# Check if this software is available for hardware, arch and distro
 					(( ${aSOFTWARE_AVAIL_G_HW_MODEL[$j,$G_HW_MODEL]:=1} && ${aSOFTWARE_AVAIL_G_HW_ARCH[$j,$G_HW_ARCH]:=1} && ${aSOFTWARE_AVAIL_G_DISTRO[$j,$G_DISTRO]:=1} )) || continue
@@ -17084,8 +17117,8 @@ List of installed software and their online documentation URLs:
 					# Installed software
 					for i in "${!aSOFTWARE_INSTALL_STATE[@]}"
 					do
-						[[ ${aSOFTWARE_INSTALL_STATE[i]} -gt 0 && ${aSOFTWARE_ONLINEDOC_URL[$i]} ]] || continue
-						string+="\n${aSOFTWARE_NAME[$i]}: ${aSOFTWARE_DESC[$i]}\n${aSOFTWARE_ONLINEDOC_URL[$i]}\n"
+						[[ ${aSOFTWARE_INSTALL_STATE[i]} -gt 0 && ${aSOFTWARE_DOCS[$i]} ]] || continue
+						string+="\n${aSOFTWARE_NAME[$i]}: ${aSOFTWARE_DESC[$i]}\n${aSOFTWARE_DOCS[$i]}\n"
 					done
 
 					G_WHIP_SIZE_X_MAX=70
@@ -17110,13 +17143,8 @@ List of installed software and their online documentation URLs:
 
 		TARGETMENUID=0 # Return to Main Menu
 
-		# 1st run install
-		if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
-
-			G_WHIP_MSG 'DietPi has not fully been installed.\nThis must be completed prior to using DietPi by selecting:\n - Go Start Install.'
-
 		# Standard exit
-		else
+		if (( $G_DIETPI_INSTALL_STAGE == 2 )); then
 
 			G_WHIP_YESNO 'Do you wish to exit DietPi-Software?\n\nAll changes to software selections will be cleared.' || return 0
 
@@ -17124,6 +17152,9 @@ List of installed software and their online documentation URLs:
 			exit 0
 
 		fi
+
+		# 1st run install
+		G_WHIP_MSG 'DietPi has not fully been installed.\nThis must be completed prior to using DietPi by selecting:\n - Go Start Install.'
 
 	}
 
@@ -17154,8 +17185,13 @@ List of installed software and their online documentation URLs:
 			# List selections and ask for confirmation
 			Menu_ConfirmInstall
 
+		# After first run setup has finished, abort install without any selections
+		elif (( $G_DIETPI_INSTALL_STAGE == 2 )); then
+
+			G_WHIP_MSG 'No changes have been detected. Unable to start installation.'
+
 		# Allow to finish first run setup without any selections
-		elif (( $G_DIETPI_INSTALL_STAGE == 1 )); then
+		else
 
 			G_WHIP_YESNO 'DietPi was unable to detect any additional software selections for install.
 \nNB: You can use dietpi-software at a later date, to install optimised software from our catalogue as required.
@@ -17163,11 +17199,6 @@ List of installed software and their online documentation URLs:
 
 			TARGETMENUID=-1 # Exit menu loop
 			GOSTARTINSTALL=1 # Set install start flag
-
-		# After first run setup has finished, abort install without any selections
-		elif (( $G_DIETPI_INSTALL_STAGE == 2 )); then
-
-			G_WHIP_MSG 'No changes have been detected. Unable to start installation.'
 
 		fi
 
@@ -17241,16 +17272,16 @@ List of installed software and their online documentation URLs:
 	Banner_Uninstalling(){ G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" "Uninstalling ${aSOFTWARE_NAME[$software_id]}: ${aSOFTWARE_DESC[$software_id]}"; }
 	Banner_Aborted(){
 
+		# Standard abort
+		if (( $G_DIETPI_INSTALL_STAGE == 2 )); then
+
+			/boot/dietpi/func/dietpi-banner 1
+
 		# 1st run abort
-		if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
+		else
 
 			/boot/dietpi/func/dietpi-banner 0
 			G_DIETPI-NOTIFY 1 '\n Installation aborted by user.\n Installation must be completed prior to using DietPi.\n Please run dietpi-software to restart the installation.\n'
-
-		# Standard abort
-		else
-
-			/boot/dietpi/func/dietpi-banner 1
 
 		fi
 
@@ -17265,8 +17296,8 @@ List of installed software and their online documentation URLs:
 	# Load .installed file, update vars, if it exists
 	Read_InstallFileList
 	#-------------------------------------------------------------------------------------
-	# CLI input mode
-	if [[ $1 ]]; then
+	# CLI input mode: Force menu mode on first run
+	if [[ $1 && $G_DIETPI_INSTALL_STAGE == 2 ]]; then
 
 		Input_Modes "$@"
 
@@ -17274,158 +17305,8 @@ List of installed software and their online documentation URLs:
 	# Standard launch
 	else
 
-		# 1st run dietpi-software
-		if (( $G_DIETPI_INSTALL_STAGE == 1 )); then
-
-			# Load all automation vars
-			FirstRun_Automation_Init
-
-			# Restore DietPi-Backup
-			if (( $AUTOINSTALL_RESTORE )); then
-
-				# Reboot only when backup restore succeeded
-				restore_succeeded=0
-
-				G_DIETPI-NOTIFY 2 'DietPi-Backup restore selected, scanning and mounting attached drives...'
-				i=0
-				while read -r line
-				do
-					# Mount drives to temporary mount points
-					mkdir -p "/mnt/dietpi-backup$i" && mount "$line" "/mnt/dietpi-backup$i"
-					((i++))
-
-				done < <(lsblk -rnpo NAME,UUID,MOUNTPOINT | mawk '$2 && ! $3 {print $1}')
-
-				G_DIETPI-NOTIFY 2 'Searching all drives for DietPi-Backup instances...'
-				mapfile -t alist < <(find /mnt -type f -name '.dietpi-backup_stats')
-
-				# Interactive restore
-				if [[ $AUTOINSTALL_RESTORE == 1 ]]; then
-
-					# Do we have any results?
-					if [[ ${alist[0]} ]]; then
-
-						# Create List for Whiptail
-						G_WHIP_MENU_ARRAY=()
-						for i in "${alist[@]}"
-						do
-							last_backup_date=$(sed -n '/ompleted/s/^.*: //p' "$i" | tail -1) # Date of last backup for this backup
-							backup_directory=${i%/.dietpi-backup_stats} # Backup directory (minus the backup file), that we can use for target backup directory.
-							G_WHIP_MENU_ARRAY+=("$backup_directory" ": $last_backup_date")
-						done
-
-						export G_DIETPI_SERVICES_DISABLE=1
-						G_WHIP_MENU 'Please select a previous backup to restore:' && /boot/dietpi/dietpi-backup -1 "$G_WHIP_RETURNED_VALUE" && restore_succeeded=1
-						unset -v G_DIETPI_SERVICES_DISABLE
-
-					else
-
-						G_WHIP_MSG 'No previous backups were found in /mnt/*. Install will continue like normal.'
-
-					fi
-
-				# Non-interactive restore
-				elif [[ $AUTOINSTALL_RESTORE == 2 ]]; then
-
-					# Do we have any results?
-					if [[ ${alist[0]} ]]; then
-
-						# Restore first found backup
-						export G_DIETPI_SERVICES_DISABLE=1
-						/boot/dietpi/dietpi-backup -1 "${alist[0]%/.dietpi-backup_stats}" && restore_succeeded=1
-						unset -v G_DIETPI_SERVICES_DISABLE
-
-					else
-
-						G_DIETPI-NOTIFY 1 'DietPi-Backup auto-restore was selected but no backup has been found in /mnt/*. Install will continue like normal.'
-
-					fi
-
-					# Downgrade dietpi.txt option
-					G_CONFIG_INJECT 'AUTO_SETUP_BACKUP_RESTORE=' 'AUTO_SETUP_BACKUP_RESTORE=1' /boot/dietpi.txt
-
-				fi
-
-				# Remove mounted drives and mount points
-				findmnt /mnt/dietpi-backup[0-9]* > /dev/null && umount /mnt/dietpi-backup[0-9]*
-				[[ -d '/mnt/dietpi-backup0' ]] && rmdir /mnt/dietpi-backup[0-9]*
-
-				# Reboot on successful restore
-				if (( $restore_succeeded )); then
-
-					G_DIETPI-NOTIFY 2 'The system will now reboot into the restored system'
-					sync # Failsafe
-					sleep 3
-					reboot
-
-				fi
-
-			fi
-
-			# Global PW
-			# - Automation, apply as per dietpi.txt
-			if (( $AUTOINSTALL_ENABLED )); then
-
-				Update_Global_Pw
-				# Set again to apply for UNIX users as well
-				/boot/dietpi/func/dietpi-set_software passwords "$GLOBAL_PW"
-
-			# - Prompt change global password and login passwords for root and dietpi users
-			else
-
-				/boot/dietpi/func/dietpi-set_software passwords
-
-			fi
-
-			# Disable serial? Must stay enabled for the following:
-			# - XU4: HC1/HC2 fail to boot into kernel without: https://github.com/MichaIng/DietPi/issues/2038#issuecomment-416089875
-			# - ROCKPro64: Fails to boot into kernel without
-			# - NanoPi NEO Air: Required for end users/debugging/setting up WiFi without automation
-			keep_serial0=1
-			if grep -q '^[[:blank:]]*CONFIG_SERIAL_CONSOLE_ENABLE=1' /boot/dietpi.txt &&
-				(( $G_HW_MODEL != 11 && $G_HW_MODEL != 42 && $G_HW_MODEL != 64 )) &&
-				G_WHIP_YESNO 'Serial console is currently enabled, would you like to disable it?\n - Disabling serial console will reduce memory consumption slightly\n - If you are unsure on what serial console is, it is safe to disable it'; then
-
-				/boot/dietpi/func/dietpi-set_hardware serialconsole disable
-				keep_serial0=0
-
-			fi
-
-			# RPi: Convert "serial0" to its actual symlink target
-			if (( $G_HW_MODEL < 10 )); then
-
-				if [[ $keep_serial0 == 1 && -L '/dev/serial0' ]]; then
-
-					tty=$(readlink -f /dev/serial0); tty=${tty#/dev/}
-					if [[ $(</boot/cmdline.txt) == *'serial0'* ]]; then
-
-						# shellcheck disable=2015
-						[[ $(</boot/cmdline.txt) == *"$tty"* ]] && sed -i "s/[[:blank:]]*console=${tty}[^\"[:blank:]]*//" /boot/cmdline.txt || sed -i "s/serial0/$tty/" /boot/cmdline.txt
-
-					fi
-					if [[ -f '/etc/systemd/system/getty.target.wants/serial-getty@serial0.service' ]]; then
-
-						systemctl disable serial-getty@serial0
-						systemctl enable "serial-getty@$tty"
-
-					fi
-
-				else
-
-					/boot/dietpi/func/dietpi-set_hardware serialconsole disable serial0
-
-				fi
-
-			fi
-			unset -v keep_serial0 tty
-
-		fi
-
-		# Prevent continue if no network or time sync is not completed: https://github.com/MichaIng/DietPi/issues/786
-		Check_Internet_and_NTPD
-
-		# Apply 1st run automation
-		(( $G_DIETPI_INSTALL_STAGE == 1 )) && FirstRun_Automation_Set
+		# DietPi-Automation pre install steps
+		(( $G_DIETPI_INSTALL_STAGE == 2 )) || DietPi-Automation_Pre
 
 		# Start DietPi Menu
 		until (( $TARGETMENUID < 0 ))
@@ -17447,6 +17328,9 @@ List of installed software and their online documentation URLs:
 
 	# Start software installs
 	Run_Installations
+
+	# DietPi-Automation post install steps
+	(( $G_DIETPI_INSTALL_STAGE == 2 )) || DietPi-Automation_Post
 
 	G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Installation completed'
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -811,7 +811,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_DEPS[$software_id]='114'
 		# Currently requires manual domain and coTURN server port input.
 		# - To resolve: Default port 5349 could be used, but reliable method to get external domain/static IP is required.
-		aSOFTWARE_REQUIRES_USERINPUT[$software_id]=1
+		aSOFTWARE_INTERACTIVE[$software_id]=1
 		#------------------
 		software_id=48
 
@@ -979,7 +979,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_CATX[$software_id]=5
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/gaming/#papermc'
 		aSOFTWARE_DEPS[$software_id]='8 9'
-		aSOFTWARE_REQUIRES_USERINPUT[$software_id]=1
+		aSOFTWARE_INTERACTIVE[$software_id]=1
 
 		#------------------
 		software_id=62
@@ -1044,7 +1044,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/social/#openbazaar'
 		aSOFTWARE_DEPS[$software_id]='188'
 		(( $G_HW_ARCH == 10 )) || aSOFTWARE_DEPS[$software_id]+=' 16'
-		aSOFTWARE_REQUIRES_USERINPUT[$software_id]=1
+		aSOFTWARE_INTERACTIVE[$software_id]=1
 
 		# Camera & Surveillance
 		#--------------------------------------------------------------------------------
@@ -1289,7 +1289,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_CATX[$software_id]=10
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/hardware_projects/#mycroft-ai'
 		aSOFTWARE_DEPS[$software_id]='5 17'
-		aSOFTWARE_REQUIRES_USERINPUT[$software_id]=1
+		aSOFTWARE_INTERACTIVE[$software_id]=1
 		#------------------
 		software_id=77
 
@@ -1414,7 +1414,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_CATX[$software_id]=13
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/dns_servers/#pi-hole'
 		aSOFTWARE_DEPS[$software_id]='17 87 89 webserver'
-		aSOFTWARE_REQUIRES_USERINPUT[$software_id]=1
+		aSOFTWARE_INTERACTIVE[$software_id]=1
 		#------------------
 		software_id=182
 
@@ -1469,7 +1469,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_CATX[$software_id]=15
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/vpn/#wireguard'
 		# Required to ask for public domain/IP and desired VPN server port
-		aSOFTWARE_REQUIRES_USERINPUT[$software_id]=1
+		aSOFTWARE_INTERACTIVE[$software_id]=1
 		# RPi/Odroids/x86_64 only
 		for ((i=22; i<=$MAX_G_HW_MODEL; i++))
 		do
@@ -1495,7 +1495,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_CATX[$software_id]=15
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/vpn/#pivpn'
 		aSOFTWARE_DEPS[$software_id]='17'
-		aSOFTWARE_REQUIRES_USERINPUT[$software_id]=1
+		aSOFTWARE_INTERACTIVE[$software_id]=1
 		aSOFTWARE_RECOMMENDS_AUTOMATED_UPGRADES[$software_id]=1
 
 		# Advanced Networking
@@ -1605,7 +1605,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_DESC[$software_id]='add a node to the Tor network'
 		aSOFTWARE_CATX[$software_id]=19
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/distributed_projects/#tor-relay'
-		aSOFTWARE_REQUIRES_USERINPUT[$software_id]=1
+		aSOFTWARE_INTERACTIVE[$software_id]=1
 		aSOFTWARE_RECOMMENDS_AUTOMATED_UPGRADES[$software_id]=1
 		#------------------
 		software_id=186
@@ -1964,7 +1964,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 
 		for i in "${!aSOFTWARE_NAME[@]}"
 		do
-			if (( ${aSOFTWARE_INSTALL_STATE[$i]} == 1 && ${aSOFTWARE_REQUIRES_USERINPUT[$i]:-0} == 1 ))
+			if (( ${aSOFTWARE_INSTALL_STATE[$i]} == 1 && ${aSOFTWARE_INTERACTIVE[$i]:-0} == 1 ))
 			then
 				# Unmark
 				aSOFTWARE_INSTALL_STATE[$i]=0
@@ -8296,7 +8296,7 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
-			mkdir -p /etc/exports.d
+			G_EXEC mkdir -p /etc/exports.d
 			[[ -f '/etc/exports.d/dietpi.exports' ]] || echo '/mnt/dietpi_userdata *(rw,async,no_root_squash,fsid=0,crossmnt,no_subtree_check)' > /etc/exports.d/dietpi.exports
 
 		fi
@@ -16365,14 +16365,9 @@ This requires an account at: https://remote.it/
 					# Check if this software is available for hardware, arch and distro
 					(( ${aSOFTWARE_AVAIL_G_HW_MODEL[$j,$G_HW_MODEL]:=1} && ${aSOFTWARE_AVAIL_G_HW_ARCH[$j,$G_HW_ARCH]:=1} && ${aSOFTWARE_AVAIL_G_DISTRO[$j,$G_DISTRO]:=1} )) || continue
 
-					# Set checkbox selection based on install state
+					# Set checkbox based on install state, including previous selection
 					local selected='off'
-					if (( ${aSOFTWARE_INSTALL_STATE[$j]} > 0 )); then
-
-						selected='on'
-						(( ${aSOFTWARE_INSTALL_STATE[$j]} == 1 )) && aSOFTWARE_INSTALL_STATE[$j]=0 # Reset pending state to 0. Menu checklists will apply back to 1
-
-					fi
+					(( ${aSOFTWARE_INSTALL_STATE[$j]} > 0 )) && selected='on'
 
 					# Add this software title to whiptail menu
 					G_WHIP_CHECKLIST_ARRAY+=("$j" "${aSOFTWARE_NAME[$j]}: ${aSOFTWARE_DESC[$j]}" "$selected")
@@ -16385,19 +16380,21 @@ This requires an account at: https://remote.it/
 
 			G_WHIP_SIZE_X_MAX=93 # Assure this is enough to show full software descriptions + scroll bar
 			G_WHIP_BUTTON_CANCEL_TEXT='Back'
-			G_WHIP_CHECKLIST "Please use the spacebar to select the software you wish to install.\n - Software and usage details: https://dietpi.com/docs/software/
- - NB: Pressing 'ESC' or selecting 'Back' will clear all changed selections"
+			G_WHIP_CHECKLIST 'Please use the spacebar to select the software you wish to install. Then press ENTER/RETURN or select "Ok" to confirm.
+ - Pressing ESC or selecting "Back" will clear all changed selections.
+ - Software and usage details: https://dietpi.com/docs/software/' || return 0
 
-			# Reset Choices made flag
+			# Reset flag
 			INSTALL_SOFTWARE_CHOICESMADE=0
 
-			# Check for matching results (selected items)
+			# Check for selected items
 			for i in $G_WHIP_RETURNED_VALUE
 			do
-				# Enable
-				(( ${aSOFTWARE_INSTALL_STATE[$i]} == 0 )) || continue
-				INSTALL_SOFTWARE_CHOICESMADE=1
+				# Skip already installed items
+				(( ${aSOFTWARE_INSTALL_STATE[$i]} == 2 )) && continue
+				# Selected and not installed item found, mark for install and set flag
 				aSOFTWARE_INSTALL_STATE[$i]=1
+				INSTALL_SOFTWARE_CHOICESMADE=1
 			done
 
 			#-----------------------------------------------------------------------------
@@ -16980,10 +16977,9 @@ We allow it to take up to 30 minutes, it's process can be followed, please be pa
 
 						fi
 
-						# Check for changes
+						# Do not allow to change preference, when another webserver is installed already
 						if (( $INDEX_WEBSERVER_TARGET != $INDEX_WEBSERVER_CURRENT )); then
 
-							# Check for existing and compatible installed stacks before allowing the change
 							local incompatible_webserver_preference=0
 							local info_currently_installed_webserver='None'
 
@@ -17230,7 +17226,7 @@ List of installed software and their online documentation URLs:
 			G_WHIP_BUTTON_CANCEL_TEXT='Back'
 			if G_WHIP_CHECKLIST 'Use the spacebar to select the software you would like to remove:'; then
 
-				# - Create list for user to review before removal
+				# Create list for user to review before removal
 				local output_string='The following software will be REMOVED from your system:'
 				for i in $G_WHIP_RETURNED_VALUE
 				do


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Software | emonHub: Align API key input boxes with each other. The one shown when selecting emonHub from the list has been overseen when a second one has been implemented into the install section. It is however fine to have both, as the old one is shown more nicely during software selection, but not when the CLI is used, so the new one serves as fallback.
+ DietPi-Software | WiFi Hotspot: Do not install own Realtek hostapd binaries anymore. They are old, require ancient LibSSL1.0.0 and are required only for non-RPi non-x86 non-Armbian SBCs with such a special Realtek WiFi adapter attached. And there were still cases where it simply didn't work.
+ DietPi-Software | LibSSL1.0.0: Remove install option, as it is not required anymore
+ DietPi-Software | Enhance software selection menu a bit: Previous selections in the same session won't be lost when exiting the checklist (ESC/"Back"), but previously already made selections will stay intact. Only when confirming (ENTER/RETURN/"Ok"), selections will be updated based on checklist tacks.
+ DietPi-Software | Only store installed software in the state file and "not installed" flag only for DietPi-RAMlog and Dropbear, as those are initialised as installed, matching our image defaults
+ DietPi-Software | Do not reinstall DietPi-RAMlog on first run, instead apply the dietpi.txt RAMlog size within the first run block
+ DietPi-Software | On first run, force menu mode and skip CLI
+ DietPi-Software | Merge first run DietPi-Automation steps into two dedicated functions, one prior to installs, where no network is strictly required, one afterwards
+ DietPi-Software | Invert first run checks: Treat all cases where the install state is not "2" as first run
+ DietPi-Software | Remove obsolete reset of choice and preference system during first run. The variables are declared with defaults and during first run, dietpi.txt settings or defaults are parsed and applied within the first run code block already. Align those defaults with what is intended.
+ DietPi-Software | Remove USB drive check and flag. It is basically wrong since /dev/sda1 is not necessarily a USB drive while it could be any /dev/sd[a-z][1-9]. Keep the two cases where it was used functionally untouched by explicitly checking findmnt there.
+ DietPi-Software | Shorten and rename aSOFTWARE_* array names to have the same length, because we can :)