### PR TITLE
DietPi-Software | RPi-Monitor: Fix CPU temperature meter

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -25,6 +25,7 @@ Fixes:
 - DietPi-Software | OpenBazaar: Since the original project has been taken down, we migrated to a fork which keeps up the marketplace for the community: https://github.com/MichaIng/DietPi/issues/5213
 - DietPi-Software | X.Org X Server: Resolved an issue where VMs without KMS/DRM support failed to start the X server, e.g. Hyper-V. The classic framebuffer DDX is now installed when no KMS/DRM support is detected on VMs.
 - DietPi-Software | Box86/Box64: Resolved an issue where the install failed when a kernel upgrade has just been done so that the "binfmt_misc" kernel module cannot be found for the loaded kernel.
+- DietPi-Software | RPi-Monitor: Resolved an issue where the CPU temperature was not shown. Many thanks to @KamikazeePL for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=10001
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/5229
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8795,6 +8795,9 @@ _EOF_
 			# Update APT package status
 			G_EXEC /usr/share/rpimonitor/scripts/updatePackagesStatus.pl
 
+			# Fix issue to display CPU Temperature correctly https://github.com/XavierBerger/RPi-Monitor/issues/374
+			G_CONFIG_INJECT 'dynamic.1.postprocess=' 'dynamic.1.postprocess=$1/1000' /etc/rpimonitor/template/temperature.conf
+
 			# USB drive stats implementation by Rich
 			if [[ ! -f '/etc/rpimonitor/template/usb_hdd.conf' ]] && findmnt -S /dev/sda1 > /dev/null
 			then

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8821,7 +8821,7 @@ dynamic.14.rrd=GAUGE
 
 web.status.1.content.9.name=USB HDD
 web.status.1.content.9.icon=usb_hdd.png
-web.status.1.content.9.line.1="<b>/sda1</b> Used: <b>"+KMG(data.usbhdd_used,'M')+"</b> (<b>"+Percent(data.udbhdd_used,data.usbhdd_total,'M')+"</b>) Free: <b>"+KMG(data.usbhdd_total-data.usbhdd_used,'M')+ "</b> Total: <b>"+ KMG(data.usbhdd_total,'M') +"</b>"
+web.status.1.content.9.line.1="<b>/sda1</b> Used: <b>"+KMG(data.usbhdd_used,'M')+"</b> (<b>"+Percent(data.usbhdd_used,data.usbhdd_total,'M')+"</b>) Free: <b>"+KMG(data.usbhdd_total-data.usbhdd_used,'M')+ "</b> Total: <b>"+ KMG(data.usbhdd_total,'M') +"</b>"
 web.status.1.content.9.line.2=ProgressBar(data.usbhdd_used,data.usbhdd_total)
 
 web.statistics.1.content.9.name=USB HDD

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8796,7 +8796,7 @@ _EOF_
 			G_EXEC /usr/share/rpimonitor/scripts/updatePackagesStatus.pl
 
 			# Fix issue to display CPU Temperature correctly https://github.com/XavierBerger/RPi-Monitor/issues/374
-			G_CONFIG_INJECT 'dynamic.1.postprocess=' 'dynamic.1.postprocess=$1/1000' /etc/rpimonitor/template/temperature.conf
+			G_CONFIG_INJECT 'dynamic.1.postprocess=' 'dynamic.1.postprocess=int($1/1000 + 0.5)' /etc/rpimonitor/template/temperature.conf
 
 			# USB drive stats implementation by Rich
 			if [[ ! -f '/etc/rpimonitor/template/usb_hdd.conf' ]] && findmnt -S /dev/sda1 > /dev/null

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1136,7 +1136,7 @@ INDEX_BROWSER=$INDEX_BROWSER"
 		software_id=66
 
 		aSOFTWARE_NAME[$software_id]='RPi-Monitor'
-		aSOFTWARE_DESC[$software_id]='Web interface for Raspberry Pi real time monitoring'
+		aSOFTWARE_DESC[$software_id]='Web interface for Raspberry Pi real-time monitoring'
 		aSOFTWARE_CATX[$software_id]=8
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/system_stats/#rpi-monitor'
 		# RPi only
@@ -8795,14 +8795,13 @@ _EOF_
 			# Update APT package status
 			G_EXEC /usr/share/rpimonitor/scripts/updatePackagesStatus.pl
 
-			# Fix issue to display CPU Temperature correctly https://github.com/XavierBerger/RPi-Monitor/issues/374
-			# shellcheck disable=SC2016# shellcheck disable=SC2016
-			G_CONFIG_INJECT 'dynamic.1.postprocess=' 'dynamic.1.postprocess=int($1/1000 + 0.5)' /etc/rpimonitor/template/temperature.conf
+			# Fix issue to display CPU temperature correctly: https://github.com/XavierBerger/RPi-Monitor/issues/374
+			# shellcheck disable=SC2016
+			G_CONFIG_INJECT 'dynamic.1.postprocess=' 'dynamic.1.postprocess=int($1/10 + 0.5)/100' /etc/rpimonitor/template/temperature.conf
 
 			# USB drive stats implementation by Rich
-			if [[ ! -f '/etc/rpimonitor/template/usb_hdd.conf' ]] && findmnt -S /dev/sda1 > /dev/null
+			if [[ $G_ROOTFS_DEV != '/dev/sda2' && ! -f '/etc/rpimonitor/template/usb_hdd.conf' ]] && findmnt -S /dev/sda1 > /dev/null
 			then
-				G_EXEC sed -i '\|include=/etc/rpimonitor/template/sdcard.conf|a\include=/etc/rpimonitor/template/usb_hdd.conf' /etc/rpimonitor/data.conf
 				cat << '_EOF_' > /etc/rpimonitor/template/usb_hdd.conf
 ########################################################################
 # Extract USB HDD (sda1) information
@@ -8812,14 +8811,12 @@ _EOF_
 #  - USBHDD1 used           - yes      - yes
 ########################################################################
 static.10.name=usbhdd_total
-static.10.source=df -t ext4
-static.10.regexp=sda1\s+(\d+)
-static.10.postprocess=$1/1024
+static.10.source=df -m
+static.10.regexp=^/dev/sda1\s+(\d+)
 
 dynamic.14.name=usbhdd_used
-dynamic.14.source=df -t ext4
-dynamic.14.regexp=sda1\s+\d+\s+(\d+)
-dynamic.14.postprocess=$1/1024
+dynamic.14.source=df -m
+dynamic.14.regexp=^/dev/sda1\s+\d+\s+(\d+)
 dynamic.14.rrd=GAUGE
 
 web.status.1.content.9.name=USB HDD
@@ -8830,12 +8827,13 @@ web.status.1.content.9.line.2=ProgressBar(data.usbhdd_used,data.usbhdd_total)
 web.statistics.1.content.9.name=USB HDD
 web.statistics.1.content.9.graph.1=usbhdd_total
 web.statistics.1.content.9.graph.2=usbhdd_used
-web.statistics.1.content.9.ds_graph_options.usbhdd_total.label=USB HDD total space (MB)
+web.statistics.1.content.9.ds_graph_options.usbhdd_total.label=USB HDD total space (MiB)
 web.statistics.1.content.9.ds_graph_options.usbhdd_total.color="#FF7777"
-web.statistics.1.content.9.ds_graph_options.usbhdd_used.label=USB HDD used space (MB)
+web.statistics.1.content.9.ds_graph_options.usbhdd_used.label=USB HDD used space (MiB)
 web.statistics.1.content.9.ds_graph_options.usbhdd_used.lines={ fill: true }
 web.statistics.1.content.9.ds_graph_options.usbhdd_used.color="#7777FF"
 _EOF_
+				G_EXEC sed -i '\|include=/etc/rpimonitor/template/sdcard.conf|a\include=/etc/rpimonitor/template/usb_hdd.conf' /etc/rpimonitor/data.conf
 			fi
 
 		fi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8796,6 +8796,7 @@ _EOF_
 			G_EXEC /usr/share/rpimonitor/scripts/updatePackagesStatus.pl
 
 			# Fix issue to display CPU Temperature correctly https://github.com/XavierBerger/RPi-Monitor/issues/374
+			# shellcheck disable=SC2016# shellcheck disable=SC2016
 			G_CONFIG_INJECT 'dynamic.1.postprocess=' 'dynamic.1.postprocess=int($1/1000 + 0.5)' /etc/rpimonitor/template/temperature.conf
 
 			# USB drive stats implementation by Rich


### PR DESCRIPTION
There is an issue to display CPU temp correctly on RPI-Monitor. It's basically an old issue and RPI-Monitor has not been updated for long. But still we should fix it. 😄 

**Status**: Ready
- [x] adjust `dietpi-siftware`
- [x] tested on RPI4B 64bit
- [x] tested on RPI3B+ 32bit

**Reference**: 
- https://dietpi.com/phpbb/viewtopic.php?t=10001
- https://github.com/XavierBerger/RPi-Monitor/issues/374

**Commit list/description**:
- DietPi-Software | RPI-Monitor - fix an issue to display CPU Temperature correctly
