### PR TITLE
Beta v7.2.1

### DIFF
--- a/.conf/dps_6/xorg_pine64.conf
+++ b/.conf/dps_6/xorg_pine64.conf
@@ -1,8 +1,6 @@
 Section "Device"
-
-        Identifier      "Allwinner A10/A13 FBDEV"
-        Driver          "fbturbo"
-        Option          "fbdev" "/dev/fb0"
-        Option          "SwapbuffersWait" "true"
-
+    Identifier  "Allwinner A10/A13 FBDEV"
+    Driver      "fbturbo"
+    Option      "fbdev" "/dev/fb0"
+    Option      "SwapbuffersWait" "true"
 EndSection

--- a/.update/version
+++ b/.update/version
@@ -1,7 +1,7 @@
 # Available DietPi version
 G_REMOTE_VERSION_CORE=7
 G_REMOTE_VERSION_SUB=2
-G_REMOTE_VERSION_RC=0
+G_REMOTE_VERSION_RC=1
 # Minimum DietPi version to allow update
 G_MIN_VERSION_CORE=6
 G_MIN_VERSION_SUB=0

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -703,7 +703,7 @@ Currently installed: $G_DISTRO_NAME (ID: $G_DISTRO)"; then
 		fi
 
 		# Install gdisk if root file system is on a GPT partition, used by DietPi-FS_partition_resize
-		[[ $(blkid -s PTTYPE -o value "$(lsblk -npo PKNAME "$(findmnt -no SOURCE /)")") == 'gpt' ]] && aPACKAGES_REQUIRED_INSTALL+=('gdisk')
+		[[ $(blkid -s PTTYPE -o value -c /dev/null "$(lsblk -npo PKNAME "$(findmnt -Ufnro SOURCE -M /)")") == 'gpt' ]] && aPACKAGES_REQUIRED_INSTALL+=('gdisk')
 
 		# Install file system tools required for file system resizing and fsck
 		while read -r line
@@ -721,7 +721,7 @@ Currently installed: $G_DISTRO_NAME (ID: $G_DISTRO)"; then
 				aPACKAGES_REQUIRED_INSTALL+=('btrfs-progs')
 			fi
 
-		done < <(blkid -s TYPE -o value | sort -u)
+		done < <(blkid -s TYPE -o value -c /dev/null | sort -u)
 
 		# Kernel/bootloader/firmware
 		# - We need to install those directly to allow G_AGA() autoremove possible older packages later: https://github.com/MichaIng/DietPi/issues/1285#issuecomment-354602594
@@ -1759,7 +1759,7 @@ _EOF_
 
 		G_DIETPI-NOTIFY 2 'Clearing items below tmpfs mount points'
 		G_EXEC mkdir -p /mnt/tmp_root
-		G_EXEC mount "$(findmnt -no SOURCE /)" /mnt/tmp_root
+		G_EXEC mount "$(findmnt -Ufnro SOURCE -M /)" /mnt/tmp_root
 		rm -vRf /mnt/tmp_root/{dev,proc,run,sys,tmp,var/log}/{,.??,.[^.]}*
 		G_EXEC umount /mnt/tmp_root
 		G_EXEC rmdir /mnt/tmp_root

--- a/dietpi/dietpi-backup
+++ b/dietpi/dietpi-backup
@@ -180,8 +180,8 @@ However, this check is a rough estimation in reasonable time, thus it could be m
 	Check_UUIDs()
 	{
 		UPDATE_UUIDs=0 UPDATE_GRUB=0 UPDATE_RPI=0 UPDATE_ARMBIAN=0 UPDATE_ODROID=0 UPDATE_UBOOT=0
-		UUID_ROOT=$(findmnt -no UUID /)
-		PARTUUID_ROOT=$(findmnt -no PARTUUID /)
+		UUID_ROOT=$(findmnt -Ufnro UUID -M /)
+		PARTUUID_ROOT=$(findmnt -Ufnro PARTUUID -M /)
 
 		# If the current rootfs' UUID or PARTUUID can be found in the the backups fstab, it can be assumed that it was created from the same drives.
 		grep -q "^UUID=${UUID_ROOT}[[:blank:]]" "$FP_TARGET/data/etc/fstab" || grep -q "^PARTUUID=${PARTUUID_ROOT}[[:blank:]]" "$FP_TARGET/data/etc/fstab" && return 0
@@ -239,12 +239,12 @@ However, this check is a rough estimation in reasonable time, thus it could be m
 		while read -r mountpoint
 		do
 			[[ $mountpoint ]] || continue
-			local uuid=$(findmnt -no UUID "$mountpoint")
+			local uuid=$(findmnt -Ufnro UUID -M "$mountpoint")
 			[[ $uuid ]] && G_EXEC sed -i "\|[[:blank:]]${mountpoint}[[:blank:]]|s|^[[:blank:]]*UUID=[^[:blank:]]*|UUID=$uuid|" /etc/fstab
-			local partuuid=$(findmnt -no PARTUUID "$mountpoint")
+			local partuuid=$(findmnt -Ufnro PARTUUID -M "$mountpoint")
 			[[ $partuuid ]] && G_EXEC sed -i "\|[[:blank:]]${mountpoint}[[:blank:]]|s|^[[:blank:]]*PARTUUID=[^[:blank:]]*|PARTUUID=$partuuid|" /etc/fstab
 
-		done < <(lsblk -no MOUNTPOINT "/dev/$(lsblk -no PKNAME "$G_ROOTFS_DEV")")
+		done < <(lsblk -no MOUNTPOINT "$(lsblk -npo PKNAME "$G_ROOTFS_DEV")")
 
 		# boot configs
 		# - x86_64

--- a/dietpi/dietpi-cpuinfo
+++ b/dietpi/dietpi-cpuinfo
@@ -9,6 +9,7 @@
 	#////////////////////////////////////
 	#
 	# Info:
+	# - Location: /boot/dietpi/dietpi-cpuinfo
 	# - Prints CPU information
 	#
 	# Usage:
@@ -18,13 +19,13 @@
 
 	# Import DietPi-Globals --------------------------------------------------------------
 	. /boot/dietpi/func/dietpi-globals
-	G_PROGRAM_NAME='DietPi-CPU_info'
+	readonly G_PROGRAM_NAME='DietPi-CPU_info'
 	G_CHECK_ROOT_USER
 	G_INIT
 	# Import DietPi-Globals --------------------------------------------------------------
 
 	# Grab input
-	disable_error=1 G_CHECK_VALIDINT "$1" && INPUT=$1 || INPUT=0
+	[[ $1 == 2 ]] && INPUT=$1 || INPUT=0
 
 	aCPU_CURRENT_FREQ=()
 	aCPU_MIN_FREQ=()
@@ -33,7 +34,6 @@
 
 		for ((i=0; i<$G_HW_CPU_CORES; i++))
 		do
-
 			if [[ -f /sys/devices/system/cpu/cpu$i/cpufreq/scaling_cur_freq ]]; then
 
 				aCPU_CURRENT_FREQ[$i]=$(<"/sys/devices/system/cpu/cpu$i/cpufreq/scaling_cur_freq")
@@ -51,7 +51,6 @@
 				aCPU_MAX_FREQ[$i]=$(<"/sys/devices/system/cpu/cpu$i/cpufreq/scaling_max_freq")
 
 			fi
-
 		done
 
 	}
@@ -67,9 +66,7 @@
 			local i
 			for ((i=10; i<=100; i+=5))
 			do
-
 				aCPU_SCALINGAVAILABLE_FREQ+=("$i")
-
 			done
 
 		# Standard
@@ -77,9 +74,7 @@
 
 			for ((i=0; i<$G_HW_CPU_CORES; i++))
 			do
-
 				aCPU_SCALINGAVAILABLE_FREQ[$i]=$(tr ' ' '\n' < "/sys/devices/system/cpu/cpu$i/cpufreq/scaling_available_frequencies" | sed 's/[^0-9]//g' | sed '/^$/d')
-
 			done
 
 		# XU4 3.x
@@ -131,9 +126,7 @@
 		(( ${#aCPU_CURRENT_FREQ[@]} )) && echo -e '\n \e[90m                Current Freq    Min Freq   Max Freq\e[0m'
 		for i in "${!aCPU_CURRENT_FREQ[@]}"
 		do
-
 			echo -e " \e[90mCPU$i         |\e[0m      $(( ${aCPU_CURRENT_FREQ[$i]:-0} / 1000 )) MHz      \e[90m$(( ${aCPU_MIN_FREQ[$i]:-0} / 1000 )) MHz    $(( ${aCPU_MAX_FREQ[$i]:-0} / 1000 )) MHz\e[0m"
-
 		done
 
 		echo
@@ -158,9 +151,7 @@
 
 			for i in "${aCPU_SCALINGAVAILABLE_FREQ[@]}"
 			do
-
 				echo "$i" >> $FP_CPU_SCALINGAVAILABLE_FREQ
-
 			done
 
 			# Order, remove dupes

--- a/dietpi/dietpi-cron
+++ b/dietpi/dietpi-cron
@@ -18,7 +18,7 @@
 
 	# Import DietPi-Globals --------------------------------------------------------------
 	. /boot/dietpi/func/dietpi-globals
-	G_PROGRAM_NAME='DietPi-Cron'
+	readonly G_PROGRAM_NAME='DietPi-Cron'
 	G_CHECK_ROOT_USER
 	G_INIT
 	# Import DietPi-Globals --------------------------------------------------------------
@@ -57,9 +57,7 @@
 		# Failsafe: Override invalid times
 		for i in "${!aCRON_TIME[@]}"
 		do
-
 			disable_error=1 G_CHECK_VALIDINT "${aCRON_TIME[$i]}" 0 || aCRON_TIME[$i]=5
-
 		done
 
 	}
@@ -146,17 +144,7 @@ _EOF_
 
 	}
 
-	aDAY_OF_WEEK_TEXT=(
-
-		'Monday'
-		'Tuesday'
-		'Wednesday'
-		'Thursday'
-		'Friday'
-		'Saturday'
-		'Sunday'
-
-	)
+	readonly aDAY_OF_WEEK_TEXT=('Monday' 'Tuesday' 'Wednesday' 'Thursday' 'Friday' 'Saturday' 'Sunday')
 	Input_DayOfWeek(){
 
 		local value=$1
@@ -351,10 +339,8 @@ _EOF_
 	# Start Menu
 	while (( $TARGETMENUID > -1 ))
 	do
-
 		G_TERM_CLEAR
 		Menu_Main
-
 	done
 	#-----------------------------------------------------------------------------------
 	exit

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -169,19 +169,19 @@ $swap_mounts
 			aDRIVE_ISFILESYSTEM[$index]=1
 			aDRIVE_MOUNT_SOURCE[$index]=$line
 			aDRIVE_MOUNT_TARGET[$index]=$(findmnt -Ufnro TARGET -S "${aDRIVE_MOUNT_SOURCE[$index]}") # Use only first result since bind mounts lead to multiple matches
-			aDRIVE_SIZE_TOTAL[$index]=$(findmnt -Ufnro SIZE -T "${aDRIVE_MOUNT_TARGET[$index]}")
-			aDRIVE_SIZE_USED[$index]=$(findmnt -Ufnro USED -T "${aDRIVE_MOUNT_TARGET[$index]}")
-			aDRIVE_SIZE_PERCENTUSED[$index]=$(findmnt -Ufnro USE% -T "${aDRIVE_MOUNT_TARGET[$index]}")
+			aDRIVE_SIZE_TOTAL[$index]=$(findmnt -Ufnro SIZE -M "${aDRIVE_MOUNT_TARGET[$index]}")
+			aDRIVE_SIZE_USED[$index]=$(findmnt -Ufnro USED -M "${aDRIVE_MOUNT_TARGET[$index]}")
+			aDRIVE_SIZE_PERCENTUSED[$index]=$(findmnt -Ufnro USE% -M "${aDRIVE_MOUNT_TARGET[$index]}")
 
 			# Physical
 			if [[ -d '/sys/block/'${aDRIVE_SOURCE_DEVICE[$index]} ]]; then
 
 				G_DIETPI-NOTIFY 2 " - Detected mounted physical drive: ${aDRIVE_MOUNT_SOURCE[$index]} > ${aDRIVE_MOUNT_TARGET[$index]}"
 
-				aDRIVE_UUID[$index]=$(findmnt -Ufnro UUID -T "${aDRIVE_MOUNT_TARGET[$index]}")
+				aDRIVE_UUID[$index]=$(findmnt -Ufnro UUID -M "${aDRIVE_MOUNT_TARGET[$index]}")
 				aDRIVE_SOURCE_DEVICE[$index]=$(Return_Drive_Without_Partitions "${aDRIVE_MOUNT_SOURCE[$index]}")
 				[[ ${aDRIVE_MOUNT_SOURCE[$index]} == /dev/${aDRIVE_SOURCE_DEVICE[$index]} ]] || aDRIVE_ISPARTITIONTABLE[$index]=1
-				(( ${aDRIVE_ISPARTITIONTABLE[$index]} )) && aDRIVE_PART_UUID[$index]=$(findmnt -Ufnro PARTUUID -T "${aDRIVE_MOUNT_TARGET[$index]}")
+				(( ${aDRIVE_ISPARTITIONTABLE[$index]} )) && aDRIVE_PART_UUID[$index]=$(findmnt -Ufnro PARTUUID -M "${aDRIVE_MOUNT_TARGET[$index]}")
 				# blkid is required here, as findmnt will show "fuseblk" for NTFS filesytems, which is a correct result but cannot be used in fstab or for mounting the drive.
 				aDRIVE_FSTYPE[$index]=$(blkid -s TYPE -o value -c /dev/null "${aDRIVE_MOUNT_SOURCE[$index]}")
 
@@ -192,7 +192,7 @@ $swap_mounts
 
 				aDRIVE_ISNETWORKED[$index]=1
 				# findmnt is required here, as blkid works only for physical block devices
-				aDRIVE_FSTYPE[$index]=$(findmnt -Ufnro FSTYPE -T "${aDRIVE_MOUNT_SOURCE[$index]}")
+				aDRIVE_FSTYPE[$index]=$(findmnt -Ufnro FSTYPE -M "${aDRIVE_MOUNT_SOURCE[$index]}")
 
 			fi
 
@@ -230,7 +230,7 @@ $swap_mounts
 			if [[ ${aDRIVE_ISNETWORKED[$index]} == 0 ]]; then
 
 				# Print error when physical drive has not UUID, as we cannot add it to fstab then
-				[[ ${aDRIVE_UUID[$index]} ]] || { G_DIETPI-NOTIFY 1 "The following drive seems to not have a UUID, skipping fstab entry:\n$(findmnt -Ufo SOURCE,TARGET,FSTYPE,UUID -T "${aDRIVE_MOUNT_TARGET[$index]}")"; continue; }
+				[[ ${aDRIVE_UUID[$index]} ]] || { G_DIETPI-NOTIFY 1 "The following drive seems to not have a UUID, skipping fstab entry:\n$(findmnt -Ufo SOURCE,TARGET,FSTYPE,UUID -M "${aDRIVE_MOUNT_TARGET[$index]}")"; continue; }
 
 				# R/W or R/O?
 				# - Add rw flag to mount options. This should be default but seems to be not in rare cases: https://github.com/MichaIng/DietPi/issues/3268
@@ -672,7 +672,7 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 
 			fi
 
-			G_EXEC sync # Sync to disk, as well to add a slight delay since XFS formatted file systems do not return a UUID (below) immediately
+			G_EXEC sync # Sync to disk, as well to add a slight delay since XFS formatted filesystems do not return a UUID (below) immediately
 
 			G_DIETPI-NOTIFY 0 "Created $info_format_fs_type filesystem: ${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
 			FORMAT_COMPLETED=1

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -192,7 +192,7 @@ $swap_mounts
 
 				aDRIVE_ISNETWORKED[$index]=1
 				# findmnt is required here, as blkid works only for physical block devices
-				aDRIVE_FSTYPE[$index]=$(findmnt -Ufnro FSTYPE -M "${aDRIVE_MOUNT_SOURCE[$index]}")
+				aDRIVE_FSTYPE[$index]=$(findmnt -Ufnro FSTYPE -M "${aDRIVE_MOUNT_TARGET[$index]}")
 
 			fi
 
@@ -282,7 +282,7 @@ $swap_mounts
 			done
 
 			# Failsafe: Must have a valid UUID! But blkid should print only drives with filesystems.
-			local uuid=$(blkid -s UUID -o value -c /dev/null -no UUID "$line")
+			local uuid=$(blkid -s UUID -o value -c /dev/null "$line")
 			[[ $uuid ]] || continue
 
 			G_DIETPI-NOTIFY 2 " - Detected unmounted drive: $line"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -905,6 +905,8 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,11]=1
 		# + ASUS TB
 		aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,52]=1
+		# - ARMv8
+		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,3]=0
 		#------------------
 		software_id=51
 
@@ -2661,37 +2663,10 @@ _EOF_
 			# Disable DPMS and screen blanking
 			dps_index=$software_id Download_Install '98-dietpi-disable_dpms.conf' /etc/X11/xorg.conf.d/98-dietpi-disable_dpms.conf
 
-			# RK3399
-			if (( $G_HW_CPUID == 3 )); then
+			# RK3399 + ASUS Tinker Board: Mesa GLESv2
+			if (( $G_HW_CPUID == 3 || $G_HW_MODEL == 52 )); then
 
-				# Buster: Mali-T864 driver by RockChip: https://github.com/rockchip-linux/rk-rootfs-build/tree/master/packages/arm64
-				if (( $G_DISTRO < 6 )); then
-
-					Download_Install 'https://dietpi.com/downloads/binaries/rk3399/libmali.deb'
-					G_EXEC cd /usr/lib/aarch64-linux-gnu
-					ln -sf libMali.so libEGL.so.1.1.0
-					ln -sf libMali.so libEGL.so
-					ln -sf libMali.so libEGL.so.1.0.0
-					ln -sf libMali.so libEGL.so.1.4
-					ln -sf libMali.so libEGL.so.1
-					ln -sf libMali.so libGLESv2.so
-					ln -sf libMali.so libGLESv2.so.2.0
-					ln -sf libMali.so libGLESv2.so.2.0.0
-					ln -sf libMali.so libGLESv1_CM.so
-					ln -sf libMali.so libGLESv1_CM.so.1
-					ln -sf libMali.so libGLESv1_CM.so.1.1
-					G_EXEC cd /tmp/$G_PROGRAM_NAME
-
-					# X.org config
-					G_BACKUP_FP /etc/X11/xorg.conf
-					dps_index=$software_id Download_Install 'xorg_rk3399.conf' /etc/X11/xorg.conf
-
-				# Bullseye: Use Mesa drivers provided by Debian repo
-				else
-
-					G_AGI libegl1 libgles2
-
-				fi
+				G_AGI libegl1 libgles2
 
 			# Odroid C2: https://dietpi.com/meveric/pool/main/s/setup-odroid/
 			elif (( $G_HW_MODEL == 12 )); then
@@ -2706,7 +2681,7 @@ _EOF_
 				# xf86-video-armsoc-odroid creates an xorg.conf
 				G_AGI firmware-samsung malit628-odroid xf86-video-armsoc-odroid
 
-			# PINE A64
+			# PINE A64: fbturbo: https://github.com/ssvb/xf86-video-fbturbo
 			elif (( $G_HW_MODEL == 40 )); then
 
 				Download_Install 'https://dietpi.com/downloads/binaries/all/libump_1-1_arm64.deb'
@@ -2714,38 +2689,6 @@ _EOF_
 				Download_Install 'https://dietpi.com/downloads/binaries/all/xf86-video-fbturbo_1-1_arm64.deb'
 				G_BACKUP_FP /etc/X11/xorg.conf
 				dps_index=$software_id Download_Install 'xorg_pine64.conf' /etc/X11/xorg.conf
-
-			# ASUS TB
-			elif (( $G_HW_MODEL == 52 )); then
-
-				# Buster: Mali-T760 driver by RockChip: https://github.com/rockchip-linux/rk-rootfs-build/tree/master/packages/armhf
-				if (( $G_DISTRO < 6 )); then
-
-					Download_Install 'https://dietpi.com/downloads/binaries/asus/libmali.deb'
-					G_EXEC cd /usr/lib/arm-linux-gnueabihf
-					ln -sf libMali.so libEGL.so.1.1.0
-					ln -sf libMali.so libEGL.so
-					ln -sf libMali.so libEGL.so.1.0.0
-					ln -sf libMali.so libEGL.so.1.4
-					ln -sf libMali.so libEGL.so.1
-					ln -sf libMali.so libGLESv2.so
-					ln -sf libMali.so libGLESv2.so.2.0
-					ln -sf libMali.so libGLESv2.so.2.0.0
-					ln -sf libMali.so libGLESv1_CM.so
-					ln -sf libMali.so libGLESv1_CM.so.1
-					ln -sf libMali.so libGLESv1_CM.so.1.1
-					G_EXEC cd /tmp/$G_PROGRAM_NAME
-
-					# X.org config
-					G_BACKUP_FP /etc/X11/xorg.conf
-					dps_index=$software_id Download_Install 'xorg_asustb.conf' /etc/X11/xorg.conf
-
-				# Bullseye: Use Mesa drivers provided by Debian repo
-				else
-
-					G_AGI libegl1 libgles2
-
-				fi
 
 			fi
 
@@ -3204,7 +3147,7 @@ _EOF_
 			# LXDE pulls in LightDM as dependency, which sets up itself as display manager so that the system boots automatically into it. So check whether a default display manager is present first, and if not, remove it afterwards.
 			local display_manager=0
 			[[ -f '/etc/systemd/system/display-manager.service' ]] && display_manager=1
-			G_AGI lxde upower $dbus_package xcompmgr
+			G_AGI lxde upower $dbus_package
 			[[ $display_manager == 0 && -f '/etc/systemd/system/display-manager.service' ]] && G_EXEC rm /etc/systemd/system/display-manager.service
 
 		fi
@@ -4124,8 +4067,8 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 			Banner_Installing
 
 			# Libraries
-			# - net-tools: WHDLoad database update checkes for "route" command currently
-			DEPS_LIST='libxml2 libfreetype6 libflac8 libmpeg2-4 libmpg123-0 net-tools' # libpng16-16 pulled by libfreetype6
+			# - wget: Used for WHDLoad database update: https://github.com/midwan/amiberry/commit/d6c103e3310bcf75c2d72a15849fbdf5eb7432b5
+			DEPS_LIST='libxml2 libfreetype6 libflac8 libmpeg2-4 libmpg123-0 wget' # libpng16-16 pulled by libfreetype6
 
 			# Platform and GPU drivers
 			# - RPi
@@ -4141,34 +4084,11 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 				local platform='xu4'
 				DEPS_LIST+=' malit628-odroid'
 
-			# - ASUS TB
+			# - ASUS Tunker Board
 			elif (( $G_HW_MODEL == 52 )); then
 
 				local platform='RK3288'
-				# Buster: Mali-T760 driver by RockChip: https://github.com/rockchip-linux/rk-rootfs-build/tree/master/packages/armhf
-				if (( $G_DISTRO < 6 )); then
-
-					Download_Install 'https://dietpi.com/downloads/binaries/asus/libmali.deb'
-					G_EXEC cd /usr/lib/arm-linux-gnueabihf
-					ln -sf libMali.so libEGL.so.1.1.0
-					ln -sf libMali.so libEGL.so
-					ln -sf libMali.so libEGL.so.1.0.0
-					ln -sf libMali.so libEGL.so.1.4
-					ln -sf libMali.so libEGL.so.1
-					ln -sf libMali.so libGLESv2.so
-					ln -sf libMali.so libGLESv2.so.2.0
-					ln -sf libMali.so libGLESv2.so.2.0.0
-					ln -sf libMali.so libGLESv1_CM.so
-					ln -sf libMali.so libGLESv1_CM.so.1
-					ln -sf libMali.so libGLESv1_CM.so.1.1
-					G_EXEC cd /tmp/$G_PROGRAM_NAME
-
-				# Bullseye: Use Mesa drivers provided by Debian repo
-				else
-
-					G_AGI libegl1 libgles2 libgl1-mesa-dri
-
-				fi
+				DEPS_LIST+=' libegl1 libgles2 libgl1-mesa-dri'
 
 			fi
 
@@ -7008,9 +6928,6 @@ exec sudo -u $ha_user dash -c '$ha_pyenv_activation; exec pip3 install -U homeas
 			#G_CONFIG_INJECT 'general.smoothScroll' 'pref("general.smoothScroll", false);' /etc/firefox-esr/firefox-esr.js
 
 			Create_Desktop_Shared_Items
-
-			# Composition manager: Enable limited server-side composition
-			dps_index=6 Download_Install 'xcompmgr.desktop' /etc/xdg/autostart/xcompmgr.desktop
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4515,7 +4515,7 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 
 			fi
 
-			local fallback_url="https://github.com/remoteit/installer/releases/download/v2.5.38/connectd_2.5.38_$arch.deb"
+			local fallback_url="https://github.com/remoteit/installer/releases/download/v2.6.39/connectd_2.6.39_$arch.deb"
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/remoteit/installer/releases/latest' | mawk -F\" "/\"browser_download_url\": .*\/connectd_[^\"\/]*_$arch\.deb\"/{print \$4}")"
 
 		fi
@@ -4641,8 +4641,8 @@ _EOF_
 			Banner_Installing
 
 			# On Stretch and ARMv6 (RPi 1/Zero) use Java 8, else most current
-			local fallback_url='https://github.com/blynkkk/blynk-server/releases/download/v0.41.15/server-0.41.15.jar' java=
-			(( $G_DISTRO < 5 || G_HW_ARCH == 1 )) && fallback_url='https://github.com/blynkkk/blynk-server/releases/download/v0.41.15/server-0.41.15-java8.jar' java='-java8'
+			local fallback_url='https://github.com/blynkkk/blynk-server/releases/download/v0.41.16/server-0.41.16.jar' java=
+			(( $G_DISTRO < 5 || G_HW_ARCH == 1 )) && fallback_url='https://github.com/blynkkk/blynk-server/releases/download/v0.41.16/server-0.41.16-java8.jar' java='-java8'
 
 			DEPS_LIST='python' Download_Install "$(curl -sSfL 'https://api.github.com/repos/blynkkk/blynk-server/releases/latest' | mawk -F\" "/\"browser_download_url\": .*\/server-[0-9.]*$java\.jar\"/{print \$4}")" /mnt/dietpi_userdata/blynk/blynkserver.jar
 
@@ -4981,7 +4981,7 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-			local fallback_url='https://github.com/gotson/komga/releases/download/v0.69.2/komga-0.69.2.jar'
+			local fallback_url='https://github.com/gotson/komga/releases/download/v0.96.2/komga-0.96.2.jar'
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/gotson/komga/releases/latest' | mawk -F\" '/"browser_download_url": .*\/komga-[^"\/]*\.jar"/{print $4}')" /mnt/dietpi_userdata/komga/komga.jar
 
 		fi
@@ -5007,12 +5007,12 @@ _EOF_
 			# Bullseye+
 			if (( $G_DISTRO > 5 ))
 			then
-				local fallback_url='https://github.com/ampache/ampache/releases/download/4.4.1/ampache-4.4.1_all.zip'
+				local fallback_url='https://github.com/ampache/ampache/releases/download/4.4.2/ampache-4.4.2_all.zip'
 				Download_Install "$(curl -sSfL 'https://api.github.com/repos/ampache/ampache/releases/latest' | mawk -F\" '/"browser_download_url": ".*\/ampache-[0-9\.]*_all.zip"/{print $4}')" ampache
 
 			# Ampache v5 requires PHP7.4, hence pull latest Ampache v4 on Buster and below: https://github.com/ampache/ampache/wiki/Ampache-Next-Changes
 			else
-				local fallback_url='https://github.com/ampache/ampache/releases/download/4.4.1/ampache-4.4.1_all.zip'
+				local fallback_url='https://github.com/ampache/ampache/releases/download/4.4.2/ampache-4.4.2_all.zip'
 				Download_Install "$(curl -sSfL 'https://api.github.com/repos/ampache/ampache/releases' | mawk -F\" '/"browser_download_url": ".*\/ampache-4[0-9\.]*_all.zip"/{print $4}' | head -1)" ampache
 			fi
 
@@ -5401,7 +5401,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			fi
 
-			local fallback_url="https://github.com/MediaBrowser/Emby.Releases/releases/download/4.5.4.0/emby-server-deb_4.5.4.0_$arch.deb"
+			local fallback_url="https://github.com/MediaBrowser/Emby.Releases/releases/download/4.6.0.50/emby-server-deb_4.6.0.50_$arch.deb"
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/MediaBrowser/Emby.Releases/releases/latest' | mawk -F\" "/\"browser_download_url\": .*\/emby-server-deb_[^\"\/]*_$arch\.deb\"/{print \$4}")"
 
 		fi
@@ -5662,7 +5662,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 				fi
 
-				local fallback_url="https://github.com/syncthing/syncthing/releases/download/v1.14.0/syncthing-linux-$arch-v1.14.0.tar.gz"
+				local fallback_url="https://github.com/syncthing/syncthing/releases/download/v1.16.1/syncthing-linux-$arch-v1.16.1.tar.gz"
 				Download_Install "$(curl -sSfL 'https://api.github.com/repos/syncthing/syncthing/releases/latest' | mawk -F\" "/\"browser_download_url\": .*\/syncthing-linux-$arch-[^\"\/]*\.tar\.gz\"/{print \$4}")"
 				G_EXEC mv syncthing-* /opt/syncthing
 
@@ -5887,7 +5887,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			HOME='/root'
 
 			# Install web vault
-			local fallback_url='https://github.com/dani-garcia/bw_web_builds/releases/download/v2.19.0d/bw_web_v2.19.0d.tar.gz'
+			local fallback_url='https://github.com/dani-garcia/bw_web_builds/releases/download/v2.20.1/bw_web_v2.20.1.tar.gz'
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/dani-garcia/bw_web_builds/releases/latest' | mawk -F\" '/"browser_download_url": .*\/bw_web_[^"\/]*\.tar\.gz"/{print $4}')" /mnt/dietpi_userdata/vaultwarden
 
 		fi
@@ -5926,7 +5926,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			DEPS_LIST="$PHP_NAME-bcmath $PHP_NAME-json $PHP_NAME-mbstring $PHP_NAME-xml $PHP_NAME-curl $PHP_NAME-sqlite3"
 
 			# Grab latest release
-			local fallback_url='https://github.com/koel/koel/releases/download/v5.1.0/koel-v5.1.0.tar.gz'
+			local fallback_url='https://github.com/koel/koel/releases/download/v5.1.4/koel-v5.1.4.tar.gz'
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/koel/koel/releases/latest' | mawk -F\" '/"browser_download_url": .*\/koel-[^"\/]*\.tar\.gz"/{print $4}')"
 
 			# Reinstall: Clear previous install, but keep existing config file
@@ -6021,25 +6021,25 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 				if (( $G_HW_ARCH == 1 ))
 				then
 					INSTALL_URL_ADDRESS=$(curl -sSfL 'https://api.github.com/repos/Radarr/Radarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux\.tar\.gz"/{print $4}')
-					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v3.1.1.4954/Radarr.master.3.1.1.4954.linux.tar.gz'
+					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v3.2.0.5048/Radarr.master.3.2.0.5048.linux.tar.gz'
 
 				# ARMv7
 				elif (( $G_HW_ARCH == 2 ))
 				then
 					INSTALL_URL_ADDRESS=$(curl -sSfL 'https://api.github.com/repos/Radarr/Radarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux-core-arm\.tar\.gz"/{print $4}')
-					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v3.1.1.4954/Radarr.master.3.1.1.4954.linux-core-arm.tar.gz'
+					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v3.2.0.5048/Radarr.master.3.2.0.5048.linux-core-arm.tar.gz'
 
 				# ARMv8
 				elif (( $G_HW_ARCH == 3 ))
 				then
 					INSTALL_URL_ADDRESS=$(curl -sSfL 'https://api.github.com/repos/Radarr/Radarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux-core-arm64\.tar\.gz"/{print $4}')
-					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v3.1.1.4954/Radarr.master.3.1.1.4954.linux-core-arm64.tar.gz'
+					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v3.2.0.5048/Radarr.master.3.2.0.5048.linux-core-arm64.tar.gz'
 
 				# x86_64
 				elif (( $G_HW_ARCH == 10 ))
 				then
 					INSTALL_URL_ADDRESS=$(curl -sSfL 'https://api.github.com/repos/Radarr/Radarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux-core-x64\.tar\.gz"/{print $4}')
-					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v3.1.1.4954/Radarr.master.3.1.1.4954.linux-core-x64.tar.gz'
+					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v3.2.0.5048/Radarr.master.3.2.0.5048.linux-core-x64.tar.gz'
 				fi
 
 				Download_Install "$INSTALL_URL_ADDRESS"
@@ -6065,7 +6065,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			else
 
-				local fallback_url='https://github.com/lidarr/Lidarr/releases/download/v0.7.2.1878/Lidarr.master.0.7.2.1878.linux.tar.gz'
+				local fallback_url='https://github.com/lidarr/Lidarr/releases/download/v0.8.1.2135/Lidarr.master.0.8.1.2135.linux.tar.gz'
 				DEPS_LIST='mediainfo' Download_Install "$(curl -sSfL 'https://api.github.com/repos/Lidarr/Lidarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux\.tar\.gz"/{print $4}')" /opt
 
 			fi
@@ -6135,7 +6135,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			# - ARMv6: Requires Mono: https://github.com/Jackett/Jackett#installation-on-linux-armv6-or-below
 			INSTALL_URL_ADDRESS=$(curl -sSfL 'https://api.github.com/repos/Jackett/Jackett/releases/latest' | mawk -F\" '/"browser_download_url": .*\/Jackett\.Binaries\.Mono\.tar\.gz"/{print $4}')
-			local fallback_url='https://github.com/Jackett/Jackett/releases/download/v0.17.513/Jackett.Binaries.Mono.tar.gz'
+			local fallback_url='https://github.com/Jackett/Jackett/releases/download/v0.18.106/Jackett.Binaries.Mono.tar.gz'
 
 			# - ARMv7
 			if (( $G_HW_ARCH == 2 )); then
@@ -6460,7 +6460,7 @@ If you want to update ${aSOFTWARE_NAME[$software_id]}, please use its internal u
 
 			fi
 
-			local fallback_url="https://github.com/go-gitea/gitea/releases/download/v1.13.6/gitea-1.13.6-linux-$arch"
+			local fallback_url="https://github.com/go-gitea/gitea/releases/download/v1.14.2/gitea-1.14.2-linux-$arch"
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/go-gitea/gitea/releases/latest' | mawk -F\" "/\"browser_download_url\": .*\/gitea-[^\"\/]*-linux-$arch\"/{print \$4}")" /mnt/dietpi_userdata/gitea/gitea
 
 		fi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1192,9 +1192,6 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		do
 			aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,$i]=0
 		done
-		# + NanoPi NEO, NEO Air, NEO2, NEO Plus2, M1, K1 Plus: https://github.com/friendlyarm/WiringNP
-		#   NanoPi M1 Plus compiling succeeds but gpio util fails
-		[[ $G_HW_MODEL =~ ^(60|64|65|57|63|67)$ ]] && aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,$G_HW_MODEL]=1
 		#------------------
 		software_id=71
 
@@ -3637,7 +3634,7 @@ Package: openssl libssl*\nPin: origin packages.sury.org\nPin-Priority: -1' > /et
 
 			else
 
-				Download_Install 'https://download.phpbb.com/pub/release/3.3/3.3.3/phpBB-3.3.3.tar.bz2'
+				Download_Install 'https://download.phpbb.com/pub/release/3.3/3.3.4/phpBB-3.3.4.tar.bz2'
 				G_EXEC mv phpBB3 /var/www/phpbb
 				# Files are shipped with strange UID:GID 1000:1000 while for security reasons it should be root:root.
 				G_EXEC chown -R root:root /var/www/phpbb
@@ -4539,15 +4536,9 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 				Download_Install 'https://github.com/WiringPi/WiringPi/archive/master.tar.gz'
 
 			# Odroids
-			elif (( $G_HW_MODEL < 20 ))
-			then
+			else
 				Download_Install 'https://github.com/hardkernel/wiringPi/archive/master.tar.gz'
 				G_EXEC mv {w,W}iringPi-master
-
-			# NanoPi
-			else
-				Download_Install 'https://github.com/friendlyarm/WiringNP/archive/master.tar.gz'
-				G_EXEC mv Wiring{NP,Pi}-master
 			fi
 
 			[[ -d '/usr/local/bin' ]] || G_EXEC mkdir -p /usr/local/bin # Failsafe, not pre-created currently: https://github.com/WiringPi/WiringPi/blob/master/gpio/Makefile
@@ -4712,7 +4703,7 @@ _EOF_
 			[[ -f '/etc/webiopi/config' ]] && reinstall=1
 
 			DEPS_LIST='python3-dev python3-setuptools patch'
-			Download_Install 'https://github.com/Freenove/WebIOPi/archive/refs/heads/master.tar.gz'
+			Download_Install 'https://github.com/Freenove/WebIOPi/archive/master.tar.gz'
 
 			G_EXEC cd WebIOPi-master/WebIOPi-*
 
@@ -4769,7 +4760,7 @@ _EOF_
 
 			Banner_Installing
 
-			local version='2.3.2'
+			local version='2.4.0'
 			DEPS_LIST='libpcre3-dev libssl-dev zlib1g-dev libsystemd-dev'
 			Download_Install "https://www.haproxy.org/download/${version%.*}/src/haproxy-$version.tar.gz"
 
@@ -4925,7 +4916,7 @@ _EOF_
 			# ARMv6: Install package manually since repo is not compatible: https://grafana.com/grafana/download?platform=arm
 			if (( $G_HW_ARCH == 1 )); then
 
-				Download_Install 'https://dl.grafana.com/oss/release/grafana-rpi_7.4.3_armhf.deb'
+				Download_Install 'https://dl.grafana.com/oss/release/grafana-rpi_7.5.7_armhf.deb'
 
 			# Else use official APT repo: https://grafana.com/docs/grafana/latest/installation/debian/#install-from-apt-repository
 			else
@@ -13609,7 +13600,7 @@ _EOF_
 
 		fi
 
-		software_id=141
+		software_id=141 # Spotify Connect Web
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
@@ -13640,6 +13631,7 @@ _EOF_
 
 			G_AGP unbound
 			[[ -d '/etc/unbound' ]] && rm -R /etc/unbound
+			[[ -d '/var/cache/unbound' ]] && rm -R /var/cache/unbound
 		fi
 
 		software_id=142 # CouchPotato
@@ -15040,7 +15032,8 @@ _EOF_
 
 			Banner_Uninstalling
 			G_AGP pijuice-base
-			[[ -d '/var/lib/dietpi/dietpi-software/installed/pijuice' ]] && G_EXEC_NOHALT=1 G_EXEC rm -R /var/lib/dietpi/dietpi-software/installed/pijuice
+			[[ -d '/var/lib/dietpi/dietpi-software/installed/pijuice' ]] && G_EXEC_NOEXIT=1 G_EXEC rm -R /var/lib/dietpi/dietpi-software/installed/pijuice
+			[[ -d '/var/lib/pijuice' ]] && G_EXEC_NOEXIT=1 G_EXEC rm -R /var/lib/pijuice
 
 		fi
 

--- a/dietpi/func/change_hostname
+++ b/dietpi/func/change_hostname
@@ -17,7 +17,7 @@
 	#////////////////////////////////////
 	# Import DietPi-Globals --------------------------------------------------------------
 	. /boot/dietpi/func/dietpi-globals
-	G_PROGRAM_NAME='DietPi-Change_hostname'
+	readonly G_PROGRAM_NAME='DietPi-Change_hostname'
 	G_CHECK_ROOT_USER
 	G_CHECK_ROOTFS_RW
 	G_INIT

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -57,7 +57,7 @@
 	# - Assign defaults/code version as fallback
 	[[ $G_DIETPI_VERSION_CORE ]] || G_DIETPI_VERSION_CORE=7
 	[[ $G_DIETPI_VERSION_SUB ]] || G_DIETPI_VERSION_SUB=2
-	[[ $G_DIETPI_VERSION_RC ]] || G_DIETPI_VERSION_RC=0
+	[[ $G_DIETPI_VERSION_RC ]] || G_DIETPI_VERSION_RC=1
 	[[ $G_GITBRANCH ]] || G_GITBRANCH='master'
 	[[ $G_GITOWNER ]] || G_GITOWNER='MichaIng'
 	# - Save current version and Git branch

--- a/dietpi/func/dietpi-logclear
+++ b/dietpi/func/dietpi-logclear
@@ -19,12 +19,12 @@
 
 	# Import DietPi-Globals --------------------------------------------------------------
 	. /boot/dietpi/func/dietpi-globals
-	G_PROGRAM_NAME='DietPi-Logclear'
+	readonly G_PROGRAM_NAME='DietPi-Logclear'
 	G_CHECK_ROOT_USER
 	G_INIT
 	# Import DietPi-Globals --------------------------------------------------------------
 
-	disable_error=1 G_CHECK_VALIDINT "$1" && INPUT=$1 || INPUT=-1
+	[[ $1 == [012] ]] && INPUT=$1 || INPUT=-1
 
 	#////////////////////////////////////////////////////////////////
 	# Global
@@ -61,7 +61,6 @@
 		local ARRAY_LOG_FILEPATH=()
 		while read -r line
 		do
-
 			ARRAY_LOG_FILEPATH+=("$line")
 
 		done <<< "$(find $FP_LOG -type f)"
@@ -69,7 +68,6 @@
 		# Process Logfiles, if there are any
 		(( ${#ARRAY_LOG_FILEPATH[@]} )) && for i in "${ARRAY_LOG_FILEPATH[@]}"
 		do
-
 			# File details
 			FILE_NAME=${i#/var/log/}
 			FILESIZE_BYTES=$(stat -c%s "$i")
@@ -142,7 +140,6 @@
 			fi
 
 			((INFO_FILES_PROCESSED++))
-
 		done
 
 	}
@@ -153,7 +150,7 @@
 
 	#----------------------------------------------------------------
 	# Print usage
-	if (( $INPUT > 2 || $INPUT < 0 )); then
+	if [[ $INPUT == '-1' ]]; then
 
 		G_DIETPI-NOTIFY 2 "Available commands:\e[0m
 \n\e[1m dietpi-logclear 0\e[0m

--- a/dietpi/func/dietpi-set_swapfile
+++ b/dietpi/func/dietpi-set_swapfile
@@ -166,7 +166,7 @@
 			fi
 
 		fi
-		SWAP_DIR="${SWAP_PATH%/*}/" SWAP_FS=$(findmnt -no FSTYPE -T "$SWAP_DIR")
+		SWAP_DIR="${SWAP_PATH%/*}/" SWAP_FS=$(findmnt -Ufnro FSTYPE -T "$SWAP_DIR")
 
 	fi
 

--- a/rootfs/var/lib/dietpi/services/fs_partition_resize.sh
+++ b/rootfs/var/lib/dietpi/services/fs_partition_resize.sh
@@ -7,7 +7,7 @@
 	! systemctl is-enabled dietpi-fs_partition_resize > /dev/null || systemctl disable dietpi-fs_partition_resize
 
 	# Detect root device
-	ROOT_DEV=$(findmnt -no SOURCE /)
+	ROOT_DEV=$(findmnt -Ufnro SOURCE -M /)
 
 	# Detect root partition and parent drive for supported naming schemes:
 	# - SCSI/SATA:	/dev/sd[a-z][1-9]
@@ -46,10 +46,10 @@
 	partprobe "$ROOT_DRIVE"
 	partx -u "$ROOT_DRIVE"
 
-	# Detect root file system type
-	ROOT_FSTYPE=$(findmnt -no FSTYPE /)
+	# Detect root filesystem type
+	ROOT_FSTYPE=$(findmnt -Ufnro FSTYPE -M /)
 
-	# Maximise root file system if type is supported
+	# Maximise root filesystem if type is supported
 	if [[ $ROOT_FSTYPE == ext[2-4] ]]; then
 
 		resize2fs "$ROOT_DEV"
@@ -66,7 +66,7 @@
 
 	else
 
-		echo "[FAILED] Unsupported root file system type ($ROOT_FSTYPE). Aborting..."
+		echo "[FAILED] Unsupported root filesystem type ($ROOT_FSTYPE). Aborting..."
 		exit 1
 
 	fi


### PR DESCRIPTION
### Beta v7.2.1
_(2021-05-25)_

#### Changes since v7.2.0
- DietPi-Software | General housekeeping: Some fallback URLs and hardcoded installed software versions have been updated and recognised left-over files after uninstalls are explicitly removed now.
- DietPi-Software | WiringPi has been disabled for NanoPi's as intended
- DietPi-Software | Amiberry has been disabled for ARMv8 as intended
- DietPi-Software | xcompmgr composite manager is not installed anymore at all. LXDE by default comes without X compositing support, which is fine when a lightweight desktop with max e.g. Kodi and Chromium performance is wanted. The initial idea behind this was when xompmgr was manually installed and started with full composite support, it was slower than when starting it with `-a` option, which is limited server-side composition. But that is still slower than no composition. And on faster SBCs or desktop PCs, users might want to have full composition, so installing a default autostart `xcompmgr -a` entry creates extra work for users which see their composition manager failing to start.
- DietPi-Software | RockChip Mali drivers are not installed anymore at all. On Stretch at least they seem to be faster than the generic Mesa drivers from Debian repo, but since Bullseye they are slower. But the bigger problem is that it never really reliably worked as intended as those drivers need to match the X server config and applications need to be build against those development libraries etc. So it only works as intended when installing all libraries and GPU accelerated software from the RockChip repo, which is how their images are set up. Also the packages we used were intended for Debian Stretch while Buster has a new repo without pre-built packages.

#### Fixes since v7.2.0
- DietPi-Drive_Manager | Filesystem types for network drives were not detected (visual issue only)
- DietPi-Drive_Manager | Unmounted (but formatted) drives were not detected as such

Since all are either minor invisible changes or v7.2.0 regression fixes, no additional CHANGELOG.txt entries are required IMO.