### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/amiberry.yml
+++ b/.github/workflows/amiberry.yml
@@ -11,8 +11,13 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.platform }}-${{ github.event.inputs.distro }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   rpi1_buster:
+    permissions:
+      contents: none
     if: ( github.event.inputs.platform == 'rpi1' || github.event.inputs.platform == 'all' ) && ( github.event.inputs.distro == 5 || github.event.inputs.distro == 'all' )
     # https://github.com/actions/virtual-environments
     runs-on: ubuntu-22.04
@@ -30,6 +35,8 @@ jobs:
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/amiberry_rpi1.deb"]}'
   rpi1_bullseye:
+    permissions:
+      contents: none
     if: ( github.event.inputs.platform == 'rpi1' || github.event.inputs.platform == 'all' ) && ( github.event.inputs.distro == 6 || github.event.inputs.distro == 'all' )
     # https://github.com/actions/virtual-environments
     runs-on: ubuntu-22.04

--- a/.github/workflows/dietpi-build.yml
+++ b/.github/workflows/dietpi-build.yml
@@ -8,9 +8,14 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   build:
     # https://github.com/actions/virtual-environments
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -3,6 +3,9 @@ on: [pull_request, push]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
