### PR TITLE
Software Nextcloud: Fix php.ini entry of memory_consumption

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4895,7 +4895,7 @@ The install script will now exit. After applying one of the the above, rerun die
 			G_DIETPI-NOTIFY 2 'Apply PHP override settings for Nextcloud.' # https://docs.nextcloud.com/server/stable/admin_manual/configuration_server/server_tuning.html#enable-php-opcache
 			local interned_strings_buffer='' memory_consumption=''
 			(( $($PHP_NAME -i | mawk '/^opcache.interned_strings_buffer/{print $5;exit}') < 8 )) && interned_strings_buffer='\nopcache.interned_strings_buffer=8'
-			(( $($PHP_NAME -i | mawk '/^opcache.memory_consumption/{print $5;exit}') < 8 )) && memory_consumption='\nopcache.memory_consumption=128'
+			(( $($PHP_NAME -i | mawk '/^opcache.memory_consumption/{print $5;exit}') < 128 )) && memory_consumption='\nopcache.memory_consumption=128'
 			echo -e "; Nextcloud PHP settings\n; priority=98\nmemory_limit=512M$memory_consumption$interned_strings_buffer\nopcache.revalidate_freq=5\napc.enable_cli=1" > $FP_PHP_BASE_DIR/mods-available/dietpi-nextcloud.ini
 			G_EXEC phpenmod dietpi-nextcloud
 


### PR DESCRIPTION
**Status**: Ready
- [x] Tested with a NanoPi R2s

**Reference**: https://github.com/MichaIng/DietPi-Docs/pull/643

**Commit list/description**:
In case of Nextcloud package installation (ID = 114) the entry `memory_consumption = 128` within  /etc/php/7.4/mods-available/dietpi-nextcloud.ini was not set correctly to 128.
As a result, Nextcloud complains about false opcache settings.
