### PR TITLE
DietPi-Software | Raspotify

### DIFF
--- a/.update/patches
+++ b/.update/patches
@@ -753,7 +753,24 @@ Patch_8_7()
 	then
 		G_DIETPI-NOTIFY 2 'Removing conflicting Webmin systemd service...'
 		G_EXEC rm /etc/systemd/system/webmin.service
-	fi	
+	fi
+
+	# https://github.com/MichaIng/DietPi/issues/5602
+	if [[ $G_HW_ARCH == 1 && -f '/etc/apt/sources.list.d/raspotify.list' ]]
+	then
+		G_DIETPI-NOTIFY 2 'Downgrading Raspotify to the last version supported on your ARMv6 SBC...'
+		# Remove repo if present and remove package to avoid downgrade error
+		G_EXEC rm /etc/apt/sources.list.d/raspotify.list
+		[[ -f '/etc/apt/trusted.gpg.d/dietpi-raspotify.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-raspotify.gpg
+		G_AGUP
+		if dpkg-query -s raspotify &> /dev/null
+		then
+			G_EXEC dpkg -r raspotify
+			G_EXEC curl -fL 'https://github.com/dtcooper/raspotify/releases/download/0.31.8.1/raspotify_0.31.8.1.librespot.v0.3.1-54-gf4be9bb_armhf.deb' -o raspotify.deb
+			G_AGI ./raspotify.deb
+			G_EXEC_HOHALT=1 G_EXEC rm raspotify.deb
+		fi
+	fi
 }
 
 # v6.35 => v7 migration

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ v8.7
 
 Bug fixes:
 - DietPi-Software | Webmin: Resolved an issue where the service failed to start. Many thanks to @alucard87pl for reporting this issue: https://github.com/MichaIng/DietPi/issues/5594
+- DietPi-Software | Raspotify: Resolved an issue where the service failed to start on ARMv6 RPi models (Raspberry Pi 1 and Zero (1)). It is not supported by latest Raspotify anymore, so we install the latest ARMv6-compatible version instead. Many thanks to @dvelluto for reporting this issue: https://github.com/MichaIng/DietPi/issues/5602
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11554,19 +11554,28 @@ _EOF_
 
 			Banner_Installing # https://dtcooper.github.io/raspotify/#hard-installation
 
-			# APT key
-			local url='https://dtcooper.github.io/raspotify/key.asc'
-			G_CHECK_URL "$url"
-			G_EXEC eval "curl -sSfL '$url' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-raspotify.gpg --yes"
+			# ARMv6 - 0.31.8.1 is the last version supporting ARMv6
+			if (( $G_HW_ARCH == 1 ))
+			then
+				Download_Install "https://github.com/dtcooper/raspotify/releases/download/0.31.8.1/raspotify_0.31.8.1.librespot.v0.3.1-54-gf4be9bb_armhf.deb"
 
-			# APT list
-			G_EXEC eval 'echo '\''deb https://dtcooper.github.io/raspotify/ raspotify main'\'' > /etc/apt/sources.list.d/raspotify.list'
-			G_AGUP
+			# ARMv7/ARMv8/AMD64
+			else
+				# APT key
+				local url='https://dtcooper.github.io/raspotify/key.asc'
+				G_CHECK_URL "$url"
+				G_EXEC eval "curl -sSfL '$url' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-raspotify.gpg --yes"
 
-			# APT package
-			G_AGI raspotify
+				# APT list
+				G_EXEC eval 'echo '\''deb https://dtcooper.github.io/raspotify/ raspotify main'\'' > /etc/apt/sources.list.d/raspotify.list'
+				G_AGUP
+
+				# APT package
+				G_AGI raspotify
+			fi
+			
+			# Stop service
 			G_EXEC systemctl stop raspotify
-
 		fi
 
 		software_id=169 # Google AIY

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11557,7 +11557,7 @@ _EOF_
 			# ARMv6 - 0.31.8.1 is the last version supporting ARMv6
 			if (( $G_HW_ARCH == 1 ))
 			then
-				Download_Install "https://github.com/dtcooper/raspotify/releases/download/0.31.8.1/raspotify_0.31.8.1.librespot.v0.3.1-54-gf4be9bb_armhf.deb"
+				Download_Install 'https://github.com/dtcooper/raspotify/releases/download/0.31.8.1/raspotify_0.31.8.1.librespot.v0.3.1-54-gf4be9bb_armhf.deb'
 
 			# ARMv7/ARMv8/AMD64
 			else

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11554,12 +11554,12 @@ _EOF_
 
 			Banner_Installing # https://dtcooper.github.io/raspotify/#hard-installation
 
-			# ARMv6 - 0.31.8.1 is the last version supporting ARMv6
+			# ARMv6: 0.31.8.1 is the last version supporting ARMv6: https://github.com/dtcooper/raspotify/commit/345f15c
 			if (( $G_HW_ARCH == 1 ))
 			then
 				Download_Install 'https://github.com/dtcooper/raspotify/releases/download/0.31.8.1/raspotify_0.31.8.1.librespot.v0.3.1-54-gf4be9bb_armhf.deb'
 
-			# ARMv7/ARMv8/AMD64
+			# ARMv7/ARMv8/x86_64
 			else
 				# APT key
 				local url='https://dtcooper.github.io/raspotify/key.asc'


### PR DESCRIPTION
Raspotify v0.31.8.1 is the last version supporting ARMv6. Installation has been adjusted to pull this version on ARMv6 systems.
