### PR TITLE
DietPi-Software | Cuberite: Remove obsolete ARMv6 workaround

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ v7.5
 Changes:
 - DietPi-Globals | A new global function G_GET_WAN_IP has been added to print the public IP and location info. This function is now used by DietPi-Banner and DietPi-VPN to show the public IP. It makes use of the public API at freegeoip.app, which may also be used by malware, like all public APIs, and may hence be present in public blocklists. The function checks, whether this is the case, via curl's exit code, and in case prints a meaningful error message. Many thanks to @cocoflan for reporting the a related case: https://github.com/MichaIng/DietPi/issues/4445
 - DietPi-Software | Java: This install option has now been split into the JRE (Java Runtime Environment) and the JDK (Java Development Kit). As our Java-written software options require the JRE only, this saves over 200 MiB of additional JDK-related disk space. For developers, however, the JDK stays with the same software ID.
+- DietPi-Software | Cuberite: Re-applied the official binary on ARMv6 systems (Raspberry Pi 1 and Zero). Since those did not support ARMv6 in the past, we installed an old self-hosted binary, but now the latest official one can be used. Many thanks to @tigerw for letting us know about the change: https://github.com/MichaIng/DietPi/issues/3664#issuecomment-901261614
 
 New Software:
 - Java JRE | The OpenJDK Java Runtime Environment has been made available as dedicated software option with ID 196 (see changes above).

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6280,7 +6280,7 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			# User
 			Create_User -d /mnt/dietpi_userdata/cuberite cuberite
 
-			# Service
+			# Service: Needs to be Type=forking, else it shuts down automatically after startup has finished :/ ...
 			cat << '_EOF_' > /etc/systemd/system/cuberite.service
 [Unit]
 Description=Cuberite Server (DietPi)
@@ -6289,7 +6289,7 @@ Description=Cuberite Server (DietPi)
 Type=forking
 User=cuberite
 WorkingDirectory=/mnt/dietpi_userdata/cuberite
-ExecStart=/mnt/dietpi_userdata/cuberite/Cuberite --service
+ExecStart=/mnt/dietpi_userdata/cuberite/Cuberite -d
 
 [Install]
 WantedBy=multi-user.target

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6277,8 +6277,36 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 
 			Download_Install "$INSTALL_URL_ADDRESS" /mnt/dietpi_userdata/cuberite
 
-			# ARMv6 workaround: https://github.com/MichaIng/DietPi/issues/3664
-			(( $G_HW_MODEL == 1 )) && Download_Install 'https://dietpi.com/downloads/binaries/buster/cuberite_armv6l.7z' /mnt/dietpi_userdata/cuberite
+			# User
+			Create_User -d /mnt/dietpi_userdata/cuberite cuberite
+
+			# Service
+			cat << '_EOF_' > /etc/systemd/system/cuberite.service
+[Unit]
+Description=Cuberite Server (DietPi)
+
+[Service]
+Type=forking
+User=cuberite
+WorkingDirectory=/mnt/dietpi_userdata/cuberite
+ExecStart=/mnt/dietpi_userdata/cuberite/Cuberite --service
+
+[Install]
+WantedBy=multi-user.target
+_EOF_
+			# Web UI settings: Do not overwrite existing!
+			[[ -f '/mnt/dietpi_userdata/cuberite/webadmin.ini' ]] || cat << _EOF_ > /mnt/dietpi_userdata/cuberite/webadmin.ini
+[User:admin]
+Password=$GLOBAL_PW
+
+[WebAdmin]
+Ports=1339
+Enabled=1
+_EOF_
+			# Permissions
+			G_EXEC chmod 0600 /mnt/dietpi_userdata/cuberite/webadmin.ini
+			G_EXEC chown -R cuberite:cuberite /mnt/dietpi_userdata/cuberite
+			G_EXEC chmod +x /mnt/dietpi_userdata/cuberite/Cuberite
 
 		fi
 
@@ -11219,44 +11247,6 @@ location = /.well-known/caldav  { return 301 /baikal/html/dav.php; }' > /etc/ngi
 
 		fi
 
-		software_id=52 # Cuberite
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Configuration
-
-			# User
-			Create_User -d /mnt/dietpi_userdata/cuberite cuberite
-
-			# Service
-			cat << '_EOF_' > /etc/systemd/system/cuberite.service
-[Unit]
-Description=Cuberite Server (DietPi)
-
-[Service]
-Type=forking
-User=cuberite
-WorkingDirectory=/mnt/dietpi_userdata/cuberite
-ExecStart=/mnt/dietpi_userdata/cuberite/Cuberite --service
-
-[Install]
-WantedBy=multi-user.target
-_EOF_
-			# Web UI settings: Do not overwrite existing!
-			[[ -f '/mnt/dietpi_userdata/cuberite/webadmin.ini' ]] || cat << _EOF_ > /mnt/dietpi_userdata/cuberite/webadmin.ini
-[User:admin]
-Password=$GLOBAL_PW
-
-[WebAdmin]
-Ports=1339
-Enabled=1
-_EOF_
-			# Permissions
-			G_EXEC chmod 0640 /mnt/dietpi_userdata/cuberite/webadmin.ini
-			G_EXEC chown -R cuberite:cuberite /mnt/dietpi_userdata/cuberite
-			G_EXEC chmod +x /mnt/dietpi_userdata/cuberite/Cuberite
-
-		fi
-
 		software_id=53 # MineOS
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 ))
 		then
@@ -15392,14 +15382,14 @@ _EOF_
 			Banner_Uninstalling
 			if [[ -f '/etc/systemd/system/cuberite.service' ]]; then
 
-				systemctl disable --now cuberite
-				rm -R /etc/systemd/system/cuberite.service*
+				G_EXEC systemctl disable --now cuberite
+				G_EXEC rm /etc/systemd/system/cuberite.service
 
 			fi
-			[[ -d '/etc/systemd/system/cuberite.service.d' ]] && rm -R /etc/systemd/system/cuberite.service.d
+			[[ -d '/etc/systemd/system/cuberite.service.d' ]] && G_EXEC rm -R /etc/systemd/system/cuberite.service.d
 			getent passwd cuberite > /dev/null && userdel cuberite
 			getent group cuberite > /dev/null && groupdel cuberite
-			[[ -d '/mnt/dietpi_userdata/cuberite' ]] && rm -R /mnt/dietpi_userdata/cuberite
+			[[ -d '/mnt/dietpi_userdata/cuberite' ]] && G_EXEC rm -R /mnt/dietpi_userdata/cuberite
 
 		fi
 


### PR DESCRIPTION
**Status**: Testing

**Commit list/description**:
+ DietPi-Software | Cuberite: Remove obsolete ARMv6 workaround
+ DietPi-Software | Cuberite: Merge install and config code blocks
+ DietPi-Software | Cuberite: Error-handle most uninstall steps