### PR TITLE
DietPi-Software | File Browser: Change port to resolve conflict with Mono

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12356,7 +12356,7 @@ _EOF_
 			then
 				G_EXEC cd /mnt/dietpi_userdata/filebrowser
 				G_EXEC /opt/filebrowser/filebrowser config init
-				G_EXEC /opt/filebrowser/filebrowser config set -a 0.0.0.0 -p 8084 -r /mnt
+				G_EXEC /opt/filebrowser/filebrowser config set -a 0.0.0.0 -p 8091 -r /mnt
 				G_EXEC_DESC="Setting up File Browser login user 'dietpi'" G_EXEC /opt/filebrowser/filebrowser users add dietpi "$GLOBAL_PW" --perm.admin
 			fi
 


### PR DESCRIPTION
There is a port conflict with Mono/Sonarr. Therefore File Browser default port would need to be changed. New port is `8091`

**Status**: Ready
- [x] change default port

**Reference**: https://github.com/MichaIng/DietPi/issues/5093

**Commit list/description**:
- DietPi-Software | File Browser - change port to 8091 to avoid conflict with Mono/Sonarr
