### PR TITLE
DietPi-Drive_Manager | Enhance network share input prompts

### DIFF
--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -1723,23 +1723,25 @@ NB: If you are planning to dedicate the drive to this system, it is recommended 
 
 		# User inputs
 		G_WHIP_DEFAULT_ITEM=$samba_clientname
-		G_WHIP_INPUTBOX 'Please enter the fileservers IP address\n - eg: 192.168.0.2' || return
+		G_WHIP_INPUTBOX 'Please enter the fileservers IP address or hostname.\n - E.g.: 192.168.0.2 or myNAS.local' || return
 		samba_clientname=$G_WHIP_RETURNED_VALUE
 
 		G_WHIP_DEFAULT_ITEM=$samba_clientshare
-		G_WHIP_INPUTBOX 'Please enter the fileservers shared folder name\n - eg: MySharedFolder' || return
-		samba_clientshare=$G_WHIP_RETURNED_VALUE
+		G_WHIP_INPUTBOX 'Please enter the fileservers shared folder name.\n - E.g.: mySharedFolder or path/to/folder' || return
+		# - Remove leading slash
+		samba_clientshare=${G_WHIP_RETURNED_VALUE#/}
 
 		G_WHIP_DEFAULT_ITEM=$samba_clientuser
-		G_WHIP_INPUTBOX 'Please enter the fileservers username\n - eg: JoeBloggs' || return
+		G_WHIP_INPUTBOX 'Please enter the fileservers username.\n - E.g.: JoeBloggs' || return
 		samba_clientuser=$G_WHIP_RETURNED_VALUE
 
-		G_WHIP_PASSWORD 'Please enter the fileservers password\n - eg: LetMeIn' || return
+		G_WHIP_PASSWORD 'Please enter the fileservers password.\n - E.g.: LetMeIn' || return
 		samba_clientpassword=$result
 		unset -v result
 
 		G_WHIP_DEFAULT_ITEM=$samba_fp_mount_target
-		G_WHIP_INPUTBOX 'Please enter a unique folder name for the mount location (eg: samba). This will be placed in /mnt/' || return
+		G_WHIP_INPUTBOX 'Please enter a unique folder name for the mount location.\n - E.g.: samba\nThis will be placed in /mnt/.
+\nNB: Please avoid white spaces or special characters for compatibility reasons.' || return
 		# - Remove leading "/mnt/" and "/" in case entered by user
 		samba_fp_mount_target=${G_WHIP_RETURNED_VALUE#/mnt/}; samba_fp_mount_target=${samba_fp_mount_target#/}
 		# - Remove trailing slash and (re-)add "/mnt/" for full mount target path
@@ -1814,11 +1816,11 @@ _EOF_
 
 		# User inputs
 		G_WHIP_DEFAULT_ITEM=$nfs_server_ip
-		G_WHIP_INPUTBOX 'Please enter the NFS servers IP address (eg: 192.168.0.2).' || return
+		G_WHIP_INPUTBOX 'Please enter the NFS servers IP address or hostname.\n - E.g.: 192.168.0.2 or myNAS.local' || return
 		nfs_server_ip=$G_WHIP_RETURNED_VALUE
 
 		G_WHIP_DEFAULT_ITEM=$nfs_fp_mount_target
-		G_WHIP_INPUTBOX 'Please enter a unique folder name for the mount location (eg: nfs_client). This will be placed in /mnt/
+		G_WHIP_INPUTBOX 'Please enter a unique folder name for the mount location.\n - E.g.: nfs_client\nThis will be placed in /mnt/.
 \nNB: Please avoid white spaces or special characters for compatibility reasons.' || return
 		# - Remove leading "/mnt/" and "/" in case entered by user
 		nfs_fp_mount_target=${G_WHIP_RETURNED_VALUE#/mnt/}; nfs_fp_mount_target=${nfs_fp_mount_target#/}

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -1727,7 +1727,7 @@ NB: If you are planning to dedicate the drive to this system, it is recommended 
 		samba_clientname=$G_WHIP_RETURNED_VALUE
 
 		G_WHIP_DEFAULT_ITEM=$samba_clientshare
-		G_WHIP_INPUTBOX 'Please enter the fileservers shared folder name.\n - E.g.: mySharedFolder or path/to/folder' || return
+		G_WHIP_INPUTBOX 'Please enter the fileservers shared folder name or path.\n - E.g.: mySharedFolder or path/to/folder' || return
 		# - Remove leading slash
 		samba_clientshare=${G_WHIP_RETURNED_VALUE#/}
 


### PR DESCRIPTION
**Status**: Review

**Commit list/description**:
- DietPi-Drive_Manager | Align network drive input prompts, allow to enter a path as SMB/CIFS server shared folder, remove leading slash when given
