### PR TITLE
HAProxy: expose prometheus-exporter

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7393,6 +7393,7 @@ backend nodes
 	bind *:1338
 	stats enable
 	stats uri /
+	http-request use-service prometheus-exporter if { path /metrics }
 	stats hide-version
 	stats auth admin:$GLOBAL_PW
 _EOF_


### PR DESCRIPTION
Building HAProxy with support for Prometheus is not enough, the service needs to be exported via the `/metrics` endpoint.

Source: https://www.haproxy.com/blog/haproxy-exposes-a-prometheus-metrics-endpoint/

This needs to be applied to the current Beta v8.6.0.

<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
