### PR TITLE
Image | Add support for generic container image

### DIFF
--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -71,7 +71,7 @@ case $HW_MODEL in
 	16) iname='OdroidC4' HW_ARCH=3 partition_start=4 root_size=764;;
 	20) iname='VM' WIFI_REQUIRED=0 HW_ARCH=${HW_ARCH:-10} VMTYPE=${VMTYPE:-raw};;
 	21) iname='NativePC-BIOS' HW_ARCH=10 root_size=1215;;
-	75) iname='Container' root_size=511;;
+	75) iname='Container' root_size=399;;
 	*) G_DIETPI-NOTIFY 1 "Invalid hardware model \"$HW_MODEL\" passed, aborting..."; exit 1;;
 esac
 
@@ -262,8 +262,8 @@ fi
 ##########################################
 # debootstrap
 ##########################################
-packages='apt,bash-completion,bzip2,ca-certificates,cron,curl,fdisk,gnupg,htop,iputils-ping,locales,nano,p7zip,parted,procps,psmisc,sudo,systemd-sysv,tzdata,udev,unzip,wget,whiptail'
-(( $HW_MODEL == 75 )) || packages+=',console-setup,ethtool,fake-hwclock,ifupdown,isc-dhcp-client,kmod,rfkill,systemd-timesyncd,usbutils'
+packages='apt,bash-completion,bzip2,ca-certificates,cron,curl,fdisk,gnupg,htop,iputils-ping,locales,nano,p7zip,parted,procps,psmisc,sudo,systemd-sysv,tzdata,udev,unzip,wget,whiptail,'
+(( $HW_MODEL == 75 )) && packages+='iproute2' || packages+='console-setup,ethtool,fake-hwclock,ifupdown,isc-dhcp-client,kmod,rfkill,systemd-timesyncd,usbutils'
 G_EXEC_OUTPUT=1 G_EXEC debootstrap --variant=minbase --exclude="gcc-7-base,gcc-8-base,gcc-9-base$exclude" --include="$packages" --arch="$parch" --keyring="$keyring" "$distro" ./rootfs "$repo"
 
 # Remove cached archives and list files created by debootstrap

--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -263,7 +263,7 @@ fi
 # debootstrap
 ##########################################
 packages='apt,bash-completion,bzip2,ca-certificates,cron,curl,fdisk,gnupg,htop,iputils-ping,locales,nano,p7zip,parted,procps,psmisc,sudo,systemd-sysv,tzdata,udev,unzip,wget,whiptail,'
-(( $HW_MODEL == 75 )) && packages+='iproute2' || packages+='console-setup,ethtool,fake-hwclock,ifupdown,isc-dhcp-client,kmod,rfkill,systemd-timesyncd,usbutils'
+(( $HW_MODEL == 75 )) && packages+='iproute2' || packages+='console-setup,dropbear,ethtool,fake-hwclock,ifupdown,isc-dhcp-client,kmod,rfkill,systemd-timesyncd,usbutils'
 G_EXEC_OUTPUT=1 G_EXEC debootstrap --variant=minbase --exclude="gcc-7-base,gcc-8-base,gcc-9-base$exclude" --include="$packages" --arch="$parch" --keyring="$keyring" "$distro" ./rootfs "$repo"
 
 # Remove cached archives and list files created by debootstrap

--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -71,7 +71,7 @@ case $HW_MODEL in
 	16) iname='OdroidC4' HW_ARCH=3 partition_start=4 root_size=764;;
 	20) iname='VM' WIFI_REQUIRED=0 HW_ARCH=${HW_ARCH:-10} VMTYPE=${VMTYPE:-raw};;
 	21) iname='NativePC-BIOS' HW_ARCH=10 root_size=1215;;
-	75) uname='Container' root_size=511;;
+	75) iname='Container' root_size=511;;
 	*) G_DIETPI-NOTIFY 1 "Invalid hardware model \"$HW_MODEL\" passed, aborting..."; exit 1;;
 esac
 

--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -71,6 +71,7 @@ case $HW_MODEL in
 	16) iname='OdroidC4' HW_ARCH=3 partition_start=4 root_size=764;;
 	20) iname='VM' WIFI_REQUIRED=0 HW_ARCH=${HW_ARCH:-10} VMTYPE=${VMTYPE:-raw};;
 	21) iname='NativePC-BIOS' HW_ARCH=10 root_size=1215;;
+	75) uname='Container' root_size=511;;
 	*) G_DIETPI-NOTIFY 1 "Invalid hardware model \"$HW_MODEL\" passed, aborting..."; exit 1;;
 esac
 
@@ -261,7 +262,9 @@ fi
 ##########################################
 # debootstrap
 ##########################################
-G_EXEC_OUTPUT=1 G_EXEC debootstrap --variant=minbase --exclude="gcc-7-base,gcc-8-base,gcc-9-base$exclude" --include='bash-completion,bzip2,ca-certificates,console-setup,cron,curl,dropbear,ethtool,fake-hwclock,fdisk,gnupg,htop,ifupdown,isc-dhcp-client,kmod,locales,nano,p7zip,parted,procps,psmisc,rfkill,sudo,systemd-sysv,systemd-timesyncd,tzdata,udev,unzip,usbutils,wget,whiptail' --arch="$parch" --keyring="$keyring" "$distro" ./rootfs "$repo"
+packages='apt,bash-completion,bzip2,ca-certificates,cron,curl,fdisk,gnupg,htop,iputils-ping,locales,nano,p7zip,parted,procps,psmisc,sudo,systemd-sysv,tzdata,udev,unzip,wget,whiptail'
+(( $HW_MODEL == 75 )) || packages+=',console-setup,ethtool,fake-hwclock,ifupdown,isc-dhcp-client,kmod,rfkill,systemd-timesyncd,usbutils'
+G_EXEC_OUTPUT=1 G_EXEC debootstrap --variant=minbase --exclude="gcc-7-base,gcc-8-base,gcc-9-base$exclude" --include="$packages" --arch="$parch" --keyring="$keyring" "$distro" ./rootfs "$repo"
 
 # Remove cached archives and list files created by debootstrap
 G_EXEC rm -R rootfs/var/{cache/apt,lib/apt/lists}/*

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,7 +5,7 @@ New software:
 - PHP Composer | The PHP package manager has been made a dedicated install option.
 
 Changes:
-- DietPi-Banner | It is not possible to hide the credits section from the DietPi banner. Run "dietpi-banner" to configure its content. Many thanks to @math-gout for contributing this feature: https://github.com/MichaIng/DietPi/pull/5355
+- DietPi-Banner | It is now possible to hide the credits section from the DietPi banner. Run "dietpi-banner" to configure its content. Many thanks to @math-gout for contributing this feature: https://github.com/MichaIng/DietPi/pull/5355
 - DietPi-Drive_Manager | Adding an NFS drive now allows to select a specific export from an NFS server, detected via "showmount -e <IP/hostname>". Entering a custom path is still possible, including the single slash "/" which was always used before. If the NFS server has no root export defined via "fsid=0", this solves the issue that the full root directory structure is mounted and allows to mount multiple shares from the same server. Many thanks to @bamyasi for doing this suggestion: https://dietpi.com/phpbb/viewtopic.php?t=5488
 - DietPi-Drive_Manager | NFS and Samba network drives can now be mounted to any directory on the server, not necessarily below /mnt.
 - DietPi-Software | motionEye: We worked together with other contributors to revive motionEye and port it over to Python 3, which also allowed us to re-enable it on Debian Bullseye systems. It requires further careful testing before a stable release can be done, but common functionality works. We enabled it with a "beta" mark in DietPi-Software. Visit the new home of motionEye, and if you want, contribute or help testing: https://github.com/motioneye-project/motioneye

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -404,6 +404,7 @@ _EOF_
 		G_DIETPI-NOTIFY 2 "Selected hardware model ID: $G_HW_MODEL"
 
 		# WiFi selection
+		[[ $G_HW_MODEL == 75 ]] && WIFI_REQUIRED=0
 		if [[ $WIFI_REQUIRED != [01] ]]
 		then
 			G_WHIP_MENU_ARRAY=(
@@ -592,81 +593,32 @@ _EOF_
 			'bash-completion'	# Auto completes a wide list of bash commands and options via <tab>
 			'bzip2'			# (.tar).bz2 archiver
 			'ca-certificates'	# Adds known ca-certificates, necessary to practically access HTTPS sources
-			'console-setup'		# DietPi-Config keyboard configuration + console fonts
 			'cron'			# Background job scheduler
 			'curl'			# Web address testing, downloading, uploading etc.
-			'ethtool'		# Force Ethernet link speed
-			'fake-hwclock'		# Hardware clock emulation, to allow correct timestamps during boot before network time sync
 			'fdisk'			# Partitioning tool used by DietPi-FS_partition_resize and DietPi-Imager
 			'gnupg'			# apt-key add / gpg
 			'htop'			# System monitor
-			'ifupdown'		# Network interface configuration
 			'iputils-ping'		# "ping" command
-			'isc-dhcp-client'	# DHCP client
-			'kmod'			# "modprobe", "lsmod", used by several DietPi scripts
 			'locales'		# Support locales, used by dietpi-config > Language/Regional Options > Locale
 			'nano'			# Simple text editor
 			'p7zip'			# .7z archiver
 			'parted'		# partprobe + drive partitioning, used by DietPi-Drive_Manager
 			'procps'		# "kill", "ps", "pgrep", "sysctl", used by several DietPi scripts
 			'psmisc'		# "killall", used by several DietPi scripts
-			'rfkill' 		# Block/unblock WiFi and Bluetooth adapters, only installed once to unblock everything, purged afterwards!
 			'sudo'			# Root permission wrapper for users permitted via /etc/sudoers(.d/)
 			'systemd-sysv'		# Includes systemd and additional commands: "poweroff", "shutdown" etc.
-			'systemd-timesyncd'	# Network time sync daemon
 			'tzdata'		# Time zone data for system clock, auto summer/winter time adjustment
 			'udev'			# /dev/ and hotplug management daemon
 			'unzip'			# .zip unpacker
-			'usbutils'		# "lsusb", used by DietPi-Software + DietPi-Bugreport
 			'wget'			# Download tool
 			'whiptail'		# DietPi dialogs
 			#'xz-utils'		# (.tar).xz archiver
 		)
 
-		# G_DISTRO specific
-		# - Dropbear: DietPi default SSH server
-		#   On Buster, "dropbear" pulls in "dropbear-initramfs", which we don't need: https://packages.debian.org/dropbear
-		#   This needs to depend on current distro version instead of target version, to assure "dropbear-run" does not get autoremoved before "dropbear" is installed.
-		if (( $G_DISTRO > 5 ))
-		then
-			aPACKAGES_REQUIRED_INSTALL+=('dropbear')
-		else
-			aPACKAGES_REQUIRED_INSTALL+=('dropbear-run')
-		fi
-
-		# G_HW_MODEL specific
-		# - initramfs: Required for generic bootloader, but not required/used by RPi bootloader, on VM install tiny-initramfs with limited features but sufficient and much smaller + faster
-		if (( $G_HW_MODEL == 20 ))
-		then
-			aPACKAGES_REQUIRED_INSTALL+=('tiny-initramfs')
-
-		elif (( $G_HW_MODEL > 9 ))
-		then
-			aPACKAGES_REQUIRED_INSTALL+=('initramfs-tools')
-		fi
-		# - Entropy daemon: Use modern rng-tools5 on all devices where it has been proven to work, else haveged: https://github.com/MichaIng/DietPi/issues/2806
-		if [[ $G_HW_MODEL -lt 10 || $G_HW_MODEL =~ ^(14|15|16|24|29|42|46|58|68|72|74)$ ]] # RPi, S922X, Odroid C4, RK3399 - 47 NanoPi R4S, Radxa Zero
-		then
-			aPACKAGES_REQUIRED_INSTALL+=('rng-tools5')
-		else
-			aPACKAGES_REQUIRED_INSTALL+=('haveged')
-		fi
-		# - Drive power management control
-		(( $G_HW_MODEL == 20 )) || aPACKAGES_REQUIRED_INSTALL+=('hdparm')
-
-		# WiFi related
-		if (( $WIFI_REQUIRED ))
-		then
-			aPACKAGES_REQUIRED_INSTALL+=('iw')			# Tools to configure WiFi adapters
-			aPACKAGES_REQUIRED_INSTALL+=('wireless-tools')		# Same as "iw", deprecated but still required for non-nl80211 adapters
-			aPACKAGES_REQUIRED_INSTALL+=('crda')			# Set WiFi frequencies according to local regulations, based on WiFi country code
-			aPACKAGES_REQUIRED_INSTALL+=('wpasupplicant')		# Support for WPA-protected WiFi network connection
-		fi
-
 		# Install gdisk if root file system is on a GPT partition, used by DietPi-FS_partition_resize
 		[[ $(blkid -s PTTYPE -o value -c /dev/null "$(lsblk -npo PKNAME "$(findmnt -Ufnro SOURCE -M /)")") == 'gpt' ]] && aPACKAGES_REQUIRED_INSTALL+=('gdisk')
 
-		# Install file system tools required for file system resizing and fsck
+		# Install filesystem tools required for filesystem resizing and fsck
 		local ae2fsprogs=('--allow-remove-essential' 'e2fsprogs')
 		while read -r line
 		do
@@ -690,40 +642,97 @@ _EOF_
 
 		done < <(blkid -s TYPE -o value -c /dev/null | sort -u)
 
-		# Kernel/bootloader/firmware
-		# - We need to install those directly to allow G_AGA() autoremove possible older packages later: https://github.com/MichaIng/DietPi/issues/1285#issuecomment-354602594
-		# - Assure that dir for additional sources is present
-		[[ -d '/etc/apt/sources.list.d' ]] || G_EXEC mkdir /etc/apt/sources.list.d
-		# - G_HW_ARCH specific
-		#	x86_64
-		if (( $G_HW_ARCH == 10 )); then
+		# G_HW_MODEL specific
+		# - All but containers
+		if (( $G_HW_MODEL != 75 ))
+		then
+			aPACKAGES_REQUIRED_INSTALL+=(
+				'console-setup'		# DietPi-Config keyboard configuration + console fonts
+				'ethtool'		# Force Ethernet link speed
+				'fake-hwclock'		# Hardware clock emulation, to allow correct timestamps during boot before network time sync
+				'ifupdown'		# Network interface configuration
+				'isc-dhcp-client'	# DHCP client
+				'kmod'			# "modprobe", "lsmod", used by several DietPi scripts
+				'rfkill' 		# Block/unblock WiFi and Bluetooth adapters, only installed once to unblock everything, purged afterwards!
+				'systemd-timesyncd'	# Network time sync daemon
+				'usbutils'		# "lsusb", used by DietPi-Software + DietPi-Bugreport
+			)
 
-			local apackages=('linux-image-amd64' 'os-prober')
+			# initramfs: Required for generic bootloader, but not required/used by RPi bootloader, on VM install tiny-initramfs with limited features but sufficient and much smaller + faster
+			if (( $G_HW_MODEL == 20 ))
+			then
+				aPACKAGES_REQUIRED_INSTALL+=('tiny-initramfs')
 
-			# As linux-image-amd64 pulls initramfs already, pre-install the intended implementation here already
-			(( $G_HW_MODEL == 20 )) && apackages+=('tiny-initramfs') || apackages+=('initramfs-tools')
-
-			# Grub EFI with secure boot compatibility
-			if [[ -d '/boot/efi' ]] || dpkg-query -s 'grub-efi-amd64' &> /dev/null; then
-
-				apackages+=('grub-efi-amd64' 'grub-efi-amd64-signed' 'shim-signed')
-
-			# Grub BIOS
-			else
-
-				apackages+=('grub-pc')
-
+			elif (( $G_HW_MODEL > 9 ))
+			then
+				aPACKAGES_REQUIRED_INSTALL+=('initramfs-tools')
 			fi
 
-			# Skip creating kernel symlinks and remove existing ones
-			echo 'do_symlinks=0' > /etc/kernel-img.conf
-			G_EXEC rm -f /{,boot/}{initrd.img,vmlinuz}{,.old}
-
-			# If /boot is on a FAT partition, create a kernel upgrade hook script to remove existing files first: https://github.com/MichaIng/DietPi/issues/4788
-			if [[ $(findmnt -Ufnro FSTYPE -M /boot) == 'vfat' ]]
+			# Entropy daemon: Use modern rng-tools5 on all devices where it has been proven to work, else haveged: https://github.com/MichaIng/DietPi/issues/2806
+			if [[ $G_HW_MODEL -lt 10 || $G_HW_MODEL =~ ^(14|15|16|24|29|42|46|58|68|72|74)$ ]] # RPi, S922X, Odroid C4, RK3399 - 47 NanoPi R4S, Radxa Zero
 			then
-				G_EXEC mkdir -p /etc/kernel/preinst.d
-				cat << '_EOF_' > /etc/kernel/preinst.d/dietpi
+				aPACKAGES_REQUIRED_INSTALL+=('rng-tools5')
+			else
+				aPACKAGES_REQUIRED_INSTALL+=('haveged')
+			fi
+
+			# G_DISTRO specific
+			# - Dropbear: DietPi default SSH server
+			#   On Buster, "dropbear" pulls in "dropbear-initramfs", which we don't need: https://packages.debian.org/dropbear
+			#   This needs to depend on current distro version instead of target version, to assure "dropbear-run" does not get autoremoved before "dropbear" is installed.
+			if (( $G_DISTRO > 5 ))
+			then
+				aPACKAGES_REQUIRED_INSTALL+=('dropbear')
+			else
+				aPACKAGES_REQUIRED_INSTALL+=('dropbear-run')
+			fi
+
+			# All but VMs: Drive power management control
+			(( $G_HW_MODEL == 20 )) || aPACKAGES_REQUIRED_INSTALL+=('hdparm')
+
+			# WiFi related
+			if (( $WIFI_REQUIRED ))
+			then
+				aPACKAGES_REQUIRED_INSTALL+=('iw')			# Tools to configure WiFi adapters
+				aPACKAGES_REQUIRED_INSTALL+=('wireless-tools')		# Same as "iw", deprecated but still required for non-nl80211 adapters
+				aPACKAGES_REQUIRED_INSTALL+=('crda')			# Set WiFi frequencies according to local regulations, based on WiFi country code
+				aPACKAGES_REQUIRED_INSTALL+=('wpasupplicant')		# Support for WPA-protected WiFi network connection
+			fi
+
+			# Kernel/bootloader/firmware
+			# - We need to install those directly to allow G_AGA() autoremove possible older packages later: https://github.com/MichaIng/DietPi/issues/1285#issuecomment-354602594
+			# - Assure that dir for additional sources is present
+			[[ -d '/etc/apt/sources.list.d' ]] || G_EXEC mkdir /etc/apt/sources.list.d
+			# - G_HW_ARCH specific
+			#	x86_64
+			if (( $G_HW_ARCH == 10 )); then
+
+				local apackages=('linux-image-amd64' 'os-prober')
+
+				# As linux-image-amd64 pulls initramfs already, pre-install the intended implementation here already
+				(( $G_HW_MODEL == 20 )) && apackages+=('tiny-initramfs') || apackages+=('initramfs-tools')
+
+				# Grub EFI with secure boot compatibility
+				if [[ -d '/boot/efi' ]] || dpkg-query -s 'grub-efi-amd64' &> /dev/null; then
+
+					apackages+=('grub-efi-amd64' 'grub-efi-amd64-signed' 'shim-signed')
+
+				# Grub BIOS
+				else
+
+					apackages+=('grub-pc')
+
+				fi
+
+				# Skip creating kernel symlinks and remove existing ones
+				echo 'do_symlinks=0' > /etc/kernel-img.conf
+				G_EXEC rm -f /{,boot/}{initrd.img,vmlinuz}{,.old}
+
+				# If /boot is on a FAT partition, create a kernel upgrade hook script to remove existing files first: https://github.com/MichaIng/DietPi/issues/4788
+				if [[ $(findmnt -Ufnro FSTYPE -M /boot) == 'vfat' ]]
+				then
+					G_EXEC mkdir -p /etc/kernel/preinst.d
+					cat << '_EOF_' > /etc/kernel/preinst.d/dietpi
 #!/bin/sh -e
 # Remove old kernel files if existing: https://github.com/MichaIng/DietPi/issues/4788
 {
@@ -741,19 +750,20 @@ do
 done
 }
 _EOF_
-				G_EXEC chmod +x /etc/kernel/preinst.d/dietpi
+					G_EXEC chmod +x /etc/kernel/preinst.d/dietpi
+				fi
+
+				G_AGI "${apackages[@]}"
+				unset -v apackages
+
+				# Remove obsolete combined keyring
+				[[ -f '/etc/apt/trusted.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg
+				[[ -f '/etc/apt/trusted.gpg~' ]] && G_EXEC rm '/etc/apt/trusted.gpg~'
 			fi
+		fi
 
-			G_AGI "${apackages[@]}"
-			unset -v apackages
-
-			# Remove obsolete combined keyring
-			[[ -f '/etc/apt/trusted.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg
-			[[ -f '/etc/apt/trusted.gpg~' ]] && G_EXEC rm '/etc/apt/trusted.gpg~'
-
-		# - G_HW_MODEL specific required firmware/kernel/bootloader packages
-		#	Odroid N2/C4: Modern single partition image
-		elif [[ $G_HW_MODEL == 1[56] && -f '/boot/dietpiEnv.txt' ]]
+		# - Odroid N2/C4: Modern single partition image
+		if [[ $G_HW_MODEL == 1[56] && -f '/boot/dietpiEnv.txt' ]]
 		then
 			# Bootstrap Armbian repository
 			G_EXEC eval "curl -sSfL 'https://apt.armbian.com/armbian.key' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-armbian.gpg --yes"
@@ -782,8 +792,8 @@ _EOF_
 			. /usr/lib/u-boot/platform_install.sh
 			write_uboot_platform "$DIR" "$(lsblk -npo PKNAME "$(findmnt -Ufnro SOURCE -M /)")"
 
-		#	Armbian grab currently installed packages
-		elif [[ $(dpkg-query -Wf '${Package} ') == *'armbian'* ]]; then
+		# - Armbian grab currently installed packages
+		elif [[ $G_HW_MODEL != 75 && $(dpkg-query -Wf '${Package} ') == *'armbian'* ]]; then
 
 			systemctl stop armbian-*
 
@@ -886,7 +896,7 @@ _EOF_
 			echo 'path-exclude /usr/lib/linux-image-current-*' > /etc/dpkg/dpkg.cfg.d/01-dietpi-exclude_doubled_devicetrees
 			G_EXEC rm -Rf /usr/lib/linux-image-current-*
 
-		#	RPi
+		# - RPi
 		elif (( $G_HW_MODEL < 10 )); then
 
 			# ARMv6/7: Add raspi-copies-and-fills
@@ -903,8 +913,8 @@ _EOF_
 			[[ -f '/etc/apt/trusted.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg
 			[[ -f '/etc/apt/trusted.gpg~' ]] && G_EXEC rm '/etc/apt/trusted.gpg~'
 
-		#	Odroid C4
-		elif (( $G_HW_MODEL == 16 )); then
+		# - Odroid C4 legacy
+		elif (( $G_HW_MODEL == 16 )) && [[ $(find /etc/apt/sources.list.d -name 'meveric*.list') ]]; then
 
 			G_AGI linux-image-arm64-odroid-c4 meveric-keyring u-boot # On C4, the kernel package does not depend on the U-Boot package
 
@@ -916,10 +926,11 @@ _EOF_
 			[[ -f '/etc/apt/trusted.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg
 			[[ -f '/etc/apt/trusted.gpg~' ]] && G_EXEC rm '/etc/apt/trusted.gpg~'
 
-		#	Odroid N2
-		elif (( $G_HW_MODEL == 15 )); then
+		# - Odroid N2 legacy
+		elif (( $G_HW_MODEL == 15 )) && [[ $(find /etc/apt/sources.list.d -name 'meveric*.list') ]]; then
 
 			G_AGI linux-image-arm64-odroid-n2 meveric-keyring
+
 			# Apply kernel postinst steps manually, that depend on /proc/cpuinfo content, not matching when running in a container.
 			[[ -f '/boot/Image' ]] && G_EXEC mv /boot/Image /boot/Image.gz
 			[[ -f '/boot/Image.gz.bak' ]] && G_EXEC rm /boot/Image.gz.bak
@@ -928,8 +939,8 @@ _EOF_
 			[[ -f '/etc/apt/trusted.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg
 			[[ -f '/etc/apt/trusted.gpg~' ]] && G_EXEC rm '/etc/apt/trusted.gpg~'
 
-		#	Odroid C2
-		elif (( $G_HW_MODEL == 12 )); then
+		# - Odroid C2 legacy
+		elif (( $G_HW_MODEL == 12 )) && [[ $(find /etc/apt/sources.list.d -name 'meveric*.list') ]]; then
 
 			G_AGI linux-image-arm64-odroid-c2 meveric-keyring
 
@@ -937,8 +948,8 @@ _EOF_
 			[[ -f '/etc/apt/trusted.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg
 			[[ -f '/etc/apt/trusted.gpg~' ]] && G_EXEC rm '/etc/apt/trusted.gpg~'
 
-		#	Odroid XU3/XU4/MC1/HC1/HC2
-		elif (( $G_HW_MODEL == 11 )); then
+		# - Odroid XU3/XU4/MC1/HC1/HC2 legacy
+		elif (( $G_HW_MODEL == 11 )) && [[ $(find /etc/apt/sources.list.d -name 'meveric*.list') ]]; then
 
 			G_AGI linux-image-4.14-armhf-odroid-xu4 meveric-keyring
 
@@ -946,7 +957,7 @@ _EOF_
 			[[ -f '/etc/apt/trusted.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg
 			[[ -f '/etc/apt/trusted.gpg~' ]] && G_EXEC rm '/etc/apt/trusted.gpg~'
 
-		#	ROCK Pi S (official Radxa Debian image)
+		# - ROCK Pi S (official Radxa Debian image)
 		elif (( $G_HW_MODEL == 73 )) && grep -q 'apt\.radxa\.com' /etc/apt/sources.list.d/*.list; then
 
 			# Install Radxa APT repo cleanly: No Bullseye repo available yet
@@ -962,7 +973,7 @@ _EOF_
 			# NB: rockpis-dtbo is not required as it doubles the overlays that are already provided (among others) with the kernel package
 			G_AGI rockpis-rk-ubootimg linux-4.4-rock-pi-s-latest rockchip-overlay u-boot-tools
 
-		#	Radxa Zero (official Radxa Debian image)
+		# - Radxa Zero (official Radxa Debian image)
 		elif (( $G_HW_MODEL == 74 )) && grep -q 'apt\.radxa\.com' /etc/apt/sources.list.d/*.list; then
 
 			# Install Radxa APT repo cleanly: No Bullseye repo available yet
@@ -982,30 +993,26 @@ _EOF_
 			G_AGI $(dpkg-query -Wf '${Package}\n' | grep -E '^linux-(image|dtb|u-boot)-|^u-boot') bc file
 
 		# - Generic kernel + device tree + U-Boot package auto detect
-		else
-
+		elif (( $G_HW_MODEL != 75 ))
+		then
 			mapfile -t apackages < <(dpkg-query -Wf '${Package}\n' | grep -E '^linux-(image|dtb|u-boot)-|^u-boot')
-			if [[ ${apackages[0]} ]]; then
-
+			if [[ ${apackages[0]} ]]
+			then
 				G_AGI "${apackages[@]}"
-
 			else
-
 				G_DIETPI-NOTIFY 2 'Unable to find kernel packages for installation. Assuming non-APT/.deb kernel installation.'
-
 			fi
 			unset -v apackages
-
 		fi
 		G_EXEC apt-get clean # Remove downloaded archives
 
 		# - Firmware
-		if dpkg-query -s 'armbian-firmware' &> /dev/null
+		if (( $G_HW_MODEL != 75 )) && dpkg-query -s 'armbian-firmware' &> /dev/null
 		then
 			aPACKAGES_REQUIRED_INSTALL+=('armbian-firmware')
 
 		# - Do not install additional firmware on Radxa Zero for now
-		elif [[ $G_HW_MODEL != 74 ]]
+		elif [[ $G_HW_MODEL != 7[45] ]]
 		then
 			# Usually no firmware should be necessary for VMs. If user manually passes though some USB device, user might need to install the firmware then.
 			if (( $G_HW_MODEL != 20 ))
@@ -1322,7 +1329,7 @@ _EOF_'
 		#-----------------------------------------------------------------------------------
 		# Network
 		G_DIETPI-NOTIFY 2 'Removing all rfkill soft blocks and the rfkill package'
-		rfkill unblock all
+		command -v rfkill > /dev/null && rfkill unblock all
 		G_AGP rfkill
 		[[ -d '/var/lib/systemd/rfkill' ]] && G_EXEC rm -R /var/lib/systemd/rfkill
 
@@ -1341,8 +1348,10 @@ _EOF_'
 		# ifupdown starts the daemon outside of systemd, the enabled systemd unit just throws an error on boot due to missing dbus and with dbus might interfere with ifupdown
 		systemctl list-unit-files 'wpa_supplicant.service' &> /dev/null && G_EXEC systemctl disable wpa_supplicant
 
-		G_EXEC_DESC='Configuring network interfaces'
-		G_EXEC eval 'cat << _EOF_ > /etc/network/interfaces
+		if (( $G_HW_MODEL != 75 ))
+		then
+			G_EXEC_DESC='Configuring network interfaces'
+			G_EXEC eval 'cat << _EOF_ > /etc/network/interfaces
 # Location: /etc/network/interfaces
 # Please modify network settings via: dietpi-config
 # Or create your own drop-ins in: /etc/network/interfaces.d/
@@ -1368,8 +1377,9 @@ gateway 192.168.0.1
 wireless-power off
 wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf
 _EOF_'
-		# Wait for network at boot by default
-		/boot/dietpi/func/dietpi-set_software boot_wait_for_network 1
+			# Wait for network at boot by default
+			/boot/dietpi/func/dietpi-set_software boot_wait_for_network 1
+		fi
 
 		#-----------------------------------------------------------------------------------
 		# MISC
@@ -1482,7 +1492,7 @@ _EOF_'
 		fi
 
 		# Re-set dietpi.txt setting on non-VMs to indicated enabled serial console
-		(( $G_HW_MODEL == 20 )) || G_CONFIG_INJECT 'CONFIG_SERIAL_CONSOLE_ENABLE=' 'CONFIG_SERIAL_CONSOLE_ENABLE=1' /boot/dietpi.txt
+		(( $G_HW_MODEL == 20 || $G_HW_MODEL == 75 )) || G_CONFIG_INJECT 'CONFIG_SERIAL_CONSOLE_ENABLE=' 'CONFIG_SERIAL_CONSOLE_ENABLE=1' /boot/dietpi.txt
 
 		G_DIETPI-NOTIFY 2 'Disabling static and automatic login prompts on consoles tty2 to tty6:'
 		G_EXEC systemctl mask --now getty-static
@@ -1498,14 +1508,17 @@ _EOF_'
 		G_EXEC ln -s /usr/share/zoneinfo/UTC /etc/localtime
 		G_EXEC dpkg-reconfigure -f noninteractive tzdata
 
-		G_DIETPI-NOTIFY 2 'Configuring keyboard:'
-		echo -e 'XKBMODEL="pc105"\nXKBLAYOUT="gb"' > /etc/default/keyboard
-		dpkg-reconfigure -f noninteractive keyboard-configuration # Keyboard must be plugged in for this to work!
+		if (( $G_HW_MODEL != 75 ))
+		then
+			G_DIETPI-NOTIFY 2 'Configuring keyboard:'
+			echo -e 'XKBMODEL="pc105"\nXKBLAYOUT="gb"' > /etc/default/keyboard
+			dpkg-reconfigure -f noninteractive keyboard-configuration # Keyboard must be plugged in for this to work!
 
-		G_DIETPI-NOTIFY 2 'Configuring console:' # This can be wrong, e.g. when selecting a non-UTF-8 locale during Debian installer
-		G_CONFIG_INJECT 'CHARMAP=' 'CHARMAP="UTF-8"' /etc/default/console-setup
-		G_EXEC eval "debconf-set-selections <<< 'console-setup console-setup/charmap47 select UTF-8'"
-		G_EXEC setupcon --save
+			G_DIETPI-NOTIFY 2 'Configuring console:' # This can be wrong, e.g. when selecting a non-UTF-8 locale during Debian installer
+			G_CONFIG_INJECT 'CHARMAP=' 'CHARMAP="UTF-8"' /etc/default/console-setup
+			G_EXEC eval "debconf-set-selections <<< 'console-setup console-setup/charmap47 select UTF-8'"
+			G_EXEC setupcon --save
+		fi
 
 		G_DIETPI-NOTIFY 2 'Applying architecture-specific tweaks:'
 		if (( $G_HW_ARCH == 10 )); then
@@ -1519,7 +1532,9 @@ _EOF_'
 			if command -v update-tirfs > /dev/null
 			then
 				G_EXEC_OUTPUT=1 G_EXEC update-tirfs
-			else
+
+			elif command -v update-initramfs > /dev/null
+			then
 				G_EXEC_OUTPUT=1 G_EXEC update-initramfs -u
 			fi
 
@@ -1530,7 +1545,7 @@ _EOF_'
 		fi
 
 		G_DIETPI-NOTIFY 2 'Applying board-specific tweaks:'
-		if (( $G_HW_MODEL != 20 ))
+		if (( $G_HW_MODEL != 20 && $G_HW_MODEL != 75 ))
 		then
 			G_EXEC_DESC='Configuring hdparm'
 			# Since Debian Bullseye, spindown_time is not applied if APM is not supported by the drive. force_spindown_time is required to override that.
@@ -1727,7 +1742,7 @@ _EOF_
 
 		# Apply cgroups-v2 workaround if the kernel does not support it: https://github.com/MichaIng/DietPi/issues/4705
 		# - This is required on Bullseye only, but we'll apply it on Buster as well to cover later distro upgrades, since the logic is too complicated for our upgrade blog article.
-		if [[ ! $(find /lib/modules -maxdepth 1 -type d -name '5.[0-9]*') ]]
+		if [[ $G_HW_MODEL != 75 && ! $(find /lib/modules -maxdepth 1 -type d -name '5.[0-9]*') ]]
 		then
 			# Odroids
 			if [[ $G_HW_MODEL -gt 9 && $G_HW_MODEL -le 16 && -f '/boot/boot.ini' ]] && ! grep -q 'systemd.unified_cgroup_hierarchy=0' /boot/boot.ini
@@ -1754,9 +1769,12 @@ _EOF_
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" "[$SETUP_STEP] Finalise system for first boot of DietPi"; ((SETUP_STEP++))
 		#------------------------------------------------------------------------------------------------
 
-		G_EXEC_DESC='Enable Dropbear autostart' G_EXEC sed -i '/NO_START=1/c\NO_START=0' /etc/default/dropbear
-		G_EXEC systemctl unmask dropbear
-		G_EXEC systemctl enable dropbear
+		if (( $G_HW_MODEL != 75 ))
+		then
+			G_EXEC_DESC='Enable Dropbear autostart' G_EXEC sed -i '/NO_START=1/c\NO_START=0' /etc/default/dropbear
+			G_EXEC systemctl unmask dropbear
+			G_EXEC systemctl enable dropbear
+		fi
 
 		G_DIETPI-NOTIFY 2 'Configuring services'
 		/boot/dietpi/dietpi-services stop
@@ -1769,7 +1787,7 @@ _EOF_
 		/boot/dietpi/func/dietpi-set_swapfile 0 /var/swap
 		[[ -e '/var/swap' ]] && rm -v /var/swap # still exists on some images...
 		# - Re-enable for next run
-		G_CONFIG_INJECT 'AUTO_SETUP_SWAPFILE_SIZE=' 'AUTO_SETUP_SWAPFILE_SIZE=1' /boot/dietpi.txt
+		(( $G_HW_MODEL == 75 )) || G_CONFIG_INJECT 'AUTO_SETUP_SWAPFILE_SIZE=' 'AUTO_SETUP_SWAPFILE_SIZE=1' /boot/dietpi.txt
 		# - Reset /tmp size to default (512 MiB)
 		sed -i '\|/tmp|s|size=[^,]*,||' /etc/fstab
 
@@ -1779,8 +1797,8 @@ _EOF_
 		# - Set WiFi
 		local tmp_info='Disabling'
 		local tmp_mode='disable'
-		if (( $WIFI_REQUIRED )); then
-
+		if (( $WIFI_REQUIRED ))
+		then
 			G_DIETPI-NOTIFY 2 'Generating default wpa_supplicant.conf'
 			/boot/dietpi/func/dietpi-wifidb 1
 			# Move to /boot/ so users can modify as needed for automated
@@ -1788,17 +1806,19 @@ _EOF_
 
 			tmp_info='Enabling'
 			tmp_mode='enable'
-
 		fi
 
-		G_DIETPI-NOTIFY 2 "$tmp_info onboard WiFi modules by default"
-		/boot/dietpi/func/dietpi-set_hardware wifimodules onboard_$tmp_mode
+		if (( $G_HW_MODEL != 75 ))
+		then
+			G_DIETPI-NOTIFY 2 "$tmp_info onboard WiFi modules by default"
+			/boot/dietpi/func/dietpi-set_hardware wifimodules onboard_$tmp_mode
 
-		G_DIETPI-NOTIFY 2 "$tmp_info generic WiFi by default"
-		/boot/dietpi/func/dietpi-set_hardware wifimodules $tmp_mode
+			G_DIETPI-NOTIFY 2 "$tmp_info generic WiFi by default"
+			/boot/dietpi/func/dietpi-set_hardware wifimodules $tmp_mode
+		fi
 
 		# - x86_64: GRUB install and config
-		if (( $G_HW_ARCH == 10 )); then
+		if (( $G_HW_ARCH == 10 && $G_HW_MODEL != 75 )); then
 
 			G_EXEC_DESC='Detecting additional OS installed on system' G_EXEC_OUTPUT=1 G_EXEC os-prober
 

--- a/PREP_SYSTEM_FOR_DIETPI.sh
+++ b/PREP_SYSTEM_FOR_DIETPI.sh
@@ -1493,6 +1493,9 @@ _EOF_'
 			/boot/dietpi/func/dietpi-set_hardware serialconsole enable
 		fi
 
+		# Re-set dietpi.txt setting physical systems to indicated enabled serial console
+		(( $G_HW_MODEL == 20 || $G_HW_MODEL == 75 )) || G_CONFIG_INJECT 'CONFIG_SERIAL_CONSOLE_ENABLE=' 'CONFIG_SERIAL_CONSOLE_ENABLE=1' /boot/dietpi.txt
+
 		G_DIETPI-NOTIFY 2 'Disabling static and automatic login prompts on consoles tty2 to tty6:'
 		G_EXEC systemctl mask --now getty-static
 		# - logind features are usually not needed and (aside of automatic getty spawn) require the libpam-systemd package.

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -15876,8 +15876,8 @@ This requires an account at: https://remote.it/
 		sed -i "\|[[:blank:]]/var/log[[:blank:]]|c\tmpfs /var/log tmpfs size=${AUTOINSTALL_RAMLOG_SIZE}M,noatime,lazytime,nodev,nosuid,mode=1777" /etc/fstab
 		findmnt /var/log > /dev/null && G_EXEC mount -o remount /var/log
 
-		# Set time sync mode
-		/boot/dietpi/func/dietpi-set_software ntpd-mode $AUTOINSTALL_TIMESYNCMODE
+		# Set time sync mode if no container system
+		(( $G_HW_MODEL == 75 )) || /boot/dietpi/func/dietpi-set_software ntpd-mode $AUTOINSTALL_TIMESYNCMODE
 
 		# Apply choice and preference system settings
 		Apply_SSHServer_Choices "$AUTOINSTALL_SSHINDEX"
@@ -15943,7 +15943,7 @@ This requires an account at: https://remote.it/
 		#hwclock &> /dev/null && G_AGP fake-hwclock
 
 		# x86_64 microcode updates, skip on VM
-		if (( $G_HW_ARCH == 10 && $G_HW_MODEL != 20 ))
+		if (( $G_HW_ARCH == 10 && $G_HW_MODEL != 20 && $G_HW_MODEL != 75 ))
 		then
 			grep -qi 'vendor_id.*intel' /proc/cpuinfo && G_AGI intel-microcode
 			grep -qi 'vendor_id.*amd' /proc/cpuinfo && G_AGI amd64-microcode

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -15835,7 +15835,7 @@ This requires an account at: https://remote.it/
 		fi
 
 		# Disable serial console?
-		if ! grep -q '^[[:blank:]]*CONFIG_SERIAL_CONSOLE_ENABLE=0' /boot/dietpi.txt &&
+		if (( $G_HW_MODEL != 75 )) && ! grep -q '^[[:blank:]]*CONFIG_SERIAL_CONSOLE_ENABLE=0' /boot/dietpi.txt &&
 			[[ ! $(readlink -f /proc/$$/fd/1) =~ ^/dev/tty(S|AMA|SAC|AML|SC)[0-9]$ ]] &&
 			G_WHIP_YESNO 'A serial console is currently enabled, would you like to disable it?
  - Disabling the serial console will reduce memory consumption slightly.

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -1467,7 +1467,7 @@ Press any key to continue...'
 	# Check for missing kernel modules, e.g. after a kernel upgrade, and in case create a flag
 	G_CHECK_KERNEL()
 	{
-		[[ -d /lib/modules/$(uname -r) ]] || systemd-detect-virt -c > /dev/null || return 1
+		[[ $G_HW_MODEL == 75 || -d /lib/modules/$(uname -r) ]] || grep -zaq '^container=' /proc/1/environ || return 1
 		return 0
 	}
 

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -1343,8 +1343,8 @@ Do you want to continue and disable the serial login console?' || return 1
 		# - All
 		local aWIFI_MODULES=('cfg80211')
 
-		# + RPi with onboard WiFi
-		if (( $G_HW_ONBOARD_WIFI )); then
+		# + RPi with onboard WiFi and NanoPi NEO Air
+		if (( $G_HW_ONBOARD_WIFI || $G_HW_MODEL == 64 )); then
 
 			aWIFI_MODULES+=('brcmfmac' 'brcmutil')
 
@@ -1358,20 +1358,6 @@ Do you want to continue and disable the serial login console?' || return 1
 
 			aWIFI_MODULES+=('8723bs')
 
-		# + NanoPi NEO Air
-		elif (( $G_HW_MODEL == 64 )); then
-
-			# 4.9 uses brcm, only enable dhd for 3.x
-			if [[ -d '/boot/dtb' ]]; then
-
-				aWIFI_MODULES+=('brcmfmac' 'brcmutil')
-
-			else
-
-				aWIFI_MODULES+=('dhd')
-
-			fi
-
 		# + NanoPi M3/T3/Fire3
 		elif (( $G_HW_MODEL == 62 )); then
 
@@ -1384,9 +1370,12 @@ Do you want to continue and disable the serial login console?' || return 1
 			# Disable onboard WiFi as well
 			(( $G_HW_ONBOARD_WIFI )) && INPUT_DEVICE_VALUE='onboard_disable' Wifi_Modules_Main
 
-			# Reset blacklists and remove powersaving settings
-			> /etc/modprobe.d/dietpi-disable_wifi.conf
+			# Remove powersaving setting
 			[[ -f '/etc/modprobe.d/dietpi-disable_wifi_powersaving.conf' ]] && rm /etc/modprobe.d/dietpi-disable_wifi_powersaving.conf
+
+			# Reset blacklists
+			[[ -d '/etc/modprobe.d' ]] || G_EXEC mkdir /etc/modprobe.d
+			> /etc/modprobe.d/dietpi-disable_wifi.conf
 
 			# cfg80211 last
 			for ((i=$(( ${#aWIFI_MODULES[@]} - 1 )); i>=0; i--))
@@ -1398,19 +1387,17 @@ Do you want to continue and disable the serial login console?' || return 1
 		elif [[ $INPUT_DEVICE_VALUE == 'enable' ]]; then
 
 			# Disable known powersaving options for specific chipsets
+			[[ -d '/etc/modprobe.d' ]] || G_EXEC mkdir /etc/modprobe.d
 			cat << _EOF_ > /etc/modprobe.d/dietpi-disable_wifi_powersaving.conf
-options 8192cu rtw_power_mgnt=0
-options 8188eu rtw_power_mgnt=0
-# OPi Plus
+# NanoPi K1 Plus
 options 8189es rtw_power_mgnt=0
-# Pine A64
+# PINE A64
 options 8723bs rtw_power_mgnt=0
 # Sparky SBC
 options wlan_8192eu rtw_power_mgnt=0
 # - https://github.com/sparky-sbc/sparky-test/tree/master/rtl8812au
 options wlan_8812au rtw_power_mgnt=0
 _EOF_
-
 			# Remove blacklists
 			[[ -f '/etc/modprobe.d/dietpi-disable_wifi.conf' ]] && rm /etc/modprobe.d/dietpi-disable_wifi.conf
 

--- a/dietpi/func/dietpi-set_swapfile
+++ b/dietpi/func/dietpi-set_swapfile
@@ -82,7 +82,7 @@
 	Swap_Disable(){
 
 		G_DIETPI-NOTIFY 2 'Disabling and deleting all existing swap files'
-		G_EXEC_NOHALT=1 G_EXEC swapoff -a
+		(( $G_HW_MODEL == 75 )) || grep -zaq '^container=' /proc/1/environ || G_EXEC swapoff -a
 		rm -fv "${SWAP_FILES_ACTIVE[@]}"
 		sed -i '/[[:blank:]]swap[[:blank:]]/d' /etc/fstab
 		# zram-swap
@@ -179,7 +179,7 @@
 		SWAP_SIZE=0
 
 	# Unsupported in container
-	elif grep -qza '^container=' /proc/1/environ; then
+	elif (( $G_HW_MODEL == 75 )) || grep -zaq '^container=' /proc/1/environ; then
 
 		Error_Reset 'Swap space cannot be controlled form within a container.'
 

--- a/dietpi/func/run_ntpd
+++ b/dietpi/func/run_ntpd
@@ -116,6 +116,11 @@ NB: We highly recommend choosing "Retry" first. Failing that, try to change the 
 		G_EXEC mkdir -p /run/systemd/timesync
 		> "$FP_FLAG"
 
+	# Container: Skip time sync
+	elif (( $G_HW_MODEL == 75 )) || grep -zaq '^container=' /proc/1/environ
+	then
+		G_DIETPI-NOTIFY 2 'Container detected, skipping time sync'
+
 	# Forced mode or flag does not exist: Sync
 	else
 		EXIT_CODE=1

--- a/rootfs/var/lib/dietpi/services/dietpi-firstboot.bash
+++ b/rootfs/var/lib/dietpi/services/dietpi-firstboot.bash
@@ -143,9 +143,6 @@ _EOF_
 
 		fi
 
-		# Disable serial console if set in dietpi.txt
-		grep -q '^[[:blank:]]*CONFIG_SERIAL_CONSOLE_ENABLE=0' /boot/dietpi.txt && /boot/dietpi/func/dietpi-set_hardware serialconsole disable
-
 		# Apply login password if it has not been encrypted before to avoid applying the informational text
 		if [[ ! -f '/var/lib/dietpi/dietpi-software/.GLOBAL_PW.bin' ]]; then
 
@@ -191,7 +188,7 @@ _EOF_
 
 		fi
 
-		# Skip keyboard, SSH and network setup on container systems
+		# Skip keyboard, SSH, serial console and network setup on container systems
 		(( $G_HW_MODEL == 75 )) && return 0
 
 		# Apply keyboard layout
@@ -213,6 +210,9 @@ _EOF_
 			rm -v "$i"
 			dropbearkey -t "$type" -f "$i"
 		done
+
+		# Disable serial console if set in dietpi.txt
+		grep -q '^[[:blank:]]*CONFIG_SERIAL_CONSOLE_ENABLE=0' /boot/dietpi.txt && /boot/dietpi/func/dietpi-set_hardware serialconsole disable
 
 		# Apply forced Ethernet link speed if set in dietpi.txt
 		/boot/dietpi/func/dietpi-set_hardware eth-forcespeed "$(sed -n '/^[[:blank:]]*AUTO_SETUP_NET_ETH_FORCE_SPEED=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)"

--- a/rootfs/var/lib/dietpi/services/dietpi-firstboot.bash
+++ b/rootfs/var/lib/dietpi/services/dietpi-firstboot.bash
@@ -114,42 +114,8 @@
 		# Apply swap settings
 		/boot/dietpi/func/dietpi-set_swapfile
 
-		# Apply time zone
-		local autoinstall_timezone=$(sed -n '/^[[:blank:]]*AUTO_SETUP_TIMEZONE=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-		if [[ -f /usr/share/zoneinfo/$autoinstall_timezone && $autoinstall_timezone != $(</etc/timezone) ]]; then
-
-			G_DIETPI-NOTIFY 2 "Setting time zone $autoinstall_timezone. Please wait..."
-			rm -fv /etc/{timezoner,localtime}
-			ln -s "/usr/share/zoneinfo/$autoinstall_timezone" /etc/localtime
-			dpkg-reconfigure -f noninteractive tzdata
-
-		fi
-
-		# Apply language (locale)
-		local autoinstall_language=$(sed -n '/^[[:blank:]]*AUTO_SETUP_LOCALE=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-		grep -q "^$autoinstall_language UTF-8$" /usr/share/i18n/SUPPORTED || autoinstall_language='C.UTF-8'
-		if ! locale | grep -qE "(LANG|LC_ALL)=[\'\"]?${autoinstall_language}[\'\"]?" || ! locale -a | grep -qiE 'C\.UTF-?8'; then
-
-			G_DIETPI-NOTIFY 2 "Setting locale $autoinstall_language. Please wait..."
-			/boot/dietpi/func/dietpi-set_software locale "$autoinstall_language"
-
-		fi
-
-		# Apply keyboard layout
-		local autoinstall_keyboard=$(sed -n '/^[[:blank:]]*AUTO_SETUP_KEYBOARD_LAYOUT=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-		if [[ $autoinstall_keyboard ]] && ! grep -q "XKBLAYOUT=\"$autoinstall_keyboard\"" /etc/default/keyboard; then
-
-			G_DIETPI-NOTIFY 2 "Setting keyboard layout $autoinstall_keyboard. Please wait..."
-			G_CONFIG_INJECT 'XKBLAYOUT=' "XKBLAYOUT=\"$autoinstall_keyboard\"" /etc/default/keyboard
-			setupcon --save # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=818065
-
-		fi
-
 		# Apply headless mode if set in dietpi.txt (RPi, Odroid C1/C2)
 		(( $G_HW_MODEL < 11 || $G_HW_MODEL == 12 )) && /boot/dietpi/func/dietpi-set_hardware headless "$(grep -cm1 '^[[:blank:]]*AUTO_SETUP_HEADLESS=1' /boot/dietpi.txt)"
-
-		# Apply forced Ethernet link speed if set in dietpi.txt
-		/boot/dietpi/func/dietpi-set_hardware eth-forcespeed "$(sed -n '/^[[:blank:]]*AUTO_SETUP_NET_ETH_FORCE_SPEED=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)"
 
 		# Set hostname
 		/boot/dietpi/func/change_hostname "$(sed -n '/^[[:blank:]]*AUTO_SETUP_NET_HOSTNAME=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)"
@@ -199,6 +165,45 @@ _EOF_
 		(( $G_HW_MODEL < 10 )) && (( $G_RASPBIAN )) && target_repo='CONFIG_APT_RASPBIAN_MIRROR'
 		/boot/dietpi/func/dietpi-set_software apt-mirror "$(sed -n "/^[[:blank:]]*$target_repo=/{s/^[^=]*=//p;q}" /boot/dietpi.txt)"
 
+		# Recreate machine-id: https://github.com/MichaIng/DietPi/issues/2015
+		[[ -f '/etc/machine-id' ]] && rm /etc/machine-id
+		[[ -f '/var/lib/dbus/machine-id' ]] && rm /var/lib/dbus/machine-id
+		systemd-machine-id-setup
+
+		# Apply time zone
+		local autoinstall_timezone=$(sed -n '/^[[:blank:]]*AUTO_SETUP_TIMEZONE=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+		if [[ -f /usr/share/zoneinfo/$autoinstall_timezone && $autoinstall_timezone != $(</etc/timezone) ]]; then
+
+			G_DIETPI-NOTIFY 2 "Setting time zone $autoinstall_timezone. Please wait..."
+			rm -fv /etc/{timezoner,localtime}
+			ln -s "/usr/share/zoneinfo/$autoinstall_timezone" /etc/localtime
+			dpkg-reconfigure -f noninteractive tzdata
+
+		fi
+
+		# Apply language (locale)
+		local autoinstall_language=$(sed -n '/^[[:blank:]]*AUTO_SETUP_LOCALE=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+		grep -q "^$autoinstall_language UTF-8$" /usr/share/i18n/SUPPORTED || autoinstall_language='C.UTF-8'
+		if ! locale | grep -qE "(LANG|LC_ALL)=[\'\"]?${autoinstall_language}[\'\"]?" || ! locale -a | grep -qiE 'C\.UTF-?8'; then
+
+			G_DIETPI-NOTIFY 2 "Setting locale $autoinstall_language. Please wait..."
+			/boot/dietpi/func/dietpi-set_software locale "$autoinstall_language"
+
+		fi
+
+		# Skip keyboard, SSH and network setup on container systems
+		(( $G_HW_MODEL == 75 )) && return 0
+
+		# Apply keyboard layout
+		local autoinstall_keyboard=$(sed -n '/^[[:blank:]]*AUTO_SETUP_KEYBOARD_LAYOUT=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+		if [[ $autoinstall_keyboard ]] && ! grep -q "XKBLAYOUT=\"$autoinstall_keyboard\"" /etc/default/keyboard; then
+
+			G_DIETPI-NOTIFY 2 "Setting keyboard layout $autoinstall_keyboard. Please wait..."
+			G_CONFIG_INJECT 'XKBLAYOUT=' "XKBLAYOUT=\"$autoinstall_keyboard\"" /etc/default/keyboard
+			setupcon --save # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=818065
+
+		fi
+
 		# Regenerate unique Dropbear host keys
 		local i type
 		for i in /etc/dropbear/dropbear_*_host_key
@@ -209,10 +214,8 @@ _EOF_
 			dropbearkey -t "$type" -f "$i"
 		done
 
-		# Recreate machine-id: https://github.com/MichaIng/DietPi/issues/2015
-		[[ -f '/etc/machine-id' ]] && rm /etc/machine-id
-		[[ -f '/var/lib/dbus/machine-id' ]] && rm /var/lib/dbus/machine-id
-		systemd-machine-id-setup
+		# Apply forced Ethernet link speed if set in dietpi.txt
+		/boot/dietpi/func/dietpi-set_hardware eth-forcespeed "$(sed -n '/^[[:blank:]]*AUTO_SETUP_NET_ETH_FORCE_SPEED=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)"
 
 		# Network setup
 		# - Grab available network interfaces


### PR DESCRIPTION
- DietPi-PREP | Add support for simple container images without bootloader, kernel, initramfs, firmware, network and console/keyboard packages
