### PR TITLE
Security | Allow applying SSH key and disable password logins

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,8 @@ New software:
 
 Changes:
 - Security | It is now possible to enter the WPA-PSK WiFi key as 64-digit hexadecimal key, as e.g. returned by "wpa_passphrase". It will be converted as needed, stored and applied to wpa_supplicant config automatically in this format. In case of using "dietpi-wifi.txt" on a fresh DietPi installation, please note that this requires an image with DietPi v8.5 pre-installed, i.e. dated after May 28, 2022. Many thanks to @robinemde for doing this suggestion: https://github.com/MichaIng/DietPi/issues/5406
+- Security | It is now possible to add public SSH keys to dietpi.txt, to be applied at first boot for public key authentication with "dietpi" and "root" users. Additionally, SSH password authentication can be disabled for all users or "root" only. Have a look at "AUTO_SETUP_SSH_PUBKEY" and "SOFTWARE_DISABLE_SSH_PASSWORD_LOGINS" settings in /boot/dietpi.txt.
+- DietPi-Software | Dropbear/OpenSSH: Password authentication is now disabled if set via "SOFTWARE_DISABLE_SSH_PASSWORD_LOGINS" setting in /boot/dietpi.txt.
 - DietPi-Software | Amiberry: Updated to latest version 5.1 and shipped now as DEB package. Also the included libSDL2 libraries have been updated to latest stable versions. Additionally builds for all SBCs and architectures, including x86_64, have been added, i.e. Amiberry is now available on all platforms.
 - DietPi-Software | WiringPi: Build dependencies have been reduced so that only the actually required tools and headers are installed instead of the whole Build-Essential package.
 

--- a/dietpi.txt
+++ b/dietpi.txt
@@ -78,6 +78,12 @@ AUTO_SETUP_BACKUP_RESTORE=0
 # SSH server choice: 0=none/custom | -1=Dropbear | -2=OpenSSH
 AUTO_SETUP_SSH_SERVER_INDEX=-1
 
+# SSH server pubkey
+# - Public key(s) for "root" and "dietpi" users, which will be added to ~/.ssh/authorized_keys
+# - Use the same setting multiple times for adding multiple keys.
+# - See SOFTWARE_DISABLE_SSH_PASSWORD_LOGINS below for disabling SSH password logins.
+#AUTO_SETUP_SSH_PUBKEY=ssh-ed25519 AAAAAAAA111111111111BBBBBBBBBBBB222222222222cccccccccccc333333333333 mySSHkey
+
 # Logging mode choice: 0=none/custom | -1=RAMlog hourly clear | -2=RAMlog hourly save to disk + clear | -3=Rsyslog + Logrotate
 AUTO_SETUP_LOGGING_INDEX=-1
 # RAMlog max tmpfs size (MiB). 50 MiB should be fine for single use. 200+ MiB for heavy webserver access log etc.
@@ -211,6 +217,13 @@ CONFIG_NTP_MIRROR=debian.pool.ntp.org
 #------------------------------------------------------------------------------------------------------
 ##### DietPi-Software settings #####
 #------------------------------------------------------------------------------------------------------
+# SSH Server
+# - Disable SSH password logins, e.g. when using pubkey authentication
+#	0=Allow password logins for all users, including root
+#	root=Disable password login for root user only
+#	1=Disable password logins for all users, assure that you have a valid SSH key applied!
+SOFTWARE_DISABLE_SSH_PASSWORD_LOGINS=0
+
 # VNC Server
 SOFTWARE_VNCSERVER_WIDTH=1280
 SOFTWARE_VNCSERVER_HEIGHT=720

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2828,8 +2828,11 @@ _EOF_
 			fi
 			aSTART_SERVICES+=('dropbear')
 
-			# Enable Dropbear daemon
-			G_CONFIG_INJECT 'NO_START=' 'NO_START=0' /etc/default/dropbear
+			# Apply password login setting from dietpi.txt or default
+			/boot/dietpi/func/dietpi-set_software disable_ssh_password_logins
+
+			# Enable Dropbear daemon, obsolete since Bookworm
+			(( $G_DISTRO > 6 )) || G_CONFIG_INJECT 'NO_START=' 'NO_START=0' /etc/default/dropbear
 
 			# Mark OpenSSH for uninstall
 			dpkg-query -s 'openssh-server' &> /dev/null && aSOFTWARE_INSTALL_STATE[105]=-1
@@ -2847,8 +2850,8 @@ _EOF_
 			G_AGI openssh-server
 			aSTART_SERVICES+=('ssh')
 
-			# Allow root login
-			G_CONFIG_INJECT 'PermitRootLogin[[:blank:]]' 'PermitRootLogin yes' /etc/ssh/sshd_config
+			# Apply password login setting from dietpi.txt or default
+			/boot/dietpi/func/dietpi-set_software disable_ssh_password_logins
 
 			# Reload SSH server now so root users can login during setup
 			systemctl reload ssh

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -13,16 +13,18 @@
 	readonly FP_SCRIPT='/boot/dietpi/func/dietpi-set_software'
 	readonly AVAIABLE_COMMANDS="
 Available commands:
-$FP_SCRIPT	locale			xx_XX.UTF-8 (eg: en_GB.UTF-8)
-$FP_SCRIPT	allo			eth_dhcp|eth_static [<address>] [<gateway>] [<netmask>] [<dns-nameservers>]
-$FP_SCRIPT	useradd			X=create user with name X and default permissions, using global DietPi password (dietpi)
-$FP_SCRIPT	userdel			X=delete user with name X
-$FP_SCRIPT	apt-mirror		<url>|default
-$FP_SCRIPT	apt			clean|reset|cache|lists|archives|compress [enable|disable|ram|disk]
-$FP_SCRIPT	ntpd-mode		[0-4] Time sync modes: 0=custom|1=boot|2=boot+daily|3=boot+hourly|4=daemon+drift
-$FP_SCRIPT	verify_dietpi.txt	Verifies dietpi.txt entries, adds missing entries if required
-$FP_SCRIPT	passwords		NULL=Prompt user to change DietPi related passwords | X=optional set X as global password for future dietpi-software installations and \"root\" + \"dietpi\" login passwords.
-$FP_SCRIPT	boot_wait_for_network	[01] Enable or disable waiting for network interface configuration before DietPi-PostBoot is started, including postboot.d custom scripts and service startups
+$FP_SCRIPT	locale				xx_XX.UTF-8 (eg: en_GB.UTF-8)
+$FP_SCRIPT	allo				eth_dhcp|eth_static [<address>] [<gateway>] [<netmask>] [<dns-nameservers>]
+$FP_SCRIPT	useradd				X=create user with name X and default permissions, using global DietPi password (dietpi)
+$FP_SCRIPT	userdel				X=delete user with name X
+$FP_SCRIPT	apt-mirror			<url>|default
+$FP_SCRIPT	apt				clean|reset|cache|lists|archives|compress [enable|disable|ram|disk]
+$FP_SCRIPT	ntpd-mode			[0-4] Time sync modes: 0=custom|1=boot|2=boot+daily|3=boot+hourly|4=daemon+drift
+$FP_SCRIPT	verify_dietpi.txt		Verifies dietpi.txt entries, adds missing entries if required
+$FP_SCRIPT	passwords			NULL=Prompt user to change DietPi related passwords | X=optional set X as global password for future dietpi-software installations and \"root\" + \"dietpi\" login passwords.
+$FP_SCRIPT	boot_wait_for_network		[01] Enable or disable waiting for network interface configuration before DietPi-PostBoot is started, including postboot.d custom scripts and service startups
+$FP_SCRIPT	add_ssh_pubkeys			<empty>
+$FP_SCRIPT	disable_ssh_password_logins	[01]|root|<empty> Whether to disable SSH password logins for all users or root only; Leave empty to apply setting from /boot/dietpi.txt
 "	#////////////////////////////////////
 
 	# Grab inputs
@@ -560,6 +562,97 @@ It is highly recommended to change this password, ideally, it should be differen
 		G_CONFIG_INJECT 'AUTO_SETUP_BOOT_WAIT_FOR_NETWORK=' "AUTO_SETUP_BOOT_WAIT_FOR_NETWORK=$INPUT_MODE_VALUE" /boot/dietpi.txt
 	}
 
+	Add_SSH_Pubkeys()
+	{
+		[[ $INPUT_MODE_VALUE ]] && { Unknown_Input_Mode; return 1; }
+		while read -r line
+		do
+			local without_comment=$line
+			[[ $line =~ ^.+' '.+' ' ]] && without_comment=${line% *}
+			without_comment=${without_comment//+/\\+}
+			[[ -d '/root/.ssh' ]] || G_EXEC mkdir -p /root/.ssh
+			[[ -f '/root/.ssh/authorized_keys' ]] || > /root/.ssh/authorized_keys
+			G_EXEC chmod 0400 /root/.ssh/authorized_keys
+			G_CONFIG_INJECT "$without_comment" "$line" /root/.ssh/authorized_keys
+			if getent passwd dietpi > /dev/null
+			then
+				[[ -d '/home/dietpi/.ssh' ]] || G_EXEC mkdir -p /home/dietpi/.ssh
+				[[ -f '/home/dietpi/.ssh/authorized_keys' ]] || > /home/dietpi/.ssh/authorized_keys
+				G_EXEC chmod 0400 /home/dietpi/.ssh/authorized_keys
+				G_EXEC chown -R dietpi /home/dietpi/.ssh
+				G_CONFIG_INJECT "$without_comment" "$line" /home/dietpi/.ssh/authorized_keys
+			fi
+
+		done < <(sed -n '/^[[:blank:]]*AUTO_SETUP_SSH_PUBKEY=/s/^[^=]*=//p' /boot/dietpi.txt)
+	}
+
+	Disable_SSH_Password_Logins()
+	{
+		# If no input given, apply dietpi.txt setting, default to "0"
+		if [[ ! $INPUT_MODE_VALUE ]]
+		then
+			INPUT_MODE_VALUE=$(sed -n '/^[[:blank:]]*SOFTWARE_DISABLE_SSH_PASSWORD_LOGINS=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+			[[ $INPUT_MODE_VALUE ]] || INPUT_MODE_VALUE=0
+		fi
+
+		# Dropbear
+		if [[ -f '/etc/default/dropbear' ]]
+		then
+			# shellcheck disable=SC1091
+			. /etc/default/dropbear
+			DROPBEAR_EXTRA_ARGS=${DROPBEAR_EXTRA_ARGS%-[sg]} DROPBEAR_EXTRA_ARGS=${DROPBEAR_EXTRA_ARGS#-[sg] } DROPBEAR_EXTRA_ARGS=${DROPBEAR_EXTRA_ARGS// -[sg] }
+			DROPBEAR_EXTRA_ARGS=${DROPBEAR_EXTRA_ARGS%-[sg]} DROPBEAR_EXTRA_ARGS=${DROPBEAR_EXTRA_ARGS#-[sg] } DROPBEAR_EXTRA_ARGS=${DROPBEAR_EXTRA_ARGS// -[sg] }
+			DROPBEAR_EXTRA_ARGS=$(sed -E 's/(-[^[:blank:]]*)[sg]/\1/g' <<< "$DROPBEAR_EXTRA_ARGS")
+			if [[ $INPUT_MODE_VALUE == 1 ]]
+			then
+				DROPBEAR_EXTRA_ARGS+=' -s'
+
+			elif [[ $INPUT_MODE_VALUE == 'root' ]]
+			then
+				DROPBEAR_EXTRA_ARGS+=' -g'
+
+			elif [[ $INPUT_MODE_VALUE != 0 ]]
+			then
+				Unknown_Input_Mode
+				return 1
+			fi
+
+			DROPBEAR_EXTRA_ARGS=${DROPBEAR_EXTRA_ARGS# }
+			DROPBEAR_EXTRA_ARGS=${DROPBEAR_EXTRA_ARGS% } DROPBEAR_EXTRA_ARGS=${DROPBEAR_EXTRA_ARGS% }
+			G_CONFIG_INJECT 'DROPBEAR_EXTRA_ARGS=' "DROPBEAR_EXTRA_ARGS=\"$DROPBEAR_EXTRA_ARGS\"" /etc/default/dropbear
+			systemctl -q is-active dropbear && G_EXEC_NOHALT=1 G_EXEC systemctl restart dropbear
+		fi
+
+		# OpenSSH
+		if [[ -f '/etc/ssh/sshd_config' ]]
+		then
+			[[ -d '/etc/ssh/sshd_config.d' ]] || G_EXEC mkdir /etc/ssh/sshd_config.d
+			[[ -f '/etc/ssh/sshd_config.d/dietpi.conf' ]] || > /etc/ssh/sshd_config.d/dietpi.conf
+			if [[ $INPUT_MODE_VALUE == 1 ]]
+			then
+				G_CONFIG_INJECT 'PubkeyAuthentication[[:blank:]]' 'PubkeyAuthentication yes' /etc/ssh/sshd_config.d/dietpi.conf
+				G_CONFIG_INJECT 'PasswordAuthentication[[:blank:]]' 'PasswordAuthentication no' /etc/ssh/sshd_config.d/dietpi.conf
+
+			elif [[ $INPUT_MODE_VALUE == 'root' ]]
+			then
+				G_CONFIG_INJECT 'PubkeyAuthentication[[:blank:]]' 'PubkeyAuthentication yes' /etc/ssh/sshd_config.d/dietpi.conf
+				G_CONFIG_INJECT 'PermitRootLogin[[:blank:]]' 'PermitRootLogin prohibit-password' /etc/ssh/sshd_config.d/dietpi.conf
+				G_CONFIG_INJECT 'PasswordAuthentication[[:blank:]]' 'PasswordAuthentication yes' /etc/ssh/sshd_config.d/dietpi.conf
+
+			elif [[ $INPUT_MODE_VALUE == 0 ]]
+			then
+				G_CONFIG_INJECT 'PasswordAuthentication[[:blank:]]' 'PasswordAuthentication yes' /etc/ssh/sshd_config.d/dietpi.conf
+				G_CONFIG_INJECT 'PermitRootLogin[[:blank:]]' 'PermitRootLogin yes' /etc/ssh/sshd_config.d/dietpi.conf
+			else
+				Unknown_Input_Mode
+				return 1
+			fi
+			systemctl -q is-active ssh && G_EXEC_NOHALT=1 G_EXEC systemctl restart ssh
+		fi
+
+		G_CONFIG_INJECT 'SOFTWARE_DISABLE_SSH_PASSWORD_LOGINS=' "SOFTWARE_DISABLE_SSH_PASSWORD_LOGINS=$INPUT_MODE_VALUE" /boot/dietpi.txt
+	}
+
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# Main Loop
 	#/////////////////////////////////////////////////////////////////////////////////////
@@ -607,6 +700,14 @@ It is highly recommended to change this password, ideally, it should be differen
 	elif [[ $INPUT_MODE_NAME == 'boot_wait_for_network' ]]; then
 
 		Boot_Wait_For_Network
+
+	elif [[ $INPUT_MODE_NAME == 'add_ssh_pubkeys' ]]; then
+
+		Add_SSH_Pubkeys
+
+	elif [[ $INPUT_MODE_NAME == 'disable_ssh_password_logins' ]]; then
+
+		Disable_SSH_Password_Logins
 
 	else
 

--- a/rootfs/var/lib/dietpi/services/dietpi-firstboot.bash
+++ b/rootfs/var/lib/dietpi/services/dietpi-firstboot.bash
@@ -202,6 +202,14 @@ _EOF_
 			dropbearkey -t "$type" -f "$i"
 		done
 
+		# Apply SSH pubkey(s) from dietpi.txt
+		/boot/dietpi/func/dietpi-set_software add_ssh_pubkeys
+
+		# Apply SSH password login setting
+		local disable_ssh_password_logins=$(sed -n '/^[[:blank:]]*SOFTWARE_DISABLE_SSH_PASSWORD_LOGINS=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+		[[ $disable_ssh_password_logins ]] || disable_ssh_password_logins=0
+		/boot/dietpi/func/dietpi-set_software disable_ssh_password_logins "$disable_ssh_password_logins"
+
 		# Disable serial console if set in dietpi.txt
 		grep -q '^[[:blank:]]*CONFIG_SERIAL_CONSOLE_ENABLE=0' /boot/dietpi.txt && /boot/dietpi/func/dietpi-set_hardware serialconsole disable
 


### PR DESCRIPTION
- Security | It is now possible to add public SSH keys to dietpi.txt, to be applied at first boot for public key authentication with "dietpi" and "root" users. Additionally, SSH password authentication can be disabled for all users or "root" only. Have a look at "AUTO_SETUP_SSH_PUBKEY" and "SOFTWARE_DISABLE_SSH_PASSWORD_LOGINS" settings in /boot/dietpi.txt.
- DietPi-Software | Dropbear/OpenSSH: Password authentication is now disabled if set via "SOFTWARE_DISABLE_SSH_PASSWORD_LOGINS" setting in /boot/dietpi.txt.
