### PR TITLE
Updated Bitwarden_rs to vaultwarden

### DIFF
--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -473,7 +473,7 @@ shopt -s extglob
 	unset -v 'aSOFTWARE_NAME6_34[137]' # CloudPrint
 	aSOFTWARE_NAME6_34[181]='PaperMC'
 	aSOFTWARE_NAME6_34[182]='Unbound'
-	aSOFTWARE_NAME6_34[183]='Bitwarden_RS'
+	aSOFTWARE_NAME6_34[183]='vaultwarden'
 	aSOFTWARE_NAME6_34[184]='Tor Relay'
 	aSOFTWARE_NAME6_34[185]='Portainer'
 

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Links to hardware and software manufacturers, sources and build instructions use
 - [Bazarr](https://github.com/morpheus65535/bazarr)
 - [PaperMC](https://github.com/PaperMC/Paper)
 - [Unbound](https://github.com/NLnetLabs/unbound)
-- [Bitwarden_RS](https://github.com/dani-garcia/bitwarden_rs)
+- [vaultwarden](https://github.com/dani-garcia/vaultwarden)
 - [Docker](https://github.com/docker/docker-ce)
 - [Portainer](https://github.com/portainer/portainer)
 - [Tor](https://gitlab.torproject.org/tpo/core/tor)

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -144,7 +144,7 @@ Available services:
 			'gogs'
 			'gitea'
 			'firefox-sync'
-			'bitwarden_rs'
+			'vaultwarden'
 
 			# - Emulation/Gaming
 			'mineos'

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -953,7 +953,7 @@ _EOF_
 		#------------------
 		software_id=183
 
-		aSOFTWARE_NAME[$software_id]='Bitwarden_RS'
+		aSOFTWARE_NAME[$software_id]='vaultwarden'
 		aSOFTWARE_DESC[$software_id]='Unofficial Bitwarden password manager server written in Rust'
 		aSOFTWARE_CATEGORY_INDEX[$software_id]=4
 		aSOFTWARE_ONLINEDOC_URL[$software_id]='https://dietpi.com/docs/software/cloud/#bitwarden_rs'
@@ -6167,22 +6167,22 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 		fi
 
-		software_id=183 # Bitwarden_RS
+		software_id=183 # vaultwarden
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
 
-			# Dependencies: https://github.com/dani-garcia/bitwarden_rs/wiki/Building-binary#dependencies
+			# Dependencies: https://github.com/dani-garcia/vaultwarden/wiki/Building-binary#dependencies
 			DEPS_LIST='pkg-config libssl-dev'
 
 			# Download
-			local version=$(curl -sSfL 'https://api.github.com/repos/dani-garcia/bitwarden_rs/releases/latest' | mawk -F\" '/"tag_name": /{print $4}')
+			local version=$(curl -sSfL 'https://api.github.com/repos/dani-garcia/vaultwarden/releases/latest' | mawk -F\" '/"tag_name": /{print $4}')
 			[[ $version ]] || { version='1.19.0'; G_DIETPI-NOTIFY 1 "Automatic latest ${aSOFTWARE_NAME[$software_id]} version detection failed. Version \"$version\" will be installed as fallback, but a newer version might be available. Please report this at: https://github.com/MichaIng/DietPi/issues"; }
-			Download_Install "https://github.com/dani-garcia/bitwarden_rs/archive/$version.tar.gz"
+			Download_Install "https://github.com/dani-garcia/vaultwarden/archive/$version.tar.gz"
 
 			# Replace old instance on reinstall
 			[[ -d '/opt/bitwarden_rs' ]] && G_EXEC rm -R /opt/bitwarden_rs
-			G_EXEC mv "bitwarden_rs-$version" /opt/bitwarden_rs
+			G_EXEC mv "vaultwarden-$version" /opt/bitwarden_rs
 
 			# Assure 2 GiB overall memory (-100 MiB to avoid tiny swap space) is available and limit concurrent cargo build jobs to 2 if less than 3 GiB memory is available.
 			local jobs=
@@ -11934,7 +11934,7 @@ _EOF_
 
 		fi
 
-		software_id=183 # Bitwarden_RS
+		software_id=183 # vaultwarden
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -11963,11 +11963,11 @@ _EOF_
 			G_EXEC chown -R bitwarden_rs:bitwarden_rs /mnt/dietpi_userdata/bitwarden_rs
 			G_EXEC chmod +x /opt/bitwarden_rs/target/release/bitwarden_rs
 
-			# Service: https://github.com/dani-garcia/bitwarden_rs/wiki/Setup-as-a-systemd-service
+			# Service: https://github.com/dani-garcia/vaultwarden/wiki/Setup-as-a-systemd-service
 			cat << '_EOF_' > /etc/systemd/system/bitwarden_rs.service
 [Unit]
 Description=Bitwarden Server (Rust Edition)
-Documentation=https://github.com/dani-garcia/bitwarden_rs
+Documentation=https://github.com/dani-garcia/vaultwarden
 
 After=dietpi-boot.service network.target
 
@@ -13949,7 +13949,7 @@ _EOF_
 
 		fi
 
-		software_id=183 # Bitwarden_RS
+		software_id=183 # vaultwarden
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling


### PR DESCRIPTION
Recently Bitwarden_rs was renamed to vaultwarden. This broke the install script [at this point](https://github.com/MichaIng/DietPi/blob/86c5e377c607c2e1d8e97138c7cb9d377120a55d/dietpi/dietpi-software#L6185) with the error message:
`[FAILED] DietPi-Software | mv bitwarden_rs-1.21.0 /opt/bitwarden_rs`

I fixed it by updating all references to the repo to the new url https://github.com/dani-garcia/vaultwarden and renaming to downloaded directory to `bitwarden_rs`. I kept everything else, because I suppose a lot of old installations would break, if everything is renamed.

**Status**: Ready

