### PR TITLE
DietPi-Software | Mosquitto: Fix install on ARMv8

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -48,6 +48,7 @@ Fixes:
 - DietPi-Software | Kodi: Resolved an issue where an attempt was made during install to create a desktop entry, even if no desktop environment was installed. Many thanks to @sidgeg for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=8995
 - DietPi-Software | Bitwarden_RS: This project has been renamed by its author into "vaultwarden", to avoid confusion and potential legal issues with original Bitwarden software. This caused our install option to fail. To apply this important change to all Bitwarden_RS instances, it will be migrated via reinstall during DietPi update. As compiling can take up to several hours, users are informed at the beginning of the DietPi update, with the option to cancel and apply it at a later time. All data and configs will be preserved during the reinstall. Many thanks to @math-gout for informing us about this change: https://github.com/MichaIng/DietPi/issues/4325
 - DietPi-Software | Home Assistant: Resolved an issue where the install failed, as running "pyenv init -" does not complement the PATH variable anymore.
+- DietPi-Software | Mosquitto: Resolved an issue where the install failed on ARMv8 systems. Many thanks to @fra87 for reporting this issue: https://github.com/MichaIng/DietPi/issues/4424
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/4422
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11230,8 +11230,8 @@ _EOF_
 			if [[ ! -f '/etc/mosquitto/passwd' ]]
 			then
 				G_EXEC umask 0037
-				G_EXEC_PRE_FUNC(){ acommand[5]=$GLOBAL_PW; }
 				> /etc/mosquitto/passwd # Pre-create file, required for pre-v1.6.10 (ARMv8 up to Buster): https://github.com/MichaIng/DietPi/issues/4424
+				G_EXEC_PRE_FUNC(){ acommand[4]=$GLOBAL_PW; }
 				G_EXEC mosquitto_passwd -b /etc/mosquitto/passwd mosquitto "${GLOBAL_PW//?/X}"
 				G_EXEC chown root:mosquitto /etc/mosquitto/passwd
 				G_EXEC umask 0022

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4536,8 +4536,8 @@ _EOF_
 				G_CHECK_URL "$INSTALL_URL_ADDRESS"
 				G_EXEC eval "curl -sSLf '$INSTALL_URL_ADDRESS' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-mosquitto.gpg --yes"
 
-				# APT list: The Bullseye suite does not yet exist: https://repo.mosquitto.org/debian/dists/
-				G_EXEC eval "echo 'deb https://repo.mosquitto.org/debian/ ${G_DISTRO_NAME/bullseye/buster} main' > /etc/apt/sources.list.d/dietpi-mosquitto.list"
+				# APT list
+				G_EXEC eval "echo 'deb https://repo.mosquitto.org/debian/ $G_DISTRO_NAME main' > /etc/apt/sources.list.d/dietpi-mosquitto.list"
 				G_AGUP
 
 			fi
@@ -11231,7 +11231,8 @@ _EOF_
 			then
 				G_EXEC umask 0037
 				G_EXEC_PRE_FUNC(){ acommand[5]=$GLOBAL_PW; }
-				G_EXEC mosquitto_passwd -c -b /etc/mosquitto/passwd mosquitto "${GLOBAL_PW//?/X}"
+				> /etc/mosquitto/passwd # Pre-create file, required for pre-v1.6.10 (ARMv8 up to Buster): https://github.com/MichaIng/DietPi/issues/4424
+				G_EXEC mosquitto_passwd -b /etc/mosquitto/passwd mosquitto "${GLOBAL_PW//?/X}"
 				G_EXEC chown root:mosquitto /etc/mosquitto/passwd
 				G_EXEC umask 0022
 			fi


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Software | Mosquitto: Do not combine mosquitto_passwd "-c" and "-b" options, which is not supported on versions lower than 1.6.10, i.e. ARMv8 systems up to Buster.
+ DietPi-Software | Mosquitto: Since we do not install the Mosquitto repo on Bullseye (the Mosquitto versions match), no need to have the Bullseye => Buster suite workaround. As the Bullseye repo version is pretty current, we won't install the Mosquitto repo there until it natively supports Bullseye.