### PR TITLE
DietPi-Software | ReadyMedia/Deluge/Sonarr/Jellyfin: Stop service before usermod

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,11 @@
+v7.9
+(2021-12-11)
+
+Fixes:
+- DietPi-Software | Resolved a v7.8 regression where ReadyMedia, Deluge, Sonarr and Jellyfin installs failed with an error on "usermod", since the services were not stopped first. This has been loved via live patches for v7.8 as well.
+
 v7.8
-(2021-10-13)
+(2021-11-13)
 
 New SBC support:
 - Radxa Zero | Initial support for this Raspberry Pi Zero form factored (but way more powerful) SBC has been added to DietPi with the hardware ID 74. Many thanks to @almirus and @dhry for helping with testing and debugging an early image: https://github.com/MichaIng/DietPi/issues/4831

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5802,14 +5802,15 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-n2-kodi.conf
 			Banner_Installing
 
 			G_AGI minidlna
-
-			# User: Make "dietpi" the primary group to enable cross-access to media files
-			Create_User -g dietpi -G minidlna -d /var/lib/minidlna minidlna
+			G_EXEC systemctl stop minidlna
 
 			# Remove obsolete service files
 			Remove_SysV minidlna 1
 			[[ -f '/lib/systemd/system/minidlna.service' ]] && G_EXEC rm /lib/systemd/system/minidlna.service
 			[[ -d '/var/log/minidlna' ]] && G_EXEC rm -R /var/log/minidlna
+
+			# User: Make "dietpi" the primary group to enable cross-access to media files
+			Create_User -g dietpi -G minidlna -d /var/lib/minidlna minidlna
 
 			# Service
 			cat << _EOF_ > /etc/systemd/system/minidlna.service
@@ -6101,6 +6102,7 @@ _EOF_
 
 			# Packages
 			G_AGI deluged deluge-web deluge-console
+			G_EXEC systemctl stop deluged
 
 			# Remove SysV service leftovers, installed by Debian APT package
 			Remove_SysV deluged 1
@@ -10688,6 +10690,7 @@ _EOF_
 
 			# Install Sonarr and mediainfo
 			G_AGI sonarr mediainfo
+			G_EXEC systemctl stop sonarr
 
 			# Pre-v7.1: Remove Sonarr v2 key, PID file and database backups from DietPi-Arr_to_RAM
 			[[ $(apt-key list 'A236C58F409091A18ACA53CBEBFF6B99D9B78493' 2> /dev/null) ]] && G_EXEC_NOEXIT=1 G_EXEC apt-key del 'A236C58F409091A18ACA53CBEBFF6B99D9B78493'
@@ -12039,6 +12042,7 @@ _EOF_
 
 			# APT meta package: Server, web component and FFmpeg implementation
 			G_AGI jellyfin
+			G_EXEC systemctl stop jellyfin
 
 			# Grant dietpi group permissions and assure video access
 			Create_User -G dietpi,video,render -d /mnt/dietpi_userdata/jellyfin jellyfin


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Software | ReadyMedia/Deluge/Sonarr/Jellyfin: Stop service before usermod attempt
+ CHANGELOG | Fix v7.8 release month

This is a v7.8 regression since all install and config blocks were merged. Previously between those blocks, all services were stopped again, hence those started as part of a package install were stopped as well. This now needs to be done manually whenever a package install implies/starts a service before we want to alter or create the service user.