### PR TITLE
DietPi-Software | MineOS: Fix install on Bullseye

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,9 +6,10 @@ Changes:
 
 Fixes:
 - DietPi-Services | Resolved an issue where service edits and process tool settings were not effective as they were stored to the wrong file path. Many thanks to @TopFord and @MicDG for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?p=41509#p41509
+- DietPi-Software/DietPi-AutoStart | Chromium: Resolved an issue where the Chromium kiosk autostart option failed on all non-RPi systems. 
 - DietPi-Software | FuguHub: Resolved an issue where the uninstall failed as the service was not stopped and removed as expected, before attempting to remove the service user.
 - DietPi-Software | PHP: Resolved an issue where the PATH variable was not available for PHP applications with Lighttpd and Nginx webservers. It is now set to the static value "/usr/local/bin:/usr/bin:/bin", the default PATH excluding super user executables "sbin". Many thanks to @shanew1694 for reporting a related issue with rTorrent: https://github.com/MichaIng/DietPi/issues/5161#issuecomment-1013381362
-- DietPi-Software/DietPi-AutoStart | Chromium: Resolved an issue where the Chromium kiosk autostart option failed on all non-RPi systems. 
+- DietPi-Software | MineOS: Resolved an issue where the install failed on Bullseye: https://github.com/MichaIng/DietPi/issues/5181
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7264,10 +7264,10 @@ _EOF_
 			fi
 
 			# RPi: Install "onoff" for GPIO access
-			(( $G_HW_MODEL > 9 )) || G_EXEC_OUTPUT=1 G_EXEC npm i -g --unsafe-perm --no-audit onoff
+			(( $G_HW_MODEL > 9 )) || G_EXEC_OUTPUT=1 G_EXEC npm i -g --no-audit onoff
 
 			# Install Blynk JS library
-			G_EXEC_OUTPUT=1 G_EXEC npm i -g --unsafe-perm --no-audit blynk-library
+			G_EXEC_OUTPUT=1 G_EXEC npm i -g --no-audit blynk-library
 
 			# Preserve existing config
 			if [[ ! -f '/mnt/dietpi_userdata/blynk/server.properties' ]]
@@ -9105,8 +9105,12 @@ _EOF_
 			local url='https://github.com/hexparrot/mineos-node.git'
 			G_CHECK_URL "$url"
 
+			# Python 3 is not pulled by rdiff-backup on Buster, but required to compile Node.js posix.
+			local python=
+			(( $G_DISTRO > 5 )) || python='python3'
+
 			# APT deps
-			G_AGI rdiff-backup rsync screen
+			G_AGI rdiff-backup rsync screen $python
 
 			# Download/Update MineOS
 			[[ -d '/mnt/dietpi_userdata/mineos' ]] || G_EXEC mkdir /mnt/dietpi_userdata/mineos
@@ -9131,12 +9135,11 @@ _EOF_
 			G_EXEC git config core.filemode false
 			G_EXEC chmod +x mineos_console.js webui.js update_webui.sh reset_webui.sh generate-sslcert.sh
 
-			# Install Node 11, as MineOS is currently not compatible with newer Node versions: https://github.com/hexparrot/mineos-node/issues/374
-			G_EXEC_OUTPUT=1 G_EXEC npm i -g --unsafe-perm --no-audit n
-			G_EXEC_OUTPUT=1 G_EXEC n 11
+			# Workaround: Node.js posix needs to be installed alone first: https://github.com/MichaIng/DietPi/issues/5181
+			G_EXEC_OUTPUT=1 G_EXEC npm i --no-audit --no-package-lock posix
 
 			# Install MineOS
-			G_EXEC_OUTPUT=1 G_EXEC npm i --unsafe-perm --no-audit
+			G_EXEC_OUTPUT=1 G_EXEC npm i --no-audit
 			G_EXEC cd "$G_WORKING_DIR"
 
 			# Config: Preserve existing
@@ -13142,7 +13145,7 @@ _EOF_
 			G_EXEC rm -Rf /{root,home/*}/.node-red # Pre-v6.25
 
 			# Pre-v7.0
-			command -v npm > /dev/null && npm r -g --unsafe-perm node-red
+			command -v npm > /dev/null && npm r -g node-red
 			[[ -f '/usr/local/bin/node-red' ]] && G_EXEC rm /usr/local/bin/node-red
 			[[ -f '/usr/local/bin/node-red-pi' ]] && G_EXEC rm /usr/local/bin/node-red-pi
 
@@ -13210,7 +13213,7 @@ _EOF_
 			[[ -d '/var/log/blynk' ]] && G_EXEC rm -R /var/log/blynk
 			getent passwd blynk > /dev/null && G_EXEC userdel blynk
 			getent group blynk > /dev/null && G_EXEC groupdel blynk
-			command -v npm > /dev/null && npm r -g --unsafe-perm blynk-library
+			command -v npm > /dev/null && npm r -g blynk-library
 			[[ -f '/usr/local/bin/blynk-ctrl' ]] && G_EXEC rm /usr/local/bin/blynk-ctrl
 			[[ -f '/usr/local/bin/blynk-client' ]] && G_EXEC rm /usr/local/bin/blynk-client
 			[[ -d '/etc/blynkserver' ]] && G_EXEC rm -R /etc/blynkserver # Pre-v6.19
@@ -15529,7 +15532,7 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			command -v npm > /dev/null && npm r -g --unsafe-perm n yarn npm
+			command -v npm > /dev/null && npm r -g n yarn npm
 
 			# Old install via repo
 			G_AGP nodejs


### PR DESCRIPTION
**Status**: Testing

**Testing**:
- [x] Buster VM
- [x] Bullseye VM
- [x] Bookworm VM
- [x] Bullseye ARMv6
- [x] Bookworm ARMv7
- [x] Bullseye ARMv8

**Commit list/description**:
- DietPi-Software | Do not use the obsolete --unsafe-perm flag for npm calls anymore
- DietPi-Software | MineOS: Install Python 3 on Buster as dependency, required for the Node.js posix module but not pulled by rdiff-backup on Buster
- DietPi-Software | MineOS: As a workaround required with latest Node.js 17, install the posix module alone first, before installing the whole project: https://github.com/MichaIng/DietPi/issues/5181