### PR TITLE
DietPi-Software | Transmission: Stop service before creating config

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ v7.9
 Fixes:
 - DietPi-Backup | Resolved an issue where backup and restore failed if a non-default backup location is used, as a wrong log file path was used. This is a v7.8 regression. Many thanks to @Malinka for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?p=39909#p39909
 - DietPi-Software | Resolved a v7.8 regression where ReadyMedia, Deluge, Sonarr and Jellyfin installs failed with an error on "usermod", since the services were not stopped first. This has been loved via live patches for v7.8 as well.
+- DietPi-Software | Resolved a v7.8 regression where on fresh Transmission installs the intended configuration was not deployed. Many thanks to @kannz and @alessandro.psrt for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=9567, https://dietpi.com/phpbb/viewtopic.php?t=9683
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3589,6 +3589,7 @@ _EOF_
 			Banner_Installing
 
 			G_AGI transmission-daemon
+			G_EXEC systemctl stop transmission-daemon
 
 			# Remove obsolete service and environment files
 			Remove_SysV transmission-daemon 1

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3037,6 +3037,7 @@ _EOF_
 			G_EXEC ln -s /mnt/dietpi_userdata/postgresql /var/lib/postgresql
 
 			G_AGI postgresql
+			G_EXEC systemctl stop postgresql
 
 			# Disable TCP/IP listener and assure that UNIX domain socket is enabled at expected path
 			# NB: On Stretch (PGSQL v9.6) conf.d is not yet included by default and we skip the step there. It listens on localhost only, hence has no security impact.
@@ -3593,7 +3594,7 @@ _EOF_
 
 			# Remove obsolete service and environment files
 			Remove_SysV transmission-daemon 1
-			[[ -f '/etc/init/transmission-daemon.conf' ]] && rm -v /etc/init/transmission-daemon.conf
+			[[ -f '/etc/init/transmission-daemon.conf' ]] && G_EXEC rm /etc/init/transmission-daemon.conf
 
 			# Make "dietpi" the primary group and "debian-transmission" a supplementary group, to make downloads R/W accessible for other media software and network shares.
 			G_EXEC usermod -g dietpi -aG debian-transmission debian-transmission
@@ -3633,6 +3634,7 @@ _EOF_
 
 			G_EXEC eval "debconf-set-selections <<< 'proftpd-basic shared/proftpd/inetd_or_standalone select standalone'"
 			G_AGI proftpd-basic
+			G_EXEC systemctl stop proftpd
 
 			# Config
 			G_BACKUP_FP /etc/proftpd/proftpd.conf
@@ -3662,6 +3664,7 @@ _EOF_
 			echo 'd /run/samba-cache' > /etc/tmpfiles.d/dietpi-samba_cache.conf
 
 			G_AGI samba
+			G_EXEC systemctl stop nmbd smbd
 
 			echo -e "$GLOBAL_PW\n$GLOBAL_PW" | smbpasswd -s -a dietpi
 
@@ -3682,6 +3685,7 @@ _EOF_
 			[[ -f '/etc/vsftpd.conf' ]] || dps_index=$software_id Download_Install 'conf' /etc/vsftpd.conf
 
 			G_AGI vsftpd
+			G_EXEC systemctl stop vsftpd
 
 			# Do not allow root access via FTP
 			G_EXEC sed -i 's/^[[:blank:]]*root/#root/' /etc/ftpusers
@@ -3694,6 +3698,7 @@ _EOF_
 			Banner_Installing
 
 			G_AGI nfs-kernel-server
+			G_EXEC systemctl stop nfs-kernel-server
 
 			[[ -d '/etc/exports.d' ]] || G_EXEC mkdir /etc/exports.d
 			[[ -f '/etc/exports.d/dietpi.exports' ]] || echo '/mnt/dietpi_userdata *(rw,async,no_root_squash,fsid=0,crossmnt,no_subtree_check)' > /etc/exports.d/dietpi.exports
@@ -3712,6 +3717,7 @@ _EOF_
 			# Install certbot module, if certbot was already installed
 			(( ${aSOFTWARE_INSTALL_STATE[92]} == 2 )) && apackages+=('python3-certbot-apache')
 			G_AGI "${apackages[@]}"
+			G_EXEC systemctl stop apache2
 
 			# Config
 			G_BACKUP_FP /etc/apache2/apache2.conf
@@ -3753,6 +3759,7 @@ _EOF_
 			# Install certbot module, if certbot was already installed
 			(( ${aSOFTWARE_INSTALL_STATE[92]} == 2 )) && apackages+=('python3-certbot-nginx')
 			G_AGI "${apackages[@]}"
+			G_EXEC systemctl stop nginx
 
 			# Custom configs, included by sites-enabled/default within server directive, while nginx/(conf.d|sites-enabled) is included by nginx.conf outside server directive
 			[[ -d '/etc/nginx/sites-dietpi' ]] || G_EXEC mkdir /etc/nginx/sites-dietpi
@@ -3815,6 +3822,7 @@ _EOF_
 
 			# perl is required for lighty-enable-mod, it has been degraded to recommends only with Buster.
 			G_AGI lighttpd perl $deflate $openssl
+			G_EXEC systemctl stop lighttpd
 
 			Remove_SysV lighttpd
 
@@ -3883,6 +3891,7 @@ _EOF_
 			# Install PHP module, if PHP was already installed
 			(( ${aSOFTWARE_INSTALL_STATE[89]} == 2 )) && apackages+=("$PHP_NAME-mysql")
 			G_AGI "${apackages[@]}"
+			G_EXEC systemctl stop mariadb
 
 			Remove_SysV mysql 1
 
@@ -3924,6 +3933,7 @@ _EOF_
 			# Install PHP module, if PHP was already installed
 			(( ${aSOFTWARE_INSTALL_STATE[89]} == 2 )) && apackages+=("$PHP_NAME-redis")
 			G_AGI "${apackages[@]}"
+			G_EXEC systemctl stop redis-server
 
 			# Enable redis php module, if installed
 			command -v phpenmod > /dev/null && G_EXEC phpenmod redis
@@ -4009,6 +4019,7 @@ Package: openssl libssl*\nPin: origin packages.sury.org\nPin-Priority: -1' > /et
 			(( ${aSOFTWARE_INSTALL_STATE[91]} > 0 )) && apackages+=("$PHP_NAME-redis")
 
 			G_AGI "${apackages[@]}"
+			systemctl -q is-active "$PHP_NAME-fpm" && G_EXEC systemctl stop "$PHP_NAME-fpm"
 
 			# PHP-FPM
 			if (( ${aSOFTWARE_INSTALL_STATE[84]} > 0 || ${aSOFTWARE_INSTALL_STATE[85]} > 0 )); then
@@ -4683,6 +4694,7 @@ _EOF_
 			else
 				Download_Install 'https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v7.6/latest.deb'
 			fi
+			G_EXEC systemctl stop FAHClient
 
 			# Remove obsolete config + data directories and SysV service + config
 			[[ -d '/var/lib/fahclient' ]] && G_EXEC rm -R /var/lib/fahclient
@@ -5462,6 +5474,7 @@ _EOF_
 			# Build and install myMPD
 			G_EXEC cd myMPD-master
 			G_EXEC ./build.sh releaseinstall
+			G_EXEC systemctl stop mympd
 
 			# Cleanup
 			G_EXEC cd /tmp/$G_PROGRAM_NAME
@@ -5615,6 +5628,7 @@ _EOF_
 				G_AGI mopidy gstreamer1.0-alsa mopidy-local
 				G_EXEC_OUTPUT=1 G_EXEC pip3 install --no-cache-dir -U Mopidy-MusicBox-Webclient
 			fi
+			G_EXEC systemctl stop mopidy
 
 			# Assure user home, data and cache dir as well on custom configs
 			G_CONFIG_INJECT 'data_dir[[:blank:]]*=' 'data_dir = /mnt/dietpi_userdata/mopidy/data' /etc/mopidy/mopidy.conf '\[core\]'
@@ -5971,9 +5985,10 @@ _EOF_
 
 			debconf-set-selections <<< 'urbackup-server urbackup/backuppath string /mnt/dietpi_userdata/urbackup'
 			Download_Install "$url"
+			G_EXEC systemctl stop urbackupsrv
 
 			# As we have /tmp mounted to RAM, change tmp location
-			[[ -d '/mnt/dietpi_userdata/urbackup/tmp' ]] || mkdir -p /mnt/dietpi_userdata/urbackup/tmp
+			[[ -d '/mnt/dietpi_userdata/urbackup/tmp' ]] || G_EXEC mkdir -p /mnt/dietpi_userdata/urbackup/tmp
 			G_EXEC chown -R urbackup:urbackup /mnt/dietpi_userdata/urbackup
 			G_CONFIG_INJECT 'DAEMON_TMPDIR=' "DAEMON_TMPDIR='/mnt/dietpi_userdata/urbackup/tmp'" /etc/default/urbackupsrv
 
@@ -6194,6 +6209,7 @@ _EOF_
 
 			# APT package
 			G_AGI webmin
+			G_EXEC systemctl stop webmin
 
 			# Service
 			Remove_SysV webmin
@@ -6291,6 +6307,7 @@ _EOF_
 			Banner_Installing
 
 			G_AGI darkice icecast2
+			G_EXEC systemctl stop darkice icecast2
 
 			# IceCast: Set passwords, if not yet done (default found)
 			sed -i "/<source-password>hackme/c\        <source-password>$GLOBAL_PW</source-password>" /etc/icecast2/icecast.xml
@@ -6362,6 +6379,7 @@ _EOF_
 
 			Banner_Installing
 			G_AGI tor
+			G_EXEC systemctl stop tor
 
 			local nickname=
 			G_WHIP_BUTTON_CANCEL_TEXT='Skip'
@@ -6993,8 +7011,9 @@ _EOF_
 			then
 				G_AGI pijuice-base
 			else
-				Download_Install 'http://archive.raspberrypi.org/debian/pool/main/p/pijuice-base/pijuice-base_1.7_all.deb'
+				Download_Install 'https://archive.raspberrypi.org/debian/pool/main/p/pijuice-base/pijuice-base_1.7_all.deb'
 			fi
+			G_EXEC systemctl stop pijuice
 
 			G_EXEC mkdir -p /var/lib/dietpi/dietpi-software/installed/pijuice
 			echo -e '#!/bin/dash\npoweroff' > /var/lib/dietpi/dietpi-software/installed/pijuice/pijuice_func1.sh
@@ -7279,6 +7298,7 @@ _EOF_
 			fi
 
 			G_AGI mosquitto
+			G_EXEC systemctl stop mosquitto
 
 			Remove_SysV mosquitto
 
@@ -7435,8 +7455,9 @@ _EOF_
 
 			# Install
 			no_check_url=1 Download_Install "$url/$distro/$package"
+			G_EXEC systemctl stop networkaudiod
 
-			unset url arch distro package
+			unset -v url arch distro package
 
 		fi
 
@@ -7927,6 +7948,7 @@ _EOF_
 
 			# APT package
 			G_AGI influxdb
+			G_EXEC systemctl stop influxdb
 
 			# Move DB/datadir to userdata location
 			[[ -d '/mnt/dietpi_userdata/influxdb' ]] || G_EXEC mv /var/lib/influxdb /mnt/dietpi_userdata/
@@ -7964,6 +7986,7 @@ _EOF_
 				G_AGI grafana
 
 			fi
+			G_EXEC systemctl stop grafana-server
 
 			Remove_SysV grafana-server
 
@@ -8681,6 +8704,7 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 			lsusb | grep -qi 'RTL8188C' && apt-cache dumpavail | grep -qE '^P(ackage|rovides):.* hostapd-realtek(,|$)' && packages[0]='hostapd-realtek'
 
 			G_AGI "${packages[@]}"
+			G_EXEC systemctl stop hostapd isc-dhcp-server
 
 			# Enable WiFi modules
 			/boot/dietpi/func/dietpi-set_hardware wifimodules enable
@@ -8778,6 +8802,7 @@ _EOF_
 			Banner_Installing
 
 			G_AGI tor
+			G_EXEC systemctl stop tor
 
 			Remove_SysV tor 1
 
@@ -8858,7 +8883,7 @@ _EOF_
 			else
 
 				Download_Install 'https://download.pydio.com/pub/core/ci/pydio-latest.tar.gz' /var/www
-				mv /var/www/pydio-latest /var/www/pydio
+				G_EXEC mv /var/www/pydio-latest /var/www/pydio
 
 			fi
 
@@ -8905,19 +8930,19 @@ _EOF_
 			if [[ -d $target_data_dir ]]; then
 
 				G_DIETPI-NOTIFY 2 "Existing $target_data_dir found, will migrate..."
-				[[ -e '/var/www/pydio/data' ]] && rm -R /var/www/pydio/data
+				[[ -e '/var/www/pydio/data' ]] && G_EXEC rm -R /var/www/pydio/data
 
 			else
 
 				# - Move data structure
 				[[ -e $target_data_dir ]] && rm -R $target_data_dir
-				mv /var/www/pydio/data $target_data_dir
+				G_EXEC mv /var/www/pydio/data $target_data_dir
 
 			fi
 
 			# Create symlink
-			ln -sf $target_data_dir /var/www/pydio/data
-			chown -R www-data:www-data $target_data_dir
+			G_EXEC ln -sf $target_data_dir /var/www/pydio/data
+			G_EXEC chown -R www-data:www-data $target_data_dir
 
 		fi
 
@@ -8926,6 +8951,7 @@ _EOF_
 
 			Banner_Installing
 			Download_Install "https://dietpi.com/downloads/binaries/$G_DISTRO_NAME/squeezelite_$G_HW_ARCH_NAME.deb"
+			G_EXEC systemctl stop squeezelite
 
 		fi
 
@@ -8935,6 +8961,7 @@ _EOF_
 			Banner_Installing
 
 			Download_Install 'https://raw.githubusercontent.com/XavierBerger/RPi-Monitor-deb/develop/packages/rpimonitor_2.13-beta6_all.deb'
+			G_EXEC systemctl stop rpimonitor
 
 			# Update APT package status
 			G_EXEC /usr/share/rpimonitor/scripts/updatePackagesStatus.pl
@@ -9000,7 +9027,7 @@ _EOF_
 					Download_Install "https://dietpi.com/downloads/binaries/stretch/netdata_$G_HW_ARCH_NAME.7z"
 					G_AGI ./netdata{-core,-plugins-bash,-web,}_*.deb
 					G_AGF
-					rm netdata*
+					G_EXEC rm netdata*
 
 				fi
 
@@ -9009,6 +9036,7 @@ _EOF_
 				G_AGI netdata
 
 			fi
+			G_EXEC systemctl stop netdata
 
 			# Only required for our self-compiled package, leave defaults for Debian APT package otherwise
 			if (( $G_HW_ARCH == 1 && $G_DISTRO < 5 )); then
@@ -9017,20 +9045,20 @@ _EOF_
 				dps_index=$software_id Download_Install 'netdata.service' /etc/systemd/system/netdata.service
 
 				# Dir (failsafe)
-				mkdir -p /var/lib/netdata
+				G_EXEC mkdir -p /var/lib/netdata
 
 				# User
 				Create_User -d /var/lib/netdata netdata
 
 				# Permissions: https://docs.netdata.cloud/docs/netdata-security/#netdata-directories
 				# - R/O
-				chown -R root:netdata /etc/netdata /usr/lib/netdata /usr/libexec/netdata /usr/share/netdata
-				chmod -R 0750 /etc/netdata /usr/lib/netdata /usr/libexec/netdata /usr/share/netdata
+				G_EXEC chown -R root:netdata /etc/netdata /usr/lib/netdata /usr/libexec/netdata /usr/share/netdata
+				G_EXEC chmod -R 0750 /etc/netdata /usr/lib/netdata /usr/libexec/netdata /usr/share/netdata
 				# - apps.plugin requires root privileges to read disk I/O
-				chmod 4750 /usr/libexec/netdata/plugins.d/apps.plugin
+				G_EXEC chmod 4750 /usr/libexec/netdata/plugins.d/apps.plugin
 				# - R/W (web access: https://github.com/MichaIng/DietPi/issues/2336#issuecomment-450196178)
-				chown -R netdata:netdata /var/cache/netdata /var/lib/netdata /var/log/netdata /usr/share/netdata/web
-				chmod -R 0770 /var/cache/netdata /var/lib/netdata /var/log/netdata
+				G_EXEC chown -R netdata:netdata /var/cache/netdata /var/lib/netdata /var/log/netdata /usr/share/netdata/web
+				G_EXEC chmod -R 0770 /var/cache/netdata /var/lib/netdata /var/log/netdata
 
 			fi
 
@@ -9109,6 +9137,7 @@ location = /.well-known/caldav  { return 301 /baikal/html/dav.php; }' > /etc/ngi
 			Banner_Installing
 
 			G_AGI mumble-server
+			G_EXEC systemctl stop mumble-server
 
 			# Cap total connections
 			local max_users=$(( $G_HW_CPU_CORES * 8 ))
@@ -9147,6 +9176,7 @@ location = /.well-known/caldav  { return 301 /baikal/html/dav.php; }' > /etc/ngi
 
 			local fallback_url="https://github.com/MediaBrowser/Emby.Releases/releases/download/4.6.4.0/emby-server-deb_4.6.4.0_$arch.deb"
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/MediaBrowser/Emby.Releases/releases/latest' | mawk -F\" "/\"browser_download_url\": .*\/emby-server-deb_[^\"\/]*_$arch\.deb\"/{print \$4}")"
+			G_EXEC systemctl stop emby-server
 
 			# User: The DEB package install overrides this, hence the method needs to be changed when using an APT repository!
 			Create_User -g dietpi -G emby,video,render -d /var/lib/emby emby
@@ -9171,6 +9201,7 @@ location = /.well-known/caldav  { return 301 /baikal/html/dav.php; }' > /etc/ngi
 
 			# APT package
 			G_AGI plexmediaserver
+			G_EXEC systemctl stop plexmediaserver
 
 			# User: Run service as "dietpi" group: https://github.com/MichaIng/DietPi/issues/350#issuecomment-423763518
 			Create_User -g dietpi -G plex,video,render -d /var/lib/plexmediaserver plex
@@ -11390,6 +11421,7 @@ _EOF_
 			[[ -f '/etc/cups/cupsd.conf' ]] || dps_index=$software_id Download_Install 'cupsd.conf' /etc/cups/cupsd.conf
 
 			G_AGI cups
+			G_EXEC systemctl stop cups
 
 			G_EXEC chown root:lp /etc/cups/ /etc/cups/ppd/ /etc/cups/ssl/
 		fi
@@ -11561,6 +11593,7 @@ _EOF_
 
 			# APT package
 			G_AGI docker-ce
+			G_EXEC systemctl stop docker
 
 			# Change Docker service type to "simple": https://github.com/MichaIng/DietPi/issues/2238#issuecomment-439474766
 			[[ -d '/lib/systemd/system/docker.service.d' ]] || G_EXEC mkdir /lib/systemd/system/docker.service.d
@@ -11887,6 +11920,7 @@ _EOF_
 
 			# APT package
 			G_AGI raspotify
+			G_EXEC systemctl stop raspotify
 
 		fi
 
@@ -12024,6 +12058,8 @@ _EOF_
 			G_EXEC chmod +x rem-setup.sh
 			G_EXEC_OUTPUT=1 G_EXEC ./rem-setup.sh
 			G_EXEC_NOHALT=1 G_EXEC rm rem-setup.sh
+
+			G_EXEC systemctl stop roon-extension-manager
 
 		fi
 
@@ -12504,9 +12540,10 @@ _EOF_
 
 			local fallback_url="https://github.com/badaix/snapcast/releases/download/v0.25.0/snapserver_0.25.0-1_$arch.deb"
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/badaix/snapcast/releases/latest' | mawk -F\" "/\"browser_download_url\": .*\/snapserver_[^\"\/]*_$arch.deb\"/{print \$4}")"
+			G_EXEC systemctl stop snapserver
 
 			# Disable JSON RPC by default, if setting was never touched yet
-			sed -i '/^\[tcp\]/,/^\[/s/^#enabled = true$/enabled = false/' /etc/snapserver.conf
+			G_EXEC sed -i '/^\[tcp\]/,/^\[/s/^#enabled = true$/enabled = false/' /etc/snapserver.conf
 
 		fi
 
@@ -12520,6 +12557,7 @@ _EOF_
 
 			local fallback_url="https://github.com/badaix/snapcast/releases/download/v0.25.0/snapclient_0.25.0-1_without-pulse_$arch.deb"
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/badaix/snapcast/releases/latest' | mawk -F\" "/\"browser_download_url\": .*\/snapclient_[^\"\/]*_without-pulse_$arch.deb\"/{print \$4}")"
+			G_EXEC systemctl stop snapclient
 
 			# Client IP needs to be added to allowed IP list
 			local snapcast_server_ip


### PR DESCRIPTION
While installing Transmission package, we would need to stop the service before we are going to apply our changes. Otherwise they are not taken into account and overwritten be default settings. Not sure if this is something new with Transmission v3.

**Status**: Ready
- [x] adjust `dietpi-software`

**Reference**:
- https://dietpi.com/phpbb/viewtopic.php?t=9683
- https://dietpi.com/phpbb/viewtopic.php?t=9567

**Commit list/description**:
- DietPi-Software | Transmission - stop service before applying our configuration settings
