### PR TITLE
Add option for large format hostname in banner

### DIFF
--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -55,6 +55,7 @@
 		'Display DietPi useful commands?'
 		'MOTD'
 		'VPN status'
+		'Large Type Hostname'
 
 	)
 
@@ -131,6 +132,13 @@
 			echo "aCOLOUR[$i]='${aCOLOUR[$i]}'" >> $FP_SAVEFILE
 		done
 
+	}
+
+	Print_Figlet(){
+		if [ -x "$(command -v figlet)" ]; then
+			uname -n | cut -d. -f1 | figlet
+    			echo
+		fi
 	}
 
 	Print_Header(){
@@ -218,6 +226,8 @@ $GREEN_LINE"
 		G_TERM_CLEAR
 		Print_Header
 
+		# Figlet Hostname
+		(( ${aENABLED[14]} == 1 )) && Print_Figlet
 		# Device model
 		(( ${aENABLED[0]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[0]} $GREEN_SEPARATOR $G_HW_MODEL_NAME"
 		# Uptime


### PR DESCRIPTION
Fix for feature request #5110 

**Status**: Work in Progress
- Adds a large style hostname header in the banner using `figlet`, simple change
- I don't know how to ensure figlet is installed or to install it when required, or even if figlet is allowed on a light install like DietPi

**Commit List**
- `dietpi/func/dietpi_banner` | Adds large style banner to the top, configurable via the menu (as option 14)

**End Result**

![Screencap](https://imgur.com/NbuI7Wu.png)