### PR TITLE
DietPi-Backup | Fix file path

### DIFF
--- a/.update/patches
+++ b/.update/patches
@@ -539,7 +539,7 @@ Patch_7_8()
 	# DietPi-Backup: Move logs to persistent backup location
 	if [[ -f '/var/log/dietpi-backup.log' ]]
 	then
-		if [[ -f '/boot/dietpi/.dietpi-backup_settings' ]] && . /boot/dietpi/.dietpi-backup_settings && [[ $FP_TARGET && -d $FP_TARGET && ! -f $FP_TARGET/dietpi-backup.log ]]
+		if [[ -f '/boot/dietpi/.dietpi-backup_settings' ]] && . /boot/dietpi/.dietpi-backup_settings && [[ $FP_TARGET && -f $FP_TARGET/.dietpi-backup_stats && ! -f $FP_TARGET/dietpi-backup.log ]]
 		then
 			G_DIETPI-NOTIFY 2 "Moving DietPi-Backup log file to $FP_TARGET/dietpi-backup.log"
 			G_EXEC mv /var/log/dietpi-backup.log "$FP_TARGET/dietpi-backup.log"

--- a/.update/patches
+++ b/.update/patches
@@ -539,14 +539,9 @@ Patch_7_8()
 	# DietPi-Backup: Move logs to persistent backup location
 	if [[ -f '/var/log/dietpi-backup.log' ]]
 	then
-		if [[ -f '/boot/dietpi/.dietpi-backup_settings' ]] && . /boot/dietpi/.dietpi-backup_settings && [[ $FP_TARGET && -f $FP_TARGET/.dietpi-backup_stats && ! -f $FP_TARGET/dietpi-backup.log ]]
-		then
-			G_DIETPI-NOTIFY 2 "Moving DietPi-Backup log file to $FP_TARGET/dietpi-backup.log"
-			G_EXEC mv /var/log/dietpi-backup.log "$FP_TARGET/dietpi-backup.log"
-		else
-			G_DIETPI-NOTIFY 2 'Removing obsolete DietPi-Backup log file /var/log/dietpi-backup.log'
-			G_EXEC rm /var/log/dietpi-backup.log
-		fi
+		G_WHIP_MSG '[WARNING] Moving dietpi-backup.log out of /var/log
+\nNew DietPi-Backup log files are now created within the chosen backup directory. The existing old log is moved from /var/log/dietpi-backup.log to /tmp/dietpi-backup.log in case you need to review it.'
+		G_EXEC mv /{var/log,tmp}/dietpi-backup.log
 	fi
 
 	# On Raspberry Pi, for backwards compatibility with software compiled against older libraspberrypi0, create symlinks from old to new filenames

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ v7.9
 (2021-12-11)
 
 Fixes:
+- DietPi-Backup | Resolved an issue where backup and restore failed if a non-default backup location is used, as a wrong log file path was used. This is a v7.8 regression. Many thanks to @Malinka for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?p=39909#p39909
 - DietPi-Software | Resolved a v7.8 regression where ReadyMedia, Deluge, Sonarr and Jellyfin installs failed with an error on "usermod", since the services were not stopped first. This has been loved via live patches for v7.8 as well.
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX

--- a/dietpi/dietpi-backup
+++ b/dietpi/dietpi-backup
@@ -36,13 +36,12 @@
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Backup System
 	#/////////////////////////////////////////////////////////////////////////////////////
-	readonly FP_LOG='dietpi-backup.log'
-
 	# Backup file paths
 	FP_SOURCE='/'
 	FP_TARGET='/mnt/dietpi-backup'
 
-	# File applied to successful backups, stored in "$FP_TARGET/$FP_STATS"
+	# Stats and transfer logs, stored to: $FP_TARGET/
+	readonly FP_LOG='dietpi-backup.log'
 	readonly FP_STATS='.dietpi-backup_stats'
 
 	# Include/exclude file
@@ -54,7 +53,6 @@
 	readonly aRSYNC_RUN_OPTIONS_BACKUP=('-aH' '--info=name0' '--info=progress2' '--delete-excluded' "--exclude-from=$FP_FILTER")
 	# - Restore: Delete files in target which are not present in source, but after the transfer has finished, and leave excluded files untouched
 	readonly aRSYNC_RUN_OPTIONS_RESTORE=('-aH' '--info=name0' '--info=progress2' '--delete-after' "--exclude-from=$FP_FILTER")
-	readonly aRSYNC_LOGGING_OPTIONS=('-v' "--log-file=$FP_TARGET/$FP_LOG")
 
 	# Date format for logs
 	Print_Date(){ date '+%Y-%m-%d_%T'; }
@@ -198,7 +196,7 @@ However, this check is a rough estimation in reasonable time, thus it could be m
 			# Init log file
 			echo -e "Backup log from $(Print_Date)\n" > "$FP_TARGET/$FP_LOG"
 
-			rsync "${aRSYNC_RUN_OPTIONS_BACKUP[@]}" "${aRSYNC_LOGGING_OPTIONS[@]}" "$FP_SOURCE" "$FP_TARGET/data/"
+			rsync "${aRSYNC_RUN_OPTIONS_BACKUP[@]}" -v --log-file="$FP_TARGET/$FP_LOG" "$FP_SOURCE" "$FP_TARGET/data/"
 			EXIT_CODE=$?
 
 			/boot/dietpi/dietpi-services start
@@ -359,7 +357,7 @@ However, this check is a rough estimation in reasonable time, thus it could be m
 			# Init log file
 			echo -e "Restore log from $(Print_Date)\n" > "$FP_TARGET/$FP_LOG"
 
-			rsync "${aRSYNC_RUN_OPTIONS_RESTORE[@]}" "${aRSYNC_LOGGING_OPTIONS[@]}" "$FP_TARGET/data/" "$FP_SOURCE"
+			rsync "${aRSYNC_RUN_OPTIONS_RESTORE[@]}" -v --log-file="$FP_TARGET/$FP_LOG" "$FP_TARGET/data/" "$FP_SOURCE"
 			EXIT_CODE=$?
 
 			hash -r # Clear PATH cache


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Backup | Fix file path
+ DietPi-Patches | Only move old dietpi-backup.log if a stats file exists at the target backup location, to avoid copying to an empty mount point, if the backup drive is not currently mounted.