### PR TITLE
DietPi-JustBoom | Fix false equalizer detection

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ v7.3
 Changes:
 
 Fixes:
+- DietPi-JustBoom | Resolved an issue where the equalizer was always shown as "Off" even when it was just or previously enabled. Many thanks to @shao for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?p=35072#p35072
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/misc/dietpi-justboom
+++ b/dietpi/misc/dietpi-justboom
@@ -94,7 +94,7 @@ Please select a soundcard via 'dietpi-config' or install ALSA, or ideally an aud
 		# Remove equalizer and conversion plugin siffix
 		SOUNDCARD_CURRENT=${SOUNDCARD_CURRENT%-eq} SOUNDCARD_CURRENT=${SOUNDCARD_CURRENT%-plug}
 		SOUNDCARD_CARD_INDEX=$(mawk '/card /{print $2;exit}' /etc/asound.conf)
-		EQ_ENABLED=$(grep -cm1 '^[[:blank:]]*type equal*[[:blank:]]$' /etc/asound.conf)
+		EQ_ENABLED=$(grep -cm1 '^[[:blank:]]*type equal[[:blank:]]*$' /etc/asound.conf)
 
 		# MPD specific
 		if (( $MPD_INSTALLED )); then

--- a/dietpi/misc/dietpi-justboom
+++ b/dietpi/misc/dietpi-justboom
@@ -94,7 +94,7 @@ Please select a soundcard via 'dietpi-config' or install ALSA, or ideally an aud
 		# Remove equalizer and conversion plugin siffix
 		SOUNDCARD_CURRENT=${SOUNDCARD_CURRENT%-eq} SOUNDCARD_CURRENT=${SOUNDCARD_CURRENT%-plug}
 		SOUNDCARD_CARD_INDEX=$(mawk '/card /{print $2;exit}' /etc/asound.conf)
-		EQ_ENABLED=$(grep -cm1 '^pcm.plugequal' /etc/asound.conf)
+		EQ_ENABLED=$(grep -cm1 '^[[:blank:]]*type equal*[[:blank:]]$' /etc/asound.conf)
 
 		# MPD specific
 		if (( $MPD_INSTALLED )); then


### PR DESCRIPTION
**Status**: Ready

**Reference**: https://dietpi.com/phpbb/viewtopic.php?p=35072#p35072

**Commit list/description**:
+ DietPi-JustBoom | Fix false equalizer detection: "pcm.plugequal" has been replaced by manually declaring the PCM as "type equal" slave. Since this is and was the case as well for the control device "ctl.eq", this detection works with old and new asound.conf.