### PR TITLE
DietPi-Software | Do not disable serial console two times on Raspberry Pi

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -16167,9 +16167,9 @@ This requires an account at: https://remote.it/
 		fi
 
 		# RPi: Convert "serial0" to its actual symlink target
-		if (( $G_HW_MODEL < 10 )); then
+		if (( $G_HW_MODEL < 10 && $keep_serial0 )); then
 
-			if [[ $keep_serial0 == 1 && -L '/dev/serial0' ]]; then
+			if [[ -L '/dev/serial0' ]]; then
 
 				local tty=$(readlink -f /dev/serial0); tty=${tty#/dev/}
 				if [[ $(</boot/cmdline.txt) == *'serial0'* ]]; then


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Software | Do not disable serial console two times on Raspberry Pi, when selected, but keep disabling serial0 if it was not disabled before but the link does not exist.