### PR TITLE
DietPi-Software | vaultwarden: Set minimum memory requirement to 3/4 GiB

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7217,21 +7217,15 @@ _EOF_
 			[[ -d '/opt/vaultwarden' ]] && G_EXEC rm -R /opt/vaultwarden
 			G_EXEC mv "vaultwarden-$version" /opt/vaultwarden
 
-			# Assure 2 GiB overall memory (-100 MiB to avoid tiny swap space) is available and limit concurrent cargo build jobs to 2 if less than 3 GiB memory is available.
-			local jobs=
-			if (( $RAM_TOTAL < 1948 ))
+			# Assure 4 GiB overall memory (-200 MiB to avoid tiny swap space)
+			if (( $RAM_TOTAL < 3896 ))
 			then
-				G_DIETPI-NOTIFY 2 'Vaultwarden build requires at least 2 GiB memory. We will now increase your swap size to satisfy this requirement.'
-				/boot/dietpi/func/dietpi-set_swapfile 1
-				(( $G_HW_CPU_CORES > 2 )) && jobs=2
-
-			elif (( $RAM_TOTAL < 3072 && $G_HW_CPU_CORES > 2 ))
-			then
-				jobs=2
+				G_DIETPI-NOTIFY 2 'Vaultwarden build requires at least 4 GiB memory. We will now increase your swap size to satisfy this requirement.'
+				/boot/dietpi/func/dietpi-set_swapfile $(( 4096 - $RAM_TOTAL ))
 			fi
 
-			# Temporarily assure 1.5 GiB /tmp size for temporary Rust install
-			(( $(findmnt -bno SIZE /tmp) < 1610612736 )) && G_EXEC mount -o remount,size=1610612736 /tmp
+			# Temporarily assure 2 GiB /tmp size for temporary Rust install
+			(( $(findmnt -bno SIZE /tmp) < 2147483648 )) && G_EXEC mount -o remount,size=2G /tmp
 
 			# Clean APT cache (which includes temporarily downloaded archives) when moved to RAM
 			[[ -d '/tmp/apt' ]] && G_EXEC apt-get clean
@@ -7248,7 +7242,7 @@ _EOF_
 
 			# Build
 			G_EXEC cd /opt/vaultwarden
-			G_EXEC_OUTPUT=1 G_EXEC cargo build ${jobs:+-j $jobs} --features sqlite --release
+			G_EXEC_OUTPUT=1 G_EXEC cargo build --features sqlite --release
 			G_EXEC cd /tmp/$G_PROGRAM_NAME
 
 			# Uninstall rust after compiling

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7217,11 +7217,13 @@ _EOF_
 			[[ -d '/opt/vaultwarden' ]] && G_EXEC rm -R /opt/vaultwarden
 			G_EXEC mv "vaultwarden-$version" /opt/vaultwarden
 
-			# Assure 4 GiB overall memory (-200 MiB to avoid tiny swap space)
-			if (( $RAM_TOTAL < 3896 ))
+			# Assure 3 GiB overall memory on single-core and 4 GiB on multi-core systems (-200 MiB to avoid tiny swap space)
+			local ram_min=3
+			(( $(nproc) > 1 )) && ram_min=4
+			if (( $RAM_TOTAL < $ram_min * 1024 - 200 ))
 			then
-				G_DIETPI-NOTIFY 2 'Vaultwarden build requires at least 4 GiB memory. We will now increase your swap size to satisfy this requirement.'
-				/boot/dietpi/func/dietpi-set_swapfile $(( 4096 - $RAM_TOTAL ))
+				G_DIETPI-NOTIFY 2 "Vaultwarden build requires at least $ram_min GiB memory. We will now increase your swap size to satisfy this requirement."
+				/boot/dietpi/func/dietpi-set_swapfile $(( $ram_min * 1024 - $RAM_TOTAL ))
 			fi
 
 			# Temporarily assure 2 GiB /tmp size for temporary Rust install


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Software | vaultwarden: Set minimum memory requirement to 4 GiB to solve aborted builds, e.g. found on ARMv8. Make it a single case and always run all all processors to potentially speed up the build.