### PR TITLE
DietPi-Software | Kodi: Install our RPi 32-bit Kodi package on all 32-bit RPi images

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4396,7 +4396,7 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-c4-kodi.conf
 				fi
 
 			# RPi Raspbian Bullseye
-			elif (( $G_HW_MODEL < 10 && $G_DISTRO == 6 )) && (( $G_RASPBIAN ))
+			elif (( $G_HW_MODEL < 10 && $G_DISTRO == 6 )) && [[ $(dpkg --print-architecture) == 'armhf' ]]
 			then
 				/boot/dietpi/func/dietpi-set_hardware rpi-opengl vc4-fkms-v3d
 				Download_Install "https://dietpi.com/downloads/binaries/$G_DISTRO_NAME/kodi_$G_HW_ARCH_NAME.deb"


### PR DESCRIPTION
**Status**: WIP

**Commit list/description**:
+ DietPi-Software | Install our RPi 32-bit Kodi package on all 32-bit RPi images, not only on Raspbian.