### PR TITLE
DietPi-Software | Blynk: Assure that the default log directory exists

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Fixes:
 - DietPi-LetsEncrypt | When enabling HTTPS redirect or HSTS and ownCloud or Nextcloud are installed, the "overwrite.cli.url" setting in the config.php is updated accordingly to contain the primary HTTPS domain. This is required for cron jobs and the occ/ncc commands to access ownCloud/Nextcloud through the webserver, as the Let's Encrypt certificate is only valid for the external domain name and not "localhost". Many thanks to @droogi for reporting a possibly related issue: https://github.com/MichaIng/DietPi/issues/4353
 - DietPi-Software | TigerVNC: Resolved an issue where remote connections didn't work by default on Bullseye systems, as a different configuration file is used.
 - DietPi-Software | LXDE: Resolved an issue on Raspberry Pi, where calling lxappearance (Customize Look and Feel) failed due to incompatible RPi desktop packages. Many thanks to @pinipon for reporting this issue: https://github.com/MichaIng/DietPi/issues/4687
+- DietPi-Software | Blynk: Resolved an issue where the log directory may be missing, which breaks the service start, when the userdata were migrated from one system to a new one. Many thanks to @Phil1988 for reporting this issue: https://github.com/MichaIng/DietPi/issues/4721
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5447,7 +5447,7 @@ _EOF_
 			# RPi: Install "onoff" for GPIO access
 			(( $G_HW_MODEL > 9 )) || G_EXEC_OUTPUT=1 G_EXEC npm i -g --unsafe-perm --no-audit onoff
 
-			# Install Blynk JS libary
+			# Install Blynk JS library
 			G_EXEC_OUTPUT=1 G_EXEC npm i -g --unsafe-perm --no-audit blynk-library
 
 			# Preserve existing config
@@ -5455,7 +5455,6 @@ _EOF_
 			then
 				G_EXEC curl -sSfL 'https://raw.githubusercontent.com/Peterkn2001/blynk-server/master/server/core/src/main/resources/server.properties' -o /mnt/dietpi_userdata/blynk/server.properties
 				G_EXEC chmod 0600 /mnt/dietpi_userdata/blynk/server.properties
-				G_EXEC mkdir -p /var/log/blynk
 				G_CONFIG_INJECT 'logs.folder=' 'logs.folder=/var/log/blynk' /mnt/dietpi_userdata/blynk/server.properties
 				G_CONFIG_INJECT 'data.folder=' 'data.folder=/mnt/dietpi_userdata/blynk/data' /mnt/dietpi_userdata/blynk/server.properties
 				G_CONFIG_INJECT 'http.port=' 'http.port=8442' /mnt/dietpi_userdata/blynk/server.properties
@@ -5493,7 +5492,14 @@ PrivateTmp=true
 WantedBy=multi-user.target
 _EOF_
 			# Permissions
-			G_EXEC chown -R blynk:blynk /mnt/dietpi_userdata/blynk /var/log/blynk
+			G_EXEC chown -R blynk:blynk /mnt/dietpi_userdata/blynk
+
+			# Assure that the default log directory exists, when it is set in the config file: https://github.com/MichaIng/DietPi/issues/4721
+			if grep -q '^logs.folder=/var/log/blynk$' /mnt/dietpi_userdata/blynk/server.properties
+			then
+				G_EXEC mkdir -p /var/log/blynk
+				G_EXEC chown -R blynk:blynk /var/log/blynk
+			fi
 
 		fi
 


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Software | Blynk: Assure that the default log directory exists, when it is set in the config file: https://github.com/MichaIng/DietPi/issues/4721