### PR TITLE
DietPi-Software | qBittorrent: Some fixes and enhancements

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -436,7 +436,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_NAME[$software_id]='Squeezelite'
 		aSOFTWARE_DESC[$software_id]='audio player for lms & squeezebox'
 		aSOFTWARE_CATX[$software_id]=2
-		aSOFTWARE_DOCS[$software_id]='p=1009#p1009'
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#squeezelite'
 		aSOFTWARE_DEPS[$software_id]='5'
 		#------------------
 		software_id=37
@@ -492,7 +492,7 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_NAME[$software_id]='Mopidy'
 		aSOFTWARE_DESC[$software_id]='web interface music & radio player'
 		aSOFTWARE_CATX[$software_id]=2
-		aSOFTWARE_DOCS[$software_id]='p=3611#p3611'
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#mopidy'
 		aSOFTWARE_DEPS[$software_id]='5'
 		(( $G_DISTRO > 4 )) && aSOFTWARE_DEPS[$software_id]+=' 130'
 		#------------------
@@ -694,9 +694,9 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		software_id=46
 
 		aSOFTWARE_NAME[$software_id]='qBittorrent'
-		aSOFTWARE_DESC[$software_id]='bittorrent server with web interface (c++)'
+		aSOFTWARE_DESC[$software_id]='BitTorrent server with web interface (C++)'
 		aSOFTWARE_CATX[$software_id]=3
-		aSOFTWARE_DOCS[$software_id]='p=2272#p2272'
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/bittorrent/#qbittorrent'
 		#------------------
 		software_id=107
 
@@ -6527,13 +6527,13 @@ _EOF_
 			G_AGI qbittorrent-nox
 
 			# User
-			Create_User -g dietpi -d /home/qbittorrent -p "$GLOBAL_PW" qbittorrent
+			Create_User -g dietpi -d /home/qbittorrent qbittorrent
 
 			# Config: Create only on fresh install
 			if [[ ! -f '/home/qbittorrent/.config/qBittorrent/qBittorrent.conf' ]]; then
 
 				G_EXEC mkdir -p /home/qbittorrent/.config/qBittorrent /var/log/qbittorrent
-				G_EXEC chown -R qbittorrent: /var/log/qbittorrent
+				G_EXEC chown -R qbittorrent:root /var/log/qbittorrent
 				cat << _EOF_ > /home/qbittorrent/.config/qBittorrent/qBittorrent.conf
 [General]
 ported_to_new_savepath_system=true
@@ -6542,83 +6542,69 @@ ported_to_new_savepath_system=true
 FileLogger\Enabled=true
 FileLogger\Path=/var/log/qbittorrent
 
-[Preferences]
-Downloads\DiskWriteCacheSize=$(Optimise_BitTorrent 0)
-Downloads\DiskWriteCacheTTL=60
-Queueing\MaxActiveDownloads=$(Optimise_BitTorrent 1)
-Queueing\MaxActiveTorrents=$(Optimise_BitTorrent 1)
-Queueing\MaxActiveUploads=1
-Queueing\IgnoreSlowTorrents=false
-Bittorrent\MaxConnecs=$(Optimise_BitTorrent 2)
-Bittorrent\MaxConnecsPerTorrent=$(Optimise_BitTorrent 2)
-Bittorrent\MaxUploads=$(Optimise_BitTorrent 3)
-Bittorrent\MaxUploadsPerTorrent=$(Optimise_BitTorrent 3)
-WebUI\Port=1340
-WebUI\Enabled=true
-General\Locale=en
-Downloads\SavePath=/mnt/dietpi_userdata/downloads
-Downloads\TempPathEnabled=false
-Downloads\TempPath=/mnt/dietpi_userdata/downloads
-Downloads\ScanDirs=@Invalid()
-Downloads\DownloadInScanDirs=@Invalid()
-Downloads\TorrentExportDir=
-MailNotification\enabled=false
-MailNotification\email=
-MailNotification\smtp_server=smtp.changeme.com
-MailNotification\req_ssl=false
-MailNotification\req_auth=false
-MailNotification\username=
-MailNotification\password=
-Downloads\PreAllocation=false
-Queueing\QueueingEnabled=false
-Downloads\UseIncompleteExtension=false
-Connection\PortRangeMin=6881
-Connection\UPnP=true
-Connection\GlobalDLLimit=-1
-Connection\GlobalUPLimit=-1
-Bittorrent\uTP=true
-Bittorrent\uTP_rate_limited=false
-Advanced\IncludeOverhead=false
-Connection\GlobalDLLimitAlt=10
-Connection\GlobalUPLimitAlt=10
-Scheduler\Enabled=false
-Bittorrent\DHT=true
-Bittorrent\sameDHTPortAsBT=true
-Bittorrent\DHTPort=6881
-Bittorrent\PeX=true
-Bittorrent\LSD=true
-Bittorrent\Encryption=1
-Advanced\AnonymousMode=false
-Connection\ProxyType=-1
-Connection\Proxy\IP=0.0.0.0
-Connection\Proxy\Port=8080
-Connection\ProxyPeerConnections=false
-Connection\Proxy\Authentication=false
-Connection\Proxy\Username=
-Connection\Proxy\Password=
-IPFilter\Enabled=false
-IPFilter\File=
-WebUI\Username=qbittorrent
-WebUI\LocalHostAuth=true
-WebUI\HTTPS\Enabled=false
-DynDNS\Enabled=false
-DynDNS\Service=0
-DynDNS\Username=
-DynDNS\Password=
-DynDNS\DomainName=changeme.dyndns.org
-WebUI\Password_ha1=@ByteArray($(echo -n "$GLOBAL_PW" | md5sum | mawk '{print $1}'))
+[AutoRun]
+enabled=false
 
 [LegalNotice]
 Accepted=true
 
-[AutoRun]
-enabled=false
-program=
+[Preferences]
+Advanced\AnonymousMode=false
+Advanced\IncludeOverhead=false
+Bittorrent\DHT=true
+Bittorrent\DHTPort=6881
+Bittorrent\Encryption=1
+Bittorrent\LSD=true
+Bittorrent\MaxConnecs=$(Optimise_BitTorrent 2)
+Bittorrent\MaxConnecsPerTorrent=$(Optimise_BitTorrent 2)
+Bittorrent\MaxUploads=$(Optimise_BitTorrent 3)
+Bittorrent\MaxUploadsPerTorrent=$(Optimise_BitTorrent 3)
+Bittorrent\PeX=true
+Bittorrent\sameDHTPortAsBT=true
+Bittorrent\uTP=true
+Bittorrent\uTP_rate_limited=false
+Connection\GlobalDLLimit=-1
+Connection\GlobalDLLimitAlt=10
+Connection\GlobalUPLimit=-1
+Connection\GlobalUPLimitAlt=10
+Connection\PortRangeMin=6881
+Connection\Proxy\Authentication=false
+Connection\ProxyPeerConnections=false
+Connection\ResolvePeerCountries=false
+Connection\UPnP=true
+Downloads\DiskWriteCacheSize=$(Optimise_BitTorrent 0)
+Downloads\DiskWriteCacheTTL=60
+Downloads\PreAllocation=false
+Downloads\SavePath=/mnt/dietpi_userdata/downloads
+Downloads\TempPath=/mnt/dietpi_userdata/downloads
+Downloads\TempPathEnabled=false
+Downloads\UseIncompleteExtension=false
+DynDNS\Enabled=false
+General\Locale=en
+IPFilter\Enabled=false
+MailNotification\enabled=false
+Queueing\IgnoreSlowTorrents=false
+Queueing\MaxActiveDownloads=$(Optimise_BitTorrent 1)
+Queueing\MaxActiveTorrents=$(Optimise_BitTorrent 1)
+Queueing\MaxActiveUploads=1
+Queueing\QueueingEnabled=false
+Scheduler\Enabled=false
+WebUI\CSRFProtection=true
+WebUI\ClickjackingProtection=true
+WebUI\Enabled=true
+WebUI\HTTPS\Enabled=false
+WebUI\HostHeaderValidation=false
+WebUI\LocalHostAuth=true
+WebUI\Password_ha1=@ByteArray($(echo -n "$GLOBAL_PW" | md5sum | mawk '{print $1}'))
+WebUI\Port=1340
+WebUI\SecureCookie=true
+WebUI\UseUPnP=true
+WebUI\Username=qbittorrent
 _EOF_
 			fi
 
 			# Since v4.2.0, the PBKDF2 needs to be used: https://github.com/MichaIng/DietPi/issues/4711
-			(( $G_DISTRO < 6 )) || G_EXEC sed -i '/^WebUI\\Password_ha1/c\WebUI\Password_PBKDF2="@ByteArray(tpgNK76AcpP14rjOZP9vwg==:rQNtOB0P4HfNj20pJtxiTBi9miduS6L1Xqqazc4Y6Gpm3Rn02jMXnPPT3KH2JMDKhFQjAaTGVJz0dz5JVw2QUQ==)"' /home/qbittorrent/.config/qBittorrent/qBittorrent.conf
+			(( $G_DISTRO < 6 )) || G_EXEC sed -i '/^WebUI\\Password_ha1/c\WebUI\\Password_PBKDF2="@ByteArray(tpgNK76AcpP14rjOZP9vwg==:rQNtOB0P4HfNj20pJtxiTBi9miduS6L1Xqqazc4Y6Gpm3Rn02jMXnPPT3KH2JMDKhFQjAaTGVJz0dz5JVw2QUQ==)"' /home/qbittorrent/.config/qBittorrent/qBittorrent.conf
 
 			# Service
 			cat << _EOF_ > /etc/systemd/system/qbittorrent.service
@@ -6637,7 +6623,7 @@ ExecStart=$(command -v qbittorrent-nox)
 WantedBy=multi-user.target
 _EOF_
 			# Permissions
-			G_EXEC chown -R qbittorrent:dietpi /home/qbittorrent
+			G_EXEC chown -R qbittorrent:root /home/qbittorrent
 
 		fi
 


### PR DESCRIPTION
**Status**: Testing

**Testing**:
- [x] Bullseye
- [x] Buster
- [x] Stretch

**Commit list/description**:
+ DietPi-Software | qBittorrent: Do not apply UNIX user password for "qbittorrent" user anymore, as it is not used
+ DietPi-Software | qBittorrent: Do not grant "dietpi" group write permissions to qBittorrent config and log directories.
+ DietPi-Software | qBittorrent: Reorder and cleanup default config so that it can be better compared to what it looks like after first service start. Remove settings which are empty or unsed (due do disabled states) or where defaults are good.
+ DietPi-Software | qBittorrent: Fix applying default password PBKDF2 hash