### PR TITLE
DietPi-Software | LXDE: Fix install on RPi Bullseye

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@ Fixes:
 - DietPi-Software | VSCodium: Added the missing dependency on ALSA for cases where no desktop is installed and VSCodium is started as standalone X server session. Many thanks to @Gill-Bates for reporting this issue: https://github.com/MichaIng/DietPi/issues/4610
 - DietPi-Software | Bazarr: Resolved an issue where the install failed, as assets have been moved into an own repository, bundled with now release downloads. Many thanks to @psi5asp for reporting this issue: https://github.com/MichaIng/DietPi/issues/4615
 - DietPi-Software | phpSysInfo: Resolved an issue where the install failed because of a changed download URL. Many thanks to @robex for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=9278
+- DietPi-Software | LXDE: Resolved an issue on Raspberry Pi Bullseye systems, where the install failed. Many thanks to @ravenclaw900 for reporting this issue: https://github.com/MichaIng/DietPi/issues/4555#issuecomment-898780672
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3328,7 +3328,7 @@ _EOF_
 
 			# RPi: Block packages from RPi desktop which conflict with a native LXDE desktop: https://github.com/MichaIng/DietPi/issues/1558#issuecomment-691206284
 			(( $G_HW_MODEL > 9 )) || cat << '_EOF_' > /etc/apt/preferences.d/dietpi-lxde
-Package: pcmanfm libfm4 libfm-gtk4 lxpanel lxpanel-data
+Package: pcmanfm libfm4 libfm-gtk4 lxpanel lxpanel-data libfm-modules
 Pin: origin archive.raspberrypi.org
 Pin-Priority: -1
 _EOF_


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Software | LXDE: On RPi, prevent libfm-modules being pulled from the RPi repository, as it depends in the libfm-gtk4 from the RPi repository as well, which we blacklist already to not break the Debian LXDE desktop.