### PR TITLE
DietPi-Live_patches | Fix a bug with Deluge on Bullseye

### DIFF
--- a/.update/version
+++ b/.update/version
@@ -31,5 +31,5 @@ G_LIVE_PATCH=(
 	[1]='sed -Ei "s#s/'\''http://localhost/(own|next)cloud'\''/'\''https://\\\$primary_domain/(own|next)cloud'\''/#s|'\''http://localhost/\1cloud'\''|'\''https://\$primary_domain/\1cloud'\''|#" /boot/dietpi/dietpi-letsencrypt'
 	[2]='sed -i "s/lighty-enable-mod openssl/lighty-enable-mod ssl/" /boot/dietpi/dietpi-software'
 	[3]='sed -i "s/\$G_HW_MODEL -le 9 || \$G_HW_MODEL == 1\[56\]/\$G_HW_MODEL -le 9 \&\& \$(dpkg --print-architecture) == '\''armhf'\'' || \$G_HW_MODEL == 1\[56\]/" /boot/dietpi/dietpi-software'
-	[4]='sed -i "s/deluge-web) -l/deluge-web) -d -l" /boot/dietpi/dietpi-software'
+	[4]='sed -i "s/deluge-web) -l/deluge-web) -d -l/" /boot/dietpi/dietpi-software'
 )

--- a/.update/version
+++ b/.update/version
@@ -17,16 +17,19 @@ G_LIVE_PATCH_DESC=(
 	[1]='Fixes a bug in DietPi-LetsEncrypt which makes it fail when ownCloud or Nextcloud are installed: https://github.com/MichaIng/DietPi/issues/4752'
 	[2]='Fixes a bug in DietPi-Software where the Buster => Bullseye upgrade, following our guide, fails if HTTPS was enabled via DietPi-LetsEncrypt before: https://dietpi.com/phpbb/viewtopic.php?t=9477'
 	[3]='Fixes a bug in DietPi-Software where Kodi fails on RPi ARMv8/64-bit systems when installed without a desktop: https://dietpi.com/phpbb/viewtopic.php?p=38079#p38079'
+	[4]='Fixes a bug in DietPi-Software where the Deluge web interface fails to start on Bullseye: https://github.com/MichaIng/DietPi/issues/4785'
 )
 G_LIVE_PATCH_COND=(
 	[0]='false'
 	[1]='grep -Eq "s/'\''http://localhost/(own|next)cloud'\''/'\''https://\\\$primary_domain/(own|next)cloud'\''/" /boot/dietpi/dietpi-letsencrypt'
 	[2]='grep -q "lighty-enable-mod openssl" /boot/dietpi/dietpi-software'
 	[3]='grep -q "\$G_HW_MODEL -le 9 || \$G_HW_MODEL == 1\[56\]" /boot/dietpi/dietpi-software'
+	[4]='(( $G_DISTRO > 5 )) && ! grep -E "deluge-web)? -d" /boot/dietpi/dietpi-software'
 )
 G_LIVE_PATCH=(
 	[0]=':'
 	[1]='sed -Ei "s#s/'\''http://localhost/(own|next)cloud'\''/'\''https://\\\$primary_domain/(own|next)cloud'\''/#s|'\''http://localhost/\1cloud'\''|'\''https://\$primary_domain/\1cloud'\''|#" /boot/dietpi/dietpi-letsencrypt'
 	[2]='sed -i "s/lighty-enable-mod openssl/lighty-enable-mod ssl/" /boot/dietpi/dietpi-software'
 	[3]='sed -i "s/\$G_HW_MODEL -le 9 || \$G_HW_MODEL == 1\[56\]/\$G_HW_MODEL -le 9 \&\& \$(dpkg --print-architecture) == '\''armhf'\'' || \$G_HW_MODEL == 1\[56\]/" /boot/dietpi/dietpi-software'
+	[4]='sed -i "s/deluge-web) -l/deluge-web) -d -l" /boot/dietpi/dietpi-software'
 )


### PR DESCRIPTION
**Status**: WIP

**Commit list/description**:
+ DietPi-Live_patches | Fix a bug in DietPi-Software where the Deluge web interface fails to start on Bullseye: https://github.com/MichaIng/DietPi/issues/4785