### PR TITLE
Image | Add support for NanoPi R5S with hardware ID 76

### DIFF
--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -26,13 +26,13 @@ shopt -s extglob
 		[20]='x86_64 VM'
 		[21]='x86_64 PC'
 		[22]='Generic Device'
-		[29]='Generic Amlogic S922X'
-		[28]='Generic Amlogic S905'
-		[27]='Generic Allwinner H6'
-		[26]='Generic Allwinner H5'
-		[25]='Generic Allwinner H3'
-		[24]='Generic Rockchip RK3399'
 		[23]='Generic Rockchip RK3328'
+		[24]='Generic Rockchip RK3399'
+		[25]='Generic Allwinner H3'
+		[26]='Generic Allwinner H5'
+		[27]='Generic Allwinner H6'
+		[28]='Generic Amlogic S905'
+		[29]='Generic Amlogic S922X'
 		[30]='OrangePi PC'
 		[31]='OrangePi One'
 		[32]='OrangePi Zero (H2+)'
@@ -79,6 +79,7 @@ shopt -s extglob
 		[73]='ROCK Pi S'
 		[74]='Radxa Zero'
 		[75]='Container'
+		[76]='NanoPi R5S'
 	)
 
 	## Benchmark data arrays: aBENCH_XX[$HW_MODEL,${aBENCH_XX_INDEX[$HW_MODEL]}]

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,9 @@
 v8.7
 (2022-07-30)
 
+New images:
+- NanoPi R5S | Initial support for FriendlyELEC's new router SBC has been added, with three Ethernet ports, up to 2.5 Gbps, based on the new Rockchip RK3568 SoC.
+
 New software:
 - Readarr | The ebook manager of the Servarr family has been added as dietpi-software option.
 
@@ -1027,7 +1030,7 @@ v6.27
 (01/01/20)
 
 Changes / Improvements / Optimisations:
-- FriendlyARM ZeroPi | Initial hardware identifier (ID: 59) and support for this device has been added to DietPi. Many thanks to @Stephan for creating the related DietPi image: https://github.com/MichaIng/DietPi/issues/3221
+- FriendlyELEC ZeroPi | Initial hardware identifier (ID: 59) and support for this device has been added to DietPi. Many thanks to @Stephan for creating the related DietPi image: https://github.com/MichaIng/DietPi/issues/3221
 - RPi | An updated USBridgeSig Ethernet driver, as provided by allo.com, will be applied via postinst kernel script, until it has been merged into official RPi kernel: https://github.com/allocom/USBridgeSig/tree/master/ethernet
 - RPi4 | Added generic RPi4 revision code detection to include the new revisions [abc]03112 and potential new PCB v1.3 til v1.9 once released. Many thanks to @Joulinar for reporting the missing new revision code: https://github.com/MichaIng/DietPi/issues/3257#issuecomment-565370856
 - RPi4 | Since RPi4, bootloader and USB firmware is stored on an internal EEPROM, which is not updated/flashed by the firmware APT package installs automatically. The additional "rpi-eeprom" package comes with an EEPROM update script and boot service, which will now be installed on DietPi update and firstrun setup automatically, if RPi4 is detected. Those firmware updates include power consumption (hence heat emission) optimisations and enable additional boot methods, currently network boot and USB boot is planned as well. This was reason enough for us to implement it automatically for all RPi4 systems. Additionally you can actively install/update the EEPROM manually via dietpi-config > Advanced Options > Update RPi4 EEPROM firmware. For additional information, read the official docs: https://www.raspberrypi.org/documentation/hardware/raspberrypi/booteeprom.md Many thanks to @trueaspects for informing us about this important subject: https://github.com/MichaIng/DietPi/issues/3217

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -211,7 +211,7 @@ Available commands:
 	fi
 
 	# Available for (need to match highest value in dietpi-obtain_hw_model)
-	readonly MAX_G_HW_MODEL=75
+	readonly MAX_G_HW_MODEL=76
 	readonly MAX_G_HW_ARCH=10
 	#readonly MAX_G_DISTRO=7
 	# - 2D array (well, bash style)

--- a/dietpi/func/dietpi-obtain_hw_model
+++ b/dietpi/func/dietpi-obtain_hw_model
@@ -13,10 +13,11 @@
 	# - Called from /boot/dietpi/preboot, called by /etc/systemd/system/dietpi-preboot.service
 	#
 	# Developer note: Sync highest IDs with dietpi-software:
-	# - MAX_G_HW_MODEL=75
+	# - MAX_G_HW_MODEL=76
 	# - MAX_G_HW_ARCH=10
 	# - MAX_G_DISTRO=7
 	#
+	# G_HW_MODEL 76 NanoPi R5S
 	# G_HW_MODEL 75 Container
 	# G_HW_MODEL 74 Radxa Zero
 	# G_HW_MODEL 73 ROCK Pi S
@@ -85,18 +86,11 @@
 	# G_HW_CPUID 7 Amlogic S905
 	# G_HW_CPUID 8 Allwinner A64
 	# G_HW_CPUID 9 Rockchip RK3566
+	# G_HW_CPUID 10 Rockchip RK3568
 	# ----------------
-	# G_DISTRO 0 unknown/unsupported
-	# G_DISTRO 1 Debian Wheezy (No longer supported: https://dietpi.com/forum/t/dietpi-for-rpi-wheezy-support-ended-22nd-june-2016/360)
-	# G_DISTRO 2 Ubuntu 14.04 (No longer supported)
-	# G_DISTRO 3 Jessie (No longer supported: https://github.com/MichaIng/DietPi/issues/2332)
-	# G_DISTRO 4 Stretch (No longer supported: https://github.com/MichaIng/DietPi/pull/5068)
 	# G_DISTRO 5 Buster
 	# G_DISTRO 6 Bullseye
 	# G_DISTRO 7 Bookworm
-	# ----------------
-	# G_HW_ONBOARD_WIFI 0 Not set
-	# G_HW_ONBOARD_WIFI 1 RPi3/4/Zero W (BCM43438)
 	#////////////////////////////////////
 
 	#/////////////////////////////////////////////////////////////////////////////////////
@@ -311,7 +305,12 @@
 
 			G_HW_MODEL=$(mawk 'NR==1' "$FP_G_HW_MODEL_IDENTIFIER")
 
-			if (( $G_HW_MODEL == 75 )); then
+			if (( $G_HW_MODEL == 76 )); then
+
+				G_HW_MODEL_NAME='NanoPi R5S'
+				G_HW_CPUID=10
+
+			elif (( $G_HW_MODEL == 75 )); then
 
 				G_HW_MODEL_NAME='Container'
 				grep -q '^ID=raspbian' /etc/os-release && G_RASPBIAN=1


### PR DESCRIPTION
- NanoPi R5S | Initial support for FriendlyELEC's new router SBC has been added, with three Ethernet ports, up to 2.5 Gbps, based on the new Rockchip RK3568 SoC.