### PR TITLE
Beta v7.3.1

### DIFF
--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -528,6 +528,7 @@ shopt -s extglob
 	aSOFTWARE_NAME7_3[192]='Snapcast Client'
 	# shellcheck disable=SC2034
 	aSOFTWARE_NAME7_3[193]='K3s'
+	unset -v 'aSOFTWARE_NAME7_3[125]' # Tomcat 8
 
 	# $1 = File name
 	Process_File()

--- a/.update/patches
+++ b/.update/patches
@@ -244,6 +244,9 @@ _EOF_
 			G_EXEC rm /boot/dietpi/.dietpi-backup_inc_exc
 		fi
 	fi
+
+	# Tomcat 8: Remove obsolete install state
+	[[ -f '/boot/dietpi/.installed' ]] && grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[125\]=' /boot/dietpi/.installed && G_EXEC sed -i '/^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[125\]=/d' /boot/dietpi/.installed
 }
 
 # Main loop

--- a/.update/patches
+++ b/.update/patches
@@ -247,6 +247,9 @@ _EOF_
 
 	# Tomcat 8: Remove obsolete install state
 	[[ -f '/boot/dietpi/.installed' ]] && grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[125\]=' /boot/dietpi/.installed && G_EXEC sed -i '/^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[125\]=/d' /boot/dietpi/.installed
+
+	# Remove license (flag) file if AUTO_SETUP_AUTOMATED=1 is set, which would otherwise never happen on pre-v7.2 images, and if AUTO_SETUP_ACCEPT_LICENSE=1 is set, to assure the prompt is skipped when for some reason the script is reloaded between update and first installs.
+	[[ -f '/var/lib/dietpi/license.txt' ]] && grep -Eq '^[[:blank:]]*AUTO_SETUP_A(UTOMATED|CCEPT_LICENSE)=1' /boot/dietpi.txt && G_EXEC rm /var/lib/dietpi/license.txt
 }
 
 # Main loop

--- a/.update/version
+++ b/.update/version
@@ -1,7 +1,7 @@
 # Available DietPi version
 G_REMOTE_VERSION_CORE=7
 G_REMOTE_VERSION_SUB=3
-G_REMOTE_VERSION_RC=0
+G_REMOTE_VERSION_RC=1
 # Minimum DietPi version to allow update
 G_MIN_VERSION_CORE=6
 G_MIN_VERSION_SUB=0

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,7 @@ Removed Software:
 Fixes:
 - DietPi-JustBoom | Resolved an issue where the equalizer was always shown as "Off" even when it was just or previously enabled (v7.2 regression). Many thanks to @shao for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?p=35072#p35072
 - DietPi-Drive_Manager | Resolved an issue where network drives were detected as physical drives (v7.2 regression). Many thanks to @maartenlangeveld for reporting this issue: https://github.com/MichaIng/DietPi/issues/4479
+- DietPi-Softeare | Resolved an issue where with AUTO_SETUP_AUTOMATED=1 the OpenSSH client was always installed on first boot, even if it was not requested.
 - DietPi-Software | Node-RED: Resolved an issue where the Python 3 RPi.GPIO module was tried to be installed as dependency on non-RPi devices (v7.2 regression). Many thanks to @TheAdminFrmoHell for reporting this issue: https://github.com/MichaIng/DietPi/issues/4478
 - DietPi-Software | PI-SPC: Resolved a syntax error in the shutdown script loop. Many thanks to @renaudlarzilliere for reporting this issue: https://github.com/MichaIng/DietPi/issues/4488
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,7 +19,7 @@ Removed Software:
 Fixes:
 - DietPi-JustBoom | Resolved an issue where the equalizer was always shown as "Off" even when it was just or previously enabled (v7.2 regression). Many thanks to @shao for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?p=35072#p35072
 - DietPi-Drive_Manager | Resolved an issue where network drives were detected as physical drives (v7.2 regression). Many thanks to @maartenlangeveld for reporting this issue: https://github.com/MichaIng/DietPi/issues/4479
-- DietPi-Softeare | Resolved an issue where with AUTO_SETUP_AUTOMATED=1 the OpenSSH client was always installed on first boot, even if it was not requested.
+- DietPi-Software | Resolved an issue where with AUTO_SETUP_AUTOMATED=1 the OpenSSH client was always installed on first boot, even if it was not requested.
 - DietPi-Software | Node-RED: Resolved an issue where the Python 3 RPi.GPIO module was tried to be installed as dependency on non-RPi devices (v7.2 regression). Many thanks to @TheAdminFrmoHell for reporting this issue: https://github.com/MichaIng/DietPi/issues/4478
 - DietPi-Software | PI-SPC: Resolved a syntax error in the shutdown script loop. Many thanks to @renaudlarzilliere for reporting this issue: https://github.com/MichaIng/DietPi/issues/4488
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,9 @@ New Software:
 - Snapcast Client | The multiroom audio client component has been added with software ID 192. Many thanks to @foxy82 for implementing this software title: https://github.com/MichaIng/DietPi/pull/4465
 - K3s | Added a lightweight Kubernetes implementation as install option with ID 193. Many thanks to @mortenlj for implementing this software title: https://github.com/MichaIng/DietPi/pull/4476
 
+Removed Software:
+- Tomcat 8 | Tomcat version 8 is available until Debian Stretch only, from Buster on it's Tomcat 9. There is no reasonable configration that DietPi-Software can do on top of installing the APT package, which can be easily done manually via "apt install tomcat9". The software option is hence removed from DietPi-Software, in favour of a manual package install.
+
 Fixes:
 - DietPi-JustBoom | Resolved an issue where the equalizer was always shown as "Off" even when it was just or previously enabled (v7.2 regression). Many thanks to @shao for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?p=35072#p35072
 - DietPi-Drive_Manager | Resolved an issue where network drives were detected as physical drives (v7.2 regression). Many thanks to @maartenlangeveld for reporting this issue: https://github.com/MichaIng/DietPi/issues/4479

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ v7.3
 Changes:
 - DietPi-Automation | A new dietpi.txt setting "AUTO_SETUP_DHCP_TO_STATIC" has been added. When set to "1", DHCP leased network settings will be applied as static network settings automatically during first run setup. This works as well with older images, by adding the above setting to dietpi.txt.
 - DietPi-Backup | The include/exclude filter handling has been reworked. /mnt (dietpi_userdata) and /media related rules are added now via the editable custom filter file, which gives users more control over these. Especially it allows to include other mount points below /mnt, hence external dietpi_userdata, which was previously impossible due to the order in which those filter rules are applied.
+- DietPi-Software | Cuberite: This has been enabled for ARMv8 systems, where the available ARMv7 binaries work just fine. 
 
 New Software:
 - AdGuard Home | This DNS sinkhole ad blocker for your LAN, similar to Pi-hole, has been added with software ID 126.

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3451,6 +3451,9 @@ _EOF_
 			# perl is required for lighty-enable-mod, it has been degraded to recommends only with Buster.
 			G_AGI lighttpd perl
 
+			# Move default index page to new webroot
+			[[ -f '/var/www/html/index.lighttpd.html' ]] && G_EXEC mv /var/www/html/index.lighttpd.html /var/www/
+
 		fi
 
 		software_id=88 # MariaDB
@@ -7615,8 +7618,7 @@ _EOF_
 
 			# Webroot
 			G_CONFIG_INJECT 'server.document-root' 'server.document-root = "/var/www"' /etc/lighttpd/lighttpd.conf
-			# - Move default page
-			[[ -f '/var/www/html/index.lighttpd.html' ]] && G_EXEC mv /var/www/html/index.lighttpd.html /var/www/
+			# - Remove old webroot if empty
 			[[ -d '/var/www/html' ]] && G_EXEC rmdir --ignore-fail-on-non-empty /var/www/html
 
 			# Fix in case Lighttpd got updated to Buster version (on ARMv6 due to PHP7.3 libssl1.1 depedency)

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3073,10 +3073,20 @@ _EOF_
 
 			Banner_Installing
 
-			# On Stretch and ARMv6 (RPi 1/Zero) use Java 8, else most current
-			# Stretch does not ship Java 11 yet, ARMv6 is not Java 11 compatible, but luckily Raspbian ships Java 8 even on Bullseye: https://github.com/MichaIng/DietPi/issues/3182
-			local version=11
-			(( $G_DISTRO < 5 || G_HW_ARCH == 1 )) && version=8
+			# Stretch
+			if (( $G_DISTRO < 5 ))
+			then
+				local version=8
+
+			# Buster
+			elif (( $G_DISTRO == 5 ))
+			then
+				local version=11
+
+			# Bullseye
+			else
+				local version=17
+			fi
 
 			# Allow two attempts as workaround for ARM install issue: https://github.com/MichaIng/DietPi/issues/2524
 			G_EXEC_RETRIES=1 G_AGI ca-certificates-java openjdk-$version-jre-headless openjdk-$version-jdk-headless
@@ -5030,9 +5040,9 @@ _EOF_
 
 			Banner_Installing
 
-			# On Stretch and ARMv6 (RPi 1/Zero) use Java 8, else most current
+			# On Stretch ships Java 8
 			local fallback_url='https://github.com/blynkkk/blynk-server/releases/download/v0.41.16/server-0.41.16.jar' java=
-			(( $G_DISTRO < 5 || G_HW_ARCH == 1 )) && fallback_url='https://github.com/blynkkk/blynk-server/releases/download/v0.41.16/server-0.41.16-java8.jar' java='-java8'
+			(( $G_DISTRO < 5 )) && fallback_url='https://github.com/blynkkk/blynk-server/releases/download/v0.41.16/server-0.41.16-java8.jar' java='-java8'
 
 			DEPS_LIST='python' Download_Install "$(curl -sSfL 'https://api.github.com/repos/blynkkk/blynk-server/releases/latest' | mawk -F\" "/\"browser_download_url\": .*\/server-[0-9.]*$java\.jar\"/{print \$4}")" /mnt/dietpi_userdata/blynk/blynkserver.jar
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3738,7 +3738,7 @@ Package: openssl libssl*\nPin: origin packages.sury.org\nPin-Priority: -1' > /et
 
 			# Download latest version
 			local version=$(curl -sSfL 'https://dist.ipfs.io/go-ipfs/versions' | tail -n 1)
-			[[ $version ]] || { version='v0.8.0'; G_DIETPI-NOTIFY 1 "Automatic latest ${aSOFTWARE_NAME[$software_id]} version detection failed. Version \"$version\" will be installed as fallback, but a newer version might be available. Please report this at: https://github.com/MichaIng/DietPi/issues"; }
+			[[ $version ]] || { version='v0.9.0'; G_DIETPI-NOTIFY 1 "Automatic latest ${aSOFTWARE_NAME[$software_id]} version detection failed. Version \"$version\" will be installed as fallback, but a newer version might be available. Please report this at: https://github.com/MichaIng/DietPi/issues"; }
 			Download_Install "https://dist.ipfs.io/go-ipfs/$version/go-ipfs_${version}_linux-$arch.tar.gz"
 
 			# Install
@@ -7076,7 +7076,7 @@ If you want to update ${aSOFTWARE_NAME[$software_id]}, please use its internal u
 
 			# Download
 			local version=$(curl -sSfL 'https://api.github.com/repos/ptitSeb/box86/tags' | mawk -F\" '/"name": /{print $4;exit}')
-			[[ $version ]] || { version='v0.2.0'; G_DIETPI-NOTIFY 1 "Automatic latest ${aSOFTWARE_NAME[$software_id]} version detection failed. Version \"$version\" will be installed as fallback, but a newer version might be available. Please report this at: https://github.com/MichaIng/DietPi/issues"; }
+			[[ $version ]] || { version='v0.2.2'; G_DIETPI-NOTIFY 1 "Automatic latest ${aSOFTWARE_NAME[$software_id]} version detection failed. Version \"$version\" will be installed as fallback, but a newer version might be available. Please report this at: https://github.com/MichaIng/DietPi/issues"; }
 			Download_Install "https://github.com/ptitSeb/box86/archive/$version.tar.gz"
 
 			# Build

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -16517,7 +16517,7 @@ This requires an account at: https://remote.it/
 			aSOFTWARE_INSTALL_STATE[$software_id]=1
 			G_DIETPI-NOTIFY 2 "Automation: ${aSOFTWARE_NAME[$software_id]}. Flagged for installation."
 
-		done <<< "$(grep '^[[:blank:]]*AUTO_SETUP_INSTALL_SOFTWARE_ID=' /boot/dietpi.txt | mawk '{print $1}' | sed 's/[^0-9]*//g')"
+		done < <(grep '^[[:blank:]]*AUTO_SETUP_INSTALL_SOFTWARE_ID=' /boot/dietpi.txt | mawk '{print $1}' | sed 's/[^0-9]*//g')
 
 	}
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -677,7 +677,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_CATX[$software_id]=2
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#snapcast-client'
 		aSOFTWARE_DEPS[$software_id]='5'
-		aSOFTWARE_INTERACTIVE[$software_id]=1		
+		aSOFTWARE_INTERACTIVE[$software_id]=1
 		# Not currently available on arm64: https://github.com/badaix/snapcast/issues/706
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,3]=0
 
@@ -4713,11 +4713,12 @@ _EOF_
 			DEPS_LIST='apache2-utils'
 			Download_Install "$INSTALL_URL_ADDRESS"
 
-			# Reinstall: Stop service and remove install directory
-			[[ -f '/etc/systemd/system/adguardhome.service' ]] && G_EXEC systemctl stop adguardhome
-			[[ -d '/opt/adguardhome' ]] && G_EXEC rm -R /opt/adguardhome
+			# Install to userdata until it is possible to split binary and data/config without breaking the updater: https://github.com/AdguardTeam/AdGuardHome/issues/3286
+			[[ -d '/mnt/dietpi_userdata/adguardhome' ]] || G_EXEC mkdir -p /mnt/dietpi_userdata/adguardhome
+			G_EXEC cp -a AdGuardHome/. /mnt/dietpi_userdata/adguardhome/
+			G_EXEC rm -R AdGuardHome
 
-			G_EXEC mv AdGuardHome /opt/adguardhome
+			[[ -d '/opt/adguardhome' ]] && G_EXEC rm -R /opt/adguardhome # v7.3 beta
 
 			# Unbound: Switch port to 5335 if it was installed before, else it got just configured within its install step above
 			if (( ${aSOFTWARE_INSTALL_STATE[182]} == 2 )) && grep -q '^[[:blank:]]*port:[[:blank:]][[:blank:]]*53$' /etc/unbound/unbound.conf.d/dietpi.conf
@@ -7633,10 +7634,10 @@ _EOF_
 
 ## Start an FastCGI server using php-fpm
 fastcgi.server += ( ".php" =>
-        ((
-                "socket" => "/run/php/${PHP_NAME}-fpm.sock",
-                "broken-scriptfilename" => "enable"
-        ))
+	((
+		"socket" => "/run/php/$PHP_NAME-fpm.sock",
+		"broken-scriptfilename" => "enable"
+	))
 )
 _EOF_
 			# - Enable modules
@@ -9340,12 +9341,10 @@ _EOF_
 
 			Banner_Configuration
 
-			# Directory
-			G_EXEC mkdir -p /mnt/dietpi_userdata/adguardhome
-
 			# User
 			Create_User -d /mnt/dietpi_userdata/adguardhome adguardhome
 
+			# Config
 			if [[ ! -f '/mnt/dietpi_userdata/adguardhome/AdGuardHome.yaml' ]]
 			then
 				dps_index=$software_id Download_Install 'AdGuardHome.yaml' /mnt/dietpi_userdata/adguardhome/AdGuardHome.yaml
@@ -9354,20 +9353,17 @@ _EOF_
 			fi
 
 			# Unbound: Configure AdGuard Home to use it
-			if (( ${aSOFTWARE_INSTALL_STATE[182]} > 0 ))
+			if [[ ${aSOFTWARE_INSTALL_STATE[182]} -gt 0 && ! -f '/mnt/dietpi_userdata/adguardhome/dietpi-unbound.conf' ]]
 			then
 				G_DIETPI-NOTIFY 2 'Configuring AdGuard Home to use Unbound'
-				if [[ ! -f '/mnt/dietpi_userdata/adguardhome/dietpi-unbound.conf' ]]
-				then
-					echo '127.0.0.1:5335' > /mnt/dietpi_userdata/adguardhome/dietpi-unbound.conf
-					G_CONFIG_INJECT 'upstream_dns_file:[[:blank:]]' '  upstream_dns_file: /mnt/dietpi_userdata/adguardhome/dietpi-unbound.conf' /mnt/dietpi_userdata/adguardhome/AdGuardHome.yaml
-					systemctl -q is-active adguardhome && G_EXEC systemctl restart adguardhome
-				fi
+				echo '127.0.0.1:5335' > /mnt/dietpi_userdata/adguardhome/dietpi-unbound.conf
+				G_CONFIG_INJECT 'upstream_dns_file:[[:blank:]]' '  upstream_dns_file: /mnt/dietpi_userdata/adguardhome/dietpi-unbound.conf' /mnt/dietpi_userdata/adguardhome/AdGuardHome.yaml
+				systemctl -q is-active adguardhome && G_EXEC systemctl restart adguardhome
 			fi
 
 			# Permissions
-			G_EXEC chown -R adguardhome:adguardhome /mnt/dietpi_userdata/adguardhome /opt/adguardhome
-			G_EXEC chmod 755 /opt/adguardhome{,/AdGuardHome}
+			G_EXEC chown -R adguardhome:adguardhome /mnt/dietpi_userdata/adguardhome
+			G_EXEC chmod 0755 /mnt/dietpi_userdata/adguardhome/AdGuardHome
 
 			# Service
 			cat << '_EOF_' > /etc/systemd/system/adguardhome.service
@@ -9383,8 +9379,8 @@ StartLimitBurst=5
 [Service]
 User=adguardhome
 AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_RAW
-ExecStart=/opt/adguardhome/AdGuardHome -w /mnt/dietpi_userdata/adguardhome
-ExecReload=/opt/adguardhome/AdGuardHome -s reload
+ExecStart=/mnt/dietpi_userdata/adguardhome/AdGuardHome
+ExecReload=/mnt/dietpi_userdata/adguardhome/AdGuardHome -s reload
 Restart=on-failure
 RestartSec=5
 
@@ -13197,8 +13193,7 @@ _EOF_
 		local gpu_memory=0
 
 		# Kodi, Jellyfin
-		if (( ${aSOFTWARE_INSTALL_STATE[31]} == 1 ||
-		      ${aSOFTWARE_INSTALL_STATE[178]} == 1 )); then
+		if (( ${aSOFTWARE_INSTALL_STATE[31]} == 1 || ${aSOFTWARE_INSTALL_STATE[178]} == 1 )); then
 
 			gpu_memory=320
 			(( ${G_HW_MEMORY_SIZE:-0} > 512 )) || gpu_memory=256
@@ -13517,7 +13512,8 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			# Stop  Lighttpd service
+
+			# Stop Lighttpd service, as it may keep running on package removal
 			[[ -f '/lib/systemd/system/lighttpd.service' ]] && systemctl disable --now lighttpd
 
 			G_AGP lighttpd
@@ -13994,13 +13990,18 @@ _EOF_
 			[[ -f '/etc/pihole/setupVars.conf' ]] && grep -q '^[[:blank:]]*PIHOLE_DNS_1=127.0.0.1' /etc/pihole/setupVars.conf && G_CONFIG_INJECT 'PIHOLE_DNS_1=' 'PIHOLE_DNS_1=9.9.9.9' /etc/pihole/setupVars.conf
 
 			# AdGuard Home: Assure that it does not resolve via Unbound anymore
-			if [[ -f '/mnt/dietpi_userdata/adguardhome/dietpi-unbound.conf' ]]; then
-
+			if [[ -f '/mnt/dietpi_userdata/adguardhome/dietpi-unbound.conf' ]]
+			then
 				G_DIETPI-NOTIFY 2 'AdGuard Home upstream DNS server has been changed back to default settings due to Unbound being uninstalled.'
 				G_CONFIG_INJECT 'upstream_dns_file:[[:blank:]]' '  upstream_dns_file: ""' /mnt/dietpi_userdata/adguardhome/AdGuardHome.yaml
 				[[ -f '/mnt/dietpi_userdata/adguardhome/dietpi-unbound.conf' ]]  && G_EXEC_NOEXIT=1 G_EXEC rm /mnt/dietpi_userdata/adguardhome/dietpi-unbound.conf
 				systemctl -q is-active adguardhome && G_EXEC_NOEXIT=1 G_EXEC systemctl restart adguardhome
+			fi
 
+			# Failsafe: Add Quad9 to system resolver if only Unbound was used
+			if [[ -f '/etc/unbound/unbound.conf.d/dietpi.conf' ]] && grep -Eq '^[[:blank:]]*port:[[:blank:]]+53$' /etc/unbound/unbound.conf.d/dietpi.conf
+			then
+				grep '^[[:blank:]]*nameserver[[:blank:]]' /etc/resolv.conf | grep -qvE '[[:blank:]]127.0.0.1(:53)?$' || echo 'nameserver 9.9.9.9' >> /etc/resolv.conf # Failsafe
 			fi
 
 			G_AGP unbound
@@ -14501,13 +14502,15 @@ _EOF_
 			[[ -d '/etc/nginx/sites-dietpi' ]] && rm -f /etc/nginx/sites-dietpi/dietpi-pihole*
 
 			# Unbound: Switch port to 53 if it is still installed
-			if (( ${aSOFTWARE_INSTALL_STATE[182]} == 2 )) && grep -q '^[[:blank:]]*port:[[:blank:]][[:blank:]]*5335$' /etc/unbound/unbound.conf.d/dietpi.conf
+			if (( ${aSOFTWARE_INSTALL_STATE[182]} == 2 )) && grep -Eq '^[[:blank:]]*port:[[:blank:]]+5335$' /etc/unbound/unbound.conf.d/dietpi.conf
 			then
 				G_DIETPI-NOTIFY 2 'Reconfiguring Unbound to work on its own'
-				grep '^[[:blank:]]*nameserver[[:blank:]]' /etc/resolv.conf | grep -qvE '[[:blank:]]127.0.0.1(:53)?$' || echo 'nameserver 9.9.9.9' >> /etc/resolv.conf # Failsafe
 				G_CONFIG_INJECT 'port:[[:blank:]]' '	port: 53' /etc/unbound/unbound.conf.d/dietpi.conf
 				G_CONFIG_INJECT 'interface:[[:blank:]]' '	interface: 0.0.0.0' /etc/unbound/unbound.conf.d/dietpi.conf
+				grep -E '^[[:blank:]]*nameserver[[:blank:]]+127.0.0.1:5335$' /etc/resolv.conf && sed -Ei '/^[[:blank:]]*nameserver[[:blank:]]+127.0.0.1:5335$/c\nameserver 127.0.0.1' /etc/resolv.conf # Failsafe
 				G_EXEC_NOEXIT=1 G_EXEC systemctl restart unbound
+			else
+				grep '^[[:blank:]]*nameserver[[:blank:]]' /etc/resolv.conf | grep -qvE '[[:blank:]]127.0.0.1(:53)?$' || echo 'nameserver 9.9.9.9' >> /etc/resolv.conf # Failsafe
 			fi
 		fi
 
@@ -14522,20 +14525,22 @@ _EOF_
 
 			fi
 			[[ -d '/etc/systemd/system/adguardhome.service.d' ]] && G_EXEC rm -R /etc/systemd/system/adguardhome.service.d
-			[[ -d '/opt/adguardhome' ]] && G_EXEC rm -R /opt/adguardhome
-			
+			[[ -d '/opt/adguardhome' ]] && G_EXEC rm -R /opt/adguardhome # v7.3 beta
+
 			# Remove user and home directory
-			getent passwd adguardhome > /dev/null && userdel adguardhome
-			G_EXEC rm -Rf /mnt/dietpi_userdata/adguardhome
+			getent passwd adguardhome > /dev/null && G_EXEC userdel adguardhome
+			[[ -d '/mnt/dietpi_userdata/adguardhome' ]] && G_EXEC rm -R /mnt/dietpi_userdata/adguardhome
 
 			# Unbound: Switch port to 53 if it is still installed
-			if (( ${aSOFTWARE_INSTALL_STATE[182]} == 2 )) && grep -q '^[[:blank:]]*port:[[:blank:]][[:blank:]]*5335$' /etc/unbound/unbound.conf.d/dietpi.conf
+			if (( ${aSOFTWARE_INSTALL_STATE[182]} == 2 )) && grep -Eq '^[[:blank:]]*port:[[:blank:]]+5335$' /etc/unbound/unbound.conf.d/dietpi.conf
 			then
 				G_DIETPI-NOTIFY 2 'Reconfiguring Unbound to work on its own'
-				grep '^[[:blank:]]*nameserver[[:blank:]]' /etc/resolv.conf | grep -qvE '[[:blank:]]127.0.0.1(:53)?$' || echo 'nameserver 9.9.9.9' >> /etc/resolv.conf # Failsafe
 				G_CONFIG_INJECT 'port:[[:blank:]]' '	port: 53' /etc/unbound/unbound.conf.d/dietpi.conf
 				G_CONFIG_INJECT 'interface:[[:blank:]]' '	interface: 0.0.0.0' /etc/unbound/unbound.conf.d/dietpi.conf
+				grep -E '^[[:blank:]]*nameserver[[:blank:]]+127.0.0.1:5335$' /etc/resolv.conf && sed -Ei '/^[[:blank:]]*nameserver[[:blank:]]+127.0.0.1:5335$/c\nameserver 127.0.0.1' /etc/resolv.conf # Failsafe
 				G_EXEC_NOEXIT=1 G_EXEC systemctl restart unbound
+			else
+				grep '^[[:blank:]]*nameserver[[:blank:]]' /etc/resolv.conf | grep -qvE '[[:blank:]]127.0.0.1(:53)?$' || echo 'nameserver 9.9.9.9' >> /etc/resolv.conf # Failsafe
 			fi
 		fi
 
@@ -16148,7 +16153,7 @@ _EOF_
 		then
 			Banner_Uninstalling
 			G_AGP snapclient
-		fi		
+		fi
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Finalise uninstall'
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4648,7 +4648,7 @@ _EOF_
 		then
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://install.pi-hole.net'
+			INSTALL_URL_ADDRESS='https://raw.githubusercontent.com/pi-hole/pi-hole/master/automated%20install/basic-install.sh'
 			G_CHECK_URL "$INSTALL_URL_ADDRESS"
 
 			# Check free available memory. Increase swap size to prevent gravity running out of mem.
@@ -5434,10 +5434,7 @@ _EOF_
 
 			Banner_Installing
 
-			INSTALL_URL_ADDRESS='https://install.pivpn.io'
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-
-			G_EXEC curl -sSfL "$INSTALL_URL_ADDRESS" -o install.bash
+			G_EXEC curl -sSfL 'https://raw.githubusercontent.com/pivpn/pivpn/master/auto_install/install.sh' -o install.bash
 			G_EXEC chmod +x install.bash
 			G_DIETPI-NOTIFY 2 'Preventing reboot from within PiVPN installer'
 			G_EXEC sed -i '/shutdown[[:space:]]/d' install.bash

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1430,16 +1430,6 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_DESC[$software_id]="Obtain and renew Let's Encrypt SSL certs for HTTPS"
 		aSOFTWARE_CATX[$software_id]=12
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/system_security/#lets-encrypt'
-		#------------------
-		software_id=125
-
-		aSOFTWARE_NAME[$software_id]='Tomcat8'
-		aSOFTWARE_DESC[$software_id]='apache tomcat server'
-		aSOFTWARE_CATX[$software_id]=12
-		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/webserver_stack/#tomcat'
-		aSOFTWARE_DEPS[$software_id]='8'
-		# - non-Raspbian Buster: https://packages.debian.org/tomcat8
-		(( $G_HW_MODEL > 9 )) || (( ! $G_RASPBIAN )) && aSOFTWARE_AVAIL_G_DISTRO[$software_id,5]=0 aSOFTWARE_AVAIL_G_DISTRO[$software_id,6]=0
 
 		# DNS Servers
 		#--------------------------------------------------------------------------------
@@ -5091,14 +5081,6 @@ _EOF_
 			no_check_url=1 Download_Install "$url/$distro/$package"
 
 			unset url arch distro package
-
-		fi
-
-		software_id=125 # Tomcat8
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Installing
-			G_AGI tomcat8
 
 		fi
 
@@ -8858,17 +8840,6 @@ _EOF_
 
 			# Permissions
 			#chown -R roon:dietpi /mnt/dietpi_userdata/roon /var/log/roon
-
-		fi
-
-		software_id=125 # Tomcat8
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Configuration
-
-			local version=11
-			(( $G_DISTRO < 5 || G_HW_MODEL == 1 )) && version=8
-			G_CONFIG_INJECT 'JAVA_HOME=' "JAVA_HOME=$(find /usr/lib/jvm/ -name "java-$version-openjdk*")" /etc/default/tomcat8
 
 		fi
 
@@ -13756,14 +13727,6 @@ _EOF_
 
 			Banner_Uninstalling
 			G_AGP networkaudiod
-
-		fi
-
-		software_id=125 # Tomcat8
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
-
-			Banner_Uninstalling
-			G_AGP tomcat8
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5371,7 +5371,7 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-			local fallback_url='https://github.com/gotson/komga/releases/download/v0.96.2/komga-0.96.2.jar'
+			local fallback_url='https://github.com/gotson/komga/releases/download/v0.101.2/komga-0.101.2.jar'
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/gotson/komga/releases/latest' | mawk -F\" '/"browser_download_url": .*\/komga-[^"\/]*\.jar"/{print $4}')" /mnt/dietpi_userdata/komga/komga.jar
 
 		fi
@@ -9415,6 +9415,7 @@ Wants=network-online.target
 After=network-online.target remote-fs.target dietpi-boot.service
 
 [Service]
+SyslogIdentifier=Airsonic
 User=airsonic
 WorkingDirectory=/mnt/dietpi_userdata/airsonic
 ExecStart=$(command -v java) -Xmx${memory_limit}m -Dairsonic.home=/mnt/dietpi_userdata/airsonic -Dserver.context-path=/airsonic -Dserver.port=8080 -jar /mnt/dietpi_userdata/airsonic/airsonic.war
@@ -9912,6 +9913,7 @@ Wants=network-online.target
 After=network-online.target dietpi-boot.service
 
 [Service]
+SyslogIdentifier=Ubooquity
 User=ubooquity
 WorkingDirectory=/mnt/dietpi_userdata/ubooquity
 ExecStart=$(command -v java) -Xmx${memory_limit}m -jar /mnt/dietpi_userdata/ubooquity/Ubooquity.jar --headless --remoteadmin --adminport 2038 --libraryport 2039
@@ -9975,6 +9977,7 @@ Wants=network-online.target
 After=network-online.target dietpi-boot.service
 
 [Service]
+SyslogIdentifier=Komga
 User=komga
 WorkingDirectory=/mnt/dietpi_userdata/komga
 ExecStart=$(command -v java) -Xmx${memory_limit}m -jar komga.jar
@@ -11725,6 +11728,7 @@ Wants=network-online.target
 After=network-online.target dietpi-boot.service
 
 [Service]
+SyslogIdentifier=Blynk
 User=blynk
 WorkingDirectory=/mnt/dietpi_userdata/blynk
 ExecStart=$(command -v java) -jar /mnt/dietpi_userdata/blynk/blynkserver.jar
@@ -13048,12 +13052,12 @@ _EOF_
 			# Service
 			cat << _EOF_ > /etc/systemd/system/papermc.service
 [Unit]
-Description=papermc (DietPi)
+Description=PaperMC (DietPi)
 Documentation=https://paper.readthedocs.io/
 
 [Service]
+SyslogIdentifier=PaperMC
 User=papermc
-SyslogIdentifier=papermc
 WorkingDirectory=/mnt/dietpi_userdata/papermc
 ExecStart=$(command -v java) -Xmx${heap_size}m -jar /opt/papermc/paperclip.jar --nogui --noconsole
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -970,8 +970,6 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_DESC[$software_id]='Minecraft server with web interface (C++)'
 		aSOFTWARE_CATX[$software_id]=5
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/gaming/#cuberite'
-		# - ARMv8
-		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,3]=0
 		#------------------
 		software_id=53
 
@@ -5826,8 +5824,8 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 				INSTALL_URL_ADDRESS='https://download.cuberite.org/linux-x86_64/Cuberite.tar.gz'
 
-			# ARMv6/7
-			elif [[ $G_HW_ARCH == [12] ]]; then
+			# ARMv6/7/8: https://github.com/cuberite/cuberite/issues/5221
+			else
 
 				INSTALL_URL_ADDRESS='https://download.cuberite.org/linux-armhf-raspbian/Cuberite.tar.gz'
 
@@ -10844,8 +10842,9 @@ Ports=1339
 Enabled=1
 _EOF_
 			# Permissions
-			G_EXEC chmod +x /mnt/dietpi_userdata/cuberite/Cuberite
+			G_EXEC chmod 0640 /mnt/dietpi_userdata/cuberite/webadmin.ini
 			G_EXEC chown -R cuberite:cuberite /mnt/dietpi_userdata/cuberite
+			G_EXEC chmod +x /mnt/dietpi_userdata/cuberite/Cuberite
 
 		fi
 

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -57,7 +57,7 @@
 	# - Assign defaults/code version as fallback
 	[[ $G_DIETPI_VERSION_CORE ]] || G_DIETPI_VERSION_CORE=7
 	[[ $G_DIETPI_VERSION_SUB ]] || G_DIETPI_VERSION_SUB=3
-	[[ $G_DIETPI_VERSION_RC ]] || G_DIETPI_VERSION_RC=0
+	[[ $G_DIETPI_VERSION_RC ]] || G_DIETPI_VERSION_RC=1
 	[[ $G_GITBRANCH ]] || G_GITBRANCH='master'
 	[[ $G_GITOWNER ]] || G_GITOWNER='MichaIng'
 	# - Save current version and Git branch

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -264,18 +264,13 @@ _EOF_
 
 				# Prevent any framebuffer from being allocated
 				G_CONFIG_INJECT 'max_framebuffers=' 'max_framebuffers=0' /boot/config.txt
-				# Apply lowest possible framebuffer size
-				G_CONFIG_INJECT 'framebuffer_width=' 'framebuffer_width=16' /boot/config.txt
-				G_CONFIG_INJECT 'framebuffer_height=' 'framebuffer_height=16' /boot/config.txt
-				G_CONFIG_INJECT 'max_framebuffer_width=' 'max_framebuffer_width=16' /boot/config.txt
-				G_CONFIG_INJECT 'max_framebuffer_height=' 'max_framebuffer_height=16' /boot/config.txt
-				# - Splash cannot be seen anyway without video output
+				# Splash cannot be seen anyway without video output
 				G_CONFIG_INJECT 'disable_splash=' 'disable_splash=1' /boot/config.txt
-				# - hdmi_blanking should not play a role, however mode 1 should be generally preferred, which on idle disables HDMI output completely instead of just blanking the screen
+				# hdmi_blanking should not play a role, however mode 1 should be generally preferred, which on idle disables HDMI output completely instead of just blanking the screen
 				G_CONFIG_INJECT 'hdmi_blanking=' 'hdmi_blanking=1' /boot/config.txt
-				# - Disable HDMI hotplug detection, which requires it to be generally responsive/active
+				# Disable HDMI hotplug detection, which requires it to be generally responsive/active
 				G_CONFIG_INJECT 'hdmi_ignore_hotplug=' 'hdmi_ignore_hotplug=1' /boot/config.txt
-				# - Disable SDTV on RPi4
+				# Disable SDTV on RPi4 (default)
 				G_EXEC sed -i '/^[[:blank:]]*enable_tvout=/c\#enable_tvout=0' /boot/config.txt
 
 			# Odroid C2
@@ -297,10 +292,7 @@ _EOF_
 			if (( $G_HW_MODEL < 10 )); then
 
 				G_EXEC sed -i '/^[[:blank:]]*max_framebuffers=/c\#max_framebuffers=2' /boot/config.txt
-				G_EXEC sed -i '/^[[:blank:]]*framebuffer_width=/c\#framebuffer_width=16' /boot/config.txt
-				G_EXEC sed -i '/^[[:blank:]]*framebuffer_height=/c\#framebuffer_height=16' /boot/config.txt
-				G_EXEC sed -i '/^[[:blank:]]*max_framebuffer_width=/c\#max_framebuffer_width=16' /boot/config.txt
-				G_EXEC sed -i '/^[[:blank:]]*max_framebuffer_height=/c\#max_framebuffer_height=16' /boot/config.txt
+				#G_EXEC sed -i '/^[[:blank:]]*disable_splash=/c\#disable_splash=0' /boot/config.txt
 				G_EXEC sed -i '/^[[:blank:]]*hdmi_blanking=/c\#hdmi_blanking=0' /boot/config.txt
 				G_EXEC sed -i '/^[[:blank:]]*hdmi_ignore_hotplug=/c\#hdmi_ignore_hotplug=0' /boot/config.txt
 				G_EXEC sed -i '/^[[:blank:]]*enable_tvout=/c\#enable_tvout=0' /boot/config.txt

--- a/dietpi/preboot
+++ b/dietpi/preboot
@@ -17,7 +17,7 @@
 	# Main Loop
 	#/////////////////////////////////////////////////////////////////////////////////////
 	#-----------------------------------------------------------------------------------
-	# RPi: Disable video output when headless mode has been chosen
+	# RPi: Disable display ports in headless mode to reduce power consumption by ~0.1W even without attached display, disabled hotplug detection and no framebuffer
 	[ ! -f '/etc/.dietpi_hw_model_identifier' ] && grep -q '^[[:blank:]]*AUTO_SETUP_HEADLESS=1' /boot/dietpi.txt && tvservice -o
 
 	# Obtain hardware info: Do on every boot since some contained info can change, especially when allowing RPi SDcard swap


### PR DESCRIPTION
### Beta v7.3.1
_(2021-06-24)_

#### Changes since v7.3.0
- DietPi-Software | Cuberite: This has been enabled for ARMv8 systems, where the available ARMv7 binaries work just fine.

#### Removed Software since v7.3.0
- Tomcat 8 | Tomcat version 8 is available until Debian Stretch only, from Buster on it's Tomcat 9. There is no reasonable configration that DietPi-Software can do on top of installing the APT package, which can be easily done manually via "apt install tomcat9". The software option is hence removed from DietPi-Software, in favour of a manual package install.

#### Fixes since v7.3.0
- DietPi-Software | Resolved an issue where with AUTO_SETUP_AUTOMATED=1 the OpenSSH client was always installed on first boot, even if it was not requested.