### PR TITLE
DietPi-Software | Run all Roon applications as service users

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,9 @@ v8.2
 (2022-03-05)
 
 Changes:
+- DietPi-Software | Roon Bridge: The service now runs as "roonbridge" service user instead of as "root". The install directory has been moved to /opt/roonbridge, the data directory to /mnt/dietpi_userdata/roonbridge and the log directory to /var/log/roonbridge, for consistency. The DietPi update does not enforce the migration, but a manual reinstall via "dietpi-software reinstall 121" applies it, while preserving all data and configs.
+- DietPi-Software | Roon Extension Manager: The service now runs as "roon-extension-manager" service user instead of as "root" and the data directory has been moved to /mnt/dietpi_userdata/roon-extension-manager. The DietPi update does not enforce the migration, but a manual reinstall via "dietpi-software reinstall 86" applies it, while preserving all extensions and configs.
+- DietPi-Software | Roon Server: The service now runs as "roonserver" service user instead of as "root" and logs are now done to /var/log/roonserver, i.e. the DietPi-RAMlog by default, aligning with Roon Bridge. The DietPi update does not enforce the migration, but a manual reinstall via "dietpi-software reinstall 154" applies it, while preserving all data and configs. When you do the reinstall, note that Roon remote apps will ask you to login again and unauthorise the connected Roon Server. This is however just a formal step required as of the service user change, while all your settings and libraries appear just the same. 
 
 Fixes:
 - DietPi-Software | Resolved an issue where via AUTO_SETUP_INSTALL_SOFTWARE_ID dietpi.txt settings it was possible to install software on first boot which is actually not supported on the platform. Many thanks to @eyduh for reporting this issue: https://github.com/MichaIng/DietPi/issues/5245

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11268,6 +11268,7 @@ User=roonserver
 AmbientCapabilities=CAP_SYS_NICE
 LogsDirectory=roonserver
 Environment=ROON_DATAROOT=/mnt/dietpi_userdata/roonserver
+Environment=ROON_ID_DIR=/mnt/dietpi_userdata/roonserver
 ExecStart=/opt/roonserver/start.sh
 
 # Hardening

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4314,11 +4314,11 @@ _EOF_
 			PHPBB_LOC='phpbb'
 			[[ -d '/var/www/phpBB3' ]] && PHPBB_LOC='phpBB3'
 
-			# Skip install, if already present
+			# Reinstall: Skip download and install, advice to use internal updater from web UI
 			if [[ -d /var/www/$PHPBB_LOC ]]
 			then
 				G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[$software_id]} install dir \"/var/www/$PHPBB_LOC\" already exists. Download and install steps will be skipped.
- - If you want to update ${aSOFTWARE_NAME[$software_id]}, please follow the instructions from WebUI ACP.
+ - If you want to update ${aSOFTWARE_NAME[$software_id]}, please follow the instructions from web UI ACP.
  - If you need to reinstall (e.g. broken instance), please manually backup your config files+data, remove the install dir and rerun \"dietpi-software (re)install $software_id\"."
 
 			else
@@ -5342,12 +5342,28 @@ _EOF_
 			then
 				url='https://download.roonlabs.com/builds/RoonBridge_linuxx64.tar.bz2'
 			fi
-
 			Download_Install "$url"
 
-			# Clear dir on reinstall
-			[[ -d '/etc/roonbridge' ]] && G_EXEC rm -R /etc/roonbridge
-			G_EXEC mv RoonBridge /etc/roonbridge
+			# Always perform a clean install
+			[[ -d '/opt/roonbridge' ]] && G_EXEC rm -R /opt/roonbridge
+			[[ -d '/etc/roonbridge' ]] && G_EXEC rm -R /etc/roonbridge # Pre-v8.2
+			G_EXEC mv RoonBridge /opt/roonbridge
+
+			# Pre-v8.2 migration
+			[[ -d '/mnt/dietpi_userdata/roon' && ! -d '/mnt/dietpi_userdata/roonbridge' ]] && G_EXEC mv /mnt/dietpi_userdata/roon{,bridge}
+
+			# Log to /var/log/roonbridge
+			G_EXEC mkdir -p /mnt/dietpi_userdata/roonbridge/{RoonBridge,RAATServer}
+			G_EXEC rm -Rf /mnt/dietpi_userdata/roonbridge/{RoonBridge,RAATServer}/Logs /var/log/roon # /var/log/roon: Pre-v8.2
+			G_EXEC ln -s /var/log/roonbridge /mnt/dietpi_userdata/roonbridge/RoonBridge/Logs
+			G_EXEC ln -s /var/log/roonbridge /mnt/dietpi_userdata/roonbridge/RAATServer/Logs
+
+			# User
+			Create_User -G audio -d /mnt/dietpi_userdata/roonbridge roonbridge
+
+			# Permissions
+			G_EXEC chown -R root:root /opt/roonbridge
+			G_EXEC chown -R roonbridge:root /mnt/dietpi_userdata/roonbridge
 
 			# Service
 			cat << '_EOF_' > /etc/systemd/system/roonbridge.service
@@ -5358,22 +5374,20 @@ After=network-online.target sound.target
 
 [Service]
 SyslogIdentifier=Roon Bridge
-LogsDirectory=roon
-Environment=ROON_DATAROOT=/mnt/dietpi_userdata/roon
-Environment=ROON_ID_DIR=/mnt/dietpi_userdata/roon
-ExecStart=/etc/roonbridge/start.sh
+User=roonbridge
+AmbientCapabilities=CAP_SYS_NICE
+LogsDirectory=roonbridge
+Environment=ROON_DATAROOT=/mnt/dietpi_userdata/roonbridge
+Environment=ROON_ID_DIR=/mnt/dietpi_userdata/roonbridge
+ExecStart=/opt/roonbridge/start.sh
 Restart=on-abort
+
+# Hardening
+PrivateTmp=true
 
 [Install]
 WantedBy=multi-user.target
 _EOF_
-			# Log to /var/log/roon
-			G_EXEC mkdir -p /mnt/dietpi_userdata/roon/{RoonBridge,RAATServer}
-			# - Clear symlink locations
-			G_EXEC rm -Rf /mnt/dietpi_userdata/roon/{RoonBridge,RAATServer}/Logs
-			G_EXEC ln -s /var/log/roon /mnt/dietpi_userdata/roon/RoonBridge/Logs
-			G_EXEC ln -s /var/log/roon /mnt/dietpi_userdata/roon/RAATServer/Logs
-
 		fi
 
 		software_id=119 # CAVA
@@ -7514,11 +7528,12 @@ _EOF_
 			local json=
 			[[ $PHP_VERSION == 8* ]] || DEPS_LIST+=" php$PHP_VERSION-json" json='json'
 
+			# Reinstall: Skip download and install, advice to use internal updater from web UI
 			if [[ -d '/opt/FreshRSS' ]]
 			then
 				G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[$software_id]} install dir \"/opt/FreshRSS\" already exists. Download and install steps will be skipped.
  - If you want to update ${aSOFTWARE_NAME[$software_id]}, please use the internal updater from web UI.
- - If you need to reinstall (e.g. broken instance), please manually backup your config files+data, remove the install dir \"/opt/FreshRSS\" and rerun \"dietpi-software (re)install $software_id\"."
+ - If you need to reinstall (e.g. broken instance), please manually backup your config files+data, remove the install dir and rerun \"dietpi-software (re)install $software_id\"."
 
 				# shellcheck disable=SC2086
 				G_AGI $DEPS_LIST
@@ -8732,12 +8747,12 @@ _EOF_
 			# Install required PHP modules
 			DEPS_LIST="php$PHP_VERSION-apcu php$PHP_VERSION-gd php$PHP_VERSION-intl php$PHP_VERSION-mbstring php$PHP_VERSION-opcache php$PHP_VERSION-xml"
 
-			# Skip install if already present
+			# Reinstall: Skip download and install, advice to use internal updater from web UI
 			if [[ -d '/var/www/pydio' ]]
 			then
 				G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[$software_id]} install dir \"/var/www/pydio\" already exists. Download and install steps will be skipped.
- - Please manually backup your config files+data, remove the install dir and rerun \"dietpi-software (re)install $software_id\" if you need to reinstall.
- - If you want to update the ${aSOFTWARE_NAME[$software_id]} instance, please use the internal updater from WebUI."
+ - If you want to update ${aSOFTWARE_NAME[$software_id]}, please use the internal updater from web UI.
+ - If you need to reinstall (e.g. broken instance), please manually backup your config files+data, remove the install dir and rerun \"dietpi-software (re)install $software_id\"."
 
 				# shellcheck disable=SC2086
 				G_AGI $DEPS_LIST
@@ -9688,10 +9703,11 @@ _EOF_
 
 			DEPS_LIST='mediainfo python3'
 
+			# Reinstall: Skip download and install, advice to use internal updater from web UI
 			if [[ -d '/mnt/dietpi_userdata/medusa' ]]
 			then
 				G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[$software_id]} install dir \"/mnt/dietpi_userdata/medusa\" already exists. Download and install steps will be skipped.
- - If you want to update ${aSOFTWARE_NAME[$software_id]}, please use the internal updater from WebUI.
+ - If you want to update ${aSOFTWARE_NAME[$software_id]}, please use the internal updater from web UI.
  - If you need to reinstall (e.g. broken instance), please manually backup your config files+data, remove the install dir and rerun \"dietpi-software (re)install $software_id\"."
 
 				# shellcheck disable=SC2086
@@ -9725,11 +9741,12 @@ _EOF_
 
 			Banner_Installing
 
+			# Reinstall: Skip download and install, advice to use internal updater from web UI
 			if [[ -d '/opt/syncthing' ]]
 			then
 				G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[$software_id]} install dir \"/opt/syncthing\" already exists. Download and install steps will be skipped.
  - If you want to update ${aSOFTWARE_NAME[$software_id]}, please use the internal updater from web UI.
- - If you need to reinstall (e.g. broken instance), please manually backup your config files+data, remove the install dir \"/opt/syncthing\" and rerun \"dietpi-software (re)install $software_id\"."
+ - If you need to reinstall (e.g. broken instance), please manually remove the install dir and rerun \"dietpi-software (re)install $software_id\"."
 
 			else
 				# ARMv6/7
@@ -10596,7 +10613,7 @@ _EOF_
 			then
 				G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[$software_id]} install dir \"/opt/radarr\" already exists. Download and install steps will be skipped.
  - If you want to update ${aSOFTWARE_NAME[$software_id]}, please use the internal updater from web UI.
- - If you need to reinstall (e.g. broken instance), please manually remove the install dir \"/opt/radarr\" and rerun \"dietpi-software reinstall $software_id\"."
+ - If you need to reinstall (e.g. broken instance), please manually remove the install dir and rerun \"dietpi-software reinstall $software_id\"."
 
 				# shellcheck disable=SC2086
 				G_AGI $DEPS_LIST
@@ -10708,7 +10725,7 @@ _EOF_
 			then
 				G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[$software_id]} install dir \"/opt/lidarr\" already exists. Download and install steps will be skipped.
  - If you want to update ${aSOFTWARE_NAME[$software_id]}, please use the internal updater from web UI.
- - If you need to reinstall (e.g. broken instance), please manually remove the install dir \"/opt/lidarr\" and rerun \"dietpi-software reinstall $software_id\"."
+ - If you need to reinstall (e.g. broken instance), please manually remove the install dir and rerun \"dietpi-software reinstall $software_id\"."
 
 				# shellcheck disable=SC2086
 				G_AGI $DEPS_LIST
@@ -10796,11 +10813,12 @@ _EOF_
 
 			Banner_Installing # https://wiki.bazarr.media/Getting-Started/Installation/Linux/linux/
 
+			# Reinstall: Skip download and install, advice to use internal updater from web UI
 			if [[ -d '/opt/bazarr' ]]
 			then
 				G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[$software_id]} install dir \"/opt/bazarr\" already exists. Download and install steps will be skipped.
  - If you want to update ${aSOFTWARE_NAME[$software_id]}, please use the internal updater from web UI.
- - If you need to reinstall (e.g. broken instance), please manually remove the install dir \"/opt/bazarr\" and rerun \"dietpi-software reinstall $software_id\"."
+ - If you need to reinstall (e.g. broken instance), please manually remove the install dir and rerun \"dietpi-software reinstall $software_id\"."
 
 			else
 				Download_Install 'https://github.com/morpheus65535/bazarr/releases/latest/download/bazarr.zip' /opt/bazarr
@@ -10886,11 +10904,12 @@ _EOF_
 
 			Banner_Installing
 
+			# Reinstall: Skip download and install, advice to use internal updater from web UI
 			if [[ -d '/opt/tautulli' ]]
 			then
 				G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[$software_id]} install dir \"/opt/tautulli\" already exists. Download and install steps will be skipped.
- - If you want to update ${aSOFTWARE_NAME[$software_id]}, please use the internal updater from WebUI.
- - If you need to reinstall (e.g. broken instance), please manually backup your config files+data, remove the install dir \"/opt/tautulli\" and rerun \"dietpi-software reinstall $software_id\"."
+ - If you want to update ${aSOFTWARE_NAME[$software_id]}, please use the internal updater from web UI.
+ - If you need to reinstall (e.g. broken instance), please manually remove the install dir and rerun \"dietpi-software reinstall $software_id\"."
 
 				G_AGI python3-pkg-resources
 			else
@@ -11208,27 +11227,33 @@ _EOF_
 				DEPS_LIST='libicu67'
 			fi
 
-			# Skip download and install, if already existent, manual removal or internal updater can be used:
+			# Reinstall: Skip download and install, advice to use internal updater
 			if [[ -d '/opt/roonserver' ]]
 			then
+				G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[$software_id]} install dir \"/opt/roonserver\" already exists. Download and install steps will be skipped.
+ - If you want to update ${aSOFTWARE_NAME[$software_id]}, please use the internal updater.
+ - If you need to reinstall (e.g. broken instance), please manually remove the install dir and rerun \"dietpi-software (re)install $software_id\"."
+
 				G_AGI $DEPS_LIST
 				DEPS_LIST=
-				G_DIETPI-NOTIFY 2 "Existing install found\n
-The ${aSOFTWARE_NAME[$software_id]} target install directory /opt/roonserver already exists. This will not be overwritten.\n
-If the existing instance is broken or obsolete, please manually backup config files and data, then remove this directory and rerun \"dietpi-software\".\n
-If you want to update ${aSOFTWARE_NAME[$software_id]}, please use its internal updater."
-
 			else
 				Download_Install 'https://download.roonlabs.com/builds/RoonServer_linuxx64.tar.bz2'
 				G_EXEC mv RoonServer /opt/roonserver
 			fi
 
-			# Fix permissions
-			G_EXEC chmod 0755 /opt/roonserver
-			G_EXEC chown -R root:root /opt/roonserver
+			# Log to /var/log/roonserver
+			G_EXEC mkdir -p /mnt/dietpi_userdata/roonserver/{RoonServer,RAATServer}
+			G_EXEC rm -Rf /mnt/dietpi_userdata/roonserver/{RoonServer,RAATServer}/Logs
+			G_EXEC ln -s /var/log/roonserver /mnt/dietpi_userdata/roonserver/RoonServer/Logs
+			G_EXEC ln -s /var/log/roonserver /mnt/dietpi_userdata/roonserver/RAATServer/Logs
 
-			# Data dir
-			[[ -d '/mnt/dietpi_userdata/roonserver' ]] || G_EXEC mkdir /mnt/dietpi_userdata/roonserver
+			# User: Grant sudo permissions to create a mount point and mount SMB shares
+			Create_User -G audio -d /mnt/dietpi_userdata/roonserver roonserver
+			G_EXEC eval 'echo '\''roonserver ALL=NOPASSWD:SETENV: /bin/mkdir -p /mnt/RoonStorage_*, /sbin/mount.cifs'\'' > /etc/sudoers.d/roonserver'
+
+			# Permissions
+			G_EXEC chmod 0755 /opt/roonserver
+			G_EXEC chown -R roonserver:root /mnt/dietpi_userdata/roonserver /opt/roonserver
 
 			# Service
 			cat << '_EOF_' > /etc/systemd/system/roonserver.service
@@ -11239,6 +11264,9 @@ After=network-online.target
 
 [Service]
 SyslogIdentifier=Roon Server
+User=roonserver
+AmbientCapabilities=CAP_SYS_NICE
+LogsDirectory=roonserver
 Environment=ROON_DATAROOT=/mnt/dietpi_userdata/roonserver
 ExecStart=/opt/roonserver/start.sh
 
@@ -11860,16 +11888,32 @@ _EOF_
 
 			Banner_Installing
 
+			# Data dir
+			[[ -d '/mnt/dietpi_userdata/roon-extension-manager' ]] || G_EXEC mkdir /mnt/dietpi_userdata/roon-extension-manager
+
+			# Pre-v8.2 migration
+			if [[ -f '/etc/systemd/system/roon-extension-manager.service' ]]
+			then
+				G_EXEC systemctl stop roon-extension-manager
+				G_EXEC rm /etc/systemd/system/roon-extension-manager.service
+			fi
+			[[ -d '/root/.roon-extension-manager' && ! -d '/mnt/dietpi_userdata/roon-extension-manager/.roon-extension-manager' ]] && G_EXEC mv /{root,mnt/dietpi_userdata/roon-extension-manager}/.roon-extension-manager
+
+			# User
+			Create_User -G docker -d /mnt/dietpi_userdata/roon-extension-manager roon-extension-manager
+
+			# Permissions
+			G_EXEC chown -R roon-extension-manager:root /mnt/dietpi_userdata/roon-extension-manager
+
 			G_DIETPI-NOTIFY 2 'Starting Docker to be able to deploy the container'
 			G_EXEC systemctl start docker
 
-			# Unset SUDO_USER variable to avoid download, install and run as sudo-calling user, which fails due to $G_WORKING_DIR write permissions: https://github.com/MichaIng/DietPi/issues/4462
-			unset -v SUDO_USER
+			# Store installer to data dir, so we can reuse it on uninstall
+			DEPS_LIST='wget' Download_Install 'https://raw.githubusercontent.com/TheAppgineer/roon-extension-manager/v1.x/rem-setup.sh' /mnt/dietpi_userdata/roon-extension-manager/rem-setup.sh
+			G_EXEC chmod +x /mnt/dietpi_userdata/roon-extension-manager/rem-setup.sh
 
-			DEPS_LIST='wget' Download_Install 'https://raw.githubusercontent.com/TheAppgineer/roon-extension-manager/v1.x/rem-setup.sh'
-			G_EXEC chmod +x rem-setup.sh
-			G_EXEC_OUTPUT=1 G_EXEC ./rem-setup.sh
-			G_EXEC_NOHALT=1 G_EXEC rm rem-setup.sh
+			# Let the installer create everything for "roon-extension-manager" to run the service: https://github.com/MichaIng/DietPi/issues/5236
+			SUDO_USER='roon-extension-manager' G_EXEC_OUTPUT=1 G_EXEC /mnt/dietpi_userdata/roon-extension-manager/rem-setup.sh
 
 			G_EXEC systemctl stop roon-extension-manager
 
@@ -12010,21 +12054,21 @@ _EOF_
 			# Install required PHP modules
 			DEPS_LIST="php$PHP_VERSION-curl php$PHP_VERSION-zip" # https://github.com/reloxx13/TasmoAdmin#linux
 
-			# Skip install, if already present
+			# Reinstall: Skip download and install, advice to use internal updater from web UI
 			if [[ -d '/var/www/tasmoadmin' ]]
 			then
 				G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[$software_id]} install dir \"/var/www/tasmoadmin\" already exists. Download and install steps will be skipped.
- - Please manually backup your config files+data, remove the install dir and rerun \"dietpi-software (re)install $software_id\" if you need to reinstall.
- - If you want to update the ${aSOFTWARE_NAME[$software_id]} instance, please use the internal updater from WebUI."
+ - If you want to update ${aSOFTWARE_NAME[$software_id]}, please use the internal updater from web UI.
+ - If you need to reinstall (e.g. broken instance), please manually backup your config files+data, remove the install dir and rerun \"dietpi-software (re)install $software_id\"."
 
  				# shellcheck disable=SC2086
 				G_AGI $DEPS_LIST
 				DEPS_LIST=
 			else
 				Download_Install 'https://github.com/reloxx13/TasmoAdmin/archive/master.tar.gz'
-				mv TasmoAdmin-master/tasmoadmin /var/www/
-				rm -R TasmoAdmin-master
-				chown -R www-data:www-data /var/www/tasmoadmin
+				G_EXEC mv TasmoAdmin-master/tasmoadmin /var/www/
+				G_EXEC rm -R TasmoAdmin-master
+				G_EXEC chown -R www-data:www-data /var/www/tasmoadmin
 			fi
 
 			# Configure the webserver
@@ -13726,7 +13770,14 @@ _EOF_
 				G_EXEC rm /etc/systemd/system/roonbridge.service
 			fi
 			[[ -d '/etc/systemd/system/roonbridge.service.d' ]] && G_EXEC rm -R /etc/systemd/system/roonbridge.service.d
+			getent passwd roonbridge > /dev/null && G_EXEC userdel roonbridge
+			getent group roonbridge > /dev/null && G_EXEC groupdel roonbridge
+			[[ -d '/opt/roonbridge' ]] && G_EXEC rm -R /opt/roonbridge
+			[[ -d '/var/log/roonbridge' ]] && G_EXEC rm -R /var/log/roonbridge
+			[[ -d '/mnt/dietpi_userdata/roonbridge' ]] && G_EXEC rm -R /mnt/dietpi_userdata/roonbridge
+			# Pre-v8.2
 			[[ -d '/etc/roonbridge' ]] && G_EXEC rm -R /etc/roonbridge
+			[[ -d '/var/log/roon' ]] && G_EXEC rm -R /var/log/roon
 			[[ -d '/mnt/dietpi_userdata/roon' ]] && G_EXEC rm -R /mnt/dietpi_userdata/roon
 
 		fi
@@ -13741,7 +13792,11 @@ _EOF_
 				G_EXEC rm /etc/systemd/system/roonserver.service
 			fi
 			[[ -d '/etc/systemd/system/roonserver.service.d' ]] && G_EXEC rm -R /etc/systemd/system/roonserver.service.d
+			getent passwd roonserver > /dev/null && G_EXEC userdel roonserver
+			getent group roonserver > /dev/null && G_EXEC groupdel roonserver
+			[[ -f '/etc/sudoers.d/roonserver' ]] && G_EXEC rm /etc/sudoers.d/roonserver
 			[[ -d '/opt/roonserver' ]] && G_EXEC rm -R /opt/roonserver
+			[[ -d '/var/log/roonserver' ]] && G_EXEC rm -R /var/log/roonserver
 			[[ -d '/mnt/dietpi_userdata/roonserver' ]] && G_EXEC rm -R /mnt/dietpi_userdata/roonserver
 
 		fi
@@ -15161,10 +15216,19 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			G_EXEC curl -sSfL 'https://raw.githubusercontent.com/TheAppgineer/roon-extension-manager/v1.x/rem-setup.sh' -o rem-setup.sh
-			G_EXEC chmod +x rem-setup.sh
-			G_EXEC_OUTPUT=1 G_EXEC ./rem-setup.sh --uninstall
-			G_EXEC_NOHALT=1 G_EXEC rm rem-setup.sh
+			local installer='/mnt/dietpi_userdata/roon-extension-manager/rem-setup.sh' user='roon-extension-manager'
+			# Pre-v8.2
+			if [[ ! -f $installer ]]
+			then
+				G_EXEC curl -sSfL 'https://raw.githubusercontent.com/TheAppgineer/roon-extension-manager/v1.x/rem-setup.sh' -o rem-setup.sh
+				G_EXEC chmod +x rem-setup.sh
+				installer='./rem-setup.sh' user='root'
+			fi
+			SUDO_USER='roon-extension-manager' G_EXEC_OUTPUT=1 G_EXEC "$installer" --uninstall
+			G_EXEC_NOHALT=1 G_EXEC rm "$installer"
+			getent passwd roon-extension-manager > /dev/null && G_EXEC userdel roon-extension-manager
+			getent group roon-extension-manager > /dev/null && G_EXEC groupdel roon-extension-manager
+			[[ -d '/mnt/dietpi_userdata/roon-extension-manager' ]] && G_EXEC rm -R /mnt/dietpi_userdata/roon-extension-manager
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11900,8 +11900,8 @@ _EOF_
 			fi
 			[[ -d '/root/.roon-extension-manager' && ! -d '/mnt/dietpi_userdata/roon-extension-manager/.roon-extension-manager' ]] && G_EXEC mv /{root,mnt/dietpi_userdata/roon-extension-manager}/.roon-extension-manager
 
-			# User
-			Create_User -G docker -d /mnt/dietpi_userdata/roon-extension-manager roon-extension-manager
+			# User: Create with login shell first, since the REM installer uses "su"
+			Create_User -G docker -d /mnt/dietpi_userdata/roon-extension-manager -s /bin/dash roon-extension-manager
 
 			# Permissions
 			G_EXEC chown -R roon-extension-manager:root /mnt/dietpi_userdata/roon-extension-manager
@@ -11911,12 +11911,13 @@ _EOF_
 
 			# Store installer to data dir, so we can reuse it on uninstall
 			DEPS_LIST='wget' Download_Install 'https://raw.githubusercontent.com/TheAppgineer/roon-extension-manager/v1.x/rem-setup.sh' /mnt/dietpi_userdata/roon-extension-manager/rem-setup.sh
-			G_EXEC chmod +x /mnt/dietpi_userdata/roon-extension-manager/rem-setup.sh
+			G_EXEC cd /mnt/dietpi_userdata/roon-extension-manager
+			G_EXEC chmod +x rem-setup.sh
 
 			# Let the installer create everything for "roon-extension-manager" to run the service: https://github.com/MichaIng/DietPi/issues/5236
-			SUDO_USER='roon-extension-manager' G_EXEC_OUTPUT=1 G_EXEC /mnt/dietpi_userdata/roon-extension-manager/rem-setup.sh
-
+			SUDO_USER='roon-extension-manager' G_EXEC_OUTPUT=1 G_EXEC ./rem-setup.sh
 			G_EXEC systemctl stop roon-extension-manager
+			G_EXEC usermod -s "$(command -v nologin)" roon-extension-manager
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11906,9 +11906,6 @@ _EOF_
 			# Permissions
 			G_EXEC chown -R roon-extension-manager:root /mnt/dietpi_userdata/roon-extension-manager
 
-			G_DIETPI-NOTIFY 2 'Starting Docker to be able to deploy the container'
-			G_EXEC systemctl start docker
-
 			# Store installer to data dir, so we can reuse it on uninstall
 			DEPS_LIST='wget' Download_Install 'https://raw.githubusercontent.com/TheAppgineer/roon-extension-manager/v1.x/rem-setup.sh' /mnt/dietpi_userdata/roon-extension-manager/rem-setup.sh
 			G_EXEC cd /mnt/dietpi_userdata/roon-extension-manager
@@ -12584,9 +12581,6 @@ _EOF_
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
 
 			Banner_Installing
-
-			G_DIETPI-NOTIFY 2 'Starting Docker to be able to deploy the container'
-			G_EXEC systemctl start docker
 
 			# Check for existing Portainer container
 			local container=$(docker ps -a | mawk '/portainer\/portainer(-ce)?( |$)/{print $1;exit}')
@@ -15024,9 +15018,6 @@ _EOF_
 			# Check if Docker is still installed
 			if [[ -d '/mnt/dietpi_userdata/docker-data' ]]
 			then
-				G_DIETPI-NOTIFY 2 'Starting Docker to be able to remove the container'
-				G_EXEC systemctl start docker
-
 				# Remove Portainer container, image & volume
 				local container=$(docker ps -a | mawk '/portainer\/portainer(-ce)?( |$)/{print $1;exit}')
 				[[ $container ]] && G_EXEC docker rm -f "$container"


### PR DESCRIPTION
- DietPi-Software | Align messages printed when download & install is skipped due to existing install dir and available internal updater
- DietPi-Software | Do not explicitly start the Docker daemon for container (un)installs. It starts automatically, pulled in via socket: "systemctl status docker.socket"
- DietPi-Software | Roon Bridge: Run as "roonbridge" service user, move install dir to /opt/roonbridge, data dir to /mnt/dietpi_userdata/roonbridge and log dir to /var/log/roonbridge, for consistency
- DietPi-Software | Roon Extension Manager: Run as "roon-extension-manager" service user, with its home/data directory at /mnt/dietpi_userdata/roon-extension-manager
- DietPi-Software | Roon Server: Run as  "roonserver" service user and link logs to /var/log/roonserver like we do with Roon Bridge
- DietPi-Software | Roon Server: Apply ROON_ID_DIR now as due to changed service user, when an existing instance is reinstalled/migrated, remote apps need to be logged in again and the previous server unauthorized once anyway. However, we do not force a reinstall this time, migration is cheap and done as part of the reinstall code in dietpi-software.