### PR TITLE
Fix the typo in dietpi-initramfs_cleanup script

### DIFF
--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -898,7 +898,8 @@ _EOF_
 			else
 				cat << '_EOF_' >> /etc/kernel/preinst.d/dietpi-initramfs_cleanup
 # loop through existing initramfs images
-for v in $(ls -1 /var/lib/initramfs-tools | linux-version sort --reverse); do
+for v in $(ls -1 /var/lib/initramfs-tools | linux-version sort --reverse);
+do
         if ! linux-version compare $v eq $version; then
                 # try to delete delete old initrd images via update-initramfs
                 INITRAMFS_TOOLS_KERNEL_HOOK=y update-initramfs -d -k $v 2>/dev/null


### PR DESCRIPTION
**Status**: Ready 
- [x] Fix the bug in `dietpi-initramfs_cleanup` script

**Reference**: https://github.com/MichaIng/DietPi/issues/4868

**Commit list/description**:
- Fix the typo in dietpi-initramfs_cleanup script
