### PR TITLE
DietPi-Live-patches | Patch 0: Deluge services fail on fresh installs

### DIFF
--- a/.update/version
+++ b/.update/version
@@ -12,6 +12,6 @@ G_MIN_DEBIAN=4
 # Alternative Git branch to automatically migrate to when Debian version is too low
 G_OLD_DEBIAN_BRANCH='jessie-support'
 # Live patches
-G_LIVE_PATCH_DESC=()
-G_LIVE_PATCH_COND=()
-G_LIVE_PATCH=()
+G_LIVE_PATCH_DESC=('Deluge services fail on fresh installs')
+G_LIVE_PATCH_COND=('grep -q " \\\$salt," /boot/dietpi/dietpi-software')
+G_LIVE_PATCH=('sed -Ei -e "/max_active_limit/s/1\)'\'',\"/1\),\"/" -e "/pwd_salt/s/ \\\$salt,/ \\\\\"\\\$salt\\\\\",/" -e "/pwd_sha1/s/ \\\$\(echo (.*)\),/ \\\\\"\\\$\(echo \1\)\\\\\",/" /boot/dietpi/dietpi-software')


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Live-patches | Patch 0: Deluge services fail on fresh installs