### PR TITLE
DietPi-Software | Chromium: Fix install on RPi Buster

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ Changes:
 
 Fixes:
 - Network | Resolved an issue on some Armbian based systems where the network interface naming changed unintentionally after a kernel upgrade: https://dietpi.com/phpbb/viewtopic.php?t=10229
+- DietPi-Software | Chromium: Resolved an issue on Raspberry Pi Buster systems where the installation failed because of a syntax error. Many thanks to @bbmak for reporting this issue: https://dietpi.com/phpbb/viewtopic.php?t=10258
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9464,7 +9464,7 @@ STARTX='xinit'
 
 exec "$STARTX" "$FP_CHROMIUM" $CHROMIUM_OPTS "${URL:-https://dietpi.com/}"
 _EOF_
-			[[ $path == 'chromium.d' ]] || G_EXEC sed -i 's/chromium\.d/chromium-browser/customizations/' /var/lib/dietpi/dietpi-software/installed/chromium-autostart.sh
+			[[ $path == 'chromium.d' ]] || G_EXEC sed -i 's|chromium\.d|chromium-browser/customizations|' /var/lib/dietpi/dietpi-software/installed/chromium-autostart.sh
 			G_EXEC chmod +x /var/lib/dietpi/dietpi-software/installed/chromium-autostart.sh
 
 		fi


### PR DESCRIPTION
There seems to be an issue on the `sed` command on new install to change `chromium.d` into `chromium-browser/customizations/` inside `/var/lib/dietpi/dietpi-software/installed/chromium-autostart.sh`. The slash would need to be mask.

Reference: https://dietpi.com/phpbb/viewtopic.php?t=10258
