### PR TITLE
Update Komga new setting for v0.107.0

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9943,13 +9943,9 @@ _EOF_
 komga:
   libraries-scan-startup: true # Scan libraries at startup
   libraries-scan-cron: "* 2 * * * *" # Scan libraries periodically every hour at :02
+  file-hashing: false # Compute a filehash for your files. This is required for the trash bin functionality to work, but can consume lots of resources on large libraries or slow hardware
   database:
     file: /mnt/dietpi_userdata/komga/database.sqlite
-  database-backup:
-    enabled: true # Enable database backups
-    startup: false # Do not create a backup at startup
-    schedule: "* 22 4 * * *" # Create a backup every night at 4:22
-    path: /mnt/dietpi_userdata/komga/database-backup.zip
   remember-me:
     key: $(openssl rand -hex 32)
 logging:
@@ -9959,9 +9955,6 @@ logging:
     root: WARN # TRACE DEBUG INFO WARN ERROR
 server:
   port: 2037
-spring:
-  datasource:
-    url: jdbc:h2:/mnt/dietpi_userdata/komga/database.h2
 _EOF_
 			# Optimise memory limit
 			local memory_limit=$(( $RAM_PHYS / 5 ))


### PR DESCRIPTION
**Status**:  Ready
- [x] Remove old configuration keys.
- [x] Set file-hashing to `false`

**Commit list/description**:
- DietPi-Software | Modify Komga configuration

**Reference**: https://komga.org/installation/configuration.html#optional-configuration

There is a new configuration key in v0.107.0. 
file-hashing, a boolean indicating if Komga should compute a filehash for your files. This is required for the trash bin functionality to work, but can consume lots of resources on large libraries or slow hardware. Defaults to true.

I think set `false` is better because arm device is kind of slow. If the user want to use trash bin, they can change back to `true` later.