### PR TITLE
Beta v7.4.1

### DIFF
--- a/.update/pre-patches
+++ b/.update/pre-patches
@@ -73,5 +73,12 @@ Package: linux-image-* linux-headers-* linux-dtb-* linux-u-boot-* armbian-firmwa
 \nPackage: *\nPin: origin apt.armbian.com\nPin-Priority: -1' > /etc/apt/preferences.d/dietpi-armbian"
 fi
 
+# v7.4: Update APT repositories once, accepting the suite change, when Bullseye has been released, as pre-v7.4 G_AGUP does not include this yet.
+if (( $G_DIETPI_VERSION_CORE == 7 && $G_DIETPI_VERSION_SUB < 4 )) && curl -sSfL 'https://deb.debian.org/debian/dists/bullseye/Release' | grep -q '^Suite: stable$'
+then
+	G_DIETPI-NOTIFY 2 'Debian Bullseye has been released, so we accept the repository suite change once.'
+	G_EXEC apt-get --allow-releaseinfo-change-suite -q update
+fi
+
 exit 0
 }

--- a/.update/pre-patches
+++ b/.update/pre-patches
@@ -74,7 +74,7 @@ Package: linux-image-* linux-headers-* linux-dtb-* linux-u-boot-* armbian-firmwa
 fi
 
 # v7.4: Update APT repositories once, accepting the suite change, when Bullseye has been released, as pre-v7.4 G_AGUP does not include this yet.
-if (( $G_DIETPI_VERSION_CORE == 7 && $G_DIETPI_VERSION_SUB < 4 )) && curl -sSfL 'https://deb.debian.org/debian/dists/bullseye/Release' | grep -q '^Suite: stable$'
+if (( $G_DIETPI_VERSION_CORE < 7 || ( $G_DIETPI_VERSION_CORE == 7 && $G_DIETPI_VERSION_SUB < 4 ) )) && curl -sSfL 'https://deb.debian.org/debian/dists/bullseye/Release' | grep -q '^Suite: stable$'
 then
 	G_DIETPI-NOTIFY 2 'Debian Bullseye has been released, so we accept the repository suite change once.'
 	G_EXEC apt-get --allow-releaseinfo-change-suite -q update

--- a/.update/version
+++ b/.update/version
@@ -17,10 +17,10 @@ G_LIVE_PATCH_DESC=(
 	[1]='This is a second test patch. You should not be able to apply it, as its condition should always return false.'
 )
 G_LIVE_PATCH_COND=(
-	[0]='[[ 'This condition is true' ]]'
-	[1]='[[ ! 'This condition is false' ]]'
+	[0]='[[ "This condition is true" ]]'
+	[1]='[[ ! "This condition is false" ]]'
 )
 G_LIVE_PATCH=(
 	[0]='echo "Live patch 0 applied at: $(date)"'
-	[1]='echo "Live patch 1 applied at: $(date)\nThis was never intended to happen :(!"'
+	[1]='echo -e "Live patch 1 applied at $(date). This was never intended to happen :(!"'
 )

--- a/.update/version
+++ b/.update/version
@@ -11,3 +11,16 @@ G_OLD_VERSION_BRANCH='master'
 G_MIN_DEBIAN=4
 # Alternative Git branch to automatically migrate to when Debian version is too low
 G_OLD_DEBIAN_BRANCH='jessie-support'
+# Live patches
+G_LIVE_PATCH_DESC=(
+	[0]='This is the first test patch. You can apply it, but it will not do anything aside of printing a message to console.'
+	[1]='This is a second test patch. You should not be able to apply it, as its condition should always return false.'
+)
+G_LIVE_PATCH_COND=(
+	[0]='[[ 'This condition is true' ]]'
+	[1]='[[ ! 'This condition is false' ]]'
+)
+G_LIVE_PATCH=(
+	[0]='echo "Live patch 0 applied at: $(date)"'
+	[1]='echo "Live patch 1 applied at: $(date)\nThis was never intended to happen :(!"'
+)

--- a/.update/version
+++ b/.update/version
@@ -1,7 +1,7 @@
 # Available DietPi version
 G_REMOTE_VERSION_CORE=7
 G_REMOTE_VERSION_SUB=4
-G_REMOTE_VERSION_RC=0
+G_REMOTE_VERSION_RC=1
 # Minimum DietPi version to allow update
 G_MIN_VERSION_CORE=6
 G_MIN_VERSION_SUB=0

--- a/BRANCH_SYSTEM.md
+++ b/BRANCH_SYSTEM.md
@@ -4,16 +4,16 @@ The goal of the beta branch, is to allow for public testing of our next release.
 
 By joining the Beta and reporting issues, you will be assisting DietPi (and all our users) to ensure stability before stable release.
 
-Beta on fresh image:
+#### Beta on a fresh image:
 1. Write the DietPi image to SD card.
 2. Open the file `/boot/dietpi.txt` on the 1st partition.
-3. Change `DEV_GITBRANCH=master` to `DEV_GITBRANCH=beta` (located at the bottom of file).
+3. Change `DEV_GITBRANCH=master` to `DEV_GITBRANCH=beta` (located near the bottom of the file).
 4. Save the file, eject media and power on.
 
-Beta on an existing installation:
+#### Beta on an existing installation:
 1. Recommended: Backup your system with `dietpi-backup` (or backup quickly with `dietpi-backup 1`).
 2. Run the following command to switch to "beta" branch:
-    ```
+    ```sh
     G_CONFIG_INJECT 'DEV_GITBRANCH=' 'DEV_GITBRANCH=beta' /boot/dietpi.txt
     ```
 3. Run `dietpi-update` to update the system, then reboot (or update quickly with `dietpi-backup 1`).

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,7 @@ New Software:
 
 Fixes:
 - Debian Stretch | Since Armbian dropped support for Debian Stretch from their APT repository, Armbian-based Stretch systems will have their APT sources adjusted to pull kernel, device tree, bootloader and firmware packages from the Armbian Buster suite. These are compatible with all Debian versions and have no dependencies or depandants which could cause conflicts.
+- DietPi-Set_swapfile | Resolved an issue where remounting the /tmp tmpfs filesystem failed, if another filesystem type was mounted at /tmp. This could be especially the case during DietPi-PREP image creation. Many thanks to @timocapa for reporting this issue: https://github.com/MichaIng/DietPi/issues/4573#issuecomment-884993352
 - DietPi-Software | X.Org X Server: Resolved an issue where the X server failed on PINE A64 as the wrong DDX driver packages were installed. Many thanks to @exadeci for reporting this issue: https://github.com/MichaIng/DietPi/issues/4541
 - DietPi-Software | PaperMC: Resolved an issue where the install of Geyser and Floodgate plugins failed as the download link changed.
 - DietPi-Software | Home Assistant: Resolved an issue where install on ARMv6/7 failed if g++ was not installed.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ v7.4
 (2021-07-24)
 
 Changes:
+- DietPi-Update | A new live patching system has been implemented. This allows us to ship little fixes and updates, that are safe to apply with a one-line command, until the next DietPi version is released. Live patches are checked for together with DietPi updates and a notification is shown in the login banner as well, when new live patches have been found. When available, each patch can be individually applied or dismissed and the login banner won't bother you again about patches that you have seen in the dietpi-update menu already, regardless whether you applied them or not.
 - DietPi-Software | Home Assistant: On ARMv6/7, piwheels.org is now used within pyenv, which ships pre-compiled wheels for many Python modules and by this speeds up the installation, first service start and install of new integrations.
 - DietPi-Software | myMPD: Updated config steps to work with the new myMPD v8.0.0. Many thanks to @jcorporation for informing us about this major update and how to adjust our config steps: https://github.com/MichaIng/DietPi/issues/4562
 - DietPi-Software | Komga: Obsolete entries have been removed from the default config and file hashing will be disabled on new installs. Many thanks to @quyentruong for contributing this change: https://github.com/MichaIng/DietPi/pull/4570

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ v7.4
 Changes:
 - DietPi-Software | Home Assistant: On ARMv6/7, piwheels.org is now used within pyenv, which ships pre-compiled wheels for many Python modules and by this speeds up the installation, first service start and install of new integrations.
 - DietPi-Software | myMPD: Updated config steps to work with the new myMPD v8.0.0. Many thanks to @jcorporation for informing us about this major update and how to adjust our config steps: https://github.com/MichaIng/DietPi/issues/4562
+- DietPi-Software | Komga: Obsolete entries have been removed from the default config and file hashing will be disabled on new installs. Many thanks to @quyentruong for contributing this change: https://github.com/MichaIng/DietPi/pull/4570
 
 New Software:
 - Synapse | A Matrix homeserver implementation has been added with software ID 125.

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -588,7 +588,7 @@ Currently installed: $G_DISTRO_NAME (ID: $G_DISTRO)"; then
 			if eval "${G_LIVE_PATCH_COND[$i]}"
 			then
 				G_DIETPI-NOTIFY 2 "Applying live patch $i"
-				eval "${G_LIVE_PATCH[@]}"
+				eval "${G_LIVE_PATCH[$i]}"
 				G_LIVE_PATCH_STATUS[$i]='applied'
 			else
 				G_LIVE_PATCH_STATUS[$i]='not applicable'

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -50,7 +50,7 @@
 	export PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 
 	# Make /tmp a tmpfs if it is not yet a dedicated mount
-	findmnt /tmp > /dev/null || mount -t tmpfs none /tmp
+	findmnt -M /tmp > /dev/null || mount -t tmpfs tmpfs /tmp
 
 	# Work inside /tmp tmpfs to reduce disk I/O and speed up download and unpacking
 	# - Save full script path beforehand: https://github.com/MichaIng/DietPi/pull/2341#discussion_r241784962

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -575,12 +575,28 @@ Currently installed: $G_DISTRO_NAME (ID: $G_DISTRO)"; then
 		G_EXEC_DESC='Clean download location' G_EXEC rm -R "DietPi-$G_GITBRANCH"
 		G_EXEC_DESC='Set execute permissions for DietPi scripts' G_EXEC chmod -R +x /boot/dietpi /var/lib/dietpi/services /etc/cron.*/dietpi
 
-		# Apply MOTD live-patches
-		G_EXEC_DESC='Applying live-patches to fix known bugs in this DietPi version'
-		G_EXEC curl -sSfLO https://dietpi.com/motd
-		. ./motd
-		G_EXEC rm motd
-		unset -v motd
+		G_DIETPI-NOTIFY 2 'Storing DietPi version info:'
+		G_CONFIG_INJECT 'DEV_GITBRANCH=' "DEV_GITBRANCH=$G_GITBRANCH" /boot/dietpi.txt
+		G_CONFIG_INJECT 'DEV_GITOWNER=' "DEV_GITOWNER=$G_GITOWNER" /boot/dietpi.txt
+		G_VERSIONDB_SAVE
+		G_EXEC cp /boot/dietpi/.version /var/lib/dietpi/.dietpi_image_version
+
+		# Apply live patches
+		G_DIETPI-NOTIFY 2 'Applying DietPi live patches to fix known bugs in this version'
+		for i in "${!G_LIVE_PATCH[@]}"
+		do
+			if eval "${G_LIVE_PATCH_COND[$i]}"
+			then
+				G_DIETPI-NOTIFY 2 "Applying live patch $i"
+				eval "${G_LIVE_PATCH[@]}"
+				G_LIVE_PATCH_STATUS[$i]='applied'
+			else
+				G_LIVE_PATCH_STATUS[$i]='not applicable'
+			fi
+
+			# Store new status of live patch to /boot/dietpi/.version
+			G_CONFIG_INJECT "G_LIVE_PATCH_STATUS\[$i\]=" "G_LIVE_PATCH_STATUS[$i]='${G_LIVE_PATCH_STATUS[$i]}'" /boot/dietpi/.version.version
+		done
 
 		G_EXEC systemctl daemon-reload
 
@@ -1751,14 +1767,13 @@ _EOF_
 		G_DIETPI-NOTIFY 2 'Resetting DietPi auto-generated settings and flag files'
 		rm -v /boot/dietpi/.??*
 
+		G_EXEC cp /var/lib/dietpi/.dietpi_image_version /boot/dietpi/.version
+
 		G_DIETPI-NOTIFY 2 'Set init .install_stage to -1 (first boot)'
 		echo -1 > /boot/dietpi/.install_stage
 
 		G_DIETPI-NOTIFY 2 'Writing PREP information to file'
-		cat << _EOF_ > /boot/dietpi/.prep_info
-$IMAGE_CREATOR
-$PREIMAGE_INFO
-_EOF_
+		echo -e "$IMAGE_CREATOR\n$PREIMAGE_INFO" > /boot/dietpi/.prep_info
 
 		G_DIETPI-NOTIFY 2 'Generating GPLv2 license readme'
 		cat << _EOF_ > /var/lib/dietpi/license.txt
@@ -1781,12 +1796,6 @@ _EOF_
 
 		G_EXEC_DESC='Enabling automated partition and file system resize for first boot' G_EXEC systemctl enable dietpi-fs_partition_resize
 		G_EXEC_DESC='Enabling first boot installation process' G_EXEC systemctl enable dietpi-firstboot
-
-		G_DIETPI-NOTIFY 2 'Storing DietPi version info:'
-		G_CONFIG_INJECT 'DEV_GITBRANCH=' "DEV_GITBRANCH=$G_GITBRANCH" /boot/dietpi.txt
-		G_CONFIG_INJECT 'DEV_GITOWNER=' "DEV_GITOWNER=$G_GITOWNER" /boot/dietpi.txt
-		G_VERSIONDB_SAVE
-		G_EXEC cp /boot/dietpi/.version /var/lib/dietpi/.dietpi_image_version
 
 		G_DIETPI-NOTIFY 2 'Clearing lost+found'
 		rm -Rfv /lost+found/{,.??,.[^.]}*

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10201,13 +10201,9 @@ _EOF_
 komga:
   libraries-scan-startup: true # Scan libraries at startup
   libraries-scan-cron: "* 2 * * * *" # Scan libraries periodically every hour at :02
+  file-hashing: false # Compute a filehash for your files. This is required for the trash bin functionality to work, but can consume lots of resources on large libraries or slow hardware
   database:
     file: /mnt/dietpi_userdata/komga/database.sqlite
-  database-backup:
-    enabled: true # Enable database backups
-    startup: false # Do not create a backup at startup
-    schedule: "* 22 4 * * *" # Create a backup every night at 4:22
-    path: /mnt/dietpi_userdata/komga/database-backup.zip
   remember-me:
     key: $(openssl rand -hex 32)
 logging:
@@ -10217,9 +10213,6 @@ logging:
     root: WARN # TRACE DEBUG INFO WARN ERROR
 server:
   port: 2037
-spring:
-  datasource:
-    url: jdbc:h2:/mnt/dietpi_userdata/komga/database.h2
 _EOF_
 			# Optimise memory limit
 			local memory_limit=$(( $RAM_PHYS / 5 ))

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -250,7 +250,7 @@
 		do
 			[[ ${G_LIVE_PATCH_STATUS[$i]} == 'not applied' ]] || continue
 			G_DIETPI-NOTIFY 2 "Applying live patch $i"
-			eval "${G_LIVE_PATCH[@]}"
+			eval "${G_LIVE_PATCH[$i]}"
 
 			# Store new status of live patch to /boot/dietpi/.version
 			G_LIVE_PATCH_STATUS[$i]='applied'

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -232,10 +232,10 @@
 				G_DIETPI-NOTIFY 1 "Please report this issue at: https://github.com/$G_GITOWNER/DietPi/issues"
 				unset -v "G_LIVE_PATCH[$i]" "G_LIVE_PATCH_DESC[$i]" "G_LIVE_PATCH_COND[$i]"
 			fi
-
-			# Remove flag file when patches have been applied or will be shown in menu (no check only mode)
-			[[ $INPUT != 2 && -f '/run/dietpi/.live_patches' ]] && rm /run/dietpi/.live_patches
 		done
+
+		# Remove flag file when patches will be applied or shown in menu (no check only mode)
+		[[ $INPUT != 2 && -f '/run/dietpi/.live_patches' ]] && rm /run/dietpi/.live_patches
 
 		# No live patches available
 		[[ ${G_LIVE_PATCH[0]} ]] || { G_DIETPI-NOTIFY 2 'No live patches are currently available'; return 1; }

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -10,21 +10,22 @@
 	#
 	# Info:
 	# - Location: /boot/dietpi/dietpi-update
-	# - Updates DietPi from Git or dietpi.com repo
-	# - Uses pre-patch_file for patches that need to be done prior to APT calls and DietPi code update
-	# - Uses patch_file for incremental patching after APT calls and DietPi code update
+	# - Updates DietPi from a chosen GitHub repository
+	# - Uses pre-patch_file/pre-patches for patches that need to be done prior to APT calls or DietPi code updates
+	# - Uses patch_file/patches for incremental patching after APT calls and DietPi code updates
 	#
 	# Usage:
-	# - dietpi-update	= Check for DietPi update and in case open interactive menu
-	#			  Else, if CONFIG_CHECK_APT_UPDATES is set, check for APT updates and store results to /run/dietpi/.apt_updates to be used by DietPi-Banner
+	# - dietpi-update	= Check for DietPi update and if available open interactive menu
+	#			  Else, if CONFIG_CHECK_APT_UPDATES=[12] is set, check for APT updates and store results to /run/dietpi/.apt_updates to be used by DietPi-Banner
 	# - dietpi-update 1	= Check for DietPi update and in case apply noninteractively
-	#			  Else, if CONFIG_CHECK_APT_UPDATES=2 is set, check for and apply APT upgrades noninteractively.
-	# - dietpi-update 2	= Check for DietPi update only and in case store result to /run/dietpi/.update_available to be used by DietPi-Banner
-	#			  If CONFIG_CHECK_APT_UPDATES is set, check for APT updates and store results to /run/dietpi/.apt_updates to be used by DietPi-Banner
+	#			  Else, if CONFIG_CHECK_APT_UPDATES=2 is set, check for and apply APT updates noninteractively
+	# - dietpi-update 2	= Check for DietPi update and in case store result to /run/dietpi/.update_available to be used by DietPi-Banner
+	#			  Else, if CONFIG_CHECK_APT_UPDATES=[12] is set, check for APT updates and store results to /run/dietpi/.apt_updates to be used by DietPi-Banner
 	# - dietpi-update -1	= Like "1" but internally reduce subversion by 1 to reapply the last update, e.g. to apply latest dev branch changes
 	#////////////////////////////////////
 
 	# Import DietPi-Globals --------------------------------------------------------------
+	G_LIVE_PATCH_STATUS=() # Reset potentially exported array, to be freshly sourced via DietPi-Globals
 	. /boot/dietpi/func/dietpi-globals
 	readonly G_PROGRAM_NAME='DietPi-Update'
 	G_CHECK_ROOT_USER
@@ -33,7 +34,7 @@
 	# Import DietPi-Globals --------------------------------------------------------------
 
 	# Grab input
-	disable_error=1 G_CHECK_VALIDINT "$1" && INPUT=$1 || INPUT=0
+	[[ $1 =~ ^(-?1|2)$ ]] && INPUT=$1 || INPUT=0
 
 	# Prefix G_DIETPI-NOTIFY 3 header text with "Phase" instead of "Mode" when not checking for available updates only
 	[[ $INPUT == 2 ]] || G_NOTIFY_3_MODE='Phase'
@@ -63,29 +64,33 @@
 	G_MIN_DEBIAN=
 	# - Alternative Git branch to automatically migrate to when Debian version is too low
 	G_OLD_DEBIAN_BRANCH=
+	# - Live patch arrays
+	G_LIVE_PATCH_DESC=()
+	G_LIVE_PATCH_COND=()
+	G_LIVE_PATCH=()
 
 	# Version info to print to console
 	INFO_CURRENT_VERSION=
-	INFO_SERVER_VERSION=
+	INFO_REMOTE_VERSION=
 	INFO_VERSIONS_UPDATE(){
 
 		INFO_CURRENT_VERSION="Current version : v$G_DIETPI_VERSION_CORE.$G_DIETPI_VERSION_SUB.$G_DIETPI_VERSION_RC"
-		INFO_SERVER_VERSION="Latest version  : v$G_REMOTE_VERSION_CORE.$G_REMOTE_VERSION_SUB.$G_REMOTE_VERSION_RC"
+		INFO_REMOTE_VERSION="Latest version  : v$G_REMOTE_VERSION_CORE.$G_REMOTE_VERSION_SUB.$G_REMOTE_VERSION_RC"
 
 		# Show Git repo, when it changed
 		[[ $G_GITBRANCH != "$GITBRANCH_TARGET" || $G_GITOWNER != "$GITOWNER_TARGET" ]] || return
 
 		INFO_CURRENT_VERSION+=" (branch: $G_GITOWNER/$G_GITBRANCH)"
-		INFO_SERVER_VERSION+=" (branch: $GITOWNER_TARGET/$GITBRANCH_TARGET)"
+		INFO_REMOTE_VERSION+=" (branch: $GITOWNER_TARGET/$GITBRANCH_TARGET)"
 
 	}
 
-	Get_Server_Version(){
+	Get_Remote_Version(){
 
 		local url="https://raw.githubusercontent.com/$GITOWNER_TARGET/DietPi/$GITBRANCH_TARGET/.update/version"
 
-		G_DIETPI-NOTIFY 2 "Getting repository version: $url"
-		if curl -sSfL "$url" -o version; then
+		G_DIETPI-NOTIFY 2 "Getting latest version from: $url"
+		if curl -sSfLO "$url"; then
 
 			# Source file
 			. version
@@ -95,23 +100,24 @@
 				disable_error=1 G_CHECK_VALIDINT "$G_REMOTE_VERSION_SUB" &&
 				disable_error=1 G_CHECK_VALIDINT "$G_REMOTE_VERSION_RC"; then
 
-				G_DIETPI-NOTIFY 0 'Got valid repository version'
+				G_DIETPI-NOTIFY 0 "Got valid latest version: $G_REMOTE_VERSION_CORE.$G_REMOTE_VERSION_SUB.$G_REMOTE_VERSION_RC"
 				return 0
 
 			else
 
-				G_DIETPI-NOTIFY 1 "Got invalid repository version (${G_REMOTE_VERSION_CORE:-NULL}.${G_REMOTE_VERSION_SUB:-NULL}.${G_REMOTE_VERSION_RC:-NULL}). Please check the target Git reposiory and your network connection, then rerun dietpi-update."
+				G_DIETPI-NOTIFY 1 "Got invalid latest version: ${G_REMOTE_VERSION_CORE:-NULL}.${G_REMOTE_VERSION_SUB:-NULL}.${G_REMOTE_VERSION_RC:-NULL}"
 
 			fi
 
 		else
 
-			G_DIETPI-NOTIFY 1 'Unable to get repository version. Please check your network connection, then rerun dietpi-update.'
+			G_DIETPI-NOTIFY 1 'Unable to get latest version.'
 
 		fi
 
 		# No valid update server response
-		G_DIETPI-NOTIFY 1 'If this error persists, please report at: https://github.com/MichaIng/DietPi/issues'
+		G_DIETPI-NOTIFY 2 'Please check the target Git repository and your network connection, then rerun dietpi-update.'
+		G_DIETPI-NOTIFY 2 'If this error persists, please report at: https://github.com/MichaIng/DietPi/issues'
 		return 1
 
 	}
@@ -126,7 +132,7 @@
 			G_DIETPI-NOTIFY 2 "Your Debian version is too low to update to the current branch: $G_DISTRO_NAME ($G_DISTRO)"
 			G_DIETPI-NOTIFY 2 "We're switching to an alternative branch: $G_OLD_DEBIAN_BRANCH"
 			GITBRANCH_TARGET=$G_OLD_DEBIAN_BRANCH
-			Get_Server_Version || return 1
+			Get_Remote_Version || return 1
 			G_CONFIG_INJECT 'DEV_GITBRANCH=' "DEV_GITBRANCH=$GITBRANCH_TARGET" /boot/dietpi.txt
 
 		elif (( $G_DIETPI_VERSION_CORE < $G_MIN_VERSION_CORE || ( $G_DIETPI_VERSION_CORE == $G_MIN_VERSION_CORE && $G_DIETPI_VERSION_SUB < $G_MIN_VERSION_SUB ) ))
@@ -134,7 +140,7 @@
 			G_DIETPI-NOTIFY 2 "Your DietPi version is too low to update to the current branch: v$G_DIETPI_VERSION_CORE.$G_DIETPI_VERSION_SUB"
 			G_DIETPI-NOTIFY 2 "We're switching to an alternative branch: $G_OLD_VERSION_BRANCH"
 			GITBRANCH_TARGET=$G_OLD_VERSION_BRANCH
-			Get_Server_Version || return 1
+			Get_Remote_Version || return 1
 			G_CONFIG_INJECT 'DEV_GITBRANCH=' "DEV_GITBRANCH=$GITBRANCH_TARGET" /boot/dietpi.txt
 		fi
 	}
@@ -181,10 +187,75 @@
 
 		INFO_VERSIONS_UPDATE
 		G_DIETPI-NOTIFY 2 "$INFO_CURRENT_VERSION"
-		G_DIETPI-NOTIFY 2 "$INFO_SERVER_VERSION"
+		G_DIETPI-NOTIFY 2 "$INFO_REMOTE_VERSION"
 
 		return $result
 
+	}
+
+	Check_Live_Patches()
+	{
+		# Skip live patches when Git repo changed and remove flag, else patches for repo code may not match installed DietPi code
+		[[ $G_GITBRANCH == "$GITBRANCH_TARGET" && $G_GITOWNER == "$GITOWNER_TARGET" ]] || { [[ -f '/run/dietpi/.live_patches' ]] && rm /run/dietpi/.live_patches; return 1; }
+
+		G_DIETPI-NOTIFY 2 'Checking for available live patches'
+
+		# Loop through live patches sourced from version file in Get_Remote_Version()
+		local i
+		for i in "${!G_LIVE_PATCH[@]}"
+		do
+			# Check whether all expected array entries are set
+			if [[ ${G_LIVE_PATCH[$i]} && ${G_LIVE_PATCH_DESC[$i]} && ${G_LIVE_PATCH_COND[$i]} ]]
+			then
+				G_DIETPI-NOTIFY 2 "Found valid live patch $i:\n - Description: ${G_LIVE_PATCH_DESC[$i]}\n - Condition: ${G_LIVE_PATCH_COND[$i]}\n - Patch: ${G_LIVE_PATCH[$i]}"
+
+				# Skip patches already known
+				[[ ${G_LIVE_PATCH_STATUS[$i]} ]] && { G_DIETPI-NOTIFY 2 "Live patch $i is already known."; continue; }
+
+				# Check whether patch is applicable or not
+				if eval "${G_LIVE_PATCH_COND[$i]}"
+				then
+					G_DIETPI-NOTIFY 2 "Live patch $i is applicable on your system"
+					G_LIVE_PATCH_STATUS[$i]='not applied'
+
+					# When checking for updates only, store flag file
+					[[ $INPUT == 2 ]] && > /run/dietpi/.live_patches
+				else
+					G_DIETPI-NOTIFY 2 "Live patch $i is not applicable on your system"
+					G_LIVE_PATCH_STATUS[$i]='not applicable'
+				fi
+
+				# Store status of new live patch to /boot/dietpi/.version to be sourced by future DietPi-Update executions
+				G_CONFIG_INJECT "G_LIVE_PATCH_STATUS\[$i\]=" "G_LIVE_PATCH_STATUS[$i]='${G_LIVE_PATCH_STATUS[$i]}'" /boot/dietpi/.version
+			else
+				G_DIETPI-NOTIFY 1 "Found invalid live patch $i:\n${G_LIVE_PATCH_DESC[$i]:-NULL}\n - Condition: ${G_LIVE_PATCH_COND[$i]:-NULL}\n - Patch: ${G_LIVE_PATCH[$i]:-NULL}"
+				G_DIETPI-NOTIFY 1 "Please report this issue at: https://github.com/$G_GITOWNER/DietPi/issues"
+				unset -v "G_LIVE_PATCH[$i]" "G_LIVE_PATCH_DESC[$i]" "G_LIVE_PATCH_COND[$i]"
+			fi
+
+			# Remove flag file when patches have been applied or will be shown in menu (no check only mode)
+			[[ $INPUT != 2 && -f '/run/dietpi/.live_patches' ]] && rm /run/dietpi/.live_patches
+		done
+
+		# No live patches available
+		[[ ${G_LIVE_PATCH[0]} ]] || { G_DIETPI-NOTIFY 2 'No live patches are currently available'; return 1; }
+	}
+
+	# $1: Optional argument to apply a single live patch only, used in menu
+	Apply_Live_Patches()
+	{
+		# If no argument given, apply all applicable and not applied live patches
+		# shellcheck disable=SC2066
+		for i in "${1:-${!G_LIVE_PATCH[@]}}"
+		do
+			[[ ${G_LIVE_PATCH_STATUS[$i]} == 'not applied' ]] || continue
+			G_DIETPI-NOTIFY 2 "Applying live patch $i"
+			eval "${G_LIVE_PATCH[@]}"
+
+			# Store new status of live patch to /boot/dietpi/.version
+			G_LIVE_PATCH_STATUS[$i]='applied'
+			G_CONFIG_INJECT "G_LIVE_PATCH_STATUS\[$i\]=" "G_LIVE_PATCH_STATUS[$i]='${G_LIVE_PATCH_STATUS[$i]}'" /boot/dietpi/.version
+		done
 	}
 
 	#/////////////////////////////////////////////////////////////////////////////////////
@@ -210,17 +281,17 @@
 			G_EXEC_DESC='Applying execute permission' G_EXEC chmod +x pre-patch_file
 			if ! ./pre-patch_file $G_DIETPI_VERSION_SUB
 			then
-				G_DIETPI-NOTIFY 1 "An error occured during pre-patch $?. Please check the above log or $FP_LOG for errors, and rerun \"dietpi-update\" after the cause has been solved."
+				G_DIETPI-NOTIFY 1 "An error occurred during pre-patch $?. Please check the above log or $FP_LOG for errors, and rerun \"dietpi-update\" after the cause has been solved."
 				exit 1
 			fi
 
-		# DietPi v6 pre-patches internally apply DietPi v7 pre-patches, hence do not apply then separately.
+		# DietPi v6 pre-patches internally apply DietPi v7 pre-patches, hence do not apply them separately.
 		else
 			G_EXEC_DESC='Downloading pre-patches' G_EXEC curl -sSfLO "https://raw.githubusercontent.com/$GITOWNER_TARGET/DietPi/$GITBRANCH_TARGET/.update/pre-patches"
 			G_EXEC_DESC='Applying execute permission' G_EXEC chmod +x pre-patches
 			if ! ./pre-patches
 			then
-				G_DIETPI-NOTIFY 1 "An error occured during pre-patching. Please check the above log or $FP_LOG for errors, and rerun \"dietpi-update\" after the cause has been solved."
+				G_DIETPI-NOTIFY 1 "An error occurred during pre-patching. Please check the above log or $FP_LOG for errors, and rerun \"dietpi-update\" after the cause has been solved."
 				exit 1
 			fi
 		fi
@@ -251,7 +322,7 @@
 		# Verify/update dietpi.txt entries
 		if ! /boot/dietpi/func/dietpi-set_software verify_dietpi.txt; then
 
-			G_DIETPI-NOTIFY 1 "An error occured during dietpi.txt updates. Please check the above log or $FP_LOG for errors, and rerun \"dietpi-update\" after the cause has been solved."
+			G_DIETPI-NOTIFY 1 "An error occurred during dietpi.txt updates. Please check the above log or $FP_LOG for errors, and rerun \"dietpi-update\" after the cause has been solved."
 			exit 1
 
 		fi
@@ -265,12 +336,12 @@
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Applying incremental patches'
 		INFO_VERSIONS_UPDATE
 		G_DIETPI-NOTIFY 2 "$INFO_CURRENT_VERSION"
-		G_DIETPI-NOTIFY 2 "$INFO_SERVER_VERSION"
+		G_DIETPI-NOTIFY 2 "$INFO_REMOTE_VERSION"
 
 		# DietPi v6 incremental patches
 		if (( $G_DIETPI_VERSION_CORE == 6 )) && ! /boot/dietpi/patch_file; then
 
-			G_DIETPI-NOTIFY 1 "An error occured during incremental patching. Please check the above log or $FP_LOG for errors, and rerun \"dietpi-update\" after the cause has been solved."
+			G_DIETPI-NOTIFY 1 "An error occurred during incremental patching. Please check the above log or $FP_LOG for errors, and rerun \"dietpi-update\" after the cause has been solved."
 			exit 1
 
 		fi
@@ -279,7 +350,7 @@
 
 		if ! "DietPi-$G_GITBRANCH/.update/patches"; then
 
-			G_DIETPI-NOTIFY 1 "An error occured during incremental patching. Please check the above log or $FP_LOG for errors, and rerun \"dietpi-update\" after the cause has been solved."
+			G_DIETPI-NOTIFY 1 "An error occurred during incremental patching. Please check the above log or $FP_LOG for errors, and rerun \"dietpi-update\" after the cause has been solved."
 			exit 1
 
 		fi
@@ -293,6 +364,10 @@
 		G_DIETPI_VERSION_RC=$G_REMOTE_VERSION_RC
 		G_VERSIONDB_SAVE
 		G_DIETPI-NOTIFY 0 "Incremental patching to v$G_REMOTE_VERSION_CORE.$G_REMOTE_VERSION_SUB.$G_REMOTE_VERSION_RC completed"
+
+		# Reset and check for and apply all applicable live patches
+		G_LIVE_PATCH_STATUS=()
+		Check_Live_Patches && Apply_Live_Patches
 
 	}
 
@@ -310,7 +385,6 @@
 
 		while :
 		do
-
 			G_WHIP_BUTTON_CANCEL_TEXT='Exit'
 			G_WHIP_MENU_ARRAY=(
 
@@ -323,7 +397,7 @@
 			)
 
 			G_WHIP_DEFAULT_ITEM='Update'
-			if G_WHIP_MENU "Update available:\n - $INFO_CURRENT_VERSION\n - $INFO_SERVER_VERSION\n
+			if G_WHIP_MENU "Update available:\n - $INFO_CURRENT_VERSION\n - $INFO_REMOTE_VERSION\n
 Please select 'Update' option to apply the update."; then
 
 				if [[ $G_WHIP_RETURNED_VALUE == 'Update' ]]; then
@@ -351,9 +425,49 @@ Do you wish to continue and update DietPi to v$G_REMOTE_VERSION_CORE.$G_REMOTE_V
 				return 1 # Exit
 
 			fi
-
 		done
 
+	}
+
+	Menu_Live_Patches()
+	{
+		local i G_WHIP_MENU_ARRAY G_WHIP_LAST_ITEM=0 info
+		while :
+		do
+			G_WHIP_MENU_ARRAY=()
+			for i in "${!G_LIVE_PATCH[@]}"
+			do
+				G_WHIP_MENU_ARRAY+=("$i" "[${G_LIVE_PATCH_STATUS[$i]}]")
+			done
+
+			G_WHIP_BUTTON_CANCEL_TEXT='Exit'
+			G_WHIP_DEFAULT_ITEM=$G_WHIP_LAST_ITEM
+			if G_WHIP_MENU 'No DietPi update is available, but live patches have been found for your current version to fix little bugs until the next version is released.\n\nSelect a patch below for further details:'
+			then
+				i=$G_WHIP_RETURNED_VALUE
+				G_WHIP_LAST_ITEM=$i
+
+				info="Live patch $i:\n\n${G_LIVE_PATCH_DESC[$i]}\n\nCondition: ${G_LIVE_PATCH_COND[$i]}\n\nPatch: ${G_LIVE_PATCH[$i]}"
+
+				# Not applicable
+				if [[ ${G_LIVE_PATCH_STATUS[$i]} == 'not applicable' ]]
+				then
+					G_WHIP_MSG "$info\n\nYour system does not fulfil the conditions for this patch."
+
+				# Already applied
+				elif [[ ${G_LIVE_PATCH_STATUS[$i]} == 'applied' ]]
+				then
+					G_WHIP_MSG "$info\n\nThis patch has been applied already."
+
+				# Applicable and not applied yet
+				elif G_WHIP_YESNO "$info\n\nDo you want to apply this patch now?"
+				then
+					Apply_Live_Patches "$i"
+				fi
+			else
+				return 0 # Exit
+			fi
+		done
 	}
 
 	#/////////////////////////////////////////////////////////////////////////////////////
@@ -362,78 +476,95 @@ Do you wish to continue and update DietPi to v$G_REMOTE_VERSION_CORE.$G_REMOTE_V
 	#----------------------------------------------------------------
 	G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Checking for available DietPi update'
 	#----------------------------------------------------------------
-	# Check for DietPi update and in case store result to /run/dietpi/.update_available for use by DietPi-Banner
-	if Get_Server_Version && Check_Git_Migration && Check_DietPi_Update; then
-
-		# Exit if check-only input
-		(( $INPUT == 2 )) && exit 0
-
-		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Checking for update pre-requirements'
-
-		# Verify userdata location
-		G_CHECK_USERDATA
-
-		# Check for sufficient free space
-		G_CHECK_FREESPACE / 100 || exit 1
-
-		#----------------------------------------------------------------
-		# Noninteractive update or ask user
-		if (( $INPUT == 1 )) || Menu_Update; then
-
-			# Disable powersaving on main screen
-			setterm -blank 0 -powersave off 2> /dev/null
-
-			# Stop Services
-			/boot/dietpi/dietpi-services stop
-
-			# Run_DietPi_Update: https://github.com/MichaIng/DietPi/issues/1877#issuecomment-403866204
-			# - Log to file by redirecting to subshell instead of piping, else G_EXEC cannot exit the script via "kill -INT $$": https://github.com/MichaIng/DietPi/issues/3127
-			Run_DietPi_Update &> >(tee $FP_LOG); wait $!
-
-			# Mark 1st run update as completed
-			Apply_1st_Run_Update_Success
-
-			# Remove .update_available flag file
-			rm /run/dietpi/.update_available
-
-			G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Completed'
-			INFO_VERSIONS_UPDATE
-			G_DIETPI-NOTIFY 2 "$INFO_CURRENT_VERSION"
-			G_DIETPI-NOTIFY 2 "$INFO_SERVER_VERSION"
-
-			# Update DietPi-Survey
-			/boot/dietpi/dietpi-survey 1
-
-			# Failsafe: Force sync to disk
-			sync
-
-			# Start services only on finished install state, else dietpi-software will follow immediately
-			(( $G_DIETPI_INSTALL_STAGE == 2 )) && /boot/dietpi/dietpi-services restart
-
-		fi
-		#----------------------------------------------------------------
-		# Desktop run, exit key prompt
-		[[ $DISPLAY ]] && read -rp 'Press any key to exit DietPi-Update...'
-
-	# Else, check for and in case apply APT updates based on input mode and dietpi.txt choice
-	else
-		mode=$(sed -n '/^[[:blank:]]*CONFIG_CHECK_APT_UPDATES=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-		# Forced update input and mode 2: Apply APT upgrades, if available
-		if [[ $INPUT == 1 && $mode == 2 ]]
+	# Check for valid Git repository
+	if Get_Remote_Version && Check_Git_Migration
+	then
+		# Check for DietPi update and in case store result to /run/dietpi/.update_available for use by DietPi-Banner
+		if Check_DietPi_Update
 		then
-			G_AGUP -v
-			if (( $G_AGUP_COUNT ))
+			# Exit if check-only input
+			(( $INPUT == 2 )) && exit 0
+
+			G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Checking for update pre-requirements'
+
+			# Verify userdata location
+			G_CHECK_USERDATA
+
+			# Check for sufficient free space
+			G_CHECK_FREESPACE / 100 || exit 1
+
+			# Noninteractive update or ask user
+			if (( $INPUT == 1 )) || Menu_Update
 			then
-				G_AGUG &> >(tee /var/tmp/dietpi/logs/dietpi-upgrade_apt.log)
-				# Assure all services are up since APT upgrades might stop them
-				(( $G_DIETPI_INSTALL_STAGE == 2 )) && /boot/dietpi/dietpi-services start
+				# Disable powersaving on main screen
+				setterm -blank 0 -powersave off 2> /dev/null
+
+				# Stop Services
+				/boot/dietpi/dietpi-services stop
+
+				# Run_DietPi_Update: https://github.com/MichaIng/DietPi/issues/1877#issuecomment-403866204
+				# - Log to file by redirecting to subshell instead of piping, else G_EXEC cannot exit the script via "kill -INT $$": https://github.com/MichaIng/DietPi/issues/3127
+				Run_DietPi_Update &> >(tee $FP_LOG); wait $!
+
+				# Mark 1st run update as completed
+				Apply_1st_Run_Update_Success
+
+				# Remove .update_available flag file
+				rm /run/dietpi/.update_available
+
+				G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Completed'
+				INFO_VERSIONS_UPDATE
+				G_DIETPI-NOTIFY 2 "$INFO_CURRENT_VERSION"
+				G_DIETPI-NOTIFY 2 "$INFO_REMOTE_VERSION"
+
+				# Update DietPi-Survey
+				/boot/dietpi/dietpi-survey 1
+
+				# Failsafe: Force sync to disk
+				sync
+
+				# Start services only on finished install state, else dietpi-software will follow immediately
+				(( $G_DIETPI_INSTALL_STAGE == 2 )) && /boot/dietpi/dietpi-services restart
 			fi
 
-		# No forced update input but APT updates check not disabled: Check for APT updates and store result to /run/dietpi/.apt_updates to be used by DietPi-Banner
-		elif [[ $mode != 0 ]]
+			# Desktop run, exit key prompt
+			[[ $DISPLAY ]] && read -rp 'Press any key to exit DietPi-Update...'
+			exit 0
+
+		# No update available: Check for live patches
+		elif Check_Live_Patches
 		then
-			G_AGUP -f
+			# Forced update mode
+			if (( $INPUT == 1 ))
+			then
+				Apply_Live_Patches
+
+			# Menu mode
+			elif (( $INPUT == 0 ))
+			then
+				Menu_Live_Patches
+				exit 0
+			fi
 		fi
+	fi
+
+	# If no DietPi update is available, check for and in case apply APT updates based on input mode and dietpi.txt choice
+	mode=$(sed -n '/^[[:blank:]]*CONFIG_CHECK_APT_UPDATES=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+	# Forced update input and mode 2: Apply APT updates if available
+	if [[ $INPUT == 1 && $mode == 2 ]]
+	then
+		G_AGUP -v
+		if (( $G_AGUP_COUNT ))
+		then
+			G_AGUG &> >(tee /var/tmp/dietpi/logs/dietpi-upgrade_apt.log)
+			# Assure all services are up since APT updates might stop some
+			(( $G_DIETPI_INSTALL_STAGE == 2 )) && /boot/dietpi/dietpi-services start
+		fi
+
+	# No forced update input but APT updates check not disabled: Check for APT updates and store result to /run/dietpi/.apt_updates to be used by DietPi-Banner
+	elif [[ $mode != 0 ]]
+	then
+		G_AGUP -f
 	fi
 	#----------------------------------------------------------------
 	exit 0

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -143,7 +143,7 @@
 		# New DietPi live patches available?
 		elif Check_DietPi_Live_Patches; then
 
-			local text_update_available_date='New live patches available'
+			local text_update_available_date="${aCOLOUR[3]}New live patches available"
 
 		# APT update available?
 		elif Check_APT_Updates; then
@@ -183,12 +183,12 @@ $GREEN_LINE"
 		# DietPi update available?
 		if [[ $AVAILABLE_UPDATE ]]; then
 
-			echo -e " ${aCOLOUR[1]}dietpi-update$COLOUR_RESET   $GREEN_SEPARATOR ${aCOLOUR[3]}Run now to update DietPi from v$DIETPI_VERSION to v$AVAILABLE_UPDATE.$COLOUR_RESET\n"
+			echo -e " ${aCOLOUR[1]}dietpi-update$COLOUR_RESET   $GREEN_SEPARATOR ${aCOLOUR[3]}Run now to update DietPi from v$DIETPI_VERSION to v$AVAILABLE_UPDATE$COLOUR_RESET\n"
 
 		# New DietPi live patches available?
 		elif (( $LIVE_PATCHES )); then
 
-			echo -e " ${aCOLOUR[1]}dietpi-update$COLOUR_RESET   $GREEN_SEPARATOR ${aCOLOUR[3]}Run now to check out new available DietPi live patches\n"
+			echo -e " ${aCOLOUR[1]}dietpi-update$COLOUR_RESET   $GREEN_SEPARATOR ${aCOLOUR[3]}Run now to check out new available DietPi live patches$COLOUR_RESET\n"
 
 		# APT updates available?
 		elif (( $PACKAGE_COUNT )); then

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -10,7 +10,7 @@
 	#
 	# Info:
 	# - Location: /boot/dietpi/func/dietpi-banner
-	# - Checks /run/dietpi/.update_available, /run/dietpi/.apt_updates, /run/dietpi/.network, /run/dietpi/.dietpi_motd and /boot/dietpi/.prep_info
+	# - Checks /run/dietpi/.update_available, /run/dietpi/.live_patches, /run/dietpi/.apt_updates, /run/dietpi/.network, /run/dietpi/.dietpi_motd and /boot/dietpi/.prep_info
 	#
 	# Usage:
 	# - dietpi-banner   = banner customisation menu
@@ -96,6 +96,16 @@
 
 	}
 
+	# New DietPi live patches available?
+	LIVE_PATCHES=0
+	Check_DietPi_Live_Patches(){
+
+		[[ -f '/run/dietpi/.live_patches' ]] || return 1
+		LIVE_PATCHES=1
+		return 0
+
+	}
+
 	# APT updates available?
 	PACKAGE_COUNT=0
 	Check_APT_Updates(){
@@ -129,6 +139,11 @@
 		if Check_DietPi_Update; then
 
 			local text_update_available_date="${aCOLOUR[3]}Update available"
+
+		# New DietPi live patches available?
+		elif Check_DietPi_Live_Patches; then
+
+			local text_update_available_date='New live patches available'
 
 		# APT update available?
 		elif Check_APT_Updates; then
@@ -170,10 +185,15 @@ $GREEN_LINE"
 
 			echo -e " ${aCOLOUR[1]}dietpi-update$COLOUR_RESET   $GREEN_SEPARATOR ${aCOLOUR[3]}Run now to update DietPi from v$DIETPI_VERSION to v$AVAILABLE_UPDATE.$COLOUR_RESET\n"
 
+		# New DietPi live patches available?
+		elif (( $LIVE_PATCHES )); then
+
+			echo -e " ${aCOLOUR[1]}dietpi-update$COLOUR_RESET   $GREEN_SEPARATOR ${aCOLOUR[3]}Run now to check out new available DietPi live patches\n"
+
 		# APT updates available?
 		elif (( $PACKAGE_COUNT )); then
 
-			echo -e " ${aCOLOUR[1]}apt upgrade$COLOUR_RESET     $GREEN_SEPARATOR ${aCOLOUR[3]}Run now to apply $PACKAGE_COUNT available APT package upgrades.$COLOUR_RESET\n"
+			echo -e " ${aCOLOUR[1]}apt upgrade$COLOUR_RESET     $GREEN_SEPARATOR ${aCOLOUR[3]}Run now to apply $PACKAGE_COUNT available APT package upgrades$COLOUR_RESET\n"
 
 		fi
 
@@ -181,11 +201,11 @@ $GREEN_LINE"
 
 	Print_Useful_Commands(){
 
-		echo -e " ${aCOLOUR[1]}dietpi-launcher$COLOUR_RESET $GREEN_SEPARATOR All the DietPi programs in one place.
- ${aCOLOUR[1]}dietpi-config$COLOUR_RESET   $GREEN_SEPARATOR Feature rich configuration tool for your device.
- ${aCOLOUR[1]}dietpi-software$COLOUR_RESET $GREEN_SEPARATOR Select optimized software for installation.
- ${aCOLOUR[1]}htop$COLOUR_RESET            $GREEN_SEPARATOR Resource monitor.
- ${aCOLOUR[1]}cpu$COLOUR_RESET             $GREEN_SEPARATOR Shows CPU information and stats.\n"
+		echo -e " ${aCOLOUR[1]}dietpi-launcher$COLOUR_RESET $GREEN_SEPARATOR All the DietPi programs in one place
+ ${aCOLOUR[1]}dietpi-config$COLOUR_RESET   $GREEN_SEPARATOR Feature rich configuration tool for your device
+ ${aCOLOUR[1]}dietpi-software$COLOUR_RESET $GREEN_SEPARATOR Select optimised software for installation
+ ${aCOLOUR[1]}htop$COLOUR_RESET            $GREEN_SEPARATOR Resource monitor
+ ${aCOLOUR[1]}cpu$COLOUR_RESET             $GREEN_SEPARATOR Shows CPU information and stats\n"
 
 	}
 

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -57,7 +57,7 @@
 	# - Assign defaults/code version as fallback
 	[[ $G_DIETPI_VERSION_CORE ]] || G_DIETPI_VERSION_CORE=7
 	[[ $G_DIETPI_VERSION_SUB ]] || G_DIETPI_VERSION_SUB=4
-	[[ $G_DIETPI_VERSION_RC ]] || G_DIETPI_VERSION_RC=0
+	[[ $G_DIETPI_VERSION_RC ]] || G_DIETPI_VERSION_RC=1
 	[[ $G_GITBRANCH ]] || G_GITBRANCH='master'
 	[[ $G_GITOWNER ]] || G_GITOWNER='MichaIng'
 	# - Save current version and Git branch

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -1303,7 +1303,7 @@ $log_content" || break # Exit error handler menu loop on cancel
 		G_EXEC_PRE_FUNC(){ apt-get clean; declare -F G_EXEC_PRE_FUNC_ORIG &> /dev/null && G_EXEC_PRE_FUNC_ORIG; }
 
 		G_EXEC_DESC='\e[0mAPT update'
-		G_EXEC_OUTPUT=1 G_EXEC_OUTPUT_COL='\e[90m' G_EXEC apt-get -q update
+		G_EXEC_OUTPUT=1 G_EXEC_OUTPUT_COL='\e[90m' G_EXEC apt-get --allow-releaseinfo-change-suite -q update
 		local exit_code=$?
 
 		unset -f G_EXEC_PRE_FUNC_ORIG

--- a/dietpi/func/dietpi-set_swapfile
+++ b/dietpi/func/dietpi-set_swapfile
@@ -72,7 +72,7 @@
 		systemctl daemon-reload
 
 		# Apply now to existing mount via "remount" to preserve current content and avoid doubled mount
-		findmnt /tmp > /dev/null && G_EXEC mount -o remount /tmp
+		[[ $(findmnt -Ufnro FSTYPE -M /tmp) == 'tmpfs' ]] && G_EXEC mount -o remount /tmp
 
 	}
 


### PR DESCRIPTION
### Beta v7.4.1
_(2021-07-23)_

#### Changes since v7.4.0
- DietPi-Update | A new live patching system has been implemented. This allows us to ship little fixes and updates, that are safe to apply with a one-line command, until the next DietPi version is released. Live patches are checked for together with DietPi updates and a notification is shown in the login banner as well, when new live patches have been found. When available, each patch can be individually applied or dismissed and the login banner won't bother you again about patches that you have seen in the dietpi-update menu already, regardless whether you applied them or not.
- DietPi-Software | Komga: Obsolete entries have been removed from the default config and file hashing will be disabled on new installs. Many thanks to @quyentruong for contributing this change: https://github.com/MichaIng/DietPi/pull/4570

#### Fixes since v7.4.0
- DietPi-Set_swapfile | Resolved an issue where remounting the /tmp tmpfs filesystem failed, if another filesystem type was mounted at /tmp. This could be especially the case during DietPi-PREP image creation. Many thanks to @timocapa for reporting this issue: https://github.com/MichaIng/DietPi/issues/4573#issuecomment-884993352