### PR TITLE
Beta v7.6.2

### DIFF
--- a/.conf/dps_199/spotifyd.conf
+++ b/.conf/dps_199/spotifyd.conf
@@ -1,0 +1,90 @@
+[global]
+# Your Spotify account name.
+#username = "username"
+
+# Your Spotify account password.
+#password = "password"
+
+# A command that gets executed and can be used to
+# retrieve your password.
+# The command should return the password on stdout.
+#
+# This is an alternative to the `password` field. Both
+# can't be used simultaneously.
+#password_cmd = "command_that_writes_password_to_stdout"
+
+# If set to true, `spotifyd` tries to look up your
+# password in the system's password storage.
+#
+# This is an alternative to the `password` field. Both
+# can't be used simultaneously.
+#use_keyring = true
+
+#
+# If set to true, `spotifyd` tries to bind to the session dbus
+# and expose MPRIS controls. When running headless, without a dbus session,
+# then set this to false to avoid binding errors
+#
+use_mpris = false
+
+# The audio backend used to play the your music. To get
+# a list of possible backends, run `/opt/spotifyd/spotifyd --help`.
+backend = "alsa"
+
+# The alsa audio device to stream audio to. To get a
+# list of valid devices, run `aplay -L`,
+#device = "alsa_audio_device"
+
+# The alsa control device. By default this is the same
+# name as the `device` field.
+#control = "alsa_audio_device"
+
+# The alsa mixer used by `spotifyd`.
+#mixer = "PCM"
+
+# The volume controller. Each one behaves different to
+# volume increases. For possible values, run
+# `/opt/spotifyd/spotifyd --help`.
+volume_controller = "alsa"
+
+# A command that gets executed in your shell after each song changes.
+#on_song_change_hook = "command_to_run_on_playback_events"
+
+# The name that gets displayed under the connect tab on
+# official clients. Spaces are not allowed!
+#device_name = "device_name_in_spotify_connect"
+
+# The audio bitrate. 96, 160 or 320 kbit/s
+#bitrate = 160
+
+# The directory used to cache audio data. This setting can save
+# a lot of bandwidth when activated, as it will avoid re-downloading
+# audio files when replaying them.
+#
+# Note: The file path does not get expanded. Environment variables and
+# shell placeholders like $HOME or ~ don't work!
+cache_path = "/mnt/dietpi_userdata/spotifyd/cache"
+
+# If set to true, audio data does NOT get cached.
+#no_audio_cache = true
+
+# Volume on startup between 0 and 100
+# NOTE: This variable's type will change in v0.4, to a number (instead of string)
+#initial_volume = "90"
+
+# If set to true, enables volume normalisation between songs.
+#volume_normalisation = true
+
+# The normalisation pregain that is applied for each song.
+#normalisation_pregain = -10
+
+# The port `spotifyd` uses to announce its service over the network.
+#zeroconf_port = 1234
+
+# The proxy `spotifyd` will use to connect to spotify.
+#proxy = "http://proxy.example.org:8080"
+
+# The displayed device type in Spotify clients.
+# Can be unknown, computer, tablet, smartphone, speaker, t_v,
+# a_v_r (Audio/Video Receiver), s_t_b (Set-Top Box), and audio_dongle.
+device_type = "speaker"

--- a/.conf/dps_39/minidlna.conf
+++ b/.conf/dps_39/minidlna.conf
@@ -1,7 +1,7 @@
-# WARNING: After changing this option, you need to rebuild the database. Either
-#          run minidlna with the '-R' option, or delete the 'files.db' file
-#          from the db_dir directory (see below).
-#          On Debian, you can run, as root, 'service minidlna force-reload' instead.
+# WARNING: After changing this option, you need to restart the service
+#          via: "systemctl force-reload minidlna"
+
+# Media paths
 media_dir=A,/mnt/dietpi_userdata/Music
 media_dir=P,/mnt/dietpi_userdata/Pictures
 media_dir=V,/mnt/dietpi_userdata/Video
@@ -11,7 +11,7 @@ db_dir=/mnt/dietpi_userdata/.MiniDLNA_Cache
 
 # Must be one of "off", "fatal", "error", "warn", "info" or "debug".
 # "off" turns of logging entirely, "fatal" is the highest level of importance.
-# Access logs via: "journalctl -u minidlna"
+# Access logs via: "journalctl -u minidlna", on Bullseye in /var/log/minidlna.
 log_level=warn
 
 # Use a different container as the root of the directory tree presented to

--- a/.conf/dps_39/minidlna.conf
+++ b/.conf/dps_39/minidlna.conf
@@ -1,5 +1,5 @@
 # WARNING: After changing this option, you need to restart the service
-#          via: "systemctl force-reload minidlna"
+#          via: "systemctl restart minidlna"
 
 # Media paths
 media_dir=A,/mnt/dietpi_userdata/Music

--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -557,8 +557,12 @@ shopt -s extglob
 		aSOFTWARE["${aSOFTWARE_NAME7_6[$i]}"]=0
 	done
 	aSOFTWARE_NAME7_6[197]='Box64'
-	# shellcheck disable=SC2034
 	aSOFTWARE_NAME7_6[198]='File Browser'
+	# shellcheck disable=SC2034
+	aSOFTWARE_NAME7_6[199]='Spotifyd'
+	aSOFTWARE['Box64']=0
+	aSOFTWARE['File Browser']=0
+	aSOFTWARE['Spotifyd']=0
 
 	# $1 = File name
 	Process_File()

--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -553,16 +553,16 @@ shopt -s extglob
 	for i in "${!aSOFTWARE_NAME7_5[@]}"
 	do
 		aSOFTWARE_NAME7_6[$i]=${aSOFTWARE_NAME7_5[$i]}
-		# Pre-create software counter array so that we can see also software with 0 installs
-		aSOFTWARE["${aSOFTWARE_NAME7_6[$i]}"]=0
 	done
 	aSOFTWARE_NAME7_6[197]='Box64'
 	aSOFTWARE_NAME7_6[198]='File Browser'
-	# shellcheck disable=SC2034
 	aSOFTWARE_NAME7_6[199]='Spotifyd'
-	aSOFTWARE['Box64']=0
-	aSOFTWARE['File Browser']=0
-	aSOFTWARE['Spotifyd']=0
+
+	# Pre-create software counter array so that we can see also software (available in newest version) with 0 installs
+	for i in "${aSOFTWARE_NAME7_6[@]}"
+	do
+		aSOFTWARE["$i"]=0
+	done
 
 	# $1 = File name
 	Process_File()

--- a/.update/version
+++ b/.update/version
@@ -1,7 +1,7 @@
 # Available DietPi version
 G_REMOTE_VERSION_CORE=7
 G_REMOTE_VERSION_SUB=6
-G_REMOTE_VERSION_RC=1
+G_REMOTE_VERSION_RC=2
 # Minimum DietPi version to allow update
 G_MIN_VERSION_CORE=6
 G_MIN_VERSION_SUB=0

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -33,7 +33,7 @@ Fixes:
 - DietPi-Software | qBittorrent: Resolved an issue on Bullseye systems where login to the web interface was not possible with the global software password since the required hash algorithm has changed. Many thanks to @aftensleuk for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?p=22564#p22564
 - DietPi-Software | ReadyMedia: Resolved an issue on Bullseye where the service does not start unless the log directory is manually created. Due to a Debian package patch, on Bullseye logs are forced to file logging again, so that /var/log/minidlna again needs to exist. Many thanks to @AnzoP for reporting this issue: https://github.com/MichaIng/DietPi/issues/4745
 
-As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
+As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/4747
 
 Known/Outstanding Issues:
 - DietPi-Config | Enabling WiFi + Ethernet adapters, both on different subnets, breaks WiFi connection in some cases: https://github.com/MichaIng/DietPi/issues/2103

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,7 @@ Changes:
 New Software:
 - Box64 | This x86_64 userspace emulator allows you to run x86_64 binaries on an ARMv8/arm64 system. It works very similar to Box86, hence is able to use arm64 shared libraries with the x86_64 binaries, so that often no additional libraries need to be installed. Thanks to binfmt, it is invoked automatically if an x86_64 binary is tried to be executed. Many thanks to @ravenclaw900 for implementing this software title: https://github.com/MichaIng/DietPi/pull/4625
 - File Browser | Access and manage your data from anywhere via browser with this lightweight remote file manager. Other than ownCloud and Nextcloud, it accesses the raw data on your filesystem, based on a chosen root directory, which makes it similar to Syncthing. You can setup multiple users with their own root directory and also sharing files and directories via password-protected link is possible.
+- Spotifyd | Spotifyd streams music just like the official client, but is more lightweight. It also supports the Spotify Connect protocol, which makes it show up as a device that can be controlled from the official clients. Many thanks to @ressu for implementing this software title: https://github.com/MichaIng/DietPi/pull/4713
 
 Fixes:
 - General | Resolved an issue on ARMv7 Buster and Bullseye system, where the haveged entropy daemon crashes due to limited syscall permissions. This can lead to several issues, like hanging boot, hanging installs or services starts. Many thanks to @jg777 for reporting this issue: https://github.com/MichaIng/DietPi/issues/4710

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -31,6 +31,7 @@ Fixes:
 - DietPi-Software | LXDE: Resolved an issue where the hotkey setup didn't work because of a missing openbox plugin. Many thanks to @pinipon for reporting the issue and solution: https://github.com/MichaIng/DietPi/issues/4687
 - DietPi-Software | Blynk: Resolved an issue where the log directory may be missing, which breaks the service start, when the userdata were migrated from one system to a new one. Many thanks to @Phil1988 for reporting this issue: https://github.com/MichaIng/DietPi/issues/4721
 - DietPi-Software | qBittorrent: Resolved an issue on Bullseye systems where login to the web interface was not possible with the global software password since the required hash algorithm has changed. Many thanks to @aftensleuk for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?p=22564#p22564
+- DietPi-Software | ReadyMedia: Resolved an issue on Bullseye where the service does not start unless the log directory is manually created. Due to a Debian package patch, on Bullseye logs are forced to file logging again, so that /var/log/minidlna again needs to exist. Many thanks to @AnzoP for reporting this issue: https://github.com/MichaIng/DietPi/issues/4745
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ Links to hardware and software manufacturers, sources and build instructions use
 - [OpenJDK](https://github.com/openjdk)
 - [Blynk Server](https://github.com/Peterkn2001/blynk-server)
 - [File Browser](https://github.com/filebrowser/filebrowser)
+- [Spotifyd](https://github.com/Spotifyd/spotifyd)
 
 ---
 

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -128,6 +128,7 @@ Available services:
 			'komga'
 			'jellyfin'
 			'snapclient'
+			'spotifyd'
 
 			# - Download/BitTorrent
 			'medusa'

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10122,9 +10122,6 @@ _EOF_
 
 			Banner_Configuration
 
-			# Disable non-required dhcpcd, which is installed by Pi-hole installer
-			systemctl disable --now dhcpcd
-
 			# Apply most resource friendly and officially recommended NULL blocking: https://docs.pi-hole.net/ftldns/blockingmode/
 			G_CONFIG_INJECT 'BLOCKINGMODE=' 'BLOCKINGMODE=NULL' /etc/pihole/pihole-FTL.conf
 
@@ -13645,6 +13642,7 @@ _EOF_
 	Uninstall_Software(){
 
 		# NB: "systemctl daemon-reload" is executed at the end of this function
+		G_NOTIFY_3_MODE='Step'
 		local software_id
 
 		software_id=23 # LXDE
@@ -13866,29 +13864,6 @@ _EOF_
 			Banner_Uninstalling
 			[[ -d '/var/www/linuxdash' ]] && rm -R /var/www/linuxdash
 
-		fi
-
-		software_id=62 # Box86
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 ))
-		then
-			Banner_Uninstalling
-			[[ -f '/usr/local/bin/box86' ]] && G_EXEC rm /usr/local/bin/box86
-			[[ -f '/etc/binfmt.d/box86.conf' ]] && G_EXEC rm /etc/binfmt.d/box86.conf
-			[[ -f '/usr/lib/i386-linux-gnu/libstdc++.so.6' ]] && G_EXEC rm /usr/lib/i386-linux-gnu/libstdc++.so.6
-			[[ -f '/usr/lib/i386-linux-gnu/libstdc++.so.5' ]] && G_EXEC rm /usr/lib/i386-linux-gnu/libstdc++.so.5
-			[[ -f '/usr/lib/i386-linux-gnu/libgcc_s.so.1' ]] && G_EXEC rm /usr/lib/i386-linux-gnu/libgcc_s.so.1
-			[[ -d '/usr/lib/i386-linux-gnu' ]] && G_EXEC rmdir --ignore-fail-on-non-empty /usr/lib/i386-linux-gnu
-		fi
-
-		software_id=197 # Box64
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 ))
-		then
-			Banner_Uninstalling
-			[[ -f '/usr/local/bin/box64' ]] && G_EXEC rm /usr/local/bin/box64
-			[[ -f '/etc/binfmt.d/box64.conf' ]] && G_EXEC rm /etc/binfmt.d/box64.conf
-			[[ -f '/usr/lib/x86_64-linux-gnu/libstdc++.so.6' ]] && G_EXEC rm /usr/lib/x86_84-linux-gnu/libstdc++.so.6
-			[[ -f '/usr/lib/x86_64-linux-gnu/libgcc_s.so.1' ]] && G_EXEC rm /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
-			[[ -d '/usr/lib/x86_64-linux-gnu' ]] && G_EXEC rmdir --ignore-fail-on-non-empty /usr/lib/x86_64-linux-gnu
 		fi
 
 		software_id=27 # TasmoAdmin
@@ -14752,7 +14727,30 @@ _EOF_
 		then
 			Banner_Uninstalling
 			G_AGP steam
-			rm -Rf /{root,home/*}/{.steam{,path,pid},Desktop/steam.desktop} /mnt/dietpi_userdata/steam
+			G_EXEC rm -Rf /{root,home/*}/{.steam{,path,pid},Desktop/steam.desktop} /mnt/dietpi_userdata/steam
+		fi
+
+		software_id=62 # Box86
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 ))
+		then
+			Banner_Uninstalling
+			[[ -f '/usr/local/bin/box86' ]] && G_EXEC rm /usr/local/bin/box86
+			[[ -f '/etc/binfmt.d/box86.conf' ]] && G_EXEC rm /etc/binfmt.d/box86.conf
+			[[ -f '/usr/lib/i386-linux-gnu/libstdc++.so.6' ]] && G_EXEC rm /usr/lib/i386-linux-gnu/libstdc++.so.6
+			[[ -f '/usr/lib/i386-linux-gnu/libstdc++.so.5' ]] && G_EXEC rm /usr/lib/i386-linux-gnu/libstdc++.so.5
+			[[ -f '/usr/lib/i386-linux-gnu/libgcc_s.so.1' ]] && G_EXEC rm /usr/lib/i386-linux-gnu/libgcc_s.so.1
+			[[ -d '/usr/lib/i386-linux-gnu' ]] && G_EXEC rmdir --ignore-fail-on-non-empty /usr/lib/i386-linux-gnu
+		fi
+
+		software_id=197 # Box64
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 ))
+		then
+			Banner_Uninstalling
+			[[ -f '/usr/local/bin/box64' ]] && G_EXEC rm /usr/local/bin/box64
+			[[ -f '/etc/binfmt.d/box64.conf' ]] && G_EXEC rm /etc/binfmt.d/box64.conf
+			[[ -f '/usr/lib/x86_64-linux-gnu/libstdc++.so.6' ]] && G_EXEC rm /usr/lib/x86_64-linux-gnu/libstdc++.so.6
+			[[ -f '/usr/lib/x86_64-linux-gnu/libgcc_s.so.1' ]] && G_EXEC rm /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
+			[[ -d '/usr/lib/x86_64-linux-gnu' ]] && G_EXEC rmdir --ignore-fail-on-non-empty /usr/lib/x86_64-linux-gnu
 		fi
 
 		software_id=119 # CAVA
@@ -14760,7 +14758,7 @@ _EOF_
 		then
 			Banner_Uninstalling
 			G_AGP cava
-			rm -Rf /{root,home/*}/{.config/cava,cava.psf}
+			G_EXEC rm -Rf /{root,home/*}/{.config/cava,cava.psf}
 		fi
 
 		software_id=118 # Mopidy
@@ -16657,7 +16655,7 @@ _EOF_
 
 		fi
 
-		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Finalise uninstall'
+		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Finalising uninstall'
 
 		# Uninstall finished, set all uninstalled software to state 0 (not installed)
 		# - Apply same states to Allo and Allo_update
@@ -16701,12 +16699,14 @@ _EOF_
 		#----------------------------------------------------------------------
 		# Done, reset uninstall flag
 		UNINSTALL_REQUIRED=0
+		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Uninstall completed'
 		#----------------------------------------------------------------------
 
 	}
 
 	Run_Installations(){
 
+		G_NOTIFY_3_MODE='Step'
 		#------------------------------------------------------------
 		# Prevent continue if Network or NTPD is not completed: https://github.com/MichaIng/DietPi/issues/786
 		Check_Net_and_Time_sync
@@ -16756,6 +16756,8 @@ _EOF_
 		# Configure software, stop services of newly installed APT packages to reduce memory usage during config steps
 		/boot/dietpi/dietpi-services stop
 		Configure_Software
+
+		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Finalising install'
 
 		# Reload systemd units
 		G_EXEC systemctl daemon-reload
@@ -16824,6 +16826,8 @@ This requires an account at: https://remote.it/
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Setup steps prior to installs and network check
 	DietPi-Automation_Pre(){
+
+		G_NOTIFY_3_MODE='Step'
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Applying initial first run setup steps'
 
@@ -17016,7 +17020,7 @@ This requires an account at: https://remote.it/
 		# Automated installs
 		(( $AUTOINSTALL_ENABLED > 0 )) || return 0
 
-		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Running automated installation'
+		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Running automated install'
 
 		TARGETMENUID=-1 # Skip menu loop
 		GOSTARTINSTALL=1 # Set install start flag
@@ -18404,7 +18408,7 @@ List of installed software and their online documentation URLs:
 	# DietPi-Automation post install steps
 	(( $G_DIETPI_INSTALL_STAGE == 2 )) || DietPi-Automation_Post
 
-	G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Installation completed'
+	G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Install completed'
 
 	# Upload DietPi-Survey Data, if opted in, prompt user choice, if no settings file exists
 	# - Skip, if G_SERVICE_CONTROL == 0, which is exported by patch_file (DietPi-Update) which sends survey already

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9871,19 +9871,21 @@ After=network-online.target dietpi-boot.service
 
 [Service]
 User=minidlna
-RuntimeDirectory=minidlna
-ExecStart=$(command -v minidlnad) -S -R -f /etc/minidlna.conf
+ExecStart=$(command -v minidlnad) -S -R -f /etc/minidlna.conf -P /dev/null
 
 [Install]
 WantedBy=multi-user.target
 _EOF_
+			# Bullseye: Debian patched forced file logging inside, overriding "-S": https://github.com/MichaIng/DietPi/issues/4745
+			(( $G_DISTRO < 6 )) || G_CONFIG_INJECT 'LogsDirectory=' 'LogsDirectory=minidlna' /etc/systemd/system/minidlna.service '^User='
+
 			# Config
 			G_BACKUP_FP /etc/minidlna.conf
 			dps_index=$software_id Download_Install 'minidlna.conf' /etc/minidlna.conf
 
 			# Cache
 			G_EXEC mkdir -p /mnt/dietpi_userdata/.MiniDLNA_Cache
-			G_EXEC chown -R minidlna:dietpi /mnt/dietpi_userdata/.MiniDLNA_Cache
+			G_EXEC chown -R minidlna:root /mnt/dietpi_userdata/.MiniDLNA_Cache
 
 			Download_Test_Media
 
@@ -14806,6 +14808,7 @@ _EOF_
 			getent passwd minidlna > /dev/null && userdel minidlna
 			getent group minidlna > /dev/null && groupdel minidlna
 			[[ -d '/mnt/dietpi_userdata/.MiniDLNA_Cache' ]] && G_EXEC rm -R /mnt/dietpi_userdata/.MiniDLNA_Cache
+			[[ -d '/var/log/minidlna' ]] && G_EXEC rm -R /var/log/minidlna
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3609,6 +3609,7 @@ _EOF_
 			Banner_Installing
 
 			local deflate=
+			local openssl=
 
 			# Migrate existing configs in case of distro upgrades
 			if [[ $G_DISTRO -gt 4 && -f '/etc/lighttpd/lighttpd.conf' ]]
@@ -3628,18 +3629,28 @@ _EOF_
 					G_EXEC sed -i '/^[[:blank:]]*"mod_compress",$/d' /etc/lighttpd/lighttpd.conf
 					deflate='lighttpd-mod-deflate'
 				fi
+
+				# Bullseye: Install OpenSSL module if DietPi-LetsEncrypt was used
+				if [[ $G_DISTRO -gt 5 && -f '/boot/dietpi/.dietpi-letsencrypt' ]]
+				then
+					G_DIETPI-NOTIFY 2 'DietPi-LetsEncrypt usage detected: Installing OpenSSL module'
+					openssl='lighttpd-mod-openssl'
+				fi
 			fi
 
 			# Apply preference index
 			INDEX_WEBSERVER_TARGET=-2 INDEX_WEBSERVER_CURRENT=-2
 
 			# perl is required for lighty-enable-mod, it has been degraded to recommends only with Buster.
-			G_AGI lighttpd perl $deflate
+			G_AGI lighttpd perl $deflate $openssl
 
 			Remove_SysV lighttpd
 
 			# Enable mod_deflate, if flagged
 			[[ $deflate && ! -f '/etc/lighttpd/conf-enabled/20-deflate.conf' ]] && G_EXEC lighty-enable-mod deflate
+
+			# Enable mod_openssl, if flagged
+			[[ $openssl && ! -f '/etc/lighttpd/conf-enabled/10-ssl.conf' ]] && G_EXEC lighty-enable-mod openssl
 
 			# Change webroot from /var/www/html to /var/www
 			G_CONFIG_INJECT 'server.document-root' 'server.document-root = "/var/www"' /etc/lighttpd/lighttpd.conf

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8371,7 +8371,7 @@ _EOF_
 				G_EXEC cd /mnt/dietpi_userdata/filebrowser
 				G_EXEC /opt/filebrowser/filebrowser config init
 				G_EXEC /opt/filebrowser/filebrowser config set -a 0.0.0.0 -p 8085 -r /mnt
-				G_EXEC_DESC="Setting up File Browser login user 'dietpi'" G_EXEC /opt/filebrowser/filebrowser users add dietpi "$GLOBAL_PW"
+				G_EXEC_DESC="Setting up File Browser login user 'dietpi'" G_EXEC /opt/filebrowser/filebrowser users add dietpi "$GLOBAL_PW" --perm.admin
 			fi
 
 			# Permissions

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -674,6 +674,16 @@ INDEX_BROWSER_TARGET=$INDEX_BROWSER_TARGET"
 		aSOFTWARE_INTERACTIVE[$software_id]=1
 		# Not currently available on arm64: https://github.com/badaix/snapcast/issues/706
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,3]=0
+		#------------------
+		software_id=199
+
+		aSOFTWARE_NAME[$software_id]='Spotifyd'
+		aSOFTWARE_DESC[$software_id]='Open source Spotify client running as UNIX daemon'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#spotifyd'
+		aSOFTWARE_DEPS[$software_id]='5'
+		# - ARMv8
+		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,3]=0
 
 		# BitTorrent & Download
 		#--------------------------------------------------------------------------------
@@ -7051,8 +7061,24 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
+
+			# Download and merge into existing directory
 			Download_Install 'https://github.com/Fornoth/spotify-connect-web/releases/download/0.0.4-alpha/spotify-connect-web_0.0.4-alpha.tar.gz' /mnt/dietpi_userdata
 
+			# Service
+			cat << '_EOF_' > /etc/systemd/system/spotify-connect-web.service
+[Unit]
+Description=Spotify Connect Web (DietPi)
+Wants=network-online.target
+After=network-online.target sound.target
+
+[Service]
+WorkingDirectory=/mnt/dietpi_userdata/spotify-connect-web
+ExecStart=/mnt/dietpi_userdata/spotify-connect-web/spotify-connect-web
+
+[Install]
+WantedBy=multi-user.target
+_EOF_
 		fi
 
 		software_id=142 # CouchPotato
@@ -8240,7 +8266,7 @@ _EOF_
 			DEPS_LIST='libusb-0.1 libcurl3-gnutls'
 
 			# Reinstall: Clean old install dir
-			[[ -d '/opt/domoticz' ]] && rm -R /opt/domoticz
+			[[ -d '/opt/domoticz' ]] && G_EXEC rm -R /opt/domoticz
 			Download_Install "https://releases.domoticz.com/releases/release/domoticz_linux_${G_HW_ARCH_NAME/armv6l/armv7l}.tgz" /opt/domoticz
 
 		fi
@@ -8367,9 +8393,70 @@ ExecStart=/opt/filebrowser/filebrowser -d /mnt/dietpi_userdata/filebrowser/fileb
 [Install]
 WantedBy=multi-user.target
 _EOF_
-			
 		fi
-		
+
+		software_id=199 # Spotifyd
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+
+			Banner_Installing 
+
+			# ARMv6
+			local fallback_url='https://github.com/Spotifyd/spotifyd/releases/download/v0.3.2/spotifyd-linux-armv6-slim.tar.gz'
+			local file='spotifyd-linux-armv6-slim'
+
+			case $G_HW_ARCH in
+				# ARMv7
+				2)
+					fallback_url="https://github.com/Spotifyd/spotifyd/releases/download/v0.3.2/spotifyd-linux-armhf-full.tar.gz"
+					file='spotifyd-linux-armhf-full'
+				;;
+				# x86_64
+				10)
+					fallback_url="https://github.com/Spotifyd/spotifyd/releases/download/v0.3.2/spotifyd-linux-full.tar.gz"
+					file='spotifyd-linux-full'
+				;;
+			esac
+
+			# Reinstall: Remove old install dir
+			[[ -d '/opt/spotifyd' ]] && G_EXEC rm -R /opt/spotifyd
+
+			# x86_64 only deps: Both ARM binaries are not compiled against these. dbus would be required for MPRIS support, but let's keep it slim for now.
+			(( $G_HW_ARCH == 10 )) && DEPS_LIST='libdbus-1-3 libpulse0'
+
+			Download_Install "$(curl -sSfL 'https://api.github.com/repos/Spotifyd/spotifyd/releases/latest' | mawk -F\" "/\"browser_download_url\": .*\/$file\.tar\.gz\"/{print \$4}")" /opt/spotifyd
+
+			# User
+			Create_User -g audio -d /mnt/dietpi_userdata/spotifyd spotifyd
+
+			# Config: Do not touch on reinstall
+			if [[ ! -f '/mnt/dietpi_userdata/spotifyd/spotifyd.conf' ]]
+			then
+				G_EXEC mkdir -p /mnt/dietpi_userdata/spotifyd/cache
+				dps_index=$software_id Download_Install 'spotifyd.conf' /mnt/dietpi_userdata/spotifyd/spotifyd.conf
+				G_EXEC chmod 0600 /mnt/dietpi_userdata/spotifyd/spotifyd.conf
+			fi
+
+			# Service
+			cat << '_EOF_' > /etc/systemd/system/spotifyd.service
+[Unit]
+Description=Spotifyd (DietPi)
+Wants=network-online.target
+After=network-online.target sound.target
+
+[Service]
+User=spotifyd
+WorkingDirectory=/mnt/dietpi_userdata/spotifyd
+ExecStart=/opt/spotifyd/spotifyd --no-daemon --config-path=/mnt/dietpi_userdata/spotifyd/spotifyd.conf
+
+[Install]
+WantedBy=multi-user.target
+_EOF_
+			# Permissions
+			G_EXEC chown -R spotifyd:root /mnt/dietpi_userdata/spotifyd
+			G_EXEC chmod +x /opt/spotifyd/spotifyd
+
+		fi
+
 	}
 
 	Apply_SSHServer_Choices(){
@@ -12590,26 +12677,6 @@ WantedBy=multi-user.target
 _EOF_
 		fi
 
-		software_id=141 # Spotify Connect Web
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
-			Banner_Configuration
-
-			cat << '_EOF_' > /etc/systemd/system/spotify-connect-web.service
-[Unit]
-Description=Spotify Connect Web (DietPi)
-Wants=network-online.target
-After=network-online.target sound.target
-
-[Service]
-WorkingDirectory=/mnt/dietpi_userdata/spotify-connect-web
-ExecStart=/mnt/dietpi_userdata/spotify-connect-web/spotify-connect-web
-
-[Install]
-WantedBy=multi-user.target
-_EOF_
-		fi
-
 		software_id=142 # CouchPotato
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
@@ -14349,12 +14416,12 @@ _EOF_
 			Banner_Uninstalling
 			if [[ -f '/etc/systemd/system/spotify-connect-web.service' ]]; then
 
-				systemctl disable --now spotify-connect-web
-				rm -R /etc/systemd/system/spotify-connect-web.service*
+				G_EXEC systemctl disable --now spotify-connect-web
+				G_EXEC rm /etc/systemd/system/spotify-connect-web.service
 
 			fi
-			[[ -d '/etc/systemd/system/spotify-connect-web.service.d' ]] && rm -R /etc/systemd/system/spotify-connect-web.service.d
-			[[ -d '/mnt/dietpi_userdata/spotify-connect-web' ]] && rm -R /mnt/dietpi_userdata/spotify-connect-web
+			[[ -d '/etc/systemd/system/spotify-connect-web.service.d' ]] && G_EXEC rm -R /etc/systemd/system/spotify-connect-web.service.d
+			[[ -d '/mnt/dietpi_userdata/spotify-connect-web' ]] && G_EXEC rm -R /mnt/dietpi_userdata/spotify-connect-web
 
 		fi
 
@@ -15778,12 +15845,13 @@ _EOF_
 
 		fi
 
-		software_id=167
+		software_id=167 # Raspotify
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
 			G_AGP raspotify
-			[[ -f '/etc/apt/sources.list.d/raspotify.list' ]] && rm /etc/apt/sources.list.d/raspotify.list
+			[[ -f '/etc/apt/sources.list.d/raspotify.list' ]] && G_EXEC rm /etc/apt/sources.list.d/raspotify.list
+			[[ -f '/etc/apt/trusted.gpg.d/dietpi-raspotify.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-raspotify.gpg
 
 		fi
 
@@ -16568,6 +16636,25 @@ _EOF_
 			# Remove user and home directory
 			getent passwd filebrowser > /dev/null && G_EXEC userdel filebrowser
 			[[ -d '/mnt/dietpi_userdata/filebrowser' ]] && G_EXEC rm -R /mnt/dietpi_userdata/filebrowser
+		fi
+
+		software_id=199 # Spotifyd
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
+
+			Banner_Uninstalling
+			# Service
+			if [[ -f '/etc/systemd/system/spotifyd.service' ]]
+			then
+				G_EXEC systemctl disable --now spotifyd
+				G_EXEC rm /etc/systemd/system/spotifyd.service
+			fi
+			[[ -d '/etc/systemd/system/spotifyd.service.d' ]] && G_EXEC rm -R /etc/systemd/system/spotifyd.service.d
+			# User
+			getent passwd spotifyd > /dev/null && G_EXEC userdel spotifyd
+			# Files
+			[[ -d '/opt/spotifyd' ]] && G_EXEC rm -R /opt/spotifyd
+			[[ -d '/mnt/dietpi_userdata/spotifyd' ]] && G_EXEC rm -R /mnt/dietpi_userdata/spotifyd
+
 		fi
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Finalise uninstall'

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -57,7 +57,7 @@
 	# - Assign defaults/code version as fallback
 	[[ $G_DIETPI_VERSION_CORE ]] || G_DIETPI_VERSION_CORE=7
 	[[ $G_DIETPI_VERSION_SUB ]] || G_DIETPI_VERSION_SUB=6
-	[[ $G_DIETPI_VERSION_RC ]] || G_DIETPI_VERSION_RC=1
+	[[ $G_DIETPI_VERSION_RC ]] || G_DIETPI_VERSION_RC=2
 	[[ $G_GITBRANCH ]] || G_GITBRANCH='master'
 	[[ $G_GITOWNER ]] || G_GITOWNER='MichaIng'
 	# - Save current version and Git branch
@@ -461,7 +461,7 @@ $grey─────────────────────────
 
 		# Update backtitle
 		WHIP_BACKTITLE=$G_HW_MODEL_NAME
-		[[ -r '/run/dietpi/.network' ]] && WHIP_BACKTITLE+=" | IP: $(mawk 'NR==4' /run/dietpi/.network)"
+		[[ -f '/run/dietpi/.network' ]] && WHIP_BACKTITLE+=" | IP: $(mawk 'NR==4' /run/dietpi/.network)"
 
 		# Set default button text, if not defined
 		G_WHIP_BUTTON_OK_TEXT=${G_WHIP_BUTTON_OK_TEXT:-Ok}
@@ -791,7 +791,7 @@ $grey─────────────────────────
 		then
 			local WHIP_ERROR WHIP_BACKTITLE WHIP_SCROLLTEXT WHIP_SIZE_X WHIP_SIZE_Y WHIP_SIZE_Z WHIP_MESSAGE=$*
 			G_WHIP_INIT 3
-			G_WHIP_RETURNED_VALUE=$(whiptail ${G_PROGRAM_NAME:+--title "$G_PROGRAM_NAME"} --backtitle "$WHIP_BACKTITLE" --checklist "$WHIP_MESSAGE" --separate-output --ok-button "$G_WHIP_BUTTON_OK_TEXT" --cancel-button "$G_WHIP_BUTTON_CANCEL_TEXT" --default-item "$G_WHIP_DEFAULT_ITEM" $WHIP_SCROLLTEXT "$WHIP_SIZE_Y" "$WHIP_SIZE_X" $WHIP_SIZE_Z "${G_WHIP_CHECKLIST_ARRAY[@]}" 3>&1 1>&2 2>&3-; echo $? > /tmp/.WHIP_CHECKLIST_RESULT)
+			G_WHIP_RETURNED_VALUE=$(whiptail ${G_PROGRAM_NAME:+--title "$G_PROGRAM_NAME"} --backtitle "$WHIP_BACKTITLE | Use spacebar to toggle selection" --checklist "$WHIP_MESSAGE" --separate-output --ok-button "$G_WHIP_BUTTON_OK_TEXT" --cancel-button "$G_WHIP_BUTTON_CANCEL_TEXT" --default-item "$G_WHIP_DEFAULT_ITEM" $WHIP_SCROLLTEXT "$WHIP_SIZE_Y" "$WHIP_SIZE_X" $WHIP_SIZE_Z "${G_WHIP_CHECKLIST_ARRAY[@]}" 3>&1 1>&2 2>&3-; echo $? > /tmp/.WHIP_CHECKLIST_RESULT)
 			G_WHIP_RETURNED_VALUE=$(echo -e "$G_WHIP_RETURNED_VALUE" | tr '\n' ' ')
 			result=$(</tmp/.WHIP_CHECKLIST_RESULT); rm -f /tmp/.WHIP_CHECKLIST_RESULT
 		fi
@@ -917,7 +917,6 @@ $log_content
 			# Enter error handler menu loop in interactive mode
 			[[ $G_INTERACTIVE == 1 ]] && while :
 			do
-
 				G_WHIP_MENU_ARRAY=('Retry' ': Re-run the last command that failed')
 				# Add targeted solution suggestions, passed via $G_EXEC_ARRAY_TEXT[] and $G_EXEC_ARRAY_ACTION[${G_EXEC_ARRAY_TEXT[]}]
 				[[ $G_EXEC_ARRAY_TEXT ]] && G_WHIP_MENU_ARRAY+=("${G_EXEC_ARRAY_TEXT[@]}")
@@ -991,7 +990,6 @@ $log_content" || break # Exit error handler menu loop on cancel
 					read -rp 'Press any key to return to error handler menu...'
 
 				fi
-
 			done
 
 			# Error has not been solved, print GitHub issue template if it was produced and exit error handler menu loop
@@ -2001,8 +1999,6 @@ could not be found in file \$3
 
 	}
 
-	#-----------------------------------------------------------------------------------
-	[[ $G_DEBUG == 1 ]] && G_DIETPI-NOTIFY 2 'DietPi-Globals loaded'
 	#-----------------------------------------------------------------------------------
 	: # Return exit code 0, by triggering null as last command to output
 	#-----------------------------------------------------------------------------------


### PR DESCRIPTION
### Beta v7.6.2
_(2021-09-18)_

#### New software since v7.6.1
- Spotifyd | Spotifyd streams music just like the official client, but is more lightweight. It also supports the Spotify Connect protocol, which makes it show up as a device that can be controlled from the official clients. Many thanks to @ressu for implementing this software title: https://github.com/MichaIng/DietPi/pull/4713

#### Fixes since v7.6.1
- DietPi-Software | ReadyMedia: Resolved an issue on Bullseye where the service does not start unless the log directory is manually created. Due to a Debian package patch, on Bullseye logs are forced to file logging again, so that /var/log/minidlna again needs to exist. Many thanks to @AnzoP for reporting this issue: https://github.com/MichaIng/DietPi/issues/4745