### PR TITLE
DietPi-Software | Pi-hole: Whitelist GEO IP API we use in banner and DietPi-VPN

### DIFF
--- a/.update/patches
+++ b/.update/patches
@@ -159,7 +159,11 @@ Patch_7_2()
 \nNB: Roon extensions which were installed via the legacy method must be reinstalled with the new Roon Extension Manager. Extensions which were installed as Docker images already, will continue to function.'
 
 	# Pi-hole: Whitelist domain of GEO IP API we use in banner and DietPi-VPN as this is part of public blocklists: https://github.com/MichaIng/DietPi/pull/4398#issuecomment-845477200
-	command -v pihole > /dev/null && pihole -w freegeoip.app
+	if command -v pihole > /dev/null
+	then
+		G_DIETPI-NOTIFY 2 'Whitelisting "freegeoip.app" in Pi-hole, which is used by dietpi-banner and dietpi-vpn to obtain your public IP and location...'
+		pihole -w freegeoip.app --comment 'Used by dietpi-banner and dietpi-vpn to obtain your public IP and location'
+	fi
 }
 
 # v6.35 => v7 migration

--- a/.update/patches
+++ b/.update/patches
@@ -157,6 +157,9 @@ Patch_7_2()
 \nThe Roon Extension Manager received a major upgrade to v1.0. It is now implemented as Docker container, rather than as Node.js module.
 \nYou may upgrade via: dietpi-software reinstall 86
 \nNB: Roon extensions which were installed via the legacy method must be reinstalled with the new Roon Extension Manager. Extensions which were installed as Docker images already, will continue to function.'
+
+	# Pi-hole: Whitelist domain of GEO IP API we use in banner and DietPi-VPN as this is part of public blocklists: https://github.com/MichaIng/DietPi/pull/4398#issuecomment-845477200
+	command -v pihole > /dev/null && pihole -w freegeoip.app
 }
 
 # v6.35 => v7 migration

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9053,6 +9053,9 @@ _EOF_
 			# Set web interface PW: https://github.com/MichaIng/DietPi/issues/662
 			pihole -a -p "$GLOBAL_PW"
 
+			# Pi-hole: Whitelist domain of GEO IP API we use in banner and DietPi-VPN as this is part of public blocklists: https://github.com/MichaIng/DietPi/pull/4398#issuecomment-845477200
+			pihole -w freegeoip.app
+
 		fi
 
 		software_id=33 # Airsonic

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9054,7 +9054,8 @@ _EOF_
 			pihole -a -p "$GLOBAL_PW"
 
 			# Pi-hole: Whitelist domain of GEO IP API we use in banner and DietPi-VPN as this is part of public blocklists: https://github.com/MichaIng/DietPi/pull/4398#issuecomment-845477200
-			pihole -w freegeoip.app
+			G_DIETPI-NOTIFY 2 'Whitelisting "freegeoip.app", which is used by dietpi-banner and dietpi-vpn to obtain your public IP and location...'
+			pihole -w freegeoip.app --comment 'Used by dietpi-banner and dietpi-vpn to obtain your public IP and location'
 
 		fi
 


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Patches | Pi-hole: Whitelist domain of GEO IP API we use in banner and DietPi-VPN as this is part of public blocklists
+ DietPi-Software | Pi-hole: Whitelist domain of GEO IP API we use in banner and DietPi-VPN as this is part of public blocklists