### PR TITLE
Beta v7.4.2

### DIFF
--- a/.conf/dps_93/apache.block_public_admin.conf
+++ b/.conf/dps_93/apache.block_public_admin.conf
@@ -1,4 +1,4 @@
 # Block public access to admin panel
 <Directory ~ /var/www(/html)?/admin>
-	Require ip 127 192.168 10 172.16.0.0/12
+	Require ip 127 192.168 10 172.16.0.0/12 ::1/128 fe80::/10 fc00::/7
 </Directory>

--- a/.conf/dps_93/lighttpd.block_public_admin.conf
+++ b/.conf/dps_93/lighttpd.block_public_admin.conf
@@ -1,6 +1,6 @@
 # Block non-LAN access to Pi-hole admin panel
 $HTTP["url"] =~ "^(/html)?/admin(/|$)" {
-	$HTTP["remoteip"] !~ "^1(27|92\.168|0|72\.(1[6-9]|2[0-9]|3[0-1]))\." {
+	$HTTP["remoteip"] !~ "^(1(27|92\.168|0|72\.(1[6-9]|2[0-9]|3[0-1]))\.|::1|fe[89ab].:|f[cd]..:)" {
 		url.access-deny = ("")
 	}
 }

--- a/.conf/dps_93/nginx.block_public_admin.conf
+++ b/.conf/dps_93/nginx.block_public_admin.conf
@@ -6,4 +6,7 @@ allow 127.0.0.0/8;
 allow 192.168.0.0/16;
 allow 10.0.0.0/8;
 allow 172.16.0.0/12;
+allow ::1/128;
+allow fe80::/10;
+allow fc00::/7;
 deny all;

--- a/.update/patches
+++ b/.update/patches
@@ -263,6 +263,17 @@ _EOF_
 	[[ -f '/boot/dietpi/.installed' ]] && grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[160\]=2' /boot/dietpi/.installed && /boot/dietpi/dietpi-software reinstall 160
 }
 
+Patch_7_4()
+{
+	if [[ $G_HW_ARCH == [12] && ! -f '/etc/pip.conf' && -f '/boot/dietpi/.installed' ]] && grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[130\]=2' /boot/dietpi/.installed
+	then
+		G_WHIP_BUTTON_CANCEL_TEXT='No' G_WHIP_YESNO 'Adding piwheels.org to your pip sources
+\nPython 3 pip is installed on your system, but piwheels.org is not used as source for pre-compiled Python 3 wheels. To speed up the installation and upgrade of modules via pip and reduce build dependencies, we highly recommend to make use of it.
+\nRead more about the project at: https://piwheels.org/
+\nDo you want pip to pull Python 3 wheels from piwheels.org automatically?' && G_EXEC eval "echo -e '[global]\nextra-index-url=https://www.piwheels.org/simple/' > /etc/pip.conf"
+	fi
+}
+
 # Main loop
 while :
 do

--- a/.update/pre-patches
+++ b/.update/pre-patches
@@ -89,5 +89,14 @@ then
 	fi	
 fi
 
+# v7.4
+if getent passwd debian-transmission > /dev/null && ! getent group debian-transmission > /dev/null
+then
+	G_DIETPI-NOTIFY 2 'Recreating the "debian-transmission" group for the "debian-transmission" user to prevent Transmission package upgrade issues: https://github.com/MichaIng/DietPi/issues/4244'
+	G_EXEC groupadd -r debian-transmission
+	G_EXEC usermod -aG debian-transmission debian-transmission
+
+fi
+
 exit 0
 }

--- a/.update/pre-patches
+++ b/.update/pre-patches
@@ -76,8 +76,17 @@ fi
 # v7.4: Update APT repositories once, accepting the suite change, when Bullseye has been released, as pre-v7.4 G_AGUP does not include this yet.
 if (( $G_DIETPI_VERSION_CORE < 7 || ( $G_DIETPI_VERSION_CORE == 7 && $G_DIETPI_VERSION_SUB < 4 ) )) && curl -sSfL 'https://deb.debian.org/debian/dists/bullseye/Release' | grep -q '^Suite: stable$'
 then
-	G_DIETPI-NOTIFY 2 'Debian Bullseye has been released, so we accept the repository suite change once.'
-	G_EXEC apt-get --allow-releaseinfo-change-suite -q update
+	if (( $G_DISTRO > 4 ))
+	then
+		G_DIETPI-NOTIFY 2 'Debian Bullseye has been released, so we accept the repository suite change once.'
+		G_EXEC apt-get --allow-releaseinfo-change-suite -q update
+
+	# On Stretch that option is not supported yet. If it's an interactive call, allow to accept it manually:
+	elif [[ $G_INTERACTIVE == 1 ]]
+	then
+		G_DIETPI-NOTIFY 2 'Debian Bullseye has been released, so you need to accept the repository suite change once.'
+		apt-get update
+	fi	
 fi
 
 exit 0

--- a/.update/version
+++ b/.update/version
@@ -1,7 +1,7 @@
 # Available DietPi version
 G_REMOTE_VERSION_CORE=7
 G_REMOTE_VERSION_SUB=4
-G_REMOTE_VERSION_RC=1
+G_REMOTE_VERSION_RC=2
 # Minimum DietPi version to allow update
 G_MIN_VERSION_CORE=6
 G_MIN_VERSION_SUB=0
@@ -12,15 +12,6 @@ G_MIN_DEBIAN=4
 # Alternative Git branch to automatically migrate to when Debian version is too low
 G_OLD_DEBIAN_BRANCH='jessie-support'
 # Live patches
-G_LIVE_PATCH_DESC=(
-	[0]='This is the first test patch. You can apply it, but it will not do anything aside of printing a message to console.'
-	[1]='This is a second test patch. You should not be able to apply it, as its condition should always return false.'
-)
-G_LIVE_PATCH_COND=(
-	[0]='[[ "This condition is true" ]]'
-	[1]='[[ ! "This condition is false" ]]'
-)
-G_LIVE_PATCH=(
-	[0]='echo "Live patch 0 applied at: $(date)"'
-	[1]='echo -e "Live patch 1 applied at $(date). This was never intended to happen :(!"'
-)
+G_LIVE_PATCH_DESC=()
+G_LIVE_PATCH_COND=()
+G_LIVE_PATCH=()

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ v7.4
 
 Changes:
 - DietPi-Update | A new live patching system has been implemented. This allows us to ship little fixes and updates, that are safe to apply with a one-line command, until the next DietPi version is released. Live patches are checked for together with DietPi updates and a notification is shown in the login banner as well, when new live patches have been found. When available, each patch can be individually applied or dismissed and the login banner won't bother you again about patches that you have seen in the dietpi-update menu already, regardless whether you applied them or not.
+- DietPi-Globals | G_AGUP: Our "apt-get update" wrapper will now throw an error, when some index files couldn't be downloaded, e.g. due to DNS failure. Currently "apt-get update" prints a warning but does not return an error code. It is better to have an error handler prompt here, where we have an associated command output, than later when package installs or upgrades fail because of outdated information or missing list files.
 - DietPi-Software | Home Assistant: On ARMv6/7, piwheels.org is now used within pyenv, which ships pre-compiled wheels for many Python modules and by this speeds up the installation, first service start and install of new integrations.
 - DietPi-Software | myMPD: Updated config steps to work with the new myMPD v8.0.0. Many thanks to @jcorporation for informing us about this major update and how to adjust our config steps: https://github.com/MichaIng/DietPi/issues/4562
 - DietPi-Software | Komga: Obsolete entries have been removed from the default config and file hashing will be disabled on new installs. Many thanks to @quyentruong for contributing this change: https://github.com/MichaIng/DietPi/pull/4570
@@ -18,7 +19,7 @@ Fixes:
 - DietPi-Software | X.Org X Server: Resolved an issue where the X server failed on PINE A64 as the wrong DDX driver packages were installed. Many thanks to @exadeci for reporting this issue: https://github.com/MichaIng/DietPi/issues/4541
 - DietPi-Software | PaperMC: Resolved an issue where the install of Geyser and Floodgate plugins failed as the download link changed.
 - DietPi-Software | Home Assistant: Resolved an issue where install on ARMv6/7 failed if g++ was not installed.
-- DietPi-Software | Pi-hole: Resolved an issue where local/LAN access via IPv6 was blocked, when the option to block public access to the admin panel was selected. Many thanks to @dunxd for reporting this issue: https://github.com/MichaIng/DietPi/issues/4575
+- DietPi-Software | Pi-hole: Resolved an issue where local/LAN access via IPv6 was blocked, when the option to block public access to the admin panel was selected. This does not work when global unicast IPv6 addresses (GLA) are used within the LAN, hence unique local addresses (ULA) needs to be enabled and used to access the Pi-hole admin panel. Many thanks to @dunxd for reporting this issue: https://github.com/MichaIng/DietPi/issues/4575
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,7 +21,7 @@ Fixes:
 - DietPi-Software | Home Assistant: Resolved an issue where install on ARMv6/7 failed if g++ was not installed.
 - DietPi-Software | Pi-hole: Resolved an issue where local/LAN access via IPv6 was blocked, when the option to block public access to the admin panel was selected. This does not work when global unicast IPv6 addresses (GLA) are used within the LAN, hence unique local addresses (ULA) needs to be enabled and used to access the Pi-hole admin panel. Many thanks to @dunxd for reporting this issue: https://github.com/MichaIng/DietPi/issues/4575
 
-As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
+As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/4584
 
 Known/Outstanding Issues:
 - DietPi-Config | Enabling WiFi + Ethernet adapters, both on different subnets, breaks WiFi connection in some cases: https://github.com/MichaIng/DietPi/issues/2103

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,7 @@ Fixes:
 - DietPi-Software | X.Org X Server: Resolved an issue where the X server failed on PINE A64 as the wrong DDX driver packages were installed. Many thanks to @exadeci for reporting this issue: https://github.com/MichaIng/DietPi/issues/4541
 - DietPi-Software | PaperMC: Resolved an issue where the install of Geyser and Floodgate plugins failed as the download link changed.
 - DietPi-Software | Home Assistant: Resolved an issue where install on ARMv6/7 failed if g++ was not installed.
+- DietPi-Software | Pi-hole: Resolved an issue where local/LAN access via IPv6 was blocked, when the option to block public access to the admin panel was selected. Many thanks to @dunxd for reporting this issue: https://github.com/MichaIng/DietPi/issues/4575
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9566,6 +9566,9 @@ _EOF_
  - 192.168.*
  - 10.*
  - 172.16.* - 172.31.*
+ - ::1
+ - fe80:* - febf:*
+ - fc00:* - fdff:*
 \nYou can always enable/disable this later using the commands:
  - $enable_cmd
  - $disable_cmd

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -57,7 +57,7 @@
 	# - Assign defaults/code version as fallback
 	[[ $G_DIETPI_VERSION_CORE ]] || G_DIETPI_VERSION_CORE=7
 	[[ $G_DIETPI_VERSION_SUB ]] || G_DIETPI_VERSION_SUB=4
-	[[ $G_DIETPI_VERSION_RC ]] || G_DIETPI_VERSION_RC=1
+	[[ $G_DIETPI_VERSION_RC ]] || G_DIETPI_VERSION_RC=2
 	[[ $G_GITBRANCH ]] || G_GITBRANCH='master'
 	[[ $G_GITOWNER ]] || G_GITOWNER='MichaIng'
 	# - Save current version and Git branch
@@ -1302,11 +1302,19 @@ $log_content" || break # Exit error handler menu loop on cancel
 		declare -F G_EXEC_PRE_FUNC &> /dev/null && eval "G_EXEC_PRE_FUNC_ORIG()$(declare -f G_EXEC_PRE_FUNC | tail -n +2)"
 		G_EXEC_PRE_FUNC(){ apt-get clean; declare -F G_EXEC_PRE_FUNC_ORIG &> /dev/null && G_EXEC_PRE_FUNC_ORIG; }
 
+		# Fail when some index files couldn't be downloaded, e.g. due to DNS failure. Currently apt-get update prints a warning but does not return an error code.
+		declare -F G_EXEC_POST_FUNC &> /dev/null && eval "G_EXEC_POST_FUNC_ORIG()$(declare -f G_EXEC_POST_FUNC | tail -n +2)"
+		G_EXEC_POST_FUNC(){ [[ $exit_code == 0 && $(<$fp_log) == *'W: Some index files failed to download.'* ]] && exit_code=255; declare -F G_EXEC_POST_FUNC_ORIG &> /dev/null && G_EXEC_POST_FUNC_ORIG; }
+
+		# Allow suite changes on Buster and up (not yet supported on Stretch)
+		local allow_suite
+		(( $G_DISTRO > 4 )) && allow_suite='--allow-releaseinfo-change-suite'
+
 		G_EXEC_DESC='\e[0mAPT update'
-		G_EXEC_OUTPUT=1 G_EXEC_OUTPUT_COL='\e[90m' G_EXEC apt-get --allow-releaseinfo-change-suite -q update
+		G_EXEC_OUTPUT=1 G_EXEC_OUTPUT_COL='\e[90m' G_EXEC apt-get $allow_suite -q update
 		local exit_code=$?
 
-		unset -f G_EXEC_PRE_FUNC_ORIG
+		unset -f G_EXEC_{PRE,POST}_FUNC_ORIG
 
 		if [[ $1 == '-'[fv] ]]
 		then


### PR DESCRIPTION
### Beta v7.4.2
_(2021-07-24)_

#### Changes since v7.4.1
- DietPi-Globals | G_AGUP: Our "apt-get update" wrapper will now throw an error, when some index files couldn't be downloaded, e.g. due to DNS failure. Currently "apt-get update" prints a warning but does not return an error code. It is better to have an error handler prompt here, where we have an associated command output, than later when package installs or upgrades fail because of outdated information or missing list files.

#### Fixes since v7.4.1
- DietPi-Software | Pi-hole: Resolved an issue where local/LAN access via IPv6 was blocked, when the option to block public access to the admin panel was selected. This does not work when global unicast IPv6 addresses (GLA) are used within the LAN, hence unique local addresses (ULA) need to be enabled and used to access the Pi-hole admin panel. Many thanks to @dunxd for reporting this issue: https://github.com/MichaIng/DietPi/issues/4575