### PR TITLE
DietPi-Build | Proxmox support via VirtIO PCI controller driver in initramfs

### DIFF
--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -284,7 +284,7 @@ _EOF_
 echo '[ INFO ] Rebuilding virtual machine initramfs to support all virtualizers...'
 version=\$(dpkg --get-selections | mawk '\$1~/^linux-image-.*-$parch\$/{print \$1;exit}') || poweroff
 version=\${version#linux-image-}
-mktirfs -m no -M no --include-modules='ahci,sd_mod,vmw_pvscsi,hv_storvsc,virtio_scsi,$FSTYPE' -o "/boot/initrd.img-\$version" "\$version" || poweroff
+mktirfs -m no -M no --include-modules='ahci,sd_mod,vmw_pvscsi,hv_storvsc,virtio_scsi,virtio_pci,virtio_mmio,$FSTYPE' -o "/boot/initrd.img-\$version" "\$version" || poweroff
 _EOF_
 
 cat << '_EOF_' >> rootfs/etc/rc.local

--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -284,7 +284,7 @@ _EOF_
 echo '[ INFO ] Rebuilding virtual machine initramfs to support all virtualizers...'
 version=\$(dpkg --get-selections | mawk '\$1~/^linux-image-.*-$parch\$/{print \$1;exit}') || poweroff
 version=\${version#linux-image-}
-mktirfs -m no -M no --include-modules='ahci,sd_mod,vmw_pvscsi,hv_storvsc,virtio_scsi,virtio_pci,virtio_mmio,$FSTYPE' -o "/boot/initrd.img-\$version" "\$version" || poweroff
+mktirfs -m no -M no --include-modules='ahci,sd_mod,vmw_pvscsi,hv_storvsc,virtio_scsi,virtio_pci,$FSTYPE' -o "/boot/initrd.img-\$version" "\$version" || poweroff
 _EOF_
 
 cat << '_EOF_' >> rootfs/etc/rc.local


### PR DESCRIPTION
This also allows using the VirtIO SCSI controller with VirtualBox and other virtualizers.