### PR TITLE
DietPi-Software | Pi-hole: Enable LAN IPv6 access for blocked public admin panel access

### DIFF
--- a/.conf/dps_93/apache.block_public_admin.conf
+++ b/.conf/dps_93/apache.block_public_admin.conf
@@ -1,4 +1,4 @@
 # Block public access to admin panel
 <Directory ~ /var/www(/html)?/admin>
-	Require ip 127 192.168 10 172.16.0.0/12
+	Require ip 127 192.168 10 172.16.0.0/12 ::1/128 fe80::/10 fc00::/7
 </Directory>

--- a/.conf/dps_93/lighttpd.block_public_admin.conf
+++ b/.conf/dps_93/lighttpd.block_public_admin.conf
@@ -1,6 +1,6 @@
 # Block non-LAN access to Pi-hole admin panel
 $HTTP["url"] =~ "^(/html)?/admin(/|$)" {
-	$HTTP["remoteip"] !~ "^1(27|92\.168|0|72\.(1[6-9]|2[0-9]|3[0-1]))\." {
+	$HTTP["remoteip"] !~ "^(1(27|92\.168|0|72\.(1[6-9]|2[0-9]|3[0-1]))\.|::1|fe[89ab].:|f[cd]..:)" {
 		url.access-deny = ("")
 	}
 }

--- a/.conf/dps_93/nginx.block_public_admin.conf
+++ b/.conf/dps_93/nginx.block_public_admin.conf
@@ -6,4 +6,7 @@ allow 127.0.0.0/8;
 allow 192.168.0.0/16;
 allow 10.0.0.0/8;
 allow 172.16.0.0/12;
+allow ::1/128;
+allow fe80::/10;
+allow fc00::/7;
 deny all;

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,7 @@ Fixes:
 - DietPi-Software | X.Org X Server: Resolved an issue where the X server failed on PINE A64 as the wrong DDX driver packages were installed. Many thanks to @exadeci for reporting this issue: https://github.com/MichaIng/DietPi/issues/4541
 - DietPi-Software | PaperMC: Resolved an issue where the install of Geyser and Floodgate plugins failed as the download link changed.
 - DietPi-Software | Home Assistant: Resolved an issue where install on ARMv6/7 failed if g++ was not installed.
+- DietPi-Software | Pi-hole: Resolved an issue where local/LAN access via IPv6 was blocked, when the option to block public access to the admin panel was selected. Many thanks to @dunxd for reporting this issue: https://github.com/MichaIng/DietPi/issues/4575
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9566,6 +9566,9 @@ _EOF_
  - 192.168.*
  - 10.*
  - 172.16.* - 172.31.*
+ - ::1
+ - fe80:* - febf:*
+ - fc00:* - fdff:*
 \nYou can always enable/disable this later using the commands:
  - $enable_cmd
  - $disable_cmd


### PR DESCRIPTION
**Status**: Ready

This includes the loopback IP `::1/128`, SLAAC/auto-configured IP range `fe80::/10` and LAN IP range `fc00::/7`.

**Commit list/description**:
+ DietPi-Software | Pi-hole: Enable LAN IPv6 access for blocked public admin panel access