### PR TITLE
DietPi-Software | Bazarr

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Enhancements:
 - DietPi-Globals | The network connection checks during first boot, dietpi-update and dietpi-software installs have been enhanced: The timeout can be doubled and network settings can be entered right from the error handler menu. A dedicated IPv6 check is done and if it fails, IPv6 can be disabled from the error handler menu. The DNS check does no ping any more, but only tries to resolve the test domain.
 - DietPi-Software | Prowlarr: Logging is now done to /var/log/prowlarr as intended. For this change to take effect, existing instances need to be reinstalled once: dietpi-software reinstall 151
 - DietPi-Software | vaultwarden: DEB packages are now hosted on dietpi.com, replacing the time consuming in-place compiling. This also solves issues where builds failed due to insufficient memory.
+- DietPi-Software | Pi-hole: The web interface and web server dialogues from the Pi-hole installer are now skipped. Since we force the installation of a web server and PHP, but allow to choose the web server freely, not installing the web interface as well as installing Pi-hole Lighttpd setup are no reasonable choices.
 
 Bug fixes:
 - DietPi-Software | Resolved an issue where "cgroup_enable=memory" was unnecessarily added multiple times on Raspberry Pi when installing or reinstalling container engines. Many thanks to @mdsjip for fixing this issue: https://github.com/MichaIng/DietPi/pull/5600
@@ -21,6 +22,7 @@ Bug fixes:
 - DietPi-Software | Unbound: Resolved an issue on Debian Bookworm where the service failed to start because of missing root trust anchors. Many thanks to @smittyj for reporting this issue: https://github.com/MichaIng/DietPi/issues/5612
 - DietPi-Software | Tailscale: Resolved an issue where APT updates failed after Tailscale was uninstalled. Many thanks to @SlowRaid for resolving this issue: https://github.com/MichaIng/DietPi/issues/5623
 - DietPi-Software | Pi-hole: Resolved an issue where the dialog windows looked ugly when executed via SSH and keyboard inputs caused characters to appear on the screen.
+- DietPi-Software | Bazarr: Worked around an issue where on ARMv8 systems the service failed to start since for some reason the previously working aarch64 unrar binary (which is actually an ARMv5tel one) does not work on recent arm64 Debian anymore. A fix with a real aarch64 binary has been sent upstream. Many thanks to @dioxide0363 for reporting this issue: https://dietpi.com/forum/t/bazarr-fails-to-start-on-freshly-installed-dietpi/13658
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/5658
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,7 +12,7 @@ Enhancements:
 - DietPi-Globals | The network connection checks during first boot, dietpi-update and dietpi-software installs have been enhanced: The timeout can be doubled and network settings can be entered right from the error handler menu. A dedicated IPv6 check is done and if it fails, IPv6 can be disabled from the error handler menu. The DNS check does no ping any more, but only tries to resolve the test domain.
 - DietPi-Software | Prowlarr: Logging is now done to /var/log/prowlarr as intended. For this change to take effect, existing instances need to be reinstalled once: dietpi-software reinstall 151
 - DietPi-Software | vaultwarden: DEB packages are now hosted on dietpi.com, replacing the time consuming in-place compiling. This also solves issues where builds failed due to insufficient memory.
-- DietPi-Software | Pi-hole: The web interface and web server dialogues from the Pi-hole installer are now skipped. Since we force the installation of a web server and PHP, but allow to choose the web server freely, not installing the web interface as well as installing Pi-hole Lighttpd setup are no reasonable choices.
+- DietPi-Software | Pi-hole: The web interface and web server dialogues from the Pi-hole installer are now skipped. Since we force the installation of a web server and PHP, but allow to choose the web server freely, not installing the web interface as well as installing Pi-hole's Lighttpd setup are no reasonable choices.
 
 Bug fixes:
 - DietPi-Software | Resolved an issue where "cgroup_enable=memory" was unnecessarily added multiple times on Raspberry Pi when installing or reinstalling container engines. Many thanks to @mdsjip for fixing this issue: https://github.com/MichaIng/DietPi/pull/5600

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10515,8 +10515,8 @@ _EOF_
 		fi
 
 		software_id=180 # Bazarr
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 ))
+		then
 			Banner_Installing # https://wiki.bazarr.media/Getting-Started/Installation/Linux/linux/
 
 			# Reinstall: Skip download and install, advice to use internal updater from web UI
@@ -10537,6 +10537,13 @@ _EOF_
 			G_EXEC cd /opt/bazarr
 			G_EXEC_OUTPUT=1 G_EXEC pip3 install --no-cache-dir -Ur requirements.txt
 			G_EXEC cd "$G_WORKING_DIR"
+
+			# Workaround for https://github.com/morpheus65535/bazarr/issues/1908 until https://github.com/morpheus65535/bazarr-binaries/pull/1 has been released
+			if (( $G_HW_ARCH == 3 )) && md5sum -c --status <<< '07a6371cc7db8493352739ce26b19ea1  /opt/bazarr/bin/Linux/aarch64/unrar/unrar'
+			then
+				G_EXEC curl -sSf 'https://raw.githubusercontent.com/morpheus65535/bazarr-binaries/ce98ece/bin/Linux/aarch64/unrar/unrar' -o /opt/bazarr/bin/Linux/aarch64/unrar/unrar
+				G_EXEC sed -i 's/07a6371cc7db8493352739ce26b19ea1/be7a08a75ffb1dcc5f8c6b16a75e822c/' /opt/bazarr/bazarr/utilities/binaries.json
+			fi
 
 			# Data dir
 			[[ -d '/mnt/dietpi_userdata/bazarr' ]] || G_EXEC mkdir /mnt/dietpi_userdata/bazarr
@@ -10603,7 +10610,6 @@ _EOF_
 					G_CONFIG_INJECT 'use_radarr[[:blank:]]*=' 'use_radarr = True' /mnt/dietpi_userdata/bazarr/config/config.ini '\[general\]'
 				fi
 			fi
-
 		fi
 
 		software_id=146 # Tautulli

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10541,7 +10541,9 @@ _EOF_
 			# Workaround for https://github.com/morpheus65535/bazarr/issues/1908 until https://github.com/morpheus65535/bazarr-binaries/pull/1 has been released
 			if (( $G_HW_ARCH == 3 )) && md5sum -c --status <<< '07a6371cc7db8493352739ce26b19ea1  /opt/bazarr/bin/Linux/aarch64/unrar/unrar'
 			then
-				G_EXEC curl -sSf 'https://raw.githubusercontent.com/morpheus65535/bazarr-binaries/ce98ece/bin/Linux/aarch64/unrar/unrar' -o /opt/bazarr/bin/Linux/aarch64/unrar/unrar
+				G_EXEC curl -sSfO 'https://raw.githubusercontent.com/morpheus65535/bazarr-binaries/ce98ece/bin/Linux/aarch64/unrar/unrar'
+				G_EXEC sha512sum -c --quiet <<< '645f25992dc99fce597dc3aa65654a74fc31a022951202786e69d61f73c3df33ad85b89df8535735e3b21faeaf4e63ff9c70929a060511125d415fd5308396ee  unrar'
+				G_EXEC mv {,/opt/bazarr/bin/Linux/aarch64/unrar/}unrar
 				G_EXEC sed -i 's/07a6371cc7db8493352739ce26b19ea1/be7a08a75ffb1dcc5f8c6b16a75e822c/' /opt/bazarr/bazarr/utilities/binaries.json
 			fi
 


### PR DESCRIPTION
fix dependency for ARMv8

```
root@DietPi4:~# uname -a
Linux DietPi4 5.15.32-v8+ #1538 SMP PREEMPT Thu Mar 31 19:40:39 BST 2022 aarch64 GNU/Linux
root@DietPi4:~#
root@DietPi4:~# journalctl -u bazarr
-- Journal begins at Mon 2022-07-11 23:09:38 CEST, ends at Mon 2022-07-11 23:24:54 CEST. --
Jul 11 23:24:42 DietPi4 systemd[1]: Started Bazarr (DietPi).
Jul 11 23:24:52 DietPi4 Bazarr[4359]: 2022-07-11 23:24:52,694 - root                             (7faea1d040) :  ERROR (init:209) - BAZARR requires a rar archive extraction utilities (unrar, unar) and it can't be found.
```
