### PR TITLE
Have Roon database in separate directory when installing Roon Server

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -13113,7 +13113,8 @@ After=network-online.target
 
 [Service]
 SyslogIdentifier=roonserver
-Environment=ROON_DATAROOT=/mnt/dietpi_userdata/roonserver
+Environment=ROON_DATAROOT=/mnt/dietpi_userdata/roondatabase
+Environment=ROON_ID_DIR=/mnt/dietpi_userdata/roondatabase
 Group=dietpi
 ExecStart=/mnt/dietpi_userdata/roonserver/start.sh
 
@@ -14592,6 +14593,10 @@ _EOF_
 			fi
 			[[ -d '/etc/systemd/system/roonserver.service.d' ]] && G_EXEC rm -R /etc/systemd/system/roonserver.service.d
 			[[ -d '/mnt/dietpi_userdata/roonserver' ]] && G_EXEC rm -R /mnt/dietpi_userdata/roonserver
+
+			G_DIETPI-NOTIFY 2 "Roon database is kept\n
+The Roon database directory /mnt/dietpi_userdata/roondatabase is kept.\n
+If you no longer need the library metadata, edits, playlists, settings, etc. then please manually remove this directory.\n"
 
 		fi
 


### PR DESCRIPTION
<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
**Status**: Ready (from my side)
- Confirmed the issue with current version
- Confirmed that with this change the issue is no longer there

**References**:
https://community.roonlabs.com/t/dietpi-server-on-nuc-update-issue/173775
https://community.roonlabs.com/t/after-updating-roon-on-dietpi-os-loss-of-database/95179
https://dietpi.com/phpbb/viewtopic.php?t=7543

**Commit list/description**:
<!--
- DietPi-Config | Add "Fan control" option to "Performance Options"
![Screenshot](https://xxx.github.com/images/xxx.png)
- DietPi-Config | Add "Fan control" support for Odroid C2
- DietPi-Config | Syntax fix
-->
- DietPi-Software | Have Roon database in separate directory when installing Roon Server

Hi DietPi team,

There are multiple reports, both in the Roon and Dietpi community, that when Roon Server is installed in DietPi (x86) and the Roon Labs team pushes an update of the Roon Server that the database gets destroyed. Reports are listed in References.

It turns out that having the database in the installation directory is causing this issue. This PR modifies the service file and uses a separate directory in `/mnt/dietpi_userdata`. During uninstall I keep the database, in case it was unintentional, this is reported to the user with a `G_DIETPI-NOTIFY`.

Remarks, suggestions, questions are welcome.

Best regards,
Jan Koudijs