### PR TITLE
DietPi-Software | myMPD: Migrate from source build to APT repo

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ Stretch support:
 Changes:
 - DietPi-Software | Mono: "mono-complete" won't be installed anymore but only "mono-devel" instead. This skips the XSP4 webserver service, which listens on port 8084 by default where it conflicts with File Browser. This only affects new instals. You can manually apply this change via "apt-mark manual mono-devel && apt --autoremove purge mono-complete". Many thanks to @jaguar489 for reporting this issue: https://github.com/MichaIng/DietPi/issues/5093
 - DietPi-Software | FuguHub: The outdated official installer has been replaced with a fully automated own setup, removing the obsolete or even harmful interactive dialogues. On fresh installs, an admin account "dietpi" with global software password is created as well.
+- DietPi-Software | myMPD: Installation is now done via official APT repository, which means quicker install compared to compiling from source, fewer dependencies and easier updates via "apt upgrade": https://github.com/MichaIng/DietPi/issues/5115
 
 Fixes:
 - Raspberry Pi | Resolved an issue where unintentionally the turbo mode was enabled. This got backported to v7.9, to our existing RPi images and via live patch. Many thanks to @ayo-x and @whyisthisbroken for reporting this issue: https://github.com/MichaIng/DietPi/issues/5088
@@ -21,6 +22,7 @@ Fixes:
 - DietPi-Software | Mycroft AI: Resolved an issue on Bullseye (and above) systems where "mycroft-cli-client" command fails with a permissions issue, even as root user. Many thanks to @berndverhofstadt for reporting this issue: https://github.com/MichaIng/DietPi/issues/5100
 - DietPi-Software | Nukkit: Resolved an issue where the install failed due to a changed download URL. The Jenkins instance has moved to ci.opencollab.dev, where also the Geyser and Floodgate projects are hosted.
 - DietPi-Software | FuguHub: Resolved an issue where the uninstall failed as the process was not stopped as intended. Many thanks to @kd9352 for reporting this issue: https://github.com/MichaIng/DietPi/issues/5058
+- DietPi-Software | myMPD: Resolved an issue where the installation failed due to an updated dependency. Many thanks to @supersexy for reporting this issue: https://github.com/MichaIng/DietPi/issues/5115
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5338,7 +5338,7 @@ _EOF_
 			fi
 
 			# APT key
-			G_EXEC curl -sSfL "https://download.opensuse.org/repositories/home:/jcorporation/$distro/Release.gpg" -o /etc/apt/trusted.gpg.d/dietpi-mympd.gpg
+			G_EXEC eval "curl -sSfL 'https://download.opensuse.org/repositories/home:/jcorporation/$distro/Release.key' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-mympd.gpg --yes"
 
 			# APT list
 			G_EXEC eval "echo 'deb https://download.opensuse.org/repositories/home:/jcorporation/$distro/ /' > /etc/apt/sources.list.d/dietpi-mympd.list"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8160,14 +8160,14 @@ _EOF_
 				fi
 
 				# Pre-v6.26 cleanup
-				[[ -f '/etc/openvpn/dh2048.pem' ]] && rm /etc/openvpn/dh2048.pem
+				[[ -f '/etc/openvpn/dh2048.pem' ]] && G_EXEC_NOEXIT=1 G_EXEC rm /etc/openvpn/dh2048.pem
 				dpkg-query -s easy-rsa &> /dev/null && G_AGP easy-rsa
 
 				# Download latest easy-rsa from GitHub
 				G_DIETPI-NOTIFY 2 'Downloading latest easy-rsa for certificate and key generation...'
 				local fallback_url='https://github.com/OpenVPN/easy-rsa/releases/download/v3.0.8/EasyRSA-3.0.8.tgz'
 				Download_Install "$(curl -sSfL 'https://api.github.com/repos/OpenVPN/easy-rsa/releases/latest' | mawk -F\" '/"browser_download_url": .*\/EasyRSA-[^"\/]*\.tgz"/{print $4}')"
-				[[ -d '/etc/openvpn/easy-rsa' ]] && rm -R /etc/openvpn/easy-rsa
+				[[ -d '/etc/openvpn/easy-rsa' ]] && G_EXEC rm -R /etc/openvpn/easy-rsa
 				G_EXEC mv EasyRSA-* /etc/openvpn/easy-rsa
 
 				# Cert and key generation via easy-rsa
@@ -8804,8 +8804,8 @@ _EOF_
 
 			else
 
-				# - Move data structure
-				[[ -e $target_data_dir ]] && rm -R $target_data_dir
+				# Move data structure
+				[[ -e $target_data_dir ]] && G_EXEC rm -R $target_data_dir
 				G_EXEC mv /var/www/pydio/data $target_data_dir
 
 			fi
@@ -12753,7 +12753,7 @@ _EOF_
 
 			Banner_Uninstalling
 			G_AGP xrdp xorgxrdp
-			[[ -f '/etc/apt/preferences.d/dietpi-xrdp' ]] && rm -v /etc/apt/preferences.d/dietpi-xrdp
+			[[ -f '/etc/apt/preferences.d/dietpi-xrdp' ]] && G_EXEC rm /etc/apt/preferences.d/dietpi-xrdp
 
 		fi
 
@@ -12762,10 +12762,10 @@ _EOF_
 
 			Banner_Uninstalling
 			G_AGP transmission-daemon
-			getent passwd debian-transmission > /dev/null && userdel debian-transmission
-			getent group debian-transmission > /dev/null && groupdel debian-transmission
-			[[ -f '/etc/systemd/system/transmission-daemon.service' ]] && rm /etc/systemd/system/transmission-daemon.service # pre v6.17
-			[[ -d '/etc/systemd/system/transmission-daemon.service.d' ]] && rm -R /etc/systemd/system/transmission-daemon.service.d # post v6.17
+			getent passwd debian-transmission > /dev/null && G_EXEC userdel debian-transmission
+			getent group debian-transmission > /dev/null && G_EXEC groupdel debian-transmission
+			[[ -f '/etc/systemd/system/transmission-daemon.service' ]] && G_EXEC rm /etc/systemd/system/transmission-daemon.service # pre v6.17
+			[[ -d '/etc/systemd/system/transmission-daemon.service.d' ]] && G_EXEC rm -R /etc/systemd/system/transmission-daemon.service.d # post v6.17
 
 		fi
 
@@ -12814,7 +12814,7 @@ _EOF_
 				rm /etc/apache2/conf-available/dietpi-dav_redirect.conf
 
 			fi
-			grep -q 'owncloud' /etc/nginx/sites-dietpi/dietpi-dav_redirect.conf &> /dev/null && rm /etc/nginx/sites-dietpi/dietpi-dav_redirect.conf
+			grep -q 'owncloud' /etc/nginx/sites-dietpi/dietpi-dav_redirect.conf &> /dev/null && G_EXEC rm /etc/nginx/sites-dietpi/dietpi-dav_redirect.conf
 
 		fi
 
@@ -12823,8 +12823,8 @@ _EOF_
 
 			Banner_Uninstalling
 			G_AGP coturn
-			[[ -f '/etc/turnserver.conf' ]] && rm /etc/turnserver.conf
-			[[ -d '/etc/systemd/system/coturn.service.d' ]] && rm -R /etc/systemd/system/coturn.service.d
+			[[ -f '/etc/turnserver.conf' ]] && G_EXEC rm /etc/turnserver.conf
+			[[ -d '/etc/systemd/system/coturn.service.d' ]] && G_EXEC rm -R /etc/systemd/system/coturn.service.d
 			systemctl start mariadb
 			systemctl start redis-server
 			ncc maintenance:mode --off
@@ -12877,7 +12877,7 @@ _EOF_
 				rm /etc/apache2/conf-available/dietpi-dav_redirect.conf
 
 			fi
-			grep -q 'nextcloud' /etc/nginx/sites-dietpi/dietpi-dav_redirect.conf &> /dev/null && rm /etc/nginx/sites-dietpi/dietpi-dav_redirect.conf
+			grep -q 'nextcloud' /etc/nginx/sites-dietpi/dietpi-dav_redirect.conf &> /dev/null && G_EXEC rm /etc/nginx/sites-dietpi/dietpi-dav_redirect.conf
 
 		fi
 
@@ -12885,7 +12885,7 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			[[ -d '/var/www/linuxdash' ]] && rm -R /var/www/linuxdash
+			[[ -d '/var/www/linuxdash' ]] && G_EXEC rm -R /var/www/linuxdash
 
 		fi
 
@@ -12893,14 +12893,14 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			[[ -d '/var/www/tasmoadmin' ]] && rm -R /var/www/tasmoadmin
+			[[ -d '/var/www/tasmoadmin' ]] && G_EXEC rm -R /var/www/tasmoadmin
 
 			# Remove webserver configs
 			command -v a2dissite > /dev/null && a2dissite dietpi-tasmoadmin
-			[[ -f '/etc/apache2/conf-available/dietpi-tasmoadmin.conf' ]] && rm /etc/apache2/conf-available/dietpi-tasmoadmin.conf
-			[[ -f '/etc/nginx/sites-dietpi/dietpi-tasmoadmin.conf' ]] && rm /etc/nginx/sites-dietpi/dietpi-tasmoadmin.conf
+			[[ -f '/etc/apache2/conf-available/dietpi-tasmoadmin.conf' ]] && G_EXEC rm /etc/apache2/conf-available/dietpi-tasmoadmin.conf
+			[[ -f '/etc/nginx/sites-dietpi/dietpi-tasmoadmin.conf' ]] && G_EXEC rm /etc/nginx/sites-dietpi/dietpi-tasmoadmin.conf
 			command -v lighty-disable-mod > /dev/null && lighty-disable-mod dietpi-tasmoadmin
-			[[ -f '/etc/lighttpd/conf-available/99-dietpi-tasmoadmin.conf' ]] && rm /etc/lighttpd/conf-available/99-dietpi-tasmoadmin.conf
+			[[ -f '/etc/lighttpd/conf-available/99-dietpi-tasmoadmin.conf' ]] && G_EXEC rm /etc/lighttpd/conf-available/99-dietpi-tasmoadmin.conf
 
 		fi
 
@@ -13004,7 +13004,7 @@ _EOF_
 				G_EXEC systemctl disable --now tor
 				G_EXEC rm /lib/systemd/system/tor.service
 			fi
-			[[ -d '/etc/systemd/system/tor.service.d' ]] && rm -R /etc/systemd/system/tor.service.d
+			[[ -d '/etc/systemd/system/tor.service.d' ]] && G_EXEC rm -R /etc/systemd/system/tor.service.d
 			G_AGP tor obfs4proxy
 		fi
 
@@ -13015,8 +13015,8 @@ _EOF_
 			systemctl start mariadb
 			mysqladmin -f drop phpbb drop phpbb3 # phpbb3: Pre-v6.33
 			mysql -e 'drop user phpbb@localhost; drop user phpbb3@localhost' # phpbb3: Pre-v6.33
-			[[ -d '/var/www/phpbb' ]] && rm -R /var/www/phpbb
-			[[ -d '/var/www/phpBB3' ]] && rm -R /var/www/phpBB3 # Pre-v6.33
+			[[ -d '/var/www/phpbb' ]] && G_EXEC rm -R /var/www/phpbb
+			[[ -d '/var/www/phpBB3' ]] && G_EXEC rm -R /var/www/phpBB3 # Pre-v6.33
 
 		fi
 
@@ -13074,7 +13074,8 @@ _EOF_
 			command -v mympd > /dev/null && G_EXEC rm "$(command -v mympd)"
 			command -v mympd-config > /dev/null && G_EXEC rm "$(command -v mympd-config)" # myMPD pre-v8.0.0
 			command -v mympd-script > /dev/null && G_EXEC rm "$(command -v mympd-script)"
-			G_EXEC rm -Rf /usr/share/doc/mympd /usr/share/man/man1/mympd* /etc/mympd.conf* # /etc: myMPD pre-v8.0.0
+			[[ -d '/usr/share/doc/mympd' ]] && G_EXEC rm -R /usr/share/doc/mympd
+			G_EXEC rm -f /usr/share/man/man1/mympd* /etc/mympd.conf* # /etc: myMPD pre-v8.0.0
 
 		fi
 
@@ -13225,7 +13226,7 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			[[ -d '/var/www/aria2' ]] && rm -R /var/www/aria2
+			[[ -d '/var/www/aria2' ]] && G_EXEC rm -R /var/www/aria2
 			if [[ -f '/etc/systemd/system/aria2.service' ]]
 			then
 				G_EXEC systemctl disable --now aria2
@@ -13444,8 +13445,8 @@ _EOF_
 			fi
 
 			G_AGP unbound
-			[[ -d '/etc/unbound' ]] && rm -R /etc/unbound
-			[[ -d '/var/cache/unbound' ]] && rm -R /var/cache/unbound
+			[[ -d '/etc/unbound' ]] && G_EXEC rm -R /etc/unbound
+			[[ -d '/var/cache/unbound' ]] && G_EXEC rm -R /var/cache/unbound
 		fi
 
 		software_id=143 # Koel
@@ -14414,10 +14415,10 @@ _EOF_
 
 			fi
 			# - Nginx
-			[[ -f '/etc/nginx/sites-dietpi/dietpi-dav_redirect.conf' ]] && rm -v /etc/nginx/sites-dietpi/dietpi-dav_redirect.conf
-			[[ -f '/etc/nginx/sites-dietpi/dietpi-baikal.conf' ]] && rm -v /etc/nginx/sites-dietpi/dietpi-baikal.conf
+			[[ -f '/etc/nginx/sites-dietpi/dietpi-dav_redirect.conf' ]] && G_EXEC rm /etc/nginx/sites-dietpi/dietpi-dav_redirect.conf
+			[[ -f '/etc/nginx/sites-dietpi/dietpi-baikal.conf' ]] && G_EXEC rm /etc/nginx/sites-dietpi/dietpi-baikal.conf
 
-			[[ -d '/var/www/baikal' ]] && rm -R /var/www/baikal
+			[[ -d '/var/www/baikal' ]] && G_EXEC rm -R /var/www/baikal
 
 			# Drop database
 			systemctl start mariadb

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5330,7 +5330,7 @@ _EOF_
 			then
 				distro+='10'
 
-			elif (( $G_DISTRO == 6 )) || [[ distro == 'Raspbian_' ]] # No Testing/Bullseye suite available for Raspbian yet
+			elif (( $G_DISTRO == 6 )) || [[ $distro == 'Raspbian_' ]] # No Testing/Bullseye suite available for Raspbian yet
 			then
 				distro+='11'
 			else

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -13066,6 +13066,7 @@ _EOF_
 			getent passwd mympd > /dev/null && G_EXEC userdel mympd
 			getent group mympd > /dev/null && G_EXEC groupdel mympd
 			[[ -d '/var/lib/mympd' ]] && G_EXEC rm -R /var/lib/mympd
+			[[ -d '/var/cache/mympd' ]] && G_EXEC rm -R /var/cache/mympd
 			[[ -f '/etc/apt/sources.list.d/dietpi-mympd.list' ]] && G_EXEC rm /etc/apt/sources.list.d/dietpi-mympd.list
 			[[ -f '/etc/apt/trusted.gpg.d/dietpi-mympd.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-mympd.gpg
 			# Pre-v8.0

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5322,20 +5322,31 @@ _EOF_
 
 			Banner_Installing
 
-			# Install dependencies: https://github.com/jcorporation/myMPD/blob/master/build.sh#L615-L616
-			DEPS_LIST='make gcc cmake perl libc6-dev libssl-dev libid3tag0-dev libflac-dev liblua5.3-dev pkg-config libpcre3-dev'
+			# Distro: https://download.opensuse.org/repositories/home:/jcorporation/
+			local distro='Debian_'
+			(( $G_HW_MODEL < 10 )) && (( $G_RASPBIAN )) && distro='Raspbian_'
 
-			# Download source
-			Download_Install 'https://github.com/jcorporation/myMPD/archive/master.tar.gz'
+			if (( $G_DISTRO == 5 ))
+			then
+				distro+='10'
 
-			# Build and install myMPD
-			G_EXEC cd myMPD-master
-			G_EXEC ./build.sh releaseinstall
+			elif (( $G_DISTRO == 6 )) || [[ distro == 'Raspbian_' ]] # No Testing/Bullseye suite available for Raspbian yet
+			then
+				distro+='11'
+			else
+				distro+='Testing'
+			fi
+
+			# APT key
+			G_EXEC curl -sSfL "https://download.opensuse.org/repositories/home:/jcorporation/$distro/Release.gpg" -o /etc/apt/trusted.gpg.d/dietpi-mympd.gpg
+
+			# APT list
+			G_EXEC eval "echo 'deb https://download.opensuse.org/repositories/home:/jcorporation/$distro/ /' > /etc/apt/sources.list.d/dietpi-mympd.list"
+			G_AGUP
+
+			# APT package
+			G_AGI mympd
 			G_EXEC systemctl stop mympd
-
-			# Cleanup
-			G_EXEC cd /tmp/$G_PROGRAM_NAME
-			G_EXEC_NOHALT=1 G_EXEC rm -R myMPD-master
 
 			# User: Switch to primary group "dietpi" to allow media access and create media files as "dietpi" group: https://github.com/MichaIng/DietPi/issues/3382
 			G_EXEC usermod -g dietpi mympd
@@ -5357,10 +5368,10 @@ _EOF_
 				G_EXEC chown -R mympd:dietpi /var/lib/mympd/state
 			fi
 
-			# myMPD pre-v8.0.0 migration: Remove obsolete file
+			# myMPD pre-v8.0.0 migration: Remove obsolete files
 			[[ -f '/etc/mympd.conf' ]] && G_EXEC_NOEXIT=1 G_EXEC rm /etc/mympd.conf
 			[[ -f '/etc/mympd.conf.dist' ]] && G_EXEC_NOEXIT=1 G_EXEC rm /etc/mympd.conf.dist
-			command -v mympd-config > /dev/null && G_EXEC rm "$(command -v mympd-config)"
+			command -v mympd-config > /dev/null && G_EXEC_NOEXIT=1 G_EXEC rm "$(command -v mympd-config)"
 
 		fi
 
@@ -13044,6 +13055,9 @@ _EOF_
 
 		software_id=148 # myMPD
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
+
+			Banner_Uninstalling
+			G_AGP mympd
 
 			if [[ -f '/lib/systemd/system/mympd.service' ]]
 			then

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5349,8 +5349,8 @@ _EOF_
 			G_EXEC systemctl stop mympd
 
 			# User: Switch to primary group "dietpi" to allow media access and create media files as "dietpi" group: https://github.com/MichaIng/DietPi/issues/3382
+			# - Leave "mympd" group in place, as it is recreated on package upgrades
 			G_EXEC usermod -g dietpi mympd
-			getent group mympd > /dev/null && G_EXEC_NOEXIT=1 G_EXEC groupdel mympd
 
 			# Config: Create on fresh install
 			# - On reinstall /var/lib/mympd exists, so use its existence as reinstall flag
@@ -5365,7 +5365,7 @@ _EOF_
 				echo '/mnt/dietpi_userdata/Music' > /var/lib/mympd/state/playlist_directory
 				echo '/mnt/dietpi_userdata/Music' > /var/lib/mympd/state/music_directory
 				G_EXEC chmod 0600 /var/lib/mympd/state/*
-				G_EXEC chown -R mympd:dietpi /var/lib/mympd/state
+				G_EXEC chown -R mympd:root /var/lib/mympd/state
 			fi
 
 			# myMPD pre-v8.0.0 migration: Remove obsolete files
@@ -13023,11 +13023,10 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			if [[ -f '/etc/systemd/system/webmin.service' ]]; then
-
+			if [[ -f '/etc/systemd/system/webmin.service' ]]
+			then
 				G_EXEC systemctl disable --now webmin
 				G_EXEC rm /etc/systemd/system/webmin.service
-
 			fi
 			[[ -d '/etc/systemd/system/webmin.service.d' ]] && G_EXEC rm -R /etc/systemd/system/webmin.service.d
 			G_AGP webmin
@@ -13040,11 +13039,10 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			if [[ -f '/etc/systemd/system/ympd.service' ]]; then
-
+			if [[ -f '/etc/systemd/system/ympd.service' ]]
+			then
 				G_EXEC systemctl disable --now ympd
 				G_EXEC rm /etc/systemd/system/ympd.service
-
 			fi
 			[[ -d '/etc/systemd/system/ympd.service.d' ]] && G_EXEC rm -R /etc/systemd/system/ympd.service.d
 			getent passwd ympd > /dev/null && G_EXEC userdel ympd
@@ -13057,8 +13055,6 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			G_AGP mympd
-
 			if [[ -f '/lib/systemd/system/mympd.service' ]]
 			then
 				G_EXEC systemctl unmask mympd
@@ -13066,14 +13062,15 @@ _EOF_
 				G_EXEC rm /lib/systemd/system/mympd.service
 			fi
 			[[ -d '/etc/systemd/system/mympd.service.d' ]] && G_EXEC rm -R /etc/systemd/system/mympd.service.d
-
+			G_AGP mympd
 			getent passwd mympd > /dev/null && G_EXEC userdel mympd
-			getent group mympd > /dev/null && G_EXEC groupdel mympd # pre-v6.29
-
+			getent group mympd > /dev/null && G_EXEC groupdel mympd
+			[[ -d '/var/lib/mympd' ]] && G_EXEC rm -R /var/lib/mympd
+			# Pre-v8.0
 			command -v mympd > /dev/null && G_EXEC rm "$(command -v mympd)"
 			command -v mympd-config > /dev/null && G_EXEC rm "$(command -v mympd-config)" # myMPD pre-v8.0.0
 			command -v mympd-script > /dev/null && G_EXEC rm "$(command -v mympd-script)"
-			G_EXEC rm -Rf /{usr/share/doc,var/lib}/mympd /usr/share/man/man1/mympd.* /etc/mympd.conf* # /etc: myMPD pre-v8.0.0
+			G_EXEC rm -Rf /usr/share/doc/mympd /usr/share/man/man1/mympd* /etc/mympd.conf* # /etc: myMPD pre-v8.0.0
 
 		fi
 
@@ -13081,18 +13078,17 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			if [[ -f '/lib/systemd/system/mpd.service' ]]; then
-
+			if [[ -f '/lib/systemd/system/mpd.service' ]]
+			then
 				G_EXEC systemctl unmask mpd
 				G_EXEC systemctl disable --now mpd
 				G_EXEC rm /lib/systemd/system/mpd.service
-
 			fi
 			[[ -d '/etc/systemd/system/mpd.service.d' ]] && G_EXEC rm -R /etc/systemd/system/mpd.service.d
 			[[ -f '/lib/systemd/system/mpd.socket' ]] && G_EXEC rm /lib/systemd/system/mpd.socket
+			G_AGP mpd libmpdclient2
 			getent passwd mpd > /dev/null && G_EXEC userdel mpd
 			getent group mpd > /dev/null && G_EXEC groupdel mpd # pre-v6.29
-			G_AGP mpd libmpdclient2
 			[[ -d '/var/log/mpd' ]] && G_EXEC rm -R /var/log/mpd
 			[[ -d '/mnt/dietpi_userdata/.mpd_cache' ]] && G_EXEC rm -R /mnt/dietpi_userdata/.mpd_cache
 			[[ -f '/etc/mpd.conf' ]] && G_EXEC rm /etc/mpd.conf
@@ -13107,11 +13103,10 @@ _EOF_
 			Banner_Uninstalling
 
 			# Service
-			if [[ -f '/etc/systemd/system/node-red.service' ]]; then
-
+			if [[ -f '/etc/systemd/system/node-red.service' ]]
+			then
 				G_EXEC systemctl disable --now node-red
 				G_EXEC rm /etc/systemd/system/node-red.service
-
 			fi
 			[[ -d '/etc/systemd/system/node-red.service.d' ]] && G_EXEC rm -R /etc/systemd/system/node-red.service.d
 
@@ -13146,11 +13141,10 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			if [[ -f '/etc/systemd/system/mosquitto.service' ]]; then
-
+			if [[ -f '/etc/systemd/system/mosquitto.service' ]]
+			then
 				G_EXEC systemctl disable --now mosquitto
 				G_EXEC rm /etc/systemd/system/mosquitto.service
-
 			fi
 			[[ -d '/etc/systemd/system/mosquitto.service.d' ]] && G_EXEC rm -R /etc/systemd/system/mosquitto.service.d
 			G_AGP mosquitto

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -13066,6 +13066,8 @@ _EOF_
 			getent passwd mympd > /dev/null && G_EXEC userdel mympd
 			getent group mympd > /dev/null && G_EXEC groupdel mympd
 			[[ -d '/var/lib/mympd' ]] && G_EXEC rm -R /var/lib/mympd
+			[[ -f '/etc/apt/sources.list.d/dietpi-mympd.list' ]] && G_EXEC rm /etc/apt/sources.list.d/dietpi-mympd.list
+			[[ -f '/etc/apt/trusted.gpg.d/dietpi-mympd.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-mympd.gpg
 			# Pre-v8.0
 			command -v mympd > /dev/null && G_EXEC rm "$(command -v mympd)"
 			command -v mympd-config > /dev/null && G_EXEC rm "$(command -v mympd-config)" # myMPD pre-v8.0.0

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2760,6 +2760,7 @@ _EOF_
 
 			Banner_Installing
 			G_AGI avahi-daemon
+			G_EXEC systemctl stop avahi-daemon
 
 		fi
 


### PR DESCRIPTION
**Status**: Testing

**Testing**:
- [x] x86_64 Buster
- [x] x86_64 Bullseye
- [x] x86_64 Bookworm
- [x] ARM Buster
- [x] ARM Bullseye
- [x] ARM Bookworm
- [x] Raspbian Buster
- [x] Raspbian Bullseye
- [x] Raspbian Bookworm

**Commit list/description**:
- DietPi-Software | myMPD: Installation is now done via official APT repository, which means quicker install compared to compiling from source, less dependencies and easier updates via "apt upgrade": https://github.com/MichaIng/DietPi/issues/5115
- DietPi-Software | myMPD: Resolved an issue where the installation failed due to an updated dependency. Many thanks to @supersexy for reporting this issue: https://github.com/MichaIng/DietPi/issues/5115