### PR TITLE
DietPi-Banner | Use Cloudflare worker on own domain for GeoIP

### DIFF
--- a/.update/patches
+++ b/.update/patches
@@ -157,13 +157,6 @@ Patch_7_2()
 \nYou may upgrade via: dietpi-software reinstall 86
 \nNB: Roon extensions which were installed via the legacy method must be reinstalled with the new Roon Extension Manager. Extensions which were installed as Docker images already, will continue to function.'
 
-	# Pi-hole: Whitelist domain of GEO IP API we use in banner and DietPi-VPN as this is part of public blocklists: https://github.com/MichaIng/DietPi/pull/4398#issuecomment-845477200
-	if command -v pihole > /dev/null
-	then
-		G_DIETPI-NOTIFY 2 'Whitelisting "freegeoip.app" in Pi-hole, which is used by dietpi-banner and dietpi-vpn to obtain your public IP and location...'
-		pihole -w freegeoip.app --comment 'Used by dietpi-banner and dietpi-vpn to obtain your public IP and location'
-	fi
-
 	# Inform about available software updates
 	if [[ -f '/boot/dietpi/.installed' ]]
 	then

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ Remove software:
 - CouchPotato | Sadly, the CouchPotato project is not maintained anymore and has been abandoned. In turn we removed it from DietPi. The instance installed on your system will remain, but it cannot be installed, reinstalled or uninstalled anymore. We recommend to migrate to an alternative project, like Radarr, which can be found in DietPi-Software was well. Manual CouchPotato uninstall instructions: https://github.com/MichaIng/DietPi/issues/4323#issuecomment-927128724
 
 Changes:
+- DietPi-Globals | G_GET_WAN_IP: We use our own GEO IP service now to show the systems WAN IP and location in the DietPi banner and DietPi-VPN. When Pi-hole was used, with a previous update, "freegeoip.app" was added to Pi-hole's whitlist, which is now not required anymore. You may hence remove that entry from the whitelist.
 - DietPi-Login | The DietPi banner on login won't be shown anymore if ~/.hushlogin exists, which is a common method to prevent the shell from printing /etc/motd on login and should hence be respected for the DietPi banner as well. Many thanks to @dnknth for doing this suggestion: https://github.com/MichaIng/DietPi/issues/4786
 
 Fixes:

--- a/dietpi/dietpi-vpn
+++ b/dietpi/dietpi-vpn
@@ -68,7 +68,7 @@ Available commands:
 	RX='N/A'
 	TX='N/A'
 
-	Update_WAN_IP(){ WAN_IP=$(G_GET_WAN_IP); }
+	Update_WAN_IP(){ WAN_IP=$(G_GET_WAN_IP 2>&1); }
 
 	Check_Connected()
 	{

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -227,7 +227,7 @@ $GREEN_LINE"
 		# LAN IP [5]
 		Print_Local_Ip
 		# WAN IP + location info: Move this to /run/dietpi/.network?
-		(( ${aENABLED[6]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[6]} $GREEN_SEPARATOR $(G_GET_WAN_IP)"
+		(( ${aENABLED[6]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[6]} $GREEN_SEPARATOR $(G_GET_WAN_IP 2>&1)"
 		# DietPi-VPN connection status
 		(( ${aENABLED[13]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[13]} $GREEN_SEPARATOR $(/boot/dietpi/dietpi-vpn status 2>&1)"
 		# Freespace (RootFS)
@@ -235,14 +235,14 @@ $GREEN_LINE"
 		# Freespace (DietPi userdata)
 		(( ${aENABLED[8]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[8]} $GREEN_SEPARATOR $(df -h --output=avail /mnt/dietpi_userdata | mawk 'NR==2 {print $1}' 2>&1)"
 		# Weather
-		(( ${aENABLED[9]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[9]} $GREEN_SEPARATOR $(curl -sSfLm 3 https://wttr.in/?format=4 2>&1)"
+		(( ${aENABLED[9]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[9]} $GREEN_SEPARATOR $(curl -sSfLm 3 'https://wttr.in/?format=4' 2>&1)"
 		# Custom
 		[[ ${aENABLED[10]} == 1 && -x $FP_CUSTOM ]] && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[10]} $GREEN_SEPARATOR $(bash $FP_CUSTOM 2>&1)"
 		# MOTD
 		if (( ${aENABLED[12]} == 1 )); then
 
 			local motd fp_motd='/run/dietpi/.dietpi_motd'
-			[[ -f $fp_motd ]] || curl -sSfLm 3 https://dietpi.com/motd -o $fp_motd
+			[[ -f $fp_motd ]] || curl -sSfLm 3 'https://dietpi.com/motd' -o $fp_motd
 			[[ -f $fp_motd ]] && . $fp_motd &> /dev/null && [[ $motd ]] && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[12]} $GREEN_SEPARATOR $motd"
 
 		fi

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -1177,10 +1177,7 @@ $log_content" || break # Exit error handler menu loop on cancel
 			esac
 			shift
 		done
-		local response=$(curl -sSfLm "$timeout" https://freegeoip.app/csv/ 2>&1 | mawk -F, '($5){r=$5" "}{print $1" "r$3}')
-		# https://github.com/MichaIng/DietPi/issues/4445
-		[[ $response == 'curl: (60)'* ]] && response='freegeoip.app seems to be blocked via DNS, please add it to the whitelist to allow WAN IP retrieval.'
-		echo "$response"		
+		curl -sSfLm "$timeout" 'https://dietpi.com/geoip'
 	}
 
 	# $1 = directory to test permissions support


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Banner | Use Cloudflare worker on own domain to provide GeoIP information

This should once and for all solve those nasty blocklist issues as long as we take care that no unintended 3rd parties start to use it (in which case we may implement a user agent or headers based filter).

One change compared to the previous solution is that the country is shown with the two letter country code, e.g. `DE` instead of `Germany`. There is no native Cloudflare workers API to get the long name. It is trivial to add additional fields to the response, e.g. we can achieve this via GET parameters in future DietPi versions, keeping the default `<IP> [<region if available] <country>` if no query string is passed, to keep backwards compatibility.

Another thing: I'm not sure how the public APIs handle it, but in our case, AFAIK a proxy will lead to the proxy servers IP and location being shown, as we do not respect the proxy headers, just the Cloudflare request headers. But could be tested, probably Cloudflare itself overrides its client IP header with the proxy header, when present. I however think this is actually fine so that one can check whether a proxy is used as expected, similar to how the VPN server IP is shown when a VPN is used (in which case there is no original client header available, of course).