### PR TITLE
Live patch 2 | Fix CPU freq scaling on RPi 3B+ 64-bit systems

### DIFF
--- a/.update/version
+++ b/.update/version
@@ -15,12 +15,15 @@ G_OLD_DEBIAN_BRANCH='stretch'
 G_LIVE_PATCH_DESC=(
 	[0]='Fix Apache2 installs: https://github.com/MichaIng/DietPi/issues/5248'
 	[1]='Fix Nextcloud installs: https://github.com/MichaIng/DietPi/issues/5251'
+	[2]='Fix CPU freq scaling on RPi 3B+: https://github.com/raspberrypi/linux/issues/4875'
 )
 G_LIVE_PATCH_COND=(
 	[0]='grep -q "cat << '\''_EOF_'\'' > /etc/apache2/sites-available/000-default.conf" /boot/dietpi/dietpi-software'
 	[1]='grep -q "memory_consumption=64'\''$" /boot/dietpi/dietpi-software'
+	[2]='[[ $G_HW_MODEL_NAME == '\''RPi 3 Model B+ (aarch64)'\'' ]] && grep -q '\''^[[:blank:]]*initial_turbo=[^0]'\'' /boot/config.txt'
 )
 G_LIVE_PATCH=(
 	[0]='sed -i "s|cat << '\''_EOF_'\'' > /etc/apache2/sites-available/000-default.conf|cat << _EOF_ > /etc/apache2/sites-available/000-default.conf|" /boot/dietpi/dietpi-software'
 	[1]='sed -i "s/memory_consumption=64'\''$/memory_consumption=64'\'' || memory_consumption=/" /boot/dietpi/dietpi-software'
+	[2]='sed -i '\''s/^[[:blank:]]*initial_turbo=/#initial_turbo=/'\'' /boot/config.txt'
 )


### PR DESCRIPTION
- Live patch 2 | Fix CPU freq scaling on RPi 3B+ 64-bit systems: https://github.com/raspberrypi/linux/issues/4875