### PR TITLE
DietPi-Software | Mono: Install only "mono-devel" instead of "mono-complete"

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ v8.0
 (2022-01-08)
 
 Changes:
+- DietPi-Software | Mono: "mono-complete" won't be installed anymore but only "mono-devel" instead. This skips the XSP4 webserver service, which listens on port 8084 by default where it conflicts with File Browser. This only affects new instals. You can manually apply this change via "apt-mark manual mono-devel && apt --autoremove purge mono-complete". Many thanks to @jaguar489 for reporting this issue: https://github.com/MichaIng/DietPi/issues/5093
 
 Fixes:
 - DietPi-Software | Resolved an issue where on first boot, choice and preference menu selections triggered an error as the install state file did not exist yet. Many thanks to @bsheeres for reporting this issue: https://github.com/MichaIng/DietPi/issues/5080

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -13562,6 +13562,7 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
+			# shellcheck disable=SC2046
 			apt-mark auto $(dpkg --get-selections 'mono-*' 'libmono-*' 2> /dev/null | mawk '{print $1}') 2> /dev/null
 			[[ -f '/etc/apt/sources.list.d/dietpi-mono.list' ]] && G_EXEC rm /etc/apt/sources.list.d/dietpi-mono.list
 			[[ -f '/etc/apt/trusted.gpg.d/dietpi-mono.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-mono.gpg

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3197,7 +3197,7 @@ unix_socket_directories = '/run/postgresql'" > "$i/00dietpi.conf"
 			G_AGUP
 
 			# APT package
-			G_AGI mono-runtime mono-complete
+			G_AGI mono-devel
 
 			G_EXEC rm -f /tmp/mono* # https://github.com/MichaIng/DietPi/issues/1877#issuecomment-403856446
 
@@ -13562,7 +13562,7 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			apt-mark auto mono-complete mono-devel mono-runtime libmono-cil-dev 2>/dev/null
+			apt-mark auto $(dpkg --get-selections 'mono-*' 'libmono-*' 2> /dev/null | mawk '{print $1}') 2> /dev/null
 			[[ -f '/etc/apt/sources.list.d/dietpi-mono.list' ]] && G_EXEC rm /etc/apt/sources.list.d/dietpi-mono.list
 			[[ -f '/etc/apt/trusted.gpg.d/dietpi-mono.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-mono.gpg
 


### PR DESCRIPTION
**Status**: Ready

**Commit list/description**:
- CHANGELOG | Mono: "mono-complete" won't be installed anymore but only "mono-devel" instead. This skips the XSP4 webserver service, which listens on port 8084 by default where it conflicts with File Browser. This only affects new instals. You can manually apply this change via "apt-mark manual mono-devel && apt --autoremove purge mono-complete". Many thanks to @jaguar489 for reporting this issue: https://github.com/MichaIng/DietPi/issues/5093