### PR TITLE
DietPi-Software | Go: Do not set GOPATH anymore

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ New features:
 
 Enhancements:
 - DietPi-Software | Plex Media Server: The "plex" system group is now removed on uninstall. This was not done automatically on package removal, since we change the primary group of the "plex" system user to "dietpi". Many thanks to @mail2rst for reporting this issue: https://dietpi.com/forum/t/plex-installation-broken-via-dietpi-software-after-uninstallation-of-docker-docker-compose/14130
+- DietPi-Software | Go: GOPATH is not set anymore to /mnt/dietpi_userdata/go on fresh installs and will default to ~/go instead. This especially makes multi-user setups easier where usually every user wants its own Go workspace. Many thanks to @tlgs for bringing this to our attention: https://github.com/MichaIng/DietPi/issues/5735
 
 Bug fixes:
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3179,19 +3179,11 @@ unix_socket_directories = '/run/postgresql'" > "$i/00dietpi.conf"
 
 			Banner_Installing # https://golang.org/doc/install#install
 
-			# Obtain architecture string
-			# - ARMv6/7
-			local arch='armv6l'
-			# - ARMv8
-			if (( $G_HW_ARCH == 3 ))
-			then
-				arch='arm64'
-
-			# - x86_64
-			elif (( $G_HW_ARCH == 10 ))
-			then
-				arch='amd64'
-			fi
+			case $G_HW_ARCH in
+				3) local arch='arm64';;
+				10) local arch='amd64';;
+				*) local arch='armv6l';;
+			esac
 
 			# Get latest version
 			local file=$(curl -sSfL 'https://golang.org/dl/?mode=json' | grep -wo "go[0-9.]*\.linux-$arch\.tar\.gz" | head -1)
@@ -3492,10 +3484,10 @@ _EOF_
 
 			Banner_Installing
 
-			case $G_HW_ARCH_NAME in
-				'armv6l') local arch='armv6';;
-				'armv7l') local arch='armv7';;
-				'aarch64') local arch='arm64';;
+			case $G_HW_ARCH in
+				1) local arch='armv6';;
+				2) local arch='armv7';;
+				3) local arch='arm64';;
 				*) local arch='amd64';;
 			esac
 
@@ -9011,12 +9003,12 @@ _EOF_
 			local url='https://dietpi.com/downloads/binaries/all/gogs_armv6.zip'
 
 			# Else install latest binaries from GitHub
-			if (( $G_HW_MODEL != 1 ))
+			if (( $G_HW_ARCH != 1 ))
 			then
 				case $G_HW_ARCH in
+					2) local arch='armv7';;
 					3) local arch='armv8';;
-					10) local arch='amd64';;
-					*) local arch='armv7';;
+					*) local arch='amd64';;
 				esac
 
 				local fallback_url="https://github.com/gogs/gogs/releases/download/v0.12.10/gogs_0.12.10_linux_$arch.tar.gz"
@@ -11405,9 +11397,9 @@ _EOF_
 
 			# ARMv7: As of v1.8 there were issues with ARMv7 binaries on Raspbian which are hence not provided anymore: https://github.com/go-gitea/gitea/issues/6700
 			case $G_HW_ARCH in
-				[12]) local arch='arm-6';;
 				3) local arch='arm64';;
-				*) local arch='amd64';;
+				10) local arch='amd64';;
+				*) local arch='arm-6';;
 			esac
 
 			# ToDo: Implement xz-support: https://github.com/go-gitea/gitea/releases/download/v1.17.2/gitea-1.17.2-linux-amd64.xz
@@ -12423,11 +12415,10 @@ _EOF_
 
 			Banner_Installing
 
-			local file='spotifyd-linux-armv6-slim' # ARMv6
 			case $G_HW_ARCH in
-				2) file='spotifyd-linux-armhf-full';; # ARMv7
-				10) file='spotifyd-linux-full';; # x86_64
-				*) :;;
+				1) local file='spotifyd-linux-armv6-slim';;
+				2) local file='spotifyd-linux-armhf-full';;
+				*) local file='spotifyd-linux-full';;
 			esac
 
 			# Reinstall: Remove old install dir

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3203,6 +3203,7 @@ unix_socket_directories = '/run/postgresql'" > "$i/00dietpi.conf"
 			Download_Install "https://golang.org/dl/$file" /usr/local
 
 			# Add to PATH, but do not overwrite existing script since we did set GOPATH until v8.9 and do not want to cause a breaking change for existing installs
+			# shellcheck disable=SC2016
 			[[ -f '/etc/bashrc.d/go.sh' ]] || echo 'export PATH="$PATH:/usr/local/go/bin"' /etc/bashrc.d/go.sh
 			# shellcheck disable=SC1091
 			. /etc/bashrc.d/go.sh

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3202,13 +3202,8 @@ unix_socket_directories = '/run/postgresql'" > "$i/00dietpi.conf"
 
 			Download_Install "https://golang.org/dl/$file" /usr/local
 
-			# Export Go path variables
-			G_EXEC mkdir -p /mnt/dietpi_userdata/go/{bin,pkg,src}
-			cat << '_EOF_' > /etc/bashrc.d/go.sh
-#!/bin/dash
-export GOPATH=/mnt/dietpi_userdata/go
-export PATH="$PATH:/usr/local/go/bin:$GOPATH/bin"
-_EOF_
+			# Add to PATH, but do not overwrite existing script since we did set GOPATH until v8.9 and do not want to cause a breaking change for existing installs
+			[[ -f '/etc/bashrc.d/go.sh' ]] || echo 'export PATH="$PATH:/usr/local/go/bin"' /etc/bashrc.d/go.sh
 			# shellcheck disable=SC1091
 			. /etc/bashrc.d/go.sh
 
@@ -15909,8 +15904,6 @@ _EOF_
 			Banner_Uninstalling
 			[[ -f '/etc/bashrc.d/go.sh' ]] && G_EXEC rm /etc/bashrc.d/go.sh
 			[[ -d '/usr/local/go' ]] && G_EXEC rm -R /usr/local/go
-			# Keep GOPATH so that Go can be uninstalled without loosing all installed packages, sources etc.
-			#[[ -d '/mnt/dietpi_userdata/go' ]] && G_EXEC rm -R /mnt/dietpi_userdata/go
 
 		fi
 


### PR DESCRIPTION
- DietPi-Software | Go: `GOPATH` is not set anymore to `/mnt/dietpi_userdata/go` on fresh installs and will default to `~/go` instead. This especially makes multi-user setups easier where usually every user wants its own Go workspace. Many thanks to @tlgs for bringing this to our attention: https://github.com/MichaIng/DietPi/issues/5735
