### PR TITLE
Fix php not executing in rutorrent folder

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ Fixes:
 - DietPi-TimeSync | Resolved an issue where the script threw a syntax error where it shouldn't, which however didn't affect functionality. Many thanks to @adminy for reporting this issue: https://github.com/MichaIng/DietPi/issues/5347
 - DietPi-Software | Kodi: Resolved an issue on Raspberry Pi Bullseye systems where libraries were missing to run Kodi via KMS/DRM. Many thanks to @derebo for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=10161
 - DietPi-Software | Mopidy: Resolved an issue where there installation failed. Many thanks to @amibumpin for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=10188
+- DietPi-Software | rTorrent: Resolved an issue where the web interface didn't work with Nginx because the PHP handler wasn't set. Many thanks to @vinhtq115 for providing the solution: https://github.com/MichaIng/DietPi/pull/5375
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9047,6 +9047,11 @@ location ^~ /rutorrent {
 	auth_basic "ruTorrent login";
 	auth_basic_user_file /etc/.rutorrent-htaccess;
 	location ~ ^/rutorrent/(?:conf|share)(?:/|$) { return 404; }
+
+	location ~ \.php$ {
+		include snippets/fastcgi-php.conf;
+		fastcgi_pass unix:/var/run/php/php-fpm.sock;
+	}
 }
 location ^~ /RPC2 {
 	auth_basic "rTorrent login";

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9047,10 +9047,9 @@ location ^~ /rutorrent {
 	auth_basic "ruTorrent login";
 	auth_basic_user_file /etc/.rutorrent-htaccess;
 	location ~ ^/rutorrent/(?:conf|share)(?:/|$) { return 404; }
-
-	location ~ \.php$ {
+	location ~ \.php(?:$|/) {
 		include snippets/fastcgi-php.conf;
-		fastcgi_pass unix:/var/run/php/php-fpm.sock;
+		fastcgi_pass php;
 	}
 }
 location ^~ /RPC2 {


### PR DESCRIPTION
Issue on forum: [https://dietpi.com/phpbb/viewtopic.php?p=44679#p44679](https://dietpi.com/phpbb/viewtopic.php?p=44679#p44679)

When installing rTorrent, I met this error when opening `http://<dietpi IP>/rutorrent`:

```
[25.03.2022 11:48:40] WebUI started.
[25.03.2022 11:48:40] Bad response from server: (200 [parsererror,getplugins]) SyntaxError: expected expression, got '<'
```

I also created a `phpinfo.php` file at `/var/www/rutorrent/phpinfo.php` and PHP didn't execute it (tested on browser with URL `http://<dietpi IP>/rutorrent/phpinfo.php`). However, the one outside `rutorrent` at `/var/www/phpinfo.php` (`http://<dietpi IP>/phpinfo.php`) worked fine.

It seemed that in `rutorrent` of `/etc/nginx/sites-dietpi/dietpi-rutorrent.conf` lacked PHP so it didn't work. Adding these lines fixed it for me.