### PR TITLE
Beta v8.8.0

### DIFF
--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -330,8 +330,8 @@ G_EXEC losetup -d "$FP_LOOP"
 # DietPi-Imager
 ##########################################
 # Do not pack and upload raw VM image if not explicitly requested
-[[ $VMTYPE && ! $VMTYPE =~ ^(raw|all)$ ]] && SHRINK_ONLY='On' || SHRINK_ONLY='Off'
-export FP_ROOT_DEV CLONING_TOOL OUTPUT_IMG_NAME MOUNT_IT='Off' SHRINK_ONLY
+[[ $VMTYPE && ! $VMTYPE =~ ^(raw|all)$ ]] && SKIP_ARCHIVE=1 || SKIP_ARCHIVE=0
+export FP_ROOT_DEV CLONING_TOOL OUTPUT_IMG_NAME MOUNT_IT='Off' SKIP_ARCHIVE
 [[ $EDITION && $EDITION != 'all' ]] || bash -c "$(curl -sSf "https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.build/images/dietpi-imager")" 'DietPi-Imager' "$OUTPUT_IMG_NAME.img" || exit 1
 
 # Amiberry edition: Install automatically on first boot, enable autostart option and onboard audio on RPi

--- a/.build/images/dietpi-imager
+++ b/.build/images/dietpi-imager
@@ -68,7 +68,8 @@
 	OUTPUT_IMG_EXT='img'
 	#OUTPUT_IMG_NAME=
 	[[ $MOUNT_IT == 'On' ]] || MOUNT_IT='Off'
-	[[ $SHRINK_ONLY == 'On' ]] || SHRINK_ONLY='Off'
+	(( $SHRINK_ONLY == 1 )) || SHRINK_ONLY=0
+	(( $SKIP_ARCHIVE == 1 )) || SKIP_ARCHIVE=0
 
 	Unmount_tmp()
 	{
@@ -335,6 +336,8 @@
 		G_EXEC mount "$FP_ROOT_DEV" "$FP_MNT_TMP"
 		# - Remove bash history and DHCP leases, which are stored on shutdown, hence cannot be removed via DietPi-PREP
 		G_EXEC rm -f "$FP_MNT_TMP/"{root,home/*}/.bash_history "$FP_MNT_TMP/var/lib/dhcp/"*.leases
+		# - Enable DietPi-FS_partition_resize to have both, old and new image being resized on next boot automatically
+		[[ -f $FP_MNT_TMP/etc/systemd/system/dietpi-fs_partition_resize.service && ! -L $FP_MNT_TMP/etc/systemd/system/local-fs.target.wants/dietpi-fs_partition_resize.service ]] && G_EXEC ln -s "$FP_MNT_TMP/etc/systemd/system/"{,'local-fs.target.wants/'}'dietpi-fs_partition_resize.service'
 		if [[ $MOUNT_IT == 'On' ]] && G_WHIP_MSG "The ${SOURCE_TYPE,,} has been mounted to allow you reviewing or editing its content:
 - $FP_ROOT_DEV > $FP_MNT_TMP
 \nAn interactive bash subshell will open.
@@ -472,6 +475,9 @@
 			G_EXEC partprobe "$FP_SOURCE"
 			G_EXEC partx -u "$FP_SOURCE"
 		fi
+
+		# Exit now if source shall be shrunk only
+		(( $SHRINK_ONLY )) && exit 0
 
 		# Finished: Derive final image size from last partition end + failsafe buffer
 		IMAGE_SIZE=$(( ( $(sfdisk -qlo End "$FP_SOURCE" | tail -1) + 1 ) * 512 )) # 512 byte sectors => Byte
@@ -635,8 +641,8 @@ _EOF_
 			G_EXEC sync
 		fi
 
-		# Exit now when image shall be shrunk only
-		[[ $SHRINK_ONLY == 'On' ]] && exit 0
+		# Exit now when archive shall be skipped
+		(( $SKIP_ARCHIVE )) && exit 0
 
 		# Generate hashes: MD5, SHA1, SHA256
 		G_DIETPI-NOTIFY 2 'Generating hashes to pack with image, please wait...'

--- a/.build/images/dietpi-imager
+++ b/.build/images/dietpi-imager
@@ -370,8 +370,7 @@
 
 			# Run multiple times until no change is done any more
 			G_DIETPI-NOTIFY 2 'Shrinking last filesystem to minimum size...'
-			local out
-			FS_SIZE=0
+			local out last_fs_size=$(tune2fs -l "$last_part_dev" | mawk '/^Block count/{print $3;exit}') # blocks
 			while :
 			do
 				resize2fs -M "$last_part_dev" 2>&1 | tee resize2fs_out
@@ -380,13 +379,16 @@
 					rm resize2fs_out
 					FS_SIZE=$(mawk '{print $5}' <<< "$out") # blocks
 					BLOCK_SIZE=${out%%k) *} BLOCK_SIZE=${BLOCK_SIZE##*\(} # KiB
-					# Re-add 4 MiB if it would still fit into the partition, which was required on Raspbian Buster for successful boot.
-					if (( $(<"/sys/class/block/${last_part_dev##*/}/size") > $FS_SIZE * $BLOCK_SIZE * 2 + 8 )) # 512 byte sectors
+					# Re-add 4 MiB if it would be still smaller than before, which was required on Raspbian Buster for successful boot, else leave original size
+					if (( $last_fs_size > $FS_SIZE + 4096/$BLOCK_SIZE )) # blocks
 					then
 						FS_SIZE=$(( $FS_SIZE + 4096/$BLOCK_SIZE )) # blocks
-						G_EXEC resize2fs "$last_part_dev" "$FS_SIZE"
+						G_DIETPI-NOTIFY 0 "Reducing last filesystem size to $(( $FS_SIZE * $BLOCK_SIZE / 1024 + 1 )) MiB"
+					else
+						FS_SIZE=$last_fs_size
+						G_DIETPI-NOTIFY 0 "Leaving last filesystem size at $(( $FS_SIZE * $BLOCK_SIZE / 1024 + 1 )) MiB"
 					fi
-					G_DIETPI-NOTIFY 0 "Reduced last filesystem size to $(( $FS_SIZE * $BLOCK_SIZE / 1024 + 1 )) MiB"
+					G_EXEC resize2fs "$last_part_dev" "$FS_SIZE"
 					FS_SIZE=$(( $FS_SIZE * $BLOCK_SIZE * 2 )) # blocks => 512 byte sectors
 					break
 
@@ -396,30 +398,30 @@
 				fi
 			done
 
-		#elif [[ $last_fs_type == 'f2fs' && ! $(lsblk -rno FSUSE% "$last_part_dev") =~ ^(9[5-9]|100)%$ ]]
-		#then
+		elif [[ $last_fs_type == 'f2fs' && ! $(lsblk -rno FSUSE% "$last_part_dev") =~ ^(9[5-9]|100)%$ ]]
+		then
 			# F2FS does not support shrinking: https://www.reddit.com/r/archlinux/comments/bpp77f/shrinking_a_f2fs_partition/
-			# Hence copy all data outside, remove and re-create a smaller filesytem, then copy them back in, as long as disk usage is not >=95% already.
+			# Hence copy all data outside, remove and re-create a smaller filesystem, then copy them back in, as long as disk usage is not >=95% already.
 			# The UUID changes and there is currently no way to change it back...
-			#local usage=$(lsblk -rnbo FSUSED "$last_part_dev") # bytes
-			#local sector_size=$(lsblk -rnbo LOG-SEC "$last_part_dev") # bytes
-			#FS_SIZE=$(( ( $usage + 4*1024**2 ) / $sector_size )) # bytes + 4 MiB buffer => sectors
-			#G_DIETPI-NOTIFY 2 'Copying last filesystem content to temporary directory'
-			#G_EXEC mkdir "${FP_MNT_TMP}_backup"
-			#G_EXEC mount -o ro "$last_part_dev" "$FP_MNT_TMP"
-			#G_EXEC cp -a "$FP_MNT_TMP/." "${FP_MNT_TMP}_backup/"
-			#G_EXEC umount "$FP_MNT_TMP"
-			#G_DIETPI-NOTIFY 2 'Purging last filesystem'
-			#G_EXEC dd if=/dev/zero of="$last_part_dev" bs=4K count=10
-			#G_DIETPI-NOTIFY 2 'Re-creating smaller last filesystem' # Probably sload.f2fs can replace this? https://manpages.debian.org/sload.f2fs
-			#G_EXEC_OUTPUT=1 G_EXEC mkfs.f2fs -w "$sector_size" "$last_part_dev" "$FS_SIZE"
-			#G_DIETPI-NOTIFY 2 'Moving last filesystem content back'
-			#G_EXEC mount "$last_part_dev" "$FP_MNT_TMP"
-			#G_EXEC cp -a "${FP_MNT_TMP}_backup/." "$FP_MNT_TMP/"
-			#G_EXEC rm -R "${FP_MNT_TMP}_backup"
-			#Unmount_tmp
-			# Assure last filesystem size is in 512 byte sectors, as this is what sfdisk assmes
-			#FS_SIZE=$(( $FS_SIZE * $sector_size / 512 ))
+			local usage=$(lsblk -rnbo FSUSED "$last_part_dev") # bytes
+			local sector_size=$(lsblk -rnbo LOG-SEC "$last_part_dev") # bytes
+			FS_SIZE=$(( ( $usage + 4*1024**2 ) / $sector_size )) # bytes + 4 MiB buffer => sectors
+			G_DIETPI-NOTIFY 2 'Copying last filesystem content to temporary directory'
+			G_EXEC mkdir "${FP_MNT_TMP}_backup"
+			G_EXEC mount -o ro "$last_part_dev" "$FP_MNT_TMP"
+			G_EXEC cp -a "$FP_MNT_TMP/." "${FP_MNT_TMP}_backup/"
+			G_EXEC umount "$FP_MNT_TMP"
+			G_DIETPI-NOTIFY 2 'Purging last filesystem'
+			G_EXEC dd if=/dev/zero of="$last_part_dev" bs=4K count=10
+			G_DIETPI-NOTIFY 2 'Re-creating smaller last filesystem' # Probably sload.f2fs can replace this? https://manpages.debian.org/sload.f2fs
+			G_EXEC_OUTPUT=1 G_EXEC mkfs.f2fs -w "$sector_size" "$last_part_dev" "$FS_SIZE"
+			G_DIETPI-NOTIFY 2 'Moving last filesystem content back'
+			G_EXEC mount "$last_part_dev" "$FP_MNT_TMP"
+			G_EXEC cp -a "${FP_MNT_TMP}_backup/." "$FP_MNT_TMP/"
+			G_EXEC rm -R "${FP_MNT_TMP}_backup"
+			Unmount_tmp
+			# Assure last filesystem size is in 512 byte sectors, as this is what sfdisk assumes
+			FS_SIZE=$(( $FS_SIZE * $sector_size / 512 ))
 
 		elif [[ $last_fs_type == 'btrfs' ]]
 		then

--- a/.build/images/dietpi-imager
+++ b/.build/images/dietpi-imager
@@ -373,7 +373,7 @@
 			local out last_fs_size=$(tune2fs -l "$last_part_dev" | mawk '/^Block count/{print $3;exit}') # blocks
 			while :
 			do
-				resize2fs -M "$last_part_dev" 2>&1 | tee resize2fs_out
+				resize2fs -Mp "$last_part_dev" 2>&1 | tee resize2fs_out
 				if out=$(grep -im1 'nothing to do!' resize2fs_out)
 				then
 					rm resize2fs_out
@@ -490,18 +490,16 @@
 			[[ $PWD/$OUTPUT_IMG_NAME.$OUTPUT_IMG_EXT != "$(readlink -f "$FP_SOURCE_IMG")" ]] && G_EXEC mv "$FP_SOURCE_IMG" "$OUTPUT_IMG_NAME.$OUTPUT_IMG_EXT"
 
 			# Check for sufficient free disk space to store the 7z archive with 100 MiB buffer
-			NEEDED_FREE_SPACE=$(( $IMAGE_SIZE * 15/100  / 1024**2 + 100 ))
-			G_CHECK_FREESPACE . "$NEEDED_FREE_SPACE" || exit 1 
+			G_CHECK_FREESPACE . $(( $IMAGE_SIZE * 15/100 / 1024**2 + 100 )) || exit 1 
 
 		# Drive source and dd target
 		elif [[ $CLONING_TOOL == 'dd' ]]
 		then
 			# Check for sufficient free disk space to store the image and the 7z archive with 100 MiB buffer
-			NEEDED_FREE_SPACE=$(( $IMAGE_SIZE * 115/100 / 1024**2 + 100 ))
-			G_CHECK_FREESPACE . "$NEEDED_FREE_SPACE" || exit 1 
+			G_CHECK_FREESPACE . $(( $IMAGE_SIZE * 115/100 / 1024**2 + 100 )) || exit 1 
 
 			G_DIETPI-NOTIFY 2 "Creating final image with actually used size: $(( $IMAGE_SIZE / 1024**2 + 1 )) MiB"
-			G_EXEC dd if="$FP_SOURCE" of="$OUTPUT_IMG_NAME.$OUTPUT_IMG_EXT" bs=1M status=progress count=$(( $IMAGE_SIZE / 1024**2 + 1 ))
+			G_EXEC_OUTPUT=1 G_EXEC dd if="$FP_SOURCE" of="$OUTPUT_IMG_NAME.$OUTPUT_IMG_EXT" bs=1M status=progress count=$(( $IMAGE_SIZE / 1024**2 + 1 ))
 
 		# Clonezilla target
 		else
@@ -512,7 +510,7 @@
 			# - We need Clonezilla 5.x for loop device support
 			if [[ $(dpkg-query -Wf '${Version}' clonezilla 2> /dev/null) != '5'* ]]
 			then
-				G_EXEC curl -sSf 'https://deb.debian.org/debian/pool/main/c/clonezilla/clonezilla_5.1.10-1_all.deb' -o clonezilla.deb
+				G_EXEC curl -sSf 'https://deb.debian.org/debian/pool/main/c/clonezilla/clonezilla_5.2.2-1_all.deb' -o clonezilla.deb
 				G_EXEC dpkg -i ./clonezilla.deb
 				G_EXEC rm clonezilla.deb
 			fi
@@ -527,7 +525,7 @@
 			CLONEZILLA_SIZE=$(curl -sSfIL "${CLONEZILLA_URL/amd64.zip/amd64.iso}" | mawk '/^[Cc]ontent-[Ll]ength:/{print $2}' | tail -1); CLONEZILLA_SIZE=${CLONEZILLA_SIZE%$'\r'}
 			(( $CLONEZILLA_SIZE )) || Error_Exit 'Could not retrieve Clonezilla Live size, aborting...'
 			NEEDED_FREE_SPACE=$(( ( $CLONEZILLA_SIZE + $IMAGE_SIZE * 20/100 ) * 2 / 1024**2 + 100 )) REMOVE_IMG=0
-			# If free space is insufficient and the source an image on the same filesystem, check whether it fits when we remove the source image before generating the ISO
+			# If free space is insufficient and the source is an image on the same filesystem, check whether it fits when we remove the source image before generating the ISO
 			if ! G_CHECK_FREESPACE . "$NEEDED_FREE_SPACE"
 			then
 				[[ $FP_SOURCE_IMG && $(findmnt -Ufnro TARGET -T "$FP_SOURCE_IMG") == $(findmnt -Ufnro TARGET -T .) ]] || exit 1

--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -985,11 +985,11 @@ _EOF_
 			G_EXEC rm "firmware-$variant.deb"
 
 		# - NanoPi R5S
-		#elif [[ $G_HW_MODEL == 76 && $(findmnt -Ufnro TARGET -T /boot) == '/' ]]
-		#then
-		#	G_EXEC curl -sSfLO 'https://dietpi.com/downloads/binaries/firmware-nanopi5.deb'
-		#	G_EXEC_OUTPUT=1 G_EXEC dpkg -i firmware-nanopi5.deb
-		#	G_EXEC rm firmware-nanopi5.deb
+		elif [[ $G_HW_MODEL == 76 && $(findmnt -Ufnro TARGET -T /boot) == '/' ]]
+		then
+			G_EXEC curl -sSfLO 'https://dietpi.com/downloads/binaries/firmware-nanopi5.deb'
+			G_EXEC_OUTPUT=1 G_EXEC dpkg -i firmware-nanopi5.deb
+			G_EXEC rm firmware-nanopi5.deb
 
 		# - NanoPi M2/T2 Linux 4.4: Requires dedicated boot partition, starting at 4 MiB for U-Boot, with ext4 filesystem
 		elif [[ $G_HW_MODEL == 61 && $(findmnt -Ufnro FSTYPE -M /boot) == 'ext4' ]] && (( $(sfdisk -qlo Start "$BOOT_DEVICE)" | mawk 'NR==2') >= 8192 ))

--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -417,6 +417,28 @@ _EOF_
 
 		G_DIETPI-NOTIFY 2 "Selected hardware model ID: $G_HW_MODEL"
 
+		# Check for partition table: https://github.com/MichaIng/DietPi/issues/5691
+		local BOOT_DEVICE=$(lsblk -npo PKNAME "$(findmnt -Ufnro SOURCE -T /boot)")
+		# - Ignore for containers
+		if [[ ! $BOOT_DEVICE && $G_HW_MODEL != 75 ]]
+		then
+			# Allow missing partition table for VMs and temporarily for generic device until we support ARM VMs
+			if [[ $G_HW_MODEL == 2[02] ]]
+			then
+				G_WHIP_BUTTON_OK_TEXT='Continue'
+				G_WHIP_BUTTON_CANCEL_TEXT='Exit'
+				if ! G_WHIP_YESNO '[WARNING] The boot drive does not contain a partition table!
+\nWithout a partition table, the bootloader cannot be flashed, which can leave this system unbootable. It is however expected with some VPS providers, like Linode, which use external bootloaders. If this is the case, hit "Continue" to run the DietPi-Installer regardless.'
+				then
+					G_DIETPI-NOTIFY 0 'Exit selected. Aborting...\n'
+					exit 0
+				fi
+			else
+				G_DIETPI-NOTIFY 1 'Unable to flash the bootloader: The boot drive does not contain a partition table. Aborting...\n'
+				exit 1
+			fi
+		fi
+
 		# WiFi selection
 		(( $G_HW_MODEL == 20 || $G_HW_MODEL == 75 )) && WIFI_REQUIRED=0
 		if [[ $WIFI_REQUIRED != [01] ]]
@@ -642,7 +664,7 @@ _EOF_
 			#'xz-utils'		# (.tar).xz archiver
 		)
 
-		# Install gdisk if root file system is on a GPT partition, used by DietPi-FS_partition_resize
+		# Install gdisk if root filesystem is on a GPT partition, used by DietPi-FS_partition_resize
 		[[ $(blkid -s PTTYPE -o value -c /dev/null "$(lsblk -npo PKNAME "$(findmnt -Ufnro SOURCE -M /)")") == 'gpt' ]] && aPACKAGES_REQUIRED_INSTALL+=('gdisk')
 
 		# Install filesystem tools required for filesystem resizing and fsck
@@ -834,13 +856,13 @@ _EOF_
 			# shellcheck disable=SC1091
 			. /usr/lib/u-boot/platform_install.sh
 			# shellcheck disable=SC2154
-			write_uboot_platform "$DIR" "$(lsblk -npo PKNAME "$(findmnt -Ufnro SOURCE -T /boot)")"
+			write_uboot_platform "$DIR" "$BOOT_DEVICE"
 			# Workaround for Odroid N2 failing to boot from eMMC: https://forum.armbian.com/topic/20206-odroid-n2-issues-with-recent-firmware-and-emmc-modules/#comment-142409
 			if (( $G_HW_MODEL == 15 ))
 			then
 				G_EXEC curl -sSfLO 'https://dietpi.com/downloads/binaries/u-boot-odroidn2.bin.gz'
 				G_EXEC gzip -d u-boot-odroidn2.bin.gz
-				G_EXEC dd bs=512 seek=1 conv=notrunc if=u-boot-odroidn2.bin "of=$(lsblk -npo PKNAME "$(findmnt -Ufnro SOURCE -T /boot)")"
+				G_EXEC dd bs=512 seek=1 conv=notrunc if=u-boot-odroidn2.bin "of=$BOOT_DEVICE"
 			fi
 
 		# - Armbian grab currently installed packages
@@ -970,7 +992,7 @@ _EOF_
 		#	G_EXEC rm firmware-nanopi5.deb
 
 		# - NanoPi M2/T2 Linux 4.4: Requires dedicated boot partition, starting at 4 MiB for U-Boot, with ext4 filesystem
-		elif [[ $G_HW_MODEL == 61 && $(findmnt -Ufnro FSTYPE -M /boot) == 'ext4' ]] && (( $(sfdisk -qlo Start "$(lsblk -npo PKNAME "$(findmnt -Ufnro SOURCE -M /boot)")" | mawk 'NR==2') >= 8192 ))
+		elif [[ $G_HW_MODEL == 61 && $(findmnt -Ufnro FSTYPE -M /boot) == 'ext4' ]] && (( $(sfdisk -qlo Start "$BOOT_DEVICE)" | mawk 'NR==2') >= 8192 ))
 		then
 			G_EXEC curl -sSfLO 'https://dietpi.com/downloads/binaries/firmware-nanopi2.deb'
 			G_EXEC_OUTPUT=1 G_EXEC dpkg -i firmware-nanopi2.deb
@@ -1873,7 +1895,7 @@ _EOF_
 
 			# BIOS
 			else
-				G_EXEC_DESC='Installing GRUB for BIOS' G_EXEC_OUTPUT=1 G_EXEC grub-install --recheck "$(lsblk -npo PKNAME "$(findmnt -Ufnro SOURCE -T /boot)")"
+				[[ $BOOT_DEVICE ]] && G_EXEC_DESC='Installing GRUB for BIOS' G_EXEC_OUTPUT=1 G_EXEC grub-install --recheck "$BOOT_DEVICE"
 			fi
 
 			# Update config

--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -771,31 +771,6 @@ _EOF_
 				echo 'do_symlinks=0' > /etc/kernel-img.conf
 				G_EXEC rm -f /{,boot/}{initrd.img,vmlinuz}{,.old}
 
-				# If /boot is on a FAT partition, create a kernel upgrade hook script to remove existing files first: https://github.com/MichaIng/DietPi/issues/4788
-				if [[ $(findmnt -Ufnro FSTYPE -M /boot) == 'vfat' ]]
-				then
-					G_EXEC mkdir -p /etc/kernel/preinst.d
-					cat << '_EOF_' > /etc/kernel/preinst.d/dietpi
-#!/bin/sh -e
-# Remove old kernel files if existing: https://github.com/MichaIng/DietPi/issues/4788
-{
-# Fail if the package name was not passed, which is done when being invoked by dpkg
-if [ -z "$DPKG_MAINTSCRIPT_PACKAGE" ]
-then
-        echo 'DPKG_MAINTSCRIPT_PACKAGE was not set, this script must be invoked by dpkg.'
-        exit 1
-fi
-
-# Loop through files in /boot, shipped by the package, and remove them, if existing
-for file in $(dpkg -L "$DPKG_MAINTSCRIPT_PACKAGE" | grep '^/boot/')
-do
-        [ ! -f "$file" ] || rm "$file"
-done
-}
-_EOF_
-					G_EXEC chmod +x /etc/kernel/preinst.d/dietpi
-				fi
-
 				G_AGI "${apackages[@]}"
 				unset -v apackages
 
@@ -1856,7 +1831,7 @@ _EOF_
 		then
 			G_DIETPI-NOTIFY 2 'Generating default wpa_supplicant.conf'
 			/boot/dietpi/func/dietpi-wifidb 1
-			# Move to /boot/ so users can modify as needed for automated
+			# Move to /boot so users can modify as needed for automation
 			G_EXEC mv /var/lib/dietpi/dietpi-wifi.db /boot/dietpi-wifi.txt
 
 			tmp_info='Enabling'
@@ -1898,7 +1873,7 @@ _EOF_
 
 			# BIOS
 			else
-				G_EXEC_DESC='Installing GRUB for BIOS' G_EXEC_OUTPUT=1 G_EXEC grub-install --recheck "$(lsblk -npo PKNAME "$(findmnt -Ufnro SOURCE -M /)")"
+				G_EXEC_DESC='Installing GRUB for BIOS' G_EXEC_OUTPUT=1 G_EXEC grub-install --recheck "$(lsblk -npo PKNAME "$(findmnt -Ufnro SOURCE -T /boot)")"
 			fi
 
 			# Update config

--- a/.build/software/Amiberry/build.bash
+++ b/.build/software/Amiberry/build.bash
@@ -42,7 +42,7 @@ else
 fi
 
 # Build libSDL2_image
-v_img='2.6.0'
+v_img='2.6.1'
 if [[ ! -d /tmp/SDL2_image-$v_img ]]
 then
 	G_DIETPI-NOTIFY 2 "Building libSDL2_image version \e[33m$v_img"
@@ -150,7 +150,7 @@ echo '/mnt/dietpi_userdata/amiberry/conf/amiberry.conf' > "$DIR/DEBIAN/conffiles
 # - prerm
 cat << '_EOF_' > "$DIR/DEBIAN/prerm"
 #!/bin/sh
-if [ -d '/run/systemd/system' ] && [ -f '/lib/systemd/system/amiberry.service' ]
+if [ "$1" = 'remove' ] && [ -d '/run/systemd/system' ] && [ -f '/lib/systemd/system/amiberry.service' ]
 then
 	echo 'Deconfiguring Amiberry systemd service ...'
 	systemctl unmask amiberry
@@ -186,7 +186,7 @@ grep -q 'raspbian' /etc/os-release && DEPS_APT_VERSIONED=$(sed 's/+rp[it][0-9]\+
 # - control
 cat << _EOF_ > "$DIR/DEBIAN/control"
 Package: amiberry
-Version: $v_ami-dietpi2
+Version: $v_ami-dietpi3
 Architecture: $(dpkg --print-architecture)
 Maintainer: MichaIng <micha@dietpi.com>
 Date: $(date -u '+%a, %d %b %Y %T %z')
@@ -195,7 +195,7 @@ Installed-Size: $(du -sk "$DIR" | mawk '{print $1}')
 Depends:$DEPS_APT_VERSIONED
 Section: games
 Priority: optional
-Homepage: https://github.com/midwan/amiberry
+Homepage: https://amiberry.com/
 Vcs-Git: https://github.com/midwan/amiberry.git
 Vcs-Browser: https://github.com/midwan/amiberry
 Description: Optimized Amiga emulator for the Raspberry Pi and other ARM boards

--- a/.build/software/Amiberry/build.bash
+++ b/.build/software/Amiberry/build.bash
@@ -2,7 +2,7 @@
 . /boot/dietpi/func/dietpi-globals || exit 1
 
 [[ $1 ]] && PLATFORM=$1
-[[ $PLATFORM ]] || { G_WHIP_INPUTBOX 'Build Amiberry? Enter platform: https://github.com/midwan/amiberry/blob/master/Makefile' && PLATFORM=$G_WHIP_RETURNED_VALUE || exit 0; }
+[[ $PLATFORM ]] || { G_WHIP_INPUTBOX 'Build Amiberry? Enter platform: https://github.com/BlitterStudio/amiberry/blob/master/Makefile' && PLATFORM=$G_WHIP_RETURNED_VALUE || exit 0; }
 G_DIETPI-NOTIFY 2 "Amiberry will be built for platform: \e[33m$PLATFORM"
 
 # APT dependencies
@@ -10,7 +10,7 @@ opengl_flags=('--enable-video-opengles2' '--disable-video-opengl')
 adeps_build=('autoconf' 'make' 'g++' 'pkg-config' 'libdrm-dev' 'libgbm-dev' 'libudev-dev' 'libxml2-dev' 'libpng-dev' 'libfreetype6-dev' 'libflac-dev' 'libmpg123-dev' 'libmpeg2-4-dev' 'libasound2-dev' 'wget' 'kbd')
 adeps=('libdrm2' 'libgl1-mesa-dri' 'libgbm1' 'libegl1' 'libudev1' 'libxml2' 'libpng16-16' 'libfreetype6' 'libflac8' 'libmpg123-0' 'libmpeg2-4' 'libasound2' 'wget' 'kbd')
 (( $G_HW_ARCH == 10 )) && opengl_flags=('--disable-video-opengles2' '--enable-video-opengl') adeps_build+=('libgl1-mesa-dev') adeps+=('libgl1') || adeps_build+=('libgles2-mesa-dev') adeps+=('libgles2')
-# - wget: Used for WHDLoad database update: https://github.com/midwan/amiberry/commit/d6c103e3310bcf75c2d72a15849fbdf5eb7432b5
+# - wget: Used for WHDLoad database update: https://github.com/BlitterStudio/amiberry/commit/d6c103e3310bcf75c2d72a15849fbdf5eb7432b5
 # - kbd: For "chvt" used in systemd unit as SDL2 spams the console with every key press
 if [[ $PLATFORM == 'rpi'* ]]
 then
@@ -23,12 +23,12 @@ G_AGDUG
 G_AG_CHECK_INSTALL_PREREQ "${adeps_build[@]}"
 
 # Build libSDL2
-v_sdl='2.0.22'
+v_sdl='2.24.0'
 if [[ ! -d /tmp/SDL2-$v_sdl ]]
 then
 	G_DIETPI-NOTIFY 2 "Building libSDL2 version \e[33m$v_sdl"
 	G_EXEC cd /tmp
-	G_EXEC curl -sSfLO "https://libsdl.org/release/SDL2-$v_sdl.tar.gz"
+	G_EXEC curl -sSfLO "https://github.com/libsdl-org/SDL/releases/download/release-$v_sdl/SDL2-$v_sdl.tar.gz"
 	G_EXEC tar xf "SDL2-$v_sdl.tar.gz"
 	G_EXEC rm "SDL2-$v_sdl.tar.gz"
 	G_EXEC cd "SDL2-$v_sdl"
@@ -47,7 +47,7 @@ if [[ ! -d /tmp/SDL2_image-$v_img ]]
 then
 	G_DIETPI-NOTIFY 2 "Building libSDL2_image version \e[33m$v_img"
 	G_EXEC cd /tmp
-	G_EXEC curl -sSfLO "https://libsdl.org/projects/SDL_image/release/SDL2_image-$v_img.tar.gz"
+	G_EXEC curl -sSfLO "https://github.com/libsdl-org/SDL_image/releases/download/release-$v_img/SDL2_image-$v_img.tar.gz"
 	G_EXEC tar xf "SDL2_image-$v_img.tar.gz"
 	G_EXEC rm "SDL2_image-$v_img.tar.gz"
 	G_EXEC cd "SDL2_image-$v_img"
@@ -66,7 +66,7 @@ if [[ ! -d /tmp/SDL2_ttf-$v_ttf ]]
 then
 	G_DIETPI-NOTIFY 2 "Building libSDL2_ttf version \e[33m$v_ttf"
 	G_EXEC cd /tmp
-	G_EXEC curl -sSfLO "https://libsdl.org/projects/SDL_ttf/release/SDL2_ttf-$v_ttf.tar.gz"
+	G_EXEC curl -sSfLO "https://github.com/libsdl-org/SDL_ttf/releases/download/release-$v_ttf/SDL2_ttf-$v_ttf.tar.gz"
 	G_EXEC tar xf "SDL2_ttf-$v_ttf.tar.gz"
 	G_EXEC rm "SDL2_ttf-$v_ttf.tar.gz"
 	G_EXEC cd "SDL2_ttf-$v_ttf"
@@ -101,7 +101,7 @@ v_ami='5.3'
 G_DIETPI-NOTIFY 2 "Building Amiberry version \e[33m$v_ami\e[90m for platform: \e[33m$PLATFORM"
 [[ -d /tmp/amiberry-$v_ami ]] && G_EXEC rm -R "/tmp/amiberry-$v_ami"
 G_EXEC cd /tmp
-G_EXEC curl -sSfLO "https://github.com/midwan/amiberry/archive/v$v_ami.tar.gz"
+G_EXEC curl -sSfLO "https://github.com/BlitterStudio/amiberry/archive/v$v_ami.tar.gz"
 G_EXEC tar xf "v$v_ami.tar.gz"
 G_EXEC rm "v$v_ami.tar.gz"
 G_EXEC cd "amiberry-$v_ami"
@@ -124,7 +124,7 @@ G_EXEC cp -a /tmp/capsimg-master/capsimg.so "$DIR/mnt/dietpi_userdata/amiberry/l
 cat << '_EOF_' > "$DIR/lib/systemd/system/amiberry.service"
 [Unit]
 Description=Amiberry Amiga Emulator (DietPi)
-Documentation=https://github.com/midwan/amiberry/wiki
+Documentation=https://github.com/BlitterStudio/amiberry/wiki
 
 [Service]
 WorkingDirectory=/mnt/dietpi_userdata/amiberry
@@ -186,7 +186,7 @@ grep -q 'raspbian' /etc/os-release && DEPS_APT_VERSIONED=$(sed 's/+rp[it][0-9]\+
 # - control
 cat << _EOF_ > "$DIR/DEBIAN/control"
 Package: amiberry
-Version: $v_ami-dietpi3
+Version: $v_ami-dietpi4
 Architecture: $(dpkg --print-architecture)
 Maintainer: MichaIng <micha@dietpi.com>
 Date: $(date -u '+%a, %d %b %Y %T %z')
@@ -196,8 +196,8 @@ Depends:$DEPS_APT_VERSIONED
 Section: games
 Priority: optional
 Homepage: https://amiberry.com/
-Vcs-Git: https://github.com/midwan/amiberry.git
-Vcs-Browser: https://github.com/midwan/amiberry
+Vcs-Git: https://github.com/BlitterStudio/amiberry.git
+Vcs-Browser: https://github.com/BlitterStudio/amiberry
 Description: Optimized Amiga emulator for the Raspberry Pi and other ARM boards
  This package ships with optimized libSDL2 and capsimg builds.
 _EOF_

--- a/.build/software/Amiberry/build.bash
+++ b/.build/software/Amiberry/build.bash
@@ -61,7 +61,7 @@ else
 fi
 
 # Build libSDL2_ttf
-v_ttf='2.20.0'
+v_ttf='2.20.1'
 if [[ ! -d /tmp/SDL2_ttf-$v_ttf ]]
 then
 	G_DIETPI-NOTIFY 2 "Building libSDL2_ttf version \e[33m$v_ttf"

--- a/.build/software/Amiberry/build.bash
+++ b/.build/software/Amiberry/build.bash
@@ -42,7 +42,7 @@ else
 fi
 
 # Build libSDL2_image
-v_img='2.6.1'
+v_img='2.6.2'
 if [[ ! -d /tmp/SDL2_image-$v_img ]]
 then
 	G_DIETPI-NOTIFY 2 "Building libSDL2_image version \e[33m$v_img"

--- a/.build/software/vaultwarden/build.bash
+++ b/.build/software/vaultwarden/build.bash
@@ -144,7 +144,7 @@ _EOF_
 # - prerm
 cat << '_EOF_' > "$DIR/DEBIAN/prerm"
 #!/bin/sh
-if [ -d '/run/systemd/system' ] && [ -f '/lib/systemd/system/vaultwarden.service' ]
+if [ "$1" = 'remove' ] && [ -d '/run/systemd/system' ] && [ -f '/lib/systemd/system/vaultwarden.service' ]
 then
 	echo 'Deconfiguring vaultwarden systemd service ...'
 	systemctl unmask vaultwarden
@@ -195,7 +195,7 @@ grep -q 'raspbian' /etc/os-release && DEPS_APT_VERSIONED=$(sed 's/+rp[it][0-9]\+
 # - control
 cat << _EOF_ > "$DIR/DEBIAN/control"
 Package: vaultwarden
-Version: $version-dietpi1
+Version: $version-dietpi2
 Architecture: $(dpkg --print-architecture)
 Maintainer: MichaIng <micha@dietpi.com>
 Date: $(date -u '+%a, %d %b %Y %T %z')

--- a/.build/software/vaultwarden/build.bash
+++ b/.build/software/vaultwarden/build.bash
@@ -113,6 +113,10 @@ echo '/mnt/dietpi_userdata/vaultwarden/vaultwarden.env' > "$DIR/DEBIAN/conffiles
 # - postinst
 cat << '_EOF_' > "$DIR/DEBIAN/postinst"
 #!/bin/bash
+
+# Enable remote web vault access for fresh package installs onto existing pre-v1.25 vaultwarden installs
+[[ $2 ]] || ! grep -q '^# ROCKET_ADDRESS=0.0.0.0$' /mnt/dietpi_userdata/vaultwarden/vaultwarden.env || sed -i '/^# ROCKET_ADDRESS=0.0.0.0$/c\ROCKET_ADDRESS=0.0.0.0' /mnt/dietpi_userdata/vaultwarden/vaultwarden.env
+
 if [[ -d '/run/systemd/system' ]]
 then
 	if getent passwd vaultwarden > /dev/null

--- a/.build/software/vaultwarden/build.bash
+++ b/.build/software/vaultwarden/build.bash
@@ -23,6 +23,9 @@ G_EXEC_OUTPUT=1 G_EXEC ./rustup-init.sh -y --profile minimal --default-toolchain
 G_EXEC_NOHALT=1 G_EXEC rm rustup-init.sh
 export PATH="$HOME/.cargo/bin:$PATH"
 
+# ARMv8: Build on disk, else GitHub workflow fails due to insufficient RAM
+(( $G_HW_ARCH == 3 )) && G_EXEC cd /root
+
 version='1.25.2'
 G_DIETPI-NOTIFY 2 "Building vaultwarden version \e[33m$version"
 [[ -d vaultwarden-$version ]] && G_EXEC rm -R "vaultwarden-$version"
@@ -30,15 +33,14 @@ G_EXEC curl -sSfLO "https://github.com/dani-garcia/vaultwarden/archive/$version.
 G_EXEC tar xf "$version.tar.gz"
 G_EXEC rm "$version.tar.gz"
 G_EXEC cd "vaultwarden-$version"
-free
-df /tmp
-G_EXEC_OUTPUT=1 G_EXEC cargo build -vv --features sqlite --release
+G_EXEC_OUTPUT=1 G_EXEC cargo build --features sqlite --release
 G_EXEC rustup self uninstall -y
 G_EXEC strip --remove-section=.comment --remove-section=.note target/release/vaultwarden
 
 # Build DEB package
 G_DIETPI-NOTIFY 2 'Building vaultwarden DEB package'
 G_EXEC cd "$HOME"
+(( $G_HW_ARCH == 3 )) && G_EXEC mv "/root/vaultwarden-$version" .
 grep -q 'raspbian' /etc/os-release && DIR='vaultwarden_armv6l' || DIR="vaultwarden_$G_HW_ARCH_NAME"
 [[ -d $DIR ]] && G_EXEC rm -R "$DIR"
 G_EXEC mkdir -p "$DIR/"{DEBIAN,opt/vaultwarden,mnt/dietpi_userdata/vaultwarden,lib/systemd/system}

--- a/.build/software/vaultwarden/build.bash
+++ b/.build/software/vaultwarden/build.bash
@@ -114,8 +114,12 @@ echo '/mnt/dietpi_userdata/vaultwarden/vaultwarden.env' > "$DIR/DEBIAN/conffiles
 cat << '_EOF_' > "$DIR/DEBIAN/postinst"
 #!/bin/bash
 
-# Enable remote web vault access for fresh package installs onto existing pre-v1.25 vaultwarden installs
-[[ $2 ]] || ! grep -q '^# ROCKET_ADDRESS=0.0.0.0$' /mnt/dietpi_userdata/vaultwarden/vaultwarden.env || sed -i '/^# ROCKET_ADDRESS=0.0.0.0$/c\ROCKET_ADDRESS=0.0.0.0' /mnt/dietpi_userdata/vaultwarden/vaultwarden.env
+# Enable web vault remote access for fresh package installs onto existing pre-v1.25 vaultwarden installs
+if [[ ! $2 ]] && grep -q '^# ROCKET_ADDRESS=0.0.0.0$' /mnt/dietpi_userdata/vaultwarden/vaultwarden.env
+then
+	echo 'Enabling web vault remote access ...'
+	sed -i '/^# ROCKET_ADDRESS=0.0.0.0$/c\ROCKET_ADDRESS=0.0.0.0' /mnt/dietpi_userdata/vaultwarden/vaultwarden.env
+fi
 
 if [[ -d '/run/systemd/system' ]]
 then

--- a/.build/software/vaultwarden/build.bash
+++ b/.build/software/vaultwarden/build.bash
@@ -30,7 +30,9 @@ G_EXEC curl -sSfLO "https://github.com/dani-garcia/vaultwarden/archive/$version.
 G_EXEC tar xf "$version.tar.gz"
 G_EXEC rm "$version.tar.gz"
 G_EXEC cd "vaultwarden-$version"
-G_EXEC_OUTPUT=1 G_EXEC cargo build --features sqlite --release
+free
+df /tmp
+G_EXEC_OUTPUT=1 G_EXEC cargo build -vv --features sqlite --release
 G_EXEC rustup self uninstall -y
 G_EXEC strip --remove-section=.comment --remove-section=.note target/release/vaultwarden
 

--- a/.github/workflows/amiberry.yml
+++ b/.github/workflows/amiberry.yml
@@ -30,7 +30,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_rpi1.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl -T rootfs/amiberry_rpi1.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/buster/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/amiberry_rpi1.deb"]}'
   rpi1_bullseye:
@@ -50,7 +50,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_rpi1.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl -T rootfs/amiberry_rpi1.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bullseye/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/amiberry_rpi1.deb"]}'
   rpi1_bookworm:
@@ -70,7 +70,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_rpi1.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl -T rootfs/amiberry_rpi1.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bookworm/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/amiberry_rpi1.deb"]}'
 
@@ -91,7 +91,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_rpi2.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl -T rootfs/amiberry_rpi2.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/buster/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/amiberry_rpi2.deb"]}'
   rpi2_bullseye:
@@ -111,7 +111,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_rpi2.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl -T rootfs/amiberry_rpi2.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bullseye/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/amiberry_rpi2.deb"]}'
   rpi2_bookworm:
@@ -131,7 +131,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_rpi2.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl -T rootfs/amiberry_rpi2.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bookworm/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/amiberry_rpi2.deb"]}'
 
@@ -152,7 +152,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_rpi3.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl -T rootfs/amiberry_rpi3.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/buster/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/amiberry_rpi3.deb"]}'
   rpi3_bullseye:
@@ -172,7 +172,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_rpi3.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl -T rootfs/amiberry_rpi3.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bullseye/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/amiberry_rpi3.deb"]}'
   rpi3_bookworm:
@@ -192,7 +192,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_rpi3.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl -T rootfs/amiberry_rpi3.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bookworm/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/amiberry_rpi3.deb"]}'
 
@@ -213,7 +213,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_rpi4.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl -T rootfs/amiberry_rpi4.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/buster/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/amiberry_rpi4.deb"]}'
   rpi4_bullseye:
@@ -233,7 +233,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_rpi4.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl -T rootfs/amiberry_rpi4.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bullseye/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/amiberry_rpi4.deb"]}'
   rpi4_bookworm:
@@ -253,7 +253,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_rpi4.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl -T rootfs/amiberry_rpi4.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bookworm/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/amiberry_rpi4.deb"]}'
 
@@ -274,7 +274,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_rpi3-64-dmx.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl -T rootfs/amiberry_rpi3-64-dmx.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/buster/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/amiberry_rpi3-64-dmx.deb"]}'
   rpi3-64-dmx_bullseye:
@@ -294,7 +294,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_rpi3-64-dmx.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl -T rootfs/amiberry_rpi3-64-dmx.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bullseye/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/amiberry_rpi3-64-dmx.deb"]}'
   rpi3-64-dmx_bookworm:
@@ -314,7 +314,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_rpi3-64-dmx.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl -T rootfs/amiberry_rpi3-64-dmx.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bookworm/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/amiberry_rpi3-64-dmx.deb"]}'
 
@@ -335,7 +335,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_rpi4-64-dmx.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl -T rootfs/amiberry_rpi4-64-dmx.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/buster/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/amiberry_rpi4-64-dmx.deb"]}'
   rpi4-64-dmx_bullseye:
@@ -355,7 +355,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_rpi4-64-dmx.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl -T rootfs/amiberry_rpi4-64-dmx.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bullseye/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/amiberry_rpi4-64-dmx.deb"]}'
   rpi4-64-dmx_bookworm:
@@ -375,7 +375,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_rpi4-64-dmx.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl -T rootfs/amiberry_rpi4-64-dmx.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bookworm/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/amiberry_rpi4-64-dmx.deb"]}'
 
@@ -396,7 +396,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_c1.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl -T rootfs/amiberry_c1.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/buster/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/amiberry_c1.deb"]}'
   c1_bullseye:
@@ -416,7 +416,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_c1.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl -T rootfs/amiberry_c1.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bullseye/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/amiberry_c1.deb"]}'
   c1_bookworm:
@@ -436,7 +436,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_c1.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl -T rootfs/amiberry_c1.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bookworm/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/amiberry_c1.deb"]}'
 
@@ -457,7 +457,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_xu4.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl -T rootfs/amiberry_xu4.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/buster/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/amiberry_xu4.deb"]}'
   xu4_bullseye:
@@ -477,7 +477,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_xu4.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl -T rootfs/amiberry_xu4.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bullseye/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/amiberry_xu4.deb"]}'
   xu4_bookworm:
@@ -497,7 +497,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_xu4.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl -T rootfs/amiberry_xu4.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bookworm/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/amiberry_xu4.deb"]}'
 
@@ -518,7 +518,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_RK3288.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl -T rootfs/amiberry_RK3288.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/buster/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/amiberry_RK3288.deb"]}'
   RK3288_bullseye:
@@ -538,7 +538,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_RK3288.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl -T rootfs/amiberry_RK3288.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bullseye/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/amiberry_RK3288.deb"]}'
   RK3288_bookworm:
@@ -558,7 +558,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_RK3288.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl -T rootfs/amiberry_RK3288.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bookworm/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/amiberry_RK3288.deb"]}'
 
@@ -579,7 +579,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_sun8i.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl -T rootfs/amiberry_sun8i.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/buster/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/amiberry_sun8i.deb"]}'
   sun8i_bullseye:
@@ -599,7 +599,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_sun8i.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl -T rootfs/amiberry_sun8i.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bullseye/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/amiberry_sun8i.deb"]}'
   sun8i_bookworm:
@@ -619,7 +619,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_sun8i.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl -T rootfs/amiberry_sun8i.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bookworm/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/amiberry_sun8i.deb"]}'
 
@@ -640,7 +640,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_s812.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl -T rootfs/amiberry_s812.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/buster/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/amiberry_s812.deb"]}'
   s812_bullseye:
@@ -660,7 +660,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_s812.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl -T rootfs/amiberry_s812.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bullseye/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/amiberry_s812.deb"]}'
   s812_bookworm:
@@ -680,7 +680,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_s812.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl -T rootfs/amiberry_s812.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bookworm/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/amiberry_s812.deb"]}'
 
@@ -701,7 +701,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_AMLSM1.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl -T rootfs/amiberry_AMLSM1.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/buster/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/amiberry_AMLSM1.deb"]}'
   AMLSM1_bullseye:
@@ -721,7 +721,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_AMLSM1.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl -T rootfs/amiberry_AMLSM1.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bullseye/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/amiberry_AMLSM1.deb"]}'
   AMLSM1_bookworm:
@@ -741,7 +741,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_AMLSM1.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl -T rootfs/amiberry_AMLSM1.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bookworm/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/amiberry_AMLSM1.deb"]}'
 
@@ -762,7 +762,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_n2.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl -T rootfs/amiberry_n2.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/buster/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/amiberry_n2.deb"]}'
   n2_bullseye:
@@ -782,7 +782,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_n2.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl -T rootfs/amiberry_n2.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bullseye/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/amiberry_n2.deb"]}'
   n2_bookworm:
@@ -802,7 +802,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_n2.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl -T rootfs/amiberry_n2.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bookworm/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/amiberry_n2.deb"]}'
 
@@ -823,7 +823,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_a64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl -T rootfs/amiberry_a64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/buster/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/amiberry_a64.deb"]}'
   a64_bullseye:
@@ -843,7 +843,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_a64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl -T rootfs/amiberry_a64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bullseye/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/amiberry_a64.deb"]}'
   a64_bookworm:
@@ -863,7 +863,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_a64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl -T rootfs/amiberry_a64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bookworm/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/amiberry_a64.deb"]}'
 
@@ -884,7 +884,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_x86-64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl -T rootfs/amiberry_x86-64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/buster/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/amiberry_x86-64.deb"]}'
   x86-64_bullseye:
@@ -904,7 +904,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_x86-64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl -T rootfs/amiberry_x86-64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bullseye/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/amiberry_x86-64.deb"]}'
   x86-64_bookworm:
@@ -924,6 +924,6 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/amiberry_x86-64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl -T rootfs/amiberry_x86-64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bookworm/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/amiberry_x86-64.deb"]}'

--- a/.github/workflows/dietpi-build.yml
+++ b/.github/workflows/dietpi-build.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         sudo dash -c 'umask 377; echo '\''${{ secrets.KNOWN_HOSTS }}'\'' > /root/.ssh/known_hosts; echo '\''${{ secrets.SSH_KEY }}'\'' > /root/.ssh/id_ed25519; > upload.sh; chmod 0711 upload.sh'
         echo '#!/bin/dash
-        curl -T "${1:-EMPTY}" --key /root/.ssh/id_ed25519 '\''sftp://github@ssh.dietpi.com/testing/'\''
+        curl -T "${1:-EMPTY}" --key /root/.ssh/id_ed25519 '\''sftp://github@ssh.dietpi.com:29248/testing/'\''
         curl '\''https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache'\'' -H '\''Authorization: Bearer ${{ secrets.CF_TOKEN }}'\'' -H '\''Content-Type: application/json'\'' \
         --data "{\"files\":[\"https://dietpi.com/downloads/images/testing/\",\"https://dietpi.com/downloads/images/testing/${1##*/}\"]}"' | sudo tee upload.sh > /dev/null
     - name: Run DietPi-Build

--- a/.github/workflows/vaultwarden.yml
+++ b/.github/workflows/vaultwarden.yml
@@ -30,7 +30,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/vaultwarden_armv6l.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl -T rootfs/vaultwarden_armv6l.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/buster/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/vaultwarden_armv6l.deb"]}'
   armv6_bullseye:
@@ -50,7 +50,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/vaultwarden_armv6l.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl -T rootfs/vaultwarden_armv6l.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bullseye/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/vaultwarden_armv6l.deb"]}'
   armv6_bookworm:
@@ -70,7 +70,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/vaultwarden_armv6l.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl -T rootfs/vaultwarden_armv6l.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bookworm/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/vaultwarden_armv6l.deb"]}'
 
@@ -91,7 +91,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/vaultwarden_armv7l.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl -T rootfs/vaultwarden_armv7l.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/buster/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/vaultwarden_armv7l.deb"]}'
   armv7_bullseye:
@@ -111,7 +111,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/vaultwarden_armv7l.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl -T rootfs/vaultwarden_armv7l.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bullseye/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/vaultwarden_armv7l.deb"]}'
   armv7_bookworm:
@@ -131,7 +131,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/vaultwarden_armv7l.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl -T rootfs/vaultwarden_armv7l.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bookworm/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/vaultwarden_armv7l.deb"]}'
 
@@ -152,7 +152,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/vaultwarden_aarch64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl -T rootfs/vaultwarden_aarch64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/buster/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/vaultwarden_aarch64.deb"]}'
   armv8_bullseye:
@@ -172,7 +172,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/vaultwarden_aarch64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl -T rootfs/vaultwarden_aarch64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bullseye/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/vaultwarden_aarch64.deb"]}'
   armv8_bookworm:
@@ -192,7 +192,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/vaultwarden_aarch64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl -T rootfs/vaultwarden_aarch64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bookworm/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/vaultwarden_aarch64.deb"]}'
 
@@ -213,7 +213,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/vaultwarden_x86_64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/buster/'
+        curl -T rootfs/vaultwarden_x86_64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/buster/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/vaultwarden_x86_64.deb"]}'
   x86_64_bullseye:
@@ -233,7 +233,7 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/vaultwarden_x86_64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bullseye/'
+        curl -T rootfs/vaultwarden_x86_64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bullseye/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/vaultwarden_x86_64.deb"]}'
   x86_64_bookworm:
@@ -253,6 +253,6 @@ jobs:
         umask 377
         echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
         echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
-        curl -T rootfs/vaultwarden_x86_64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com/bookworm/'
+        curl -T rootfs/vaultwarden_x86_64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bookworm/'
         curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
         --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/vaultwarden_x86_64.deb"]}'

--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -641,8 +641,15 @@ shopt -s extglob
 	aSOFTWARE_NAME8_7[203]='Readarr'
 	aSOFTWARE_NAME8_7[204]='Navidrome'
 
+	# v8.8
+	aSOFTWARE_NAME8_8=()
+	for i in "${!aSOFTWARE_NAME8_7[@]}"
+	do
+		aSOFTWARE_NAME8_8[$i]=${aSOFTWARE_NAME8_7[$i]}
+	done
+
 	# Pre-create software counter array so that we can see also software (available in newest version) with 0 installs
-	for i in "${aSOFTWARE_NAME8_7[@]}"
+	for i in "${aSOFTWARE_NAME8_8[@]}"
 	do
 		aSOFTWARE["$i"]=0
 	done

--- a/.update/patches
+++ b/.update/patches
@@ -648,7 +648,7 @@ Patch_8_2()
 
 	# Remove and migrate Chromium config files
 	[[ $G_HW_MODEL -gt 9 && -f '/root/.chromium-browser.init' ]] && G_EXEC rm /root/.chromium-browser.init
-	if [[ $G_DISTRO == 5 && $G_HW_MODEL -le 9 && -d '/etc/chromium.d' ]]
+	if [[ $G_DISTRO == 5 && $G_HW_MODEL -le 9 && -d '/etc/chromium.d' && -d '/etc/chromium-browser/customizations' ]]
 	then
 		[[ -f '/etc/chromium.d/custom_flags' ]] && G_EXEC mv /etc/{chromium.d/custom_flags,chromium-browser/customizations/dietpi}
 		G_EXEC rm -R /etc/chromium.d

--- a/.update/version
+++ b/.update/version
@@ -2,8 +2,8 @@
 # shellcheck disable=SC2034
 # Available DietPi version
 G_REMOTE_VERSION_CORE=8
-G_REMOTE_VERSION_SUB=7
-G_REMOTE_VERSION_RC=1
+G_REMOTE_VERSION_SUB=8
+G_REMOTE_VERSION_RC=-1
 # Minimum DietPi version to allow update
 G_MIN_VERSION_CORE=6
 G_MIN_VERSION_SUB=14

--- a/.update/version
+++ b/.update/version
@@ -14,6 +14,8 @@ G_MIN_DEBIAN=5
 # Alternative Git branch to automatically migrate to when Debian version is too low
 G_OLD_DEBIAN_BRANCH='stretch'
 # Live patches
-G_LIVE_PATCH_DESC=()
-G_LIVE_PATCH_COND=()
-G_LIVE_PATCH=()
+G_LIVE_PATCH_DESC=('Fix vaultwarden installation on Buster and Bookworm systems')
+# shellcheck disable=SC2016
+G_LIVE_PATCH_COND=('[[ $G_DISTRO != 6 ]] && grep '\''bullseye/vaultwarden'\'' /boot/dietpi/dietpi-software')
+# shellcheck disable=SC2016
+G_LIVE_PATCH=('sed -i '\''s|bullseye/vaultwarden|$G_DISTRO_NAME/vaultwarden|'\'' /boot/dietpi/dietpi-software')

--- a/.update/version
+++ b/.update/version
@@ -3,7 +3,7 @@
 # Available DietPi version
 G_REMOTE_VERSION_CORE=8
 G_REMOTE_VERSION_SUB=8
-G_REMOTE_VERSION_RC=-1
+G_REMOTE_VERSION_RC=0
 # Minimum DietPi version to allow update
 G_MIN_VERSION_CORE=6
 G_MIN_VERSION_SUB=14
@@ -14,8 +14,6 @@ G_MIN_DEBIAN=5
 # Alternative Git branch to automatically migrate to when Debian version is too low
 G_OLD_DEBIAN_BRANCH='stretch'
 # Live patches
-G_LIVE_PATCH_DESC=('Fix vaultwarden installation on Buster and Bookworm systems')
-# shellcheck disable=SC2016
-G_LIVE_PATCH_COND=('[[ $G_DISTRO != 6 ]] && grep '\''bullseye/vaultwarden'\'' /boot/dietpi/dietpi-software')
-# shellcheck disable=SC2016
-G_LIVE_PATCH=('sed -i '\''s|bullseye/vaultwarden|$G_DISTRO_NAME/vaultwarden|'\'' /boot/dietpi/dietpi-software')
+G_LIVE_PATCH_DESC=()
+G_LIVE_PATCH_COND=()
+G_LIVE_PATCH=()

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,7 +1,12 @@
 v8.8
 (2022-08-27)
 
+New features:
+- DietPi-Imager | It is now possible to skip the 7z archive creation but have the raw image file created only. Many thanks to @DrCWO for requesting this feature: https://github.com/MichaIng/DietPi/issues/5687
+
 Enhancements:
+- DietPi-Imager | It is now possible to shrink the originating image's/drive's filesystems and partitions only, instead of creating a new image file from it by passing/exporting the variable "SHRINK_ONLY=1".
+- DietPi-Imager | The dietpi-fs_partition_resize.service is now enabled automatically on the source image/drive before it is shrunk. This way it is assured that the shrunk original system as well as the newly created image will have their root partition and filesystem expanded automatically on next boot. Many thanks to @DrCWO for suggesting this enhancement: https://github.com/MichaIng/DietPi/issues/5672
 
 Bug fixes:
 - DietPi-Installer | The common Debian images on Linode VPS can now be converted into DietPi. This was previously failing since these images intentionally do not contain a partition table, so that GRUB cannot be flashed. Many thanks to @mews-se for reporting this issue: https://github.com/MichaIng/DietPi/issues/5691

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ v8.8
 Enhancements:
 
 Bug fixes:
+- DietPi-Installer | The common Debian images on Linode VPS can now be converted into DietPi. This was previously failing since these images intentionally do not contain a partition table, so that GRUB cannot be flashed. Many thanks to @mews-se for reporting this issue: https://github.com/MichaIng/DietPi/issues/5691
 - DietPi-Software | vaultwarden: Resolved an issue where the installation failed on Buster systems. Many thanks to @anubis-genix for reporting this issue: https://github.com/MichaIng/DietPi/issues/5681
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ Enhancements:
 Bug fixes:
 - DietPi-Installer | The common Debian images on Linode VPS can now be converted into DietPi. This was previously failing since these images intentionally do not contain a partition table, so that GRUB cannot be flashed. Many thanks to @mews-se for reporting this issue: https://github.com/MichaIng/DietPi/issues/5691
 - DietPi-Software | vaultwarden: Resolved an issue where the installation failed on Buster systems. Many thanks to @anubis-genix for reporting this issue: https://github.com/MichaIng/DietPi/issues/5681
+- DietPi-Software | vaultwarden: Resolved an issue where reinstalls onto existing pre-v1.25 vaultwarden installs lead to missing remote web vault access. Many thanks to @jetspeed for reporting this issue: https://dietpi.com/forum/t/vaultwarden-update-command-fail-then-vaultwarden-not-start-even-after-reboot/13350/68
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,16 @@
+v8.8
+(2022-08-27)
+
+Enhancements:
+
+Bug fixes:
+
+As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
+
+For all additional issues that may appear after release, please see the following link for active tickets: https://github.com/MichaIng/DietPi/issues
+
+-----------------------------------------------------------------------------------------------------------
+
 v8.7
 (2022-07-30)
 
@@ -26,8 +39,6 @@ Bug fixes:
 - DietPi-Software | Bazarr: Worked around an issue where on ARMv8 systems the service failed to start since for some reason the previously working aarch64 unrar binary (which is actually an ARMv5tel one) does not work on recent arm64 Debian anymore. A fix with a real aarch64 binary has been sent upstream. Many thanks to @dioxide0363 for reporting this issue: https://dietpi.com/forum/t/bazarr-fails-to-start-on-freshly-installed-dietpi/13658
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/5658
-
-For all additional issues that may appear after release, please see the following link for active tickets: https://github.com/MichaIng/DietPi/issues
 
 -----------------------------------------------------------------------------------------------------------
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ v8.8
 Enhancements:
 
 Bug fixes:
+- DietPi-Software | vaultwarden: Resolved an issue where the installation failed on Buster systems. Many thanks to @anubis-genix for reporting this issue: https://github.com/MichaIng/DietPi/issues/5681
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Creator and maintainer of the [DietPi Hyper-V images](https://github.com/yumiris
 
 ### Collaborations
 
-#### DietPi + [Amiberry](https://github.com/midwan/amiberry)
+#### DietPi + [Amiberry](https://github.com/BlitterStudio/amiberry)
 
 _Since 2016-09-02_
 
@@ -251,7 +251,7 @@ Links to hardware and software manufacturers, sources and build instructions use
 - [OpenVPN](https://github.com/OpenVPN)
 - [PiVPN](https://github.com/pivpn/pivpn)
 - [WireGuard](https://www.wireguard.com/)
-- [Amiberry](https://github.com/midwan/amiberry)
+- [Amiberry](https://github.com/BlitterStudio/amiberry)
 - [OpenTyrian](https://bitbucket.org/opentyrian/opentyrian/wiki/Home)
 - [RPi Cam Control](https://github.com/silvanmelchior/RPi_Cam_Web_Interface)
 - [Deluge](https://dev.deluge-torrent.org/wiki/Development#SourceCode)

--- a/dietpi/dietpi-backup
+++ b/dietpi/dietpi-backup
@@ -61,7 +61,7 @@
 	Error_Rsync_Already_Running(){
 
 		G_DIETPI-NOTIFY 1 'Another rsync process is already running.'
-		echo -e "$1 failed: $(Print_Date). rsync is already running." >> "$FP_TARGET/$FP_STATS"
+		echo -e "$(Print_Date)  $1 failed: rsync is already running." >> "$FP_TARGET/$FP_STATS"
 		G_WHIP_MSG "$1 Error:\n\nA $1 could not be started as rsync is already running."
 		/boot/dietpi/dietpi-services start
 
@@ -196,7 +196,7 @@ _EOF_
 However, this check is a rough estimation in reasonable time, thus it could be marginally incorrect.
 \nWould you like to override this warning and continue with the backup?'; then
 
-				echo -e "Backup cancelled due to insufficient free space    : $(Print_Date)" >> "$FP_TARGET/$FP_STATS"
+				echo -e "$(Print_Date)  Backup cancelled: Insufficient free space" >> "$FP_TARGET/$FP_STATS"
 				/boot/dietpi/dietpi-services start
 				return 1
 
@@ -208,6 +208,7 @@ However, this check is a rough estimation in reasonable time, thus it could be m
 
 		# Init log file
 		echo -e "Backup log from $(Print_Date)\n" > "$FP_TARGET/$FP_LOG"
+		echo -e "$(Print_Date)  Backup starting" >> "$FP_TARGET/$FP_STATS"
 
 		rsync "${aRSYNC_RUN_OPTIONS_BACKUP[@]}" -v --log-file="$FP_TARGET/$FP_LOG" "$FP_SOURCE" "$FP_TARGET/data/"
 		EXIT_CODE=$?
@@ -220,7 +221,7 @@ However, this check is a rough estimation in reasonable time, thus it could be m
 		G_DIETPI-NOTIFY -1 "$EXIT_CODE" "$G_PROGRAM_NAME: Backup"
 		if (( $EXIT_CODE == 0 )); then
 
-			echo -e "Backup completed    : $(Print_Date)" >> "$FP_TARGET/$FP_STATS"
+			echo -e "$(Print_Date)  Backup completed" >> "$FP_TARGET/$FP_STATS"
 			G_WHIP_MSG "Backup completed:\n - $FP_TARGET"
 
 		else
@@ -379,6 +380,7 @@ However, this check is a rough estimation in reasonable time, thus it could be m
 
 		# Init log file
 		echo -e "Restore log from $(Print_Date)\n" > "$FP_TARGET/$FP_LOG"
+		echo -e "$(Print_Date)  Restore starting" >> "$FP_TARGET/$FP_STATS"
 
 		rsync "${aRSYNC_RUN_OPTIONS_RESTORE[@]}" -v --log-file="$FP_TARGET/$FP_LOG" "$FP_TARGET/$DATA/" "$FP_SOURCE"
 		EXIT_CODE=$?
@@ -391,7 +393,7 @@ However, this check is a rough estimation in reasonable time, thus it could be m
 		G_DIETPI-NOTIFY -1 "$EXIT_CODE" "$G_PROGRAM_NAME: Restore"
 		if (( $EXIT_CODE == 0 )); then
 
-			echo -e "Restore completed    : $(Print_Date)" >> "$FP_TARGET/$FP_STATS"
+			echo -e "$(Print_Date)  Restore completed" >> "$FP_TARGET/$FP_STATS"
 			G_WHIP_MSG "Restore completed:\n - $FP_TARGET\n\nNB: A Reboot is highly recommended."
 
 		else

--- a/dietpi/dietpi-bugreport
+++ b/dietpi/dietpi-bugreport
@@ -31,7 +31,7 @@ Available commands:
 	# Grab input
 	INPUT=$*
 
-	readonly SFTP_ADDR='ssh.dietpi.com:22'
+	readonly SFTP_ADDR='ssh.dietpi.com:29248'
 	readonly SFTP_USER='dietpi-survey'
 	readonly SFTP_PASS='upload2dietpi'
 	readonly UPLOAD_FILENAME="$G_HW_UUID.7z"

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -2269,6 +2269,7 @@ _EOF_
 			'US' ': United States'
 			'JP' ': Japan'
 			'CN' ': China'
+			'IN' ': India'
 			'Manual' ': Enter a custom country code'
 		)
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5627,7 +5627,7 @@ _EOF_
 
 			Banner_Installing
 
-			# Obtain platform: https://github.com/midwan/amiberry/blob/master/Makefile
+			# Obtain platform: https://github.com/BlitterStudio/amiberry/blob/master/Makefile
 			# - RPi
 			local platform='rpi1' # Include ID -1 + 0
 			if (( $G_HW_MODEL < 10 ))
@@ -5690,7 +5690,7 @@ _EOF_
 			G_EXEC chgrp dietpi /mnt/dietpi_userdata/amiberry/kickstarts
 			G_EXEC chmod 0775 /mnt/dietpi_userdata/amiberry/kickstarts
 
-			# Pre-v6.26: Remove obsolete config file: https://github.com/midwan/amiberry/releases/tag/v2.25
+			# Pre-v6.26: Remove obsolete config file: https://github.com/BlitterStudio/amiberry/releases/tag/v2.25
 			[[ -f '/mnt/dietpi_userdata/amiberry/conf/adfdir.conf' ]] && G_EXEC rm /mnt/dietpi_userdata/amiberry/conf/adfdir.conf
 			# Pre-v8.5: Remove obsolete library and service files
 			[[ -e '/mnt/dietpi_userdata/amiberry/lib/libSDL2.so' ]] && G_EXEC rm -Rf /mnt/dietpi_userdata/amiberry/lib/libSDL2*.so{,.0.*}

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10044,7 +10044,7 @@ _EOF_
 			Banner_Installing
 			[[ -f '/opt/vaultwarden/target/release/vaultwarden' ]] && G_EXEC rm -R /opt/vaultwarden # Pre-v8.7
 			[[ -f '/etc/systemd/system/vaultwarden.service' ]] && G_EXEC rm /etc/systemd/system/vaultwarden.service # Pre-v8.7
-			Download_Install "https://dietpi.com/downloads/binaries/bullseye/vaultwarden_$G_HW_ARCH_NAME.deb"
+			Download_Install "https://dietpi.com/downloads/binaries/$G_DISTRO_NAME/vaultwarden_$G_HW_ARCH_NAME.deb"
 			G_EXEC systemctl stop vaultwarden
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2521,7 +2521,7 @@ _EOF_
 		G_EXEC_DESC="Starting ${aSOFTWARE_NAME[$software_id]} to pre-create config file in max $timeout seconds" G_EXEC systemctl start "$service"
 
 		# Print and follow output of the service startup
-		[[ $output ]] && { journalctl -fu "$service" & pid=$!; }
+		[[ $output ]] && { journalctl -fn 0 -u "$service" & pid=$!; }
 
 		# Wait for max $timeout seconds until config file has been created and required content added, if given
 		local i=0
@@ -4656,8 +4656,6 @@ Otherwise to copy an existing instance in place:
 	# cp -a /path/to/existing/owncloud/. /var/www/owncloud/
 The install script will now exit. After applying one of the the above, rerun dietpi-software, e.g.:
 	# dietpi-software install 47'
-
-					[[ -f '/var/www/owncloud/occ' ]] && G_EXEC rm /var/www/owncloud/occ
 					/boot/dietpi/dietpi-services start
 					exit 1
 
@@ -4905,8 +4903,6 @@ Otherwise to copy an existing instance in place:
 	# cp -a /path/to/existing/nextcloud/. /var/www/nextcloud/
 The install script will now exit. After applying one of the the above, rerun dietpi-software, e.g.:
 	# dietpi-software install 114'
-
-					[[ -f '/var/www/nextcloud/occ' ]] && G_EXEC rm /var/www/nextcloud/occ
 					/boot/dietpi/dietpi-services start
 					exit 1
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9019,19 +9019,11 @@ _EOF_
 			# Else install latest binaries from GitHub
 			if (( $G_HW_MODEL != 1 ))
 			then
-				# ARMv7
-				local arch='armv7'
-
-				# ARMv8
-				if (( $G_HW_ARCH == 3 ))
-				then
-					arch='armv8'
-
-				# x86_64
-				elif (( $G_HW_ARCH == 10 ))
-				then
-					arch='amd64'
-				fi
+				case $G_HW_ARCH in
+					3) local arch='armv8';;
+					10) local arch='amd64';;
+					*) local arch='armv7';;
+				esac
 
 				local fallback_url="https://github.com/gogs/gogs/releases/download/v0.12.10/gogs_0.12.10_linux_$arch.tar.gz"
 				url=$(curl -sSfL 'https://api.github.com/repos/gogs/gogs/releases/latest' | mawk -F\" "/\"browser_download_url\": \".*\/gogs_[^\"\/]*_linux_$arch.tar.gz\"/{print \$4}")

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9033,7 +9033,7 @@ _EOF_
 					arch='amd64'
 				fi
 
-				local fallback_url="https://github.com/gogs/gogs/releases/download/v0.12.9/gogs_0.12.9_linux_$arch.tar.gz"
+				local fallback_url="https://github.com/gogs/gogs/releases/download/v0.12.10/gogs_0.12.10_linux_$arch.tar.gz"
 				url=$(curl -sSfL 'https://api.github.com/repos/gogs/gogs/releases/latest' | mawk -F\" "/\"browser_download_url\": \".*\/gogs_[^\"\/]*_linux_$arch.tar.gz\"/{print \$4}")
 			fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10823,7 +10823,7 @@ _EOF_
 			else
 				# ARMv7
 				local url=$(curl -sSfL 'https://api.github.com/repos/Prowlarr/Prowlarr/releases' | mawk -F\" '/"browser_download_url": .*linux-core-arm\.tar\.gz"/{print $4}' | head -1)
-				local fallback_url='https://github.com/Prowlarr/Prowlarr/releases/download/v0.4.3.1921/Prowlarr.develop.0.4.3.1921.linux-core-arm.tar.gz'
+				local fallback_url='https://github.com/Prowlarr/Prowlarr/releases/download/v0.4.4.1947/Prowlarr.develop.0.4.4.1947.linux-core-arm.tar.gz'
 
 				# ARMv8
 				if (( $G_HW_ARCH == 3 ))

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1408,6 +1408,8 @@ Available commands:
 		done
 		# - Odroid U3
 		aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,13]=0
+		# + NanoPi R5S
+		aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,76]=1
 		# Re-enable if module is shipped with (kernel) package
 		dpkg-query -S '/lib/modules/*/wireguard.ko*' &> /dev/null || modinfo wireguard 2> /dev/null | grep -q '^filename:[[:blank:]]*(builtin)$' && aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,$G_HW_MODEL]=1 WIREGUARD_BUILTIN=1
 		#------------------
@@ -12534,46 +12536,43 @@ Package: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-
 			# Else, kernel headers and matching kernel image is required for wireguard-dkms to build the WireGuard kernel module
 			else
 
-				local apackages=()
 				# x86_64
 				if (( $G_HW_ARCH == 10 )); then
 
-					apackages=('linux-image-amd64' 'linux-headers-amd64')
+					G_AGI linux-image-amd64 linux-headers-amd64
 
 				# RPi
 				elif (( $G_HW_MODEL < 10 )); then
 
 					# Install bootloader package as well to assure we have a correctly booting system with intended kernel
-					apackages=('raspberrypi-kernel' 'raspberrypi-kernel-headers' 'raspberrypi-bootloader')
+					G_AGI raspberrypi-kernel raspberrypi-kernel-headers raspberrypi-bootloader
 
 				# Odroid XU4
 				elif (( $G_HW_MODEL == 11 )); then
 
-					apackages=('linux-image-4.14-armhf-odroid-xu4' 'linux-headers-4.14-armhf-odroid-xu4')
+					G_AGI linux-image-4.14-armhf-odroid-xu4 linux-headers-4.14-armhf-odroid-xu4
 
 				# Odroid C2
 				elif (( $G_HW_MODEL == 12 )); then
 
-					apackages=('linux-image-arm64-odroid-c2' 'linux-headers-arm64-odroid-c2')
+					G_AGI linux-image-arm64-odroid-c2 linux-headers-arm64-odroid-c2
 
 				# Odroid N2
 				elif (( $G_HW_MODEL == 15 )); then
 
-					apackages=('linux-image-arm64-odroid-n2' 'linux-headers-arm64-odroid-n2')
+					G_AGI linux-image-arm64-odroid-n2 linux-headers-arm64-odroid-n2
 
 				# Odroid C4
 				elif (( $G_HW_MODEL == 16 )); then
 
-					apackages=('linux-image-arm64-odroid-c4' 'linux-headers-arm64-odroid-c4')
+					G_AGI linux-image-arm64-odroid-c4 linux-headers-arm64-odroid-c4
+
+				# NanoPi R5S
+				elif (( $G_HW_MODEL == 76 )); then
+
+					Download_Install 'https://dietpi.com/downloads/binaries/linux-headers-nanopi5.deb'
 
 				fi
-
-				# Odroids need to purge before we install, else, does not update to latest version...
-				(( $G_HW_MODEL > 9 && $G_HW_MODEL < 20 )) && G_AGP "${apackages[@]}"
-
-				# Since G_AGUG does not upgrade packages with changed dependencies, in case of kernel image meta packages, those need to be installed+upgraded via G_AGI.
-				G_AGI "${apackages[@]}" # apt-get install overrides hold state
-				unset -v apackages
 
 				# Workaround for missing /lib/modules/<version>/build symlink: https://github.com/MichaIng/DietPi/issues/3577
 				# - Known as issue currently on Odroid C2/N2, check for new build system if linux-<version>/ holds current headers instead of linux-source-<version>/: https://dietpi.com/meveric/pool/c2/l/

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11428,7 +11428,8 @@ _EOF_
 				*) local arch='amd64';;
 			esac
 
-			local fallback_url="https://github.com/go-gitea/gitea/releases/download/v1.17.0/gitea-1.17.0-linux-$arch"
+			# ToDo: Implement xz-support: https://github.com/go-gitea/gitea/releases/download/v1.17.1/gitea-1.17.1-linux-amd64.xz
+			local fallback_url="https://github.com/go-gitea/gitea/releases/download/v1.17.1/gitea-1.17.1-linux-$arch"
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/go-gitea/gitea/releases/latest' | mawk -F\" "/\"browser_download_url\": \".*\/gitea-[^\"\/]*-linux-$arch\"/{print \$4}")" /mnt/dietpi_userdata/gitea/gitea
 
 			# User

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8676,7 +8676,7 @@ _EOF_
 			G_CONFIG_INJECT 'dynamic.1.postprocess=' 'dynamic.1.postprocess=int($1/10 + 0.5)/100' /etc/rpimonitor/template/temperature.conf
 
 			# USB drive stats implementation by Rich
-			if [[ $G_ROOTFS_DEV != '/dev/sda2' && ! -f '/etc/rpimonitor/template/usb_hdd.conf' ]] && findmnt -S /dev/sda1 > /dev/null
+			if [[ $G_ROOTFS_DEV != '/dev/sda1' && ! -f '/etc/rpimonitor/template/usb_hdd.conf' ]] && findmnt -S /dev/sda1 > /dev/null
 			then
 				cat << '_EOF_' > /etc/rpimonitor/template/usb_hdd.conf
 ########################################################################

--- a/dietpi/dietpi-survey
+++ b/dietpi/dietpi-survey
@@ -35,7 +35,7 @@
 	[[ $1 == 1 ]] && INPUT=1 || INPUT=0
 
 	readonly FP_UPLOAD="$G_HW_UUID.txt"
-	readonly SFTP_ADDR='ssh.dietpi.com'
+	readonly SFTP_ADDR='ssh.dietpi.com:29248'
 	readonly SFTP_USER='dietpi-survey'
 	readonly SFTP_PASS='upload2dietpi'
 

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -58,8 +58,8 @@
 	[[ -f '/boot/dietpi/.version' ]] && . /boot/dietpi/.version
 	# - Assign defaults/code version as fallback
 	[[ $G_DIETPI_VERSION_CORE ]] || G_DIETPI_VERSION_CORE=8
-	[[ $G_DIETPI_VERSION_SUB ]] || G_DIETPI_VERSION_SUB=7
-	[[ $G_DIETPI_VERSION_RC ]] || G_DIETPI_VERSION_RC=1
+	[[ $G_DIETPI_VERSION_SUB ]] || G_DIETPI_VERSION_SUB=8
+	[[ $G_DIETPI_VERSION_RC ]] || G_DIETPI_VERSION_RC=-1
 	[[ $G_GITBRANCH ]] || G_GITBRANCH='master'
 	[[ $G_GITOWNER ]] || G_GITOWNER='MichaIng'
 	# - Save current version and Git branch

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -1122,6 +1122,7 @@ Press any key to continue...'
 		# Obtain attempts
 		local attempts=$(sed -n '/^[[:blank:]]*CONFIG_G_CHECK_URL_ATTEMPTS=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 		disable_error=1 G_CHECK_VALIDINT "$attempts" 1 || attempts=2
+		local retries==$(( $attempts - 1 )) # 2 attempts = 1 retry
 
 		# Obtain IPv4 test address
 		local ip=$(sed -n '/^[[:blank:]]*CONFIG_CHECK_CONNECTION_IP=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
@@ -1138,7 +1139,7 @@ Press any key to continue...'
 			['Double timeout']='((acommand[4]*=2)); attempt=1; continue 2'
 			['Network settings']='/boot/dietpi/dietpi-config 8 1'
 		)
-		G_EXEC_RETRIES=$(( $attempts - 1 )) # 2 attempts = 1 retry
+		G_EXEC_RETRIES=$retries
 		G_EXEC_DESC='Checking IPv4 network connectivity' G_EXEC ping -4nc 1 -W "$timeout" "$ip"
 
 		# Do IPv6 connectivity check if an IPv6 default route is assigned
@@ -1161,7 +1162,7 @@ Press any key to continue...'
 				['Disable IPv6']='/boot/dietpi/func/dietpi-set_hardware enableipv6 0; acommand=(:); attempt=1; continue 2'
 				['Network settings']='/boot/dietpi/dietpi-config 8 1'
 			)
-			G_EXEC_RETRIES=$(( $attempts - 1 )) # 2 attempts = 1 retry
+			G_EXEC_RETRIES=$retries
 			G_EXEC_DESC='Checking IPv6 network connectivity' G_EXEC ping -6nc 1 -W "$timeout" "$ip"
 		fi
 
@@ -1172,6 +1173,7 @@ Press any key to continue...'
 		# Check DNS resolver
 		G_EXEC_ARRAY_TEXT=('Network settings' ': Enter dietpi-config network options')
 		declare -A G_EXEC_ARRAY_ACTION=(['Network settings']='/boot/dietpi/dietpi-config 8 1')
+		G_EXEC_RETRIES=$retries
 		G_EXEC_DESC='Checking DNS resolver' G_EXEC getent hosts "$domain"
 	}
 

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -59,7 +59,7 @@
 	# - Assign defaults/code version as fallback
 	[[ $G_DIETPI_VERSION_CORE ]] || G_DIETPI_VERSION_CORE=8
 	[[ $G_DIETPI_VERSION_SUB ]] || G_DIETPI_VERSION_SUB=8
-	[[ $G_DIETPI_VERSION_RC ]] || G_DIETPI_VERSION_RC=-1
+	[[ $G_DIETPI_VERSION_RC ]] || G_DIETPI_VERSION_RC=0
 	[[ $G_GITBRANCH ]] || G_GITBRANCH='master'
 	[[ $G_GITOWNER ]] || G_GITOWNER='MichaIng'
 	# - Save current version and Git branch

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -1122,7 +1122,7 @@ Press any key to continue...'
 		# Obtain attempts
 		local attempts=$(sed -n '/^[[:blank:]]*CONFIG_G_CHECK_URL_ATTEMPTS=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 		disable_error=1 G_CHECK_VALIDINT "$attempts" 1 || attempts=2
-		local retries==$(( $attempts - 1 )) # 2 attempts = 1 retry
+		local retries=$(( $attempts - 1 )) # 2 attempts = 1 retry
 
 		# Obtain IPv4 test address
 		local ip=$(sed -n '/^[[:blank:]]*CONFIG_CHECK_CONNECTION_IP=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)

--- a/dietpi/func/dietpi-wifidb
+++ b/dietpi/func/dietpi-wifidb
@@ -166,7 +166,7 @@ _EOF_
 aWIFI_SSID[$i]='${aWIFI_SSID[$i]//\'/\'\\\'\'}'
 # - WiFi key: If no key/open, leave this blank
 # - In case of WPA-PSK, alternatively enter the 64-digit hexadecimal key returned by wpa_passphrase
-# - Please do NOT escape any magic characters. The script does this automatically as required.
+# - Please replace single quote characters ' in your key with '\''. No other escaping is required.
 aWIFI_KEY[$i]='${aWIFI_KEY[$i]//\'/\'\\\'\'}'
 # - Key type: NONE (no key/open) | WPA-PSK | WEP | WPA-EAP (then use settings below)
 aWIFI_KEYMGR[$i]='${aWIFI_KEYMGR[$i]}'


### PR DESCRIPTION
### Beta v8.8.0
_(2022-08-25)_

#### New features
- DietPi-Imager | It is now possible to skip the 7z archive creation but have the raw image file created only. Many thanks to @DrCWO for requesting this feature: https://github.com/MichaIng/DietPi/issues/5687

#### Enhancements
- DietPi-Imager | It is now possible to shrink the originating image's/drive's filesystems and partitions only, instead of creating a new image file from it by passing/exporting the variable "SHRINK_ONLY=1".
- DietPi-Imager | The dietpi-fs_partition_resize.service is now enabled automatically on the source image/drive before it is shrunk. This way it is assured that the shrunk original system as well as the newly created image will have their root partition and filesystem expanded automatically on next boot. Many thanks to @DrCWO for suggesting this enhancement: https://github.com/MichaIng/DietPi/issues/5672

#### Bug fixes
- DietPi-Installer | The common Debian images on Linode VPS can now be converted into DietPi. This was previously failing since these images intentionally do not contain a partition table, so that GRUB cannot be flashed. Many thanks to @mews-se for reporting this issue: https://github.com/MichaIng/DietPi/issues/5691
- DietPi-Software | vaultwarden: Resolved an issue where the installation failed on Buster systems. Many thanks to @anubis-genix for reporting this issue: https://github.com/MichaIng/DietPi/issues/5681
- DietPi-Software | vaultwarden: Resolved an issue where reinstalls onto existing pre-v1.25 vaultwarden installs lead to missing remote web vault access. Many thanks to `@jetspeed` for reporting this issue: https://dietpi.com/forum/t/vaultwarden-update-command-fail-then-vaultwarden-not-start-even-after-reboot/13350/68