### PR TITLE
DietPi-Software | Home Assistant: Redo dependencies depending on architecture

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,7 @@ Fixes:
 - DietPi-Software | Kodi: Resolved an issue on RPi ARMv8/64-bit systems where Kodi fails to start when it was installed without a desktop. Many thanks to @Klola for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?p=38079#p38079
 - DietPi-Software | Deluge: Resolved an issue on Bullseye where the web interface service did not start as a new command line flag "-d" is required to keep it in foregound. Many thanks to @quyentruong for reporting this issue: https://github.com/MichaIng/DietPi/issues/4785
 - DietPi-Software | Home Assistant: The Python version compiled with Home Assistant has been bumped to v3.9.7, which resolves and issue with installs on 32-bit ARM systems. Many thanks to @Przemek for reporting this issue: https://github.com/MichaIng/DietPi/issues/4372#issuecomment-936656595
+- DietPi-Software | Home Assistant: Resolved an issue where Home Assistant did not start on ARM systems due to newly required runtime libraries.
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8132,9 +8132,9 @@ _EOF_
 			local custom_apt_deps=$(sed -n '/^[[:blank:]]*SOFTWARE_HOMEASSISTANT_APT_DEPS=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			# - All: gcc, libc6-dev, make, libssl-dev, zlib1g-dev for Python built and libbz2-dev, libreadline-dev, libsqlite3-dev to suppress warnings
 			# - All: libffi-dev for cffi on ARMv6/7 and for python-slugify==4.0.1 on ARMv8/x86_64
-			DEPS_LIST="gcc libc6-dev make libssl-dev zlib1g-dev libffi-dev libbz2-dev libreadline-dev libsqlite3-dev libopenjp2-7 libtiff5 $custom_apt_deps"
-			# - ARMv6/7: libjpeg-dev for Pillow and g++ for greenlet
-			[[ $G_HW_ARCH == [12] ]] && DEPS_LIST+=' libjpeg-dev g++'
+			DEPS_LIST="gcc libc6-dev make libssl-dev zlib1g-dev libffi-dev libbz2-dev libreadline-dev libsqlite3-dev $custom_apt_deps"
+			# - ARMv6/7: libjpeg-dev for Pillow, g++ for greenlet and libopenjp2-7 + libtiff5 for runtime
+			[[ $G_HW_ARCH == [12] ]] && DEPS_LIST+=' libjpeg-dev g++ libopenjp2-7 libtiff5'
 
 			# Install pyenv to $ha_home
 			G_EXEC mkdir -p $ha_home

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8133,8 +8133,8 @@ _EOF_
 			# - All: gcc, libc6-dev, make, libssl-dev, zlib1g-dev for Python built and libbz2-dev, libreadline-dev, libsqlite3-dev to suppress warnings
 			# - All: libffi-dev for cffi on ARMv6/7 and for python-slugify==4.0.1 on ARMv8/x86_64
 			DEPS_LIST="gcc libc6-dev make libssl-dev zlib1g-dev libffi-dev libbz2-dev libreadline-dev libsqlite3-dev $custom_apt_deps"
-			# - ARMv6/7: libjpeg-dev for Pillow, g++ for greenlet and libopenjp2-7 + libtiff5 for runtime
-			[[ $G_HW_ARCH == [12] ]] && DEPS_LIST+=' libjpeg-dev g++ libopenjp2-7 libtiff5'
+			# - ARMv6/7: libjpeg-dev for Pillow, g++ for greenlet and libopenjp2-7 + libtiff5 + libxcb1 for runtime
+			[[ $G_HW_ARCH == [12] ]] && DEPS_LIST+=' libjpeg-dev g++ libopenjp2-7 libtiff5 libxcb1'
 
 			# Install pyenv to $ha_home
 			G_EXEC mkdir -p $ha_home


### PR DESCRIPTION
**Status**: Ready

**ToDo**:
- [x] Check in which cases `libxcb1` is required: https://github.com/MichaIng/DietPi/pull/4809#issuecomment-937983327

**Commit list/description**:
+ DietPi-Software | Home Assistant: Redo dependencies depending on architecture