### PR TITLE
DietPi-Software | VNC server enhancements

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,8 +2,12 @@ v7.6
 (2021-09-18)
 
 Changes:
+- DietPi-Software | TigerVNC: Instead of x11vnc, TigerVNC's own scraping server is now used for shared desktop mode, which is a bit lighter and shares a lot of libraries with the TigerVNC standaline server package.
+- DietPi-Software | RealVNC: Having desktop autologin enabled does not force the shared desktop VNC mode anymore. Furthermore our "vncserver.service" does not call RealVNC's "vncserver-x11-serviced.service" for the shared desktop mode, but instead the actual vncserver-x11 executable is called directly. This has some benefits, e.g. it allows to use our service for a virtual desktop while using RealVNC's service to allow connections to the shared local desktop independently. Many thanks to @K92Pi for bringing this idea to us: https://github.com/MichaIng/DietPi/issues/4672
+- DietPi-Software | RealVNC: The VNC server is now started with "VncAuth" authentication by default, which allows any VNC viewer to connect, not just RealVNC's ones. Use "vncpasswd" to change the password, which is now independent of the UNIX user passwords. It defaults to the global software password on a fresh install.
 
 Fixes:
+- DietPi-Software | TigerVNC: Resolved an issue where remote connections didn't work by default on Bullseye systems, as a different configuration file is used.
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10326,7 +10326,6 @@ case "$1" in
 			killall -qw Xtigervnc tigervncserver /usr/bin/vncserver-virtual vncserver-virtual Xvnc-core
 
 		fi
-		
 	;;
 
 esac

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2407,7 +2407,7 @@ _EOF_
 
 	Create_UserContent_Folders(){
 
-		G_EXEC mkdir -p /mnt/dietpi_userdata/{Music,Pictures,Video,downloads} /var/www /opt
+		G_EXEC mkdir -p /mnt/dietpi_userdata/{Music,Pictures,Video,downloads} /var/www /opt /usr/local/bin
 		G_EXEC chown dietpi:dietpi /mnt/dietpi_userdata/{Music,Pictures,Video,downloads}
 		G_EXEC chmod 0775 /mnt/dietpi_userdata/{Music,Pictures,Video,downloads}
 
@@ -3284,7 +3284,7 @@ unix_socket_directories = '/run/postgresql'" > "$i/00dietpi.conf"
 			# Reinstall: Remove previous instance
 			[[ -d '/usr/local/go' ]] && G_EXEC_NOEXIT=1 G_EXEC rm -R /usr/local/go
 
-			Download_Install "https://golang.org/dl/$file" /usr/local/
+			Download_Install "https://golang.org/dl/$file" /usr/local
 
 			# Export Go path variables
 			G_EXEC mkdir -p /mnt/dietpi_userdata/go/{bin,pkg,src}
@@ -3964,9 +3964,6 @@ _EOF_
 			[[ -d '/mnt/dietpi_userdata/go/src/github.com' ]] && G_EXEC_NOEXIT=1 G_EXEC rmdir --ignore-fail-on-non-empty /mnt/dietpi_userdata/go/src/github.com
 			[[ -d '/etc/openbazaar-server' ]] && G_EXEC_NOEXIT=1 G_EXEC rm -R /etc/openbazaar-server # Pre-v6.15
 
-			# Failsafe: Local bin dir
-			[[ -d '/usr/local/bin' ]] || G_EXEC mkdir -p /usr/local/bin
-
 			# x86_64: Download pre-compiled binary
 			if (( $G_HW_ARCH == 10 ))
 			then
@@ -4604,7 +4601,6 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 			# Setup Raspimjpeg binary
 			# - Use Stretch binary on Stretch
 			(( $G_DISTRO < 5 )) && G_EXEC mv bin/raspimjpeg{-stretch,}
-			[[ -d '/usr/local/bin' ]] || G_EXEC mkdir -p /usr/local/bin
 			G_EXEC cp {,/usr/local/}bin/raspimjpeg
 			G_EXEC chmod +x /usr/local/bin/raspimjpeg
 
@@ -4650,7 +4646,6 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 
 			# youtube-dl supports Python 2 and Python 3, but its shebang calls Python 2, else fails: https://github.com/ytdl-org/youtube-dl/issues/27649
 			# We hence install the binary with Python 2 suffix and create a shell wrapper to call it with Python 3.
-			G_EXEC mkdir -p /usr/local/bin
 			Download_Install 'https://yt-dl.org/downloads/latest/youtube-dl' /usr/local/bin/youtube-dl-py2
 			echo -e '#!/bin/dash\nexec python3 /usr/local/bin/youtube-dl-py2 "$@"' > /usr/local/bin/youtube-dl
 			G_EXEC chmod +x /usr/local/bin/youtube-dl{,-py2}
@@ -5125,7 +5120,6 @@ _EOF_
 				G_EXEC mv {w,W}iringPi-master
 			fi
 
-			[[ -d '/usr/local/bin' ]] || G_EXEC mkdir -p /usr/local/bin # Failsafe, not pre-created currently: https://github.com/WiringPi/WiringPi/blob/master/gpio/Makefile
 			G_EXEC cd WiringPi-master
 			G_EXEC_OUTPUT=1 G_EXEC ./build
 			G_EXEC strip --remove-section=.comment --remove-section=.note /usr/local/bin/gpio
@@ -5268,7 +5262,7 @@ _EOF_
 			done
 			local mode=$G_WHIP_RETURNED_VALUE
 
-			G_EXEC mkdir -p /etc/frp /usr/local/bin
+			G_EXEC mkdir -p /etc/frp
 			Create_User frp -d /etc/frp
 
 			local token=
@@ -6775,9 +6769,6 @@ _EOF_
 				G_EXEC cp '/boot/dietpi-k3s.yaml' '/etc/rancher/k3s/config.yaml'
 			fi
 
-			# Pre-create binary directory, as it might not always exist
-			G_EXEC mkdir -p /usr/local/bin
-
 			# Install
 			G_EXEC curl -sSfL 'https://get.k3s.io/' -o install.sh
 			G_EXEC chmod +x install.sh
@@ -6839,7 +6830,6 @@ _EOF_
 			G_EXEC mv koel /mnt/dietpi_userdata/koel
 
 			# Download and install composer
-			G_EXEC mkdir -p /usr/local/bin
 			G_EXEC curl -sSfL https://getcomposer.org/composer-stable.phar -o /usr/local/bin/composer
 			G_EXEC chmod +x /usr/local/bin/composer
 
@@ -7341,8 +7331,6 @@ If you want to update ${aSOFTWARE_NAME[$software_id]}, please use its internal u
 				INSTALL_URL_ADDRESS='https://dl.minio.io/server/minio/release/linux-amd64/minio'
 
 			fi
-			G_CHECK_URL "$INSTALL_URL_ADDRESS"
-			[[ -d '/usr/local/bin' ]] || G_EXEC mkdir -p /usr/local/bin
 			G_EXEC curl -sSfLo /usr/local/bin/minio "$INSTALL_URL_ADDRESS"
 			G_EXEC chmod +x /usr/local/bin/minio
 
@@ -7477,10 +7465,10 @@ If you want to update ${aSOFTWARE_NAME[$software_id]}, please use its internal u
 			DEPS_LIST+=' gstreamer1.0-alsa gstreamer1.0-libav gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly'
 
 			Download_Install "https://dietpi.com/downloads/binaries/$G_DISTRO_NAME/gmediarender_$G_HW_ARCH_NAME.7z" /usr/local/bin
-			chmod +x /usr/local/bin/gmediarender
+			G_EXEC chmod +x /usr/local/bin/gmediarender
 
 			# Create dummy icons for now. ToDo: Add real icons, GMediaRender or DietPi ones, or disable via build options?
-			mkdir -p /usr/local/share/gmediarender
+			G_EXEC mkdir -p /usr/local/share/gmediarender
 			> /usr/local/share/gmediarender/grender-64x64.png
 			> /usr/local/share/gmediarender/grender-128x128.png
 
@@ -7899,7 +7887,6 @@ _EOF_
 			# Minecraft rcon client for remote administration and server maintenance scripts
 			DEPS_LIST='gcc libc6-dev'
 			Download_Install 'https://github.com/Tiiffi/mcrcon/archive/master.tar.gz'
-			[[ -d '/usr/local/bin' ]] || G_EXEC mkdir -p /usr/local/bin
 			G_EXEC gcc -g0 -O3 mcrcon-master/mcrcon.c -o /usr/local/bin/mcrcon
 			G_EXEC rm -R mcrcon-master
 			G_EXEC strip --remove-section=.comment --remove-section=.note /usr/local/bin/mcrcon
@@ -12280,16 +12267,16 @@ _EOF_
 			(( $G_HW_MODEL < 10 )) && /boot/dietpi/func/dietpi-set_hardware rpi-camera enable
 
 			# Config
-			mkdir -p /etc/motioneye
+			G_EXEC mkdir -p /etc/motioneye
 			G_BACKUP_FP /etc/motioneye/motioneye.conf
-			cp /usr/local/share/motioneye/extra/motioneye.conf.sample /etc/motioneye/motioneye.conf
+			G_EXEC cp /usr/local/share/motioneye/extra/motioneye.conf.sample /etc/motioneye/motioneye.conf
 
 			# Data
-			mkdir -p /mnt/dietpi_userdata/motioneye
-			sed -i '/^media_path/c\media_path /mnt/dietpi_userdata/motioneye' /etc/motioneye/motioneye.conf
+			G_EXEC mkdir -p /mnt/dietpi_userdata/motioneye
+			G_EXEC sed -i '/^media_path/c\media_path /mnt/dietpi_userdata/motioneye' /etc/motioneye/motioneye.conf
 
 			# Service
-			cp /usr/local/share/motioneye/extra/motioneye.systemd-unit-local /etc/systemd/system/motioneye.service
+			G_EXEC cp /usr/local/share/motioneye/extra/motioneye.systemd-unit-local /etc/systemd/system/motioneye.service
 
 		fi
 
@@ -13231,7 +13218,7 @@ _EOF_
 			Banner_Configuration
 
 			# Conig file to autostart -- english default
-			G_EXEC curl -sSfL -o /usr/local/bin/nukkit/nukkit.yml https://github.com/Nukkit/Languages/raw/master/eng/nukkit.yml
+			G_EXEC curl -sSfLo /usr/local/bin/nukkit/nukkit.yml 'https://github.com/Nukkit/Languages/raw/master/eng/nukkit.yml'
 
 			# Service
 			cat << '_EOF_' > /etc/systemd/system/nukkit.service

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10270,6 +10270,9 @@ _EOF_
 			G_EXEC systemctl enable vncserver
 			aSTART_SERVICES+=('vncserver')
 
+			# RealVNC: Assure that its services are disabled when ours is enabled
+			(( ${aSOFTWARE_INSTALL_STATE[120]} == 1 )) && G_EXEC systemctl disable vncserver-virtuald vncserver-x11-serviced
+
 			cat << '_EOF_' > /usr/local/bin/vncserver
 #!/bin/dash
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10350,13 +10350,16 @@ esac
 _EOF_
 			G_EXEC chmod +x /usr/local/bin/vncserver
 
-			# Stretch + TigerVNC: Permit remote connections which implies TLSVnc authentications being enabled additionally
+			# TigerVNC: Permit remote connections which implies TLSVnc authentications being enabled additionally
 			# shellcheck disable=SC2016
-			[[ -f '/etc/vnc.conf' ]] && GCI_PRESERVE=1 G_CONFIG_INJECT '\$localhost[[:blank:]]*=' '$localhost = "no";' /etc/vnc.conf
+			[[ -f '/etc/vnc.conf' ]] && GCI_PRESERVE=1 G_CONFIG_INJECT '\$localhost[[:blank:]]*=' '$localhost = "no";' /etc/vnc.conf # Stretch/Buster
+			# shellcheck disable=SC2016
+			[[ -f '/etc/tigervnc/vncserver-config-defaults' ]] && GCI_PRESERVE=1 G_CONFIG_INJECT '\$localhost[[:blank:]]*=' '$localhost = "no";' /etc/tigervnc/vncserver-config-defaults # Bullseye
 
 			# TigerVNC: Set control + read-only passwords
 			if [[ ${aSOFTWARE_INSTALL_STATE[28]} == 1 && ! -f '/root/.vnc/passwd' ]]
 			then
+				[[ -d '/root/.vnc' ]] || G_EXEC mkdir /root/.vnc
 				tigervncpasswd -f <<< "$GLOBAL_PW
 $GLOBAL_PW" > /root/.vnc/passwd
 				G_EXEC chmod 600 /root/.vnc/passwd

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10250,7 +10250,7 @@ _EOF_
 			# Service
 			cat << '_EOF_' > /etc/systemd/system/vncserver.service
 [Unit]
-Description=Manage VNC Server (DietPi)
+Description=VNC Server (DietPi)
 Before=xrdp.service xrdp-sesman.service
 Wants=network-online.target
 After=network-online.target dietpi-boot.service
@@ -10276,11 +10276,13 @@ _EOF_
 # RealVNC or TigerVNC?
 if [ -f '/usr/bin/vncserver-virtual' ]; then
 
+	echo '[  OK  ] RealVNC detected'
 	FP_BINARY='/usr/bin/vncserver-virtual -Authentication VncAuth'
-	FP_SHARED='/usr/bin/vncserver-x11-serviced'
+	FP_SHARED='/usr/bin/vncserver-x11-serviced -fg'
 
 elif [ -f '/usr/bin/tigervncserver' ]; then
 
+	echo '[  OK  ] TigerVNC detected'
 	FP_BINARY='/usr/bin/tigervncserver -fg'
 	FP_SHARED='/usr/bin/x0tigervncserver :0'
 
@@ -10297,7 +10299,8 @@ case "$1" in
 		# Shared desktop mode
 		if grep -q '^[[:blank:]]*SOFTWARE_VNCSERVER_SHARE_DESKTOP=1' /boot/dietpi.txt; then
 
-			exec $FP_SHARED -fg || exit 1
+			echo '[ INFO ] Connecting to shared desktop'
+			exec $FP_SHARED || exit $?
 
 		# Virtual desktop mode
 		else
@@ -10306,7 +10309,8 @@ case "$1" in
 			WIDTH=$(sed -n '/^[[:blank:]]*SOFTWARE_VNCSERVER_WIDTH=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			HEIGHT=$(sed -n '/^[[:blank:]]*SOFTWARE_VNCSERVER_HEIGHT=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			DEPTH=$(sed -n '/^[[:blank:]]*SOFTWARE_VNCSERVER_DEPTH=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-			exec $FP_BINARY ":${DISPLAY:-1}" -geometry "${WIDTH:-1280}x${HEIGHT:-720}" -depth "${DEPTH:-16}" || exit 1
+			echo "[ INFO ] Starting virtual desktop at display :${DISPLAY:-1} in ${WIDTH:-1280}x${HEIGHT:-720}x${DEPTH:-16}"
+			exec $FP_BINARY ":${DISPLAY:-1}" -geometry "${WIDTH:-1280}x${HEIGHT:-720}" -depth "${DEPTH:-16}" || exit $?
 
 		fi
 	;;
@@ -10315,15 +10319,17 @@ case "$1" in
 		# Shared desktop mode
 		if grep -q '^[[:blank:]]*SOFTWARE_VNCSERVER_SHARE_DESKTOP=1' /boot/dietpi.txt; then
 
+			echo '[ INFO ] Disconnecting from shared desktop'
 			$FP_SHARED -kill ':0' 2> /dev/null
-			killall -qw X0tigervnc x0tigervncserver /usr/bin/vncserver-x11-serviced vncserver-x11-serviced Xvnc-core
+			killall -qw X0tigervnc x0tigervncserver vncserver-x11-serviced
 
 		# Virtual desktop mode
 		else
 
 			DISPLAY=$(sed -n '/^[[:blank:]]*SOFTWARE_VNCSERVER_DISPLAY_INDEX=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+			echo "[ INFO ] Stopping virtual desktop at display :${DISPLAY:-1}"
 			$FP_BINARY -kill ":${DISPLAY:-1}" 2> /dev/null
-			killall -qw Xtigervnc tigervncserver /usr/bin/vncserver-virtual vncserver-virtual Xvnc-core
+			killall -qw Xtigervnc tigervncserver vncserver-virtual
 
 		fi
 	;;

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10273,33 +10273,29 @@ _EOF_
 			cat << '_EOF_' > /usr/local/bin/vncserver
 #!/bin/dash
 
-# RealVNC or TigerVNC?
-if [ -f '/usr/bin/vncserver-virtual' ]; then
-
+if [ -f '/usr/bin/vncserver-virtual' ]
+then
 	echo '[  OK  ] RealVNC detected'
-	FP_BINARY='/usr/bin/vncserver-virtual -Authentication VncAuth,TLSVnc'
-	FP_SHARED='/usr/bin/vncserver-x11 -Authentication VncAuth,TLSVnc'
+	FP_BINARY='/usr/bin/vncserver-virtual -Authentication VncAuth'
+	FP_SHARED='/usr/bin/vncserver-x11 -service -Authentication VncAuth'
 
-elif [ -f '/usr/bin/tigervncserver' ]; then
-
+elif [ -f '/usr/bin/tigervncserver' ]
+then
 	echo '[  OK  ] TigerVNC detected'
 	FP_BINARY='/usr/bin/tigervncserver'
 	[ -f '/usr/bin/X0tigervnc' ] && FP_SHARED='/usr/bin/X0tigervnc' || FP_SHARED='/usr/bin/x0tigervncserver'
 	FP_SHARED="$FP_SHARED -display :0  -rfbauth $HOME/.vnc/passwd"
-
 else
-
 	echo '[FAILED] No supported VNC server installed'
 	exit 1
-
 fi
 
 case "$1" in
 
 	start)
 		# Shared desktop mode
-		if grep -q '^[[:blank:]]*SOFTWARE_VNCSERVER_SHARE_DESKTOP=1' /boot/dietpi.txt; then
-
+		if grep -q '^[[:blank:]]*SOFTWARE_VNCSERVER_SHARE_DESKTOP=1' /boot/dietpi.txt
+		then
 			echo '[ INFO ] Waiting for X server...'
 			while :
 			do
@@ -10313,40 +10309,39 @@ case "$1" in
 
 		# Virtual desktop mode
 		else
-
 			DISPLAY=$(sed -n '/^[[:blank:]]*SOFTWARE_VNCSERVER_DISPLAY_INDEX=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			WIDTH=$(sed -n '/^[[:blank:]]*SOFTWARE_VNCSERVER_WIDTH=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			HEIGHT=$(sed -n '/^[[:blank:]]*SOFTWARE_VNCSERVER_HEIGHT=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			DEPTH=$(sed -n '/^[[:blank:]]*SOFTWARE_VNCSERVER_DEPTH=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			echo "[ INFO ] Starting virtual desktop at display :${DISPLAY:-1} in ${WIDTH:-1280}x${HEIGHT:-720}x${DEPTH:-16}"
+			export SHELL='/bin/bash'
 			exec $FP_BINARY ":${DISPLAY:-1}" -geometry "${WIDTH:-1280}x${HEIGHT:-720}" -depth "${DEPTH:-16}"
-
 		fi
 	;;
 
 	stop)
 		# Shared desktop mode
-		if grep -q '^[[:blank:]]*SOFTWARE_VNCSERVER_SHARE_DESKTOP=1' /boot/dietpi.txt; then
-
+		if grep -q '^[[:blank:]]*SOFTWARE_VNCSERVER_SHARE_DESKTOP=1' /boot/dietpi.txt
+		then
 			echo '[ INFO ] Disconnecting from shared desktop'
-			killall -qw vncserver-x11 x0tigervncserver
+			killall -qw vncserver-x11-core x0tigervncserver X0tigervnc
 
 		# Virtual desktop mode
 		else
-
 			DISPLAY=$(sed -n '/^[[:blank:]]*SOFTWARE_VNCSERVER_DISPLAY_INDEX=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			echo "[ INFO ] Stopping virtual desktop at display :${DISPLAY:-1}"
 			$FP_BINARY -kill ":${DISPLAY:-1}"
-
 		fi
 	;;
-	
+
         *)
                 echo "[FAILED] Invalid command ($1), please use \"start\" or \"stop\""
                 exit 1
         ;;
 
 esac
+
+exit 0
 _EOF_
 			G_EXEC chmod +x /usr/local/bin/vncserver
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10257,8 +10257,8 @@ After=network-online.target dietpi-boot.service
 
 [Service]
 RemainAfterExit=yes
-User=root
 PAMName=login
+User=root
 Environment=HOME=/root
 ExecStart=/usr/local/bin/vncserver start
 ExecStop=/usr/local/bin/vncserver stop
@@ -10277,14 +10277,15 @@ _EOF_
 if [ -f '/usr/bin/vncserver-virtual' ]; then
 
 	echo '[  OK  ] RealVNC detected'
-	FP_BINARY='/usr/bin/vncserver-virtual -Authentication VncAuth'
-	FP_SHARED='/usr/bin/vncserver-x11-serviced -fg'
+	FP_BINARY='/usr/bin/vncserver-virtual -Authentication VncAuth,TLSVnc'
+	FP_SHARED='/usr/bin/vncserver-x11 -Authentication VncAuth,TLSVnc'
 
 elif [ -f '/usr/bin/tigervncserver' ]; then
 
 	echo '[  OK  ] TigerVNC detected'
-	FP_BINARY='/usr/bin/tigervncserver -fg'
-	FP_SHARED='/usr/bin/x0tigervncserver :0'
+	FP_BINARY='/usr/bin/tigervncserver'
+	[ -f '/usr/bin/X0tigervnc' ] && FP_SHARED='/usr/bin/X0tigervnc' || FP_SHARED='/usr/bin/x0tigervncserver'
+	FP_SHARED="$FP_SHARED -display :0  -rfbauth $HOME/.vnc/passwd"
 
 else
 
@@ -10299,8 +10300,16 @@ case "$1" in
 		# Shared desktop mode
 		if grep -q '^[[:blank:]]*SOFTWARE_VNCSERVER_SHARE_DESKTOP=1' /boot/dietpi.txt; then
 
-			echo '[ INFO ] Connecting to shared desktop'
-			exec $FP_SHARED || exit $?
+			echo '[ INFO ] Waiting for X server...'
+			while :
+			do
+				until pgrep Xorg > /dev/null 2>&1; do sleep 1; done
+				echo '[ INFO ] Connecting to shared desktop'
+				$FP_SHARED
+				sleep 2
+				pgrep Xorg > /dev/null 2>&1 && exit 1
+				echo '[ INFO ] X server stopped, waiting for next session...'
+			done
 
 		# Virtual desktop mode
 		else
@@ -10310,7 +10319,7 @@ case "$1" in
 			HEIGHT=$(sed -n '/^[[:blank:]]*SOFTWARE_VNCSERVER_HEIGHT=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			DEPTH=$(sed -n '/^[[:blank:]]*SOFTWARE_VNCSERVER_DEPTH=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			echo "[ INFO ] Starting virtual desktop at display :${DISPLAY:-1} in ${WIDTH:-1280}x${HEIGHT:-720}x${DEPTH:-16}"
-			exec $FP_BINARY ":${DISPLAY:-1}" -geometry "${WIDTH:-1280}x${HEIGHT:-720}" -depth "${DEPTH:-16}" || exit $?
+			exec $FP_BINARY ":${DISPLAY:-1}" -geometry "${WIDTH:-1280}x${HEIGHT:-720}" -depth "${DEPTH:-16}"
 
 		fi
 	;;
@@ -10320,69 +10329,30 @@ case "$1" in
 		if grep -q '^[[:blank:]]*SOFTWARE_VNCSERVER_SHARE_DESKTOP=1' /boot/dietpi.txt; then
 
 			echo '[ INFO ] Disconnecting from shared desktop'
-			$FP_SHARED -kill ':0' 2> /dev/null
-			killall -qw X0tigervnc x0tigervncserver vncserver-x11-serviced
+			killall -qw vncserver-x11 x0tigervncserver
 
 		# Virtual desktop mode
 		else
 
 			DISPLAY=$(sed -n '/^[[:blank:]]*SOFTWARE_VNCSERVER_DISPLAY_INDEX=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			echo "[ INFO ] Stopping virtual desktop at display :${DISPLAY:-1}"
-			$FP_BINARY -kill ":${DISPLAY:-1}" 2> /dev/null
-			killall -qw Xtigervnc tigervncserver vncserver-virtual
+			$FP_BINARY -kill ":${DISPLAY:-1}"
 
 		fi
 	;;
+	
+        *)
+                echo "[FAILED] Invalid command ($1), please use \"start\" or \"stop\""
+                exit 1
+        ;;
 
 esac
-
-exit 0
 _EOF_
 			G_EXEC chmod +x /usr/local/bin/vncserver
 
-			# Stretch + TigerVNC: Disable Localhost only by default
+			# Stretch + TigerVNC: Permit remote connections which implies TLSVnc authentications being enabled additionally
 			# shellcheck disable=SC2016
 			[[ -f '/etc/vnc.conf' ]] && GCI_PRESERVE=1 G_CONFIG_INJECT '\$localhost[[:blank:]]*=' '$localhost = "no";' /etc/vnc.conf
-
-			local cmd_launch_desktop=
-			# LXDE
-			if (( ${aSOFTWARE_INSTALL_STATE[23]} > 0 )); then
-
-				cmd_launch_desktop='lxsession -s LXDE -e LXDE'
-
-			# MATE
-			elif (( ${aSOFTWARE_INSTALL_STATE[24]} > 0 )); then
-
-				cmd_launch_desktop='mate-session'
-
-			# GNUstep
-			elif (( ${aSOFTWARE_INSTALL_STATE[26]} > 0 )); then
-
-				cmd_launch_desktop='x-window-manager'
-
-			# Xfce
-			elif (( ${aSOFTWARE_INSTALL_STATE[25]} > 0 )); then
-
-				cmd_launch_desktop='xfce4-session'
-
-			# LXQt
-			elif (( ${aSOFTWARE_INSTALL_STATE[173]} > 0 )); then
-
-				cmd_launch_desktop='startlxqt'
-
-			fi
-
-			G_EXEC mkdir -p /root/.vnc
-			cat << _EOF_ > /root/.vnc/xstartup
-#!/bin/dash
-export SHELL='/bin/bash'
-[ -x '/etc/vnc/xstartup' ] && exec /etc/vnc/xstartup
-[ -r '/root/.Xresources' ] && xrdb /root/.Xresources
-xsetroot -solid grey
-vncconfig -iconic &
-exec $cmd_launch_desktop
-_EOF_
-			G_EXEC chmod +x /root/.vnc/xstartup
 
 			# TigerVNC: Set control + read-only passwords
 			if [[ ${aSOFTWARE_INSTALL_STATE[28]} == 1 && ! -f '/root/.vnc/passwd' ]]

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10277,7 +10277,7 @@ if [ -f '/usr/bin/vncserver-virtual' ]
 then
 	echo '[  OK  ] RealVNC detected'
 	FP_BINARY='/usr/bin/vncserver-virtual -Authentication VncAuth'
-	FP_SHARED='/usr/bin/vncserver-x11 -service -Authentication VncAuth'
+	FP_SHARED='exec /usr/bin/vncserver-x11 -service -Authentication VncAuth'
 
 elif [ -f '/usr/bin/tigervncserver' ]
 then
@@ -10299,11 +10299,11 @@ case "$1" in
 			echo '[ INFO ] Waiting for X server...'
 			while :
 			do
-				until pgrep Xorg > /dev/null 2>&1; do sleep 1; done
+				until pgrep '^X' > /dev/null 2>&1; do sleep 1; done
 				echo '[ INFO ] Connecting to shared desktop'
 				$FP_SHARED
 				sleep 2
-				pgrep Xorg > /dev/null 2>&1 && exit 1
+				pgrep '^X' > /dev/null 2>&1 && exit 1
 				echo '[ INFO ] X server stopped, waiting for next session...'
 			done
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5678,16 +5678,14 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-			# TigerVNC allows connecting to a virtual desktop
-			# X11VNC allows connecting to a real desktop session, thus shared desktop sessions as well
 			# netbase is required until Bullseye to solve: "Use of uninitialized value $proto in socket at /usr/bin/tigervncserver"
 			# - It is a recommendation and no dependency of perl, but expected by some packages depending on perl only: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=939055
-			local netbase=
-			(( $G_DISTRO < 6 )) && netbase='netbase'
+			# tigervnc-common is required as it is a recommendation only until Bullseye.
+			local apackages=()
+			(( $G_DISTRO > 5 )) || apackages=('tigervnc-common' 'netbase')
 			# https://github.com/MichaIng/DietPi/issues/1558#issuecomment-701547904
-			local dbus_package=
-			(( ${aSOFTWARE_INSTALL_STATE[23]} > 0 )) && dbus_package='dbus-user-session'
-			G_AGI tigervnc-standalone-server tigervnc-common x11vnc $netbase $dbus_package
+			(( ${aSOFTWARE_INSTALL_STATE[23]} > 0 )) && apackages+=('dbus-user-session')
+			G_AGI tigervnc-standalone-server tigervnc-scraping-server "${apackages[@]}"
 
 		fi
 
@@ -10286,21 +10284,18 @@ _EOF_
 			aSTART_SERVICES+=('vncserver')
 
 			cat << '_EOF_' > /usr/local/bin/vncserver
-#!/bin/bash
-
-# Shared or virtual desktop?
-SHARED_MODE=$(grep -cm1 '^[[:blank:]]*SOFTWARE_VNCSERVER_SHARE_DESKTOP=1' /boot/dietpi.txt)
+#!/bin/dash
 
 # RealVNC or TigerVNC?
-if [[ -f '/usr/bin/vncserver-virtual' ]]; then
+if [ -f '/usr/bin/vncserver-virtual' ]; then
 
-	REALVNC=1
 	FP_BINARY='/usr/bin/vncserver-virtual -Authentication VncAuth'
+	FP_SHARED='/usr/bin/vncserver-x11-serviced'
 
-elif [[ -f '/usr/bin/tigervncserver' ]]; then
+elif [ -f '/usr/bin/tigervncserver' ]; then
 
-	REALVNC=0
 	FP_BINARY='/usr/bin/tigervncserver -fg'
+	FP_SHARED='/usr/bin/x0tigervncserver :0'
 
 else
 
@@ -10312,33 +10307,39 @@ fi
 case "$1" in
 
 	start)
-		# Virtual desktop mode
-		if (( ! $SHARED_MODE )); then
+		# Shared desktop mode
+		if grep -q '^[[:blank:]]*SOFTWARE_VNCSERVER_SHARE_DESKTOP=1' /boot/dietpi.txt; then
 
+			exec $FP_SHARED -fg || exit 1
+
+		# Virtual desktop mode
+		else
+
+			DISPLAY=$(sed -n '/^[[:blank:]]*SOFTWARE_VNCSERVER_DISPLAY_INDEX=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			WIDTH=$(sed -n '/^[[:blank:]]*SOFTWARE_VNCSERVER_WIDTH=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			HEIGHT=$(sed -n '/^[[:blank:]]*SOFTWARE_VNCSERVER_HEIGHT=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			DEPTH=$(sed -n '/^[[:blank:]]*SOFTWARE_VNCSERVER_DEPTH=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-			DISPLAY=$(sed -n '/^[[:blank:]]*SOFTWARE_VNCSERVER_DISPLAY_INDEX=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			exec $FP_BINARY ":${DISPLAY:-1}" -geometry "${WIDTH:-1280}x${HEIGHT:-720}" -depth "${DEPTH:-16}" || exit 1
-
-		# TigerVNC shared desktop mode
-		elif (( ! $REALVNC )); then
-
-			exec x11vnc -display 'WAIT:0' -usepw -forever || exit 1
-
-		# RealVNC shared desktop mode
-		else
-
-			systemctl start vncserver-x11-serviced || exit 1
 
 		fi
 	;;
 
 	stop)
-		DISPLAY=$(sed -n '/^[[:blank:]]*SOFTWARE_VNCSERVER_DISPLAY_INDEX=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-		$FP_BINARY -kill ":${DISPLAY:-1}" 2> /dev/null
-		(( $REALVNC )) && systemctl stop vncserver-x11-serviced
-		killall -qw x11vnc Xtigervnc /usr/bin/vncserver-x11-serviced vncserver-x11-serviced Xvnc-core
+		# Shared desktop mode
+		if grep -q '^[[:blank:]]*SOFTWARE_VNCSERVER_SHARE_DESKTOP=1' /boot/dietpi.txt; then
+
+			$FP_SHARED -kill ':0' 2> /dev/null
+			killall -qw X0tigervnc x0tigervncserver /usr/bin/vncserver-x11-serviced vncserver-x11-serviced Xvnc-core
+
+		# Virtual desktop mode
+		else
+
+			DISPLAY=$(sed -n '/^[[:blank:]]*SOFTWARE_VNCSERVER_DISPLAY_INDEX=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+			$FP_BINARY -kill ":${DISPLAY:-1}" 2> /dev/null
+			killall -qw Xtigervnc tigervncserver /usr/bin/vncserver-virtual vncserver-virtual Xvnc-core
+
+		fi
+		
 	;;
 
 esac
@@ -10391,17 +10392,22 @@ exec $cmd_launch_desktop
 _EOF_
 			G_EXEC chmod +x /root/.vnc/xstartup
 
-			# TigerVNC: Set control + read-only passwords (RealVNC uses UNIX user authentication by default, does not support the "-f" option and uses different files!)
-			if command -v tigervncpasswd > /dev/null; then
-
-				tigervncpasswd -f << _EOF_ > /root/.vnc/passwd
-$GLOBAL_PW
-$GLOBAL_PW
-_EOF_
+			# TigerVNC: Set control + read-only passwords
+			if [[ ${aSOFTWARE_INSTALL_STATE[28]} == 1 && ! -f '/root/.vnc/passwd' ]]
+			then
+				tigervncpasswd -f <<< "$GLOBAL_PW
+$GLOBAL_PW" > /root/.vnc/passwd
 				G_EXEC chmod 600 /root/.vnc/passwd
-
 			fi
 
+			# RealVNC: Set virtual + shared desktop passwords
+			if [[ ${aSOFTWARE_INSTALL_STATE[120]} == 1 && ! -f '/root/.vnc/config.d/Xvnc' ]]
+			then
+				vncpasswd -virtual <<< "$GLOBAL_PW
+$GLOBAL_PW"
+				vncpasswd -service <<< "$GLOBAL_PW
+$GLOBAL_PW"
+			fi
 		fi
 
 		software_id=74 # InfluxDB
@@ -15022,19 +15028,21 @@ _EOF_
 
 			if [[ -f '/etc/systemd/system/vncserver.service' ]]; then
 
-				systemctl disable --now vncserver
-				rm -R /etc/systemd/system/vncserver.service*
+				G_EXEC systemctl disable --now vncserver
+				G_EXEC rm /etc/systemd/system/vncserver.service
 
 			fi
-			[[ -d '/etc/systemd/system/vncserver.service.d' ]] && rm -R /etc/systemd/system/vncserver.service.d
+			[[ -d '/etc/systemd/system/vncserver.service.d' ]] && G_EXEC rm -R /etc/systemd/system/vncserver.service.d
 			if [[ -f '/etc/init.d/vncserver' ]]; then
 
-				rm /etc/init.d/vncserver
-				update-rc.d -f vncserver remove
+				G_EXEC systemctl unmask vncserver
+				G_EXEC systemctl disable --now vncserver
+				G_EXEC rm /etc/init.d/vncserver
+				G_EXEC update-rc.d -f vncserver remove
 
 			fi
-			[[ -f '/usr/local/bin/vncserver' ]] && rm /usr/local/bin/vncserver
-			rm -Rf /{root,home/*}/.vnc
+			[[ -f '/usr/local/bin/vncserver' ]] && G_EXEC rm /usr/local/bin/vncserver
+			G_EXEC rm -Rf /{root,home/*}/.vnc
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10295,14 +10295,12 @@ SHARED_MODE=$(grep -cm1 '^[[:blank:]]*SOFTWARE_VNCSERVER_SHARE_DESKTOP=1' /boot/
 if [[ -f '/usr/bin/vncserver-virtual' ]]; then
 
 	REALVNC=1
-	FP_BINARY='/usr/bin/vncserver-virtual'
-	# Set shared desktop mode if autostart is enabled for desktops. This prevents another VNC server being launched on :1.
-	[[ -f '/boot/dietpi/.dietpi-autostart_index' && $(</boot/dietpi/.dietpi-autostart_index) == 2 ]] && SHARED_MODE=1
+	FP_BINARY='/usr/bin/vncserver-virtual -Authentication VncAuth'
 
 elif [[ -f '/usr/bin/tigervncserver' ]]; then
 
 	REALVNC=0
-	FP_BINARY='/usr/bin/tigervncserver'
+	FP_BINARY='/usr/bin/tigervncserver -fg'
 
 else
 
@@ -10321,22 +10319,16 @@ case "$1" in
 			HEIGHT=$(sed -n '/^[[:blank:]]*SOFTWARE_VNCSERVER_HEIGHT=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			DEPTH=$(sed -n '/^[[:blank:]]*SOFTWARE_VNCSERVER_DEPTH=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			DISPLAY=$(sed -n '/^[[:blank:]]*SOFTWARE_VNCSERVER_DISPLAY_INDEX=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-			$FP_BINARY :${DISPLAY:-1} -geometry ${WIDTH:-1280}'x'${HEIGHT:-720} -depth ${DEPTH:-16} || exit 1
+			exec $FP_BINARY ":${DISPLAY:-1}" -geometry "${WIDTH:-1280}x${HEIGHT:-720}" -depth "${DEPTH:-16}" || exit 1
 
 		# TigerVNC shared desktop mode
 		elif (( ! $REALVNC )); then
 
-			echo 'Waiting for X11 to start...'
-			until pgrep Xorg; do sleep 2; done
-
-			sleep 5 # Give system some time to finish setting up X11 + desktop
-			xset dpms force on # Disable screen blanking
-			x11vnc -display :0 -usepw -forever || exit 1
+			exec x11vnc -display 'WAIT:0' -usepw -forever || exit 1
 
 		# RealVNC shared desktop mode
 		else
 
-			# No need to wait for X, this service detects the first appearing X session and attaches to it.
 			systemctl start vncserver-x11-serviced || exit 1
 
 		fi
@@ -10344,7 +10336,7 @@ case "$1" in
 
 	stop)
 		DISPLAY=$(sed -n '/^[[:blank:]]*SOFTWARE_VNCSERVER_DISPLAY_INDEX=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-		$FP_BINARY -kill :${DISPLAY:-1} 2> /dev/null
+		$FP_BINARY -kill ":${DISPLAY:-1}" 2> /dev/null
 		(( $REALVNC )) && systemctl stop vncserver-x11-serviced
 		killall -qw x11vnc Xtigervnc /usr/bin/vncserver-x11-serviced vncserver-x11-serviced Xvnc-core
 	;;


### PR DESCRIPTION
**Status**: Ready

**Testing**:
🈯 TigerVNC Bullseye virtual
🈯 TigerVNC Buster virtual
🈯 TigerVNC Stretch virtual
🈯 TigerVNC Bullseye shared
🈯 TigerVNC Buster shared
🈯 TigerVNC Stretch shared
🈯 RealVNC Buster virtual
🈯 RealVNC Buster shared
🈯 RealVNC Stretch virtual
🈯 RealVNC Stretch shared
🈯 RealVNC Bullseye virtual
🈯 RealVNC Bullseye shared

**Commit list/description**:
+ DietPi-Software | RealVNC: So not force shared desktop mode when dietpi-autostart desktop autologin is enabled, to remain consistency with TigerVNC and allow concurrent and independent local desktop and virtual VNC sessions.
+ DietPi-Software | TigerVNC: Run virtual desktop process in foreground, for better systemd process handling, logs etc. Replace the wrapper script with the processes to reduce overhead a little.
+ DietPi-Software | TigerVNC: In shared desktop mode, use x11vnc's internal desktop session wait feature. It waits for an actual client connection before connecting to the local X session, which is not exactly the same as what we did (connecting to the X session once ready), but actually even better. The only downside which needs to be tested is whether a client connection prior to local desktop being up leads to a server termination or not. Also DPMS does not need to be disabled here as we do this via X config by default.