### PR TITLE
DietPi-Software | VirtualHere: Several little enhancements

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ New images:
 Changes:
 - DietPi-Software | Box86: On ASUS Tinker Board, compiling is now done with an optimised build target flag. You can update Box86 by reinstalling it: dietpi-software reinstall 62
 - DietPi-Software | Box64: On Odroid N2, compiling is now done with an optimised build target flag. You can update Box64 by reinstalling it: dietpi-software reinstall 197
+- DietPi-Software | VirtualHere: On new installs and reinstalls, VirtualHere is now installed to /opt/virtualhere to align with most other software options. Logging is now done to system log, viewable via "journalctl -u virtualhere", instead of using the /var/log/virtualhere.log plain text file. By default, the system hostname is now used as VirtualHere server name, instead of the hardcoded "DietPi". An existing config file is never touched on reinstalls.
 
 Fixes:
 - Network | Resolved an issue on some Armbian based systems where the network interface naming changed unintentionally after a kernel upgrade: https://dietpi.com/phpbb/viewtopic.php?t=10229

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9579,39 +9579,52 @@ _EOF_
 			local url='https://virtualhere.com/sites/default/files/usbserver/vhusbd'
 
 			# ARMv6/7
-			if [[ $G_HW_ARCH == [12] ]]; then
-
+			if [[ $G_HW_ARCH == [12] ]]
+			then
 				url+='arm'
 
 			# ARMv8
-			elif (( $G_HW_ARCH == 3 )); then
-
+			elif (( $G_HW_ARCH == 3 ))
+			then
 				url+='arm64'
 
 			# x86_64
-			elif (( $G_HW_ARCH == 10 )); then
-
+			elif (( $G_HW_ARCH == 10 ))
+			then
 				url+='x86_64'
-
 			fi
 
-			[[ -d '/etc/vhusbd' ]] || G_EXEC mkdir /etc/vhusbd
-			G_EXEC curl -sSfL "$url" -o /etc/vhusbd/vhusbd
-			G_EXEC chmod +x /etc/vhusbd/vhusbd
+			Download_Install "$url" /opt/virtualhere/vhusbd
+			G_EXEC chmod +x /opt/virtualhere/vhusbd
+
+			# Config
+			if [[ ! -f '/opt/virtualhere/config.ini' ]]
+			then
+				if [[ -f '/etc/vhusbd/config.ini' ]]
+				then
+					G_EXEC mv /etc/vhusbd/config.ini /opt/virtualhere/config.ini
+				else
+					# shellcheck disable=SC2016
+					echo 'ServerName=$HOSTNAME$' > /opt/virtualhere/config.ini
+				fi
+			fi
 
 			# Service
 			cat << '_EOF_' > /etc/systemd/system/virtualhere.service
 [Unit]
 Description=VirtualHere (DietPi)
+Wants=network-online.target
+After=network-online.target
 
 [Service]
-ExecStart=/etc/vhusbd/vhusbd -r /var/log/virtualhere.log
+ExecStart=/opt/virtualhere/vhusbd
 
 [Install]
 WantedBy=multi-user.target
 _EOF_
-			# Config
-			echo "ServerName='DietPi'" > /etc/vhusbd/config.ini
+			# Pre-v8.4
+			[[ -d '/etc/vhusbd' ]] && G_EXEC rm -R /etc/vhusbd
+			[[ -f '/var/log/virtualhere.log' ]] && G_EXEC rm /var/log/virtualhere.log
 
 		fi
 
@@ -13214,7 +13227,9 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 				G_EXEC rm /etc/systemd/system/virtualhere.service
 			fi
 			[[ -d '/etc/systemd/system/virtualhere.service.d' ]] && G_EXEC rm -R /etc/systemd/system/virtualhere.service.d
-			[[ -d '/etc/vhusbd' ]] && G_EXEC rm -R /etc/vhusbd
+			[[ -d '/opt/virtualhere' ]] && G_EXEC rm -R /opt/virtualhere
+			[[ -d '/etc/vhusbd' ]] && G_EXEC rm -R /etc/vhusbd # Pre-v8.4
+			[[ -f '/var/log/virtualhere.log' ]] && G_EXEC rm /var/log/virtualhere.log # Pre-v8.4
 
 		fi
 


### PR DESCRIPTION
- DietPi-Software | VirtualHere: Move binary and config from /etc/vhusbd to /opt/virtualhere to better align with other software options. Do never overwrite existing configs and use the hostname as default ServerName instead of "DietPi". Start the service after network has been configured and log to syslog instead of log file.