### PR TITLE
DietPi-Software | Prowlarr

### DIFF
--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -617,6 +617,7 @@ shopt -s extglob
 	do
 		aSOFTWARE_NAME8_5[$i]=${aSOFTWARE_NAME8_4[$i]}
 	done
+	aSOFTWARE_NAME8_5[151]='Prowlarr'
 
 	# Pre-create software counter array so that we can see also software (available in newest version) with 0 installs
 	for i in "${aSOFTWARE_NAME8_5[@]}"

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,9 @@
 v8.5
 (2022-05-28)
 
+New software:
+- Prowlarr | The indexer manager of the Servarr family has been added as dietpi-software option.
+
 Changes:
 - DietPi-Software | Amiberry: Updated to latest version 5.1 and shipped now as DEB package. Also the included libSDL2 libraries have been updated to latest stable versions. Additionally builds for all SBCs and architectures, including x86_64, have been added, i.e. Amiberry is now available on all platforms.
 - DietPi-Software | WiringPi: Build dependencies have been reduced so that only the actually required tools and headers are installed instead of the whole Build-Essential package.

--- a/README.md
+++ b/README.md
@@ -313,6 +313,11 @@ Links to hardware and software manufacturers, sources and build instructions use
 - [Allo GUI](https://github.com/MichaIng/DietPi-AlloGUI)
 - [PHP Composer](https://github.com/composer/composer)
 - [motionEye](https://github.com/motioneye-project/motioneye)
+- [Sonarr](https://github.com/Sonarr/Sonarr)
+- [Radarr](https://github.com/Radarr/Radarr)
+- [Lidarr](https://github.com/Lidarr/Lidarr)
+- [Prowlarr](https://github.com/Prowlarr/Prowlarr)
+- [Jackett](https://github.com/Jackett/Jackett)
 
 ---
 

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -140,6 +140,7 @@ Available services:
 			'lidarr'
 			'bazarr'
 			'deluge-web'
+			'prowlarr'
 
 			# - Cloud/Backups
 			'bdd'

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10186,12 +10186,11 @@ _EOF_
 			# - .NET: https://packages.microsoft.com/debian/
 			if (( $G_HW_ARCH != 1 ))
 			then
-				if (( $G_DISTRO == 5 ))
-				then
-					aDEPS+=('libicu63')
-				else
-					aDEPS+=('libicu67')
-				fi
+				case $G_DISTRO in
+					5) aDEPS+=('libicu63');;
+					6) aDEPS+=('libicu67');;
+					*) aDEPS+=('libicu71');;
+				esac
 			fi
 
 			# Reinstall: Skip download and install, advice to use internal updater from web UI
@@ -10206,26 +10205,25 @@ _EOF_
 			else
 				# ARMv6
 				local url=$(curl -sSfL 'https://api.github.com/repos/Radarr/Radarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux\.tar\.gz"/{print $4}')
-				local version='4.0.4.5922'
-				local fallback_url="https://github.com/Radarr/Radarr/releases/download/v$version/Radarr.master.$version.linux.tar.gz"
+				local fallback_url='https://github.com/Radarr/Radarr/releases/download/v4.0.4.5922/Radarr.master.4.0.4.5922.linux.tar.gz'
 
 				# ARMv7
 				if (( $G_HW_ARCH == 2 ))
 				then
-					url=$(curl -sSfL 'https://api.github.com/repos/Radarr/Radarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux-core-arm\.tar\.gz"/{print $4}')
-					fallback_url="https://github.com/Radarr/Radarr/releases/download/v$version/Radarr.master.$version.linux-core-arm.tar.gz"
+					url=${url/linux/linux-core-arm}
+					fallback_url=${fallback_url/linux/linux-core-arm}
 
 				# ARMv8
 				elif (( $G_HW_ARCH == 3 ))
 				then
-					url=$(curl -sSfL 'https://api.github.com/repos/Radarr/Radarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux-core-arm64\.tar\.gz"/{print $4}')
-					fallback_url="https://github.com/Radarr/Radarr/releases/download/v$version/Radarr.master.$version.linux-core-arm64.tar.gz"
+					url=${url/linux/linux-core-arm64}
+					fallback_url=${fallback_url/linux/linux-core-arm64}
 
 				# x86_64
 				elif (( $G_HW_ARCH == 10 ))
 				then
-					url=$(curl -sSfL 'https://api.github.com/repos/Radarr/Radarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux-core-x64\.tar\.gz"/{print $4}')
-					fallback_url="https://github.com/Radarr/Radarr/releases/download/v$version/Radarr.master.$version.linux-core-x64.tar.gz"
+					url=${url/linux/linux-core-x64}
+					fallback_url=${fallback_url/linux/linux-core-x64}
 				fi
 
 				Download_Install "$url"
@@ -10294,12 +10292,11 @@ _EOF_
 			# - .NET: https://packages.microsoft.com/debian/
 			if (( $G_HW_ARCH != 1 ))
 			then
-				if (( $G_DISTRO == 5 ))
-				then
-					aDEPS+=('libicu63')
-				else
-					aDEPS+=('libicu67')
-				fi
+				case $G_DISTRO in
+					5) aDEPS+=('libicu63');;
+					6) aDEPS+=('libicu67');;
+					*) aDEPS+=('libicu71');;
+				esac
 			fi
 
 			# Pre-v7.5 ARMv6: Migrate old install dir
@@ -10317,26 +10314,25 @@ _EOF_
 			else
 				# ARMv6
 				local url=$(curl -sSfL 'https://api.github.com/repos/Lidarr/Lidarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux\.tar\.gz"/{print $4}')
-				local version='0.8.1.2135'
-				local fallback_url="https://github.com/Lidarr/Lidarr/releases/download/v$version/Lidarr.master.$version.linux.tar.gz"
+				local fallback_url='https://github.com/Lidarr/Lidarr/releases/download/v0.8.1.2135/Lidarr.master.0.8.1.2135.linux.tar.gz'
 
 				# ARMv7
 				if (( $G_HW_ARCH == 2 ))
 				then
-					url=$(curl -sSfL 'https://api.github.com/repos/Lidarr/Lidarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux-core-arm\.tar\.gz"/{print $4}')
-					fallback_url="https://github.com/Lidarr/Lidarr/releases/download/v$version/Lidarr.master.$version.linux-core-arm.tar.gz"
+					url=${url/linux/linux-core-arm}
+					fallback_url=${fallback_url/linux/linux-core-arm}
 
 				# ARMv8
 				elif (( $G_HW_ARCH == 3 ))
 				then
-					url=$(curl -sSfL 'https://api.github.com/repos/Lidarr/Lidarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux-core-arm64\.tar\.gz"/{print $4}')
-					fallback_url="https://github.com/Lidarr/Lidarr/releases/download/v$version/Lidarr.master.$version.linux-core-arm64.tar.gz"
+					url=${url/linux/linux-core-arm64}
+					fallback_url=${fallback_url/linux/linux-core-arm64}
 
 				# x86_64
 				elif (( $G_HW_ARCH == 10 ))
 				then
-					url=$(curl -sSfL 'https://api.github.com/repos/Lidarr/Lidarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux-core-x64\.tar\.gz"/{print $4}')
-					fallback_url="https://github.com/Lidarr/Lidarr/releases/download/v$version/Lidarr.master.$version.linux-core-x64.tar.gz"
+					url=${url/linux/linux-core-x64}
+					fallback_url=${fallback_url/linux/linux-core-x64}
 				fi
 
 				Download_Install "$url"
@@ -10565,12 +10561,11 @@ _EOF_
 			if (( $G_HW_ARCH != 1 ))
 			then
 				aDEPS=('liblttng-ust0')
-				if (( $G_DISTRO == 5 ))
-				then
-					aDEPS+=('libicu63')
-				else
-					aDEPS+=('libicu67')
-				fi
+				case $G_DISTRO in
+					5) aDEPS+=('libicu63');;
+					6) aDEPS+=('libicu67');;
+					*) aDEPS+=('libicu71');;
+				esac
 			fi
 
 			Download_Install "$url"
@@ -10688,18 +10683,12 @@ _EOF_
 
 			Banner_Installing
 
-			# APT dependencies
-			aDEPS=('mediainfo')
-			# - .NET: https://packages.microsoft.com/debian/
-			if (( $G_HW_ARCH != 1 ))
-			then
-				if (( $G_DISTRO == 5 ))
-				then
-					aDEPS+=('libicu63')
-				else
-					aDEPS+=('libicu67')
-				fi
-			fi
+			# .NET dependency: https://packages.microsoft.com/debian/
+			case $G_DISTRO in
+				5) aDEPS=('libicu63');;
+				6) aDEPS=('libicu67');;
+				*) aDEPS=('libicu71');;
+			esac
 
 			# Reinstall: Skip download and install, advice to use internal updater from web UI
 			if [[ -d '/opt/prowlarr' ]]
@@ -10712,22 +10701,20 @@ _EOF_
 				aDEPS=()
 			else
 				# ARMv7
-				#local url=$(curl -sSfL 'https://api.github.com/repos/Prowlarr/Prowlarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux-core-arm\.tar\.gz"/{print $4}')
-				#local version='0.3.0.1730'
-				local version=$(curl -sSf 'https://api.github.com/repos/Prowlarr/Prowlarr/tags' | mawk -F\" '/"name": "v.*",/{print substr($4,2); }' | head -n1)
-				local url="https://github.com/Prowlarr/Prowlarr/releases/download/v$version/Prowlarr.develop.$version.linux-core-arm.tar.gz"
+				local url=$(curl -sSfL 'https://api.github.com/repos/Prowlarr/Prowlarr/releases' | mawk -F\" '/"browser_download_url": .*linux-core-arm\.tar\.gz"/{print $4}' | head -1)
+				local fallback_url='https://github.com/Prowlarr/Prowlarr/releases/download/v0.3.0.1730/Prowlarr.develop.0.3.0.1730.linux-core-arm.tar.gz'
 
 				# ARMv8
 				if (( $G_HW_ARCH == 3 ))
 				then
-					#url=$(curl -sSfL 'https://api.github.com/repos/Prowlarr/Prowlarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux-core-arm64\.tar\.gz"/{print $4}')
-					url="https://github.com/Prowlarr/Prowlarr/releases/download/v$version/Prowlarr.develop.$version.linux-core-arm64.tar.gz"
+					url=${url/arm/arm64}
+					fallback_url=${fallback_url/arm/arm64}
 
 				# x86_64
 				elif (( $G_HW_ARCH == 10 ))
 				then
-					#url=$(curl -sSfL 'https://api.github.com/repos/Prowlarr/Prowlarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux-core-x64\.tar\.gz"/{print $4}')
-					url="https://github.com/Prowlarr/Prowlarr/releases/download/v$version/Prowlarr.develop.$version.linux-core-x64.tar.gz"
+					url=${url/arm/x64}
+					fallback_url=${fallback_url/arm/x64}
 				fi
 
 				Download_Install "$url"
@@ -10768,7 +10755,6 @@ ReadWritePaths=-/opt/prowlarr -/mnt -/media -/var/log/prowlarr -/tmp
 [Install]
 WantedBy=multi-user.target
 _EOF_
-
 			# Permissions
 			G_EXEC chown -R prowlarr:dietpi /mnt/dietpi_userdata/prowlarr /opt/prowlarr
 		fi
@@ -10894,12 +10880,11 @@ _EOF_
 			Banner_Installing # https://help.roonlabs.com/portal/en/kb/articles/linux-install#Downloads
 
 			# .NET dependency: https://packages.microsoft.com/debian/
-			if (( $G_DISTRO == 5 ))
-			then
-				aDEPS=('libicu63')
-			else
-				aDEPS=('libicu67')
-			fi
+			case $G_DISTRO in
+				5) aDEPS=('libicu63');;
+				6) aDEPS=('libicu67');;
+				*) aDEPS=('libicu71');;
+			esac
 
 			# Reinstall: Skip download and install, advice to use internal updater
 			if [[ -d '/opt/roonserver' ]]

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10183,7 +10183,7 @@ _EOF_
 
 			# APT dependencies
 			aDEPS=('mediainfo')
-			# - .NET: https://packages.microsoft.com/debian/
+			# - .NET: https://github.com/dotnet/core/blob/main/Documentation/linux-prereqs.md
 			if (( $G_HW_ARCH != 1 ))
 			then
 				case $G_DISTRO in
@@ -10289,7 +10289,7 @@ _EOF_
 
 			# APT dependencies
 			aDEPS=('mediainfo')
-			# - .NET: https://packages.microsoft.com/debian/
+			# - .NET: https://github.com/dotnet/core/blob/main/Documentation/linux-prereqs.md
 			if (( $G_HW_ARCH != 1 ))
 			then
 				case $G_DISTRO in
@@ -10557,14 +10557,13 @@ _EOF_
 				fallback_url=${fallback_url/Mono/LinuxAMDx64}
 			fi
 
-			# .NET dependencies: https://packages.microsoft.com/debian/
+			# .NET dependency: https://github.com/dotnet/core/blob/main/Documentation/linux-prereqs.md
 			if (( $G_HW_ARCH != 1 ))
 			then
-				aDEPS=('liblttng-ust0')
 				case $G_DISTRO in
-					5) aDEPS+=('libicu63');;
-					6) aDEPS+=('libicu67');;
-					*) aDEPS+=('libicu71');;
+					5) aDEPS=('libicu63');;
+					6) aDEPS=('libicu67');;
+					*) aDEPS=('libicu71');;
 				esac
 			fi
 
@@ -10683,7 +10682,7 @@ _EOF_
 
 			Banner_Installing
 
-			# .NET dependency: https://packages.microsoft.com/debian/
+			# .NET dependency: https://github.com/dotnet/core/blob/main/Documentation/linux-prereqs.md
 			case $G_DISTRO in
 				5) aDEPS=('libicu63');;
 				6) aDEPS=('libicu67');;
@@ -10879,7 +10878,7 @@ _EOF_
 
 			Banner_Installing # https://help.roonlabs.com/portal/en/kb/articles/linux-install#Downloads
 
-			# .NET dependency: https://packages.microsoft.com/debian/
+			# .NET dependency: https://github.com/dotnet/core/blob/main/Documentation/linux-prereqs.md
 			case $G_DISTRO in
 				5) aDEPS=('libicu63');;
 				6) aDEPS=('libicu67');;

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -704,6 +704,15 @@ Available commands:
 		aSOFTWARE_CATX[$software_id]=3
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/bittorrent/#nzbget'
 		#------------------
+		software_id=151
+		aSOFTWARE_NAME[$software_id]='Prowlarr'
+		aSOFTWARE_DESC[$software_id]='Indexer Manager & Proxy for PVR'
+		aSOFTWARE_CATX[$software_id]=3
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/bittorrent/#prowlarr'
+		aSOFTWARE_DEPS[$software_id]='87'
+		# - ARMv6
+		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
+		#------------------
 		software_id=155
 		aSOFTWARE_NAME[$software_id]='HTPC Manager'
 		aSOFTWARE_DESC[$software_id]='Manage your HTPC from anywhere'
@@ -10672,6 +10681,97 @@ ExecStart=/mnt/dietpi_userdata/nzbget/nzbget -D
 WantedBy=multi-user.target
 _EOF_
 		fi
+		
+		software_id=151 # Prowlarr
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 ))
+		then
+
+			Banner_Installing
+
+			# APT dependencies
+			aDEPS=('mediainfo')
+			# - .NET: https://packages.microsoft.com/debian/
+			if (( $G_HW_ARCH != 1 ))
+			then
+				if (( $G_DISTRO == 5 ))
+				then
+					aDEPS+=('libicu63')
+				else
+					aDEPS+=('libicu67')
+				fi
+			fi
+
+			# Reinstall: Skip download and install, advice to use internal updater from web UI
+			if [[ -d '/opt/prowlarr' ]]
+			then
+				G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[$software_id]} install dir \"/opt/prowlarr\" already exists. Download and install steps will be skipped.
+ - If you want to update ${aSOFTWARE_NAME[$software_id]}, please use the internal updater from web UI.
+ - If you need to reinstall (e.g. broken instance), please manually remove the install dir and rerun \"dietpi-software reinstall $software_id\"."
+
+				G_AGI "${aDEPS[@]}"
+				aDEPS=()
+			else
+				# ARMv7
+				#local url=$(curl -sSfL 'https://api.github.com/repos/Prowlarr/Prowlarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux-core-arm\.tar\.gz"/{print $4}')
+				#local version='0.3.0.1730'
+				local version=$(curl -sSf 'https://api.github.com/repos/Prowlarr/Prowlarr/tags' | mawk -F\" '/"name": "v.*",/{print substr($4,2); }' | head -n1)
+				local url="https://github.com/Prowlarr/Prowlarr/releases/download/v$version/Prowlarr.develop.$version.linux-core-arm.tar.gz"
+
+				# ARMv8
+				if (( $G_HW_ARCH == 3 ))
+				then
+					#url=$(curl -sSfL 'https://api.github.com/repos/Prowlarr/Prowlarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux-core-arm64\.tar\.gz"/{print $4}')
+					url="https://github.com/Prowlarr/Prowlarr/releases/download/v$version/Prowlarr.develop.$version.linux-core-arm64.tar.gz"
+
+				# x86_64
+				elif (( $G_HW_ARCH == 10 ))
+				then
+					#url=$(curl -sSfL 'https://api.github.com/repos/Prowlarr/Prowlarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux-core-x64\.tar\.gz"/{print $4}')
+					url="https://github.com/Prowlarr/Prowlarr/releases/download/v$version/Prowlarr.develop.$version.linux-core-x64.tar.gz"
+				fi
+
+				Download_Install "$url"
+				G_EXEC mv Prowlarr /opt/prowlarr
+			fi
+
+			# Data dir
+			[[ -d '/mnt/dietpi_userdata/prowlarr' ]] || G_EXEC mkdir /mnt/dietpi_userdata/prowlarr
+
+			# User
+			Create_User -g dietpi -d /mnt/dietpi_userdata/prowlarr prowlarr
+
+			# Service: https://wiki.servarr.com/prowlarr/installation
+			cat << '_EOF_' > /etc/systemd/system/prowlarr.service
+[Unit]
+Description=prowlarr (DietPi)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+SyslogIdentifier=Prowlarr
+User=prowlarr
+UMask=002
+LogsDirectory=prowlarr
+ExecStart=/opt/prowlarr/Prowlarr -nobrowser -data=/mnt/dietpi_userdata/prowlarr
+TimeoutStopSec=20
+KillMode=process
+Restart=on-failure
+
+# Hardening
+ProtectSystem=strict
+ProtectHome=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+ReadWritePaths=-/opt/prowlarr -/mnt -/media -/var/log/prowlarr -/tmp
+
+[Install]
+WantedBy=multi-user.target
+_EOF_
+
+			# Permissions
+			G_EXEC chown -R prowlarr:dietpi /mnt/dietpi_userdata/prowlarr /opt/prowlarr
+		fi
 
 		software_id=155 # HTPC Manager
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
@@ -13492,6 +13592,21 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 			getent passwd nzbget > /dev/null && G_EXEC userdel nzbget
 			getent group nzbget > /dev/null && G_EXEC groupdel nzbget # Pre-v6.33
 			[[ -d '/mnt/dietpi_userdata/nzbget' ]] && G_EXEC rm -R /mnt/dietpi_userdata/nzbget
+
+		fi
+		
+		software_id=151 # Prowlarr
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
+
+			Banner_Uninstalling
+			if [[ -f '/etc/systemd/system/prowlarr.service' ]]
+			then
+				G_EXEC systemctl disable --now prowlarr
+				G_EXEC rm /etc/systemd/system/prowlarr.service
+			fi
+			[[ -d '/etc/systemd/system/prowlarr.service.d' ]] && G_EXEC rm -R /etc/systemd/system/prowlarr.service.d
+			getent passwd prowlarr > /dev/null && G_EXEC userdel prowlarr
+			G_EXEC rm -Rf /opt/prowlarr /mnt/dietpi_userdata/prowlarr /var/log/prowlarr
 
 		fi
 


### PR DESCRIPTION
 - add new software title Prowlarr `ID 151`

already tested on 
- RPi ARMv7 Bullseye
- RPi ARMv8 Bullseye
- VM x86 Bullseye

Challenges
- disabled on ARMv6 as it doesn't seems to be supported
- I'm not 100% sure if `mediainfo` package is needed
- there is no `latest` tag on `https://github.com/Prowlarr/Prowlarr` . Therefore I'm going to grab latest version from `Prowlarr/Prowlarr/tags`
- it seems still in development and has not been released as finial