### PR TITLE
DietPi-Software | Jellyfin

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@ Enhancements:
 Bug fixes:
 - DietPi-Software | Radarr: Resolved an issue where the installation on ARMv6 Raspberry Pi models (Raspberry Pi 1 and Zero (1)) failed, since Radarr v4 does not support Mono anymore. The latest v3 will be installed now on these models. Many thanks to @eddiermar for reporting this issue: https://github.com/MichaIng/DietPi/issues/5537
 - DietPi-Software | Lidarr: Precautionary, on ARMv6 Raspberry Pi models, the latest v0.8 will be installed from now on, since the upcoming v1 won't support Mono anymore. 
+- DietPi-Software | Jellyfin: Resolved an issue where the installation failed due to a missing config file. Many thanks to @TomEighty15 for reporting this issue: https://dietpi.com/forum/t/jellyfin-installation-error/13402
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11704,7 +11704,7 @@ _EOF_
 
 			# APT meta package: Server, web component and FFmpeg implementation
 			G_AGI jellyfin
-			[[ -f '/etc/jellyfin/network.xml' ]] || CREATE_CONFIG_CONTENT='AddPeopleQueryIndex' Create_Config '/etc/jellyfin/migrations.xml' jellyfin 40
+			[[ -f '/etc/jellyfin/network.xml' ]] || CREATE_CONFIG_CONTENT='AddPeopleQueryIndex' Create_Config '/etc/jellyfin/migrations.xml' jellyfin 60
 			G_EXEC systemctl stop jellyfin
 
 			# Grant dietpi group permissions and assure video access
@@ -11720,7 +11720,8 @@ _EOF_
 				[[ -d '/var/lib/jellyfin' ]] && G_EXEC mv /var/lib/jellyfin /mnt/dietpi_userdata/jellyfin || G_EXEC mkdir /mnt/dietpi_userdata/jellyfin
 				G_CONFIG_INJECT 'JELLYFIN_DATA_DIR=' 'JELLYFIN_DATA_DIR=/mnt/dietpi_userdata/jellyfin' /etc/default/jellyfin
 				# Change default WorkingDirectory
-				G_CONFIG_INJECT 'WorkingDirectory' 'WorkingDirectory = /mnt/dietpi_userdata/jellyfin' /lib/systemd/system/jellyfin.service
+				[[ -d '/etc/systemd/system/jellyfin.service.d' ]] || G_EXEC mkdir /etc/systemd/system/jellyfin.service.d
+				G_EXEC eval 'echo -e '\''[Service]\nWorkingDirectory=/mnt/dietpi_userdata/jellyfin'\'' > /etc/systemd/system/jellyfin.service.d/dietpi.conf'
 				# Cache dir
 				# shellcheck disable=SC2015
 				[[ -d '/var/cache/jellyfin' ]] && G_EXEC mv /var/cache/jellyfin /mnt/dietpi_userdata/jellyfin/cache || G_EXEC mkdir /mnt/dietpi_userdata/jellyfin/cache

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11615,6 +11615,14 @@ _EOF_
 
 			# APT meta package: Server, web component and FFmpeg implementation
 			G_AGI jellyfin
+			local i=0
+			local timeout=30
+			until (( $i >= $timeout )) || [[ -f '/etc/jellyfin/network.xml' ]]
+				do
+				((i++))
+				G_DIETPI-NOTIFY -2 "Waiting for ${aSOFTWARE_NAME[$software_id]} service to complete first startup ($i/$timeout)"
+				G_SLEEP 1
+				done
 			G_EXEC systemctl stop jellyfin
 
 			# Grant dietpi group permissions and assure video access
@@ -11629,6 +11637,8 @@ _EOF_
 				# shellcheck disable=SC2015
 				[[ -d '/var/lib/jellyfin' ]] && G_EXEC mv /var/lib/jellyfin /mnt/dietpi_userdata/jellyfin || G_EXEC mkdir /mnt/dietpi_userdata/jellyfin
 				G_CONFIG_INJECT 'JELLYFIN_DATA_DIR=' 'JELLYFIN_DATA_DIR=/mnt/dietpi_userdata/jellyfin' /etc/default/jellyfin
+				# Change default WorkingDirectory
+				G_CONFIG_INJECT 'WorkingDirectory' 'WorkingDirectory = /mnt/dietpi_userdata/jellyfin' /lib/systemd/system/jellyfin.service
 				# Cache dir
 				# shellcheck disable=SC2015
 				[[ -d '/var/cache/jellyfin' ]] && G_EXEC mv /var/cache/jellyfin /mnt/dietpi_userdata/jellyfin/cache || G_EXEC mkdir /mnt/dietpi_userdata/jellyfin/cache

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11704,14 +11704,7 @@ _EOF_
 
 			# APT meta package: Server, web component and FFmpeg implementation
 			G_AGI jellyfin
-			local i=0
-			local timeout=30
-			until (( $i >= $timeout )) || [[ -f '/etc/jellyfin/network.xml' ]]
-				do
-				((i++))
-				G_DIETPI-NOTIFY -2 "Waiting for ${aSOFTWARE_NAME[$software_id]} service to complete first startup ($i/$timeout)"
-				G_SLEEP 1
-				done
+			[[ -f '/etc/jellyfin/network.xml' ]] || CREATE_CONFIG_CONTENT='AddPeopleQueryIndex' Create_Config '/etc/jellyfin/migrations.xml' jellyfin 40
 			G_EXEC systemctl stop jellyfin
 
 			# Grant dietpi group permissions and assure video access
@@ -11721,7 +11714,7 @@ _EOF_
 			if [[ ! -d '/mnt/dietpi_userdata/jellyfin' ]]
 			then
 				# Start service until /etc/jellyfin/network.xml exists
-				Create_Config /etc/jellyfin/network.xml jellyfin
+				Create_Config '/etc/jellyfin/network.xml' jellyfin
 				# Data dir
 				# shellcheck disable=SC2015
 				[[ -d '/var/lib/jellyfin' ]] && G_EXEC mv /var/lib/jellyfin /mnt/dietpi_userdata/jellyfin || G_EXEC mkdir /mnt/dietpi_userdata/jellyfin


### PR DESCRIPTION
Jellyfin service needs some time now to finish first time startup. Otherwise config files are not created next time we start the service. https://dietpi.com/forum/t/jellyfin-installation-error/13402

I'm not quite happy with the delay of 30 sec, maybe you have a better idea @MichaIng 

Furthermore we need to changed `WorkingDirectory` within service config to point to `/mnt/dietpi_userdata/jellyfin` as well.
