### PR TITLE
Prevent prompt for License Auto-Accept

### DIFF
--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -1775,10 +1775,6 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program. If not, please see http://www.gnu.org/licenses/
 _EOF_
 
-		# Allow any user to accept license without confirmation.
-		# This prevents the interactive "remove write-protected regular file" prompt when the first interactive login is non-root.
-		G_EXEC chmod 666 /var/lib/dietpi/license.txt
-
 		G_DIETPI-NOTIFY 2 'Disabling and clearing APT cache'
 		/boot/dietpi/func/dietpi-set_software apt-cache cache disable
 		/boot/dietpi/func/dietpi-set_software apt-cache clean

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -1775,6 +1775,10 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program. If not, please see http://www.gnu.org/licenses/
 _EOF_
 
+		# Allow any user to accept license without confirmation.
+		# This prevents the interactive "remove write-protected regular file" prompt when the first interactive login is non-root.
+		G_EXEC chmod 666 /var/lib/dietpi/license.txt
+
 		G_DIETPI-NOTIFY 2 'Disabling and clearing APT cache'
 		/boot/dietpi/func/dietpi-set_software apt-cache cache disable
 		/boot/dietpi/func/dietpi-set_software apt-cache clean

--- a/dietpi.txt
+++ b/dietpi.txt
@@ -7,6 +7,7 @@
 #------------------------------------------------------------------------------------------------------
 # By setting this to "1" you accept the DietPi GPLv2 license and skip the related interactive dialog.
 # - Full license text: /boot/dietpi-LICENSE.txt
+# - This setting is ignored (and assumed to be affirmative) if AUTO_SETUP_AUTOMATED=1
 AUTO_SETUP_ACCEPT_LICENSE=0
 
 ##### Language/Regional Options #####
@@ -111,6 +112,7 @@ AUTO_SETUP_AUTOSTART_LOGIN_USER=root
 # On first login, run update, initial setup and software installs without any user input
 # - Setting this to "1" is required for below settings to take effect
 # - It is HIGHLY recommended to also set CONFIG_BOOT_WAIT_FOR_NETWORK=2, to force infinite wait for network connection during boot and prevent connection timeout errors.
+# - Setting this to "1" indicates that you accept the DietPi GPLv2 license, available at /boot/dietpi-LICENSE.txt, superseding any setting of AUTO_SETUP_ACCEPT_LICENSE.
 AUTO_SETUP_AUTOMATED=0
 
 # Global Password to be applied for the system

--- a/dietpi/dietpi-login
+++ b/dietpi/dietpi-login
@@ -23,8 +23,8 @@
 	Show_License(){
 
 		(( $G_INTERACTIVE )) && [[ -f '/var/lib/dietpi/license.txt' ]] || return
-		grep -q '^[[:blank:]]*AUTO_SETUP_ACCEPT_LICENSE=1' /boot/dietpi.txt || G_WHIP_VIEWFILE /var/lib/dietpi/license.txt
-		rm -f /var/lib/dietpi/license.txt
+		G_WHIP_VIEWFILE /var/lib/dietpi/license.txt
+		rm /var/lib/dietpi/license.txt
 
 	}
 

--- a/dietpi/dietpi-login
+++ b/dietpi/dietpi-login
@@ -23,8 +23,8 @@
 	Show_License(){
 
 		(( $G_INTERACTIVE )) && [[ -f '/var/lib/dietpi/license.txt' ]] || return
-		G_WHIP_VIEWFILE /var/lib/dietpi/license.txt
-		rm /var/lib/dietpi/license.txt
+		grep -q '^[[:blank:]]*AUTO_SETUP_ACCEPT_LICENSE=1' /boot/dietpi.txt || G_WHIP_VIEWFILE /var/lib/dietpi/license.txt
+		rm -f /var/lib/dietpi/license.txt
 
 	}
 

--- a/dietpi/dietpi-login
+++ b/dietpi/dietpi-login
@@ -23,7 +23,9 @@
 	Show_License(){
 
 		(( $G_INTERACTIVE )) && [[ -f '/var/lib/dietpi/license.txt' ]] || return
-		grep -q '^[[:blank:]]*AUTO_SETUP_ACCEPT_LICENSE=1' /boot/dietpi.txt || G_WHIP_VIEWFILE /var/lib/dietpi/license.txt
+		# If AUTO_SETUP_ACCEPT_LICENSE=1, neither prompt nor delete the license file.
+		grep -q '^[[:blank:]]*AUTO_SETUP_ACCEPT_LICENSE=1' /boot/dietpi.txt && return
+		G_WHIP_VIEWFILE /var/lib/dietpi/license.txt
 		rm /var/lib/dietpi/license.txt
 
 	}

--- a/dietpi/dietpi-login
+++ b/dietpi/dietpi-login
@@ -24,7 +24,7 @@
 
 		(( $G_INTERACTIVE )) && [[ -f '/var/lib/dietpi/license.txt' ]] || return
 		grep -q '^[[:blank:]]*AUTO_SETUP_ACCEPT_LICENSE=1' /boot/dietpi.txt || G_WHIP_VIEWFILE /var/lib/dietpi/license.txt
-		rm /var/lib/dietpi/license.txt
+		rm -f /var/lib/dietpi/license.txt
 
 	}
 

--- a/dietpi/dietpi-login
+++ b/dietpi/dietpi-login
@@ -23,7 +23,7 @@
 	Show_License(){
 
 		(( $G_INTERACTIVE )) && [[ -f '/var/lib/dietpi/license.txt' ]] || return
-		grep -q '^[[:blank:]]*AUTO_SETUP_ACCEPT_LICENSE=1' /boot/dietpi.txt || G_WHIP_VIEWFILE /var/lib/dietpi/license.txt
+		G_WHIP_VIEWFILE /var/lib/dietpi/license.txt
 		rm /var/lib/dietpi/license.txt
 
 	}

--- a/dietpi/dietpi-login
+++ b/dietpi/dietpi-login
@@ -22,7 +22,7 @@
 
 	Show_License(){
 
-		(( $G_INTERACTIVE )) && [[ -f '/var/lib/dietpi/license.txt' ]] || return
+		[[ -f '/var/lib/dietpi/license.txt' ]] || return
 		G_WHIP_VIEWFILE /var/lib/dietpi/license.txt
 		rm /var/lib/dietpi/license.txt
 
@@ -195,7 +195,7 @@ Please login again as user "root" with password "dietpi", respectively the one y
 				/boot/dietpi/func/run_ntpd
 
 				# Start DietPi-Update
-				/boot/dietpi/dietpi-update 1 # Sets G_DIETPI_INSTALL_STAGE=1
+				/boot/dietpi/dietpi-update 1 # Sets /boot/dietpi/.install_stage > G_DIETPI_INSTALL_STAGE=1
 
 				# Prompt on failure
 				(( $(</boot/dietpi/.install_stage) == 1 )) || Prompt_on_Failure
@@ -204,7 +204,7 @@ Please login again as user "root" with password "dietpi", respectively the one y
 			elif (( $G_DIETPI_INSTALL_STAGE == 1 )); then
 
 				# Start DietPi-Software
-				/boot/dietpi/dietpi-software 2>&1 | tee $FP_DIETPI_FIRSTRUNSETUP_LOG # Sets G_DIETPI_INSTALL_STAGE=2
+				/boot/dietpi/dietpi-software 2>&1 | tee $FP_DIETPI_FIRSTRUNSETUP_LOG # Sets /boot/dietpi/.install_stage > G_DIETPI_INSTALL_STAGE=2
 
 				# Prompt on failure
 				(( $(</boot/dietpi/.install_stage) == 2 )) || Prompt_on_Failure
@@ -222,7 +222,6 @@ Please login again as user "root" with password "dietpi", respectively the one y
 
 		while :
 		do
-
 			# Import DietPi-Globals --------------------------------------------------------------
 			. /boot/dietpi/func/dietpi-globals
 			G_PROGRAM_NAME='DietPi-Login'
@@ -235,7 +234,6 @@ Please login again as user "root" with password "dietpi", respectively the one y
 			# Normal Login
 			if (( $G_DIETPI_INSTALL_STAGE == 2 )); then
 
-				Show_License
 				/boot/dietpi/func/dietpi-banner 1
 
 				# DietPi-AutoStart
@@ -265,7 +263,6 @@ Please login again as user "root" with password "dietpi", respectively the one y
 				Prompt_on_Failure
 
 			fi
-
 		done
 
 	}

--- a/dietpi/dietpi-login
+++ b/dietpi/dietpi-login
@@ -23,9 +23,7 @@
 	Show_License(){
 
 		(( $G_INTERACTIVE )) && [[ -f '/var/lib/dietpi/license.txt' ]] || return
-		# If AUTO_SETUP_ACCEPT_LICENSE=1, neither prompt nor delete the license file.
-		grep -q '^[[:blank:]]*AUTO_SETUP_ACCEPT_LICENSE=1' /boot/dietpi.txt && return
-		G_WHIP_VIEWFILE /var/lib/dietpi/license.txt
+		grep -q '^[[:blank:]]*AUTO_SETUP_ACCEPT_LICENSE=1' /boot/dietpi.txt || G_WHIP_VIEWFILE /var/lib/dietpi/license.txt
 		rm /var/lib/dietpi/license.txt
 
 	}

--- a/dietpi/dietpi-login
+++ b/dietpi/dietpi-login
@@ -24,7 +24,7 @@
 
 		(( $G_INTERACTIVE )) && [[ -f '/var/lib/dietpi/license.txt' ]] || return
 		grep -q '^[[:blank:]]*AUTO_SETUP_ACCEPT_LICENSE=1' /boot/dietpi.txt || G_WHIP_VIEWFILE /var/lib/dietpi/license.txt
-		rm -f /var/lib/dietpi/license.txt
+		rm /var/lib/dietpi/license.txt
 
 	}
 

--- a/rootfs/var/lib/dietpi/services/dietpi-firstboot.bash
+++ b/rootfs/var/lib/dietpi/services/dietpi-firstboot.bash
@@ -297,13 +297,6 @@ _EOF_
 		# shellcheck disable=SC2015
 		(( $wifi_enabled )) && ifup wlan$index_wlan || ifup eth$index_eth
 
-		# If the user has flagged AUTO_SETUP_ACCEPT_LICENSE, rename the file to mark it as auto-accepted.
-		#
-		# Historically, this was invoked on first-interactive-login in Show_License, but we've moved it 
-		# to first-run because we consider modifying the license file to be the responsibility of root,
-		# (the file's owner), not whomever is the first user to open an interactive shell.
-		grep -q '^[[:blank:]]*AUTO_SETUP_ACCEPT_LICENSE=1' /boot/dietpi.txt && mv /var/lib/dietpi/license.txt /var/lib/dietpi/license.auto-accepted.txt
-
 	}
 
 	#/////////////////////////////////////////////////////////////////////////////////////

--- a/rootfs/var/lib/dietpi/services/dietpi-firstboot.bash
+++ b/rootfs/var/lib/dietpi/services/dietpi-firstboot.bash
@@ -155,9 +155,9 @@
 		# Set hostname
 		/boot/dietpi/func/change_hostname "$(sed -n '/^[[:blank:]]*AUTO_SETUP_NET_HOSTNAME=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)"
 
-		# Set root # if automated firstrun setup was chosen, will be reverted after firstrun installs
 		if grep -q '^[[:blank:]]*AUTO_SETUP_AUTOMATED=1' /boot/dietpi.txt; then
 
+			# Enable root autologin on local console (/dev/tty1) and container console (/dev/console), reverted during firstrun setup
 			mkdir -p /etc/systemd/system/{getty@tty1,console-getty}.service.d
 			cat << '_EOF_' > /etc/systemd/system/getty@tty1.service.d/dietpi-autologin.conf
 [Service]
@@ -169,6 +169,12 @@ _EOF_
 ExecStart=
 ExecStart=-/sbin/agetty -a root --noclear --keep-baud console 115200,38400,9600 $TERM
 _EOF_
+			# Assume accepted license in automated installs: https://github.com/MichaIng/DietPi/pull/4477
+			rm /var/lib/dietpi/license.txt
+
+		elif grep -q '^[[:blank:]]*AUTO_SETUP_ACCEPT_LICENSE=1' /boot/dietpi.txt; then
+
+			rm /var/lib/dietpi/license.txt
 
 		fi
 

--- a/rootfs/var/lib/dietpi/services/dietpi-firstboot.bash
+++ b/rootfs/var/lib/dietpi/services/dietpi-firstboot.bash
@@ -297,6 +297,13 @@ _EOF_
 		# shellcheck disable=SC2015
 		(( $wifi_enabled )) && ifup wlan$index_wlan || ifup eth$index_eth
 
+		# If the user has flagged AUTO_SETUP_ACCEPT_LICENSE, rename the file to mark it as auto-accepted.
+		#
+		# Historically, this was invoked on first-interactive-login in Show_License, but we've moved it 
+		# to first-run because we consider modifying the license file to be the responsibility of root,
+		# (the file's owner), not whomever is the first user to open an interactive shell.
+		grep -q '^[[:blank:]]*AUTO_SETUP_ACCEPT_LICENSE=1' /boot/dietpi.txt && mv /var/lib/dietpi/license.txt /var/lib/dietpi/license.auto-accepted.txt
+
 	}
 
 	#/////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
When a user with AUTO_SETUP_ACCEPT_LICENSE=1 invokes an interactive
prompt, they are presented with the following dialog.

    rm: remove write-protected regular file '/var/lib/dietpi/license.txt'?

Instead, prevent _any_ manual license interaction and file removal for users
with AUTO_SETUP_ACCEPT_LICENSE enabled (but leave the license file in
place)

<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
**Status**: WIP

**Reference**: No issue filed, yet.

**Commit list/description**:

Above, see commit description.