### PR TITLE
DietPi-Software | Update hardcoded software versions

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1192,9 +1192,6 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		do
 			aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,$i]=0
 		done
-		# + NanoPi NEO, NEO Air, NEO2, NEO Plus2, M1, K1 Plus: https://github.com/friendlyarm/WiringNP
-		#   NanoPi M1 Plus compiling succeeds but gpio util fails
-		[[ $G_HW_MODEL =~ ^(60|64|65|57|63|67)$ ]] && aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,$G_HW_MODEL]=1
 		#------------------
 		software_id=71
 
@@ -3637,7 +3634,7 @@ Package: openssl libssl*\nPin: origin packages.sury.org\nPin-Priority: -1' > /et
 
 			else
 
-				Download_Install 'https://download.phpbb.com/pub/release/3.3/3.3.3/phpBB-3.3.3.tar.bz2'
+				Download_Install 'https://download.phpbb.com/pub/release/3.3/3.3.4/phpBB-3.3.4.tar.bz2'
 				G_EXEC mv phpBB3 /var/www/phpbb
 				# Files are shipped with strange UID:GID 1000:1000 while for security reasons it should be root:root.
 				G_EXEC chown -R root:root /var/www/phpbb
@@ -4539,15 +4536,9 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 				Download_Install 'https://github.com/WiringPi/WiringPi/archive/master.tar.gz'
 
 			# Odroids
-			elif (( $G_HW_MODEL < 20 ))
-			then
+			else
 				Download_Install 'https://github.com/hardkernel/wiringPi/archive/master.tar.gz'
 				G_EXEC mv {w,W}iringPi-master
-
-			# NanoPi
-			else
-				Download_Install 'https://github.com/friendlyarm/WiringNP/archive/master.tar.gz'
-				G_EXEC mv Wiring{NP,Pi}-master
 			fi
 
 			[[ -d '/usr/local/bin' ]] || G_EXEC mkdir -p /usr/local/bin # Failsafe, not pre-created currently: https://github.com/WiringPi/WiringPi/blob/master/gpio/Makefile
@@ -4712,7 +4703,7 @@ _EOF_
 			[[ -f '/etc/webiopi/config' ]] && reinstall=1
 
 			DEPS_LIST='python3-dev python3-setuptools patch'
-			Download_Install 'https://github.com/Freenove/WebIOPi/archive/refs/heads/master.tar.gz'
+			Download_Install 'https://github.com/Freenove/WebIOPi/archive/master.tar.gz'
 
 			G_EXEC cd WebIOPi-master/WebIOPi-*
 
@@ -4769,7 +4760,7 @@ _EOF_
 
 			Banner_Installing
 
-			local version='2.3.2'
+			local version='2.4.0'
 			DEPS_LIST='libpcre3-dev libssl-dev zlib1g-dev libsystemd-dev'
 			Download_Install "https://www.haproxy.org/download/${version%.*}/src/haproxy-$version.tar.gz"
 
@@ -4925,7 +4916,7 @@ _EOF_
 			# ARMv6: Install package manually since repo is not compatible: https://grafana.com/grafana/download?platform=arm
 			if (( $G_HW_ARCH == 1 )); then
 
-				Download_Install 'https://dl.grafana.com/oss/release/grafana-rpi_7.4.3_armhf.deb'
+				Download_Install 'https://dl.grafana.com/oss/release/grafana-rpi_7.5.7_armhf.deb'
 
 			# Else use official APT repo: https://grafana.com/docs/grafana/latest/installation/debian/#install-from-apt-repository
 			else
@@ -13609,7 +13600,7 @@ _EOF_
 
 		fi
 
-		software_id=141
+		software_id=141 # Spotify Connect Web
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
@@ -13640,6 +13631,7 @@ _EOF_
 
 			G_AGP unbound
 			[[ -d '/etc/unbound' ]] && rm -R /etc/unbound
+			[[ -d '/var/cache/unbound' ]] && rm -R /var/cache/unbound
 		fi
 
 		software_id=142 # CouchPotato
@@ -15040,7 +15032,8 @@ _EOF_
 
 			Banner_Uninstalling
 			G_AGP pijuice-base
-			[[ -d '/var/lib/dietpi/dietpi-software/installed/pijuice' ]] && G_EXEC_NOHALT=1 G_EXEC rm -R /var/lib/dietpi/dietpi-software/installed/pijuice
+			[[ -d '/var/lib/dietpi/dietpi-software/installed/pijuice' ]] && G_EXEC_NOEXIT=1 G_EXEC rm -R /var/lib/dietpi/dietpi-software/installed/pijuice
+			[[ -d '/var/lib/pijuice' ]] && G_EXEC_NOEXIT=1 G_EXEC rm -R /var/lib/pijuice
 
 		fi
 


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Software | WiringPi: Remove NanoPi support, as FriendlyARM's WiringNP works (reliable) with their kernel only, while we use Armbian or Debian kernel
+ DietPi-Software | phpBB: Install v3.3.4
+ DietPi-Software | HAProxy: Install v2.4.0
+ DietPi-Software | Grafana: On ARMv6 install v7.5.7
+ DietPi-Software | Unbound: Remove cache files on uninstall
+ DietPi-Software | PiJuice: Remove variable files on uninstall