### PR TITLE
DietPi-Software | Java: Split into JDK and JRE and fix ARMv6 install

### DIFF
--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -189,7 +189,7 @@ shopt -s extglob
 		[5]='ALSA'
 		[6]='X.Org X Server'
 		[7]='FFmpeg'
-		[8]='Java'
+		[8]='Java JDK'
 		[9]='Node.js'
 		[10]='iftop'
 		[11]='IPTraf'
@@ -311,7 +311,7 @@ shopt -s extglob
 		[127]='NeoVim'
 		[128]='MPD'
 		[129]='O!MPD'
-		[130]='Python Pip'
+		[130]='Python pip'
 		[131]='Blynk Server'
 		[132]='Aria2'
 		[133]='YaCy'
@@ -544,9 +544,10 @@ shopt -s extglob
 	aSOFTWARE_NAME7_5=()
 	for i in "${!aSOFTWARE_NAME7_4[@]}"
 	do
-		# shellcheck disable=SC2034
 		aSOFTWARE_NAME7_5[$i]=${aSOFTWARE_NAME7_4[$i]}
 	done
+	# shellcheck disable=SC2034
+	aSOFTWARE_NAME7_5[196]='Java JRE'
 
 	# $1 = File name
 	Process_File()

--- a/.update/patches
+++ b/.update/patches
@@ -274,6 +274,12 @@ Patch_7_4()
 	fi
 }
 
+Patch_7_5()
+{
+	# Mark JRE as installed when JDK is installed
+	[[ -f '/boot/dietpi/.installed' ]] && grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[8\]=' /boot/dietpi/.installed && G_CONFIG_INJECT 'aSOFTWARE_INSTALL_STATE\[196\]=' 'aSOFTWARE_INSTALL_STATE[196]=2' /boot/dietpi/.installed
+}
+
 # Main loop
 while :
 do

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,9 +2,14 @@ v7.5
 (2021-08-21)
 
 Changes:
+- DietPi-Software | Java: This install option has now been split into the JRE (Java Runtime Environment) and the JDK (Java Development Kit). As our Java-written software options require the JRE only, this saves over 200 MiB of additional JDK-related disk space. For developers, however, the JDK stays with the same software ID.
+
+New Software:
+- Java JRE | The OpenJDK Java Runtime Environment has been made available as dedicated software option with ID 196 (see changes above).
 
 Fixes:
 - DietPi-Software | Roon Extension Manager: Resolved an issue where the installer failed when dietpi-software was executed with sudo as unprivileged user. The installer internally uses the SUDO_USER variable to perform some tasks, which fails to download the container startup shell script, as only root can write to the download location. Many thanks to @Esad-np for reporting this issue: https://github.com/MichaIng/DietPi/issues/4462
+- DietPi-Software | Java JRE: Resolved an issue where the install failed on ARMv6: https://github.com/MichaIng/DietPi/issues/4509#issuecomment-876413815
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Links to hardware and software manufacturers, sources and build instructions use
 - [Synapse](https://github.com/matrix-org/synapse)
 - [youtube-dl](https://github.com/ytdl-org/youtube-dl)
 - [PostgreSQL](https://git.postgresql.org/gitweb/?p=postgresql.git)
+- [OpenJDK](https://github.com/openjdk)
 
 ---
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3161,6 +3161,8 @@ unix_socket_directories = '/run/postgresql'" > "$i/00dietpi.conf"
 			# Bullseye
 			else
 				local version=17
+				# Raspbian for some reason misses the Java 17 builds: http://raspbian.raspberrypi.org/raspbian/pool/main/o/openjdk-17/
+				(( $G_HW_MODEL > 9 )) || (( $G_RASPBIAN == 0 )) || version=11
 			fi
 
 			# Allow two attempts as workaround for ARM install issue: https://github.com/MichaIng/DietPi/issues/2524
@@ -3192,6 +3194,8 @@ unix_socket_directories = '/run/postgresql'" > "$i/00dietpi.conf"
 			# Bullseye
 			else
 				local version=17
+				# Raspbian for some reason misses the Java 17 builds: http://raspbian.raspberrypi.org/raspbian/pool/main/o/openjdk-17/
+				(( $G_HW_MODEL > 9 )) || (( $G_RASPBIAN == 0 )) || version=11
 			fi
 
 			G_AGI openjdk-$version-jdk-headless

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -417,7 +417,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_DESC[$software_id]='web interface media streaming server'
 		aSOFTWARE_CATX[$software_id]=2
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#airsonic'
-		aSOFTWARE_DEPS[$software_id]='5 7 8'
+		aSOFTWARE_DEPS[$software_id]='5 7 196'
 		#------------------
 		software_id=34
 
@@ -425,7 +425,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_DESC[$software_id]='web interface media streaming server'
 		aSOFTWARE_CATX[$software_id]=2
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#subsonic'
-		aSOFTWARE_DEPS[$software_id]='5 7 8'
+		aSOFTWARE_DEPS[$software_id]='5 7 196'
 		# - Buster: https://github.com/MichaIng/DietPi/issues/2787
 		aSOFTWARE_AVAIL_G_DISTRO[$software_id,5]=0
 		aSOFTWARE_AVAIL_G_DISTRO[$software_id,6]=0
@@ -626,7 +626,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_DESC[$software_id]='free home server for your comics and ebooks library'
 		aSOFTWARE_CATX[$software_id]=2
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#ubooquity'
-		aSOFTWARE_DEPS[$software_id]='8'
+		aSOFTWARE_DEPS[$software_id]='196'
 		#------------------
 		software_id=179
 
@@ -634,7 +634,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_DESC[$software_id]='free and open source comics/mangas media server with web UI'
 		aSOFTWARE_CATX[$software_id]=2
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#komga'
-		aSOFTWARE_DEPS[$software_id]='8'
+		aSOFTWARE_DEPS[$software_id]='196'
 		#------------------
 		software_id=86
 
@@ -984,7 +984,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_DESC[$software_id]='Minecraft servers with web interface (Java/Node.js)'
 		aSOFTWARE_CATX[$software_id]=5
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/gaming/#mineos'
-		aSOFTWARE_DEPS[$software_id]='8 9 16 17'
+		aSOFTWARE_DEPS[$software_id]='196 9 16 17'
 		#------------------
 		software_id=156
 
@@ -1005,7 +1005,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_DESC[$software_id]='A nuclear-powered server for Minecraft Pocket Edition'
 		aSOFTWARE_CATX[$software_id]=5
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/gaming/#nukkit'
-		aSOFTWARE_DEPS[$software_id]='8'
+		aSOFTWARE_DEPS[$software_id]='196'
 		#------------------
 		software_id=181
 
@@ -1013,7 +1013,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_DESC[$software_id]='Highly optimised Minecraft server with plugins, written in Java'
 		aSOFTWARE_CATX[$software_id]=5
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/gaming/#papermc'
-		aSOFTWARE_DEPS[$software_id]='8 9'
+		aSOFTWARE_DEPS[$software_id]='196 9'
 		aSOFTWARE_INTERACTIVE[$software_id]=1
 
 		#------------------
@@ -1304,7 +1304,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_DESC[$software_id]='msg controller for blynk mobile app and sbcs'
 		aSOFTWARE_CATX[$software_id]=10
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/hardware_projects/#blynk-server'
-		aSOFTWARE_DEPS[$software_id]='8 9 16'
+		aSOFTWARE_DEPS[$software_id]='196 9 16'
 		#------------------
 		software_id=166
 
@@ -1652,7 +1652,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_DESC[$software_id]='decentralised open source search engine'
 		aSOFTWARE_CATX[$software_id]=19
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/distributed_projects/#yacy'
-		aSOFTWARE_DEPS[$software_id]='8'
+		aSOFTWARE_DEPS[$software_id]='196'
 		#------------------
 		software_id=184
 
@@ -1873,8 +1873,15 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		#------------------
 		software_id=8
 
-		aSOFTWARE_NAME[$software_id]='Java'
-		aSOFTWARE_DESC[$software_id]='OpenJDK runtime environment and development kit'
+		aSOFTWARE_NAME[$software_id]='Java JDK'
+		aSOFTWARE_DESC[$software_id]='OpenJDK Development Kit'
+		aSOFTWARE_CATX[$software_id]=26
+		aSOFTWARE_DEPS[$software_id]='196'
+		#------------------
+		software_id=196
+
+		aSOFTWARE_NAME[$software_id]='Java JRE'
+		aSOFTWARE_DESC[$software_id]='OpenJDK Runtime Environment'
 		aSOFTWARE_CATX[$software_id]=26
 		#------------------
 		software_id=9
@@ -3136,7 +3143,7 @@ unix_socket_directories = '/run/postgresql'" > "$i/00dietpi.conf"
 
 		fi
 
-		software_id=8 # Java
+		software_id=196 # Java JRE
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
@@ -3157,7 +3164,37 @@ unix_socket_directories = '/run/postgresql'" > "$i/00dietpi.conf"
 			fi
 
 			# Allow two attempts as workaround for ARM install issue: https://github.com/MichaIng/DietPi/issues/2524
-			G_EXEC_RETRIES=1 G_AGI ca-certificates-java openjdk-$version-jre-headless openjdk-$version-jdk-headless
+			# Additionally, on ARMv6 postinst failure, remove postinst script to avoid failing certs update: https://github.com/MichaIng/DietPi/issues/4509
+			if (( $G_HW_ARCH == 1 ))
+			then
+				echo 'cacerts_updates=no' > /etc/default/cacerts
+				G_EXEC_POST_FUNC(){ [[ $exit_code == 1 && $(<$fp_log) == *'Server VM is only supported on ARMv7+ VFP'* ]] && rm -v /var/lib/dpkg/info/ca-certificates-java.postinst; }
+			fi
+			G_EXEC_RETRIES=1 G_AGI ca-certificates-java openjdk-$version-jre-headless
+
+		fi
+
+		software_id=8 # Java JDK
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing
+
+			# Stretch
+			if (( $G_DISTRO < 5 ))
+			then
+				local version=8
+
+			# Buster
+			elif (( $G_DISTRO == 5 ))
+			then
+				local version=11
+
+			# Bullseye
+			else
+				local version=17
+			fi
+
+			G_AGI openjdk-$version-jdk-headless
 
 		fi
 
@@ -16224,12 +16261,21 @@ _EOF_
 
 		fi
 
-		software_id=8 # Java
+		software_id=8 # Java JDK
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
 			# shellcheck disable=SC2046
-			apt-mark auto $(dpkg --get-selections 'default-jre*' 'default-jdk*' 'openjdk-*' ca-certificates-java 2> /dev/null | mawk '{print $1}') 2> /dev/null
+			apt-mark auto $(dpkg --get-selections 'default-jdk*' 'openjdk-*-jdk*' 'openjdk-*-doc' 'openjdk-*-source' 2> /dev/null | mawk '{print $1}') 2> /dev/null
+
+		fi
+
+		software_id=196 # Java JRE
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
+
+			Banner_Uninstalling
+			# shellcheck disable=SC2046
+			apt-mark auto $(dpkg --get-selections 'default-jre*' 'openjdk-*-jre*' 'openjdk-*-dbg' 'openjdk-*-demo' ca-certificates-java 2> /dev/null | mawk '{print $1}') 2> /dev/null
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3170,7 +3170,7 @@ unix_socket_directories = '/run/postgresql'" > "$i/00dietpi.conf"
 			if (( $G_HW_ARCH == 1 ))
 			then
 				echo 'cacerts_updates=no' > /etc/default/cacerts
-				G_EXEC_POST_FUNC(){ [[ $exit_code == 1 && $(<$fp_log) == *'Server VM is only supported on ARMv7+ VFP'* ]] && rm -v /var/lib/dpkg/info/ca-certificates-java.postinst; }
+				G_EXEC_POST_FUNC(){ [[ $exit_code == 100 && $(<$fp_log) == *'Server VM is only supported on ARMv7+ VFP'* ]] && rm -v /var/lib/dpkg/info/ca-certificates-java.postinst; }
 			fi
 			G_EXEC_RETRIES=1 G_AGI ca-certificates-java openjdk-$version-jre-headless
 


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Software | Java: Split Java Runtime Environment and Java Development Kit: All our software options require the runtime only, so ~200 MiB disk space can be saved.
+ DietPi-Software | Java JRE: Extend ca-certificates-java install workaround to include failing keytool (certs update) call on ARMv6, where it is simply not supported.
+ DietPi-Patches | Mark JRE as installed when JDK is installed