### PR TITLE
DietPi-Software | Jellyfin: Change default port to 8097 to resolve conflict with Emby

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Changes:
 - DietPi-Drive_Manager | Btrfs subvolume mounts are now preserved in /etc/fstab. Many thanks to @laddde for implementing this feature: https://github.com/MichaIng/DietPi/pull/5176
 - DietPi-Drive_Manager | The Samba mount dialogues do now indicate that a hostname can be entered instead of a server IP and a shared folder path instead of a share name only.
 - DietPi-Backup | A notification is not printed when rsync dry-run to obtain required disk space is starting, since this can take a while. Many thanks to @whisdol for reporting the the impression of a hanging script: https://github.com/MichaIng/DietPi/issues/5209
+- DietPi-Software | Jellyfin: For new installs, the default web interface port has been changed from 8086 to 8089 to resolve a port conflict with Emby.
 
 Fixes:
 - DietPi-Services | Resolved an issue where service edits and process tool settings were not effective as they were stored to the wrong file path. Many thanks to @TopFord and @MicDG for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?p=41509#p41509

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,7 +9,7 @@ Changes:
 - DietPi-Drive_Manager | Btrfs subvolume mounts are now preserved in /etc/fstab. Many thanks to @laddde for implementing this feature: https://github.com/MichaIng/DietPi/pull/5176
 - DietPi-Drive_Manager | The Samba mount dialogues do now indicate that a hostname can be entered instead of a server IP and a shared folder path instead of a share name only.
 - DietPi-Backup | A notification is not printed when rsync dry-run to obtain required disk space is starting, since this can take a while. Many thanks to @whisdol for reporting the the impression of a hanging script: https://github.com/MichaIng/DietPi/issues/5209
-- DietPi-Software | Jellyfin: For new installs, the default web interface port has been changed from 8086 to 8089 to resolve a port conflict with Emby.
+- DietPi-Software | Jellyfin: For new installs, the default web interface port has been changed from 8096 to 8097 to resolve a port conflict with Emby.
 
 Fixes:
 - DietPi-Services | Resolved an issue where service edits and process tool settings were not effective as they were stored to the wrong file path. Many thanks to @TopFord and @MicDG for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?p=41509#p41509

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11874,6 +11874,9 @@ _EOF_
 				# shellcheck disable=SC2015
 				[[ -d '/var/cache/jellyfin' ]] && G_EXEC mv /var/cache/jellyfin /mnt/dietpi_userdata/jellyfin/cache || G_EXEC mkdir /mnt/dietpi_userdata/jellyfin/cache
 				G_CONFIG_INJECT 'JELLYFIN_CACHE_DIR=' 'JELLYFIN_CACHE_DIR=/mnt/dietpi_userdata/jellyfin/cache' /etc/default/jellyfin
+				# Change default port due to conflict with Emby
+				G_CONFIG_INJECT '<PublicPort>' '<PublicPort>8097</PublicPort>' /etc/jellyfin/network.xml
+				G_CONFIG_INJECT '<HttpServerPortNumber>' '  <HttpServerPortNumber>8097</HttpServerPortNumber>' /etc/jellyfin/network.xml
 			fi
 
 			# Permissions


### PR DESCRIPTION
@MichaIng 
We have a port conflict between Emby and Jellyfin. Both are using `8096` on a default install. Therefore we might need to switch one to another port. I checked and port `8097` seems to be free. 

Personally I would do this on new install only, to avoid migration of existing installs. Maybe some user expose Jellyfin to the web or use a revers proxy. In case of migration, these configs (outside DietPi control) would need to be adjusted as well.

**Status**: Ready
- [x] change default port

**Reference**: reported via Facebook

**Commit list/description**:
- DietPi-Software | Jellyfin - Change default port due to conflict with Emby
