### PR TITLE
DietPi-Login/Firstrun - Adding a delay of 5 seconds between time sync and update

### DIFF
--- a/dietpi/dietpi-login
+++ b/dietpi/dietpi-login
@@ -194,6 +194,11 @@ Please login again as user "root" with password "dietpi", respectively the one y
 
 				# Network time sync
 				/boot/dietpi/func/run_ntpd
+				
+				# To prevent update failure on low power devices (Raspberry Pi Zero W)
+				G_DIETPI-NOTIFY 2 'Waiting 5 seconds'
+				sleep 5
+				G_DIETPI-NOTIFY 0 'Wait complete proceeding to Update'
 
 				# Start DietPi-Update
 				/boot/dietpi/dietpi-update 1 # Sets /boot/dietpi/.install_stage > G_DIETPI_INSTALL_STAGE=1


### PR DESCRIPTION
**Reference**: https://github.com/MichaIng/DietPi/issues/4651

**Commit list/description**:
Slower devices like Raspberry Pi Zero W keeps failing when ```AUTO_SETUP_AUTOMATED=1``` . 
Adding a delay of 5 seconds between time sync and update only for the first boot. 

Tests done. 
Without delay: 5 tried | 5 failed
With 30 seconds delay: 1 try | 0 failed
![IMG_52A9B8806B25-1](https://user-images.githubusercontent.com/5348524/130018744-5809a609-026d-47e2-a9d7-197dd7bf1e6a.jpeg)

With 5 seconds delay: 2 try | 0 failed
![IMG_1877](https://user-images.githubusercontent.com/5348524/130018780-0a140987-8116-4589-bd11-4aba1293d4b6.PNG)
