### PR TITLE
DietPi-Software | Ampache: Fix install of v5 (Bullseye)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,7 @@ Fixes:
 - DietPi-Software | MineOS: Resolved an issue where the install failed on Bullseye: https://github.com/MichaIng/DietPi/issues/5181
 - DietPi-Software | Cuberite: Resolved an issue where the server failed to start on ARMv8 systems: https://github.com/MichaIng/DietPi/issues/5180
 - DietPi-Software | MATE: Resolved an issue where the install failed when LXDE is installed already. Many thanks to @n0valis for reporting this issue: https://github.com/MichaIng/DietPi/issues/5214
+- DietPi-Software | Ampache: Resolved an issue on Bullseye systems where Ampache v5 installs/reinstalls did not work because of a changed webroot directory: https://github.com/MichaIng/DietPi/pull/5205
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8028,22 +8028,30 @@ _EOF_
 			then
 				local fallback_url='https://github.com/ampache/ampache/releases/download/5.2.0/ampache-5.2.0_all.zip'
 				Download_Install "$(curl -sSfL 'https://api.github.com/repos/ampache/ampache/releases/latest' | mawk -F\" '/"browser_download_url": ".*\/ampache-[0-9\.]*_all.zip"/{print $4}')" ampache
+				# Ampache is installed to /mnt/dietpi_userdata/ampache and the "public" directory linked to /var/www/ampache: https://github.com/MichaIng/DietPi/pull/5205
+				local fp_install='/mnt/dietpi_userdata'
 
 			# Ampache v5 requires PHP7.4, hence pull latest Ampache v4 on Buster: https://github.com/ampache/ampache/wiki/Ampache-Next-Changes
 			else
 				local fallback_url='https://github.com/ampache/ampache/releases/download/4.4.3/ampache-4.4.3_all.zip'
 				Download_Install "$(curl -sSfL 'https://api.github.com/repos/ampache/ampache/releases' | mawk -F\" '/"browser_download_url": ".*\/ampache-4[0-9\.]*_all.zip"/{print $4}' | head -1)" ampache
+				# Ampache is installed to /var/www/ampache.
+				local fp_install='/var/www'
 			fi
 
-			# Reinstall: Preserve existing config files
+			# Reinstall: Preserve configs from old and new paths
 			[[ -f '/var/www/ampache/config/ampache.cfg.php' ]] && G_EXEC mv /var/www/ampache/config/ampache.cfg.php ampache/config/
 			[[ -f '/var/www/ampache/config/registration_agreement.php' ]] && G_EXEC mv /var/www/ampache/config/registration_agreement.php ampache/config/
+			[[ -f '/mnt/dietpi_userdata/ampache/config/ampache.cfg.php' ]] && G_EXEC mv /mnt/dietpi_userdata/ampache/config/ampache.cfg.php ampache/config/
+			[[ -f '/mnt/dietpi_userdata/ampache/config/registration_agreement.php' ]] && G_EXEC mv /mnt/dietpi_userdata/ampache/config/registration_agreement.php ampache/config/
 			[[ -f '/var/www/ampache/channel/.htaccess' ]] && G_EXEC mv /var/www/ampache/channel/.htaccess ampache/channel/
 			[[ -f '/var/www/ampache/rest/.htaccess' ]] && G_EXEC mv /var/www/ampache/rest/.htaccess ampache/rest/
 			[[ -f '/var/www/ampache/play/.htaccess' ]] && G_EXEC mv /var/www/ampache/play/.htaccess ampache/play/
-			[[ -d '/var/www/ampache' ]] && G_EXEC rm -R /var/www/ampache
+			[[ -d '/var/www/ampache' || -L '/var/www/ampache' ]] && G_EXEC rm -R /var/www/ampache
+			[[ -d '/mnt/dietpi_userdata/ampache' ]] && G_EXEC rm -R /mnt/dietpi_userdata/ampache
 
-			G_EXEC mv {,/var/www/}ampache
+			G_EXEC mv {,"$fp_install/"}ampache
+			[[ -d '/mnt/dietpi_userdata/ampache/public' ]] && G_EXEC ln -s /mnt/dietpi_userdata/ampache/public /var/www/ampache
 
 			Download_Test_Media
 
@@ -8058,39 +8066,39 @@ _EOF_
 				G_EXEC mysql ampache < ampache.sql
 				G_EXEC_NOHALT=1 G_EXEC rm ampache.sql
 				# Also update password here for rare but possible case that database was lost but config file still exists
-				[[ -f '/var/www/ampache/config/ampache.cfg.php' ]] && G_CONFIG_INJECT 'database_password[[:blank:]]+=' "database_password = \"$GLOBAL_PW\"" /var/www/ampache/config/ampache.cfg.php
+				[[ -f $fp_install/ampache/config/ampache.cfg.php ]] && G_CONFIG_INJECT 'database_password[[:blank:]]+=' "database_password = \"$GLOBAL_PW\"" "$fp_install/ampache/config/ampache.cfg.php"
 
 			fi
 
 			# Create new config, if not existent already
-			if [[ ! -f '/var/www/ampache/config/ampache.cfg.php' ]]; then
+			if [[ ! -f $fp_install/ampache/config/ampache.cfg.php ]]; then
 
-				G_EXEC mv /var/www/ampache/config/ampache.cfg.php{.dist,}
-				G_CONFIG_INJECT 'web_path[[:blank:]]+=' 'web_path = "/ampache/public"' /var/www/ampache/config/ampache.cfg.php
-				G_CONFIG_INJECT 'database_hostname[[:blank:]]+=' 'database_hostname = /run/mysqld/mysqld.sock' /var/www/ampache/config/ampache.cfg.php
-				G_CONFIG_INJECT 'database_name[[:blank:]]+=' 'database_name = ampache' /var/www/ampache/config/ampache.cfg.php
-				G_CONFIG_INJECT 'database_username[[:blank:]]+=' 'database_username = ampache' /var/www/ampache/config/ampache.cfg.php
-				G_CONFIG_INJECT 'database_password[[:blank:]]+=' "database_password = \"$GLOBAL_PW\"" /var/www/ampache/config/ampache.cfg.php
-				G_CONFIG_INJECT 'waveform[[:blank:]]+=' 'waveform = "true"' /var/www/ampache/config/ampache.cfg.php
-				G_CONFIG_INJECT 'tmp_dir_path[[:blank:]]+=' 'tmp_dir_path = "/tmp"' /var/www/ampache/config/ampache.cfg.php
-				G_CONFIG_INJECT 'generate_video_preview[[:blank:]]+=' 'generate_video_preview = "true"' /var/www/ampache/config/ampache.cfg.php
-				G_CONFIG_INJECT 'channel[[:blank:]]+=' 'channel = "true"' /var/www/ampache/config/ampache.cfg.php
-				G_CONFIG_INJECT 'transcode_m4a[[:blank:]]+=' 'transcode_m4a = "required"' /var/www/ampache/config/ampache.cfg.php
-				G_CONFIG_INJECT 'transcode_flac[[:blank:]]+=' 'transcode_flac = "required"' /var/www/ampache/config/ampache.cfg.php
-				G_CONFIG_INJECT 'transcode_mpc[[:blank:]]+=' 'transcode_mpc = "required"' /var/www/ampache/config/ampache.cfg.php
-				G_CONFIG_INJECT 'transcode_ogg[[:blank:]]+=' 'transcode_ogg = "allowed"' /var/www/ampache/config/ampache.cfg.php
-				G_CONFIG_INJECT 'transcode_wav[[:blank:]]+=' 'transcode_wav = "required"' /var/www/ampache/config/ampache.cfg.php
-				G_CONFIG_INJECT 'transcode_avi[[:blank:]]+=' 'transcode_avi = "allowed"' /var/www/ampache/config/ampache.cfg.php
-				G_CONFIG_INJECT 'transcode_mkv[[:blank:]]+=' 'transcode_mkv = "allowed"' /var/www/ampache/config/ampache.cfg.php
-				G_CONFIG_INJECT 'transcode_mpg[[:blank:]]+=' 'transcode_mpg = "allowed"' /var/www/ampache/config/ampache.cfg.php
-				G_CONFIG_INJECT 'encode_target[[:blank:]]+=' 'encode_target = mp3' /var/www/ampache/config/ampache.cfg.php
-				G_CONFIG_INJECT 'encode_video_target[[:blank:]]+=' 'encode_video_target = webm' /var/www/ampache/config/ampache.cfg.php
-				G_CONFIG_INJECT 'transcode_cmd[[:blank:]]+=' 'transcode_cmd = "ffmpeg"' /var/www/ampache/config/ampache.cfg.php
+				G_EXEC mv "$fp_install/ampache/config/ampache.cfg.php"{.dist,}
+				G_CONFIG_INJECT 'web_path[[:blank:]]+=' 'web_path = "/ampache"' "$fp_install/ampache/config/ampache.cfg.php"
+				G_CONFIG_INJECT 'database_hostname[[:blank:]]+=' 'database_hostname = /run/mysqld/mysqld.sock' "$fp_install/ampache/config/ampache.cfg.php"
+				G_CONFIG_INJECT 'database_name[[:blank:]]+=' 'database_name = ampache' "$fp_install/ampache/config/ampache.cfg.php"
+				G_CONFIG_INJECT 'database_username[[:blank:]]+=' 'database_username = ampache' "$fp_install/ampache/config/ampache.cfg.php"
+				G_CONFIG_INJECT 'database_password[[:blank:]]+=' "database_password = \"$GLOBAL_PW\"" "$fp_install/ampache/config/ampache.cfg.php"
+				G_CONFIG_INJECT 'waveform[[:blank:]]+=' 'waveform = "true"' "$fp_install/ampache/config/ampache.cfg.php"
+				G_CONFIG_INJECT 'tmp_dir_path[[:blank:]]+=' 'tmp_dir_path = "/tmp"' "$fp_install/ampache/config/ampache.cfg.php"
+				G_CONFIG_INJECT 'generate_video_preview[[:blank:]]+=' 'generate_video_preview = "true"' "$fp_install/ampache/config/ampache.cfg.php"
+				G_CONFIG_INJECT 'channel[[:blank:]]+=' 'channel = "true"' "$fp_install/ampache/config/ampache.cfg.php"
+				G_CONFIG_INJECT 'transcode_m4a[[:blank:]]+=' 'transcode_m4a = "required"' "$fp_install/ampache/config/ampache.cfg.php"
+				G_CONFIG_INJECT 'transcode_flac[[:blank:]]+=' 'transcode_flac = "required"' "$fp_install/ampache/config/ampache.cfg.php"
+				G_CONFIG_INJECT 'transcode_mpc[[:blank:]]+=' 'transcode_mpc = "required"' "$fp_install/ampache/config/ampache.cfg.php"
+				G_CONFIG_INJECT 'transcode_ogg[[:blank:]]+=' 'transcode_ogg = "allowed"' "$fp_install/ampache/config/ampache.cfg.php"
+				G_CONFIG_INJECT 'transcode_wav[[:blank:]]+=' 'transcode_wav = "required"' "$fp_install/ampache/config/ampache.cfg.php"
+				G_CONFIG_INJECT 'transcode_avi[[:blank:]]+=' 'transcode_avi = "allowed"' "$fp_install/ampache/config/ampache.cfg.php"
+				G_CONFIG_INJECT 'transcode_mkv[[:blank:]]+=' 'transcode_mkv = "allowed"' "$fp_install/ampache/config/ampache.cfg.php"
+				G_CONFIG_INJECT 'transcode_mpg[[:blank:]]+=' 'transcode_mpg = "allowed"' "$fp_install/ampache/config/ampache.cfg.php"
+				G_CONFIG_INJECT 'encode_target[[:blank:]]+=' 'encode_target = mp3' "$fp_install/ampache/config/ampache.cfg.php"
+				G_CONFIG_INJECT 'encode_video_target[[:blank:]]+=' 'encode_video_target = webm' "$fp_install/ampache/config/ampache.cfg.php"
+				G_CONFIG_INJECT 'transcode_cmd[[:blank:]]+=' 'transcode_cmd = "ffmpeg"' "$fp_install/ampache/config/ampache.cfg.php"
 
 			fi
 
 			# Permissions: Ampache can automatically migrate old configs to the new config file
-			G_EXEC chown www-data /var/www/ampache/config/ampache.cfg.php
+			G_EXEC chown www-data "$fp_install/ampache/config/ampache.cfg.php"
 
 		fi
 
@@ -14155,7 +14163,8 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			[[ -d '/var/www/ampache' ]] && G_EXEC rm -R /var/www/ampache
+			[[ -d '/var/www/ampache' || -L '/var/www/ampache' ]] && G_EXEC rm -R /var/www/ampache
+			[[ -d '/mnt/dietpi_userdata/ampache' ]] && G_EXEC rm -R /mnt/dietpi_userdata/ampache
 
 			# Drop database
 			systemctl start mariadb

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8066,7 +8066,7 @@ _EOF_
 			if [[ ! -f '/var/www/ampache/config/ampache.cfg.php' ]]; then
 
 				G_EXEC mv /var/www/ampache/config/ampache.cfg.php{.dist,}
-				G_CONFIG_INJECT 'web_path[[:blank:]]+=' 'web_path = "/ampache"' /var/www/ampache/config/ampache.cfg.php
+				G_CONFIG_INJECT 'web_path[[:blank:]]+=' 'web_path = "/ampache/public"' /var/www/ampache/config/ampache.cfg.php
 				G_CONFIG_INJECT 'database_hostname[[:blank:]]+=' 'database_hostname = /run/mysqld/mysqld.sock' /var/www/ampache/config/ampache.cfg.php
 				G_CONFIG_INJECT 'database_name[[:blank:]]+=' 'database_name = ampache' /var/www/ampache/config/ampache.cfg.php
 				G_CONFIG_INJECT 'database_username[[:blank:]]+=' 'database_username = ampache' /var/www/ampache/config/ampache.cfg.php

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8029,14 +8029,14 @@ _EOF_
 				local fallback_url='https://github.com/ampache/ampache/releases/download/5.2.0/ampache-5.2.0_all.zip'
 				Download_Install "$(curl -sSfL 'https://api.github.com/repos/ampache/ampache/releases/latest' | mawk -F\" '/"browser_download_url": ".*\/ampache-[0-9\.]*_all.zip"/{print $4}')" ampache
 				# Ampache is installed to /mnt/dietpi_userdata/ampache and the "public" directory linked to /var/www/ampache: https://github.com/MichaIng/DietPi/pull/5205
-				local fp_install='/mnt/dietpi_userdata'
+				local fp_install='/mnt/dietpi_userdata' fp_public='ampache/public'
 
 			# Ampache v5 requires PHP7.4, hence pull latest Ampache v4 on Buster: https://github.com/ampache/ampache/wiki/Ampache-Next-Changes
 			else
 				local fallback_url='https://github.com/ampache/ampache/releases/download/4.4.3/ampache-4.4.3_all.zip'
 				Download_Install "$(curl -sSfL 'https://api.github.com/repos/ampache/ampache/releases' | mawk -F\" '/"browser_download_url": ".*\/ampache-4[0-9\.]*_all.zip"/{print $4}' | head -1)" ampache
 				# Ampache is installed to /var/www/ampache.
-				local fp_install='/var/www'
+				local fp_install='/var/www' fp_public='ampache'
 			fi
 
 			# Reinstall: Preserve configs from old and new paths
@@ -8044,9 +8044,9 @@ _EOF_
 			[[ -f '/var/www/ampache/config/registration_agreement.php' ]] && G_EXEC mv /var/www/ampache/config/registration_agreement.php ampache/config/
 			[[ -f '/mnt/dietpi_userdata/ampache/config/ampache.cfg.php' ]] && G_EXEC mv /mnt/dietpi_userdata/ampache/config/ampache.cfg.php ampache/config/
 			[[ -f '/mnt/dietpi_userdata/ampache/config/registration_agreement.php' ]] && G_EXEC mv /mnt/dietpi_userdata/ampache/config/registration_agreement.php ampache/config/
-			[[ -f '/var/www/ampache/channel/.htaccess' ]] && G_EXEC mv /var/www/ampache/channel/.htaccess ampache/channel/
-			[[ -f '/var/www/ampache/rest/.htaccess' ]] && G_EXEC mv /var/www/ampache/rest/.htaccess ampache/rest/
-			[[ -f '/var/www/ampache/play/.htaccess' ]] && G_EXEC mv /var/www/ampache/play/.htaccess ampache/play/
+			[[ -f '/var/www/ampache/channel/.htaccess' ]] && G_EXEC mv /var/www/ampache/channel/.htaccess "$fp_public/channel/"
+			[[ -f '/var/www/ampache/rest/.htaccess' ]] && G_EXEC mv /var/www/ampache/rest/.htaccess "$fp_public/rest/"
+			[[ -f '/var/www/ampache/play/.htaccess' ]] && G_EXEC mv /var/www/ampache/play/.htaccess "$fp_public/play/"
 			[[ -d '/var/www/ampache' || -L '/var/www/ampache' ]] && G_EXEC rm -R /var/www/ampache
 			[[ -d '/mnt/dietpi_userdata/ampache' ]] && G_EXEC rm -R /mnt/dietpi_userdata/ampache
 


### PR DESCRIPTION
Since version 5, Ampache web path has been changed to `/ampache/public`

https://github.com/ampache/ampache/wiki/Ampache-Next-Changes#you-will-need-to-update-the-web-server-document-root

**Status**: Ready
- [x] adjust install

**Reference**: https://dietpi.com/phpbb/viewtopic.php?t=9947

**Commit list/description**:
- DietPi-Software | Ampache - web server path has been changed on Ampache 5
