### PR TITLE
DietPi-Software | Pydio: Fix data directory permissions

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,7 @@ Fixes:
 - DietPi-Software | Folding@Home: Resolved an issue where reinstalls failed since a removed SysV service is tried to be stopped. Many thanks to @eyduh for reporting this issue: https://github.com/MichaIng/DietPi/issues/5255
 - DietPi-Software | Bazarr: Resolved an issue where the service entered an endless restart loop because of a missing dependency. Many thanks to @alleyu2 for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=10050
 - DietPi-Software | Python 3: Worked around an issue on ARMv6/7 Buster systems where installing numpy or any module which depends on numpy failed: https://github.com/piwheels/packages/issues/287
+- DietPi-Software | Pydio: Resolved an issue where the data directory was not writeable. Many thanks @holocronology for reporting this issue: https://github.com/MichaIng/DietPi/issues/5274
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8815,7 +8815,7 @@ _EOF_
 			G_EXEC ln -sf $target_data_dir /var/www/pydio/data
 
 			# Permissions: Fix some files being 444 mode, breaking internal updater
-			G_EXEC chown -R www-data:www-data /var/www/pydio
+			G_EXEC chown -R www-data:www-data /var/www/pydio $target_data_dir
 			G_EXEC chmod -R u+w /var/www/pydio
 
 		fi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8800,22 +8800,27 @@ _EOF_
 			/boot/dietpi/func/create_mysql_db pydio pydio "$GLOBAL_PW"
 
 			# Setup data directory
-			local target_data_dir=/mnt/dietpi_userdata/pydio_data
+			local data_dir='/mnt/dietpi_userdata/pydio_data'
 			# - Skip if already existent
-			if [[ -d $target_data_dir ]]
+			if [[ -d $data_dir ]]
 			then
-				G_DIETPI-NOTIFY 2 "Existing $target_data_dir found, will migrate..."
+				G_DIETPI-NOTIFY 2 "Existing $data_dir found, will migrate..."
 				[[ -e '/var/www/pydio/data' ]] && G_EXEC rm -R /var/www/pydio/data
 			else
 				# Move data structure
-				[[ -e $target_data_dir ]] && G_EXEC rm -R $target_data_dir
-				G_EXEC mv /var/www/pydio/data $target_data_dir
+				[[ -e $data_dir || -L $data_dir ]] && G_EXEC rm -R $data_dir
+				if [[ -d '/var/www/pydio/data' ]]
+				then
+					G_EXEC mv /var/www/pydio/data $data_dir
+				else
+					G_EXEC mkdir $data_dir
+				fi
 			fi
 			# - Create symlink
-			G_EXEC ln -sf $target_data_dir /var/www/pydio/data
+			G_EXEC ln -sf $data_dir /var/www/pydio/data
 
 			# Permissions: Fix some files being 444 mode, breaking internal updater
-			G_EXEC chown -R www-data:www-data /var/www/pydio $target_data_dir
+			G_EXEC chown -R www-data:www-data /var/www/pydio $data_dir
 			G_EXEC chmod -R u+w /var/www/pydio
 
 		fi


### PR DESCRIPTION
DietPi-Software | Pydio: fix an issue where data directory was not writable

`/mnt/dietpi_userdata/pydio_data` was not writable.

@MichaIng 
I noticed that there is a successor application of Pydio, called Cells v3 https://pydio.com/en/docs/administration-guides

Install guide: https://pydio.com/en/docs/kb/deployment/install-cells-debianubuntu