### PR TITLE
Beta v8.7.0

### DIFF
--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -112,7 +112,7 @@ exclude=
 case $DISTRO in
 	5) distro='buster'; [[ $HW_MODEL == 75 ]] || { G_DIETPI-NOTIFY 1 "Invalid distro \"$DISTRO\" passed, aborting..."; exit 1; };;
 	6) distro='bullseye' exclude=',gcc-8-base,gcc-9-base';;
-	7) distro='bookworm' exclude=',gcc-8-base,gcc-9-base,gcc-10-base,gcc-11-base'; [[ $HW_MODEL == 21 ]] && ((root_size+=256));; # Raise root size where required
+	7) distro='bookworm' exclude=',gcc-8-base,gcc-9-base,gcc-10-base,gcc-11-base'; [[ $HW_MODEL == 21 ]] && ((root_size+=384));; # Raise root size where required
 	*) G_DIETPI-NOTIFY 1 "Invalid distro \"$DISTRO\" passed, aborting..."; exit 1;;
 esac
 

--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -88,15 +88,13 @@ esac
 
 if [[ $VMTYPE ]]
 then
-	[[ $HW_MODEL == 20 ]] || { G_DIETPI-NOTIFY 1 "Unsupported option \"-v\" (virtual machine type) for hardware model \"$HW_MODEL\" pased, aborting..."; exit 1; }
+	[[ $HW_MODEL == 20 ]] || { G_DIETPI-NOTIFY 1 "Unsupported option \"-v\" (virtual machine type) for hardware model \"$HW_MODEL\" passed, aborting..."; exit 1; }
 	[[ $VMTYPE =~ ^(raw|vbox|vmware|esxi|hyperv|utm|parallels|proxmox|all)$ ]] || { G_DIETPI-NOTIFY 1 "Invalid virtual machine type \"$VMTYPE\" passed, aborting..."; exit 1; }
 fi
 
 if [[ $EDITION ]]
 then
-	[[ $HW_MODEL == 0 || $HW_MODEL == 70 ]] || { G_DIETPI-NOTIFY 1 "Unsupported option \"-e\" (edition) for hardware model \"$HW_MODEL\" passed, aborting..."; exit 1; }
 	[[ $EDITION =~ ^(Amiberry|AlloGUI|all)$ ]] || { G_DIETPI-NOTIFY 1 "Invalid edition \"$EDITION\" passed, aborting..."; exit 1; }
-	[[ $EDITION == 'AlloGUI' || $HW_MODEL == 0 ]] || { G_DIETPI-NOTIFY 1 "Unsupported edition \"$EDITION\" for hardware model \"$HW_MODEL\" passed, aborting..."; exit 1; }
 fi
 
 # Check for valid target architecture and set variables accordingly
@@ -349,8 +347,13 @@ then
 
 	# Mount filesystems
 	G_EXEC mkdir rootfs
-	G_EXEC mount "${FP_LOOP}p2" rootfs
-	G_EXEC mount "${FP_LOOP}p1" rootfs/boot
+	if (( $boot_size ))
+	then
+		G_EXEC mount "${FP_LOOP}p2" rootfs
+		G_EXEC mount "${FP_LOOP}p1" rootfs/boot
+	else
+		G_EXEC mount "${FP_LOOP}p1" rootfs
+	fi
 
 	# Install Amiberry via automated first run setup
 	G_CONFIG_INJECT 'AUTO_SETUP_AUTOMATED=' 'AUTO_SETUP_AUTOMATED=1' rootfs/boot/dietpi.txt
@@ -367,9 +370,10 @@ then
 	G_EXEC losetup -d "$FP_LOOP"
 
 	bash -c "$(curl -sSf "https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.build/images/dietpi-imager")" 'DietPi-Imager' "$OUTPUT_IMG_NAME.img" || exit 1
+fi
 
 # AlloGUI edition: Pre-install Allo GUI with all managed audiophile software
-elif [[ $EDITION =~ ^(AlloGUI|all)$ ]]
+if [[ $EDITION =~ ^(AlloGUI|all)$ ]]
 then
 	G_EXEC mv "$OUTPUT_IMG_NAME.img" "${OUTPUT_IMG_NAME%_Amiberry}_AlloGUI.img"
 	OUTPUT_IMG_NAME="${OUTPUT_IMG_NAME%_Amiberry}_AlloGUI"
@@ -389,8 +393,13 @@ then
 
 	# Mount filesystems
 	G_EXEC mkdir rootfs
-	G_EXEC mount "${FP_LOOP}p2" rootfs
-	G_EXEC mount "${FP_LOOP}p1" rootfs/boot
+	if (( $boot_size ))
+	then
+		G_EXEC mount "${FP_LOOP}p2" rootfs
+		G_EXEC mount "${FP_LOOP}p1" rootfs/boot
+	else
+		G_EXEC mount "${FP_LOOP}p1" rootfs
+	fi
 
 	# Install Allo GUI via automated first run setup right here
 	G_CONFIG_INJECT 'AUTO_SETUP_AUTOMATED=' 'AUTO_SETUP_AUTOMATED=1' rootfs/boot/dietpi.txt
@@ -485,7 +494,7 @@ _EOF_
 	bash -c "$(curl -sSf "https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.build/images/dietpi-imager")" 'DietPi-Imager' "$OUTPUT_IMG_NAME.img" || exit 1
 fi
 
-[[ $VMTYPE ]] || exit 0
+[[ $VMTYPE && $VMTYPE != 'raw' ]] || exit 0
 
 ##########################################
 # Virtual machines

--- a/.build/software/Amiberry/build.bash
+++ b/.build/software/Amiberry/build.bash
@@ -6,11 +6,10 @@
 G_DIETPI-NOTIFY 2 "Amiberry will be built for platform: \e[33m$PLATFORM"
 
 # APT dependencies
-arch='armhf' opengl_flags=('--enable-video-opengles2' '--disable-video-opengl')
+opengl_flags=('--enable-video-opengles2' '--disable-video-opengl')
 adeps_build=('autoconf' 'make' 'g++' 'pkg-config' 'libdrm-dev' 'libgbm-dev' 'libudev-dev' 'libxml2-dev' 'libpng-dev' 'libfreetype6-dev' 'libflac-dev' 'libmpg123-dev' 'libmpeg2-4-dev' 'libasound2-dev' 'wget' 'kbd')
 adeps=('libdrm2' 'libgl1-mesa-dri' 'libgbm1' 'libegl1' 'libudev1' 'libxml2' 'libpng16-16' 'libfreetype6' 'libflac8' 'libmpg123-0' 'libmpeg2-4' 'libasound2' 'wget' 'kbd')
-(( $G_HW_ARCH == 3 )) && arch='arm64'
-(( $G_HW_ARCH == 10 )) && arch='amd64' opengl_flags=('--disable-video-opengles2' '--enable-video-opengl') adeps_build+=('libgl1-mesa-dev') adeps+=('libgl1') || adeps_build+=('libgles2-mesa-dev') adeps+=('libgles2')
+(( $G_HW_ARCH == 10 )) && opengl_flags=('--disable-video-opengles2' '--enable-video-opengl') adeps_build+=('libgl1-mesa-dev') adeps+=('libgl1') || adeps_build+=('libgles2-mesa-dev') adeps+=('libgles2')
 # - wget: Used for WHDLoad database update: https://github.com/midwan/amiberry/commit/d6c103e3310bcf75c2d72a15849fbdf5eb7432b5
 # - kbd: For "chvt" used in systemd unit as SDL2 spams the console with every key press
 if [[ $PLATFORM == 'rpi'* ]]
@@ -187,11 +186,11 @@ grep -q 'raspbian' /etc/os-release && DEPS_APT_VERSIONED=$(sed 's/+rp[it][0-9]\+
 # - control
 cat << _EOF_ > "$DIR/DEBIAN/control"
 Package: amiberry
-Version: $v_ami-dietpi1
-Architecture: $arch
+Version: $v_ami-dietpi2
+Architecture: $(dpkg --print-architecture)
 Maintainer: MichaIng <micha@dietpi.com>
 Date: $(date -u '+%a, %d %b %Y %T %z')
-Standards-Version: 4.6.0.1
+Standards-Version: 4.6.1.0
 Installed-Size: $(du -sk "$DIR" | mawk '{print $1}')
 Depends:$DEPS_APT_VERSIONED
 Section: games

--- a/.build/software/Amiberry/build.bash
+++ b/.build/software/Amiberry/build.bash
@@ -43,7 +43,7 @@ else
 fi
 
 # Build libSDL2_image
-v_img='2.0.5'
+v_img='2.6.0'
 if [[ ! -d /tmp/SDL2_image-$v_img ]]
 then
 	G_DIETPI-NOTIFY 2 "Building libSDL2_image version \e[33m$v_img"

--- a/.build/software/Amiberry/build.bash
+++ b/.build/software/Amiberry/build.bash
@@ -62,7 +62,7 @@ else
 fi
 
 # Build libSDL2_ttf
-v_ttf='2.0.18'
+v_ttf='2.20.0'
 if [[ ! -d /tmp/SDL2_ttf-$v_ttf ]]
 then
 	G_DIETPI-NOTIFY 2 "Building libSDL2_ttf version \e[33m$v_ttf"

--- a/.build/software/vaultwarden/build.bash
+++ b/.build/software/vaultwarden/build.bash
@@ -1,0 +1,220 @@
+{
+. /boot/dietpi/func/dietpi-globals || exit 1
+
+G_AGUP
+G_AGDUG
+
+# APT dependencies: https://github.com/dani-garcia/vaultwarden/wiki/Building-binary#dependencies
+adeps_build=('gcc' 'libc6-dev' 'pkg-config' 'libssl-dev')
+adeps=('bash' 'libc6' 'openssl')
+(( $G_DISTRO > 6 )) && adeps+=('libssl3') || adeps+=('libssl1.1')
+G_AG_CHECK_INSTALL_PREREQ "${adeps_build[@]}"
+
+# Install Rust via https://rustup.rs/
+# - Needs to be installed in tmpfs, else builds fail in emulated 32-bit ARM environments: https://github.com/rust-lang/cargo/issues/8719
+export HOME='/tmp/vaultwarden'
+[[ -d $HOME ]] || G_EXEC mkdir "$HOME"
+G_EXEC cd "$HOME"
+G_EXEC curl -sSfL 'https://sh.rustup.rs' -o rustup-init.sh
+G_EXEC chmod +x rustup-init.sh
+G_EXEC_OUTPUT=1 G_EXEC ./rustup-init.sh -y --profile minimal --default-toolchain none
+G_EXEC_NOHALT=1 G_EXEC rm rustup-init.sh
+export PATH="$HOME/.cargo/bin:$PATH"
+
+version='1.25.1'
+G_DIETPI-NOTIFY 2 "Building vaultwarden version \e[33m$version"
+[[ -d vaultwarden-$version ]] && G_EXEC rm -R "vaultwarden-$version"
+G_EXEC curl -sSfLO "https://github.com/dani-garcia/vaultwarden/archive/$version.tar.gz"
+G_EXEC tar xf "$version.tar.gz"
+G_EXEC rm "$version.tar.gz"
+G_EXEC cd "vaultwarden-$version"
+G_EXEC_OUTPUT=1 G_EXEC cargo build --features sqlite --release
+G_EXEC rustup self uninstall -y
+G_EXEC strip --remove-section=.comment --remove-section=.note target/release/vaultwarden
+
+# Build DEB package
+G_DIETPI-NOTIFY 2 'Building vaultwarden DEB package'
+G_EXEC cd "$HOME"
+grep -q 'raspbian' /etc/os-release && DIR='vaultwarden_armv6l' || DIR="vaultwarden_$G_HW_ARCH_NAME"
+[[ -d $DIR ]] && G_EXEC rm -R "$DIR"
+G_EXEC mkdir -p "$DIR/"{DEBIAN,opt/vaultwarden,mnt/dietpi_userdata/vaultwarden,lib/systemd/system}
+
+# - Copy files in place
+G_EXEC mv "vaultwarden-$version/target/release/vaultwarden" "$DIR/opt/vaultwarden/"
+G_EXEC mv "vaultwarden-$version/.env.template" "$DIR/mnt/dietpi_userdata/vaultwarden/vaultwarden.env"
+G_EXEC rm -R "vaultwarden-$version"
+
+# - web vault
+wv_version='2022.6.2'
+G_DIETPI-NOTIFY 2 "Downloading web vault version \e[33m$wv_version"
+G_EXEC curl -sSfLO "https://github.com/dani-garcia/bw_web_builds/releases/download/v$wv_version/bw_web_v$wv_version.tar.gz"
+G_EXEC tar xf "bw_web_v$wv_version.tar.gz" --one-top-level="$DIR/mnt/dietpi_userdata/vaultwarden"
+G_EXEC rm "bw_web_v$wv_version.tar.gz"
+
+# - Configuration
+G_CONFIG_INJECT 'DATA_FOLDER=' 'DATA_FOLDER=/mnt/dietpi_userdata/vaultwarden' "$DIR/mnt/dietpi_userdata/vaultwarden/vaultwarden.env"
+G_CONFIG_INJECT 'ROCKET_ADDRESS=' 'ROCKET_ADDRESS=0.0.0.0' "$DIR/mnt/dietpi_userdata/vaultwarden/vaultwarden.env"
+G_CONFIG_INJECT 'ROCKET_PORT=' 'ROCKET_PORT=8001' "$DIR/mnt/dietpi_userdata/vaultwarden/vaultwarden.env" # Avoid port conflict with IceCast
+G_CONFIG_INJECT 'ROCKET_TLS=' 'ROCKET_TLS={certs="./cert.pem",key="./privkey.pem"}' "$DIR/mnt/dietpi_userdata/vaultwarden/vaultwarden.env"
+G_CONFIG_INJECT 'WEB_VAULT_ENABLED=' 'WEB_VAULT_ENABLED=true' "$DIR/mnt/dietpi_userdata/vaultwarden/vaultwarden.env"
+
+# - systemd service
+cat << '_EOF_' > "$DIR/lib/systemd/system/vaultwarden.service"
+[Unit]
+Description=vaultwarden (DietPi)
+Documentation=https://github.com/dani-garcia/vaultwarden
+Wants=network-online.target
+After=network-online.target
+
+# Restart attempt only 5 times
+StartLimitIntervalSec=500
+StartLimitBurst=5
+
+[Service]
+# Server sometimes fails to start on startup, this should fix it
+Restart=on-failure
+RestartSec=5s
+# The user vaultwarden is run under. the working directory (see below) should allow write and read access to this user
+User=vaultwarden
+# The location of the .env file for configuration
+EnvironmentFile=/mnt/dietpi_userdata/vaultwarden/vaultwarden.env
+# The location of the compiled binary
+ExecStart=/opt/vaultwarden/vaultwarden
+# Set reasonable connection and process limits
+LimitNOFILE=1048576
+LimitNPROC=64
+# Isolate vaultwarden from the rest of the system
+PrivateTmp=true
+PrivateDevices=true
+ProtectHome=true
+ProtectSystem=strict
+# Only allow writes to the following directory and set it to the working directory (user and password data are stored here)
+WorkingDirectory=/mnt/dietpi_userdata/vaultwarden
+ReadWritePaths=-/mnt/dietpi_userdata/vaultwarden
+# Allow vaultwarden to bind ports in the range of 0-1024
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+[Install]
+WantedBy=multi-user.target
+_EOF_
+
+# - Permissions
+G_EXEC find "$DIR" -type f -exec chmod 0644 {} +
+G_EXEC find "$DIR" -type d -exec chmod 0755 {} +
+G_EXEC chmod +x "$DIR/opt/vaultwarden/vaultwarden"
+
+# Control files
+
+# - conffiles
+echo '/mnt/dietpi_userdata/vaultwarden/vaultwarden.env' > "$DIR/DEBIAN/conffiles"
+
+# - postinst
+cat << '_EOF_' > "$DIR/DEBIAN/postinst"
+#!/bin/bash
+if [[ -d '/run/systemd/system' ]]
+then
+	if getent passwd vaultwarden > /dev/null
+	then
+		echo 'Configuring vaultwarden service user ...'
+		usermod -d /mnt/dietpi_userdata/vaultwarden -s /usr/sbin/nologin vaultwarden
+	else
+		echo 'Creating vaultwarden service user ...'
+		useradd -rMU -d /mnt/dietpi_userdata/vaultwarden -s /usr/sbin/nologin vaultwarden
+	fi
+
+	if [[ ! -f '/mnt/dietpi_userdata/vaultwarden/cert.pem' || ! -f '/mnt/dietpi_userdata/vaultwarden/privkey.pem' ]]
+	then
+		ip=$(ip -br a s dev "$(ip r l 0/0 | mawk '{print $5;exit}')" | mawk '{print $3;exit}') ip=${ip%/*}
+		openssl req -reqexts SAN -subj '/CN=DietPi Vaultwarden' -config <(cat /etc/ssl/openssl.cnf <(echo -ne "[SAN]\nsubjectAltName=DNS:$(</etc/hostname),IP:$ip\nbasicConstraints=CA:TRUE,pathlen:0"))\
+			-x509 -days 7200 -sha256 -extensions SAN -out /mnt/dietpi_userdata/vaultwarden/cert.pem\
+			-newkey rsa:4096 -nodes -keyout /mnt/dietpi_userdata/vaultwarden/privkey.pem
+	fi
+
+	echo 'Set vaultwarden userdata owner ...'
+	chown -R vaultwarden:vaultwarden /mnt/dietpi_userdata/vaultwarden
+
+	echo 'Configuring vaultwarden systemd service ...'
+	systemctl unmask vaultwarden
+	systemctl enable --now vaultwarden
+fi
+_EOF_
+
+# - prerm
+cat << '_EOF_' > "$DIR/DEBIAN/prerm"
+#!/bin/sh
+if [ -d '/run/systemd/system' ] && [ -f '/lib/systemd/system/vaultwarden.service' ]
+then
+	echo 'Deconfiguring vaultwarden systemd service ...'
+	systemctl unmask vaultwarden
+	systemctl disable --now vaultwarden
+fi
+_EOF_
+
+# - postrm
+cat << '_EOF_' > "$DIR/DEBIAN/postrm"
+#!/bin/sh
+if [ "$1" = 'purge' ]
+then
+	if [ -d '/etc/systemd/system/vaultwarden.service.d' ]
+	then
+		echo 'Removing vaultwarden systemd service overrides ...'
+		rm -Rv /etc/systemd/system/vaultwarden.service.d
+	fi
+
+	if getent passwd vaultwarden > /dev/null
+	then
+		echo 'Removing vaultwarden service user ...'
+		userdel vaultwarden
+	fi
+
+	if getent group vaultwarden > /dev/null
+	then
+		echo 'Removing vaultwarden service group ...'
+		groupdel vaultwarden
+	fi
+fi
+_EOF_
+
+G_EXEC chmod +x "$DIR/DEBIAN/"{postinst,prerm,postrm}
+
+# - md5sums
+find "$DIR" ! \( -path "$DIR/DEBIAN" -prune \) -type f -exec md5sum {} + | sed "s|$DIR/||" > "$DIR/DEBIAN/md5sums"
+
+# - Obtain DEB dependency versions
+DEPS_APT_VERSIONED=
+for i in "${adeps[@]}"
+do
+	DEPS_APT_VERSIONED+=" $i (>= $(dpkg-query -Wf '${VERSION}' "$i")),"
+done
+DEPS_APT_VERSIONED=${DEPS_APT_VERSIONED%,}
+# shellcheck disable=SC2001
+grep -q 'raspbian' /etc/os-release && DEPS_APT_VERSIONED=$(sed 's/+rp[it][0-9]\+)/)/g' <<< "$DEPS_APT_VERSIONED") || DEPS_APT_VERSIONED=$(sed 's/+b[0-9]\+)/)/g' <<< "$DEPS_APT_VERSIONED")
+
+# - control
+cat << _EOF_ > "$DIR/DEBIAN/control"
+Package: vaultwarden
+Version: $version-dietpi1
+Architecture: $(dpkg --print-architecture)
+Maintainer: MichaIng <micha@dietpi.com>
+Date: $(date -u '+%a, %d %b %Y %T %z')
+Standards-Version: 4.6.1.0
+Installed-Size: $(du -sk "$DIR" | mawk '{print $1}')
+Depends:$DEPS_APT_VERSIONED
+Section: misc
+Priority: optional
+Homepage: https://github.com/dani-garcia/vaultwarden
+Vcs-Git: https://github.com/dani-garcia/vaultwarden.git
+Vcs-Browser: https://github.com/dani-garcia/vaultwarden
+Description: Alternative implementation of the Bitwarden server API written in
+ Rust and compatible with upstream Bitwarden clients, perfect for self-hosted
+ deployment where running the official resource-heavy service might not be ideal.
+_EOF_
+G_CONFIG_INJECT 'Installed-Size: ' "Installed-Size: $(du -sk "$DIR" | mawk '{print $1}')" "$DIR/DEBIAN/control"
+
+# Build DEB package
+G_EXEC rm -Rf "$DIR.deb"
+G_EXEC_OUTPUT=1 G_EXEC dpkg-deb -b "$DIR"
+G_EXEC rm -Rf "$DIR"
+
+exit 0
+}

--- a/.build/software/vaultwarden/container_build.bash
+++ b/.build/software/vaultwarden/container_build.bash
@@ -21,7 +21,7 @@ case $G_HW_ARCH_NAME in
 	'x86_64') export G_HW_ARCH=10;;
 	*) G_DIETPI-NOTIFY 1 "Unsupported host system architecture \"$G_HW_ARCH_NAME\" detected, aborting..."; exit 1;;
 esac
-readonly G_PROGRAM_NAME='DietPi-Amiberry_container_setup'
+readonly G_PROGRAM_NAME='DietPi-vaultwarden_container_setup'
 G_CHECK_ROOT_USER
 G_CHECK_ROOTFS_RW
 readonly FP_ORIGIN=$PWD # Store origin dir
@@ -32,12 +32,12 @@ G_EXEC cd "$FP_ORIGIN" # Process everything in origin dir instead of /tmp/$G_PRO
 # Process inputs
 ##########################################
 DISTRO=
-PLATFORM=
+ARCH=
 while (( $# ))
 do
 	case $1 in
 		'-d') shift; DISTRO=$1;;
-		'-p') shift; PLATFORM=$1;;
+		'-a') shift; ARCH=$1;;
 		*) G_DIETPI-NOTIFY 1 "Invalid input \"$1\", aborting..."; exit 1;;
 	esac
 	shift
@@ -50,19 +50,20 @@ case $DISTRO in
 	*) G_DIETPI-NOTIFY 1 "Invalid distro \"$DISTRO\" passed, aborting..."; exit 1;;
 esac
 image=
-case $PLATFORM in
-        'rpi'[1-4]) image="DietPi_Container-ARMv6-${distro^}";;
-	'c1'|'xu4'|'RK3288'|'sun8i'|'s812') image="DietPi_Container-ARMv7-${distro^}";;
-	'rpi'[34]'-64-dmx'|'AMLSM1'|'n2'|'a64') image="DietPi_Container-ARMv8-${distro^}";;
-	'x86-64') image="DietPi_Container-x86_64-${distro^}";;
-	*) G_DIETPI-NOTIFY 1 "Invalid platform \"$PLATFORM\" passed, aborting..."; exit 1;;
+arch=
+case $ARCH in
+	1) image="DietPi_Container-ARMv6-${distro^}" arch='armv6l';;
+	2) image="DietPi_Container-ARMv7-${distro^}" arch='armv7l';;
+	3) image="DietPi_Container-ARMv8-${distro^}" arch='aarch64';;
+	10) image="DietPi_Container-x86_64-${distro^}" arch='x86_64';;
+	*) G_DIETPI-NOTIFY 1 "Invalid architecture \"$ARCH\" passed, aborting..."; exit 1;;
 esac
 
 ##########################################
 # Dependencies
 ##########################################
 apackages=('7zip' 'parted' 'fdisk' 'systemd-container')
-[[ $PLATFORM == 'x86-64' ]] || apackages+=('qemu-user-static' 'binfmt-support')
+(( $G_HW_ARCH == $ARCH || ( $G_HW_ARCH < 10 && $G_HW_ARCH > $ARCH ) )) || apackages+=('qemu-user-static' 'binfmt-support')
 G_AG_CHECK_INSTALL_PREREQ "${apackages[@]}"
 
 ##########################################
@@ -89,23 +90,12 @@ G_EXEC mkdir rootfs
 G_EXEC mount "${FP_LOOP}p1" rootfs
 
 # Automated build
-cat << '_EOF_' > rootfs/etc/rc.local || exit 1
+cat << _EOF_ > rootfs/etc/rc.local || exit 1
 #!/bin/dash
-infocmp "$TERM" > /dev/null 2>&1 || TERM='dumb'
-echo '[ INFO ] Running Amiberry build script...'
-_EOF_
-
-# - RPi 64-bit: Add RPi repo, ARMv6 container images contain it already
-[[ $PLATFORM == 'rpi'[34]'-64-dmx' ]] && cat << _EOF_ >> rootfs/etc/rc.local
-echo 'deb https://archive.raspberrypi.org/debian/ ${distro/bookworm/bullseye} main' > /etc/apt/sources.list.d/raspi.list
-curl -sSf 'https://archive.raspberrypi.org/debian/pool/main/r/raspberrypi-archive-keyring/raspberrypi-archive-keyring_2021.1.1+rpt1_all.deb' -o /tmp/keyring.deb
-dpkg -i /tmp/keyring.deb
-rm -v /tmp/keyring.deb
-_EOF_
-
-cat << _EOF_ >> rootfs/etc/rc.local || exit 1
-bash -c "\$(curl -sSf 'https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.build/software/Amiberry/build.bash')" 'DietPi-Amiberry_build' '$PLATFORM'
-mv -v '/tmp/amiberry_$PLATFORM.deb' '/amiberry_$PLATFORM.deb'
+infocmp "\$TERM" > /dev/null 2>&1 || TERM='dumb'
+echo '[ INFO ] Running vaultwarden build script...'
+bash -c "\$(curl -sSf 'https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.build/software/vaultwarden/build.bash')"
+mv -v '/tmp/vaultwarden/vaultwarden_$arch.deb' '/vaultwarden_$arch.deb'
 poweroff
 _EOF_
 G_EXEC chmod +x rootfs/etc/rc.local
@@ -118,5 +108,5 @@ G_EXEC eval 'echo -e '\''[Unit]\nAfter=dietpi-postboot.service'\'' > rootfs/etc/
 # Boot container
 ##########################################
 systemd-nspawn -bD rootfs --bind="$FP_LOOP"{,p1} --bind=/dev/disk
-[[ -f rootfs/amiberry_$PLATFORM.deb ]] || exit 1
+[[ -f rootfs/vaultwarden_$arch.deb ]] || exit 1
 }

--- a/.github/workflows/vaultwarden.yml
+++ b/.github/workflows/vaultwarden.yml
@@ -2,19 +2,19 @@ name: vaultwarden
 on:
   workflow_dispatch:
     inputs:
-      architecture:
-        description: 'Target architecture index to build vaultwarden for (1, 2, 3 or 10)'
+      arch:
+        description: 'Target architecture index: 1, 2, 3, 10 or all'
         required: true
       distro:
-        description: 'Debian version index to build vaultwarden for (5, 6, 7)'
+        description: 'Target Debian version index: 5, 6, 7 or all'
         required: true
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.inputs.architecture }}-${{ github.event.inputs.distro }}
+  group: ${{ github.workflow }}-${{ github.event.inputs.arch }}-${{ github.event.inputs.distro }}
   cancel-in-progress: true
 permissions: {}
 jobs:
   armv6_buster:
-    if: ( github.event.inputs.platform == 1 || github.event.inputs.platform == 'all' ) && ( github.event.inputs.distro == 5 || github.event.inputs.distro == 'all' )
+    if: ( github.event.inputs.arch == 1 || github.event.inputs.arch == 'all' ) && ( github.event.inputs.distro == 5 || github.event.inputs.distro == 'all' )
     # https://github.com/actions/virtual-environments
     runs-on: ubuntu-22.04
     defaults:
@@ -30,11 +30,11 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/vaultwarden_armv6hf.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl -T rootfs/vaultwarden_armv6l.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
-        --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/vaultwarden_armv6hf.deb"]}'
+        --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/vaultwarden_armv6l.deb"]}'
   armv6_bullseye:
-    if: ( github.event.inputs.platform == 1 || github.event.inputs.platform == 'all' ) && ( github.event.inputs.distro == 6 || github.event.inputs.distro == 'all' )
+    if: ( github.event.inputs.arch == 1 || github.event.inputs.arch == 'all' ) && ( github.event.inputs.distro == 6 || github.event.inputs.distro == 'all' )
     # https://github.com/actions/virtual-environments
     runs-on: ubuntu-22.04
     defaults:
@@ -50,11 +50,11 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/vaultwarden_armv6hf.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl -T rootfs/vaultwarden_armv6l.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
-        --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/vaultwarden_armv6hf.deb"]}'
+        --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/vaultwarden_armv6l.deb"]}'
   armv6_bookworm:
-    if: ( github.event.inputs.platform == 1 || github.event.inputs.platform == 'all' ) && ( github.event.inputs.distro == 7 || github.event.inputs.distro == 'all' )
+    if: ( github.event.inputs.arch == 1 || github.event.inputs.arch == 'all' ) && ( github.event.inputs.distro == 7 || github.event.inputs.distro == 'all' )
     # https://github.com/actions/virtual-environments
     runs-on: ubuntu-22.04
     defaults:
@@ -70,12 +70,12 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/vaultwarden_armv6hf.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl -T rootfs/vaultwarden_armv6l.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
-        --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/vaultwarden_armv6hf.deb"]}'
+        --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/vaultwarden_armv6l.deb"]}'
 
   armv7_buster:
-    if: ( github.event.inputs.platform == 2 || github.event.inputs.platform == 'all' ) && ( github.event.inputs.distro == 5 || github.event.inputs.distro == 'all' )
+    if: ( github.event.inputs.arch == 2 || github.event.inputs.arch == 'all' ) && ( github.event.inputs.distro == 5 || github.event.inputs.distro == 'all' )
     # https://github.com/actions/virtual-environments
     runs-on: ubuntu-22.04
     defaults:
@@ -91,11 +91,11 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/vaultwarden_armhf.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl -T rootfs/vaultwarden_armv7l.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
-        --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/vaultwarden_armhf.deb"]}'
+        --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/vaultwarden_armv7l.deb"]}'
   armv7_bullseye:
-    if: ( github.event.inputs.platform == 2 || github.event.inputs.platform == 'all' ) && ( github.event.inputs.distro == 6 || github.event.inputs.distro == 'all' )
+    if: ( github.event.inputs.arch == 2 || github.event.inputs.arch == 'all' ) && ( github.event.inputs.distro == 6 || github.event.inputs.distro == 'all' )
     # https://github.com/actions/virtual-environments
     runs-on: ubuntu-22.04
     defaults:
@@ -111,11 +111,11 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/vaultwarden_armhf.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl -T rootfs/vaultwarden_armv7l.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
-        --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/vaultwarden_armhf.deb"]}'
+        --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/vaultwarden_armv7l.deb"]}'
   armv7_bookworm:
-    if: ( github.event.inputs.platform == 2 || github.event.inputs.platform == 'all' ) && ( github.event.inputs.distro == 7 || github.event.inputs.distro == 'all' )
+    if: ( github.event.inputs.arch == 2 || github.event.inputs.arch == 'all' ) && ( github.event.inputs.distro == 7 || github.event.inputs.distro == 'all' )
     # https://github.com/actions/virtual-environments
     runs-on: ubuntu-22.04
     defaults:
@@ -131,12 +131,12 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/vaultwarden_armhf.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl -T rootfs/vaultwarden_armv7l.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
-        --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/vaultwarden_armhf.deb"]}'
+        --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/vaultwarden_armv7l.deb"]}'
 
   armv8_buster:
-    if: ( github.event.inputs.platform == 3 || github.event.inputs.platform == 'all' ) && ( github.event.inputs.distro == 5 || github.event.inputs.distro == 'all' )
+    if: ( github.event.inputs.arch == 3 || github.event.inputs.arch == 'all' ) && ( github.event.inputs.distro == 5 || github.event.inputs.distro == 'all' )
     # https://github.com/actions/virtual-environments
     runs-on: ubuntu-22.04
     defaults:
@@ -152,11 +152,11 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/vaultwarden_arm64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl -T rootfs/vaultwarden_aarch64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
-        --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/vaultwarden_arm64.deb"]}'
+        --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/vaultwarden_aarch64.deb"]}'
   armv8_bullseye:
-    if: ( github.event.inputs.platform == 3 || github.event.inputs.platform == 'all' ) && ( github.event.inputs.distro == 6 || github.event.inputs.distro == 'all' )
+    if: ( github.event.inputs.arch == 3 || github.event.inputs.arch == 'all' ) && ( github.event.inputs.distro == 6 || github.event.inputs.distro == 'all' )
     # https://github.com/actions/virtual-environments
     runs-on: ubuntu-22.04
     defaults:
@@ -172,11 +172,11 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/vaultwarden_arm64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl -T rootfs/vaultwarden_aarch64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
-        --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/vaultwarden_arm64.deb"]}'
+        --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/vaultwarden_aarch64.deb"]}'
   armv8_bookworm:
-    if: ( github.event.inputs.platform == 3 || github.event.inputs.platform == 'all' ) && ( github.event.inputs.distro == 7 || github.event.inputs.distro == 'all' )
+    if: ( github.event.inputs.arch == 3 || github.event.inputs.arch == 'all' ) && ( github.event.inputs.distro == 7 || github.event.inputs.distro == 'all' )
     # https://github.com/actions/virtual-environments
     runs-on: ubuntu-22.04
     defaults:
@@ -192,12 +192,12 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/vaultwarden_arm64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl -T rootfs/vaultwarden_aarch64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
-        --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/vaultwarden_arm64.deb"]}'
+        --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/vaultwarden_aarch64.deb"]}'
 
   x86_64_buster:
-    if: ( github.event.inputs.platform == 10 || github.event.inputs.platform == 'all' ) && ( github.event.inputs.distro == 5 || github.event.inputs.distro == 'all' )
+    if: ( github.event.inputs.arch == 10 || github.event.inputs.arch == 'all' ) && ( github.event.inputs.distro == 5 || github.event.inputs.distro == 'all' )
     # https://github.com/actions/virtual-environments
     runs-on: ubuntu-22.04
     defaults:
@@ -213,11 +213,11 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/vaultwarden_amd64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl -T rootfs/vaultwarden_x86_64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
-        --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/vaultwarden_amd64.deb"]}'
+        --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/vaultwarden_x86_64.deb"]}'
   x86_64_bullseye:
-    if: ( github.event.inputs.platform == 10 || github.event.inputs.platform == 'all' ) && ( github.event.inputs.distro == 6 || github.event.inputs.distro == 'all' )
+    if: ( github.event.inputs.arch == 10 || github.event.inputs.arch == 'all' ) && ( github.event.inputs.distro == 6 || github.event.inputs.distro == 'all' )
     # https://github.com/actions/virtual-environments
     runs-on: ubuntu-22.04
     defaults:
@@ -233,11 +233,11 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/vaultwarden_amd64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl -T rootfs/vaultwarden_x86_64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
-        --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/vaultwarden_amd64.deb"]}'
+        --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/vaultwarden_x86_64.deb"]}'
   x86_64_bookworm:
-    if: ( github.event.inputs.platform == 10 || github.event.inputs.platform == 'all' ) && ( github.event.inputs.distro == 7 || github.event.inputs.distro == 'all' )
+    if: ( github.event.inputs.arch == 10 || github.event.inputs.arch == 'all' ) && ( github.event.inputs.distro == 7 || github.event.inputs.distro == 'all' )
     # https://github.com/actions/virtual-environments
     runs-on: ubuntu-22.04
     defaults:
@@ -253,6 +253,6 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/vaultwarden_amd64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl -T rootfs/vaultwarden_x86_64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
-        --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/vaultwarden_amd64.deb"]}'
+        --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/vaultwarden_x86_64.deb"]}'

--- a/.github/workflows/vaultwarden.yml
+++ b/.github/workflows/vaultwarden.yml
@@ -1,0 +1,258 @@
+name: vaultwarden
+on:
+  workflow_dispatch:
+    inputs:
+      architecture:
+        description: 'Target architecture index to build vaultwarden for (1, 2, 3 or 10)'
+        required: true
+      distro:
+        description: 'Debian version index to build vaultwarden for (5, 6, 7)'
+        required: true
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.architecture }}-${{ github.event.inputs.distro }}
+  cancel-in-progress: true
+permissions: {}
+jobs:
+  armv6_buster:
+    if: ( github.event.inputs.platform == 1 || github.event.inputs.platform == 'all' ) && ( github.event.inputs.distro == 5 || github.event.inputs.distro == 'all' )
+    # https://github.com/actions/virtual-environments
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: sh
+        working-directory: /dev/shm
+    steps:
+    - name: Start build container
+      run: sudo bash -c "G_GITOWNER=$GITHUB_REPOSITORY_OWNER G_GITBRANCH=${GITHUB_REF#refs/heads/}; $(curl -sSf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY_OWNER/DietPi/${GITHUB_REF#refs/heads/}/.build/software/vaultwarden/container_build.bash")" 'DietPi-Build_vaultwarden' -a 1 -d 5
+    - name: Upload package
+      run: |
+        [ -d ~/.ssh ] || mkdir ~/.ssh
+        umask 377
+        echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+        echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
+        curl -T rootfs/vaultwarden_armv6hf.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
+        --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/vaultwarden_armv6hf.deb"]}'
+  armv6_bullseye:
+    if: ( github.event.inputs.platform == 1 || github.event.inputs.platform == 'all' ) && ( github.event.inputs.distro == 6 || github.event.inputs.distro == 'all' )
+    # https://github.com/actions/virtual-environments
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: sh
+        working-directory: /dev/shm
+    steps:
+    - name: Start build container
+      run: sudo bash -c "G_GITOWNER=$GITHUB_REPOSITORY_OWNER G_GITBRANCH=${GITHUB_REF#refs/heads/}; $(curl -sSf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY_OWNER/DietPi/${GITHUB_REF#refs/heads/}/.build/software/vaultwarden/container_build.bash")" 'DietPi-Build_vaultwarden' -a 1 -d 6
+    - name: Upload package
+      run: |
+        [ -d ~/.ssh ] || mkdir ~/.ssh
+        umask 377
+        echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+        echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
+        curl -T rootfs/vaultwarden_armv6hf.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
+        --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/vaultwarden_armv6hf.deb"]}'
+  armv6_bookworm:
+    if: ( github.event.inputs.platform == 1 || github.event.inputs.platform == 'all' ) && ( github.event.inputs.distro == 7 || github.event.inputs.distro == 'all' )
+    # https://github.com/actions/virtual-environments
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: sh
+        working-directory: /dev/shm
+    steps:
+    - name: Start build container
+      run: sudo bash -c "G_GITOWNER=$GITHUB_REPOSITORY_OWNER G_GITBRANCH=${GITHUB_REF#refs/heads/}; $(curl -sSf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY_OWNER/DietPi/${GITHUB_REF#refs/heads/}/.build/software/vaultwarden/container_build.bash")" 'DietPi-Build_vaultwarden' -a 1 -d 7
+    - name: Upload package
+      run: |
+        [ -d ~/.ssh ] || mkdir ~/.ssh
+        umask 377
+        echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+        echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
+        curl -T rootfs/vaultwarden_armv6hf.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
+        --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/vaultwarden_armv6hf.deb"]}'
+
+  armv7_buster:
+    if: ( github.event.inputs.platform == 2 || github.event.inputs.platform == 'all' ) && ( github.event.inputs.distro == 5 || github.event.inputs.distro == 'all' )
+    # https://github.com/actions/virtual-environments
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: sh
+        working-directory: /dev/shm
+    steps:
+    - name: Start build container
+      run: sudo bash -c "G_GITOWNER=$GITHUB_REPOSITORY_OWNER G_GITBRANCH=${GITHUB_REF#refs/heads/}; $(curl -sSf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY_OWNER/DietPi/${GITHUB_REF#refs/heads/}/.build/software/vaultwarden/container_build.bash")" 'DietPi-Build_vaultwarden' -a 2 -d 5
+    - name: Upload package
+      run: |
+        [ -d ~/.ssh ] || mkdir ~/.ssh
+        umask 377
+        echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+        echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
+        curl -T rootfs/vaultwarden_armhf.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
+        --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/vaultwarden_armhf.deb"]}'
+  armv7_bullseye:
+    if: ( github.event.inputs.platform == 2 || github.event.inputs.platform == 'all' ) && ( github.event.inputs.distro == 6 || github.event.inputs.distro == 'all' )
+    # https://github.com/actions/virtual-environments
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: sh
+        working-directory: /dev/shm
+    steps:
+    - name: Start build container
+      run: sudo bash -c "G_GITOWNER=$GITHUB_REPOSITORY_OWNER G_GITBRANCH=${GITHUB_REF#refs/heads/}; $(curl -sSf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY_OWNER/DietPi/${GITHUB_REF#refs/heads/}/.build/software/vaultwarden/container_build.bash")" 'DietPi-Build_vaultwarden' -a 2 -d 6
+    - name: Upload package
+      run: |
+        [ -d ~/.ssh ] || mkdir ~/.ssh
+        umask 377
+        echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+        echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
+        curl -T rootfs/vaultwarden_armhf.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
+        --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/vaultwarden_armhf.deb"]}'
+  armv7_bookworm:
+    if: ( github.event.inputs.platform == 2 || github.event.inputs.platform == 'all' ) && ( github.event.inputs.distro == 7 || github.event.inputs.distro == 'all' )
+    # https://github.com/actions/virtual-environments
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: sh
+        working-directory: /dev/shm
+    steps:
+    - name: Start build container
+      run: sudo bash -c "G_GITOWNER=$GITHUB_REPOSITORY_OWNER G_GITBRANCH=${GITHUB_REF#refs/heads/}; $(curl -sSf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY_OWNER/DietPi/${GITHUB_REF#refs/heads/}/.build/software/vaultwarden/container_build.bash")" 'DietPi-Build_vaultwarden' -a 2 -d 7
+    - name: Upload package
+      run: |
+        [ -d ~/.ssh ] || mkdir ~/.ssh
+        umask 377
+        echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+        echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
+        curl -T rootfs/vaultwarden_armhf.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
+        --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/vaultwarden_armhf.deb"]}'
+
+  armv8_buster:
+    if: ( github.event.inputs.platform == 3 || github.event.inputs.platform == 'all' ) && ( github.event.inputs.distro == 5 || github.event.inputs.distro == 'all' )
+    # https://github.com/actions/virtual-environments
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: sh
+        working-directory: /dev/shm
+    steps:
+    - name: Start build container
+      run: sudo bash -c "G_GITOWNER=$GITHUB_REPOSITORY_OWNER G_GITBRANCH=${GITHUB_REF#refs/heads/}; $(curl -sSf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY_OWNER/DietPi/${GITHUB_REF#refs/heads/}/.build/software/vaultwarden/container_build.bash")" 'DietPi-Build_vaultwarden' -a 3 -d 5
+    - name: Upload package
+      run: |
+        [ -d ~/.ssh ] || mkdir ~/.ssh
+        umask 377
+        echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+        echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
+        curl -T rootfs/vaultwarden_arm64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
+        --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/vaultwarden_arm64.deb"]}'
+  armv8_bullseye:
+    if: ( github.event.inputs.platform == 3 || github.event.inputs.platform == 'all' ) && ( github.event.inputs.distro == 6 || github.event.inputs.distro == 'all' )
+    # https://github.com/actions/virtual-environments
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: sh
+        working-directory: /dev/shm
+    steps:
+    - name: Start build container
+      run: sudo bash -c "G_GITOWNER=$GITHUB_REPOSITORY_OWNER G_GITBRANCH=${GITHUB_REF#refs/heads/}; $(curl -sSf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY_OWNER/DietPi/${GITHUB_REF#refs/heads/}/.build/software/vaultwarden/container_build.bash")" 'DietPi-Build_vaultwarden' -a 3 -d 6
+    - name: Upload package
+      run: |
+        [ -d ~/.ssh ] || mkdir ~/.ssh
+        umask 377
+        echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+        echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
+        curl -T rootfs/vaultwarden_arm64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
+        --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/vaultwarden_arm64.deb"]}'
+  armv8_bookworm:
+    if: ( github.event.inputs.platform == 3 || github.event.inputs.platform == 'all' ) && ( github.event.inputs.distro == 7 || github.event.inputs.distro == 'all' )
+    # https://github.com/actions/virtual-environments
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: sh
+        working-directory: /dev/shm
+    steps:
+    - name: Start build container
+      run: sudo bash -c "G_GITOWNER=$GITHUB_REPOSITORY_OWNER G_GITBRANCH=${GITHUB_REF#refs/heads/}; $(curl -sSf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY_OWNER/DietPi/${GITHUB_REF#refs/heads/}/.build/software/vaultwarden/container_build.bash")" 'DietPi-Build_vaultwarden' -a 3 -d 7
+    - name: Upload package
+      run: |
+        [ -d ~/.ssh ] || mkdir ~/.ssh
+        umask 377
+        echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+        echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
+        curl -T rootfs/vaultwarden_arm64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
+        --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/vaultwarden_arm64.deb"]}'
+
+  x86_64_buster:
+    if: ( github.event.inputs.platform == 10 || github.event.inputs.platform == 'all' ) && ( github.event.inputs.distro == 5 || github.event.inputs.distro == 'all' )
+    # https://github.com/actions/virtual-environments
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: sh
+        working-directory: /dev/shm
+    steps:
+    - name: Start build container
+      run: sudo bash -c "G_GITOWNER=$GITHUB_REPOSITORY_OWNER G_GITBRANCH=${GITHUB_REF#refs/heads/}; $(curl -sSf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY_OWNER/DietPi/${GITHUB_REF#refs/heads/}/.build/software/vaultwarden/container_build.bash")" 'DietPi-Build_vaultwarden' -a 10 -d 5
+    - name: Upload package
+      run: |
+        [ -d ~/.ssh ] || mkdir ~/.ssh
+        umask 377
+        echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+        echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
+        curl -T rootfs/vaultwarden_amd64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
+        --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/vaultwarden_amd64.deb"]}'
+  x86_64_bullseye:
+    if: ( github.event.inputs.platform == 10 || github.event.inputs.platform == 'all' ) && ( github.event.inputs.distro == 6 || github.event.inputs.distro == 'all' )
+    # https://github.com/actions/virtual-environments
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: sh
+        working-directory: /dev/shm
+    steps:
+    - name: Start build container
+      run: sudo bash -c "G_GITOWNER=$GITHUB_REPOSITORY_OWNER G_GITBRANCH=${GITHUB_REF#refs/heads/}; $(curl -sSf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY_OWNER/DietPi/${GITHUB_REF#refs/heads/}/.build/software/vaultwarden/container_build.bash")" 'DietPi-Build_vaultwarden' -a 10 -d 6
+    - name: Upload package
+      run: |
+        [ -d ~/.ssh ] || mkdir ~/.ssh
+        umask 377
+        echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+        echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
+        curl -T rootfs/vaultwarden_amd64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
+        --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/vaultwarden_amd64.deb"]}'
+  x86_64_bookworm:
+    if: ( github.event.inputs.platform == 10 || github.event.inputs.platform == 'all' ) && ( github.event.inputs.distro == 7 || github.event.inputs.distro == 'all' )
+    # https://github.com/actions/virtual-environments
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: sh
+        working-directory: /dev/shm
+    steps:
+    - name: Start build container
+      run: sudo bash -c "G_GITOWNER=$GITHUB_REPOSITORY_OWNER G_GITBRANCH=${GITHUB_REF#refs/heads/}; $(curl -sSf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY_OWNER/DietPi/${GITHUB_REF#refs/heads/}/.build/software/vaultwarden/container_build.bash")" 'DietPi-Build_vaultwarden' -a 10 -d 7
+    - name: Upload package
+      run: |
+        [ -d ~/.ssh ] || mkdir ~/.ssh
+        umask 377
+        echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+        echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
+        curl -T rootfs/vaultwarden_amd64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
+        --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/vaultwarden_amd64.deb"]}'

--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -631,8 +631,15 @@ shopt -s extglob
 	aSOFTWARE_NAME8_6[201]='ZeroTier'
 	aSOFTWARE_NAME8_6[202]='Rclone'
 
+	# v8.7
+	aSOFTWARE_NAME8_7=()
+	for i in "${!aSOFTWARE_NAME8_6[@]}"
+	do
+		aSOFTWARE_NAME8_7[$i]=${aSOFTWARE_NAME8_6[$i]}
+	done
+
 	# Pre-create software counter array so that we can see also software (available in newest version) with 0 installs
-	for i in "${aSOFTWARE_NAME8_6[@]}"
+	for i in "${aSOFTWARE_NAME8_7[@]}"
 	do
 		aSOFTWARE["$i"]=0
 	done

--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -637,6 +637,7 @@ shopt -s extglob
 	do
 		aSOFTWARE_NAME8_7[$i]=${aSOFTWARE_NAME8_6[$i]}
 	done
+	aSOFTWARE_NAME8_7[203]='Readarr'
 
 	# Pre-create software counter array so that we can see also software (available in newest version) with 0 installs
 	for i in "${aSOFTWARE_NAME8_7[@]}"

--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -26,13 +26,13 @@ shopt -s extglob
 		[20]='x86_64 VM'
 		[21]='x86_64 PC'
 		[22]='Generic Device'
-		[29]='Generic Amlogic S922X'
-		[28]='Generic Amlogic S905'
-		[27]='Generic Allwinner H6'
-		[26]='Generic Allwinner H5'
-		[25]='Generic Allwinner H3'
-		[24]='Generic Rockchip RK3399'
 		[23]='Generic Rockchip RK3328'
+		[24]='Generic Rockchip RK3399'
+		[25]='Generic Allwinner H3'
+		[26]='Generic Allwinner H5'
+		[27]='Generic Allwinner H6'
+		[28]='Generic Amlogic S905'
+		[29]='Generic Amlogic S922X'
 		[30]='OrangePi PC'
 		[31]='OrangePi One'
 		[32]='OrangePi Zero (H2+)'
@@ -79,6 +79,7 @@ shopt -s extglob
 		[73]='ROCK Pi S'
 		[74]='Radxa Zero'
 		[75]='Container'
+		[76]='NanoPi R5S'
 	)
 
 	## Benchmark data arrays: aBENCH_XX[$HW_MODEL,${aBENCH_XX_INDEX[$HW_MODEL]}]

--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -639,6 +639,7 @@ shopt -s extglob
 		aSOFTWARE_NAME8_7[$i]=${aSOFTWARE_NAME8_6[$i]}
 	done
 	aSOFTWARE_NAME8_7[203]='Readarr'
+	aSOFTWARE_NAME8_7[204]='Navidrome'
 
 	# Pre-create software counter array so that we can see also software (available in newest version) with 0 installs
 	for i in "${aSOFTWARE_NAME8_7[@]}"

--- a/.update/patches
+++ b/.update/patches
@@ -771,6 +771,13 @@ Patch_8_7()
 			G_EXEC_HOHALT=1 G_EXEC rm raspotify.deb
 		fi
 	fi
+
+	# https://github.com/MichaIng/DietPi/pull/5600
+	(( $G_HW_MODEL > 9 )) || while grep -q 'cgroup_enable=memory.* cgroup_enable=memory' /boot/cmdline.txt
+	do
+		G_DIETPI-NOTIFY 2 'Removing duplicate "cgroup_enable=memory" kernel command-line argument...'
+		G_EXEC sed -i 's/ cgroup_enable=memory//' /boot/cmdline.txt
+	done
 }
 
 # v6.35 => v7 migration

--- a/.update/patches
+++ b/.update/patches
@@ -753,7 +753,24 @@ Patch_8_7()
 	then
 		G_DIETPI-NOTIFY 2 'Removing conflicting Webmin systemd service...'
 		G_EXEC rm /etc/systemd/system/webmin.service
-	fi	
+	fi
+
+	# https://github.com/MichaIng/DietPi/issues/5602
+	if [[ $G_HW_ARCH == 1 && -f '/etc/apt/sources.list.d/raspotify.list' ]]
+	then
+		G_DIETPI-NOTIFY 2 'Downgrading Raspotify to the last version supported on your ARMv6 SBC...'
+		# Remove repo if present and remove package to avoid downgrade error
+		G_EXEC rm /etc/apt/sources.list.d/raspotify.list
+		[[ -f '/etc/apt/trusted.gpg.d/dietpi-raspotify.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-raspotify.gpg
+		G_AGUP
+		if dpkg-query -s raspotify &> /dev/null
+		then
+			G_EXEC dpkg -r raspotify
+			G_EXEC curl -fL 'https://github.com/dtcooper/raspotify/releases/download/0.31.8.1/raspotify_0.31.8.1.librespot.v0.3.1-54-gf4be9bb_armhf.deb' -o raspotify.deb
+			G_AGI ./raspotify.deb
+			G_EXEC_HOHALT=1 G_EXEC rm raspotify.deb
+		fi
+	fi
 }
 
 # v6.35 => v7 migration

--- a/.update/patches
+++ b/.update/patches
@@ -693,10 +693,7 @@ Patch_8_2()
 	fi
 }
 
-Patch_8_3()
-{
-	:
-}
+Patch_8_3(){ :; }
 
 Patch_8_4()
 {
@@ -746,14 +743,17 @@ Patch_8_4()
 	[[ -f '/boot/dietpi/.installed' ]] && grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[58\]=' /boot/dietpi/.installed && G_EXEC sed -i '/^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[58\]=/d' /boot/dietpi/.installed
 }
 
-Patch_8_5()
-{
-	:
-}
+Patch_8_5(){ :; }
+Patch_8_6(){ :; }
 
-Patch_8_6()
+Patch_8_7()
 {
-	:
+	# https://github.com/MichaIng/DietPi/issues/5594
+	if [[ -f '/boot/dietpi/.installed' && -f '/etc/systemd/system/webmin.service' && -f '/lib/systemd/system/webmin.service' ]] && grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[115\]=2' /boot/dietpi/.installed
+	then
+		G_DIETPI-NOTIFY 2 'Removing conflicting Webmin systemd service...'
+		G_EXEC rm /etc/systemd/system/webmin.service
+	fi	
 }
 
 # v6.35 => v7 migration

--- a/.update/pre-patches
+++ b/.update/pre-patches
@@ -200,5 +200,12 @@ _EOF_
 	G_EXEC ln -sf /etc/kernel/post{inst,rm}.d/dietpi-initramfs_cleanup
 fi
 
+# v8.7
+if (( $G_DIETPI_VERSION_CORE < 8 || ( $G_DIETPI_VERSION_CORE == 8 && $G_DIETPI_VERSION_SUB < 7 ) )) && [[ -f '/etc/apt/sources.list.d/dietpi-tailscale.list' && ! -f '/etc/apt/trusted.gpg.d/dietpi-tailscale.gpg' ]]
+then
+	G_DIETPI-NOTIFY 2 'Removing invalid Tailscale APT list'
+	G_EXEC rm /etc/apt/sources.list.d/dietpi-tailscale.list
+fi
+
 exit 0
 }

--- a/.update/version
+++ b/.update/version
@@ -14,15 +14,6 @@ G_MIN_DEBIAN=5
 # Alternative Git branch to automatically migrate to when Debian version is too low
 G_OLD_DEBIAN_BRANCH='stretch'
 # Live patches
-G_LIVE_PATCH_DESC=(
-	[0]='Fix Webmin service start after installation'
-	[1]='Fix missing APT list removal on Tailscale uninstall'
-)
-G_LIVE_PATCH_COND=(
-	[0]='grep -q '\''cat << ._EOF_. > /etc/systemd/system/webmin.service'\'' /boot/dietpi/dietpi-software'
-	[1]='grep -q '\''/tailscale.list'\'' /boot/dietpi/dietpi-software'
-)
-G_LIVE_PATCH=(
-	[0]='sed -i '\''/cat << ._EOF_. > .etc.systemd.system.webmin.service/,/_EOF_/d'\'' /boot/dietpi/dietpi-software'
-	[1]='sed -i '\''s|/tailscale.list|/dietpi-tailscale.list|'\'' /boot/dietpi/dietpi-software'
-)
+G_LIVE_PATCH_DESC=()
+G_LIVE_PATCH_COND=()
+G_LIVE_PATCH=()

--- a/.update/version
+++ b/.update/version
@@ -14,6 +14,6 @@ G_MIN_DEBIAN=5
 # Alternative Git branch to automatically migrate to when Debian version is too low
 G_OLD_DEBIAN_BRANCH='stretch'
 # Live patches
-G_LIVE_PATCH_DESC=()
-G_LIVE_PATCH_COND=()
-G_LIVE_PATCH=()
+G_LIVE_PATCH_DESC=('Fix Webmin service start after installation')
+G_LIVE_PATCH_COND=('grep -q '\''cat << ._EOF_. > /etc/systemd/system/webmin.service'\'' /boot/dietpi/dietpi-software')
+G_LIVE_PATCH=('sed -i '\''/cat << ._EOF_. > .etc.systemd.system.webmin.service/,/_EOF_/d'\'' /boot/dietpi/dietpi-software')

--- a/.update/version
+++ b/.update/version
@@ -2,8 +2,8 @@
 # shellcheck disable=SC2034
 # Available DietPi version
 G_REMOTE_VERSION_CORE=8
-G_REMOTE_VERSION_SUB=6
-G_REMOTE_VERSION_RC=1
+G_REMOTE_VERSION_SUB=7
+G_REMOTE_VERSION_RC=-1
 # Minimum DietPi version to allow update
 G_MIN_VERSION_CORE=6
 G_MIN_VERSION_SUB=14

--- a/.update/version
+++ b/.update/version
@@ -3,7 +3,7 @@
 # Available DietPi version
 G_REMOTE_VERSION_CORE=8
 G_REMOTE_VERSION_SUB=7
-G_REMOTE_VERSION_RC=-1
+G_REMOTE_VERSION_RC=0
 # Minimum DietPi version to allow update
 G_MIN_VERSION_CORE=6
 G_MIN_VERSION_SUB=14

--- a/.update/version
+++ b/.update/version
@@ -14,6 +14,15 @@ G_MIN_DEBIAN=5
 # Alternative Git branch to automatically migrate to when Debian version is too low
 G_OLD_DEBIAN_BRANCH='stretch'
 # Live patches
-G_LIVE_PATCH_DESC=('Fix Webmin service start after installation')
-G_LIVE_PATCH_COND=('grep -q '\''cat << ._EOF_. > /etc/systemd/system/webmin.service'\'' /boot/dietpi/dietpi-software')
-G_LIVE_PATCH=('sed -i '\''/cat << ._EOF_. > .etc.systemd.system.webmin.service/,/_EOF_/d'\'' /boot/dietpi/dietpi-software')
+G_LIVE_PATCH_DESC=(
+	[0]='Fix Webmin service start after installation'
+	[1]='Fix missing APT list removal on Tailscale uninstall'
+)
+G_LIVE_PATCH_COND=(
+	[0]='grep -q '\''cat << ._EOF_. > /etc/systemd/system/webmin.service'\'' /boot/dietpi/dietpi-software'
+	[1]='grep -q '\''/tailscale.list'\'' /boot/dietpi/dietpi-software'
+)
+G_LIVE_PATCH=(
+	[0]='sed -i '\''/cat << ._EOF_. > .etc.systemd.system.webmin.service/,/_EOF_/d'\'' /boot/dietpi/dietpi-software'
+	[1]='sed -i '\''s|/tailscale.list|/dietpi-tailscale.list|'\'' /boot/dietpi/dietpi-software'
+)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ v8.7
 (2022-XX-XX)
 
 Bug fixes:
+- DietPi-Software | Resolved an issue where "cgroup_enable=memory" was unnecessarily added multiple times on Raspberry Pi when installing or reinstalling container engines. Many thanks to @mdsjip for fixing this issue: https://github.com/MichaIng/DietPi/pull/5600
 - DietPi-Software | Webmin: Resolved an issue where the service failed to start. Many thanks to @alucard87pl for reporting this issue: https://github.com/MichaIng/DietPi/issues/5594
 - DietPi-Software | Raspotify: Resolved an issue where the service failed to start on ARMv6 RPi models (Raspberry Pi 1 and Zero (1)). It is not supported by latest Raspotify anymore, so we install the latest ARMv6-compatible version instead. Many thanks to @dvelluto for reporting this issue: https://github.com/MichaIng/DietPi/issues/5602
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,12 @@
 v8.7
 (2022-07-30)
 
+New software:
+- Readarr | The ebook manager of the Servarr family has been added as dietpi-software option.
+
+Enhancements:
+- DietPi-Software | Prowlarr: Logging is now done to /var/log/prowlarr as intended. For this change to take effect, existing instances need to be reinstalled once: dietpi-software reinstall 151
+
 Bug fixes:
 - DietPi-Software | Resolved an issue where "cgroup_enable=memory" was unnecessarily added multiple times on Raspberry Pi when installing or reinstalling container engines. Many thanks to @mdsjip for fixing this issue: https://github.com/MichaIng/DietPi/pull/5600
 - DietPi-Software | Webmin: Resolved an issue where the service failed to start. Many thanks to @alucard87pl for reporting this issue: https://github.com/MichaIng/DietPi/issues/5594

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ v8.7
 
 Bug fixes:
 - DietPi-Software | Webmin: Resolved an issue where the service failed to start. Many thanks to @alucard87pl for reporting this issue: https://github.com/MichaIng/DietPi/issues/5594
+- DietPi-Software | Raspotify: Resolved an issue where the service failed to start on ARMv6 RPi models (Raspberry Pi 1 and Zero (1)). It is not supported by latest Raspotify anymore, so we install the latest ARMv6-compatible version instead. Many thanks to @dvelluto for reporting this issue: https://github.com/MichaIng/DietPi/issues/5602
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ Bug fixes:
 - DietPi-Software | Webmin: Resolved an issue where the service failed to start. Many thanks to @alucard87pl for reporting this issue: https://github.com/MichaIng/DietPi/issues/5594
 - DietPi-Software | Raspotify: Resolved an issue where the service failed to start on ARMv6 RPi models (Raspberry Pi 1 and Zero (1)). It is not supported by latest Raspotify anymore, so we install the latest ARMv6-compatible version instead. Many thanks to @dvelluto for reporting this issue: https://github.com/MichaIng/DietPi/issues/5602
 - DietPi-Software | Rclone: Resolved an issue where on ARMv6 the x86_64 package was attempted to be installed. Many thanks to @eddiermar for reporting this issue: https://github.com/MichaIng/DietPi/issues/5601
+- DietPi-Software | Unbound: Resolved an issue on Debian Bookworm where the service failed to start because of missing root trust anchors. Many thanks to @smittyj for reporting this issue: https://github.com/MichaIng/DietPi/issues/5612
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ New images:
 
 New software:
 - Readarr | The ebook manager of the Servarr family has been added as dietpi-software option.
+- Navidrome | An open source web-based music collection server and streamer has been added as dietpi-software option.
 
 Enhancements:
 - DietPi-Software | Prowlarr: Logging is now done to /var/log/prowlarr as intended. For this change to take effect, existing instances need to be reinstalled once: dietpi-software reinstall 151

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ New software:
 
 Enhancements:
 - DietPi-Software | Prowlarr: Logging is now done to /var/log/prowlarr as intended. For this change to take effect, existing instances need to be reinstalled once: dietpi-software reinstall 151
+- DietPi-Software | vaultwarden: DEB packages are now hosted on dietpi.com, replacing the time consuming in-place compiling. This also solves issues where builds failed due to insufficient memory.
 
 Bug fixes:
 - DietPi-Software | Resolved an issue where "cgroup_enable=memory" was unnecessarily added multiple times on Raspberry Pi when installing or reinstalling container engines. Many thanks to @mdsjip for fixing this issue: https://github.com/MichaIng/DietPi/pull/5600

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ Bug fixes:
 - DietPi-Software | Resolved an issue where "cgroup_enable=memory" was unnecessarily added multiple times on Raspberry Pi when installing or reinstalling container engines. Many thanks to @mdsjip for fixing this issue: https://github.com/MichaIng/DietPi/pull/5600
 - DietPi-Software | Webmin: Resolved an issue where the service failed to start. Many thanks to @alucard87pl for reporting this issue: https://github.com/MichaIng/DietPi/issues/5594
 - DietPi-Software | Raspotify: Resolved an issue where the service failed to start on ARMv6 RPi models (Raspberry Pi 1 and Zero (1)). It is not supported by latest Raspotify anymore, so we install the latest ARMv6-compatible version instead. Many thanks to @dvelluto for reporting this issue: https://github.com/MichaIng/DietPi/issues/5602
+- DietPi-Software | Rclone: Resolved an issue where on ARMv6 the x86_64 package was attempted to be installed. Many thanks to @eddiermar for reporting this issue: https://github.com/MichaIng/DietPi/issues/5601
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,15 @@
+v8.7
+(2022-XX-XX)
+
+Bug fixes:
+- DietPi-Software | Webmin: Resolved an issue where the service failed to start. Many thanks to @alucard87pl for reporting this issue: https://github.com/MichaIng/DietPi/issues/5594
+
+As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
+
+For all additional issues that may appear after release, please see the following link for active tickets: https://github.com/MichaIng/DietPi/issues
+
+-----------------------------------------------------------------------------------------------------------
+
 v8.6
 (2022-07-02)
 
@@ -28,8 +40,6 @@ Bug fixes:
 - DietPi-Software | WiringPi: Resolved an issue where the installation failed on Odroids because of a missing dependency. Many thanks to @Guchshenskaya for reporting this issue: https://github.com/MichaIng/DietPi/issues/5543
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/5591
-
-For all additional issues that may appear after release, please see the following link for active tickets: https://github.com/MichaIng/DietPi/issues
 
 -----------------------------------------------------------------------------------------------------------
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,9 @@
 v8.7
 (2022-07-30)
 
+New images:
+- NanoPi R5S | Initial support for FriendlyELEC's new router SBC has been added, with three Ethernet ports, up to 2.5 Gbps, based on the new Rockchip RK3568 SoC.
+
 New software:
 - Readarr | The ebook manager of the Servarr family has been added as dietpi-software option.
 
@@ -1027,7 +1030,7 @@ v6.27
 (01/01/20)
 
 Changes / Improvements / Optimisations:
-- FriendlyARM ZeroPi | Initial hardware identifier (ID: 59) and support for this device has been added to DietPi. Many thanks to @Stephan for creating the related DietPi image: https://github.com/MichaIng/DietPi/issues/3221
+- FriendlyELEC ZeroPi | Initial hardware identifier (ID: 59) and support for this device has been added to DietPi. Many thanks to @Stephan for creating the related DietPi image: https://github.com/MichaIng/DietPi/issues/3221
 - RPi | An updated USBridgeSig Ethernet driver, as provided by allo.com, will be applied via postinst kernel script, until it has been merged into official RPi kernel: https://github.com/allocom/USBridgeSig/tree/master/ethernet
 - RPi4 | Added generic RPi4 revision code detection to include the new revisions [abc]03112 and potential new PCB v1.3 til v1.9 once released. Many thanks to @Joulinar for reporting the missing new revision code: https://github.com/MichaIng/DietPi/issues/3257#issuecomment-565370856
 - RPi4 | Since RPi4, bootloader and USB firmware is stored on an internal EEPROM, which is not updated/flashed by the firmware APT package installs automatically. The additional "rpi-eeprom" package comes with an EEPROM update script and boot service, which will now be installed on DietPi update and firstrun setup automatically, if RPi4 is detected. Those firmware updates include power consumption (hence heat emission) optimisations and enable additional boot methods, currently network boot and USB boot is planned as well. This was reason enough for us to implement it automatically for all RPi4 systems. Additionally you can actively install/update the EEPROM manually via dietpi-config > Advanced Options > Update RPi4 EEPROM firmware. For additional information, read the official docs: https://www.raspberrypi.org/documentation/hardware/raspberrypi/booteeprom.md Many thanks to @trueaspects for informing us about this important subject: https://github.com/MichaIng/DietPi/issues/3217

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,5 @@
 v8.7
-(2022-XX-XX)
+(2022-07-30)
 
 Bug fixes:
 - DietPi-Software | Resolved an issue where "cgroup_enable=memory" was unnecessarily added multiple times on Raspberry Pi when installing or reinstalling container engines. Many thanks to @mdsjip for fixing this issue: https://github.com/MichaIng/DietPi/pull/5600
@@ -7,6 +7,7 @@ Bug fixes:
 - DietPi-Software | Raspotify: Resolved an issue where the service failed to start on ARMv6 RPi models (Raspberry Pi 1 and Zero (1)). It is not supported by latest Raspotify anymore, so we install the latest ARMv6-compatible version instead. Many thanks to @dvelluto for reporting this issue: https://github.com/MichaIng/DietPi/issues/5602
 - DietPi-Software | Rclone: Resolved an issue where on ARMv6 the x86_64 package was attempted to be installed. Many thanks to @eddiermar for reporting this issue: https://github.com/MichaIng/DietPi/issues/5601
 - DietPi-Software | Unbound: Resolved an issue on Debian Bookworm where the service failed to start because of missing root trust anchors. Many thanks to @smittyj for reporting this issue: https://github.com/MichaIng/DietPi/issues/5612
+- DietPi-Software | Tailscale: Resolved an issue where APT updates failed after Tailscale was uninstalled. Many thanks to @SlowRaid for resolving this issue: https://github.com/MichaIng/DietPi/issues/5623
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,7 +2,7 @@ v8.6
 (2022-07-02)
 
 New images:
-- Quartz64 | Support and images for the PINE64 Quartz64 series have been added to DietPi, modern feature-rich SBCs based on the new Rockchip RK3366 SoC.
+- Quartz64 | Support and images for the PINE64 Quartz64 series have been added to DietPi, modern feature-rich SBCs based on the new Rockchip RK3566 SoC.
 
 New software:
 - Prometheus Node Exporter: A Prometheus exporter for hardware and OS metrics, written in Go, has been added to the DietPi software catalogue. Many thanks to @alexiri for implementing this software option: https://github.com/MichaIng/DietPi/pull/5551

--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ Links to hardware and software manufacturers, sources and build instructions use
 - [Tailscale](https://github.com/tailscale/tailscale)
 - [Rclone](https://github.com/rclone/rclone)
 - [ZeroTier](https://github.com/zerotier/ZeroTierOne)
+- [Navidrome](https://github.com/navidrome/navidrome)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ Links to hardware and software manufacturers, sources and build instructions use
 - [Radarr](https://github.com/Radarr/Radarr)
 - [Lidarr](https://github.com/Lidarr/Lidarr)
 - [Prowlarr](https://github.com/Prowlarr/Prowlarr)
+- [Readarr](https://github.com/Readarr/Readarr)
 - [Jackett](https://github.com/Jackett/Jackett)
 - [HAProxy](https://github.com/haproxy/haproxy)
 - [Prometheus Node Exporter](https://github.com/prometheus/node_exporter)

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -103,6 +103,7 @@ Available services:
 			'icecast2' 'darkice'
 			'voice-recognizer'
 			'snapserver'
+			'navidrome'
 
 			# - Download/BitTorrent
 			'transmission-daemon'

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -141,6 +141,7 @@ Available services:
 			'bazarr'
 			'deluge-web'
 			'prowlarr'
+			'readarr'
 
 			# - Cloud/Backups
 			'bdd'

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -618,7 +618,14 @@ Available commands:
 		aSOFTWARE_DEPS[$software_id]='5'
 		# - ARMv8
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,3]=0
-
+		#------------------
+		software_id=204
+		aSOFTWARE_NAME[$software_id]='Navidrome'
+		aSOFTWARE_DESC[$software_id]='Web interface media streaming server'
+		aSOFTWARE_CATX[$software_id]=2
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#navidrome'
+		aSOFTWARE_DEPS[$software_id]='5 7'
+		
 		# BitTorrent & Download
 		#--------------------------------------------------------------------------------
 		software_id=44
@@ -6716,6 +6723,102 @@ _EOF_
 			# Grab our test media for user
 			Download_Test_Media
 
+		fi
+
+		software_id=204 # Navidrome
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 ))
+		then
+
+			Banner_Installing
+
+			case $G_HW_ARCH in
+				1) local arch='armv6';;
+				2) local arch='armv7';;
+				3) local arch='arm64';;
+				*) local arch='x86_64';;
+			esac
+			
+			local fallback_url="https://github.com/navidrome/navidrome/releases/download/v0.47.5/navidrome_0.47.5_Linux_$arch.tar.gz"
+			Download_Install "$(curl -sSfL 'https://api.github.com/repos/navidrome/navidrome/releases/latest' | mawk -F\" "/\"browser_download_url\": .*\/navidrome_[0-9.]*_Linux_$arch\.tar\.gz\"/{print \$4}")" /opt/navidrome/
+
+			# Data dir
+			[[ -d '/mnt/dietpi_userdata/navidrome' ]] || G_EXEC mkdir /mnt/dietpi_userdata/navidrome
+
+			# User
+			Create_User -g dietpi -d /mnt/dietpi_userdata/navidrome navidrome
+
+			# Config: https://www.navidrome.org/docs/usage/configuration-options/#available-options
+			cat << '_EOF_' > /mnt/dietpi_userdata/navidrome/navidrome.toml
+DataFolder = '/mnt/dietpi_userdata/navidrome/data'
+MusicFolder = '/mnt/dietpi_userdata/Music'
+ImageCacheSize = '100MiB'
+
+LogLevel = 'warn'
+SessionTimeout = '24h'
+AuthRequestLimit = '5'
+AuthWindowLength = '20s'
+ScanSchedule = '@every 1h'
+EnableLogRedacting = 'true'
+Scanner.Extractor = 'taglib'
+
+CoverJpegQuality = '75'
+CoverArtPriority = 'embedded'
+_EOF_
+
+			# Service: https://www.navidrome.org/docs/installation/linux/#create-a-systemd-unit
+			cat << '_EOF_' > /etc/systemd/system/navidrome.service
+[Unit]
+Description=navidrome (DietPi)
+Wants=network-online.target
+After=network-online.target
+AssertPathExists=/mnt/dietpi_userdata/navidrome
+
+[Service]
+User=navidrome
+ExecStart=/opt/navidrome/navidrome --configfile "/mnt/dietpi_userdata/navidrome/navidrome.toml"
+WorkingDirectory=/mnt/dietpi_userdata/navidrome
+TimeoutStopSec=20
+KillMode=process
+Restart=on-failure
+
+# See https://www.freedesktop.org/software/systemd/man/systemd.exec.html
+DevicePolicy=closed
+NoNewPrivileges=yes
+PrivateTmp=yes
+PrivateUsers=yes
+ProtectControlGroups=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictRealtime=yes
+SystemCallFilter=~@clock @debug @module @mount @obsolete @reboot @setuid @swap
+ReadWritePaths=/mnt/dietpi_userdata/navidrome
+
+# You can uncomment the following line if you're not using the jukebox This
+# will prevent navidrome from accessing any real (physical) devices
+#PrivateDevices=yes
+
+# You can change the following line to `strict` instead of `full` if you don't
+# want navidrome to be able to write anything on your filesystem outside of
+# /mnt/dietpi_userdata/navidrome.
+ProtectSystem=full
+
+# You can uncomment the following line if you don't have any media in /home/*.
+# This will prevent navidrome from ever reading/writing anything there.
+#ProtectHome=true
+
+# You can customize some Navidrome config options by setting environment variables here. Ex:
+#Environment=ND_BASEURL="/navidrome"
+
+[Install]
+WantedBy=multi-user.target
+_EOF_
+
+			# Permissions
+			G_EXEC chown -R navidrome:dietpi /mnt/dietpi_userdata/navidrome
+
+			Download_Test_Media
 		fi
 
 		software_id=68 # Remot3.it
@@ -14308,6 +14411,21 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 			[[ -d '/etc/systemd/system/airsonic.service.d' ]] && G_EXEC rm -R /etc/systemd/system/airsonic.service.d
 			getent passwd airsonic > /dev/null && G_EXEC userdel airsonic
 			[[ -d '/mnt/dietpi_userdata/airsonic' ]] && G_EXEC rm -R /mnt/dietpi_userdata/airsonic
+
+		fi
+		
+		software_id=204 # Navidrome
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
+
+			Banner_Uninstalling
+			if [[ -f '/etc/systemd/system/navidrome.service' ]]
+			then
+				G_EXEC systemctl disable --now navidrome
+				G_EXEC rm /etc/systemd/system/navidrome.service
+			fi
+			[[ -d '/etc/systemd/system/navidrome.service.d' ]] && G_EXEC rm -R /etc/systemd/system/navidrome.service.d
+			getent passwd navidrome > /dev/null && G_EXEC userdel navidrome
+			G_EXEC rm -Rf /opt/navidrome /mnt/dietpi_userdata/navidrome
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5051,7 +5051,7 @@ The install script will now exit. After applying one of the the above, rerun die
 			do
 				G_WHIP_DEFAULT_ITEM=$port
 				if G_WHIP_INPUTBOX "${invalid_text}Please enter the network port, that should be used for your TURN server:\n
-NB: This port needs to be forwarded by your router and/or opened in your firewall settings. Default value is: 3478" && disable_error=1 G_CHECK_VALIDINT "$G_WHIP_RETURNED_VALUE" 0; then
+NB: This port (UDP + TCP) needs to be forwarded by your router and/or opened in your firewall settings. Default value is: 3478" && disable_error=1 G_CHECK_VALIDINT "$G_WHIP_RETURNED_VALUE" 0; then
 
 					port=$G_WHIP_RETURNED_VALUE
 					break

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6342,7 +6342,8 @@ _EOF_
 
 			G_DIETPI-NOTIFY 2 'Pre-configuring Unbound to avoid port binding conflicts'
 
-			# Download/update list of root hints
+			# Install/update root trust anchors and hints
+			(( $G_DISTRO > 6 )) && aDEPS=('dns-root-data')
 			Download_Install 'https://www.internic.net/domain/named.root' /var/lib/unbound/root.hints
 
 			# Create monthly cron job to keep root hints updated

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -388,7 +388,7 @@ Available commands:
 		#------------------
 		software_id=35
 		aSOFTWARE_NAME[$software_id]='Logitech Media Server'
-		aSOFTWARE_DESC[$software_id]='aka SlimServer, SqueezeCenter, Squeezebox Server'
+		aSOFTWARE_DESC[$software_id]='aka. LMS, fka. SlimServer, SqueezeCenter, SqueezeboxServer, SliMP3'
 		aSOFTWARE_CATX[$software_id]=2
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#logitech-media-server'
 		#------------------
@@ -7407,33 +7407,15 @@ _EOF_
 			local arch='arm'
 			(( $G_HW_ARCH == 10 )) && arch='amd64'
 
-			# Grab latest package URL: Force HTTPS!
+			# Grab latest package URL
 			local fallback_url="https://downloads.slimdevices.com/LogitechMediaServer_v8.2.0/logitechmediaserver_8.2.0_$arch.deb"
-			Download_Install "$(curl -sSfL "https://www.mysqueezebox.com/update/?version=8.2&geturl=1&os=deb$arch" | sed 's|^http://|https://|')"
+			Download_Install "$(curl -sSfL "https://www.mysqueezebox.com/update/?version=8.2&geturl=1&os=deb$arch")"
+			G_EXEC systemctl stop logitechmediaserver
+			Remove_SysV logitechmediaserver
 
-			# Remove bundled SysVinit service
-			systemctl -q is-enabled logitechmediaserver 2> /dev/null || systemctl -q is-active logitechmediaserver && G_EXEC systemctl disable --now logitechmediaserver
-			killall -qwr squeezeboxserver* # Provided service may not wait for exit, kill: https://github.com/MichaIng/DietPi/issues/1613#issuecomment-372787574
-			Remove_SysV logitechmediaserver 1
-
-			# Grant user access to DietPi media files
+			# Grant user write access to DietPi media dirs for creating infobrowser.opml.
 			G_EXEC usermod -aG dietpi squeezeboxserver
 
-			# systemd service
-			cat << _EOF_ > /etc/systemd/system/logitechmediaserver.service
-[Unit]
-Description=Logitech Media Server (DietPi)
-
-[Service]
-User=squeezeboxserver
-LogsDirectory=squeezeboxserver
-ExecStart=$(command -v squeezeboxserver) --prefsdir /var/lib/squeezeboxserver/prefs --logdir /var/log/squeezeboxserver/ --cachedir /var/lib/squeezeboxserver/cache --charset=utf8 --logfile /var/log/squeezeboxserver/error.log
-Restart=on-failure
-RestartSec=5
-
-[Install]
-WantedBy=multi-user.target
-_EOF_
 			# Grab our test media for user
 			Download_Test_Media
 
@@ -14281,17 +14263,21 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
+			# Pre-v8.7
 			if [[ -f '/etc/systemd/system/logitechmediaserver.service' ]]
 			then
 				G_EXEC systemctl disable --now logitechmediaserver
 				G_EXEC rm /etc/systemd/system/logitechmediaserver.service
+
+			elif [[ -f '/lib/systemd/system/logitechmediaserver.service' ]]
+			then
+				# Stop systemd service, which is not done by postinst, failing to remove user then
+				G_EXEC systemctl unmask plexmediaserver
+				G_EXEC systemctl disable --now logitechmediaserver
 			fi
 			[[ -d '/etc/systemd/system/logitechmediaserver.service.d' ]] && G_EXEC rm -R /etc/systemd/system/logitechmediaserver.service.d
 			G_AGP logitechmediaserver
-			getent passwd squeezeboxserver > /dev/null && G_EXEC userdel squeezeboxserver
-			getent group squeezeboxserver > /dev/null && G_EXEC groupdel squeezeboxserver
 			[[ -d '/var/lib/squeezeboxserver' ]] && G_EXEC rm -R /var/lib/squeezeboxserver
-			[[ -d '/usr/share/squeezeboxserver' ]] && G_EXEC rm -R /usr/share/squeezeboxserver
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4319,7 +4319,6 @@ _EOF_
 			# - Recreate cache dir
 			G_EXEC mkdir /mnt/dietpi_userdata/.mpd_cache
 
-			# Grab our test music for the user
 			Download_Test_Media
 
 			# Permissions
@@ -6720,7 +6719,6 @@ _EOF_
 			G_EXEC chmod +x /mnt/dietpi_userdata/airsonic/airsonic.war
 			G_EXEC chown airsonic:root /mnt/dietpi_userdata/airsonic
 
-			# Grab our test media for user
 			Download_Test_Media
 
 		fi
@@ -7529,7 +7527,6 @@ _EOF_
 			# Grant user write access to DietPi media dirs for creating infobrowser.opml.
 			G_EXEC usermod -aG dietpi squeezeboxserver
 
-			# Grab our test media for user
 			Download_Test_Media
 
 		fi
@@ -10051,126 +10048,12 @@ _EOF_
 		fi
 
 		software_id=183 # vaultwarden
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 )); then
-
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 ))
+		then
 			Banner_Installing
-
-			# Dependencies: https://github.com/dani-garcia/vaultwarden/wiki/Building-binary#dependencies
-			aDEPS=('gcc' 'libc6-dev' 'pkg-config' 'libssl-dev')
-
-			# Download
-			local version=$(curl -sSfL 'https://api.github.com/repos/dani-garcia/vaultwarden/releases/latest' | mawk -F\" '/"tag_name": /{print $4}')
-			[[ $version ]] || { version='1.25.1'; G_DIETPI-NOTIFY 1 "Automatic latest ${aSOFTWARE_NAME[$software_id]} version detection failed. Version \"$version\" will be installed as fallback, but a newer version might be available. Please report this at: https://github.com/MichaIng/DietPi/issues"; }
-			Download_Install "https://github.com/dani-garcia/vaultwarden/archive/$version.tar.gz"
-
-			# Replace old instance on reinstall using new project name
-			[[ -d '/opt/vaultwarden' ]] && G_EXEC rm -R /opt/vaultwarden
-			G_EXEC mv "vaultwarden-$version" /opt/vaultwarden
-
-			# Assure 3 GiB overall memory on single-core and 4 GiB on multi-core systems (-200 MiB to avoid tiny swap space)
-			local ram_min=4
-			(( $G_HW_ARCH == 3 )) && ram_min=6
-			if (( $RAM_TOTAL < $ram_min * 1024 - 200 ))
-			then
-				G_DIETPI-NOTIFY 2 "The vaultwarden build requires at least $ram_min GiB memory. We will now increase your swap size to satisfy this requirement."
-				/boot/dietpi/func/dietpi-set_swapfile $(( $ram_min * 1024 - $RAM_TOTAL ))
-			fi
-
-			# Temporarily assure 2 GiB /tmp size for temporary Rust install
-			(( $(findmnt -bno SIZE /tmp) < 2147483648 )) && G_EXEC mount -o remount,size=2G /tmp
-
-			# Clean APT cache (which includes temporarily downloaded archives) when moved to RAM
-			[[ -d '/tmp/apt' ]] && G_EXEC apt-get clean
-
-			# Override $HOME to allow temporary Rust install to RAMdisk and DietPi-Software working directory, so all leftovers are automatically removed on script exit and/or reboot
-			export HOME=$G_WORKING_DIR
-
-			# Install Rust via https://rustup.rs/
-			G_EXEC curl -sSfL 'https://sh.rustup.rs' -o rustup-init.sh
-			G_EXEC chmod +x rustup-init.sh
-			G_EXEC_OUTPUT=1 G_EXEC ./rustup-init.sh -y --profile minimal --default-toolchain none
-			G_EXEC_NOHALT=1 G_EXEC rm rustup-init.sh
-			G_EXEC . .cargo/env
-
-			# Build
-			G_EXEC cd /opt/vaultwarden
-			G_EXEC_OUTPUT=1 G_EXEC cargo build --features sqlite --release
-			G_EXEC cd "$G_WORKING_DIR"
-
-			# Uninstall rust after compiling
-			G_EXEC rustup self uninstall -y
-
-			# Restore $HOME
-			HOME='/root'
-
-			# Install web vault
-			local fallback_url='https://github.com/dani-garcia/bw_web_builds/releases/download/v2022.6.2/bw_web_v2022.6.2.tar.gz'
-			Download_Install "$(curl -sSfL 'https://api.github.com/repos/dani-garcia/bw_web_builds/releases/latest' | mawk -F\" '/"browser_download_url": .*\/bw_web_[^"\/]*\.tar\.gz"/{print $4}')" /mnt/dietpi_userdata/vaultwarden
-
-			# User
-			Create_User -d /mnt/dietpi_userdata/vaultwarden vaultwarden
-
-			[[ ! -d '/mnt/dietpi_userdata/vaultwarden' ]] && G_EXEC mkdir /mnt/dietpi_userdata/vaultwarden
-
-			# Config: Preserve old
-			if [[ ! -f '/mnt/dietpi_userdata/vaultwarden/vaultwarden.env' ]]
-			then
-				G_EXEC cp /opt/vaultwarden/.env.template /mnt/dietpi_userdata/vaultwarden/vaultwarden.env
-				G_CONFIG_INJECT 'DATA_FOLDER=' 'DATA_FOLDER=/mnt/dietpi_userdata/vaultwarden' /mnt/dietpi_userdata/vaultwarden/vaultwarden.env
-				# Create TLS certificate for web vault: Currently only RSA is supported. Add SAN with local IP and hostname, required for the client to accept the connection.
-				G_EXEC_OUTPUT=1 G_EXEC openssl req -reqexts SAN -subj '/CN=DietPi Vaultwarden' -config <(cat /etc/ssl/openssl.cnf <(echo -ne "[SAN]\nsubjectAltName=DNS:$(</etc/hostname),IP:$(G_GET_NET ip)\nbasicConstraints=CA:TRUE,pathlen:0"))\
-					-x509 -days 7200 -sha256 -extensions SAN -out /mnt/dietpi_userdata/vaultwarden/cert.pem\
-					-newkey rsa:4096 -nodes -keyout /mnt/dietpi_userdata/vaultwarden/privkey.pem
-				G_CONFIG_INJECT 'ROCKET_TLS=' 'ROCKET_TLS={certs="./cert.pem",key="./privkey.pem"}' /mnt/dietpi_userdata/vaultwarden/vaultwarden.env
-				G_CONFIG_INJECT 'ROCKET_PORT=' 'ROCKET_PORT=8001' /mnt/dietpi_userdata/vaultwarden/vaultwarden.env # Avoid port conflict with IceCast
-				G_CONFIG_INJECT 'WEB_VAULT_ENABLED=' 'WEB_VAULT_ENABLED=true' /mnt/dietpi_userdata/vaultwarden/vaultwarden.env
-			fi
-			# - Since v1.25.0, respectively web vault somewhere up to 2.28.1, by default it binds to localhost only. To preserve the previous behaviour, we actively bind to all IPs/interfaces, but preserve any stricter value: https://dietpi.com/forum/t/vaultwarden-update-to-1-25-web-access/13248
-			GCI_PRESERVE=1 G_CONFIG_INJECT 'ROCKET_ADDRESS=' 'ROCKET_ADDRESS=0.0.0.0' /mnt/dietpi_userdata/vaultwarden/vaultwarden.env
-
-			# Permissions
-			G_EXEC chown -R vaultwarden:vaultwarden /mnt/dietpi_userdata/vaultwarden
-			G_EXEC chmod +x /opt/vaultwarden/target/release/vaultwarden
-
-			# Service: https://github.com/dani-garcia/vaultwarden/wiki/Setup-as-a-systemd-service
-			cat << '_EOF_' > /etc/systemd/system/vaultwarden.service
-[Unit]
-Description=vaultwarden (DietPi)
-Documentation=https://github.com/dani-garcia/vaultwarden
-Wants=network-online.target
-After=network-online.target
-
-# Restart attempt only 5 times
-StartLimitIntervalSec=500
-StartLimitBurst=5
-
-[Service]
-# Server sometimes fails to start on startup, this should fix it
-Restart=on-failure
-RestartSec=5s
-# The user vaultwarden is run under. the working directory (see below) should allow write and read access to this user
-User=vaultwarden
-# The location of the .env file for configuration
-EnvironmentFile=/mnt/dietpi_userdata/vaultwarden/vaultwarden.env
-# The location of the compiled binary
-ExecStart=/opt/vaultwarden/target/release/vaultwarden
-# Set reasonable connection and process limits
-LimitNOFILE=1048576
-LimitNPROC=64
-# Isolate vaultwarden from the rest of the system
-PrivateTmp=true
-PrivateDevices=true
-ProtectHome=true
-ProtectSystem=strict
-# Only allow writes to the following directory and set it to the working directory (user and password data are stored here)
-WorkingDirectory=/mnt/dietpi_userdata/vaultwarden
-ReadWritePaths=-/mnt/dietpi_userdata/vaultwarden
-# Allow vaultwarden to bind ports in the range of 0-1024
-AmbientCapabilities=CAP_NET_BIND_SERVICE
-
-[Install]
-WantedBy=multi-user.target
-_EOF_
+			[[ -f '/opt/vaultwarden/target/release/vaultwarden' ]] && G_EXEC rm -R /opt/vaultwarden # Pre-v8.7
+			[[ -f '/etc/systemd/system/vaultwarden.service' ]] && G_EXEC rm /etc/systemd/system/vaultwarden.service # Pre-v8.7
+			Download_Install "https://dietpi.com/downloads/binaries/bullseye/vaultwarden_$G_HW_ARCH_NAME.deb"
 		fi
 
 		software_id=193 # K3s
@@ -10312,7 +10195,6 @@ _EOF_
 				G_EXEC systemctl restart mariadb
 			fi
 
-			# Download test media
 			Download_Test_Media
 
 			# Init
@@ -13711,18 +13593,21 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 
 			Banner_Uninstalling
 
+			# Pre-v8.7
 			if [[ -f '/etc/systemd/system/vaultwarden.service' ]]
 			then
 				G_EXEC systemctl disable --now vaultwarden
 				G_EXEC rm /etc/systemd/system/vaultwarden.service
 			fi
-			[[ -d '/etc/systemd/system/vaultwarden.service.d' ]] && G_EXEC rm -R /etc/systemd/system/vaultwarden.service.d
 
+			G_AGP vaultwarden
+			[[ -d '/mnt/dietpi_userdata/vaultwarden' ]] && G_EXEC rm -R /mnt/dietpi_userdata/vaultwarden
+
+			# Pre-v8.7
+			[[ -d '/etc/systemd/system/vaultwarden.service.d' ]] && G_EXEC rm -R /etc/systemd/system/vaultwarden.service.d
 			getent passwd vaultwarden > /dev/null && G_EXEC userdel vaultwarden
 			getent group vaultwarden > /dev/null && G_EXEC groupdel vaultwarden
-
 			[[ -d '/opt/vaultwarden' ]] && G_EXEC rm -R /opt/vaultwarden
-			[[ -d '/mnt/dietpi_userdata/vaultwarden' ]] && G_EXEC rm -R /mnt/dietpi_userdata/vaultwarden
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11438,8 +11438,8 @@ _EOF_
 			# ARMv7: As of v1.8 there were issues with ARMv7 binaries on Raspbian which are hence not provided anymore: https://github.com/go-gitea/gitea/issues/6700
 			case $G_HW_ARCH in
 				[12]) local arch='arm-6';;
-				3) local arch='arm64'
-				*) local arch='amd64'
+				3) local arch='arm64';;
+				*) local arch='amd64';;
 			esac
 
 			local fallback_url="https://github.com/go-gitea/gitea/releases/download/v1.16.9/gitea-1.16.9-linux-$arch"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -529,7 +529,9 @@ Available commands:
 		aSOFTWARE_DESC[$software_id]='Audiophile web interface with all dependencies'
 		aSOFTWARE_CATX[$software_id]=-1
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/forum/t/dietpi-allo-com-web-gui-image/1523'
-		aSOFTWARE_DEPS[$software_id]='5 36 37 65 88 89 96 121 124 128 129 152 160 163 webserver'
+		aSOFTWARE_DEPS[$software_id]='5 36 37 65 88 89 96 124 128 129 152 160 163 webserver'
+		# Roon Bridge is not supported on ARMv6
+		(( $G_HW_ARCH == 1 )) || aSOFTWARE_DEPS[$software_id]+=' 121'
 		#------------------
 		software_id=160
 		aSOFTWARE_NAME[$software_id]='Allo GUI'

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9957,7 +9957,7 @@ _EOF_
 
 			# Download
 			local version=$(curl -sSfL 'https://api.github.com/repos/dani-garcia/vaultwarden/releases/latest' | mawk -F\" '/"tag_name": /{print $4}')
-			[[ $version ]] || { version='1.25.0'; G_DIETPI-NOTIFY 1 "Automatic latest ${aSOFTWARE_NAME[$software_id]} version detection failed. Version \"$version\" will be installed as fallback, but a newer version might be available. Please report this at: https://github.com/MichaIng/DietPi/issues"; }
+			[[ $version ]] || { version='1.25.1'; G_DIETPI-NOTIFY 1 "Automatic latest ${aSOFTWARE_NAME[$software_id]} version detection failed. Version \"$version\" will be installed as fallback, but a newer version might be available. Please report this at: https://github.com/MichaIng/DietPi/issues"; }
 			Download_Install "https://github.com/dani-garcia/vaultwarden/archive/$version.tar.gz"
 
 			# Replace old instance on reinstall using new project name
@@ -12039,7 +12039,7 @@ _EOF_
 			local ha_user='homeassistant'
 			local ha_home="/home/$ha_user"
 			local ha_pyenv_activation=". $ha_home/pyenv-activate.sh"
-			local ha_python_version='3.9.10' # https://www.python.org/downloads/
+			local ha_python_version='3.9.13' # https://www.python.org/downloads/
 
 			G_DIETPI-NOTIFY 2 "Home Assistant user:  $ha_user"
 			G_DIETPI-NOTIFY 2 "Home Assistant home:  $ha_home"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10009,7 +10009,7 @@ _EOF_
 			HOME='/root'
 
 			# Install web vault
-			local fallback_url='https://github.com/dani-garcia/bw_web_builds/releases/download/v2022.5.2/bw_web_v2022.5.2.tar.gz'
+			local fallback_url='https://github.com/dani-garcia/bw_web_builds/releases/download/v2022.6.0/bw_web_v2022.6.0.tar.gz'
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/dani-garcia/bw_web_builds/releases/latest' | mawk -F\" '/"browser_download_url": .*\/bw_web_[^"\/]*\.tar\.gz"/{print $4}')" /mnt/dietpi_userdata/vaultwarden
 
 			# User
@@ -10846,7 +10846,7 @@ _EOF_
 			else
 				# ARMv7
 				local url=$(curl -sSfL 'https://api.github.com/repos/Prowlarr/Prowlarr/releases' | mawk -F\" '/"browser_download_url": .*linux-core-arm\.tar\.gz"/{print $4}' | head -1)
-				local fallback_url='https://github.com/Prowlarr/Prowlarr/releases/download/v0.4.1.1838/Prowlarr.develop.0.4.1.1838.linux-core-arm.tar.gz'
+				local fallback_url='https://github.com/Prowlarr/Prowlarr/releases/download/v0.4.2.1879/Prowlarr.develop.0.4.2.1879.linux-core-arm.tar.gz'
 
 				# ARMv8
 				if (( $G_HW_ARCH == 3 ))

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5593,6 +5593,7 @@ amvdec_vp9' > /etc/modules-load.d/dietpi-n2-kodi.conf
 			cat << _EOF_ > /etc/systemd/system/minidlna.service
 [Unit]
 Description=ReadyMedia (DietPi)
+Documentation=man:minidlnad(1) man:minidlna.conf(5)
 Wants=network-online.target
 After=network-online.target
 
@@ -10039,7 +10040,7 @@ _EOF_
 			# Service: https://github.com/dani-garcia/vaultwarden/wiki/Setup-as-a-systemd-service
 			cat << '_EOF_' > /etc/systemd/system/vaultwarden.service
 [Unit]
-Description=vaultwarden Server (Rust Edition)
+Description=vaultwarden (DietPi)
 Documentation=https://github.com/dani-garcia/vaultwarden
 Wants=network-online.target
 After=network-online.target

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -723,6 +723,15 @@ Available commands:
 		# - ARMv6
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
 		#------------------
+		software_id=203
+		aSOFTWARE_NAME[$software_id]='Readarr'
+		aSOFTWARE_DESC[$software_id]='Ebook and audiobook collection manager'
+		aSOFTWARE_CATX[$software_id]=3
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/bittorrent/#readarr'
+		aSOFTWARE_DEPS[$software_id]='87'
+		# - ARMv6
+		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
+		#------------------
 		software_id=155
 		aSOFTWARE_NAME[$software_id]='HTPC Manager'
 		aSOFTWARE_DESC[$software_id]='Manage your HTPC from anywhere'
@@ -10882,8 +10891,104 @@ ReadWritePaths=-/opt/prowlarr -/mnt -/media -/var/log/prowlarr -/tmp
 [Install]
 WantedBy=multi-user.target
 _EOF_
+			# Logs to RAM
+			G_EXEC rm -Rf /mnt/dietpi_userdata/prowlarr/logs*
+			G_EXEC ln -s /var/log/prowlarr /mnt/dietpi_userdata/prowlarr/logs
+			G_EXEC ln -s /var/log/prowlarr/logs.db /mnt/dietpi_userdata/prowlarr/logs.db
+			G_EXEC ln -s /var/log/prowlarr/logs.db-shm /mnt/dietpi_userdata/prowlarr/logs.db-shm
+			G_EXEC ln -s /var/log/prowlarr/logs.db-wal /mnt/dietpi_userdata/prowlarr/logs.db-wal
+
 			# Permissions
 			G_EXEC chown -R prowlarr:dietpi /mnt/dietpi_userdata/prowlarr /opt/prowlarr
+		fi
+		
+		software_id=203 # Readarr
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == 1 ))
+		then
+
+			Banner_Installing
+
+			# .NET dependency: https://github.com/dotnet/core/blob/main/Documentation/linux-prereqs.md
+			case $G_DISTRO in
+				5) aDEPS=('libicu63');;
+				6) aDEPS=('libicu67');;
+				*) aDEPS=('libicu71');;
+			esac
+
+			# Reinstall: Skip download and install, advice to use internal updater from web UI
+			if [[ -d '/opt/readarr' ]]
+			then
+				G_DIETPI-NOTIFY 2 "${aSOFTWARE_NAME[$software_id]} install dir \"/opt/readarr\" already exists. Download and install steps will be skipped.
+ - If you want to update ${aSOFTWARE_NAME[$software_id]}, please use the internal updater from web UI.
+ - If you need to reinstall (e.g. broken instance), please manually remove the install dir and rerun \"dietpi-software reinstall $software_id\"."
+
+				G_AGI "${aDEPS[@]}"
+				aDEPS=()
+			else
+				# ARMv7
+				local url=$(curl -sSfL 'https://api.github.com/repos/Readarr/Readarr/releases' | mawk -F\" '/"browser_download_url": .*linux-core-arm\.tar\.gz"/{print $4}' | head -1)
+				local fallback_url='https://github.com/Readarr/Readarr/releases/download/v0.1.1.1320/Readarr.develop.0.1.1.1320.linux-core-arm.tar.gz'
+
+				# ARMv8
+				if (( $G_HW_ARCH == 3 ))
+				then
+					url=${url/arm/arm64}
+					fallback_url=${fallback_url/arm/arm64}
+
+				# x86_64
+				elif (( $G_HW_ARCH == 10 ))
+				then
+					url=${url/arm/x64}
+					fallback_url=${fallback_url/arm/x64}
+				fi
+
+				Download_Install "$url"
+				G_EXEC mv Readarr /opt/readarr
+			fi
+
+			# Data dir
+			[[ -d '/mnt/dietpi_userdata/readarr' ]] || G_EXEC mkdir /mnt/dietpi_userdata/readarr
+
+			# User
+			Create_User -g dietpi -d /mnt/dietpi_userdata/readarr readarr
+
+			# Service: https://wiki.servarr.com/readarr/installation
+			cat << '_EOF_' > /etc/systemd/system/readarr.service
+[Unit]
+Description=readarr (DietPi)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+SyslogIdentifier=Readarr
+User=readarr
+UMask=002
+LogsDirectory=readarr
+ExecStart=/opt/readarr/Readarr -nobrowser -data=/mnt/dietpi_userdata/readarr
+TimeoutStopSec=20
+KillMode=process
+Restart=on-failure
+
+# Hardening
+ProtectSystem=strict
+ProtectHome=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+ReadWritePaths=-/opt/readarr -/mnt -/media -/var/log/readarr -/tmp
+
+[Install]
+WantedBy=multi-user.target
+_EOF_
+			# Logs to RAM
+			G_EXEC rm -Rf /mnt/dietpi_userdata/readarr/logs*
+			G_EXEC ln -s /var/log/readarr /mnt/dietpi_userdata/readarr/logs
+			G_EXEC ln -s /var/log/readarr/logs.db /mnt/dietpi_userdata/readarr/logs.db
+			G_EXEC ln -s /var/log/readarr/logs.db-shm /mnt/dietpi_userdata/readarr/logs.db-shm
+			G_EXEC ln -s /var/log/readarr/logs.db-wal /mnt/dietpi_userdata/readarr/logs.db-wal
+
+			# Permissions
+			G_EXEC chown -R readarr:dietpi /mnt/dietpi_userdata/readarr /opt/readarr
 		fi
 
 		software_id=155 # HTPC Manager
@@ -13789,6 +13894,21 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 			[[ -d '/etc/systemd/system/prowlarr.service.d' ]] && G_EXEC rm -R /etc/systemd/system/prowlarr.service.d
 			getent passwd prowlarr > /dev/null && G_EXEC userdel prowlarr
 			G_EXEC rm -Rf /opt/prowlarr /mnt/dietpi_userdata/prowlarr /var/log/prowlarr
+
+		fi
+		
+		software_id=203 # Readarr
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
+
+			Banner_Uninstalling
+			if [[ -f '/etc/systemd/system/readarr.service' ]]
+			then
+				G_EXEC systemctl disable --now readarr
+				G_EXEC rm /etc/systemd/system/readarr.service
+			fi
+			[[ -d '/etc/systemd/system/readarr.service.d' ]] && G_EXEC rm -R /etc/systemd/system/readarr.service.d
+			getent passwd readarr > /dev/null && G_EXEC userdel readarr
+			G_EXEC rm -Rf /opt/readarr /mnt/dietpi_userdata/readarr /var/log/readarr
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -14445,7 +14445,7 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 			[[ -d '/etc/systemd/system/tailscale.service.d' ]] && G_EXEC rm -R /etc/systemd/system/tailscale.service.d
 			[[ -d '/var/lib/tailscale' ]] && G_EXEC rm -R /var/lib/tailscale
 			[[ -f '/etc/sysctl.d/dietpi-tailscale.conf' ]] && G_EXEC rm /etc/sysctl.d/dietpi-tailscale.conf
-			[[ -f '/etc/apt/sources.list.d/tailscale.list' ]] && G_EXEC rm /etc/apt/sources.list.d/dietpi-tailscale.list
+			[[ -f '/etc/apt/sources.list.d/dietpi-tailscale.list' ]] && G_EXEC rm /etc/apt/sources.list.d/dietpi-tailscale.list
 			[[ -f '/etc/apt/trusted.gpg.d/dietpi-tailscale.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-tailscale.gpg
 
 		fi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -211,7 +211,7 @@ Available commands:
 	fi
 
 	# Available for (need to match highest value in dietpi-obtain_hw_model)
-	readonly MAX_G_HW_MODEL=75
+	readonly MAX_G_HW_MODEL=76
 	readonly MAX_G_HW_ARCH=10
 	#readonly MAX_G_DISTRO=7
 	# - 2D array (well, bash style)

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12291,23 +12291,12 @@ _EOF_
 
 			Banner_Installing
 
-			# ARMv6
-			local arch='arm'
-
-			# ARMv7
-			if (( $G_HW_ARCH == 2 ))
-			then
-				arch+='-v7'
-
-			# ARMv8
-			elif (( $G_HW_ARCH == 3 ))
-			then
-				arch='arm64'
-
-			# x86_64
-			else
-				arch='amd64'
-			fi
+			case $G_HW_ARCH in
+				1) local arch='arm';;
+				2) local arch='arm-v7';;
+				3) local arch='arm64';;
+				*) local arch='amd64';;
+			esac
 
 			local fallback_url="https://github.com/rclone/rclone/releases/download/v1.58.1/rclone-v1.58.1-linux-$arch.deb"
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/rclone/rclone/releases/latest' | mawk -F\" "/\"browser_download_url\": .*\/rclone-v[^\"\/]*linux-$arch.deb\"/{print \$4}")"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2575,7 +2575,7 @@ _EOF_
 		{
 			if (( $G_HW_MODEL < 10 ))
 			then
-				grep -Eq '(^|[[:blank]])cgroup_enable=memory([[:blank]]|$)' /boot/cmdline.txt || G_EXEC sed -i '/root=/s/[[:blank:]]*$/ cgroup_enable=memory/' /boot/cmdline.txt
+				grep -Eq '(^|[[:blank:]])cgroup_enable=memory([[:blank:]]|$)' /boot/cmdline.txt || G_EXEC sed -i '/root=/s/[[:blank:]]*$/ cgroup_enable=memory/' /boot/cmdline.txt
 
 			elif [[ -f '/boot/boot.scr' ]] && grep -q 'docker_optimizations' /boot/boot.scr
 			then

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11555,19 +11555,28 @@ _EOF_
 
 			Banner_Installing # https://dtcooper.github.io/raspotify/#hard-installation
 
-			# APT key
-			local url='https://dtcooper.github.io/raspotify/key.asc'
-			G_CHECK_URL "$url"
-			G_EXEC eval "curl -sSfL '$url' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-raspotify.gpg --yes"
+			# ARMv6: 0.31.8.1 is the last version supporting ARMv6: https://github.com/dtcooper/raspotify/commit/345f15c
+			if (( $G_HW_ARCH == 1 ))
+			then
+				Download_Install 'https://github.com/dtcooper/raspotify/releases/download/0.31.8.1/raspotify_0.31.8.1.librespot.v0.3.1-54-gf4be9bb_armhf.deb'
 
-			# APT list
-			G_EXEC eval 'echo '\''deb https://dtcooper.github.io/raspotify/ raspotify main'\'' > /etc/apt/sources.list.d/raspotify.list'
-			G_AGUP
+			# ARMv7/ARMv8/x86_64
+			else
+				# APT key
+				local url='https://dtcooper.github.io/raspotify/key.asc'
+				G_CHECK_URL "$url"
+				G_EXEC eval "curl -sSfL '$url' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-raspotify.gpg --yes"
 
-			# APT package
-			G_AGI raspotify
+				# APT list
+				G_EXEC eval 'echo '\''deb https://dtcooper.github.io/raspotify/ raspotify main'\'' > /etc/apt/sources.list.d/raspotify.list'
+				G_AGUP
+
+				# APT package
+				G_AGI raspotify
+			fi
+			
+			# Stop service
 			G_EXEC systemctl stop raspotify
-
 		fi
 
 		software_id=169 # Google AIY

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10001,7 +10001,7 @@ _EOF_
 			HOME='/root'
 
 			# Install web vault
-			local fallback_url='https://github.com/dani-garcia/bw_web_builds/releases/download/v2022.6.0/bw_web_v2022.6.0.tar.gz'
+			local fallback_url='https://github.com/dani-garcia/bw_web_builds/releases/download/v2022.6.2/bw_web_v2022.6.2.tar.gz'
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/dani-garcia/bw_web_builds/releases/latest' | mawk -F\" '/"browser_download_url": .*\/bw_web_[^"\/]*\.tar\.gz"/{print $4}')" /mnt/dietpi_userdata/vaultwarden
 
 			# User
@@ -11435,21 +11435,14 @@ _EOF_
 
 			Banner_Installing
 
-			# ARMv6 + ARMv7 since as of v1.8 there were issues with ARMv7 binaries on Raspbian which are hence not provided anymore: https://github.com/MichaIng/DietPi/issues/2959
-			local arch='arm-6'
+			# ARMv7: As of v1.8 there were issues with ARMv7 binaries on Raspbian which are hence not provided anymore: https://github.com/go-gitea/gitea/issues/6700
+			case $G_HW_ARCH in
+				[12]) local arch='arm-6';;
+				3) local arch='arm64'
+				*) local arch='amd64'
+			esac
 
-			# ARMv8
-			if (( $G_HW_ARCH == 3 ))
-			then
-				arch='arm64'
-
-			# x86_64
-			elif (( $G_HW_ARCH == 10 ))
-			then
-				arch='amd64'
-			fi
-
-			local fallback_url="https://github.com/go-gitea/gitea/releases/download/v1.16.8/gitea-1.16.8-linux-$arch"
+			local fallback_url="https://github.com/go-gitea/gitea/releases/download/v1.16.9/gitea-1.16.9-linux-$arch"
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/go-gitea/gitea/releases/latest' | mawk -F\" "/\"browser_download_url\": \".*\/gitea-[^\"\/]*-linux-$arch\"/{print \$4}")" /mnt/dietpi_userdata/gitea/gitea
 
 			# User

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5989,25 +5989,8 @@ _EOF_
 			# APT package
 			G_AGI webmin
 			G_EXEC systemctl stop webmin
-
-			# Service
 			Remove_SysV webmin
-			cat << '_EOF_' > /etc/systemd/system/webmin.service
-[Unit]
-Description=Webmin (DietPi)
-Documentation=https://doxfer.webmin.com/Webmin/Main_Page
 
-[Service]
-Type=forking
-GuessMainPID=no
-SyslogIdentifier=Webmin
-ExecStart=/etc/webmin/start
-ExecStop=/etc/webmin/stop
-ExecReload=/etc/webmin/reload
-
-[Install]
-WantedBy=multi-user.target
-_EOF_
 		fi
 
 		software_id=195 # youtube-dl
@@ -13190,10 +13173,11 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
 
 			Banner_Uninstalling
-			if [[ -f '/etc/systemd/system/webmin.service' ]]
+			if [[ -f '/lib/systemd/system/webmin.service' ]]
 			then
+				G_EXEC systemctl unmask webmin
 				G_EXEC systemctl disable --now webmin
-				G_EXEC rm /etc/systemd/system/webmin.service
+				G_EXEC rm /lib/systemd/system/webmin.service
 			fi
 			[[ -d '/etc/systemd/system/webmin.service.d' ]] && G_EXEC rm -R /etc/systemd/system/webmin.service.d
 			G_AGP webmin

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -59,7 +59,7 @@
 	# - Assign defaults/code version as fallback
 	[[ $G_DIETPI_VERSION_CORE ]] || G_DIETPI_VERSION_CORE=8
 	[[ $G_DIETPI_VERSION_SUB ]] || G_DIETPI_VERSION_SUB=7
-	[[ $G_DIETPI_VERSION_RC ]] || G_DIETPI_VERSION_RC=-1
+	[[ $G_DIETPI_VERSION_RC ]] || G_DIETPI_VERSION_RC=0
 	[[ $G_GITBRANCH ]] || G_GITBRANCH='master'
 	[[ $G_GITOWNER ]] || G_GITOWNER='MichaIng'
 	# - Save current version and Git branch

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -58,8 +58,8 @@
 	[[ -f '/boot/dietpi/.version' ]] && . /boot/dietpi/.version
 	# - Assign defaults/code version as fallback
 	[[ $G_DIETPI_VERSION_CORE ]] || G_DIETPI_VERSION_CORE=8
-	[[ $G_DIETPI_VERSION_SUB ]] || G_DIETPI_VERSION_SUB=6
-	[[ $G_DIETPI_VERSION_RC ]] || G_DIETPI_VERSION_RC=1
+	[[ $G_DIETPI_VERSION_SUB ]] || G_DIETPI_VERSION_SUB=7
+	[[ $G_DIETPI_VERSION_RC ]] || G_DIETPI_VERSION_RC=-1
 	[[ $G_GITBRANCH ]] || G_GITBRANCH='master'
 	[[ $G_GITOWNER ]] || G_GITOWNER='MichaIng'
 	# - Save current version and Git branch

--- a/dietpi/func/dietpi-obtain_hw_model
+++ b/dietpi/func/dietpi-obtain_hw_model
@@ -13,10 +13,11 @@
 	# - Called from /boot/dietpi/preboot, called by /etc/systemd/system/dietpi-preboot.service
 	#
 	# Developer note: Sync highest IDs with dietpi-software:
-	# - MAX_G_HW_MODEL=75
+	# - MAX_G_HW_MODEL=76
 	# - MAX_G_HW_ARCH=10
 	# - MAX_G_DISTRO=7
 	#
+	# G_HW_MODEL 76 NanoPi R5S
 	# G_HW_MODEL 75 Container
 	# G_HW_MODEL 74 Radxa Zero
 	# G_HW_MODEL 73 ROCK Pi S
@@ -85,18 +86,11 @@
 	# G_HW_CPUID 7 Amlogic S905
 	# G_HW_CPUID 8 Allwinner A64
 	# G_HW_CPUID 9 Rockchip RK3566
+	# G_HW_CPUID 10 Rockchip RK3568
 	# ----------------
-	# G_DISTRO 0 unknown/unsupported
-	# G_DISTRO 1 Debian Wheezy (No longer supported: https://dietpi.com/forum/t/dietpi-for-rpi-wheezy-support-ended-22nd-june-2016/360)
-	# G_DISTRO 2 Ubuntu 14.04 (No longer supported)
-	# G_DISTRO 3 Jessie (No longer supported: https://github.com/MichaIng/DietPi/issues/2332)
-	# G_DISTRO 4 Stretch (No longer supported: https://github.com/MichaIng/DietPi/pull/5068)
 	# G_DISTRO 5 Buster
 	# G_DISTRO 6 Bullseye
 	# G_DISTRO 7 Bookworm
-	# ----------------
-	# G_HW_ONBOARD_WIFI 0 Not set
-	# G_HW_ONBOARD_WIFI 1 RPi3/4/Zero W (BCM43438)
 	#////////////////////////////////////
 
 	#/////////////////////////////////////////////////////////////////////////////////////
@@ -311,7 +305,12 @@
 
 			G_HW_MODEL=$(mawk 'NR==1' "$FP_G_HW_MODEL_IDENTIFIER")
 
-			if (( $G_HW_MODEL == 75 )); then
+			if (( $G_HW_MODEL == 76 )); then
+
+				G_HW_MODEL_NAME='NanoPi R5S'
+				G_HW_CPUID=10
+
+			elif (( $G_HW_MODEL == 75 )); then
 
 				G_HW_MODEL_NAME='Container'
 				grep -q '^ID=raspbian' /etc/os-release && G_RASPBIAN=1


### PR DESCRIPTION
### Beta v8.7.0
_(2022-07-23)_

#### New images
- NanoPi R5S | Initial support for FriendlyELEC's new router SBC has been added, with three Ethernet ports, up to 2.5 Gbps, based on the new Rockchip RK3568 SoC.

#### New software
- Readarr | The ebook manager of the Servarr family has been added as dietpi-software option.
- Navidrome | An open source web-based music collection server and streamer has been added as dietpi-software option.

#### Enhancements
- DietPi-Software | Prowlarr: Logging is now done to /var/log/prowlarr as intended. For this change to take effect, existing instances need to be reinstalled once: dietpi-software reinstall 151
- DietPi-Software | vaultwarden: DEB packages are now hosted on dietpi.com, replacing the time consuming in-place compiling. This also solves issues where builds failed due to insufficient memory.

#### Bug fixes
- DietPi-Software | Resolved an issue where "cgroup_enable=memory" was unnecessarily added multiple times on Raspberry Pi when installing or reinstalling container engines. Many thanks to @mdsjip for fixing this issue: https://github.com/MichaIng/DietPi/pull/5600
- DietPi-Software | Webmin: Resolved an issue where the service failed to start. Many thanks to @alucard87pl for reporting this issue: https://github.com/MichaIng/DietPi/issues/5594
- DietPi-Software | Raspotify: Resolved an issue where the service failed to start on ARMv6 RPi models (Raspberry Pi 1 and Zero (1)). It is not supported by latest Raspotify anymore, so we install the latest ARMv6-compatible version instead. Many thanks to @dvelluto for reporting this issue: https://github.com/MichaIng/DietPi/issues/5602
- DietPi-Software | Rclone: Resolved an issue where on ARMv6 the x86_64 package was attempted to be installed. Many thanks to @eddiermar for reporting this issue: https://github.com/MichaIng/DietPi/issues/5601
- DietPi-Software | Unbound: Resolved an issue on Debian Bookworm where the service failed to start because of missing root trust anchors. Many thanks to @smittyj for reporting this issue: https://github.com/MichaIng/DietPi/issues/5612
- DietPi-Software | Tailscale: Resolved an issue where APT updates failed after Tailscale was uninstalled. Many thanks to @SlowRaid for resolving this issue: https://github.com/MichaIng/DietPi/issues/5623