### PR TITLE
DietPi-Software | Plex 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ v8.9
 New features:
 
 Enhancements:
+- DietPi-Software | Plex Media Server: The "plex" system group is now removed on uninstall. This was not done automatically on package removal, since we change the primary group of the "plex" system user to "dietpi". Many thanks to @mail2rst for reporting this issue: https://dietpi.com/forum/t/plex-installation-broken-via-dietpi-software-after-uninstallation-of-docker-docker-compose/14130
 
 Bug fixes:
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -14810,6 +14810,8 @@ _EOF_
 
 			Banner_Uninstalling
 			G_AGP plexmediaserver
+			# Force deletion of plex user group as group plex it not removed automatically because it is not the primary group of user plex 
+			getent group plex > /dev/null && G_EXEC groupdel plex
 			# Remove systemd unit which currently survives the package purging: https://github.com/MichaIng/DietPi/issues/3551
 			if [[ -f '/lib/systemd/system/plexmediaserver.service' ]]
 			then


### PR DESCRIPTION
DietPi-Software | Plex - remove plex user group during uninstall

Based on https://dietpi.com/forum/t/plex-installation-broken-via-dietpi-software-after-uninstallation-of-docker-docker-compose/14130
