### PR TITLE
DietPi-Software | Synapse: Fix install due to Rust integration

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4130,8 +4130,27 @@ _EOF_
 				G_AGI gcc libpq-dev
 			fi
 
+			# Temporarily assure 2 GiB /tmp size for temporary Rust install
+			(( $(findmnt -bno SIZE /tmp) < 2147483648 )) && G_EXEC mount -o remount,size=2G /tmp
+
+			# Clean APT cache (which includes temporarily downloaded archives) when moved to RAM
+			[[ -d '/tmp/apt' ]] && G_EXEC apt-get clean
+
+			# Override $HOME to allow temporary Rust install to RAMdisk and DietPi-Software working directory, so all leftovers are automatically removed on script exit and/or reboot
+			export HOME=$G_WORKING_DIR
+
+			# Install Rust via https://rustup.rs/
+			G_EXEC curl -sSfL 'https://sh.rustup.rs' -o rustup-init.sh
+			G_EXEC chmod +x rustup-init.sh
+			G_EXEC_OUTPUT=1 G_EXEC ./rustup-init.sh -y --profile minimal
+			G_EXEC_NOHALT=1 G_EXEC rm rustup-init.sh
+			G_EXEC . .cargo/env
+
 			# Install
 			G_EXEC_OUTPUT=1 G_EXEC pip3 install --no-cache-dir -U matrix-synapse psycopg2
+
+			# Uninstall rust after compiling
+			G_EXEC rustup self uninstall -y 
 
 			# User
 			Create_User -d /mnt/dietpi_userdata/synapse synapse


### PR DESCRIPTION
**STATUS** - wip

DietPi-Software | Synapse - add rust as it seems to be required by install process now

@MichaIng 
something we need to have a look into. We have a report on our forum about failing install due to missing `rust` install. 
https://dietpi.com/forum/t/matrix-synapse-fails-to-update/14460

It's not 100% clear to me if this is now required or not because there is a statement that it is not required using PyPI.
https://matrix-org.github.io/synapse/v1.68/upgrade.html#rust-requirement-when-building-from-source

But there is no version for aarch64 on PyPI https://pypi.org/project/matrix-synapse/1.68.0/#files

On PiWheels build is failing as well https://www.piwheels.org/project/matrix-synapse/

Question is, should we add rust or hope it will be fixed upstream?? I just did a basic implementation without checking ram usage and other checks like architecture. 