### PR TITLE
Live patch 0 | Fix vaultwarden installation on Buster and Bookworm systems

### DIFF
--- a/.update/version
+++ b/.update/version
@@ -14,6 +14,8 @@ G_MIN_DEBIAN=5
 # Alternative Git branch to automatically migrate to when Debian version is too low
 G_OLD_DEBIAN_BRANCH='stretch'
 # Live patches
-G_LIVE_PATCH_DESC=()
-G_LIVE_PATCH_COND=()
-G_LIVE_PATCH=()
+G_LIVE_PATCH_DESC=('Fix vaultwarden installation on Buster and Bookworm systems')
+# shellcheck disable=SC2016
+G_LIVE_PATCH_COND=('[[ $G_DISTRO != 6 ]] && grep '\''bullseye/vaultwarden'\'' /boot/dietpi/dietpi-software')
+# shellcheck disable=SC2016
+G_LIVE_PATCH=('sed -i '\''s|bullseye/vaultwarden|$G_DISTRO_NAME/vaultwarden|'\'' /boot/dietpi/dietpi-software')


### PR DESCRIPTION
- Live patch 0 | Fix vaultwarden installation on Buster and Bookworm systems: https://github.com/MichaIng/DietPi/pull/5682