### PR TITLE
DietPi-Software | K3s

### DIFF
--- a/dietpi.txt
+++ b/dietpi.txt
@@ -260,6 +260,13 @@ SOFTWARE_HOMEASSISTANT_APT_DEPS=
 #	Add Python modules with version string at best, e.g.: firstModule==1.2.3 secondModule==4.5.6
 SOFTWARE_HOMEASSISTANT_PIP_DEPS=
 
+# K3s
+# Command with flags to use for launching K3s in the service
+# The value of this variable is copied directly into the INSTALL_K3S_EXEC environment variable before
+# running the k3s installer.
+# https://rancher.com/docs/k3s/latest/en/installation/install-options/#options-for-installation-with-script
+SOFTWARE_K3S_EXEC=
+
 #------------------------------------------------------------------------------------------------------
 ##### Dev settings #####
 #------------------------------------------------------------------------------------------------------

--- a/dietpi.txt
+++ b/dietpi.txt
@@ -263,8 +263,12 @@ SOFTWARE_HOMEASSISTANT_PIP_DEPS=
 # K3s
 # Command with flags to use for launching K3s in the service
 # The value of this variable is copied directly into the INSTALL_K3S_EXEC environment variable before
-# running the k3s installer.
+# running the K3s installer.
 # https://rancher.com/docs/k3s/latest/en/installation/install-options/#options-for-installation-with-script
+#
+# Optionally, you can add a configuration file named /boot/dietpi-k3s.yaml,
+# which will copied into place during installation
+# https://rancher.com/docs/k3s/latest/en/installation/install-options/#configuration-file
 SOFTWARE_K3S_EXEC=
 
 #------------------------------------------------------------------------------------------------------

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -887,7 +887,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/cloud/#vaultwarden'
 		aSOFTWARE_DEPS[$software_id]='16 87'
 		#------------------
-		software_id=126
+		software_id=192
 
 		aSOFTWARE_NAME[$software_id]='k3s'
 		aSOFTWARE_DESC[$software_id]='The certified Kubernetes distribution built for IoT & Edge computing'
@@ -5810,7 +5810,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 		fi
 
-    software_id=126 # K3s
+    software_id=192 # K3s
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -11613,7 +11613,7 @@ WantedBy=multi-user.target
 _EOF_
 		fi
 
-		software_id=126 # K3s
+		software_id=192 # K3s
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Configuration
@@ -13558,7 +13558,7 @@ _EOF_
 
 		fi
 
-		software_id=126 # K3s
+		software_id=192 # K3s
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5818,6 +5818,12 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			INSTALL_URL_ADDRESS='https://get.k3s.io'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
+      # Fetch config file if it exists
+			if [[ -f '/boot/dietpi-k3s.yaml' ]]; then
+				mkdir -p '/etc/rancher/k3s/'
+				cp '/boot/dietpi-k3s.yaml' '/etc/rancher/k3s/config.yaml'
+			fi
+
 			# Install
 			G_EXEC curl -sSfL "$INSTALL_URL_ADDRESS" -o install.sh
 			G_EXEC chmod +x install.sh
@@ -11611,17 +11617,6 @@ AmbientCapabilities=CAP_NET_BIND_SERVICE
 [Install]
 WantedBy=multi-user.target
 _EOF_
-		fi
-
-		software_id=192 # K3s
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Configuration
-
-			if [[ -f '/boot/dietpi-k3s.yaml' ]]; then
-				mkdir -p '/etc/rancher/k3s/'
-				cp '/boot/dietpi-k3s.yaml' '/etc/rancher/k3s/config.yaml'
-			fi
 		fi
 
 		software_id=141 # Spotify Connect Web

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2017,7 +2017,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 					j=84
 				fi
 
-			# Resolve desktop dependency based on install state 
+			# Resolve desktop dependency based on install state
 			elif [[ $j == 'desktop' ]]
 			then
 				# Check for existing desktop (LXDE, MATE, Xfce, GNUstep, LXQt) installation
@@ -5816,22 +5816,23 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://get.k3s.io'
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-
-      # Fetch config file if it exists
-			if [[ -f '/boot/dietpi-k3s.yaml' ]]; then
-				G_EXEC mkdir -p '/etc/rancher/k3s/'
+			# Fetch config file if it exists
+			if [[ -f '/boot/dietpi-k3s.yaml' && ! -f '/etc/rancher/k3s/config.yaml' ]]
+			then
+				G_EXEC mkdir -p '/etc/rancher/k3s'
 				G_EXEC cp '/boot/dietpi-k3s.yaml' '/etc/rancher/k3s/config.yaml'
 			fi
 
+			# Pre-create binary directory, as it might not always exist
+			G_EXEC mkdir -p /usr/local/bin
+
 			# Install
-			G_EXEC curl -sSfL "$INSTALL_URL_ADDRESS" -o install.sh
+			G_EXEC curl -sSfL 'https://get.k3s.io/' -o install.sh
 			G_EXEC chmod +x install.sh
 			export INSTALL_K3S_EXEC=$(sed -n '/^[[:blank:]]*SOFTWARE_K3S_EXEC=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			G_EXEC_NOEXIT=1 G_EXEC_OUTPUT=1 G_EXEC ./install.sh || aSOFTWARE_INSTALL_STATE[$software_id]=0
 			G_EXEC_NOHALT=1 G_EXEC rm install.sh
-			export INSTALL_K3S_EXEC=
+
 		fi
 
 		software_id=141 # Spotify Connect Web
@@ -13559,17 +13560,10 @@ _EOF_
 
 			Banner_Uninstalling
 
-			if [[ -x '/usr/local/bin/k3s-uninstall.sh' ]]; then
-				G_EXEC_OUTPUT=1 G_EXEC_NOEXIT=1 G_EXEC /usr/local/bin/k3s-uninstall.sh
-			fi
+			[[ -f '/usr/local/bin/k3s-uninstall.sh' ]] && G_EXEC_OUTPUT=1 G_EXEC_NOEXIT=1 G_EXEC /usr/local/bin/k3s-uninstall.sh
+			[[ -f '/usr/local/bin/k3s-agent-uninstall.sh' ]] && G_EXEC_OUTPUT=1 G_EXEC_NOEXIT=1 G_EXEC /usr/local/bin/k3s-agent-uninstall.sh
+			[[ -d '/etc/rancher' ]] && G_EXEC rm -R /etc/rancher
 
-			if [[ -x '/usr/local/bin/k3s-agent-uninstall.sh' ]]; then
-			  G_EXEC_OUTPUT=1 G_EXEC_NOEXIT=1 G_EXEC /usr/local/bin/k3s-agent-uninstall.sh
-			fi
-
-			if [[ -d '/etc/rancher' ]]; then
-			  G_EXEC rm -rf /etc/rancher
-      fi
 		fi
 
 		software_id=141 # Spotify Connect Web

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -886,6 +886,13 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_CATX[$software_id]=4
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/cloud/#vaultwarden'
 		aSOFTWARE_DEPS[$software_id]='16 87'
+		#------------------
+		software_id=126
+
+		aSOFTWARE_NAME[$software_id]='k3s'
+		aSOFTWARE_DESC[$software_id]='The certified Kubernetes distribution built for IoT & Edge computing'
+		aSOFTWARE_CATX[$software_id]=4
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/cloud/#k3s'
 
 		# Gaming & Emulation
 		#--------------------------------------------------------------------------------
@@ -5802,6 +5809,23 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/dani-garcia/bw_web_builds/releases/latest' | mawk -F\" '/"browser_download_url": .*\/bw_web_[^"\/]*\.tar\.gz"/{print $4}')" /mnt/dietpi_userdata/vaultwarden
 
 		fi
+
+    software_id=126 # K3s
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			INSTALL_URL_ADDRESS='https://get.k3s.io'
+			G_CHECK_URL "$INSTALL_URL_ADDRESS"
+
+			# Install
+			G_EXEC curl -sSfL "$INSTALL_URL_ADDRESS" -o install.sh
+			G_EXEC chmod +x install.sh
+      export INSTALL_K3S_EXEC=$(sed -n '/^[[:blank:]]*SOFTWARE_K3S_EXEC=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+			G_EXEC_NOEXIT=1 G_EXEC_OUTPUT=1 G_EXEC ./install.sh || aSOFTWARE_INSTALL_STATE[$software_id]=0
+			G_EXEC_NOHALT=1 G_EXEC rm install.sh
+			export INSTALL_K3S_EXEC=
+    fi
 
 		software_id=141 # Spotify Connect Web
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
@@ -11589,6 +11613,17 @@ WantedBy=multi-user.target
 _EOF_
 		fi
 
+		software_id=126 # K3s
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Configuration
+
+      if [[ -f '/boot/dietpi-k3s.yaml' ]]; then
+        mkdir -p '/etc/rancher/k3s/'
+        cp '/boot/dietpi-k3s.yaml' '/etc/rancher/k3s/config.yaml'
+      fi
+		fi
+
 		software_id=141 # Spotify Connect Web
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
@@ -13522,6 +13557,20 @@ _EOF_
 			[[ -d '/mnt/dietpi_userdata/vaultwarden' ]] && rm -R /mnt/dietpi_userdata/vaultwarden
 
 		fi
+
+		software_id=126 # K3s
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
+
+			Banner_Uninstalling
+
+			if [[ -x '/usr/local/bin/k3s-uninstall.sh' ]]; then
+			  G_EXEC_OUTPUT=1 G_EXEC_NOEXIT=1 G_EXEC /usr/local/bin/k3s-uninstall.sh
+      fi
+
+			if [[ -x '/usr/local/bin/k3s-agent-uninstall.sh' ]]; then
+			  G_EXEC_OUTPUT=1 G_EXEC_NOEXIT=1 G_EXEC /usr/local/bin/k3s-agent-uninstall.sh
+      fi
+    fi
 
 		software_id=141 # Spotify Connect Web
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5820,8 +5820,8 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
       # Fetch config file if it exists
 			if [[ -f '/boot/dietpi-k3s.yaml' ]]; then
-				mkdir -p '/etc/rancher/k3s/'
-				cp '/boot/dietpi-k3s.yaml' '/etc/rancher/k3s/config.yaml'
+				G_EXEC mkdir -p '/etc/rancher/k3s/'
+				G_EXEC cp '/boot/dietpi-k3s.yaml' '/etc/rancher/k3s/config.yaml'
 			fi
 
 			# Install
@@ -13565,6 +13565,10 @@ _EOF_
 			if [[ -x '/usr/local/bin/k3s-agent-uninstall.sh' ]]; then
 			  G_EXEC_OUTPUT=1 G_EXEC_NOEXIT=1 G_EXEC /usr/local/bin/k3s-agent-uninstall.sh
 			fi
+
+			if [[ -d '/etc/rancher' ]]; then
+			  G_EXEC rm -rf /etc/rancher
+      fi
 		fi
 
 		software_id=141 # Spotify Connect Web

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -886,13 +886,6 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_CATX[$software_id]=4
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/cloud/#vaultwarden'
 		aSOFTWARE_DEPS[$software_id]='16 87'
-		#------------------
-		software_id=192
-
-		aSOFTWARE_NAME[$software_id]='k3s'
-		aSOFTWARE_DESC[$software_id]='The certified Kubernetes distribution built for IoT & Edge computing'
-		aSOFTWARE_CATX[$software_id]=4
-		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/cloud/#k3s'
 
 		# Gaming & Emulation
 		#--------------------------------------------------------------------------------
@@ -1157,6 +1150,14 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_CATX[$software_id]=8
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/programming/#docker-compose'
 		aSOFTWARE_DEPS[$software_id]='130 162'
+
+		#------------------
+		software_id=192
+
+		aSOFTWARE_NAME[$software_id]='K3s'
+		aSOFTWARE_DESC[$software_id]='The certified Kubernetes distribution built for IoT & Edge computing'
+		aSOFTWARE_CATX[$software_id]=8
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/cloud/#k3s'
 
 		# Remote Access
 		#--------------------------------------------------------------------------------

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5810,7 +5810,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 		fi
 
-    software_id=192 # K3s
+		software_id=192 # K3s
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -5821,11 +5821,11 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			# Install
 			G_EXEC curl -sSfL "$INSTALL_URL_ADDRESS" -o install.sh
 			G_EXEC chmod +x install.sh
-      export INSTALL_K3S_EXEC=$(sed -n '/^[[:blank:]]*SOFTWARE_K3S_EXEC=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+			export INSTALL_K3S_EXEC=$(sed -n '/^[[:blank:]]*SOFTWARE_K3S_EXEC=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			G_EXEC_NOEXIT=1 G_EXEC_OUTPUT=1 G_EXEC ./install.sh || aSOFTWARE_INSTALL_STATE[$software_id]=0
 			G_EXEC_NOHALT=1 G_EXEC rm install.sh
 			export INSTALL_K3S_EXEC=
-    fi
+		fi
 
 		software_id=141 # Spotify Connect Web
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
@@ -11618,10 +11618,10 @@ _EOF_
 
 			Banner_Configuration
 
-      if [[ -f '/boot/dietpi-k3s.yaml' ]]; then
-        mkdir -p '/etc/rancher/k3s/'
-        cp '/boot/dietpi-k3s.yaml' '/etc/rancher/k3s/config.yaml'
-      fi
+			if [[ -f '/boot/dietpi-k3s.yaml' ]]; then
+				mkdir -p '/etc/rancher/k3s/'
+				cp '/boot/dietpi-k3s.yaml' '/etc/rancher/k3s/config.yaml'
+			fi
 		fi
 
 		software_id=141 # Spotify Connect Web
@@ -13564,13 +13564,13 @@ _EOF_
 			Banner_Uninstalling
 
 			if [[ -x '/usr/local/bin/k3s-uninstall.sh' ]]; then
-			  G_EXEC_OUTPUT=1 G_EXEC_NOEXIT=1 G_EXEC /usr/local/bin/k3s-uninstall.sh
-      fi
+				G_EXEC_OUTPUT=1 G_EXEC_NOEXIT=1 G_EXEC /usr/local/bin/k3s-uninstall.sh
+			fi
 
 			if [[ -x '/usr/local/bin/k3s-agent-uninstall.sh' ]]; then
 			  G_EXEC_OUTPUT=1 G_EXEC_NOEXIT=1 G_EXEC /usr/local/bin/k3s-agent-uninstall.sh
-      fi
-    fi
+			fi
+		fi
 
 		software_id=141 # Spotify Connect Web
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1152,7 +1152,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_DEPS[$software_id]='130 162'
 
 		#------------------
-		software_id=192
+		software_id=193
 
 		aSOFTWARE_NAME[$software_id]='K3s'
 		aSOFTWARE_DESC[$software_id]='The certified Kubernetes distribution built for IoT & Edge computing'
@@ -5811,10 +5811,13 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 		fi
 
-		software_id=192 # K3s
+		software_id=193 # K3s
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
+
+			# APT deps
+			G_AGI apparmor iptables
 
 			# Fetch config file if it exists
 			if [[ -f '/boot/dietpi-k3s.yaml' && ! -f '/etc/rancher/k3s/config.yaml' ]]
@@ -5829,9 +5832,14 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			# Install
 			G_EXEC curl -sSfL 'https://get.k3s.io/' -o install.sh
 			G_EXEC chmod +x install.sh
+			export INSTALL_K3S_SKIP_ENABLE=1
 			export INSTALL_K3S_EXEC=$(sed -n '/^[[:blank:]]*SOFTWARE_K3S_EXEC=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-			G_EXEC_NOEXIT=1 G_EXEC_OUTPUT=1 G_EXEC ./install.sh || aSOFTWARE_INSTALL_STATE[$software_id]=0
+			G_EXEC_NOEXIT=1 G_EXEC_OUTPUT=1 G_EXEC ./install.sh || aSOFTWARE_INSTALL_STATE[$software_id]=-1 UNINSTALL_REQUIRED=1
 			G_EXEC_NOHALT=1 G_EXEC rm install.sh
+
+			# Do not enter into a server restart loop on failure
+			[[ -d '/etc/systemd/system/k3s.service.d' ]] || G_EXEC mkdir -p /etc/systemd/system/k3s.service.d
+			echo -e '[Service]\nRestart=on-success' > /etc/systemd/system/k3s.service.d/dietpi.conf
 
 		fi
 
@@ -13555,7 +13563,7 @@ _EOF_
 
 		fi
 
-		software_id=192 # K3s
+		software_id=193 # K3s
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
@@ -13563,6 +13571,7 @@ _EOF_
 			[[ -f '/usr/local/bin/k3s-uninstall.sh' ]] && G_EXEC_OUTPUT=1 G_EXEC_NOEXIT=1 G_EXEC /usr/local/bin/k3s-uninstall.sh
 			[[ -f '/usr/local/bin/k3s-agent-uninstall.sh' ]] && G_EXEC_OUTPUT=1 G_EXEC_NOEXIT=1 G_EXEC /usr/local/bin/k3s-agent-uninstall.sh
 			[[ -d '/etc/rancher' ]] && G_EXEC rm -R /etc/rancher
+			[[ -d '/etc/systemd/system/k3s.service.d' ]] && G_EXEC rm -R /etc/systemd/system/k3s.service.d
 
 		fi
 


### PR DESCRIPTION
**Status**: WIP
- [x] Still needs testing
- [x] Needs docs

**Reference**: https://github.com/MichaIng/DietPi/issues/3772

**Commit list/description**:
- DietPi-Software | Added K3s

First shot at this, open to feedback.

I realised that my approach outlined in the issue wouldn't actually work. It is absolutely needed to be able to override the `K3S_EXEC` variable at install time, and in order to do that unattended, I guess it needs to be added to `/boot/dietpi.txt`. The other install-options can be ignored, if you need those you are going to be mucking about anyway, so might as well do it manually.

Also, after it is installed, it needs a configuration, and I opted to allow the user to provide one for the unattended install use case. K3s can run without it, but most people would need to make some changes to it, if they plan to do anything serious. I'm open to taking it out again if you absolutely don't like that pattern. It would naturally be clearly pointed out in the docs.

Next steps after getting some feedback would be to test that it works as intended, and write up some docs.
