### PR TITLE
DietPi-Live-patches | Fix DietPi-Backup when using a location other than /mnt/dietpi-backup

### DIFF
--- a/.update/version
+++ b/.update/version
@@ -12,6 +12,15 @@ G_MIN_DEBIAN=4
 # Alternative Git branch to automatically migrate to when Debian version is too low
 G_OLD_DEBIAN_BRANCH='jessie-support'
 # Live patches
-G_LIVE_PATCH_DESC=('Fix ReadyMedia, Deluge, Sonarr and Jellyfin installs')
-G_LIVE_PATCH_COND=('! grep -q "G_EXEC systemctl stop minidlna" /boot/dietpi/dietpi-software')
-G_LIVE_PATCH=('sed -Ei "s/(G_AGI (minidlna|deluged|sonarr|jellyfin).*$)/\\1\\nG_EXEC systemctl stop \\2/" /boot/dietpi/dietpi-software')
+G_LIVE_PATCH_DESC=(
+	[0]='Fix ReadyMedia, Deluge, Sonarr and Jellyfin installs'
+	[1]='Fix DietPi-Backup when using a location other than /mnt/dietpi-backup'
+)
+G_LIVE_PATCH_COND=(
+	[0]='! grep -q "G_EXEC systemctl stop minidlna" /boot/dietpi/dietpi-software'
+	[1]='grep -q "aRSYNC_LOGGING_OPTIONS" /boot/dietpi/dietpi-backup'
+)
+G_LIVE_PATCH=(
+	[0]='sed -Ei "s/(G_AGI (minidlna|deluged|sonarr|jellyfin).*$)/\\1\\nG_EXEC systemctl stop \\2/" /boot/dietpi/dietpi-software'
+	[1]='curl -sSfL "https://raw.githubusercontent.com/MichaIng/DietPi/live-patch-1-v78/dietpi/dietpi-backup" -o /boot/dietpi/dietpi-backup'
+)


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
+ DietPi-Live-patches | Fix DietPi-Backup when using a location other than /mnt/dietpi-backup