### PR TITLE
Squeezelite | Updates and add build workflow to GitHub

### DIFF
--- a/.build/software/squeezelite/build.bash
+++ b/.build/software/squeezelite/build.bash
@@ -1,0 +1,161 @@
+#!/bin/bash
+{
+. /boot/dietpi/func/dietpi-globals
+
+# Build deps
+G_AG_CHECK_INSTALL_PREREQ make gcc libc6-dev libasound2-dev libflac-dev libmad0-dev libvorbis-dev libmpg123-dev libavformat-dev libsoxr-dev liblirc-dev libfaad-dev libssl-dev libopus-dev
+
+G_DIETPI-NOTIFY 2 'Downloading source code...'
+G_EXEC cd /tmp
+G_EXEC curl -sSfLO 'https://github.com/ralph-irving/squeezelite/archive/master.tar.gz'
+G_EXEC rm -Rf squeezelite-master
+G_EXEC tar xf master.tar.gz
+G_EXEC rm master.tar.gz
+G_DIETPI-NOTIFY 2 'Compiling binary...'
+G_EXEC cd squeezelite-master
+G_EXEC_OUTPUT=1 G_EXEC make CFLAGS='-g0 -O3' OPTS='-DDSD -DFFMPEG -DRESAMPLE -DVISEXPORT -DLINKALL -DIR -DUSE_SSL'
+G_EXEC strip --remove-section=.comment --remove-section=.note squeezelite
+
+G_DIETPI-NOTIFY 2 'Starting packaging...'
+
+# Dependencies based on distro version
+adeps=('libc6' 'libasound2' 'libflac8' 'libmad0' 'libvorbisfile3' 'libmpg123-0' 'libsoxr0' 'liblirc-client0' 'libfaad2' 'libopus0')
+case $G_DISTRO in
+	[56]) adeps+=('libavformat58' 'libssl1.1');;
+	7) adeps+=('libavformat59' 'libssl3');;
+	*) G_DIETPI-NOTIFY 1 "Unsupported distro version: $G_DISTRO_NAME (ID=$G_DISTRO)"; exit 1;;
+esac
+
+# - Obtain DEB dependency versions
+DEPS_APT_VERSIONED=
+for i in "${adeps[@]}"
+do
+	DEPS_APT_VERSIONED+=" $i (>= $(dpkg-query -Wf '${VERSION}' "$i")),"
+done
+DEPS_APT_VERSIONED=${DEPS_APT_VERSIONED%,}
+# shellcheck disable=SC2001
+grep -q 'raspbian' /etc/os-release && DEPS_APT_VERSIONED=$(sed 's/+rp[it][0-9]\+)/)/g' <<< "$DEPS_APT_VERSIONED") || DEPS_APT_VERSIONED=$(sed 's/+b[0-9]\+)/)/g' <<< "$DEPS_APT_VERSIONED")
+
+# Package dir
+G_EXEC cd /tmp
+grep -q 'raspbian' /etc/os-release && DIR='squeezelite_armv6l' || DIR="squeezelite_$G_HW_ARCH_NAME"
+G_EXEC rm -Rf "$DIR"
+G_EXEC mkdir -p "$DIR/"{DEBIAN,lib/systemd/system,etc/default,usr/{bin,share/doc/squeezelite,share/man/man1}}
+# - Binary
+G_EXEC cp squeezelite-master/squeezelite "$DIR/usr/bin/"
+# - man page
+# shellcheck disable=SC2016
+G_EXEC eval 'gzip -c squeezelite-master/doc/squeezelite.1 > $DIR/usr/share/man/man1/squeezelite.1.gz'
+# - Copyright
+G_EXEC cp squeezelite-master/LICENSE.txt "$DIR/usr/share/doc/squeezelite/copyright"
+# - Environment file
+cat << '_EOF_' > "$DIR/etc/default/squeezelite"
+# Squeezelite command-line arguments: https://ralph-irving.github.io/squeezelite.html
+ARGS='-W -C 5 -n DietPi-Squeezelite'
+_EOF_
+# - systemd service
+cat << '_EOF_' > "$DIR/lib/systemd/system/squeezelite.service"
+[Unit]
+Description=Squeezelite (DietPi)
+Documentation=man:squeezelite(1) https://ralph-irving.github.io/squeezelite.html
+After=sound.target
+
+[Service]
+User=squeezelite
+EnvironmentFile=/etc/default/squeezelite
+ExecStart=/usr/bin/squeezelite $ARGS
+
+[Install]
+WantedBy=multi-user.target
+_EOF_
+# - postinst
+cat << '_EOF_' > "$DIR/DEBIAN/postinst"
+#!/bin/sh
+if [ -d '/run/systemd/system' ]
+then
+	if getent passwd squeezelite > /dev/null
+	then
+		echo 'Configuring Squeezelite service user ...'
+		usermod -aG audio -d /run/squeezelite -s /usr/sbin/nologin squeezelite
+	else
+		echo 'Creating Squeezelite service user ...'
+		useradd -rMU -G audio -d /run/squeezelite -s /usr/sbin/nologin squeezelite
+	fi
+
+	echo 'Configuring Squeezelite systemd service ...'
+	systemctl unmask squeezelite
+	systemctl enable --now squeezelite
+fi
+_EOF_
+# - prerm
+cat << '_EOF_' > "$DIR/DEBIAN/prerm"
+#!/bin/sh
+if [ "$1" = 'remove' ] && [ -d '/run/systemd/system' ] && [ -f '/lib/systemd/system/squeezelite.service' ]
+then
+	echo 'Deconfiguring Squeezelite systemd service ...'
+	systemctl unmask squeezelite
+	systemctl disable --now squeezelite
+fi
+_EOF_
+# - postrm
+cat << '_EOF_' > "$DIR/DEBIAN/postrm"
+#!/bin/sh
+if [ "$1" = 'purge' ]
+then
+	if [ -d '/etc/systemd/system/squeezelite.service.d' ]
+	then
+		echo 'Removing Squeezelite systemd service overrides ...'
+		rm -Rv /etc/systemd/system/squeezelite.service.d
+	fi
+
+	if getent passwd squeezelite > /dev/null
+	then
+		echo 'Removing Squeezelite service user ...'
+		userdel squeezelite
+	fi
+
+	if getent group squeezelite > /dev/null
+	then
+		echo 'Removing Squeezelite service group ...'
+		groupdel squeezelite
+	fi
+fi
+_EOF_
+G_EXEC chmod +x "$DIR/DEBIAN/"{postinst,prerm,postrm}
+# - control
+cat << _EOF_ > "$DIR/DEBIAN/control"
+Package: squeezelite
+Version: $(mawk -F\" '/MAJOR_VERSION/{print $2;exit}' squeezelite-master/squeezelite.h).$(mawk -F\" '/MINOR_VERSION/{print $2;exit}' squeezelite-master/squeezelite.h)-$(mawk -F\" '/MICRO_VERSION/{print $2;exit}' squeezelite-master/squeezelite.h)-dietpi1
+Architecture: $(dpkg --print-architecture)
+Maintainer: MichaIng <micha@dietpi.com>
+Date: $(date '+%a, %d %b %Y %T %z')
+Standards-Version: 4.6.1.0
+Installed-Size: $(du -sk "$DIR" | mawk '{print $1}')
+Depends:$DEPS_APT_VERSIONED
+Conflicts: squeezelite-pa, squeezelite-pulseaudio
+Section: sound
+Priority: optional
+Homepage: https://github.com/ralph-irving/squeezelite
+Vcs-Git: https://github.com/ralph-irving/squeezelite.git
+Vcs-Browser: https://github.com/ralph-irving/squeezelite
+Description: lightweight headless Squeezebox emulator - ALSA version
+ Squeezelite is a small headless Squeezebox emulator. It is aimed at
+ supporting high quality audio including USB DAC based output at multiple
+ sample rates.
+ .
+ It supports decoding PCM (WAV/AIFF), FLAC, MP3, Ogg, AAC, WMA and ALAC
+ audio formats. It can also resample audio, which allows squeezelite to
+ upsample the output to the highest sample rate supported by the output
+ device.
+ .
+ This package is built with the resampling, ffmpeg and SSL options.
+ It uses ALSA for audio output.
+_EOF_
+G_CONFIG_INJECT 'Installed-Size: ' "Installed-Size: $(du -sk "$DIR" | mawk '{print $1}')" "$DIR/DEBIAN/control"
+# - Build
+G_EXEC rm -Rf "$DIR.deb"
+G_EXEC_OUTPUT=1 G_EXEC dpkg-deb -b "$DIR"
+G_EXEC rm -Rf "$DIR"
+
+exit 0
+}

--- a/.build/software/squeezelite/container_build.bash
+++ b/.build/software/squeezelite/container_build.bash
@@ -1,0 +1,117 @@
+#!/bin/bash
+# Created by MichaIng / micha@dietpi.com / dietpi.com
+{
+##########################################
+# Load DietPi-Globals
+##########################################
+if [[ -f '/boot/dietpi/func/dietpi-globals' ]]
+then
+	. /boot/dietpi/func/dietpi-globals
+else
+	curl -sSf "https://raw.githubusercontent.com/${G_GITOWNER:=MichaIng}/DietPi/${G_GITBRANCH:=master}/dietpi/func/dietpi-globals" -o /tmp/dietpi-globals || exit 1
+	# shellcheck disable=SC1091
+	. /tmp/dietpi-globals
+	G_EXEC_NOHALT=1 G_EXEC rm /tmp/dietpi-globals
+	export G_GITOWNER G_GITBRANCH G_HW_ARCH_NAME=$(uname -m)
+fi
+case $G_HW_ARCH_NAME in
+	'armv6l') export G_HW_ARCH=1;;
+	'armv7l') export G_HW_ARCH=2;;
+	'aarch64') export G_HW_ARCH=3;;
+	'x86_64') export G_HW_ARCH=10;;
+	*) G_DIETPI-NOTIFY 1 "Unsupported host system architecture \"$G_HW_ARCH_NAME\" detected, aborting..."; exit 1;;
+esac
+readonly G_PROGRAM_NAME='DietPi-squeezelite_container_setup'
+G_CHECK_ROOT_USER
+G_CHECK_ROOTFS_RW
+readonly FP_ORIGIN=$PWD # Store origin dir
+G_INIT
+G_EXEC cd "$FP_ORIGIN" # Process everything in origin dir instead of /tmp/$G_PROGRAM_NAME
+
+##########################################
+# Process inputs
+##########################################
+DISTRO=
+ARCH=
+while (( $# ))
+do
+	case $1 in
+		'-d') shift; DISTRO=$1;;
+		'-a') shift; ARCH=$1;;
+		*) G_DIETPI-NOTIFY 1 "Invalid input \"$1\", aborting..."; exit 1;;
+	esac
+	shift
+done
+distro=
+case $DISTRO in
+        5) distro='buster';;
+	6) distro='bullseye';;
+	7) distro='bookworm';;
+	*) G_DIETPI-NOTIFY 1 "Invalid distro \"$DISTRO\" passed, aborting..."; exit 1;;
+esac
+image=
+arch=
+case $ARCH in
+	1) image="DietPi_Container-ARMv6-${distro^}" arch='armv6l';;
+	2) image="DietPi_Container-ARMv7-${distro^}" arch='armv7l';;
+	3) image="DietPi_Container-ARMv8-${distro^}" arch='aarch64';;
+	10) image="DietPi_Container-x86_64-${distro^}" arch='x86_64';;
+	*) G_DIETPI-NOTIFY 1 "Invalid architecture \"$ARCH\" passed, aborting..."; exit 1;;
+esac
+
+##########################################
+# Dependencies
+##########################################
+apackages=('7zip' 'parted' 'fdisk' 'systemd-container')
+(( $G_HW_ARCH == $ARCH || ( $G_HW_ARCH < 10 && $G_HW_ARCH > $ARCH ) )) || apackages+=('qemu-user-static' 'binfmt-support')
+G_AG_CHECK_INSTALL_PREREQ "${apackages[@]}"
+
+##########################################
+# Prepare container
+##########################################
+# Download
+G_EXEC curl -sSfO "https://dietpi.com/downloads/images/$image.7z"
+G_EXEC 7zz e "$image.7z" "$image.img"
+G_EXEC rm "$image.7z"
+G_EXEC truncate -s $((2*1024**3)) "$image.img"
+
+# Loop device
+FP_LOOP=$(losetup -f)
+G_EXEC losetup "$FP_LOOP" "$image.img"
+G_EXEC partprobe "$FP_LOOP"
+G_EXEC partx -u "$FP_LOOP"
+G_EXEC_OUTPUT=1 G_EXEC e2fsck -fp "${FP_LOOP}p1"
+G_EXEC_OUTPUT=1 G_EXEC eval "sfdisk -fN1 '$FP_LOOP' <<< ',+'"
+G_EXEC partprobe "$FP_LOOP"
+G_EXEC partx -u "$FP_LOOP"
+G_EXEC_OUTPUT=1 G_EXEC resize2fs "${FP_LOOP}p1"
+G_EXEC_OUTPUT=1 G_EXEC e2fsck -fp "${FP_LOOP}p1"
+G_EXEC mkdir rootfs
+G_EXEC mount "${FP_LOOP}p1" rootfs
+
+# Automated build
+cat << _EOF_ > rootfs/etc/rc.local || exit 1
+#!/bin/dash
+infocmp "\$TERM" > /dev/null 2>&1 || TERM='dumb'
+if grep -q 'raspbian' /etc/os-release
+then
+	sed -i '/^G_HW_ARCH=/c\G_HW_ARCH=1' /boot/dietpi/.hw_model
+	sed -i '/^G_HW_ARCH_NAME=/c\G_HW_ARCH_NAME=armv6l' /boot/dietpi/.hw_model
+fi
+echo '[ INFO ] Running Squeezelite build script...'
+bash -c "\$(curl -sSf 'https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.build/software/squeezelite/build.bash')"
+mv -v '/tmp/squeezelite_$arch.deb' '/squeezelite_$arch.deb'
+poweroff
+_EOF_
+G_EXEC chmod +x rootfs/etc/rc.local
+
+# Assure that build starts after DietPi-PostBoot
+[[ -d 'rootfs/etc/systemd/system/rc-local.service.d' ]] || G_EXEC mkdir rootfs/etc/systemd/system/rc-local.service.d
+G_EXEC eval 'echo -e '\''[Unit]\nAfter=dietpi-postboot.service'\'' > rootfs/etc/systemd/system/rc-local.service.d/dietpi.conf'
+
+##########################################
+# Boot container
+##########################################
+systemd-nspawn -bD rootfs --bind="$FP_LOOP"{,p1} --bind=/dev/disk
+[[ -f rootfs/squeezelite_$arch.deb ]] || exit 1
+}

--- a/.github/workflows/squeezelite.yml
+++ b/.github/workflows/squeezelite.yml
@@ -1,0 +1,244 @@
+name: squeezelite
+on:
+  workflow_dispatch:
+    inputs:
+      arch:
+        description: 'Target architecture index: 1, 2, 3, 10 or all'
+        required: true
+      distro:
+        description: 'Target Debian version index: 5, 6, 7 or all'
+        required: true
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.arch }}-${{ github.event.inputs.distro }}
+  cancel-in-progress: true
+permissions: {}
+jobs:
+  armv6_buster:
+    if: ( github.event.inputs.arch == 1 || github.event.inputs.arch == 'all' ) && ( github.event.inputs.distro == 5 || github.event.inputs.distro == 'all' )
+    # https://github.com/actions/virtual-environments
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: sh
+        working-directory: /dev/shm
+    steps:
+    - name: Start build container
+      run: sudo bash -c "G_GITOWNER=$GITHUB_REPOSITORY_OWNER G_GITBRANCH=${GITHUB_REF#refs/heads/}; $(curl -sSf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY_OWNER/DietPi/${GITHUB_REF#refs/heads/}/.build/software/squeezelite/container_build.bash")" 'DietPi-Build_Squeezelite' -a 1 -d 5
+    - name: Upload package
+      run: |
+        [ -d ~/.ssh ] || mkdir ~/.ssh
+        umask 377
+        echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+        echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
+        curl -T rootfs/squeezelite_armv6l.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/buster/'
+        curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
+        --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/squeezelite_armv6l.deb"]}'
+  armv6_bullseye:
+    if: ( github.event.inputs.arch == 1 || github.event.inputs.arch == 'all' ) && ( github.event.inputs.distro == 6 || github.event.inputs.distro == 'all' )
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: sh
+        working-directory: /dev/shm
+    steps:
+    - name: Start build container
+      run: sudo bash -c "G_GITOWNER=$GITHUB_REPOSITORY_OWNER G_GITBRANCH=${GITHUB_REF#refs/heads/}; $(curl -sSf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY_OWNER/DietPi/${GITHUB_REF#refs/heads/}/.build/software/squeezelite/container_build.bash")" 'DietPi-Build_Squeezelite' -a 1 -d 6
+    - name: Upload package
+      run: |
+        [ -d ~/.ssh ] || mkdir ~/.ssh
+        umask 377
+        echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+        echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
+        curl -T rootfs/squeezelite_armv6l.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bullseye/'
+        curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
+        --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/squeezelite_armv6l.deb"]}'
+  armv6_bookworm:
+    if: ( github.event.inputs.arch == 1 || github.event.inputs.arch == 'all' ) && ( github.event.inputs.distro == 7 || github.event.inputs.distro == 'all' )
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: sh
+        working-directory: /dev/shm
+    steps:
+    - name: Start build container
+      run: sudo bash -c "G_GITOWNER=$GITHUB_REPOSITORY_OWNER G_GITBRANCH=${GITHUB_REF#refs/heads/}; $(curl -sSf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY_OWNER/DietPi/${GITHUB_REF#refs/heads/}/.build/software/squeezelite/container_build.bash")" 'DietPi-Build_Squeezelite' -a 1 -d 7
+    - name: Upload package
+      run: |
+        [ -d ~/.ssh ] || mkdir ~/.ssh
+        umask 377
+        echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+        echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
+        curl -T rootfs/squeezelite_armv6l.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bookworm/'
+        curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
+        --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/squeezelite_armv6l.deb"]}'
+
+  armv7_buster:
+    if: ( github.event.inputs.arch == 2 || github.event.inputs.arch == 'all' ) && ( github.event.inputs.distro == 5 || github.event.inputs.distro == 'all' )
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: sh
+        working-directory: /dev/shm
+    steps:
+    - name: Start build container
+      run: sudo bash -c "G_GITOWNER=$GITHUB_REPOSITORY_OWNER G_GITBRANCH=${GITHUB_REF#refs/heads/}; $(curl -sSf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY_OWNER/DietPi/${GITHUB_REF#refs/heads/}/.build/software/squeezelite/container_build.bash")" 'DietPi-Build_Squeezelite' -a 2 -d 5
+    - name: Upload package
+      run: |
+        [ -d ~/.ssh ] || mkdir ~/.ssh
+        umask 377
+        echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+        echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
+        curl -T rootfs/squeezelite_armv7l.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/buster/'
+        curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
+        --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/squeezelite_armv7l.deb"]}'
+  armv7_bullseye:
+    if: ( github.event.inputs.arch == 2 || github.event.inputs.arch == 'all' ) && ( github.event.inputs.distro == 6 || github.event.inputs.distro == 'all' )
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: sh
+        working-directory: /dev/shm
+    steps:
+    - name: Start build container
+      run: sudo bash -c "G_GITOWNER=$GITHUB_REPOSITORY_OWNER G_GITBRANCH=${GITHUB_REF#refs/heads/}; $(curl -sSf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY_OWNER/DietPi/${GITHUB_REF#refs/heads/}/.build/software/squeezelite/container_build.bash")" 'DietPi-Build_Squeezelite' -a 2 -d 6
+    - name: Upload package
+      run: |
+        [ -d ~/.ssh ] || mkdir ~/.ssh
+        umask 377
+        echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+        echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
+        curl -T rootfs/squeezelite_armv7l.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bullseye/'
+        curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
+        --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/squeezelite_armv7l.deb"]}'
+  armv7_bookworm:
+    if: ( github.event.inputs.arch == 2 || github.event.inputs.arch == 'all' ) && ( github.event.inputs.distro == 7 || github.event.inputs.distro == 'all' )
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: sh
+        working-directory: /dev/shm
+    steps:
+    - name: Start build container
+      run: sudo bash -c "G_GITOWNER=$GITHUB_REPOSITORY_OWNER G_GITBRANCH=${GITHUB_REF#refs/heads/}; $(curl -sSf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY_OWNER/DietPi/${GITHUB_REF#refs/heads/}/.build/software/squeezelite/container_build.bash")" 'DietPi-Build_Squeezelite' -a 2 -d 7
+    - name: Upload package
+      run: |
+        [ -d ~/.ssh ] || mkdir ~/.ssh
+        umask 377
+        echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+        echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
+        curl -T rootfs/squeezelite_armv7l.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bookworm/'
+        curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
+        --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/squeezelite_armv7l.deb"]}'
+
+  armv8_buster:
+    if: ( github.event.inputs.arch == 3 || github.event.inputs.arch == 'all' ) && ( github.event.inputs.distro == 5 || github.event.inputs.distro == 'all' )
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: sh
+    steps:
+    - name: Start build container
+      run: sudo bash -c "G_GITOWNER=$GITHUB_REPOSITORY_OWNER G_GITBRANCH=${GITHUB_REF#refs/heads/}; $(curl -sSf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY_OWNER/DietPi/${GITHUB_REF#refs/heads/}/.build/software/squeezelite/container_build.bash")" 'DietPi-Build_Squeezelite' -a 3 -d 5
+    - name: Upload package
+      run: |
+        [ -d ~/.ssh ] || mkdir ~/.ssh
+        umask 377
+        echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+        echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
+        curl -T rootfs/squeezelite_aarch64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/buster/'
+        curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
+        --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/squeezelite_aarch64.deb"]}'
+  armv8_bullseye:
+    if: ( github.event.inputs.arch == 3 || github.event.inputs.arch == 'all' ) && ( github.event.inputs.distro == 6 || github.event.inputs.distro == 'all' )
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: sh
+    steps:
+    - name: Start build container
+      run: sudo bash -c "G_GITOWNER=$GITHUB_REPOSITORY_OWNER G_GITBRANCH=${GITHUB_REF#refs/heads/}; $(curl -sSf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY_OWNER/DietPi/${GITHUB_REF#refs/heads/}/.build/software/squeezelite/container_build.bash")" 'DietPi-Build_Squeezelite' -a 3 -d 6
+    - name: Upload package
+      run: |
+        [ -d ~/.ssh ] || mkdir ~/.ssh
+        umask 377
+        echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+        echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
+        curl -T rootfs/squeezelite_aarch64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bullseye/'
+        curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
+        --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/squeezelite_aarch64.deb"]}'
+  armv8_bookworm:
+    if: ( github.event.inputs.arch == 3 || github.event.inputs.arch == 'all' ) && ( github.event.inputs.distro == 7 || github.event.inputs.distro == 'all' )
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: sh
+    steps:
+    - name: Start build container
+      run: sudo bash -c "G_GITOWNER=$GITHUB_REPOSITORY_OWNER G_GITBRANCH=${GITHUB_REF#refs/heads/}; $(curl -sSf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY_OWNER/DietPi/${GITHUB_REF#refs/heads/}/.build/software/squeezelite/container_build.bash")" 'DietPi-Build_Squeezelite' -a 3 -d 7
+    - name: Upload package
+      run: |
+        [ -d ~/.ssh ] || mkdir ~/.ssh
+        umask 377
+        echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+        echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
+        curl -T rootfs/squeezelite_aarch64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bookworm/'
+        curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
+        --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/squeezelite_aarch64.deb"]}'
+
+  x86_64_buster:
+    if: ( github.event.inputs.arch == 10 || github.event.inputs.arch == 'all' ) && ( github.event.inputs.distro == 5 || github.event.inputs.distro == 'all' )
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: sh
+        working-directory: /dev/shm
+    steps:
+    - name: Start build container
+      run: sudo bash -c "G_GITOWNER=$GITHUB_REPOSITORY_OWNER G_GITBRANCH=${GITHUB_REF#refs/heads/}; $(curl -sSf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY_OWNER/DietPi/${GITHUB_REF#refs/heads/}/.build/software/squeezelite/container_build.bash")" 'DietPi-Build_Squeezelite' -a 10 -d 5
+    - name: Upload package
+      run: |
+        [ -d ~/.ssh ] || mkdir ~/.ssh
+        umask 377
+        echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+        echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
+        curl -T rootfs/squeezelite_x86_64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/buster/'
+        curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
+        --data '{"files":["https://dietpi.com/downloads/binaries/buster/testing/","https://dietpi.com/downloads/binaries/buster/testing/squeezelite_x86_64.deb"]}'
+  x86_64_bullseye:
+    if: ( github.event.inputs.arch == 10 || github.event.inputs.arch == 'all' ) && ( github.event.inputs.distro == 6 || github.event.inputs.distro == 'all' )
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: sh
+        working-directory: /dev/shm
+    steps:
+    - name: Start build container
+      run: sudo bash -c "G_GITOWNER=$GITHUB_REPOSITORY_OWNER G_GITBRANCH=${GITHUB_REF#refs/heads/}; $(curl -sSf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY_OWNER/DietPi/${GITHUB_REF#refs/heads/}/.build/software/squeezelite/container_build.bash")" 'DietPi-Build_Squeezelite' -a 10 -d 6
+    - name: Upload package
+      run: |
+        [ -d ~/.ssh ] || mkdir ~/.ssh
+        umask 377
+        echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+        echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
+        curl -T rootfs/squeezelite_x86_64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bullseye/'
+        curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
+        --data '{"files":["https://dietpi.com/downloads/binaries/bullseye/testing/","https://dietpi.com/downloads/binaries/bullseye/testing/squeezelite_x86_64.deb"]}'
+  x86_64_bookworm:
+    if: ( github.event.inputs.arch == 10 || github.event.inputs.arch == 'all' ) && ( github.event.inputs.distro == 7 || github.event.inputs.distro == 'all' )
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: sh
+        working-directory: /dev/shm
+    steps:
+    - name: Start build container
+      run: sudo bash -c "G_GITOWNER=$GITHUB_REPOSITORY_OWNER G_GITBRANCH=${GITHUB_REF#refs/heads/}; $(curl -sSf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY_OWNER/DietPi/${GITHUB_REF#refs/heads/}/.build/software/squeezelite/container_build.bash")" 'DietPi-Build_Squeezelite' -a 10 -d 7
+    - name: Upload package
+      run: |
+        [ -d ~/.ssh ] || mkdir ~/.ssh
+        umask 377
+        echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+        echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
+        curl -T rootfs/squeezelite_x86_64.deb --key ~/.ssh/id_ed25519 'sftp://github@ssh.dietpi.com:29248/bookworm/'
+        curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
+        --data '{"files":["https://dietpi.com/downloads/binaries/bookworm/testing/","https://dietpi.com/downloads/binaries/bookworm/testing/squeezelite_x86_64.deb"]}'

--- a/.update/patches
+++ b/.update/patches
@@ -863,6 +863,21 @@ _EOF_
 Patch_8_10()
 {
 	[[ -f '/etc/dpkg/dpkg.cfg.d/01-dietpi-exclude_doubled_devicetrees' ]] && G_EXEC_DESC='Removing obsolete DPKG exclude' G_EXEC rm /etc/dpkg/dpkg.cfg.d/01-dietpi-exclude_doubled_devicetrees
+
+	# Inform about available software updates
+	if [[ -f '/boot/dietpi/.installed' ]]
+	then
+		# Amiberry
+		grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[108\]=2' /boot/dietpi/.installed && G_WHIP_MSG '[ INFO ] Amiberry update available
+\nAn update to Amiberry v5.4 is available. Apply it via reinstall:
+# dietpi-software reinstall 108
+\nRelease notes: https://github.com/BlitterStudio/amiberry/releases/tag/v5.4'
+		# Squeezelite
+		grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[36\]=2' /boot/dietpi/.installed && G_WHIP_MSG '[ INFO ] Squeezelite update available
+\nAn update to Squeezelite v1.9.9-1403 is available. Apply it via reinstall:
+# dietpi-software reinstall 36
+\nChange log: https://github.com/ralph-irving/squeezelite/commits/bc72c0d'
+	fi
 }
 
 # v6.35 => v7 migration

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,7 +2,8 @@ v8.10
 (2022-10-22)
 
 Enhancements:
-- Amiberry | Updated to latest version 5.4, including latest LibSDL2 v2.24.1.
+- Amiberry | Updated to latest version 5.4, including latest LibSDL2 v2.24.1. The update can be applied via reinstall: dietpi-software reinstall 108
+- Squeezelite | Updated to latest version 1.9.9-1403, fixed install on Debian Bookworm and added support for the Opus audio codec format. Also the default command-line arguments have been enhanced to not enforce the audio format anymore, and they can now be easily adjusted via /etc/default/squeezelite. The update can be applied via reinstall: "dietpi-software reinstall 108". Many thanks to @scan80269 and @aposcic for doing this suggestions: https://github.com/MichaIng/DietPi/issues/4428, https://github.com/MichaIng/DietPi/issues/5791
 
 Bug fixes:
 - Raspberry Pi | Resolved an issue where some I2C and SPI device drivers were not loaded. Many thanks to @f-laurens and others for reporting this issue: https://github.com/MichaIng/DietPi/issues/5789

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -14697,7 +14697,9 @@ _EOF_
 
 			Banner_Uninstalling
 			G_AGP squeezelite
-			[[ -f '/etc/systemd/system/squeezelite.service' ]] && G_EXEC rm /etc/systemd/system/squeezelite.service # Pre-v6.31
+			# Pre-v6.31
+			[[ -f '/etc/systemd/system/squeezelite.service' ]] && G_EXEC rm /etc/systemd/system/squeezelite.service
+			# Pre-v7.3
 			[[ -d '/etc/systemd/system/squeezelite.service.d' ]] && G_EXEC rm -R /etc/systemd/system/squeezelite.service.d
 			getent passwd squeezelite > /dev/null && G_EXEC userdel squeezelite
 			getent group squeezelite > /dev/null && G_EXEC groupdel squeezelite

--- a/dietpi/patch_file
+++ b/dietpi/patch_file
@@ -1704,7 +1704,7 @@ To reinstall now, run: "dietpi-software reinstall 106 144 145"
 			#-------------------------------------------------------------------------------
 			# Reinstalls
 			#	Folding@Home: https://github.com/MichaIng/DietPi/pull/3546
-			#	SqueezeLite: https://github.com/MichaIng/DietPi/issues/2386#issuecomment-651982127
+			#	Squeezelite: https://github.com/MichaIng/DietPi/issues/2386#issuecomment-651982127
 			if (( $G_DIETPI_INSTALL_STAGE == 2 )); then
 
 				# Reset QuiteRSS install state if the package has not actually been installed: https://github.com/MichaIng/DietPi/commit/49f960a7953f44e5571ff2dde68a93efca37ec03
@@ -1712,7 +1712,7 @@ To reinstall now, run: "dietpi-software reinstall 106 144 145"
 
 				if grep -q '^aSOFTWARE_INSTALL_STATE\[36\]=2' /boot/dietpi/.installed; then
 
-					G_DIETPI-NOTIFY 2 'Preparing SqueezeLite update...'
+					G_DIETPI-NOTIFY 2 'Preparing Squeezelite update...'
 					G_EXEC rm -Rf /usr/bin/squeezelite* /etc/default/squeezelite
 					[[ -f '/etc/systemd/system/squeezelite.service' ]] && G_CONFIG_INJECT 'User=' 'User=squeezelite' /etc/systemd/system/squeezelite.service '\[Service\]'
 					echo 36 >> /var/tmp/dietpi/dietpi-update_reinstalls


### PR DESCRIPTION
- Squeezelite | Updated to latest version 1.9.9-1403, fixed install on Debian Bookworm and added support for the Opus audio codec format. Also the default command-line arguments have been enhanced to not enforce the audio format anymore, and they can now be easily adjusted via /etc/default/squeezelite. Many thanks to @scan80269 and @aposcic for doing this suggestions: https://github.com/MichaIng/DietPi/issues/4428, https://github.com/MichaIng/DietPi/issues/5791