### PR TITLE
DietPi-Software | WiringPi: Fix install on Odroids

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ Changes:
 
 Fixes:
 - DietPi-Software | Spotifyd: Resolved an issue where fresh installs failed because of a missing parent directory. Many thanks to @C0ntroller for reporting this issue: https://github.com/MichaIng/DietPi/issues/5484
+- DietPi-Software | WiringPi: Resolved an issue where the install on Odroids failed as of a change in the build scripts of Hardkernel's fork. Many thanks to @MDAR for reporting this issue: https://github.com/MichaIng/DietPi/issues/5485
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ v8.5
 (2022-05-28)
 
 Changes:
+- DietPi-Software | WiringPi: Build dependencies have been reduced so that only the actually required tools and headers are installed instead of the whole Build-Essential package.
 
 Fixes:
 - DietPi-Software | Spotifyd: Resolved an issue where fresh installs failed because of a missing parent directory. Many thanks to @C0ntroller for reporting this issue: https://github.com/MichaIng/DietPi/issues/5484

--- a/dietpi/dietpi-cleaner
+++ b/dietpi/dietpi-cleaner
@@ -325,7 +325,7 @@ $G_PROGRAM_NAME simulation has finished: Press any key to continue..."
 		Banner_Cleaning
 
 		local apackages
-		mapfile -t apackages < <(dpkg --get-selections '*-dev' build-essential make automake autoconf g++ gcc pkg-config 2> /dev/null | mawk '{print $1}')
+		mapfile -t apackages < <(dpkg --get-selections '*-dev' build-essential make automake autoconf g++ gcc pkg-config libtool 2> /dev/null | mawk '{print $1}')
 
 		if (( $DRY_RUN )); then
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1113,7 +1113,6 @@ Available commands:
 		aSOFTWARE_DESC[$software_id]='GPIO interface library (C)'
 		aSOFTWARE_CATX[$software_id]=10
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/hardware_projects/#wiringpi'
-		aSOFTWARE_DEPS[$software_id]='16'
 		# RPi + Odroids only
 		for ((i=20; i<=$MAX_G_HW_MODEL; i++))
 		do
@@ -6653,6 +6652,8 @@ _EOF_
 
 			Banner_Installing
 
+			aDEPS=('make' 'gcc' 'libc6-dev')
+
 			# RPi
 			if (( $G_HW_MODEL < 10 ))
 			then
@@ -6662,6 +6663,7 @@ _EOF_
 
 			# Odroids
 			else
+				aDEPS+=('autoconf')
 				Download_Install 'https://github.com/hardkernel/wiringPi/archive/master.tar.gz'
 				G_EXEC mv {w,W}iringPi-master
 				G_EXEC cd WiringPi-master

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6663,7 +6663,7 @@ _EOF_
 
 			# Odroids
 			else
-				aDEPS+=('automake' 'libtool' 'libgpiod-dev')
+				aDEPS+=('automake' 'libtool' 'libgpiod-dev' 'libgpiod2') # Add libgpiod2 explicitly so purging *-dev packages, e.g. via dietpi-cleaner, does not break "gpio"
 				Download_Install 'https://github.com/hardkernel/wiringPi/archive/master.tar.gz'
 				G_EXEC mv {w,W}iringPi-master
 				G_EXEC cd WiringPi-master
@@ -6674,6 +6674,7 @@ _EOF_
 			fi
 
 			G_EXEC strip --remove-section=.comment --remove-section=.note /usr/local/*bin/gpio
+			G_EXEC ldconfig
 			G_EXEC cd "$G_WORKING_DIR"
 
 			# Move source dir to disk, as it contains additional examples to compile

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6663,17 +6663,17 @@ _EOF_
 
 			# Odroids
 			else
-				aDEPS+=('autoconf')
+				aDEPS+=('automake' 'libtool' 'libgpiod-dev')
 				Download_Install 'https://github.com/hardkernel/wiringPi/archive/master.tar.gz'
 				G_EXEC mv {w,W}iringPi-master
 				G_EXEC cd WiringPi-master
 				G_EXEC_OUTPUT=1 G_EXEC ./autogen.sh
-				G_EXEC_OUTPUT=1 G_EXEC configure CFLAGS='-g0 -O3'
+				G_EXEC_OUTPUT=1 G_EXEC ./configure CFLAGS='-g0 -O3'
 				G_EXEC_OUTPUT=1 G_EXEC make "-j$(nproc)"
 				G_EXEC_OUTPUT=1 G_EXEC make install
 			fi
 
-			G_EXEC strip --remove-section=.comment --remove-section=.note /usr/local/bin/gpio
+			G_EXEC strip --remove-section=.comment --remove-section=.note /usr/local/*bin/gpio
 			G_EXEC cd "$G_WORKING_DIR"
 
 			# Move source dir to disk, as it contains additional examples to compile
@@ -14181,6 +14181,7 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 			fi
 			# GPIO utility
 			[[ -f '/usr/local/bin/gpio' ]] && G_EXEC rm /usr/local/bin/gpio
+			[[ -f '/usr/local/sbin/gpio' ]] && G_EXEC rm /usr/local/sbin/gpio
 			[[ -f '/usr/local/share/man/man1/gpio.1' ]] && G_EXEC rm /usr/local/share/man/man1/gpio.1
 			# Library
 			G_EXEC rm -f /usr/local/lib/libwiringPi.*

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6659,6 +6659,7 @@ _EOF_
 			then
 				Download_Install 'https://github.com/WiringPi/WiringPi/archive/master.tar.gz'
 				G_EXEC cd WiringPi-master
+				[[ -d '/usr/local/include' ]] || G_EXEC mkdir /usr/local/include
 				G_EXEC_OUTPUT=1 G_EXEC ./build
 
 			# Odroids
@@ -6674,6 +6675,7 @@ _EOF_
 			fi
 
 			G_EXEC strip --remove-section=.comment --remove-section=.note /usr/local/*bin/gpio
+			G_EXEC strip --strip-unneeded --remove-section=.comment --remove-section=.note /usr/local/lib/libwiringPi*.so
 			G_EXEC ldconfig
 			G_EXEC cd "$G_WORKING_DIR"
 
@@ -14184,10 +14186,11 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 			[[ -f '/usr/local/bin/gpio' ]] && G_EXEC rm /usr/local/bin/gpio
 			[[ -f '/usr/local/sbin/gpio' ]] && G_EXEC rm /usr/local/sbin/gpio
 			[[ -f '/usr/local/share/man/man1/gpio.1' ]] && G_EXEC rm /usr/local/share/man/man1/gpio.1
+			[[ -d '/usr/local/share/man/man1' ]] && G_EXEC rmdir -p --ignore-fail-on-non-empty /usr/local/share/man/man1
 			# Library
-			G_EXEC rm -f /usr/local/lib/libwiringPi.*
+			G_EXEC rm -f /usr/local/lib/libwiringPi.so*
 			# Device library
-			G_EXEC rm -f /usr/local/lib/libwiringPiDev.*
+			G_EXEC rm -f /usr/local/lib/libwiringPiDev.so*
 			# Headers
 			G_EXEC rm -f /usr/local/include/wiringPi*.h
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6657,15 +6657,20 @@ _EOF_
 			if (( $G_HW_MODEL < 10 ))
 			then
 				Download_Install 'https://github.com/WiringPi/WiringPi/archive/master.tar.gz'
+				G_EXEC cd WiringPi-master
+				G_EXEC_OUTPUT=1 G_EXEC ./build
 
 			# Odroids
 			else
 				Download_Install 'https://github.com/hardkernel/wiringPi/archive/master.tar.gz'
 				G_EXEC mv {w,W}iringPi-master
+				G_EXEC cd WiringPi-master
+				G_EXEC_OUTPUT=1 G_EXEC ./autogen.sh
+				G_EXEC_OUTPUT=1 G_EXEC configure CFLAGS='-g0 -O3'
+				G_EXEC_OUTPUT=1 G_EXEC make "-j$(nproc)"
+				G_EXEC_OUTPUT=1 G_EXEC make install
 			fi
 
-			G_EXEC cd WiringPi-master
-			G_EXEC_OUTPUT=1 G_EXEC ./build
 			G_EXEC strip --remove-section=.comment --remove-section=.note /usr/local/bin/gpio
 			G_EXEC cd "$G_WORKING_DIR"
 
@@ -14153,7 +14158,14 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 			if [[ -d '/mnt/dietpi_userdata/WiringPi' ]]
 			then
 				G_EXEC cd /mnt/dietpi_userdata/WiringPi
-				G_EXEC_NOEXIT=1 G_EXEC ./build uninstall
+				if [[ -f ./build ]]
+				then
+					G_EXEC_NOEXIT=1 G_EXEC_OUTPUT=1 G_EXEC ./build uninstall # RPi and pre-v8.5 Odroids
+
+				elif [[ -f ./Makefile ]]
+				then
+					G_EXEC_NOEXIT=1 G_EXEC_OUTPUT=1 G_EXEC make uninstall # Odroids
+				fi
 				G_EXEC cd "$G_WORKING_DIR"
 				G_EXEC rm -R /mnt/dietpi_userdata/WiringPi
 			fi
@@ -14161,7 +14173,7 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 			if [[ -d '/root/wiringPi' ]]
 			then
 				G_EXEC cd /root/wiringPi
-				G_EXEC_NOEXIT=1 G_EXEC ./build uninstall
+				G_EXEC_NOEXIT=1 G_EXEC_OUTPUT=1 G_EXEC ./build uninstall
 				G_EXEC cd "$G_WORKING_DIR"
 				G_EXEC rm -R /root/wiringPi
 			fi


### PR DESCRIPTION
- DietPi-Software | WiringPi: Resolved an issue where the install on Odroids failed as of a change in the build scripts of Hardkernel's fork. Many thanks to @MDAR for reporting this issue: https://github.com/MichaIng/DietPi/issues/5485
- DietPi-Software | WiringPi: Build dependencies have been reduced so that only the actually required tools and headers are installed instead of the whole Build-Essential package.