### PR TITLE
DietPi-Software | LXDE: Bugs and enhancements

### DIFF
--- a/.conf/desktop/lxde/panel
+++ b/.conf/desktop/lxde/panel
@@ -59,7 +59,7 @@ Plugin {
     type = launchbar
     Config {
         Button {
-            id=/usr/share/applications/firefox-esr.desktop
+            id=firefox-esr.desktop
         }
         Button {
             id=pcmanfm.desktop

--- a/.conf/desktop/lxde/panel
+++ b/.conf/desktop/lxde/panel
@@ -1,157 +1,152 @@
+# lxpanel <profile> config file. Manually editing is not recommended.
+# Use preference dialog in lxpanel to adjust config when you can.
 
 Global {
-  edge=bottom
-  allign=left
-  margin=0
-  widthtype=percent
-  width=100
-  height=36
-  transparent=1
-  tintcolor=#313131
-  alpha=255
-  autohide=0
-  heightwhenhidden=2
-  setdocktype=1
-  setpartialstrut=1
-  usefontcolor=1
-  fontsize=10
-  fontcolor=#ffffff
-  usefontsize=0
-  background=0
-  iconsize=34
+    edge=bottom
+    align=left
+    margin=0
+    widthtype=percent
+    width=100
+    height=36
+    transparent=1
+    tintcolor=#313131
+    alpha=255
+    setdocktype=1
+    setpartialstrut=1
+    autohide=0
+    heightwhenhidden=0
+    usefontcolor=1
+    fontcolor=#ffffff
+    background=0
+    iconsize=34
 }
+
 Plugin {
-  type=space
-  Config {
-    Size=5
-  }
-}
-Plugin {
-  type=menu
-  Config {
-    image=/usr/share/lxde/images/lxde-icon.png
-    system {
+    type = space
+    Config {
+        Size=5
     }
-    separator {
+}
+
+Plugin {
+    type = menu
+    Config {
+        image=/usr/share/lxde/images/lxde-icon.png
+        system {
+        }
+        separator {
+        }
+        item {
+            command=run
+        }
+        separator {
+        }
+        item {
+            image=gnome-logout
+            command=logout
+        }
     }
-    item {
-      command=run
+}
+
+Plugin {
+    type = space
+    Config {
+        Size=10
     }
-    separator {
+}
+
+Plugin {
+    type = launchbar
+    Config {
+        Button {
+            id=/usr/share/applications/firefox-esr.desktop
+        }
+        Button {
+            id=pcmanfm.desktop
+        }
+        Button {
+            id=lxterminal.desktop
+        }
     }
-    item {
-      image=gnome-logout
-      command=logout
+}
+
+Plugin {
+    type = space
+    Config {
+        Size=10
     }
-  }
 }
+
 Plugin {
-  type=space
-  Config {
-    Size=20
-  }
-}
-Plugin {
-  type=launchbar
-  Config {
-    Button {
-      id=/usr/share/applications/firefox-esr.desktop
+    type = taskbar
+    expand=1
+    Config {
+        tooltips=1
+        IconsOnly=0
+        AcceptSkipPager=1
+        ShowIconified=1
+        ShowMapped=1
+        ShowAllDesks=0
+        UseMouseWheel=1
+        UseUrgencyHint=1
+        FlatButton=0
+        MaxTaskWidth=150
+        spacing=1
     }
-  }
 }
+
 Plugin {
-  type=space
-  Config {
-    Size=5
-  }
-}
-Plugin {
-  type=launchbar
-  Config {
-    Button {
-      id=pcmanfm.desktop
+    type = space
+    Config {
+        Size=10
     }
-  }
 }
+
 Plugin {
-  type=space
-  Config {
-    Size=5
-  }
+    type = tray
 }
+
 Plugin {
-  type=launchbar
-  Config {
-    Button {
-      id=lxterminal.desktop
+    type = space
+    Config {
+        Size=5
     }
-  }
 }
+
 Plugin {
-  type=space
-  Config {
-    Size=20
-  }
+    type = cpu
 }
+
 Plugin {
-  type=taskbar
-  expand=1
-  Config {
-    tooltips=1
-    IconsOnly=0
-    AcceptSkipPager=1
-    ShowIconified=1
-    ShowMapped=1
-    ShowAllDesks=0
-    UseMouseWheel=1
-    UseUrgencyHint=1
-    FlatButton=0
-    MaxTaskWidth=150
-    spacing=2
-    UseSmallerIcons=-1
-  }
+    type = space
+    Config {
+        Size=5
+    }
 }
+
 Plugin {
-  type=space
-  Config {
-    Size=20
-  }
+    type = volumealsa
 }
+
 Plugin {
-  type=cpu
-  Config {
-    ShowPercent=1
-  }
+    type = space
+    Config {
+        Size=5
+    }
 }
+
 Plugin {
-  type=tray
-  Config {
-  }
+    type = dclock
+    Config {
+        ClockFmt=%R
+        TooltipFmt=%A %x
+        BoldFont=0
+    }
 }
+
 Plugin {
-  type=volumealsa
-  Config {
-  }
-}
-Plugin {
-  type=space
-  Config {
-    Size=5
-  }
-}
-Plugin {
-  type=dclock
-  Config {
-    ClockFmt=%R
-    TooltipFmt=%A %x
-    BoldFont=0
-    IconOnly=0
-    CenterText=0
-  }
-}
-Plugin {
-  type=space
-  Config {
-    Size=5
-  }
+    type = space
+    Config {
+        Size=5
+    }
 }

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,7 @@ Fixes:
 - DietPi-Software | Logitech Media Server: Resolved an issue where the uninstall failed as the package postinst script tried to remove the service user before the service was stopped.
 - DietPi-Software | Roon Server: Resolved an issue where the internal updater purged all Roon Server data and configs, since the data directory was located within the install directory. Roon Server will now be installed to /opt/roonserver while the data directory remains at /mnt/dietpi_userdata/roonserver. This change will be applied via DietPi update as well, your data and configs will remain untouched. Many thanks to @JanKoudijs for reporting this issue and providing a solution: https://github.com/MichaIng/DietPi/pull/4897
 - DietPi-Software | LXDE: Resolved an issue where on some cases on first desktop start, desktop icons were missing and another issue on Bullseye systems, where a "No session for pid" error message popped up on desktop start. Many thanks to @kerryland for reporting these issues: https://github.com/MichaIng/DietPi/issues/4914
+- DietPi-Software | LXDE: Resolved an issue where the Firefox browser panel icon was present even if no Firefox was installed. In this case now either Chromium or the text editor is added as replacement.
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,6 +28,7 @@ Fixes:
 - DietPi-Software | IceCast: Resolved an issue where a new install failed due to an attempted operation on a non-existing file. Many thanks to @killtux for reporting this issue: https://github.com/MichaIng/DietPi/issues/4858
 - DietPi-Software | Logitech Media Server: Resolved an issue where the uninstall failed as the package postinst script tried to remove the service user before the service was stopped.
 - DietPi-Software | Roon Server: Resolved an issue where the internal updater purged all Roon Server data and configs, since the data directory was located within the install directory. Roon Server will now be installed to /opt/roonserver while the data directory remains at /mnt/dietpi_userdata/roonserver. This change will be applied via DietPi update as well, your data and configs will remain untouched. Many thanks to @JanKoudijs for reporting this issue and providing a solution: https://github.com/MichaIng/DietPi/pull/4897
+- DietPi-Software | LXDE: Resolved an issue where on some cases on first desktop start, desktop icons were missing and another issue on Bullseye systems, where a "No session for pid" error message popped up on desktop start. Many thanks to @kerryland for reporting these issues: https://github.com/MichaIng/DietPi/issues/4914
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2332,19 +2332,8 @@ then
 fi
 
 # Disable this autostart entry
-mkdir -p ~/.config/autostart
+[ -d ~/.config/autostart ] || mkdir -p ~/.config/autostart
 echo '[Desktop Entry]\nHidden=true' > ~/.config/autostart/dietpi-desktop_setup.desktop
-
-# Apply desktop-specific configs
-if [ $XDG_CURRENT_DESKTOP = 'LXDE' ]
-then
-	pcmanfm --desktop-off
-	sleep 0.2
-	sed -i '/^desktop_shadow=/c\desktop_shadow=#333333' ~/.config/pcmanfm/LXDE/desktop-items-0.conf
-	nohup pcmanfm --desktop -p LXDE &
-	sleep 0.2
-	pcmanfm -w /var/lib/dietpi/dietpi-software/installed/desktop/wallpapers/dietpi-logo_inverted_1080p.png
-fi
 _EOF_
 
 		cat << '_EOF_' > /etc/xdg/autostart/dietpi-desktop_setup.desktop
@@ -3333,14 +3322,24 @@ _EOF_
 
 			[[ $display_manager == 0 && -f '/etc/systemd/system/display-manager.service' ]] && G_EXEC rm /etc/systemd/system/display-manager.service
 
-			# Openbox + PCmanFM + panel configs
-			G_EXEC mkdir -p /etc/xdg/{openbox/LXDE,pcmanfm/LXDE,lxpanel/LXDE/panels}
-			G_THREAD_START curl -sSfL "https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.conf/desktop/lxde/lxde-rc.xml" -o /etc/xdg/openbox/LXDE/rc.xml
-			G_THREAD_START curl -sSfL "https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.conf/desktop/lxde/pcmanfm.conf" -o /etc/xdg/pcmanfm/LXDE/pcmanfm.conf
+			# lxpanel
 			G_THREAD_START curl -sSfL "https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.conf/desktop/lxde/panel" -o /etc/xdg/lxpanel/LXDE/panels/panel
+
+			# Openbox: Enable only one desktop and disable icon animations
+			G_CONFIG_INJECT '<number>[0-9]*</number>' '<number>1</number>' /etc/xdg/openbox/LXDE/rc.xml '<desktops>'
+			G_CONFIG_INJECT '<animateIconify>.*</animateIconify>' '<animateIconify>no</animateIconify>' /etc/xdg/openbox/LXDE/rc.xml '<theme>'
+
+			# PCmanFM: Set wallpaper and desktop icon text shadow color
+			G_CONFIG_INJECT '\[desktop\]' '[desktop]' /etc/xdg/pcmanfm/LXDE/pcmanfm.conf
+			G_CONFIG_INJECT 'wallpaper_mode=' 'wallpaper_mode=fit' /etc/xdg/pcmanfm/LXDE/pcmanfm.conf '\[desktop\]'
+			G_CONFIG_INJECT 'wallpaper=' 'wallpaper=/var/lib/dietpi/dietpi-software/installed/desktop/wallpapers/dietpi-logo_inverted_1080p.png' /etc/xdg/pcmanfm/LXDE/pcmanfm.conf '\[desktop\]'
+			G_CONFIG_INJECT 'desktop_shadow=' 'desktop_shadow=#333333' /etc/xdg/pcmanfm/LXDE/pcmanfm.conf '\[desktop\]'
 
 			# Apply better default icon theme: nuoveXT2 has more individual icons than Adwaita, but lower resolution and overrides the Firefox application icon with an old low res version.
 			G_CONFIG_INJECT 'sNet/IconThemeName=' 'sNet/IconThemeName=Adwaita' /etc/xdg/lxsession/LXDE/desktop.conf '\[GTK\]'
+
+			# Bullseye: Workaround for "No session for pid" error: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=864402
+			(( $G_DISTRO < 6 )) || G_CONFIG_INJECT 'polkit/command=' 'polkit/command=' /etc/xdg/lxsession/LXDE/desktop.conf '\[Session\]'
 
 			# Disable trash
 			G_CONFIG_INJECT 'use_trash=' 'use_trash=0' /etc/xdg/libfm/libfm.conf '\[config\]'
@@ -3389,7 +3388,7 @@ _EOF_
 
 			# Disable trash
 			# - Skip on Buster since trash seems to be implemented differently: https://github.com/MichaIng/DietPi/issues/1918#issuecomment-488085982
-			(( $G_DISTRO < 5 )) && G_CONFIG_INJECT 'use_trash=' 'use_trash=0' /etc/xdg/libfm/libfm.conf
+			(( $G_DISTRO < 5 )) && G_CONFIG_INJECT 'use_trash=' 'use_trash=0' /etc/xdg/libfm/libfm.conf '\[config\]'
 
 			Create_Desktop_Shared_Items
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3323,7 +3323,7 @@ _EOF_
 			[[ $display_manager == 0 && -f '/etc/systemd/system/display-manager.service' ]] && G_EXEC rm /etc/systemd/system/display-manager.service
 
 			# lxpanel
-			G_THREAD_START curl -sSfL "https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.conf/desktop/lxde/panel" -o /etc/xdg/lxpanel/LXDE/panels/panel
+			G_EXEC curl -sSfL "https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.conf/desktop/lxde/panel" -o /etc/xdg/lxpanel/LXDE/panels/panel
 			# - Adjust Firefox app icon if it is not installed
 			if (( ${aSOFTWARE_INSTALL_STATE[67]} < 1 ))
 			then

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3324,6 +3324,16 @@ _EOF_
 
 			# lxpanel
 			G_THREAD_START curl -sSfL "https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.conf/desktop/lxde/panel" -o /etc/xdg/lxpanel/LXDE/panels/panel
+			# - Adjust Firefox app icon if it is not installed
+			if (( ${aSOFTWARE_INSTALL_STATE[67]} < 1 ))
+			then
+				for i in 'chromium-browser' 'chromium' 'mousepad' 'leafpad'
+				do
+					[[ -f /usr/share/applications/$i.desktop ]] || continue
+					G_EXEC sed -i "s/firefox-esr/$i/" /etc/xdg/lxpanel/LXDE/panels/panel
+					break
+				done
+			fi
 
 			# Openbox: Enable only one desktop and disable icon animations
 			G_CONFIG_INJECT '<number>[0-9]*</number>' '<number>1</number>' /etc/xdg/openbox/LXDE/rc.xml '<desktops>'
@@ -3338,8 +3348,8 @@ _EOF_
 			# Apply better default icon theme: nuoveXT2 has more individual icons than Adwaita, but lower resolution and overrides the Firefox application icon with an old low res version.
 			G_CONFIG_INJECT 'sNet/IconThemeName=' 'sNet/IconThemeName=Adwaita' /etc/xdg/lxsession/LXDE/desktop.conf '\[GTK\]'
 
-			# Bullseye: Workaround for "No session for pid" error: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=864402
-			(( $G_DISTRO < 6 )) || G_CONFIG_INJECT 'polkit/command=' 'polkit/command=' /etc/xdg/lxsession/LXDE/desktop.conf '\[Session\]'
+			# Workaround for "No session for pid" error: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=864402
+			G_CONFIG_INJECT 'polkit/command=' 'polkit/command=' /etc/xdg/lxsession/LXDE/desktop.conf '\[Session\]'
 
 			# Disable trash
 			G_CONFIG_INJECT 'use_trash=' 'use_trash=0' /etc/xdg/libfm/libfm.conf '\[config\]'


### PR DESCRIPTION
**Status**: Ready

**ToDo**:
- [x] Add Chromium or Firefox application icon only when installed.

**Commit list/description**:
+ DietPi-Software | LXDE: Wallpaper and desktop icon text shadows are now set via global config file instead of applying this via first session script and doing the fragile PCManFM restart.
+ DietPi-Software | LXDE: Resolve "No session for pid" error on Bullseye
+ DietPi-Software | LXDE: Remove our own Openbox and PCManFM configs and instead apply the settings we want to add/change to the Debian package default. Only for the lxpanel we use our own, as it contains much customisations. However, align the format of the lxpanel config as much as possible with the Debian package's one for better comparison.