### PR TITLE
DietPi-Drive_Manager | Preserve Btrfs subvolumes

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ v8.1
 (2022-02-05)
 
 Changes:
+- DietPi-Drive_Manager | Btrfs subvolume mounts are not preserved in /etc/fstab. Many thanks to @laddde for implementing this feature: https://github.com/MichaIng/DietPi/pull/5176
 
 Fixes:
 - DietPi-Software | FuguHub: Resolved an issue where the uninstall failed as the service was not stopped and removed as expected, before attempting to remove the service user.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,7 +2,7 @@ v8.1
 (2022-02-05)
 
 Changes:
-- DietPi-Drive_Manager | Btrfs subvolume mounts are not preserved in /etc/fstab. Many thanks to @laddde for implementing this feature: https://github.com/MichaIng/DietPi/pull/5176
+- DietPi-Drive_Manager | Btrfs subvolume mounts are now preserved in /etc/fstab. Many thanks to @laddde for implementing this feature: https://github.com/MichaIng/DietPi/pull/5176
 
 Fixes:
 - DietPi-Software | FuguHub: Resolved an issue where the uninstall failed as the service was not stopped and removed as expected, before attempting to remove the service user.

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -122,8 +122,8 @@ tmpfs /var/log tmpfs size=${var_log_size:-50}M,noatime,lazytime,nodev,nosuid,mod
 
 			swap_mounts=$(grep '^[[:blank:]]*[^#].*[[:blank:]]swap[[:blank:]]' $fp_fstab_tmp)
 			tmpfs_mounts=$(grep '^[[:blank:]]*tmpfs[[:blank:]]' $fp_fstab_tmp)
-			# ecryptfs, vboxsf, glusterfs, bind, btrfs subvolume mounts
-			misc_mounts=$(grep -E '^[[:blank:]]*[^#].*([[:blank:]](ecryptfs|vboxsf|glusterfs)[[:blank:]]|[[:blank:],]bind[[:blank:],]|[[:blank:]]btrfs[[:blank:]]+(|.+,)subvol=.+)' $fp_fstab_tmp)
+			# ecryptfs, vboxsf, glusterfs, bind, Btrfs subvolume mounts
+			misc_mounts=$(grep -E '^[[:blank:]]*[^#].*([[:blank:]](ecryptfs|vboxsf|glusterfs)[[:blank:]]|[[:blank:],]bind[[:blank:],]|[[:blank:]]btrfs[[:blank:]]+(.+,)?subvol=)' $fp_fstab_tmp)
 			# CurlFtpFS, CIFS/SMB/Samba, NFS, SSHFS
 			net_mounts=$(grep -E '^[[:blank:]]*(curlftpfs|sshfs#|[^#].*[[:blank:]](cifs|nfs4?|fuse.sshfs)[[:blank:]])' $fp_fstab_tmp)
 
@@ -142,7 +142,7 @@ $net_mounts
 $tmpfs_mounts
 
 #----------------------------------------------------------------
-# MISC: ecryptfs, vboxsf (VirtualBox shared folder), gluster, btrfs subvolume, bind mounts
+# MISC: ecryptfs, vboxsf, glusterfs, bind, Btrfs subvolume mounts
 #----------------------------------------------------------------
 $misc_mounts
 

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -122,8 +122,8 @@ tmpfs /var/log tmpfs size=${var_log_size:-50}M,noatime,lazytime,nodev,nosuid,mod
 
 			swap_mounts=$(grep '^[[:blank:]]*[^#].*[[:blank:]]swap[[:blank:]]' $fp_fstab_tmp)
 			tmpfs_mounts=$(grep '^[[:blank:]]*tmpfs[[:blank:]]' $fp_fstab_tmp)
-			# ecryptfs, vboxsf, glusterfs, bind mounts
-			misc_mounts=$(grep -E '^[[:blank:]]*[^#].*([[:blank:]](ecryptfs|vboxsf|glusterfs)[[:blank:]]|[[:blank:],]bind[[:blank:],])' $fp_fstab_tmp)
+			# ecryptfs, vboxsf, glusterfs, bind, btrfs subvolume mounts
+			misc_mounts=$(grep -E '^[[:blank:]]*[^#].*([[:blank:]](ecryptfs|vboxsf|glusterfs)[[:blank:]]|[[:blank:],]bind[[:blank:],]|[[:blank:]]btrfs[[:blank:]]+(|.+,)subvol=.+)' $fp_fstab_tmp)
 			# CurlFtpFS, CIFS/SMB/Samba, NFS, SSHFS
 			net_mounts=$(grep -E '^[[:blank:]]*(curlftpfs|sshfs#|[^#].*[[:blank:]](cifs|nfs4?|fuse.sshfs)[[:blank:]])' $fp_fstab_tmp)
 
@@ -142,7 +142,7 @@ $net_mounts
 $tmpfs_mounts
 
 #----------------------------------------------------------------
-# MISC: ecryptfs, vboxsf (VirtualBox shared folder), gluster, bind mounts
+# MISC: ecryptfs, vboxsf (VirtualBox shared folder), gluster, btrfs subvolume, bind mounts
 #----------------------------------------------------------------
 $misc_mounts
 


### PR DESCRIPTION
<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
**Status**: Ready

**Reference**: https://github.com/MichaIng/DietPi/issues/5084

**Commit list/description**:
- dietpi-drive_manager: Add btrfs subvolume mounts to "MISC" mounts, so that they are kept in /etc/fstab when the file is updated by dietpi-drive_manager
