### PR TITLE
DietPi-Set_hardware | Add support for the Allo Boss2 OLED display

### DIFF
--- a/.update/patches
+++ b/.update/patches
@@ -250,6 +250,9 @@ _EOF_
 
 	# Remove license (flag) file if AUTO_SETUP_AUTOMATED=1 is set, which would otherwise never happen on pre-v7.2 images, and if AUTO_SETUP_ACCEPT_LICENSE=1 is set, to assure the prompt is skipped when for some reason the script is reloaded between update and first installs.
 	[[ -f '/var/lib/dietpi/license.txt' ]] && grep -Eq '^[[:blank:]]*AUTO_SETUP_A(UTOMATED|CCEPT_LICENSE)=1' /boot/dietpi.txt && G_EXEC rm /var/lib/dietpi/license.txt
+
+	# Update Allo web UI with Squeezelite control fix and Allo Boss2 DAC support
+	[[ -f '/boot/dietpi/.installed' ]] && grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[160\]=2' /boot/dietpi/.installed && /boot/dietpi/dietpi-software reinstall 160
 }
 
 # Main loop

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,7 +6,6 @@ Changes:
 - DietPi-Backup | The include/exclude filter handling has been reworked. /mnt (dietpi_userdata) and /media related rules are added now via the editable custom filter file, which gives users more control over these. Especially it allows to include other mount points below /mnt, hence external dietpi_userdata, which was previously impossible due to the order in which those filter rules are applied.
 - DietPi-VPN | The killswitch has been adjusted to allow incoming SSH connections. Many thanks to @yslupdates for doing this request: https://github.com/MichaIng/DietPi/issues/4447
 - DietPi-Config | Support for the Allo Boss2 DAC OLED display has been added to the "Display Options" > "LCD/OLED Panel addon" menu. When selecting the Allo Boss2 DAC as sound card, you will be asked whether to enable the OLED display as well.
-- DietPi-Software | Cuberite: This has been enabled for ARMv8 systems, where the available ARMv7 binaries work just fine.
 - DietPi-Software | Allo web UI: Updated to v13.3 which adds support for the Allo Boss2 DAC and resolves an issue where the Squeezelite service could not be controlled as the service path has changed. All credits go to Allo for implementing these changes.
 - DietPi-Software | Cuberite: This has been enabled for ARMv8 systems, where the available ARMv7 binaries work just fine. 
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,7 +5,8 @@ Changes:
 - DietPi-Automation | A new dietpi.txt setting "AUTO_SETUP_DHCP_TO_STATIC" has been added. When set to "1", DHCP leased network settings will be applied as static network settings automatically during first run setup. This works as well with older images, by adding the above setting to dietpi.txt.
 - DietPi-Backup | The include/exclude filter handling has been reworked. /mnt (dietpi_userdata) and /media related rules are added now via the editable custom filter file, which gives users more control over these. Especially it allows to include other mount points below /mnt, hence external dietpi_userdata, which was previously impossible due to the order in which those filter rules are applied.
 - DietPi-Config | Support for the Allo Boss2 DAC OLED display has been added to the "Display Options" > "LCD/OLED Panel addon" menu. When selecting the Allo Boss2 DAC as sound card, you will be asked whether to enable the OLED display as well.
-- DietPi-Software | Cuberite: This has been enabled for ARMv8 systems, where the available ARMv7 binaries work just fine. 
+- DietPi-Software | Cuberite: This has been enabled for ARMv8 systems, where the available ARMv7 binaries work just fine.
+- DietPi-Software | Allo web UI: Updated to v13.3 which adds support for the Allo Boss2 DAC and resolves an issue where the Squeezelite service could not be controlled as the service path has changed. All credits go to Allo for implementing these changes.
 
 New Software:
 - AdGuard Home | This DNS sinkhole ad blocker for your LAN, similar to Pi-hole, has been added with software ID 126.
@@ -59,7 +60,7 @@ Changes:
 - DietPi-Software | Pi-hole: New installs and reinstall will have the DNS query logging duration reduced to 2 days. An internal discussion revealed that no-one of us uses logs old than a few hours, while those are kept for a year by default, leading to database sizes from hundreds of MiBs to GiBs. We leave it at 2 days so that dashboard graphs/diagrams are not empty on Pi-hole (re)start. Users who require long-term DNS query data for statistics or similar, can easily increase the TTL, shown as well in our docs.
 
 New Software:
-- Firefox | The Mozilla browser has now become an independent software option with the ID 67 (see changes above). 
+- Firefox | The Mozilla browser has now become an independent software option with the ID 67 (see changes above).
 
 Removed Software:
 - LibSSL1.0.0 | This old library was kept for backwards-compatibility with old binaries but is not required anymore for any binary installed by DietPi-Software. It has hence been removed from the software list.
@@ -127,7 +128,7 @@ Changes:
 - DietPi-Software | RPi.GPIO: This software option has been renamed to "Python 3 RPi.GPIO" to make clear that it is a Python package. In our efforts to migrate all software options to Python 3, only the Python 3 package is installed from now on. To install it for Python 2, one needs to run the following command manually form console: "apt install python-rpi.gpio"
 
 New Scripts:
-- DietPi-VPN | This new tool has been added, which allows you to establish VPN connections to known public VPN providers or connect via custom OpenVPN configuration file. It incorporates all features from the previous DietPi-NordVPN script and more (see changes above). 
+- DietPi-VPN | This new tool has been added, which allows you to establish VPN connections to known public VPN providers or connect via custom OpenVPN configuration file. It incorporates all features from the previous DietPi-NordVPN script and more (see changes above).
 - DietPi-DDNS | This new tool has been added, which allows you to manage domains for your dynamic IP address. Select a Dynamic DNS (DDNS) provider or add a custom API URL, to have your DDNS entry updated regularly, via cURL and Cron job. Among others, it supports No-IP and replaces the No-IP client that DietPi supported until now.
 
 New Software:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ v7.3
 Changes:
 - DietPi-Automation | A new dietpi.txt setting "AUTO_SETUP_DHCP_TO_STATIC" has been added. When set to "1", DHCP leased network settings will be applied as static network settings automatically during first run setup. This works as well with older images, by adding the above setting to dietpi.txt.
 - DietPi-Backup | The include/exclude filter handling has been reworked. /mnt (dietpi_userdata) and /media related rules are added now via the editable custom filter file, which gives users more control over these. Especially it allows to include other mount points below /mnt, hence external dietpi_userdata, which was previously impossible due to the order in which those filter rules are applied.
+- DietPi-Config | Support for the Allo Boss2 DAC OLED display has been added to the "Display Options" > "LCD/OLED Panel addon" menu. When selecting the Allo Boss2 DAC as sound card, you will be asked whether to enable the OLED display as well.
 - DietPi-Software | Cuberite: This has been enabled for ARMv8 systems, where the available ARMv7 binaries work just fine. 
 
 New Software:

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -203,7 +203,7 @@
 
 				G_WHIP_MENU_ARRAY+=('2' ': GPU/RAM Memory Split')
 				local lcdpanel_text=$(sed -n '/^[[:blank:]]*CONFIG_LCDPANEL=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-				G_WHIP_MENU_ARRAY+=('3' ": LCD Panel addon: [${lcdpanel_text:=none}]")
+				G_WHIP_MENU_ARRAY+=('3' ": LCD/OLED Panel addon: [${lcdpanel_text:=none}]")
 
 			fi
 
@@ -336,6 +336,7 @@
 					if (( $G_HW_MODEL < 10 )); then
 
 						G_WHIP_MENU_ARRAY+=('esp01215e' ': Elecrow 1024x600 7" IPS HDMI panel with touch input')
+						G_WHIP_MENU_ARRAY+=('allo-boss2-oled' ': Allo Boss2 DAC OLED display')
 
 					else
 
@@ -3959,20 +3960,16 @@ Additional benchmarks:
 
 				for i in {0..9}
 				do
-
 					[[ -f /proc/asound/card$i/id ]] || continue
 
 					for j in {0..9}
 					do
-
 						[[ -f /proc/asound/card$i/pcm${j}p/info ]] || continue
 
 						local card_name=$(<"/proc/asound/card$i/id")
 						card_name+=$(sed -n '/^name:/{s/^name://p;q}' "/proc/asound/card$i/pcm${j}p/info")
 						G_WHIP_MENU_ARRAY+=("hw:$i,$j" ": $card_name")
-
 					done
-
 				done
 
 				G_WHIP_DEFAULT_ITEM=$soundcard_current
@@ -3981,6 +3978,14 @@ Additional benchmarks:
 
 				# RPi: Reboot required to apply device tree changes, which applies to all but auto-detected selections
 				(( $G_HW_MODEL > 9 )) || [[ $G_WHIP_RETURNED_VALUE == 'hw:'[0-9]','[0-9] || $G_WHIP_RETURNED_VALUE == 'usb-dac' ]] || REBOOT_REQUIRED=1
+
+				# RPi: When Allo Boss2 DAC was selected, offer to enable OLED display right now
+				if [[ $G_WHIP_RETURNED_VALUE == 'allo-boss2-dac-audio' ]]
+				then
+					G_WHIP_BUTTON_CANCEL_TEXT='Skip' G_WHIP_YESNO 'Do you want to enable the OLED display on the Allo Boss2 case?
+\nThis can be done or disabled at any later time via:
+- "dietpi-config" > "Display Options" > "LCD/OLED Panel addon"' && /boot/dietpi/func/dietpi-set_hardware lcdpanel 'allo-boss2-oled'
+				fi
 
 			elif [[ $G_WHIP_RETURNED_VALUE == 'Auto-conversion' ]]; then
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6893,8 +6893,8 @@ If you want to update ${aSOFTWARE_NAME[$software_id]}, please use its internal u
 
 			Banner_Installing
 			# Always perform a clean reinstall
-			[[ -d '/var/www/allo' ]] && rm -R /var/www/allo
-			Download_Install 'https://dietpi.com/downloads/binaries/all/allo_web_interface_v13.2.7z' /var/www
+			[[ -d '/var/www/allo' ]] && G_EXEC rm -R /var/www/allo
+			Download_Install 'https://dietpi.com/downloads/binaries/all/allo_web_interface_v13.3.7z' /var/www
 
 		fi
 
@@ -12843,8 +12843,8 @@ _EOF_
 			# Create allo user for GUI
 			Create_User -G www-data -d /home/allo -s /bin/bash -p allo allo
 			# - Create home dir separately to avoid skeleton creation
-			mkdir -p /home/allo
-			chown -R allo:allo /home/allo
+			[[ -d '/home/allo' ]] || G_EXEC mkdir -p /home/allo
+			G_EXEC chown -R allo:allo /home/allo
 			# - Grant sudo permissions
 			echo 'allo ALL=NOPASSWD: ALL' > /etc/sudoers.d/allo
 
@@ -12855,23 +12855,23 @@ _EOF_
 
 			/boot/dietpi/func/create_mysql_db allo_db allo_db dietpi
 			mysql allo_db < /var/www/allo_db.sql
-			rm /var/www/allo_db.sql
+			G_EXEC rm /var/www/allo_db.sql
 
 			# Redirect to web interface by default:
 			rm -f /var/www/index\.*
-			cat << _EOF_ > /var/www/index.php
+			cat << '_EOF_' > /var/www/index.php
 <?php
 /* Redirect to allo web interface */
-\$host  = \$_SERVER['HTTP_HOST'];
-\$uri   = rtrim(dirname(\$_SERVER['PHP_SELF']), '/\\\\');
-\$extra = 'index.php';
-header("Location: http://\$host\$uri/allo/public/\$extra");
+$host  = $_SERVER['HTTP_HOST'];
+$uri   = rtrim(dirname($_SERVER['PHP_SELF']), '/\\\\');
+$extra = 'index.php';
+header("Location: http://$host$uri/allo/public/$extra");
 exit;
 ?>
 _EOF_
 			# Permissions
-			chown -R www-data:www-data /var/www/allo
-			chmod -R 770 /var/www/allo
+			G_EXEC chown -R www-data:www-data /var/www/allo
+			G_EXEC chmod -R 0770 /var/www/allo
 
 		fi
 
@@ -15619,6 +15619,7 @@ _EOF_
 			Banner_Uninstalling
 			[[ -d '/var/www/allo' ]] && rm -R /var/www/allo
 			getent passwd allo > /dev/null && userdel allo
+			getent group allo > /dev/null && groupdel allo
 			[[ -f '/etc/sudoers.d/allo' ]] && rm /etc/sudoers.d/allo
 			[[ -d '/home/allo' ]] && rm -R /home/allo
 			systemctl start mariadb

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -1001,7 +1001,7 @@ _EOF_
 		(( $G_HW_MODEL > 9 )) && { Unsupported_Input_Mode; return 1; } # Exit path for non-RPi
 
 		# Enable I2C
-		I2c_Main enable
+		INPUT_DEVICE_VALUE='enable' I2c_Main
 
 		# Install further requirements
 		G_AG_CHECK_INSTALL_PREREQ python3-{rpi.gpio,pil}
@@ -1058,7 +1058,7 @@ _EOF_
 		[[ -d '/opt/allo_boss2_oled' ]] && G_EXEC rm -R /opt/allo_boss2_oled
 
 		# Disable I2C
-		I2c_Main disable
+		INPUT_DEVICE_VALUE='disable' I2c_Main
 
 	}
 

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -24,7 +24,7 @@ $FP_SCRIPT	i2c			enable/disable/khz
 $FP_SCRIPT	spi			enable/disable
 $FP_SCRIPT	soundcard		target_card (non-matching name for reset to default). Add '-eq' to target_card string to enable ALSA equalizer on card. HW:x,x (specify target card and device index eg: HW:9,1)
 $FP_SCRIPT	remoteir		odroid_remote/justboom_ir_remote # Odroid/RPi only
-$FP_SCRIPT	lcdpanel		target_panel (none to remove all)
+$FP_SCRIPT	lcdpanel		target_panel (\"none\" to remove all)
 $FP_SCRIPT	headless		enable/disable
 $FP_SCRIPT	gpumemsplit		64/128/256... Range: 16-944, RPi only
 $FP_SCRIPT	rpi-camera		enable/disable
@@ -650,6 +650,10 @@ _EOF_
 
 			Lcd_Panel_ESP01215E_Enable
 
+		elif [[ ${INPUT_DEVICE_VALUE,,} == 'allo-boss2-oled' ]]; then
+
+			OLED_Allo_Boss2_Enable
+
 		# Disable all
 		elif [[ $INPUT_DEVICE_VALUE == 'none' ]]; then
 
@@ -657,6 +661,7 @@ _EOF_
 			Lcd_Panel_Odroidcloudshell_Disable
 			Lcd_Panel_OdroidLCD35_Disable
 			Lcd_Panel_ESP01215E_Disable
+			OLED_Allo_Boss2_Disable
 
 		else
 
@@ -685,6 +690,8 @@ _EOF_
 	}
 
 	Lcd_Panel_ESP01215E_Disable(){
+
+		(( $G_HW_MODEL > 9 )) && return # Skip on non-RPi
 
 		G_EXEC sed -i '/^[[:blank:]]*hdmi_force_hotplug=/c\#hdmi_force_hotplug=1' /boot/config.txt
 		G_EXEC sed -i '/^[[:blank:]]*hdmi_group=/c\#hdmi_group=2' /boot/config.txt
@@ -986,6 +993,72 @@ _EOF_
 		fi
 		[[ -d '/etc/systemd/system/odroid-lcd35.service.d' ]] && G_EXEC rm -R /etc/systemd/system/odroid-lcd35.service.d
 		[[ -f '/etc/X11/xorg.conf.d/99-odroid-lcd35.conf' ]] && G_EXEC rm /etc/X11/xorg.conf.d/99-odroid-lcd35.conf
+
+	}
+
+	OLED_Allo_Boss2_Enable(){
+
+		(( $G_HW_MODEL > 9 )) && { Unsupported_Input_Mode; return 1; } # Exit path for non-RPi
+
+		# Enable I2C
+		I2c_Main enable
+
+		# Install further requirements
+		G_AG_CHECK_INSTALL_PREREQ python3-{rpi.gpio,pil}
+
+		# Download and install Python 3 script
+		G_EXEC curl -sSfLO https://raw.githubusercontent.com/allocom/allo_boss2_oled_p3/main/boss2_oled_p3.tar.gz
+		G_EXEC tar xf boss2_oled_p3.tar.gz
+		[[ -d '/opt/allo_boss2_oled' ]] && G_EXEC rm -R /opt/allo_boss2_oled
+		G_EXEC mv boss2_oled_p3 /opt/allo_boss2_oled
+
+		# Create systemd service
+		cat << _EOF_ > /etc/systemd/system/allo_boss2_oled.service
+[Unit]
+Description=Allo Boss2 OLED (DietPi)
+After=sound.target
+
+[Service]
+SyslogIdentifier=Allo Boss2 OLED
+ExecStart=$(command -v python3) /opt/allo_boss2_oled/boss2_oled.py
+Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target
+_EOF_
+		G_EXEC systemctl daemon-reload
+		G_EXEC systemctl unmask allo_boss2_oled
+		G_EXEC systemctl enable allo_boss2_oled
+
+		# Remove possible files from Allo installer
+		if [[ -f '/etc/systemd/system/boss2oled.service' ]]
+		then
+			G_EXEC systemctl disable --now boss2oled
+			G_EXEC rm /etc/systemd/system/boss2oled.service
+		fi
+		[[ -d '/etc/systemd/system/boss2oled.service.d' ]] && G_EXEC rm -R /etc/systemd/system/boss2oled.service.d
+		[[ -d '/opt/boss2_oled_p3' ]] && G_EXEC rm -R /opt/boss2_oled_p3
+		[[ -d '/opt/boss2_oled' ]] && G_EXEC rm -R /opt/boss2_oled
+
+	}
+
+	OLED_Allo_Boss2_Disable(){
+
+		(( $G_HW_MODEL > 9 )) && return # Skip on non-RPi
+
+		# Disable and remove service
+		if [[ -f '/etc/systemd/system/allo_boss2_oled.service' ]]
+		then
+			G_EXEC systemctl disable --now allo_boss2_oled
+			G_EXEC rm /etc/systemd/system/allo_boss2_oled.service
+		fi
+		[[ -d '/etc/systemd/system/allo_boss2_oled.service.d' ]] && G_EXEC rm -R /etc/systemd/system/allo_boss2_oled.service.d
+
+		# Remove scripts
+		[[ -d '/opt/allo_boss2_oled' ]] && G_EXEC rm -R /opt/allo_boss2_oled
+
+		# Disable I2C
+		I2c_Main disable
 
 	}
 


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Set_hardware | Add support for the Allo Boss2 OLED display