### PR TITLE
DietPi-Software | PiVPN: Add unattended install

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,9 @@
 v8.6
 (2022-XX-YY)
 
+New features:
+- DietPi-Software | PiVPN: It is now possible to do an unattended install by placing a config file named "unattended_pivpn.conf" into the boot partition/directory. For example configs, have a look at https://github.com/pivpn/pivpn/tree/master/examples. Many thanks to @bastianpaetzold for implementing this feature: https://github.com/MichaIng/DietPi/pull/5546
+
 Bug fixes:
 - DietPi-Software | Radarr: Resolved an issue where the installation on ARMv6 Raspberry Pi models (Raspberry Pi 1 and Zero (1)) failed, since Radarr v4 does not support Mono anymore. The latest v3 will be installed now on these models. Many thanks to @eddiermar for reporting this issue: https://github.com/MichaIng/DietPi/issues/5537
 - DietPi-Software | Lidarr: Precautionary, on ARMv6 Raspberry Pi models, the latest v0.8 will be installed from now on, since the upcoming v1 won't support Mono anymore. 

--- a/dietpi.txt
+++ b/dietpi.txt
@@ -280,6 +280,10 @@ SOFTWARE_DIETPI_DASHBOARD_VERSION=Stable
 # Whether to only install backend or not
 SOFTWARE_DIETPI_DASHBOARD_BACKEND=0
 
+# PiVPN
+# - For an unattended install, place a config file named "unattended_pivpn.conf" into the boot partition/directory.
+# - For example configs, have a look at: https://github.com/pivpn/pivpn/tree/master/examples
+
 #------------------------------------------------------------------------------------------------------
 ##### Dev settings #####
 #------------------------------------------------------------------------------------------------------

--- a/dietpi.txt
+++ b/dietpi.txt
@@ -280,6 +280,11 @@ SOFTWARE_DIETPI_DASHBOARD_VERSION=Stable
 # Whether to only install backend or not
 SOFTWARE_DIETPI_DASHBOARD_BACKEND=0
 
+# PiVPN
+# Path to a file containing options for the PiVPN installer
+# https://github.com/pivpn/pivpn/wiki#non-interactive-installation
+SOFTWARE_PIVPN_UNATTENDED_OPTION_FILE=
+
 #------------------------------------------------------------------------------------------------------
 ##### Dev settings #####
 #------------------------------------------------------------------------------------------------------

--- a/dietpi.txt
+++ b/dietpi.txt
@@ -280,11 +280,6 @@ SOFTWARE_DIETPI_DASHBOARD_VERSION=Stable
 # Whether to only install backend or not
 SOFTWARE_DIETPI_DASHBOARD_BACKEND=0
 
-# PiVPN
-# Path to a file containing options for the PiVPN installer
-# https://github.com/pivpn/pivpn/wiki#non-interactive-installation
-SOFTWARE_PIVPN_UNATTENDED_OPTION_FILE=
-
 #------------------------------------------------------------------------------------------------------
 ##### Dev settings #####
 #------------------------------------------------------------------------------------------------------

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8116,7 +8116,7 @@ _EOF_
 			G_DIETPI-NOTIFY 2 'Preventing reboot from within PiVPN installer'
 			G_EXEC sed -i '/shutdown[[:space:]]/d' install.bash
 			G_DIETPI-NOTIFY 2 'Preventing install of unattended-upgrades'
-			G_EXEC sed -i 's/^[[:blank:]]*UNATTUPG=[[:digit:]]/UNATTUPG=0/' install.bash
+			G_EXEC sed -i '/^[[:blank:]]*askUnattendedUpgrades$/c\UNATTUPG=0' install.bash
 
 			local install_options
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8118,8 +8118,8 @@ _EOF_
 			G_DIETPI-NOTIFY 2 'Preventing install of unattended-upgrades'
 			G_EXEC sed -i '/^[[:blank:]]*askUnattendedUpgrades$/c\UNATTUPG=0' install.bash
 
+			# Unattended install
 			local options=
-
 			if [[ -f '/boot/unattended_pivpn.conf' ]]
 			then
 				G_CONFIG_INJECT 'UNATTUPG=[[:digit:]]' 'UNATTUPG=0' /boot/unattended_pivpn.conf

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8119,7 +8119,7 @@ _EOF_
 			G_EXEC sed -i '/^[[:blank:]]*askUnattendedUpgrades$/c\UNATTUPG=0' install.bash
 
 			# Unattended install
-			local options=
+			local options=()
 			if [[ -f '/boot/unattended_pivpn.conf' ]]
 			then
 				G_CONFIG_INJECT 'UNATTUPG=[[:digit:]]' 'UNATTUPG=0' /boot/unattended_pivpn.conf
@@ -8132,7 +8132,7 @@ _EOF_
 
 			G_EXEC_OUTPUT=1 G_EXEC_NOEXIT=1 G_EXEC ./install.bash "${options[@]}" || aSOFTWARE_INSTALL_STATE[$software_id]=0
 			G_EXEC_NOHALT=1 G_EXEC rm install.bash
-			[[ -f /boot/unattended_pivpn.conf ]] && G_EXEC_NOHALT=1 G_EXEC mv /boot/unattended_pivpn.conf{,.applied}
+			[[ -f '/boot/unattended_pivpn.conf' ]] && G_EXEC_NOHALT=1 G_EXEC mv /boot/unattended_pivpn.conf{,.applied}
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8121,17 +8121,17 @@ _EOF_
 			local install_options
 
 			if [[ -f /boot/unattended_pivpn.conf ]]; then
-				G_EXEC sed -i 's/^[[:blank:]]*UNATTUPG=[[:digit:]]/UNATTUPG=0/' /boot/unattended_pivpn.conf
-				install_options='--unattended /boot/unattended_pivpn.conf'
+				G_CONFIG_INJECT 'UNATTUPG=[[:digit:]]' 'UNATTUPG=0' /boot/unattended_pivpn.conf
+				install_options=('--unattended' '/boot/unattended_pivpn.conf')
 			fi
 
 			# APT deps
 			G_AGI dnsutils net-tools bsdmainutils iptables-persistent # https://github.com/pivpn/pivpn/blob/master/auto_install/install.sh#L37
 			Configure_iptables
 
-			G_EXEC_OUTPUT=1 G_EXEC_NOEXIT=1 G_EXEC ./install.bash $install_options || aSOFTWARE_INSTALL_STATE[$software_id]=0
+			G_EXEC_OUTPUT=1 G_EXEC_NOEXIT=1 G_EXEC ./install.bash "${install_options[@]}" || aSOFTWARE_INSTALL_STATE[$software_id]=0
 			G_EXEC_NOHALT=1 G_EXEC rm install.bash
-			[[ -f /boot/unattended_pivpn.conf ]] && G_EXEC_NOHALT=1 G_EXEC mv /boot/unattended_pivpn.conf{,.ignore}
+			[[ -f /boot/unattended_pivpn.conf ]] && G_EXEC_NOHALT=1 G_EXEC mv /boot/unattended_pivpn.conf{,.applied}
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8127,7 +8127,7 @@ _EOF_
 			fi
 
 			# APT deps
-			G_AGI dnsutils net-tools bsdmainutils iptables-persistent # https://github.com/pivpn/pivpn/blob/master/auto_install/install.sh#L37
+			G_AGI dnsutils grepcidr net-tools bsdmainutils iptables-persistent # https://github.com/pivpn/pivpn/blob/master/auto_install/install.sh#L37
 			Configure_iptables
 
 			G_EXEC_OUTPUT=1 G_EXEC_NOEXIT=1 G_EXEC ./install.bash "${options[@]}" || aSOFTWARE_INSTALL_STATE[$software_id]=0
@@ -14210,6 +14210,7 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
+			[[ -f '/opt/pivpn/uninstall.sh' ]] && G_EXEC sed -i 's/ askreboot;//' /opt/pivpn/uninstall.sh
 			command -v pivpn > /dev/null && G_EXEC_OUTPUT=1 G_EXEC pivpn -u
 			getent passwd pivpn > /dev/null && G_EXEC userdel pivpn
 			getent group pivpn > /dev/null && G_EXEC groupdel pivpn

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1387,8 +1387,8 @@ Available commands:
 		aSOFTWARE_CATX[$software_id]=15
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/vpn/#pivpn'
 		aSOFTWARE_DEPS[$software_id]='17'
-		# Set to interactively if no config file containing options for unattended install is present
-		[[ -f /boot/unattended_pivpn.conf ]] || aSOFTWARE_INTERACTIVE[$software_id]=1
+		# Require interactive install if no config file containing options for unattended install is present
+		[[ -f '/boot/unattended_pivpn.conf' ]] || aSOFTWARE_INTERACTIVE[$software_id]=1
 
 		# Advanced Networking
 		#--------------------------------------------------------------------------------

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8138,7 +8138,7 @@ _EOF_
 				G_AGI dnsutils net-tools bsdmainutils iptables-persistent # https://github.com/pivpn/pivpn/blob/master/auto_install/install.sh#L37
 				Configure_iptables
 
-				G_EXEC_OUTPUT=1 G_EXEC_NOEXIT=1 G_EXEC ./install.bash "$install_options" || aSOFTWARE_INSTALL_STATE[$software_id]=0
+				G_EXEC_OUTPUT=1 G_EXEC_NOEXIT=1 G_EXEC ./install.bash $install_options || aSOFTWARE_INSTALL_STATE[$software_id]=0
 				G_EXEC_NOHALT=1 G_EXEC rm install.bash
 			fi
 		fi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1387,6 +1387,8 @@ Available commands:
 		aSOFTWARE_CATX[$software_id]=15
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/vpn/#pivpn'
 		aSOFTWARE_DEPS[$software_id]='17'
+		# Set to interactively if no config file containing options for unattended install is present
+		[[ -f /boot/unattended_pivpn.conf ]] || aSOFTWARE_INTERACTIVE[$software_id]=1
 
 		# Advanced Networking
 		#--------------------------------------------------------------------------------
@@ -8109,38 +8111,28 @@ _EOF_
 
 			Banner_Installing
 
-			local config_file
+			G_EXEC curl -sSfL 'https://raw.githubusercontent.com/pivpn/pivpn/master/auto_install/install.sh' -o install.bash
+			G_EXEC chmod +x install.bash
+			G_DIETPI-NOTIFY 2 'Preventing reboot from within PiVPN installer'
+			G_EXEC sed -i '/shutdown[[:space:]]/d' install.bash
+			G_DIETPI-NOTIFY 2 'Preventing install of unattended-upgrades'
+			G_EXEC sed -i 's/^[[:blank:]]*UNATTUPG=[[:digit:]]/UNATTUPG=0/' install.bash
+
 			local install_options
 
-			if (( ! $G_INTERACTIVE )); then
-				G_DIETPI-NOTIFY 2 'Trying unattended install...'
-				config_file=$(sed -n '/^[[:blank:]]*SOFTWARE_PIVPN_UNATTENDED_OPTION_FILE=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-
-				if [[ -f "$config_file" ]]; then
-					install_options="--unattended $config_file"
-				else
-					aSOFTWARE_INSTALL_STATE[$software_id]=0
-					G_DIETPI-NOTIFY 2 "Unattended install requires an option file set via SOFTWARE_PIVPN_UNATTENDED_OPTION_FILE in /boot/dietpi.txt."
-					G_DIETPI-NOTIFY 1 "No option file found: Please run 'dietpi-software' interactively to install manually."
-				fi
+			if [[ -f /boot/unattended_pivpn.conf ]]; then
+				G_EXEC sed -i 's/^[[:blank:]]*UNATTUPG=[[:digit:]]/UNATTUPG=0/' /boot/unattended_pivpn.conf
+				install_options='--unattended /boot/unattended_pivpn.conf'
 			fi
 
-			if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-				G_EXEC curl -sSfL 'https://raw.githubusercontent.com/pivpn/pivpn/master/auto_install/install.sh' -o install.bash
-				G_EXEC chmod +x install.bash
-				G_DIETPI-NOTIFY 2 'Preventing reboot from within PiVPN installer'
-				G_EXEC sed -i '/shutdown[[:space:]]/d' install.bash
-				G_DIETPI-NOTIFY 2 'Preventing install of unattended-upgrades'
-				G_EXEC sed -i 's/^[[:blank:]]*UNATTUPG=[[:digit:]]/UNATTUPG=0/' install.bash
-				[[ -f "$config_file" ]] && G_EXEC sed -i 's/^[[:blank:]]*UNATTUPG=[[:digit:]]/UNATTUPG=0/' "$config_file"
+			# APT deps
+			G_AGI dnsutils net-tools bsdmainutils iptables-persistent # https://github.com/pivpn/pivpn/blob/master/auto_install/install.sh#L37
+			Configure_iptables
 
-				# APT deps
-				G_AGI dnsutils net-tools bsdmainutils iptables-persistent # https://github.com/pivpn/pivpn/blob/master/auto_install/install.sh#L37
-				Configure_iptables
+			G_EXEC_OUTPUT=1 G_EXEC_NOEXIT=1 G_EXEC ./install.bash $install_options || aSOFTWARE_INSTALL_STATE[$software_id]=0
+			G_EXEC_NOHALT=1 G_EXEC rm install.bash
+			[[ -f /boot/unattended_pivpn.conf ]] && G_EXEC_NOHALT=1 G_EXEC mv /boot/unattended_pivpn.conf{,.ignore}
 
-				G_EXEC_OUTPUT=1 G_EXEC_NOEXIT=1 G_EXEC ./install.bash $install_options || aSOFTWARE_INSTALL_STATE[$software_id]=0
-				G_EXEC_NOHALT=1 G_EXEC rm install.bash
-			fi
 		fi
 
 		software_id=92 # Certbot

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1387,7 +1387,6 @@ Available commands:
 		aSOFTWARE_CATX[$software_id]=15
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/vpn/#pivpn'
 		aSOFTWARE_DEPS[$software_id]='17'
-		aSOFTWARE_INTERACTIVE[$software_id]=1
 
 		# Advanced Networking
 		#--------------------------------------------------------------------------------
@@ -8110,20 +8109,38 @@ _EOF_
 
 			Banner_Installing
 
-			G_EXEC curl -sSfL 'https://raw.githubusercontent.com/pivpn/pivpn/master/auto_install/install.sh' -o install.bash
-			G_EXEC chmod +x install.bash
-			G_DIETPI-NOTIFY 2 'Preventing reboot from within PiVPN installer'
-			G_EXEC sed -i '/shutdown[[:space:]]/d' install.bash
-			G_DIETPI-NOTIFY 2 'Preventing install of unattended-upgrades'
-			G_EXEC sed -i 's/^[[:blank:]]*UNATTUPG=[[:digit:]]/UNATTUPG=0/' install.bash
+			local config_file
+			local install_options
 
-			# APT deps
-			G_AGI dnsutils net-tools bsdmainutils iptables-persistent # https://github.com/pivpn/pivpn/blob/master/auto_install/install.sh#L37
-			Configure_iptables
+			if (( ! $G_INTERACTIVE )); then
+				G_DIETPI-NOTIFY 2 'Trying unattended install...'
+				config_file=$(sed -n '/^[[:blank:]]*SOFTWARE_PIVPN_UNATTENDED_OPTION_FILE=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 
-			G_EXEC_OUTPUT=1 G_EXEC_NOEXIT=1 G_EXEC ./install.bash || aSOFTWARE_INSTALL_STATE[$software_id]=0
-			G_EXEC_NOHALT=1 G_EXEC rm install.bash
+				if [[ -f "$config_file" ]]; then
+					install_options="--unattended $config_file"
+				else
+					aSOFTWARE_INSTALL_STATE[$software_id]=0
+					G_DIETPI-NOTIFY 2 "Unattended install requires an option file set via SOFTWARE_PIVPN_UNATTENDED_OPTION_FILE in /boot/dietpi.txt."
+					G_DIETPI-NOTIFY 1 "No option file found: Please run 'dietpi-software' interactively to install manually."
+				fi
+			fi
 
+			if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
+				G_EXEC curl -sSfL 'https://raw.githubusercontent.com/pivpn/pivpn/master/auto_install/install.sh' -o install.bash
+				G_EXEC chmod +x install.bash
+				G_DIETPI-NOTIFY 2 'Preventing reboot from within PiVPN installer'
+				G_EXEC sed -i '/shutdown[[:space:]]/d' install.bash
+				G_DIETPI-NOTIFY 2 'Preventing install of unattended-upgrades'
+				G_EXEC sed -i 's/^[[:blank:]]*UNATTUPG=[[:digit:]]/UNATTUPG=0/' install.bash
+				[[ -f "$config_file" ]] && G_EXEC sed -i 's/^[[:blank:]]*UNATTUPG=[[:digit:]]/UNATTUPG=0/' "$config_file"
+
+				# APT deps
+				G_AGI dnsutils net-tools bsdmainutils iptables-persistent # https://github.com/pivpn/pivpn/blob/master/auto_install/install.sh#L37
+				Configure_iptables
+
+				G_EXEC_OUTPUT=1 G_EXEC_NOEXIT=1 G_EXEC ./install.bash "$install_options" || aSOFTWARE_INSTALL_STATE[$software_id]=0
+				G_EXEC_NOHALT=1 G_EXEC rm install.bash
+			fi
 		fi
 
 		software_id=92 # Certbot

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8114,22 +8114,23 @@ _EOF_
 			G_EXEC curl -sSfL 'https://raw.githubusercontent.com/pivpn/pivpn/master/auto_install/install.sh' -o install.bash
 			G_EXEC chmod +x install.bash
 			G_DIETPI-NOTIFY 2 'Preventing reboot from within PiVPN installer'
-			G_EXEC sed -i '/shutdown[[:space:]]/d' install.bash
+			G_EXEC sed -i '/^[[:blank:]]*if (whiptail --title "Reboot"/,/^[[:blank:]]fi$/d' install.bash
 			G_DIETPI-NOTIFY 2 'Preventing install of unattended-upgrades'
 			G_EXEC sed -i '/^[[:blank:]]*askUnattendedUpgrades$/c\UNATTUPG=0' install.bash
 
-			local install_options
+			local options=
 
-			if [[ -f /boot/unattended_pivpn.conf ]]; then
+			if [[ -f '/boot/unattended_pivpn.conf' ]]
+			then
 				G_CONFIG_INJECT 'UNATTUPG=[[:digit:]]' 'UNATTUPG=0' /boot/unattended_pivpn.conf
-				install_options=('--unattended' '/boot/unattended_pivpn.conf')
+				options=('--unattended' '/boot/unattended_pivpn.conf')
 			fi
 
 			# APT deps
 			G_AGI dnsutils net-tools bsdmainutils iptables-persistent # https://github.com/pivpn/pivpn/blob/master/auto_install/install.sh#L37
 			Configure_iptables
 
-			G_EXEC_OUTPUT=1 G_EXEC_NOEXIT=1 G_EXEC ./install.bash "${install_options[@]}" || aSOFTWARE_INSTALL_STATE[$software_id]=0
+			G_EXEC_OUTPUT=1 G_EXEC_NOEXIT=1 G_EXEC ./install.bash "${options[@]}" || aSOFTWARE_INSTALL_STATE[$software_id]=0
 			G_EXEC_NOHALT=1 G_EXEC rm install.bash
 			[[ -f /boot/unattended_pivpn.conf ]] && G_EXEC_NOHALT=1 G_EXEC mv /boot/unattended_pivpn.conf{,.applied}
 


### PR DESCRIPTION
This is a possible implementation of unattended install of PiVPN (#3350)

I know there are probably still open points like if  `/boot/unattended_pivpn.conf` should be renamed or deleted after the installation, but I hope this can serve as a starting point. Please let me know if I should adjust anything.

I tested the installation with and without the `/boot/unattended_pivpn.conf` present as well as reinstall after an unattended install.
