### PR TITLE
DietPi-Software | MotionEye: Enable Python 3 support

### DIFF
--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -321,7 +321,7 @@ shopt -s extglob
 		[133]='YaCy'
 		[134]='Tonido'
 		[135]='IceCast'
-		[136]='MotionEye'
+		[136]='motionEye'
 		[137]='CloudPrint'
 		[138]='VirtualHere'
 		[139]='SABnzbd'

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ New software:
 - PHP Composer | The PHP package manager has been made a dedicated install option.
 
 Changes:
+- DietPi-Software | motionEye: We worked together with other contributors to revive motionEye and port it over to Python 3, which also allowed us to re-enable it on Debian Bullseye systems. It requires further careful testing before a stable release can be done, but common functionality works. We enabled it with a "beta" mark in DietPi-Software. Visit the new home of motionEye, and if you want, contribute or help testing: https://github.com/motioneye-project/motioneye
 - DietPi-Software | Node-RED: The "nodered" service user is now added to the "spi" system group automatically, relevant on Raspberry Pi to grant it access to SPI-attached sensors and similar. Many thanks to @devifast for reporting a related issue: https://dietpi.com/phpbb/viewtopic.php?t=10134
 
 Fixes:

--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ Links to hardware and software manufacturers, sources and build instructions use
 - [MicroK8s](https://github.com/canonical/microk8s)
 - [Allo GUI](https://github.com/MichaIng/DietPi-AlloGUI)
 - [PHP Composer](https://github.com/composer/composer)
+- [motionEye](https://github.com/motioneye-project/motioneye)
 
 ---
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1011,10 +1011,7 @@ INDEX_BROWSER=$INDEX_BROWSER"
 		aSOFTWARE_DESC[$software_id]='Web interface & surveillance for your camera'
 		aSOFTWARE_CATX[$software_id]=7
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/camera/#motioneye'
- 		aSOFTWARE_DEPS[$software_id]='7'
-		# Python 2 only, hence not supported on Bullseye
-		aSOFTWARE_AVAIL_G_DISTRO[$software_id,6]=0
-		aSOFTWARE_AVAIL_G_DISTRO[$software_id,7]=0
+ 		aSOFTWARE_DEPS[$software_id]='7 130'
 		#------------------
 		software_id=137
 		aSOFTWARE_NAME[$software_id]='mjpg-streamer'
@@ -9476,11 +9473,10 @@ _EOF_
 			Banner_Installing
 
 			# Motion + dependencies
-			G_AGI motion v4l-utils curl python-pip python-dev gcc libssl-dev libcurl4-openssl-dev libjpeg-dev zlib1g-dev
+			G_AGI motion v4l-utils curl libssl-dev libcurl4-openssl-dev libjpeg-dev zlib1g-dev
 
 			# MotionEye
-			G_EXEC_OUTPUT=1 G_EXEC pip2 install --no-cache-dir -U pip setuptools wheel
-			G_EXEC_OUTPUT=1 G_EXEC pip2 install --no-cache-dir -U motioneye
+			G_EXEC_OUTPUT=1 G_EXEC pip3 install -U 'git+https://github.com/ccrisan/motioneye@python3#egg=motioneye'
 
 			# RPi: Enable camera module
 			(( $G_HW_MODEL > 9 )) || /boot/dietpi/func/dietpi-set_hardware rpi-camera enable
@@ -13174,7 +13170,7 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 				G_EXEC rm /etc/systemd/system/motioneye.service
 			fi
 			[[ -d '/etc/systemd/system/motioneye.service.d' ]] && G_EXEC rm -R /etc/systemd/system/motioneye.service.d
-			command -v pip2 > /dev/null && G_EXEC_OUTPUT=1 G_EXEC pip2 uninstall -y motioneye
+			command -v pip3 > /dev/null && G_EXEC_NOEXIT=1 G_EXEC pip3 uninstall -y motioneye
 			G_AGP motion
 			[[ -d '/etc/motioneye' ]] && G_EXEC rm -R /etc/motioneye
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1007,7 +1007,7 @@ INDEX_BROWSER=$INDEX_BROWSER"
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,3]=0
 		#------------------
 		software_id=136
-		aSOFTWARE_NAME[$software_id]='MotionEye'
+		aSOFTWARE_NAME[$software_id]='motionEye (beta)'
 		aSOFTWARE_DESC[$software_id]='Web interface & surveillance for your camera'
 		aSOFTWARE_CATX[$software_id]=7
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/camera/#motioneye'
@@ -9467,33 +9467,27 @@ _EOF_
 
 		fi
 
-		software_id=136 # MotionEye
+		software_id=136 # motionEye
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
 
-			# Motion + dependencies
-			G_AGI motion v4l-utils curl libssl-dev libcurl4-openssl-dev libjpeg-dev zlib1g-dev
-
-			# MotionEye
-			G_EXEC_OUTPUT=1 G_EXEC pip3 install -U 'git+https://github.com/ccrisan/motioneye@python3#egg=motioneye'
+			# x86_64/ARMv8 dependencies: libcurl4-openssl-dev gcc libssl-dev for pycurl build
+			[[ $G_HW_MODEL == [12] ]] || G_AGI libcurl4-openssl-dev gcc libssl-dev
 
 			# RPi: Enable camera module
 			(( $G_HW_MODEL > 9 )) || /boot/dietpi/func/dietpi-set_hardware rpi-camera enable
 
-			# Config
-			if [[ ! -f '/etc/motioneye/motioneye.conf' ]]
-			then
-				[[ -d '/etc/motioneye' ]] || G_EXEC mkdir /etc/motioneye
-				G_EXEC cp /usr/local/share/motioneye/extra/motioneye.conf.sample /etc/motioneye/motioneye.conf
+			# motionEye
+			G_EXEC_OUTPUT=1 G_EXEC pip3 install --no-cache-dir -U 'https://github.com/motioneye-project/motioneye/archive/dev.tar.gz'
+			G_EXEC_OUTPUT=1 G_EXEC motioneye_init --skip-apt-update
+			G_EXEC systemctl disable --now motioneye
+			G_EXEC systemctl disable --now motion # motionEye starts motion directly.
 
-				# Data
-				[[ -d '/mnt/dietpi_userdata/motioneye' ]] || G_EXEC mkdir /mnt/dietpi_userdata/motioneye
-				G_EXEC sed -i '/^media_path/c\media_path /mnt/dietpi_userdata/motioneye' /etc/motioneye/motioneye.conf
-			fi
-
-			# Service
-			G_EXEC cp /usr/local/share/motioneye/extra/motioneye.systemd-unit-local /etc/systemd/system/motioneye.service
+			# Data directory
+			[[ -d '/mnt/dietpi_userdata/motioneye' ]] || G_EXEC mkdir /mnt/dietpi_userdata/motioneye
+			G_CONFIG_INJECT 'media_path' 'media_path /mnt/dietpi_userdata/motioneye' /etc/motioneye/motioneye.conf
+			G_EXEC chown -R motion /mnt/dietpi_userdata/motioneye
 
 		fi
 
@@ -13160,7 +13154,7 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 
 		fi
 
-		software_id=136 # MotionEye
+		software_id=136 # motionEye
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
@@ -13170,9 +13164,12 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 				G_EXEC rm /etc/systemd/system/motioneye.service
 			fi
 			[[ -d '/etc/systemd/system/motioneye.service.d' ]] && G_EXEC rm -R /etc/systemd/system/motioneye.service.d
-			command -v pip3 > /dev/null && G_EXEC_NOEXIT=1 G_EXEC pip3 uninstall -y motioneye
+			command -v pip3 > /dev/null && G_EXEC_OUTPUT=1 G_EXEC pip3 uninstall -y motioneye
 			G_AGP motion
 			[[ -d '/etc/motioneye' ]] && G_EXEC rm -R /etc/motioneye
+			[[ -d '/var/log/motioneye' ]] && G_EXEC rm -R /var/log/motioneye
+			[[ -d '/var/lib/motioneye' ]] && G_EXEC rm -R /var/lib/motioneye
+			[[ -d '/mnt/dietpi_userdata/motioneye' ]] && G_DIETPI-NOTIFY 2 'The motionEye media directory is left in place. You can manually remove it via:\n         rm -R /mnt/dietpi_userdata/motioneye'
 
 		fi
 


### PR DESCRIPTION
**Status**: Testing

**Reference**: https://dietpi.com/phpbb/viewtopic.php?t=9308

**Commit list/description**:
+ DietPi-Software | MotionEye: Enable Python 3 support via experimental python3 branch