### PR TITLE
DietPi-Live_patches | Fix LXDE install on RPi Bullseye

### DIFF
--- a/.update/version
+++ b/.update/version
@@ -15,12 +15,15 @@ G_OLD_DEBIAN_BRANCH='jessie-support'
 G_LIVE_PATCH_DESC=(
 	[0]='This patch fixes the Blynk server install option. You may ignore it if you do not plan to install the Blynk home server.\n\nMore info: https://github.com/MichaIng/DietPi/pull/4594'
 	[1]='This patch fixes the phpSysInfo install option. You may ignore it if you do not plan to install phpSysInfo.\n\nMore info: https://github.com/MichaIng/DietPi/pull/4619'
+	[2]='This patch fixes the LXDE install on Raspberry Pi Bullseye images. You may ignore it if you do not plan to install LXDE: https://github.com/MichaIng/DietPi/pull/4636'
 )
 G_LIVE_PATCH_COND=(
 	[0]="[[ -w '/boot/dietpi/dietpi-software' ]] && grep -q 'blynkkk' /boot/dietpi/dietpi-software"
 	[1]="[[ -w '/boot/dietpi/dietpi-software' ]] && grep -q 'phpsysinfo-master' /boot/dietpi/dietpi-software"
+	[2]="[[ $G_HW_MODEL -le 9 && $G_DISTRO -ge 5 && -w '/boot/dietpi/dietpi-software' ]] && grep -q 'lxpanel-data$' /boot/dietpi/dietpi-software"
 )
 G_LIVE_PATCH=(
 	[0]="sed -i 's/blynkkk/Peterkn2001/' /boot/dietpi/dietpi-software"
 	[1]="sed -Ei 's#phpsysinfo(-|/archive/)master#phpsysinfo\1main#' /boot/dietpi/dietpi-software"
+	[2]="sed -i 's/lxpanel-data$/lxpanel-data libfm-modules/' /boot/dietpi/dietpi-software"
 )


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Live_patches | Fix LXDE install on RPi Bullseye: https://github.com/MichaIng/DietPi/pull/4636