### PR TITLE
DietPi-Live-patches | Fix ReadyMedia, Deluge, Sonarr and Jellyfin installs

### DIFF
--- a/.update/version
+++ b/.update/version
@@ -12,6 +12,6 @@ G_MIN_DEBIAN=4
 # Alternative Git branch to automatically migrate to when Debian version is too low
 G_OLD_DEBIAN_BRANCH='jessie-support'
 # Live patches
-G_LIVE_PATCH_DESC=()
-G_LIVE_PATCH_COND=()
-G_LIVE_PATCH=()
+G_LIVE_PATCH_DESC=('Fix ReadyMedia, Deluge, Sonarr and Jellyfin installs')
+G_LIVE_PATCH_COND=('! grep -q "G_EXEC systemctl stop minidlna" /boot/dietpi/dietpi-software')
+G_LIVE_PATCH=('sed -Ei -e "/G_AGI (minidlna|deluged|sonarr|jellyfin)/a\G_EXEC systemctl stop \\1" /boot/dietpi/dietpi-software')

--- a/.update/version
+++ b/.update/version
@@ -14,4 +14,4 @@ G_OLD_DEBIAN_BRANCH='jessie-support'
 # Live patches
 G_LIVE_PATCH_DESC=('Fix ReadyMedia, Deluge, Sonarr and Jellyfin installs')
 G_LIVE_PATCH_COND=('! grep -q "G_EXEC systemctl stop minidlna" /boot/dietpi/dietpi-software')
-G_LIVE_PATCH=('sed -Ei -e "s/(G_AGI (minidlna|deluged|sonarr|jellyfin).*$)/\\1\\nG_EXEC systemctl stop \\2/" /boot/dietpi/dietpi-software')
+G_LIVE_PATCH=('sed -Ei "s/(G_AGI (minidlna|deluged|sonarr|jellyfin).*$)/\\1\\nG_EXEC systemctl stop \\2/" /boot/dietpi/dietpi-software')

--- a/.update/version
+++ b/.update/version
@@ -14,4 +14,4 @@ G_OLD_DEBIAN_BRANCH='jessie-support'
 # Live patches
 G_LIVE_PATCH_DESC=('Fix ReadyMedia, Deluge, Sonarr and Jellyfin installs')
 G_LIVE_PATCH_COND=('! grep -q "G_EXEC systemctl stop minidlna" /boot/dietpi/dietpi-software')
-G_LIVE_PATCH=('sed -Ei -e "/G_AGI (minidlna|deluged|sonarr|jellyfin)/a\G_EXEC systemctl stop \\1" /boot/dietpi/dietpi-software')
+G_LIVE_PATCH=('sed -Ei -e "s/(G_AGI (minidlna|deluged|sonarr|jellyfin).*$)/\\1\\nG_EXEC systemctl stop \\2/" /boot/dietpi/dietpi-software')


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Live-patches | Fix ReadyMedia, Deluge, Sonarr and Jellyfin installs

Live patch for: #4960