### PR TITLE
DietPi-Installer | change default shell

### DIFF
--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -1141,7 +1141,7 @@ _EOF_
 		getent group openmediavault-webgui > /dev/null && groupdel openmediavault-webgui # OMV (NanoPi NEO2)
 
 		G_DIETPI-NOTIFY 2 'Resetting root user account'
-		G_EXEC usermod -d /root -s /bin/dash root
+		G_EXEC usermod -d /root -s /bin/bash root
 		G_EXEC eval 'chpasswd <<< '\''root:dietpi'\'
 
 		G_EXEC_DESC='Creating DietPi user account' G_EXEC /boot/dietpi/func/dietpi-set_software useradd dietpi


### PR DESCRIPTION
DietPi-Installer | change default shell for user root from `dash` to `bash`