### PR TITLE
DietPi-Banner | Add option to disable credits

### DIFF
--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -55,15 +55,16 @@
 		'MOTD'
 		'VPN status'
 		'Large hostname'
+		'Print credits'
 
 	)
 
 	# Set defaults: Disable CPU temp by default in VMs
 	if (( $G_HW_MODEL == 20 ))
 	then
-		aENABLED=(1 0 0 0 0 1 0 1 0 0 0 1 1 0 0)
+		aENABLED=(1 0 0 0 0 1 0 1 0 0 0 1 1 0 0 1)
 	else
-		aENABLED=(1 0 1 0 0 1 0 0 0 0 0 1 1 0 0)
+		aENABLED=(1 0 1 0 0 1 0 0 0 0 0 1 1 0 0 1)
 	fi
 
 	COLOUR_RESET='\e[0m'
@@ -194,7 +195,10 @@ $GREEN_LINE"
  Website         : https://dietpi.com/ | https://twitter.com/DietPi_
  Contribute      : https://dietpi.com/contribute.html
  Web Hosting by  : https://myvirtualserver.com$COLOUR_RESET\n"
+		
+	}
 
+	Print_Updates(){
 		# DietPi update available?
 		if [[ $AVAILABLE_UPDATE ]]
 		then
@@ -268,7 +272,8 @@ $GREEN_LINE"
 		fi
 		echo -e "$GREEN_LINE\n"
 
-		Print_Credits
+		(( ${aENABLED[15]} == 1 )) && Print_Credits
+		Print_Updates
 		(( ${aENABLED[11]} == 1 )) && Print_Useful_Commands
 
 	}


### PR DESCRIPTION
The credits part of ```dietpi-banner``` takes a lot of space, so I added an option to disable it.
I know that they are important so they are enabled by default.