### PR TITLE
DietPi-Software | File Browser - change default port

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8635,7 +8635,7 @@ _EOF_
 			then
 				G_EXEC cd /mnt/dietpi_userdata/filebrowser
 				G_EXEC /opt/filebrowser/filebrowser config init
-				G_EXEC /opt/filebrowser/filebrowser config set -a 0.0.0.0 -p 8085 -r /mnt
+				G_EXEC /opt/filebrowser/filebrowser config set -a 0.0.0.0 -p 8084 -r /mnt
 				G_EXEC_DESC="Setting up File Browser login user 'dietpi'" G_EXEC /opt/filebrowser/filebrowser users add dietpi "$GLOBAL_PW" --perm.admin
 			fi
 


### PR DESCRIPTION
Default port `8085` is already in use by `HTPC Manager`, therefore we would need to change to `8084` which seems to be not in use atm. Change will be applicable for new installations only.

**Status**: Ready

**Reference**: https://dietpi.com/phpbb/viewtopic.php?t=9507

**Commit list/description**:
- DietPi-Software | File Browser - change default port to 8084
