### PR TITLE
DietPi-Automation | Allow to turn DHCP leased IP as static IP

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ v7.3
 (2021-06-26)
 
 Changes:
+- DietPi-Automation | A new dietpi.txt setting "AUTO_SETUP_DHCP_TO_STATIC" has been added. When set to "1", DHCP leased network settings will be applied as static network settings automatically during first run setup. This works as well with older images, by adding the above setting to dietpi.txt.
 - DietPi-Backup | The include/exclude filter handling has been reworked. /mnt (dietpi_userdata) and /media related rules are added now via the editable custom filter file, which gives users more control over these. Especially it allows to include other mount points below /mnt, hence external dietpi_userdata, which was previously impossible due to the order in which those filter rules are applied.
 
 New Software:

--- a/dietpi.txt
+++ b/dietpi.txt
@@ -27,18 +27,21 @@ AUTO_SETUP_NET_ETHERNET_ENABLED=1
 AUTO_SETUP_NET_WIFI_ENABLED=0
 
 # Force ethernet speeds: 0=automatic speed | 10 = 10Mbit | 100 = 100Mbit etc
-# - This is mainly aimed at Pine A64 which may have an HW issue that causes unstable 1Gbit link.
+# - This is mainly aimed at PINE A64 which may have an HW issue that causes unstable 1Gbit link.
 AUTO_SETUP_NET_ETH_FORCE_SPEED=0
 
 # WiFi country code: 2 uppercase character value (e.g. GB US DE JP): https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 AUTO_SETUP_NET_WIFI_COUNTRY_CODE=GB
 
-# Enter your Static Network details below, if applicable.
+# Enter your static network details below, if applicable.
 AUTO_SETUP_NET_USESTATIC=0
 AUTO_SETUP_NET_STATIC_IP=192.168.0.100
 AUTO_SETUP_NET_STATIC_MASK=255.255.255.0
 AUTO_SETUP_NET_STATIC_GATEWAY=192.168.0.1
-AUTO_SETUP_NET_STATIC_DNS=9.9.9.9
+AUTO_SETUP_NET_STATIC_DNS=9.9.9.9 149.112.112.112
+
+# Set to "1" to convert DHCP leased network settings into static settings automatically on first boot.
+AUTO_SETUP_DHCP_TO_STATIC=0
 
 # Hostname
 AUTO_SETUP_NET_HOSTNAME=DietPi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -16502,6 +16502,7 @@ This requires an account at: https://remote.it/
 				sed -i "\|^iface wlan|,\$s|^.*netmask[[:blank:]].*\$|netmask $wlan_mask|" /etc/network/interfaces
 				sed -i "\|^iface wlan|,\$s|^.*gateway[[:blank:]].*\$|gateway $wlan_gateway|" /etc/network/interfaces
 			fi
+			unset -f cidr2mask
 
 			# Apply DNS nameservers
 			if [[ $nameservers ]]
@@ -16518,7 +16519,7 @@ This requires an account at: https://remote.it/
 				fi
 			fi
 
-			unset -f cidr2mask
+			G_DIETPI-NOTIFY 0 'Network changes will become effective with next reboot'
 		fi
 
 		# Set install stage to finished

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -16466,7 +16466,7 @@ This requires an account at: https://remote.it/
 			# Get Ethernet index
 			local nameservers eth_index=$(sed -En '/^[[:blank:]]*(allow-hotplug|auto)[[:blank:]]+eth[0-9]+$/{s/^.*eth//p;q}' /etc/network/interfaces)
 			# - Is enabled and uses DHCP
-			if [[ $eth_index ]] && grep -Eq "^[[:blank:]]*iface[[:blank:]]+eth$eth_index[[:blank:]]+inet[[:blank:]]+dhcp$" /tmp/net_interfaces
+			if [[ $eth_index ]] && grep -Eq "^[[:blank:]]*iface[[:blank:]]+eth${eth_index}[[:blank:]]+inet[[:blank:]]+dhcp$" /tmp/net_interfaces
 			then
 				G_DIETPI-NOTIFY 2 'Applying DHCP leased Ethernet settings as static Ethernet settings'
 
@@ -16486,7 +16486,7 @@ This requires an account at: https://remote.it/
 			# Get WiFi index
 			local wlan_index=$(sed -En '/^[[:blank:]]*(allow-hotplug|auto)[[:blank:]]+eth[0-9]+$/{s/^.*eth//p;q}' /etc/network/interfaces)
 			# - Is enabled and uses DHCP
-			if [[ $wlan_index ]] && grep -Eq "^[[:blank:]]*iface[[:blank:]]+wlan$wlan_index[[:blank:]]+inet[[:blank:]]+dhcp$" /tmp/net_interfaces
+			if [[ $wlan_index ]] && grep -Eq "^[[:blank:]]*iface[[:blank:]]+wlan${wlan_index}[[:blank:]]+inet[[:blank:]]+dhcp$" /tmp/net_interfaces
 			then
 				G_DIETPI-NOTIFY 2 'Applying DHCP leased WiFi settings as static WiFi settings'
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -16218,6 +16218,7 @@ This requires an account at: https://remote.it/
 		AUTOINSTALL_TIMESYNCMODE=$(sed -n '/^[[:blank:]]*CONFIG_NTP_MODE=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 		AUTOINSTALL_RESTORE=$(sed -n '/^[[:blank:]]*AUTO_SETUP_BACKUP_RESTORE=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 		AUTOINSTALL_RAMLOG_SIZE=$(sed -n '/^[[:blank:]]*AUTO_SETUP_RAMLOG_MAXSIZE=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+		AUTO_SETUP_DHCP_TO_STATIC=$(sed -n '/^[[:blank:]]*AUTO_SETUP_DHCP_TO_STATIC=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 
 		# Else set defaults
 		[[ $AUTOINSTALL_ENABLED ]] || AUTOINSTALL_ENABLED=0
@@ -16232,6 +16233,7 @@ This requires an account at: https://remote.it/
 		[[ $AUTOINSTALL_TIMESYNCMODE ]] || AUTOINSTALL_TIMESYNCMODE=2
 		[[ $AUTOINSTALL_RESTORE ]] || AUTOINSTALL_RESTORE=0
 		[[ $AUTOINSTALL_RAMLOG_SIZE ]] || AUTOINSTALL_RAMLOG_SIZE=50
+		[[ $AUTO_SETUP_DHCP_TO_STATIC == 1 ]] || AUTO_SETUP_DHCP_TO_STATIC=0
 
 		# Restore DietPi-Backup
 		if (( $AUTOINSTALL_RESTORE )); then
@@ -16433,6 +16435,91 @@ This requires an account at: https://remote.it/
 
 		# Apply AutoStart choice
 		/boot/dietpi/dietpi-autostart "$AUTOINSTALL_AUTOSTARTTARGET"
+
+		# Apply DHCP leased network settings as static network settings, if requested
+		if (( $AUTO_SETUP_DHCP_TO_STATIC ))
+		then
+			G_DIETPI-NOTIFY 2 'Applying DHCP leased network settings as static network settings'
+
+			# Function to convert CIDR notation into dot-decimal notation
+			cidr2mask()
+			{
+				local i mask full_octets=$(( $1 / 8 )) partial_octet=$(( $1%8 ))
+				for i in {0..3}
+				do
+					if (( $i < $full_octets ))
+					then
+						mask+=255
+
+					elif (( $i == $full_octets ))
+					then
+						mask+=$(( 256 - 2 ** ( 8 - $partial_octet ) ))
+
+					else
+						mask+=0
+					fi
+					(( $i < 3 )) && mask+=.
+				done
+				echo $mask
+			}
+
+			# Get Ethernet index
+			local nameservers eth_index=$(sed -En '/^[[:blank:]]*(allow-hotplug|auto)[[:blank:]]+eth[0-9]+$/{s/^.*eth//p;q}' /etc/network/interfaces)
+			# - Is enabled and uses DHCP
+			if [[ $eth_index ]] && grep -Eq "^[[:blank:]]*iface[[:blank:]]+eth$eth_index[[:blank:]]+inet[[:blank:]]+dhcp$" /tmp/net_interfaces
+			then
+				G_DIETPI-NOTIFY 2 'Applying DHCP leased Ethernet settings as static Ethernet settings'
+
+				# Get current network info
+				local eth_ip=$(ip -br -f inet a s "eth$eth_index" | mawk '{print $3}' | sed 's|/.*$||')
+				local eth_mask=$(cidr2mask "$(ip -br -f inet a s "eth$eth_index" | mawk '{print $3}' | sed 's|^.*/||')")
+				local eth_gateway=$(ip r l dev "eth$eth_index" 0/0 | mawk '{print $3;exit}')
+				nameservers=$(mawk '/^[[:blank:]]*nameserver[[:blank:]]/{print $2}' ORS=' ' /etc/resolv.conf)
+
+				# Apply current network settings statically
+				G_CONFIG_INJECT "iface[[:blank:]]+eth$eth_index" "iface eth$eth_index inet static" /etc/network/interfaces
+				sed -i "0,\|^.*address[[:blank:]].*\$|s||address $eth_ip|" /etc/network/interfaces
+				sed -i "0,\|^.*netmask[[:blank:]].*\$|s||netmask $eth_mask|" /etc/network/interfaces
+				sed -i "0,\|^.*gateway[[:blank:]].*\$|s||gateway $eth_gateway|" /etc/network/interfaces
+			fi
+
+			# Get WiFi index
+			local wlan_index=$(sed -En '/^[[:blank:]]*(allow-hotplug|auto)[[:blank:]]+eth[0-9]+$/{s/^.*eth//p;q}' /etc/network/interfaces)
+			# - Is enabled and uses DHCP
+			if [[ $wlan_index ]] && grep -Eq "^[[:blank:]]*iface[[:blank:]]+wlan$wlan_index[[:blank:]]+inet[[:blank:]]+dhcp$" /tmp/net_interfaces
+			then
+				G_DIETPI-NOTIFY 2 'Applying DHCP leased WiFi settings as static WiFi settings'
+
+				# Get current network info
+				local wlan_ip=$(ip -br -f inet a s "wlan$wlan_index" | mawk '{print $3}' | sed 's|/.*$||')
+				local wlan_mask=$(cidr2mask "$(ip -br -f inet a s "wlan$wlan_index" | mawk '{print $3}' | sed 's|^.*/||')")
+				local wlan_gateway=$(ip r l dev "wlan$wlan_index" 0/0 | mawk '{print $3;exit}')
+				[[ $nameservers ]] || nameservers=$(mawk '/^[[:blank:]]*nameserver[[:blank:]]/{print $2}' ORS=' ' /etc/resolv.conf)
+
+				# Apply current network settings statically
+				G_CONFIG_INJECT "iface[[:blank:]]+wlan$wlan_index" "iface wlan$wlan_index inet static" /etc/network/interfaces
+				sed -i "\|^iface wlan|,\$s|^.*address[[:blank:]].*\$|address $wlan_ip|" /etc/network/interfaces
+				sed -i "\|^iface wlan|,\$s|^.*netmask[[:blank:]].*\$|netmask $wlan_mask|" /etc/network/interfaces
+				sed -i "\|^iface wlan|,\$s|^.*gateway[[:blank:]].*\$|gateway $wlan_gateway|" /etc/network/interfaces
+			fi
+
+			# Apply DNS nameservers
+			if [[ $nameservers ]]
+			then
+				G_DIETPI-NOTIFY 2 'Applying DHCP leased DNS nameservers as static nameservers'
+
+				if command -v resolvconf > /dev/null
+				then
+					sed -i "/dns-nameservers[[:blank:]]/c\#dns-nameservers ${nameservers% }" /etc/network/interfaces
+					> /etc/resolv.conf
+					for i in $nameservers; do echo "nameserver $i" >> /etc/resolv.conf; done
+				else
+					sed -i "/dns-nameservers[[:blank:]]/c\dns-nameservers ${nameservers% }" /etc/network/interfaces
+				fi
+			fi
+
+			unset -f cidr2mask
+		fi
 
 		# Set install stage to finished
 		G_DIETPI_INSTALL_STAGE=2

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -16484,7 +16484,7 @@ This requires an account at: https://remote.it/
 			fi
 
 			# Get WiFi index
-			local wlan_index=$(sed -En '/^[[:blank:]]*(allow-hotplug|auto)[[:blank:]]+eth[0-9]+$/{s/^.*eth//p;q}' /etc/network/interfaces)
+			local wlan_index=$(sed -En '/^[[:blank:]]*(allow-hotplug|auto)[[:blank:]]+wlan[0-9]+$/{s/^.*wlan//p;q}' /etc/network/interfaces)
 			# - Is enabled and uses DHCP
 			if [[ $wlan_index ]] && grep -Eq "^[[:blank:]]*iface[[:blank:]]+wlan${wlan_index}[[:blank:]]+inet[[:blank:]]+dhcp$" /etc/network/interfaces
 			then

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -16511,11 +16511,11 @@ This requires an account at: https://remote.it/
 
 				if command -v resolvconf > /dev/null
 				then
+					sed -i "/dns-nameservers[[:blank:]]/c\dns-nameservers ${nameservers% }" /etc/network/interfaces
+				else
 					sed -i "/dns-nameservers[[:blank:]]/c\#dns-nameservers ${nameservers% }" /etc/network/interfaces
 					> /etc/resolv.conf
 					for i in $nameservers; do echo "nameserver $i" >> /etc/resolv.conf; done
-				else
-					sed -i "/dns-nameservers[[:blank:]]/c\dns-nameservers ${nameservers% }" /etc/network/interfaces
 				fi
 			fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -16466,7 +16466,7 @@ This requires an account at: https://remote.it/
 			# Get Ethernet index
 			local nameservers eth_index=$(sed -En '/^[[:blank:]]*(allow-hotplug|auto)[[:blank:]]+eth[0-9]+$/{s/^.*eth//p;q}' /etc/network/interfaces)
 			# - Is enabled and uses DHCP
-			if [[ $eth_index ]] && grep -Eq "^[[:blank:]]*iface[[:blank:]]+eth${eth_index}[[:blank:]]+inet[[:blank:]]+dhcp$" /tmp/net_interfaces
+			if [[ $eth_index ]] && grep -Eq "^[[:blank:]]*iface[[:blank:]]+eth${eth_index}[[:blank:]]+inet[[:blank:]]+dhcp$" /etc/network/interfaces
 			then
 				G_DIETPI-NOTIFY 2 'Applying DHCP leased Ethernet settings as static Ethernet settings'
 
@@ -16486,7 +16486,7 @@ This requires an account at: https://remote.it/
 			# Get WiFi index
 			local wlan_index=$(sed -En '/^[[:blank:]]*(allow-hotplug|auto)[[:blank:]]+eth[0-9]+$/{s/^.*eth//p;q}' /etc/network/interfaces)
 			# - Is enabled and uses DHCP
-			if [[ $wlan_index ]] && grep -Eq "^[[:blank:]]*iface[[:blank:]]+wlan${wlan_index}[[:blank:]]+inet[[:blank:]]+dhcp$" /tmp/net_interfaces
+			if [[ $wlan_index ]] && grep -Eq "^[[:blank:]]*iface[[:blank:]]+wlan${wlan_index}[[:blank:]]+inet[[:blank:]]+dhcp$" /etc/network/interfaces
 			then
 				G_DIETPI-NOTIFY 2 'Applying DHCP leased WiFi settings as static WiFi settings'
 


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ dietpi.txt | Add new setting to apply DHCP leased network settings as static network settings automatically on first boot