### PR TITLE
DietPi-Software | AdGuardHome

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10357,7 +10357,7 @@ _EOF_
 
 			# Permissions
 			G_EXEC chown -R adguardhome:adguardhome /mnt/dietpi_userdata/adguardhome
-			G_EXEC chmod 0755 /mnt/dietpi_userdata/adguardhome/AdGuardHome
+			G_EXEC chmod 0755 /mnt/dietpi_userdata/adguardhome/AdGuardHome{,.yaml}
 
 			# Service
 			cat << '_EOF_' > /etc/systemd/system/adguardhome.service

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10357,7 +10357,8 @@ _EOF_
 
 			# Permissions
 			G_EXEC chown -R adguardhome:adguardhome /mnt/dietpi_userdata/adguardhome
-			G_EXEC chmod 0755 /mnt/dietpi_userdata/adguardhome/AdGuardHome{,.yaml}
+			G_EXEC chmod 0755 /mnt/dietpi_userdata/adguardhome/AdGuardHome
+			G_EXEC chmod 0600 /mnt/dietpi_userdata/adguardhome/AdGuardHome.yaml
 
 			# Service
 			cat << '_EOF_' > /etc/systemd/system/adguardhome.service


### PR DESCRIPTION
AGH server is not able to start if user directory has been moved an external ntfs disk because configuration file will have incorrect permission.

```
---------- 1 adguardhome adguardhome     2589 Oct 17 09:34 AdGuardHome.yaml
```

To fix this, I extended permission adjustments we do during install to `AdGuardHome.yaml`

**Status**: Ready
- [x] Add config change

**Reference**: https://dietpi.com/phpbb/viewtopic.php?t=9551

**Commit list/description**:
- DietPi-Software | AdGuardHome - during install adjust file permission for config file as well
