### PR TITLE
DietPi-Software | rTorrent: Reinstall ruTorrent cleanly

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,7 @@ Changes:
 - DietPi-Software | Box86: On ASUS Tinker Board, compiling is now done with an optimised build target flag. You can update Box86 by reinstalling it: dietpi-software reinstall 62
 - DietPi-Software | Box64: On Odroid N2, compiling is now done with an optimised build target flag. You can update Box64 by reinstalling it: dietpi-software reinstall 197
 - DietPi-Software | VirtualHere: On new installs and reinstalls, VirtualHere is now installed to /opt/virtualhere to align with most other software options. Logging is now done to system log, viewable via "journalctl -u virtualhere", instead of using the /var/log/virtualhere.log plain text file. By default, the system hostname is now used as VirtualHere server name, instead of the hardcoded "DietPi". An existing config file is never touched on reinstalls.
+- DietPi-Software | rTorrent: The ruTorrent web interface is now reinstalled cleanly, i.e. configs, 3rd party plugins and themes are preserved but all other files are removed before new ruTorrent files are installed. Many thanks to @shanew1694 for reporting a related issue with remaining obsolete files: https://github.com/MichaIng/DietPi/issues/5161#issuecomment-1013286248
 
 Fixes:
 - Network | Resolved an issue on some Armbian based systems where the network interface naming changed unintentionally after a kernel upgrade: https://dietpi.com/phpbb/viewtopic.php?t=10229

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8953,24 +8953,35 @@ _EOF_
 			[[ $version ]] || { version='v3.10'; G_DIETPI-NOTIFY 1 "Automatic latest ruTorrent version detection failed. Version \"$version\" will be installed as fallback, but a newer version might be available. Please report this at: https://github.com/MichaIng/DietPi/issues"; }
 			Download_Install "https://github.com/Novik/ruTorrent/archive/$version.tar.gz"
 
-			# - Reinstall
-			if [[ -d '/var/www/rutorrent' ]]; then
+			# - Reinstall freshly with preserved configs and 3rd party plugins
+			if [[ -d '/var/www/rutorrent' ]]
+			then
+				# If old configs exist, preserve them and make new config files examples
+				[[ -f '/var/www/rutorrent/conf/config.php' ]] && { G_EXEC mv "ruTorrent-${version#v}/conf/config.php"{,.example}; G_EXEC cp -a {/var/www/rutorrent,"ruTorrent-${version#v}"}/conf/config.php; }
+				[[ -f '/var/www/rutorrent/conf/access.ini' ]] && { G_EXEC mv "ruTorrent-${version#v}/conf/access.ini"{,.example}; G_EXEC cp -a {/var/www/rutorrent,"ruTorrent-${version#v}"}/conf/access.ini; }
+				[[ -f '/var/www/rutorrent/conf/plugins.ini' ]] && { G_EXEC mv "ruTorrent-${version#v}/conf/plugins.ini"{,.example}; G_EXEC cp -a {/var/www/rutorrent,"ruTorrent-${version#v}"}/conf/plugins.ini; }
 
-				# Make new config files examples, if they exist in the old install already
-				[[ -f '/var/www/rutorrent/conf/config.php' ]] && G_EXEC mv "ruTorrent-${version#v}/conf/config.php"{,.example}
-				[[ -f '/var/www/rutorrent/conf/access.ini' ]] && G_EXEC mv "ruTorrent-${version#v}/conf/access.ini"{,.example}
-				[[ -f '/var/www/rutorrent/conf/plugins.ini' ]] && G_EXEC mv "ruTorrent-${version#v}/conf/plugins.ini"{,.example}
+				# Preserve 3rd party plugins
+				for i in /var/www/rutorrent/plugins/{,.??,.[^.]}*
+				do
+					[[ -e $i ]] || continue
+					[[ -e ruTorrent-${version#v}/plugins/${i#/var/www/rutorrent/plugins/} ]] && continue
+					G_EXEC cp -a "$i" "ruTorrent-${version#v}/plugins/"
+				done
 
-				# Merge new install into old to preserve e.g. 3rd party plugins
-				G_EXEC cp -a "ruTorrent-${version#v}/". /var/www/rutorrent/
-				G_EXEC rm -R "ruTorrent-${version#v}"
+				# Preserve 3rd party themes
+				for i in /var/www/rutorrent/plugins/theme/themes/{,.??,.[^.]}*
+				do
+					[[ -e $i ]] || continue
+					[[ -e ruTorrent-${version#v}/plugins/theme/themes/${i#/var/www/rutorrent/plugins/theme/themes/} ]] && continue
+					G_EXEC cp -a "$i" "ruTorrent-${version#v}/plugins/theme/themes/"
+				done				
 
-			# - Fresh install
-			else
-
-				G_EXEC mv "ruTorrent-${version#v}" /var/www/rutorrent
-
+				# Reinstall freshly with preserved configs, 3rd party plugins and themes
+				G_EXEC rm -R /var/www/rutorrent
 			fi
+
+			G_EXEC mv "ruTorrent-${version#v}" /var/www/rutorrent
 
 			# Install DarkBetter theme manually: https://github.com/MichaIng/DietPi/issues/3271
 			if [[ -d '/var/www/rutorrent/plugins/theme/themes/DarkBetter' ]]; then


### PR DESCRIPTION
- DietPi-Software | rTorrent: The ruTorrent web interface is now reinstalled cleanly, i.e. configs and 3rd party plugins are preserved but all other files are removed before new ruTorrent files are installed. Many thanks to @shanew1694 for reporting a related issue with remaining obsolete files: https://github.com/MichaIng/DietPi/issues/5161#issuecomment-1013286248