### PR TITLE
DietPi-Login/Autostart | Add autostart option for a custom script to be ran after automatic login.

### DIFF
--- a/dietpi/dietpi-autostart
+++ b/dietpi/dietpi-autostart
@@ -63,12 +63,12 @@
 
 		#----------------------------------------------------------------------
 		# Enable selected autostart option
-		# - Custom script, service without auto login: https://github.com/MichaIng/DietPi/issues/1024
+		# - Custom script service without autologin: https://github.com/MichaIng/DietPi/issues/1024
 		if (( $ID_AUTOSTART == 14 ))
 		then
 			cat << '_EOF_' > /etc/systemd/system/dietpi-autostart_custom.service
 [Unit]
-Description=DietPi-Autostart (Custom /var/lib/dietpi/dietpi-autostart/custom.sh)
+Description=DietPi-Autostart custom script
 Requisite=dietpi-boot.service
 After=dietpi-boot.service dietpi-postboot.service rc-local.service
 ConditionPathExists=/var/lib/dietpi/dietpi-autostart/custom.sh
@@ -76,9 +76,7 @@ ConditionPathExists=/var/lib/dietpi/dietpi-autostart/custom.sh
 [Service]
 Type=idle
 RemainAfterExit=yes
-StandardOutput=journal
 ExecStartPre=/bin/chmod +x /var/lib/dietpi/dietpi-autostart/custom.sh
-ExecStartPre=/bin/echo 'Starting DietPi-Autostart (Custom) script...'
 ExecStart=/var/lib/dietpi/dietpi-autostart/custom.sh
 
 [Install]
@@ -218,8 +216,8 @@ _EOF_
 			'9' ': DXX-Rebirth - Descent 1/2'
 			'4' ': OpenTyrian'
 			'' '●─ Other '
-			'14' ': Custom (Background) - /var/lib/dietpi/dietpi-autostart/custom.sh'
-			'17' ': Custom (Foreground) - /var/lib/dietpi/dietpi-autostart/custom.sh'
+			'14' ': Custom script (background, no autologin)'
+			'17' ': Custom script (foreground, with autologin)'
 			'5' ': DietPi-Cloudshell'
 
 		)
@@ -244,32 +242,29 @@ This mode allows for a < 2.5 second boot on an RPi3, into Amiberry.\n\nIf you ex
  - E.g.: https://dietpi.com' && G_CONFIG_INJECT 'SOFTWARE_CHROMIUM_AUTOSTART_URL=' "SOFTWARE_CHROMIUM_AUTOSTART_URL=$G_WHIP_RETURNED_VALUE" /boot/dietpi.txt
 
 			# Custom: Create template and info
-			elif [[ ( $ID_AUTOSTART == 14 || $ID_AUTOSTART == 17 ) && ! -f '/var/lib/dietpi/dietpi-autostart/custom.sh' ]]
+			elif [[ $ID_AUTOSTART == 1[47] ]]
 			then
-				G_EXEC mkdir -p /var/lib/dietpi/dietpi-autostart
-				cat << '_EOF_' > /var/lib/dietpi/dietpi-autostart/custom.sh
+				if [[ ! -f '/var/lib/dietpi/dietpi-autostart/custom.sh' ]]
+				then
+					G_EXEC mkdir -p /var/lib/dietpi/dietpi-autostart
+					cat << '_EOF_' > /var/lib/dietpi/dietpi-autostart/custom.sh
 #!/bin/bash
-#---Examples---
+# DietPi-Autostart custom script
+# Location: /var/lib/dietpi/dietpi-autostart/custom.sh
 
-# Chromium
-#xinit chromium
-
-# Desktop
-#startx
-
-# Print Hello
-#echo 'Hello'
-
-#---Put your code below this line---
+exit 0
 _EOF_
-				case "$ID_AUTOSTART" in
- 					14) CUSTOM_SCRIPT_HOOK="in the background on startup.\n\n
-You can run \"journalctl -u dietpi-autostart_custom\" at any time to see the script output" ;;
-					17) CUSTOM_SCRIPT_HOOK="in the foreground of your main console on startup" ;;
-				esac
+					case "$ID_AUTOSTART" in
+ 						14) local custom_mode_desc='background at the end of the boot sequence.
+\nYou can run \"journalctl -u dietpi-autostart_custom\" at any time to see the script output';;
+						17) local custom_mode_desc='foreground of your main screen after being automatically logged in with the chosen user';;
+					esac
 
-				G_WHIP_MSG "A template script has been created:\n - /var/lib/dietpi/dietpi-autostart/custom.sh\n
-Please edit this file and enter the required commands you wish to launch. DietPi will then execute this script $CUSTOM_SCRIPT_HOOK."
+					G_WHIP_MSG "A template script has been created:\n - /var/lib/dietpi/dietpi-autostart/custom.sh
+\nPlease edit this file and enter the required commands you wish to launch. DietPi will then execute it in the $custom_mode_desc.
+\nThe \"nano\" command line editor opens now, which allows you to exit the script. Press CTRL+O to save and CTRL+X to exit nano."
+				fi
+				nano /var/lib/dietpi/dietpi-autostart/custom.sh
 			fi
 
 			# Apply selected boot option

--- a/dietpi/dietpi-autostart
+++ b/dietpi/dietpi-autostart
@@ -76,7 +76,7 @@ ConditionPathExists=/var/lib/dietpi/dietpi-autostart/custom.sh
 [Service]
 Type=idle
 RemainAfterExit=yes
-StandardOutput=tty
+StandardOutput=journal
 ExecStartPre=/bin/chmod +x /var/lib/dietpi/dietpi-autostart/custom.sh
 ExecStartPre=/bin/echo 'Starting DietPi-Autostart (Custom) script...'
 ExecStart=/var/lib/dietpi/dietpi-autostart/custom.sh
@@ -218,8 +218,8 @@ _EOF_
 			'9' ': DXX-Rebirth - Descent 1/2'
 			'4' ': OpenTyrian'
 			'' '●─ Other '
-			'14' ': Custom - /var/lib/dietpi/dietpi-autostart/custom.sh'
-			'17' ': Custom (After Automatic Login) - /var/lib/dietpi/dietpi-autostart/custom.sh'
+			'14' ': Custom (Background) - /var/lib/dietpi/dietpi-autostart/custom.sh'
+			'17' ': Custom (Foreground) - /var/lib/dietpi/dietpi-autostart/custom.sh'
 			'5' ': DietPi-Cloudshell'
 
 		)
@@ -263,8 +263,9 @@ This mode allows for a < 2.5 second boot on an RPi3, into Amiberry.\n\nIf you ex
 #---Put your code below this line---
 _EOF_
 				case "$ID_AUTOSTART" in
- 					14) CUSTOM_SCRIPT_HOOK="during boot" ;;
-					17) CUSTOM_SCRIPT_HOOK="after automatic login on boot" ;;
+ 					14) CUSTOM_SCRIPT_HOOK="in the background on startup.\n\n
+You can run \"journalctl -u dietpi-autostart_custom\" at any time to see the script output" ;;
+					17) CUSTOM_SCRIPT_HOOK="in the foreground of your main console on startup" ;;
 				esac
 
 				G_WHIP_MSG "A template script has been created:\n - /var/lib/dietpi/dietpi-autostart/custom.sh\n

--- a/dietpi/dietpi-autostart
+++ b/dietpi/dietpi-autostart
@@ -219,6 +219,7 @@ _EOF_
 			'4' ': OpenTyrian'
 			'' '●─ Other '
 			'14' ': Custom - /var/lib/dietpi/dietpi-autostart/custom.sh'
+			'17' ': Custom (After Automatic Login) - /var/lib/dietpi/dietpi-autostart/custom.sh'
 			'5' ': DietPi-Cloudshell'
 
 		)
@@ -243,7 +244,7 @@ This mode allows for a < 2.5 second boot on an RPi3, into Amiberry.\n\nIf you ex
  - E.g.: https://dietpi.com' && G_CONFIG_INJECT 'SOFTWARE_CHROMIUM_AUTOSTART_URL=' "SOFTWARE_CHROMIUM_AUTOSTART_URL=$G_WHIP_RETURNED_VALUE" /boot/dietpi.txt
 
 			# Custom: Create template and info
-			elif [[ $ID_AUTOSTART == 14 && ! -f '/var/lib/dietpi/dietpi-autostart/custom.sh' ]]
+			elif [[ ( $ID_AUTOSTART == 14 || $ID_AUTOSTART == 17 ) && ! -f '/var/lib/dietpi/dietpi-autostart/custom.sh' ]]
 			then
 				G_EXEC mkdir -p /var/lib/dietpi/dietpi-autostart
 				cat << '_EOF_' > /var/lib/dietpi/dietpi-autostart/custom.sh
@@ -261,8 +262,13 @@ This mode allows for a < 2.5 second boot on an RPi3, into Amiberry.\n\nIf you ex
 
 #---Put your code below this line---
 _EOF_
-				G_WHIP_MSG 'A template script has been created:\n - /var/lib/dietpi/dietpi-autostart/custom.sh\n
-Please edit this file and enter the required commands you wish to launch. DietPi will then execute this script during boot.'
+				case "$ID_AUTOSTART" in
+ 					14) CUSTOM_SCRIPT_HOOK="during boot" ;;
+					17) CUSTOM_SCRIPT_HOOK="after automatic login on boot" ;;
+				esac
+
+				G_WHIP_MSG "A template script has been created:\n - /var/lib/dietpi/dietpi-autostart/custom.sh\n
+Please edit this file and enter the required commands you wish to launch. DietPi will then execute this script $CUSTOM_SCRIPT_HOOK."
 			fi
 
 			# Apply selected boot option

--- a/dietpi/dietpi-login
+++ b/dietpi/dietpi-login
@@ -88,9 +88,13 @@
 		elif (( $auto_start_index == 11 )); then
 
 			exec /var/lib/dietpi/dietpi-software/installed/chromium-autostart.sh
-
+        
+        # Custom (After Automatic Login)
 		elif (( $auto_start_index == 17 )); then
 		
+		    # Return if there is no custom script
+		    [[ -f '/var/lib/dietpi/dietpi-autostart/custom.sh' ]] || return
+
 			chmod +x /var/lib/dietpi/dietpi-autostart/custom.sh
 			echo 'Starting DietPi-Autostart (Custom) script...'
 			/var/lib/dietpi/dietpi-autostart/custom.sh

--- a/dietpi/dietpi-login
+++ b/dietpi/dietpi-login
@@ -89,6 +89,12 @@
 
 			exec /var/lib/dietpi/dietpi-software/installed/chromium-autostart.sh
 
+		elif (( $auto_start_index == 17 )); then
+		
+			chmod +x /var/lib/dietpi/dietpi-autostart/custom.sh
+			echo 'Starting DietPi-Autostart (Custom) script...'
+			/var/lib/dietpi/dietpi-autostart/custom.sh
+		
 		fi
 
 	}

--- a/dietpi/dietpi-login
+++ b/dietpi/dietpi-login
@@ -58,7 +58,7 @@
 		# Amiberry standard boot
 		elif (( $auto_start_index == 8 )); then
 
-			systemctl start amiberry
+			exec systemctl start amiberry
 
 		# DXX-Rebirth
 		elif (( $auto_start_index == 9 )); then
@@ -94,7 +94,7 @@
 
 			chmod +x /var/lib/dietpi/dietpi-autostart/custom.sh
 			G_DIETPI-NOTIFY 2 'Starting DietPi-Autostart custom script...'
-			/var/lib/dietpi/dietpi-autostart/custom.sh
+			exec /var/lib/dietpi/dietpi-autostart/custom.sh
 
 		fi
 

--- a/dietpi/dietpi-login
+++ b/dietpi/dietpi-login
@@ -89,16 +89,13 @@
 
 			exec /var/lib/dietpi/dietpi-software/installed/chromium-autostart.sh
 		
-		# Custom (After Automatic Login)
-		elif (( $auto_start_index == 17 )); then
-		
-			# Return if there is no custom script
-			[[ -f '/var/lib/dietpi/dietpi-autostart/custom.sh' ]] || return
+		# Custom script after autologin
+		elif [[ $auto_start_index == 17 && -f '/var/lib/dietpi/dietpi-autostart/custom.sh' ]]; then
 
 			chmod +x /var/lib/dietpi/dietpi-autostart/custom.sh
-			echo 'Starting DietPi-Autostart (Custom) script...'
+			G_DIETPI-NOTIFY 2 'Starting DietPi-Autostart custom script...'
 			/var/lib/dietpi/dietpi-autostart/custom.sh
-		
+
 		fi
 
 	}

--- a/dietpi/dietpi-login
+++ b/dietpi/dietpi-login
@@ -88,12 +88,12 @@
 		elif (( $auto_start_index == 11 )); then
 
 			exec /var/lib/dietpi/dietpi-software/installed/chromium-autostart.sh
-        
-        # Custom (After Automatic Login)
+		
+		# Custom (After Automatic Login)
 		elif (( $auto_start_index == 17 )); then
 		
-		    # Return if there is no custom script
-		    [[ -f '/var/lib/dietpi/dietpi-autostart/custom.sh' ]] || return
+			# Return if there is no custom script
+			[[ -f '/var/lib/dietpi/dietpi-autostart/custom.sh' ]] || return
 
 			chmod +x /var/lib/dietpi/dietpi-autostart/custom.sh
 			echo 'Starting DietPi-Autostart (Custom) script...'


### PR DESCRIPTION
**Status**: Ready

**Reference**: https://github.com/MichaIng/DietPi/issues/4633

**Commit list/description**:
DietPi-Login/Autostart | Add autostart option for a custom script to be ran after automatic login.