### PR TITLE
DietPi-Software | TasmoAdmin: Move from master to release

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ Changes:
 - DietPi-Drive_Manager | NFS and Samba network drives can now be mounted to any directory on the server, not necessarily below /mnt.
 - DietPi-Software | motionEye: We worked together with other contributors to revive motionEye and port it over to Python 3, which also allowed us to re-enable it on Debian Bullseye systems. It requires further careful testing before a stable release can be done, but common functionality works. We enabled it with a "beta" mark in DietPi-Software. Visit the new home of motionEye, and if you want, contribute or help testing: https://github.com/motioneye-project/motioneye
 - DietPi-Software | Node-RED: The "nodered" service user is now added to the "spi" system group automatically, relevant on Raspberry Pi to grant it access to SPI-attached sensors and similar. Many thanks to @devifast for reporting a related issue: https://dietpi.com/phpbb/viewtopic.php?t=10134
+- DietPi-Software | TasmoAdmin: Reduced the downloaded data size from ~150 MiB to ~4 MiB by downloading the runtime files of the latest release only instead of the whole GitHub repository archive.
 
 Fixes:
 - Network | Resolved an issue where the systemd network targets could have been reached before the network adapter was even detected. Many thanks to @Totila for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=10167

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11608,10 +11608,10 @@ _EOF_
 				G_AGI $DEPS_LIST
 				DEPS_LIST=
 			else
-				Download_Install 'https://github.com/reloxx13/TasmoAdmin/archive/master.tar.gz'
-				G_EXEC mv TasmoAdmin-master/tasmoadmin /var/www/
-				G_EXEC rm -R TasmoAdmin-master
-				G_EXEC chown -R www-data:www-data /var/www/tasmoadmin
+				local fallback_url="https://github.com/TasmoAdmin/TasmoAdmin/releases/download/v1.8.0/tasmoadmin_v1.8.0.tar.gz"
+				Download_Install "$(curl -sSfL 'https://api.github.com/repos/TasmoAdmin/TasmoAdmin/releases/latest' | mawk -F\" '/"browser_download_url": ".*\/tasmoadmin_v[^"\/]*\.tar\.gz"$/{print $4}')"
+				G_EXEC chown -R www-data:www-data tasmoadmin
+				G_EXEC mv {,/var/www/}tasmoadmin
 			fi
 
 			# Configure the webserver


### PR DESCRIPTION
- DietPi-Software | TasmoAdmin: Reduced the downloaded data size from ~150 MiB to ~4 MiB by downloading the runtime files of the latest release only instead of the whole GitHub repository archive.