### PR TITLE
DietPi-Software | Radarr: Fix install on ARMv6

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,9 +1,9 @@
 v8.6
 (2022-XX-YY)
 
-Changes:
-
-Fixes:
+Bug fixes:
+- DietPi-Software | Radarr: Resolved an issue where the installation on ARMv6 Raspberry Pi models (Raspberry Pi 1 and Zero (1)) failed, since Radarr v4 does not support Mono anymore. The latest v3 will be installed now on these models. Many thanks to @eddiermar for reporting this issue: https://github.com/MichaIng/DietPi/issues/5537
+- DietPi-Software | Lidarr: Precautionary, on ARMv6 Raspberry Pi models, the latest v0.8 will be installed from now on, since the upcoming v1 won't support Mono anymore. 
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3519,7 +3519,7 @@ _EOF_
 			then
 				dps_index=$software_id Download_Install 'conf' /etc/samba/smb.conf
 				G_CONFIG_INJECT 'max connections =' "max connections = $(( $G_HW_CPU_CORES * 2 ))" /etc/samba/smb.conf
-			fi				
+			fi
 
 			G_AGI samba
 			G_EXEC systemctl stop nmbd smbd
@@ -8993,7 +8993,7 @@ _EOF_
 					[[ -e $i ]] || continue
 					[[ -e ruTorrent-${version#v}/plugins/theme/themes/${i#/var/www/rutorrent/plugins/theme/themes/} ]] && continue
 					G_EXEC cp -a "$i" "ruTorrent-${version#v}/plugins/theme/themes/"
-				done				
+				done
 
 				# Reinstall freshly with preserved configs, 3rd party plugins and themes
 				G_EXEC rm -R /var/www/rutorrent
@@ -10209,26 +10209,27 @@ _EOF_
 				aDEPS=()
 			else
 				# ARMv6
-				local url=$(curl -sSfL 'https://api.github.com/repos/Radarr/Radarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux\.tar\.gz"/{print $4}')
-				local fallback_url='https://github.com/Radarr/Radarr/releases/download/v4.0.4.5922/Radarr.master.4.0.4.5922.linux.tar.gz'
+				if (( $G_HW_ARCH == 1 ))
+				then
+					local url='https://github.com/Radarr/Radarr/releases/download/v3.2.2.5080/Radarr.master.3.2.2.5080.linux.tar.gz'
 
 				# ARMv7
-				if (( $G_HW_ARCH == 2 ))
-				then
-					url=${url/linux/linux-core-arm}
-					fallback_url=${fallback_url/linux/linux-core-arm}
+				else
+					local url=$(curl -sSfL 'https://api.github.com/repos/Radarr/Radarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux-core-arm\.tar\.gz"/{print $4}')
+					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v4.1.0.6175/Radarr.master.4.1.0.6175.linux-core-arm.tar.gz'
+				fi
 
 				# ARMv8
-				elif (( $G_HW_ARCH == 3 ))
+				if (( $G_HW_ARCH == 3 ))
 				then
-					url=${url/linux/linux-core-arm64}
-					fallback_url=${fallback_url/linux/linux-core-arm64}
+					url=${url/arm/arm64}
+					fallback_url=${fallback_url/arm/arm64}
 
 				# x86_64
 				elif (( $G_HW_ARCH == 10 ))
 				then
-					url=${url/linux/linux-core-x64}
-					fallback_url=${fallback_url/linux/linux-core-x64}
+					url=${url/arm/x64}
+					fallback_url=${fallback_url/arm/x64}
 				fi
 
 				Download_Install "$url"
@@ -10318,26 +10319,27 @@ _EOF_
 				aDEPS=()
 			else
 				# ARMv6
-				local url=$(curl -sSfL 'https://api.github.com/repos/Lidarr/Lidarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux\.tar\.gz"/{print $4}')
-				local fallback_url='https://github.com/Lidarr/Lidarr/releases/download/v0.8.1.2135/Lidarr.master.0.8.1.2135.linux.tar.gz'
+				if (( $G_HW_ARCH == 1 ))
+				then
+					local url='https://github.com/Lidarr/Lidarr/releases/download/v0.8.1.2135/Lidarr.master.0.8.1.2135.linux.tar.gz'
 
 				# ARMv7
-				if (( $G_HW_ARCH == 2 ))
-				then
-					url=${url/linux/linux-core-arm}
-					fallback_url=${fallback_url/linux/linux-core-arm}
+				else
+					local url=$(curl -sSfL 'https://api.github.com/repos/Lidarr/Lidarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux-core-arm\.tar\.gz"/{print $4}')
+					local fallback_url='https://github.com/Lidarr/Lidarr/releases/download/v0.8.1.2135/Lidarr.master.0.8.1.2135.linux-core-arm.tar.gz'
+				fi
 
 				# ARMv8
-				elif (( $G_HW_ARCH == 3 ))
+				if (( $G_HW_ARCH == 3 ))
 				then
-					url=${url/linux/linux-core-arm64}
-					fallback_url=${fallback_url/linux/linux-core-arm64}
+					url=${url/arm/arm64}
+					fallback_url=${fallback_url/arm/arm64}
 
 				# x86_64
 				elif (( $G_HW_ARCH == 10 ))
 				then
-					url=${url/linux/linux-core-x64}
-					fallback_url=${fallback_url/linux/linux-core-x64}
+					url=${url/arm/x64}
+					fallback_url=${fallback_url/arm/x64}
 				fi
 
 				Download_Install "$url"
@@ -10541,7 +10543,7 @@ _EOF_
 			# Grab latest version download link
 			# - ARMv6: Requires Mono: https://github.com/Jackett/Jackett#installation-on-linux-armv6-or-below
 			local url=$(curl -sSfL 'https://api.github.com/repos/Jackett/Jackett/releases/latest' | mawk -F\" '/"browser_download_url": ".*\/Jackett\.Binaries\.Mono\.tar\.gz"/{print $4}')
-			local fallback_url='https://github.com/Jackett/Jackett/releases/download/v0.20.744/Jackett.Binaries.Mono.tar.gz'
+			local fallback_url='https://github.com/Jackett/Jackett/releases/download/v0.20.1127/Jackett.Binaries.Mono.tar.gz'
 
 			# - ARMv7
 			if (( $G_HW_ARCH == 2 ))
@@ -10680,7 +10682,7 @@ ExecStart=/mnt/dietpi_userdata/nzbget/nzbget -D
 WantedBy=multi-user.target
 _EOF_
 		fi
-		
+
 		software_id=151 # Prowlarr
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 ))
 		then
@@ -11660,7 +11662,7 @@ _EOF_
 			# - RPi 4
 			elif (( $G_HW_MODEL == 4 ))
 			then
-				G_EXEC cmake .. -DRPI4=1 -DNOGIT=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo		
+				G_EXEC cmake .. -DRPI4=1 -DNOGIT=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
 			# - Odroids
 			elif (( $G_HW_MODEL < 20 ))
 			then
@@ -13585,7 +13587,7 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 			[[ -d '/mnt/dietpi_userdata/nzbget' ]] && G_EXEC rm -R /mnt/dietpi_userdata/nzbget
 
 		fi
-		
+
 		software_id=151 # Prowlarr
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 


### PR DESCRIPTION
- DietPi-Software | Radarr: Resolved an issue where the installation on ARMv6 Raspberry Pi models (Raspberry Pi 1 and Zero (1)) failed, since Radarr v4 does not support Mono anymore. The latest v3 will be installed now on these models. Many thanks to @eddiermar for reporting this issue: https://github.com/MichaIng/DietPi/issues/5537
- DietPi-Software | Lidarr: Precautionary, on ARMv6 Raspberry Pi models, the latest v0.8 will be installed from now on, since the upcoming v1 won't support Mono anymore.