### PR TITLE
DietPi-Software | Home Assistant: Bump Python to v3.9.7

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,7 @@ Fixes:
 - DietPi-Software | Lighttpd: Resolved an issue where the upgrade from Buster to Bullseye, following our guide, fails if HTTPS was enabled via DietPi-LetsEncrypt before. Many thanks to @fhals for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=9477
 - DietPi-Software | Kodi: Resolved an issue on RPi ARMv8/64-bit systems where Kodi fails to start when it was installed without a desktop. Many thanks to @Klola for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?p=38079#p38079
 - DietPi-Software | Deluge: Resolved an issue on Bullseye where the web interface service did not start as a new command line flag "-d" is required to keep it in foregound. Many thanks to @quyentruong for reporting this issue: https://github.com/MichaIng/DietPi/issues/4785
+- DietPi-Software | Home Assistant: The Python version compiled with Home Assistant has been bumped to v3.9.7, which resolves and issue with installs on 32-bit ARM systems. Many thanks to @Przemek for reporting this issue: https://github.com/MichaIng/DietPi/issues/4372#issuecomment-936656595
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8132,7 +8132,7 @@ _EOF_
 			local custom_apt_deps=$(sed -n '/^[[:blank:]]*SOFTWARE_HOMEASSISTANT_APT_DEPS=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			# - All: gcc, libc6-dev, make, libssl-dev, zlib1g-dev for Python built and libbz2-dev, libreadline-dev, libsqlite3-dev to suppress warnings
 			# - All: libffi-dev for cffi on ARMv6/7 and for python-slugify==4.0.1 on ARMv8/x86_64
-			DEPS_LIST="gcc libc6-dev make libssl-dev zlib1g-dev libffi-dev libbz2-dev libreadline-dev libsqlite3-dev $custom_apt_deps"
+			DEPS_LIST="gcc libc6-dev make libssl-dev zlib1g-dev libffi-dev libbz2-dev libreadline-dev libsqlite3-dev libopenjp2-7 $custom_apt_deps"
 			# - ARMv6/7: libjpeg-dev for Pillow and g++ for greenlet
 			[[ $G_HW_ARCH == [12] ]] && DEPS_LIST+=' libjpeg-dev g++'
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8112,7 +8112,7 @@ _EOF_
 			local ha_user='homeassistant'
 			local ha_home="/home/$ha_user"
 			local ha_pyenv_activation=". $ha_home/pyenv-activate.sh"
-			local ha_python_version='3.8.11'
+			local ha_python_version='3.9.7'
 
 			G_DIETPI-NOTIFY 2 "Home Assistant user:  $ha_user"
 			G_DIETPI-NOTIFY 2 "Home Assistant home:  $ha_home"


### PR DESCRIPTION
**Status**: Ready