### PR TITLE
DietPi-Imager | Switch to free-only firmware Clonezilla Live build

### DIFF
--- a/.meta/dietpi-imager
+++ b/.meta/dietpi-imager
@@ -35,7 +35,7 @@
 	# Import DietPi-Globals ---------------------------------------------------------------
 
 	readonly FP_MNT_TMP="/tmp/${G_PROGRAM_NAME}_mnt"
-	readonly CLONEZILLA_REPO='https://sourceforge.net/projects/clonezilla/files/clonezilla_live_alternative'
+	readonly CLONEZILLA_REPO='https://sourceforge.net/projects/clonezilla/files/clonezilla_live_stable'
 	readonly DIETPI_REPO="https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH"
 
 	# Inputs
@@ -508,7 +508,7 @@
 			G_AG_CHECK_INSTALL_PREREQ unzip $clonezilla partclone xz-utils syslinux-common xorriso isolinux
 			[[ -f 'clonezilla.deb' ]] && G_EXEC rm clonezilla.deb
 
-			# Get latest version of Clonezilla Live alternative (Ubuntu based, for max compatibility with non-free drivers)
+			# Get latest version of Clonezilla Live
 			CLONEZILLA_VERSION=$(curl -sSf "$CLONEZILLA_REPO/" | mawk -F\" '/class="folder "/{print $2}' | head -1)
 			[[ $CLONEZILLA_VERSION ]] || { G_DIETPI-NOTIFY 1 'Could not retrieve latest Clonezilla Live version string, aborting...'; exit 1; }
 			CLONEZILLA_URL="$CLONEZILLA_REPO/$CLONEZILLA_VERSION/clonezilla-live-$CLONEZILLA_VERSION-amd64.zip/download"


### PR DESCRIPTION
- DietPi-Imager | Switch to free-only firmware Clonezilla Live build, based on Debian instead of Ubuntu, since we do not rely on network drivers, funky GPU features or such. Also Debian does fully support UEFI Secure Boot.