### PR TITLE
DietPi-Software | AdGuard Home: Install binary to userdata for now

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -677,7 +677,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_CATX[$software_id]=2
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#snapcast-client'
 		aSOFTWARE_DEPS[$software_id]='5'
-		aSOFTWARE_INTERACTIVE[$software_id]=1		
+		aSOFTWARE_INTERACTIVE[$software_id]=1
 		# Not currently available on arm64: https://github.com/badaix/snapcast/issues/706
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,3]=0
 
@@ -7634,10 +7634,10 @@ _EOF_
 
 ## Start an FastCGI server using php-fpm
 fastcgi.server += ( ".php" =>
-        ((
-                "socket" => "/run/php/${PHP_NAME}-fpm.sock",
-                "broken-scriptfilename" => "enable"
-        ))
+	((
+		"socket" => "/run/php/$PHP_NAME-fpm.sock",
+		"broken-scriptfilename" => "enable"
+	))
 )
 _EOF_
 			# - Enable modules
@@ -13193,8 +13193,7 @@ _EOF_
 		local gpu_memory=0
 
 		# Kodi, Jellyfin
-		if (( ${aSOFTWARE_INSTALL_STATE[31]} == 1 ||
-		      ${aSOFTWARE_INSTALL_STATE[178]} == 1 )); then
+		if (( ${aSOFTWARE_INSTALL_STATE[31]} == 1 || ${aSOFTWARE_INSTALL_STATE[178]} == 1 )); then
 
 			gpu_memory=320
 			(( ${G_HW_MEMORY_SIZE:-0} > 512 )) || gpu_memory=256
@@ -13513,7 +13512,8 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			# Stop  Lighttpd service
+
+			# Stop Lighttpd service, as it may keep running on package removal
 			[[ -f '/lib/systemd/system/lighttpd.service' ]] && systemctl disable --now lighttpd
 
 			G_AGP lighttpd
@@ -13990,13 +13990,18 @@ _EOF_
 			[[ -f '/etc/pihole/setupVars.conf' ]] && grep -q '^[[:blank:]]*PIHOLE_DNS_1=127.0.0.1' /etc/pihole/setupVars.conf && G_CONFIG_INJECT 'PIHOLE_DNS_1=' 'PIHOLE_DNS_1=9.9.9.9' /etc/pihole/setupVars.conf
 
 			# AdGuard Home: Assure that it does not resolve via Unbound anymore
-			if [[ -f '/mnt/dietpi_userdata/adguardhome/dietpi-unbound.conf' ]]; then
-
+			if [[ -f '/mnt/dietpi_userdata/adguardhome/dietpi-unbound.conf' ]]
+			then
 				G_DIETPI-NOTIFY 2 'AdGuard Home upstream DNS server has been changed back to default settings due to Unbound being uninstalled.'
 				G_CONFIG_INJECT 'upstream_dns_file:[[:blank:]]' '  upstream_dns_file: ""' /mnt/dietpi_userdata/adguardhome/AdGuardHome.yaml
 				[[ -f '/mnt/dietpi_userdata/adguardhome/dietpi-unbound.conf' ]]  && G_EXEC_NOEXIT=1 G_EXEC rm /mnt/dietpi_userdata/adguardhome/dietpi-unbound.conf
 				systemctl -q is-active adguardhome && G_EXEC_NOEXIT=1 G_EXEC systemctl restart adguardhome
+			fi
 
+			# Failsafe: Add Quad9 to system resolver if only Unbound was used
+			if [[ -f '/etc/unbound/unbound.conf.d/dietpi.conf' ]] && grep -Eq '^[[:blank:]]*port:[[:blank:]]+53$' /etc/unbound/unbound.conf.d/dietpi.conf
+			then
+				grep '^[[:blank:]]*nameserver[[:blank:]]' /etc/resolv.conf | grep -qvE '[[:blank:]]127.0.0.1(:53)?$' || echo 'nameserver 9.9.9.9' >> /etc/resolv.conf # Failsafe
 			fi
 
 			G_AGP unbound
@@ -14497,7 +14502,7 @@ _EOF_
 			[[ -d '/etc/nginx/sites-dietpi' ]] && rm -f /etc/nginx/sites-dietpi/dietpi-pihole*
 
 			# Unbound: Switch port to 53 if it is still installed
-			if (( ${aSOFTWARE_INSTALL_STATE[182]} == 2 )) && grep -q '^[[:blank:]]*port:[[:blank:]][[:blank:]]*5335$' /etc/unbound/unbound.conf.d/dietpi.conf
+			if (( ${aSOFTWARE_INSTALL_STATE[182]} == 2 )) && grep -Eq '^[[:blank:]]*port:[[:blank:]]+5335$' /etc/unbound/unbound.conf.d/dietpi.conf
 			then
 				G_DIETPI-NOTIFY 2 'Reconfiguring Unbound to work on its own'
 				G_CONFIG_INJECT 'port:[[:blank:]]' '	port: 53' /etc/unbound/unbound.conf.d/dietpi.conf
@@ -14527,7 +14532,7 @@ _EOF_
 			[[ -d '/mnt/dietpi_userdata/adguardhome' ]] && G_EXEC rm -R /mnt/dietpi_userdata/adguardhome
 
 			# Unbound: Switch port to 53 if it is still installed
-			if (( ${aSOFTWARE_INSTALL_STATE[182]} == 2 )) && grep -q '^[[:blank:]]*port:[[:blank:]][[:blank:]]*5335$' /etc/unbound/unbound.conf.d/dietpi.conf
+			if (( ${aSOFTWARE_INSTALL_STATE[182]} == 2 )) && grep -Eq '^[[:blank:]]*port:[[:blank:]]+5335$' /etc/unbound/unbound.conf.d/dietpi.conf
 			then
 				G_DIETPI-NOTIFY 2 'Reconfiguring Unbound to work on its own'
 				G_CONFIG_INJECT 'port:[[:blank:]]' '	port: 53' /etc/unbound/unbound.conf.d/dietpi.conf
@@ -16148,7 +16153,7 @@ _EOF_
 		then
 			Banner_Uninstalling
 			G_AGP snapclient
-		fi		
+		fi
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Finalise uninstall'
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4713,11 +4713,12 @@ _EOF_
 			DEPS_LIST='apache2-utils'
 			Download_Install "$INSTALL_URL_ADDRESS"
 
-			# Reinstall: Stop service and remove install directory
-			[[ -f '/etc/systemd/system/adguardhome.service' ]] && G_EXEC systemctl stop adguardhome
-			[[ -d '/opt/adguardhome' ]] && G_EXEC rm -R /opt/adguardhome
+			# Install to userdata until it is possible to split binary and data/config without breaking the updater: https://github.com/AdguardTeam/AdGuardHome/issues/3286
+			[[ -d '/mnt/dietpi_userdata/adguardhome' ]] || G_EXEC mkdir -p /mnt/dietpi_userdata/adguardhome
+			G_EXEC cp -a AdGuardHome/. /mnt/dietpi_userdata/adguardhome/
+			G_EXEC rm -R AdGuardHome
 
-			G_EXEC mv AdGuardHome /opt/adguardhome
+			[[ -d '/opt/adguardhome' ]] && G_EXEC rm -R /opt/adguardhome # v7.3 beta
 
 			# Unbound: Switch port to 5335 if it was installed before, else it got just configured within its install step above
 			if (( ${aSOFTWARE_INSTALL_STATE[182]} == 2 )) && grep -q '^[[:blank:]]*port:[[:blank:]][[:blank:]]*53$' /etc/unbound/unbound.conf.d/dietpi.conf
@@ -9340,12 +9341,10 @@ _EOF_
 
 			Banner_Configuration
 
-			# Directory
-			G_EXEC mkdir -p /mnt/dietpi_userdata/adguardhome
-
 			# User
 			Create_User -d /mnt/dietpi_userdata/adguardhome adguardhome
 
+			# Config
 			if [[ ! -f '/mnt/dietpi_userdata/adguardhome/AdGuardHome.yaml' ]]
 			then
 				dps_index=$software_id Download_Install 'AdGuardHome.yaml' /mnt/dietpi_userdata/adguardhome/AdGuardHome.yaml
@@ -9354,20 +9353,17 @@ _EOF_
 			fi
 
 			# Unbound: Configure AdGuard Home to use it
-			if (( ${aSOFTWARE_INSTALL_STATE[182]} > 0 ))
+			if [[ ${aSOFTWARE_INSTALL_STATE[182]} -gt 0 && ! -f '/mnt/dietpi_userdata/adguardhome/dietpi-unbound.conf' ]]
 			then
 				G_DIETPI-NOTIFY 2 'Configuring AdGuard Home to use Unbound'
-				if [[ ! -f '/mnt/dietpi_userdata/adguardhome/dietpi-unbound.conf' ]]
-				then
-					echo '127.0.0.1:5335' > /mnt/dietpi_userdata/adguardhome/dietpi-unbound.conf
-					G_CONFIG_INJECT 'upstream_dns_file:[[:blank:]]' '  upstream_dns_file: /mnt/dietpi_userdata/adguardhome/dietpi-unbound.conf' /mnt/dietpi_userdata/adguardhome/AdGuardHome.yaml
-					systemctl -q is-active adguardhome && G_EXEC systemctl restart adguardhome
-				fi
+				echo '127.0.0.1:5335' > /mnt/dietpi_userdata/adguardhome/dietpi-unbound.conf
+				G_CONFIG_INJECT 'upstream_dns_file:[[:blank:]]' '  upstream_dns_file: /mnt/dietpi_userdata/adguardhome/dietpi-unbound.conf' /mnt/dietpi_userdata/adguardhome/AdGuardHome.yaml
+				systemctl -q is-active adguardhome && G_EXEC systemctl restart adguardhome
 			fi
 
 			# Permissions
-			G_EXEC chown -R adguardhome:adguardhome /mnt/dietpi_userdata/adguardhome /opt/adguardhome
-			G_EXEC chmod 755 /opt/adguardhome{,/AdGuardHome}
+			G_EXEC chown -R adguardhome:adguardhome /mnt/dietpi_userdata/adguardhome
+			G_EXEC chmod 0755 /mnt/dietpi_userdata/adguardhome/AdGuardHome
 
 			# Service
 			cat << '_EOF_' > /etc/systemd/system/adguardhome.service
@@ -9383,8 +9379,8 @@ StartLimitBurst=5
 [Service]
 User=adguardhome
 AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_RAW
-ExecStart=/opt/adguardhome/AdGuardHome -w /mnt/dietpi_userdata/adguardhome
-ExecReload=/opt/adguardhome/AdGuardHome -s reload
+ExecStart=/mnt/dietpi_userdata/adguardhome/AdGuardHome
+ExecReload=/mnt/dietpi_userdata/adguardhome/AdGuardHome -s reload
 Restart=on-failure
 RestartSec=5
 
@@ -14504,10 +14500,12 @@ _EOF_
 			if (( ${aSOFTWARE_INSTALL_STATE[182]} == 2 )) && grep -q '^[[:blank:]]*port:[[:blank:]][[:blank:]]*5335$' /etc/unbound/unbound.conf.d/dietpi.conf
 			then
 				G_DIETPI-NOTIFY 2 'Reconfiguring Unbound to work on its own'
-				grep '^[[:blank:]]*nameserver[[:blank:]]' /etc/resolv.conf | grep -qvE '[[:blank:]]127.0.0.1(:53)?$' || echo 'nameserver 9.9.9.9' >> /etc/resolv.conf # Failsafe
 				G_CONFIG_INJECT 'port:[[:blank:]]' '	port: 53' /etc/unbound/unbound.conf.d/dietpi.conf
 				G_CONFIG_INJECT 'interface:[[:blank:]]' '	interface: 0.0.0.0' /etc/unbound/unbound.conf.d/dietpi.conf
+				grep -E '^[[:blank:]]*nameserver[[:blank:]]+127.0.0.1:5335$' /etc/resolv.conf && sed -Ei '/^[[:blank:]]*nameserver[[:blank:]]+127.0.0.1:5335$/c\nameserver 127.0.0.1' /etc/resolv.conf # Failsafe
 				G_EXEC_NOEXIT=1 G_EXEC systemctl restart unbound
+			else
+				grep '^[[:blank:]]*nameserver[[:blank:]]' /etc/resolv.conf | grep -qvE '[[:blank:]]127.0.0.1(:53)?$' || echo 'nameserver 9.9.9.9' >> /etc/resolv.conf # Failsafe
 			fi
 		fi
 
@@ -14522,20 +14520,22 @@ _EOF_
 
 			fi
 			[[ -d '/etc/systemd/system/adguardhome.service.d' ]] && G_EXEC rm -R /etc/systemd/system/adguardhome.service.d
-			[[ -d '/opt/adguardhome' ]] && G_EXEC rm -R /opt/adguardhome
-			
+			[[ -d '/opt/adguardhome' ]] && G_EXEC rm -R /opt/adguardhome # v7.3 beta
+
 			# Remove user and home directory
-			getent passwd adguardhome > /dev/null && userdel adguardhome
-			G_EXEC rm -Rf /mnt/dietpi_userdata/adguardhome
+			getent passwd adguardhome > /dev/null && G_EXEC userdel adguardhome
+			[[ -d '/mnt/dietpi_userdata/adguardhome' ]] && G_EXEC rm -R /mnt/dietpi_userdata/adguardhome
 
 			# Unbound: Switch port to 53 if it is still installed
 			if (( ${aSOFTWARE_INSTALL_STATE[182]} == 2 )) && grep -q '^[[:blank:]]*port:[[:blank:]][[:blank:]]*5335$' /etc/unbound/unbound.conf.d/dietpi.conf
 			then
 				G_DIETPI-NOTIFY 2 'Reconfiguring Unbound to work on its own'
-				grep '^[[:blank:]]*nameserver[[:blank:]]' /etc/resolv.conf | grep -qvE '[[:blank:]]127.0.0.1(:53)?$' || echo 'nameserver 9.9.9.9' >> /etc/resolv.conf # Failsafe
 				G_CONFIG_INJECT 'port:[[:blank:]]' '	port: 53' /etc/unbound/unbound.conf.d/dietpi.conf
 				G_CONFIG_INJECT 'interface:[[:blank:]]' '	interface: 0.0.0.0' /etc/unbound/unbound.conf.d/dietpi.conf
+				grep -E '^[[:blank:]]*nameserver[[:blank:]]+127.0.0.1:5335$' /etc/resolv.conf && sed -Ei '/^[[:blank:]]*nameserver[[:blank:]]+127.0.0.1:5335$/c\nameserver 127.0.0.1' /etc/resolv.conf # Failsafe
 				G_EXEC_NOEXIT=1 G_EXEC systemctl restart unbound
+			else
+				grep '^[[:blank:]]*nameserver[[:blank:]]' /etc/resolv.conf | grep -qvE '[[:blank:]]127.0.0.1(:53)?$' || echo 'nameserver 9.9.9.9' >> /etc/resolv.conf # Failsafe
 			fi
 		fi
 


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Software | AdGuard Home: Until the working directory can be separated from the binary without breaking the installer, we install the binary to userdata as well.
+ DietPi-Software | AdGuard Home / Pi-hole: On uninstall, when switching Unbound port, do not care about resolv.conf using 127.0.0.1:53, as Unbound will listen on it. Instead, as failsafe step, replace 127.0.0.1:5335 with 127.0.0.1:53 so that the system keeps resolving via Unbound, if this was manually configured before. If Unbound is not installed and the system is configured to use (only) AdGuard Home / Pi-hole for resolving, do the previous failsafe step which then makes sense: add Quad9 as additional nameserver.
