### PR TITLE
DietPi-Software | Home Assistant: Install HACS by default

### DIFF
--- a/.build/software/vaultwarden/build.bash
+++ b/.build/software/vaultwarden/build.bash
@@ -27,8 +27,8 @@ export PATH="$HOME/.cargo/bin:$PATH"
 
 version='1.26.0'
 G_DIETPI-NOTIFY 2 "Building vaultwarden version \e[33m$version"
-[[ -d vaultwarden-$version ]] && G_EXEC rm -R "vaultwarden-$version"
 G_EXEC curl -sSfLO "https://github.com/dani-garcia/vaultwarden/archive/$version.tar.gz"
+[[ -d vaultwarden-$version ]] && G_EXEC rm -R "vaultwarden-$version"
 G_EXEC tar xf "$version.tar.gz"
 G_EXEC rm "$version.tar.gz"
 G_EXEC cd "vaultwarden-$version"

--- a/.update/patches
+++ b/.update/patches
@@ -870,6 +870,11 @@ Patch_8_10()
 \nRelease notes:
 - https://github.com/dani-garcia/vaultwarden/releases/tag/1.26.0
 - https://github.com/dani-garcia/bw_web_builds/releases/tag/v2022.10.0'
+		# Home Assistant
+		grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[157\]=2' /boot/dietpi/.installed && G_WHIP_MSG '[ INFO ] HACS integration for Home Assistant available
+\nThe Home Assistant Community Store (HACS) is now installed by default with Home Assistant. Add it via reinstall:
+# dietpi-software reinstall 157
+\nTo activate it, follow this guide: https://hacs.xyz/docs/configuration/basic/'
 	fi
 }
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ Enhancements:
 - Amiberry | Updated to version 5.4, including LibSDL2 v2.24.1. The update can be applied via reinstall: dietpi-software reinstall 108
 - Squeezelite | Updated to version 1.9.9-1403, fixed install on Debian Bookworm and added support for the Opus audio codec format. Also the default command-line arguments have been enhanced to not enforce the audio format anymore, and they can now be easily adjusted via /etc/default/squeezelite. The update can be applied via reinstall: "dietpi-software reinstall 108". Many thanks to @scan80269 and @aposcic for doing this suggestions: https://github.com/MichaIng/DietPi/issues/4428, https://github.com/MichaIng/DietPi/issues/5791
 - vaultwarden | Updated to version 1.26.0, including web vault v2022.10.0. The update can be applied via reinstall: dietpi-software reinstall 183
+- Home Assistant | The Home Assistant Community Store (HACS) is now installed by default. For existing installs, do a reinstall: "dietpi-software reinstall 157". To activate HACS, follow this guide: https://hacs.xyz/docs/configuration/basic/. Many thanks to @pbanj for pointing us to this option: https://github.com/MichaIng/DietPi/issues/4709#issuecomment-1192069367
 
 Bug fixes:
 - Raspberry Pi | Resolved an issue where some I2C and SPI device drivers were not loaded. Many thanks to @f-laurens and others for reporting this issue: https://github.com/MichaIng/DietPi/issues/5789

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12005,7 +12005,7 @@ _EOF_
 			local ha_user='homeassistant'
 			local ha_home="/home/$ha_user"
 			local ha_pyenv_activation=". $ha_home/pyenv-activate.sh"
-			local ha_python_version='3.9.13' # https://www.python.org/downloads/
+			local ha_python_version='3.9.15' # https://www.python.org/downloads/
 
 			G_DIETPI-NOTIFY 2 "Home Assistant user:  $ha_user"
 			G_DIETPI-NOTIFY 2 "Home Assistant home:  $ha_home"
@@ -12014,10 +12014,6 @@ _EOF_
 
 			# User
 			Create_User -G dialout,gpio,i2c -d "$ha_home" "$ha_user"
-
-			# Start with fresh instance, to allow clean pyenv and Python updates and fix broken instances. All userdata and configs are preserved in: /mnt/dietpi_userdata/homeassistant
-			[[ -d $ha_home/.pyenv ]] && G_EXEC rm -R "$ha_home/.pyenv"
-			[[ -d '/srv/homeassistant' ]] && G_EXEC rm -R /srv/homeassistant # pre-v6-27
 
 			# Dependencies
 			# - MariaDB support: G_AGI libmariadb-dev; pip3 install --no-cache-dir mysqlclient|PyMySQL
@@ -12057,6 +12053,9 @@ _EOF_
 			# Install pyenv to $ha_home
 			Download_Install 'https://github.com/pyenv/pyenv/archive/master.tar.gz'
 			G_EXEC chown -R "$ha_user:$ha_user" pyenv-master
+			# - Start with fresh instance, to allow clean pyenv and Python updates and fix broken instances. All userdata and configs are preserved in: /mnt/dietpi_userdata/homeassistant
+			[[ -d $ha_home/.pyenv ]] && G_EXEC rm -R "$ha_home/.pyenv"
+			[[ -d '/srv/homeassistant' ]] && G_EXEC rm -R /srv/homeassistant # pre-v6-27
 			G_EXEC mv pyenv-master "$ha_home/.pyenv"
 
 			# Generate script to activate pyenv: This must be sourced from the originating shell, hence it does not require execute permissions.
@@ -12117,12 +12116,12 @@ _EOF_
 					G_EXEC mkdir /mnt/dietpi_userdata/homeassistant
 				fi
 			fi
-			G_EXEC rm -Rf "$ha_home/.homeassistant"
+			[[ -d $ha_home/.homeassistant ]] && G_EXEC rm -R "$ha_home/.homeassistant"
 			G_EXEC ln -s /mnt/dietpi_userdata/homeassistant "$ha_home/.homeassistant"
 
 			# Download HACS
 			Download_Install 'https://github.com/hacs/integration/releases/latest/download/hacs.zip' hacs
-			[[ -d '/mnt/dietpi_userdata/homeassistant/custom_components/hacs' ]] && G_EXEC rm -Rf /mnt/dietpi_userdata/homeassistant/custom_components/hacs
+			[[ -d '/mnt/dietpi_userdata/homeassistant/custom_components/hacs' ]] && G_EXEC rm -R /mnt/dietpi_userdata/homeassistant/custom_components/hacs
 			G_EXEC mv hacs /mnt/dietpi_userdata/homeassistant/custom_components/
 			G_EXEC chown -R "$ha_user:$ha_user" /mnt/dietpi_userdata/homeassistant
 			G_DIETPI-NOTIFY 2 "Home Assistant Community Store has been installed in addition. How-To activate, check HACS setup guide at https://hacs.xyz/docs/configuration/basic/"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12124,7 +12124,7 @@ _EOF_
 			[[ -d '/mnt/dietpi_userdata/homeassistant/custom_components/hacs' ]] && G_EXEC rm -R /mnt/dietpi_userdata/homeassistant/custom_components/hacs
 			G_EXEC mv hacs /mnt/dietpi_userdata/homeassistant/custom_components/
 			G_EXEC chown -R "$ha_user:$ha_user" /mnt/dietpi_userdata/homeassistant
-			G_DIETPI-NOTIFY 2 "Home Assistant Community Store has been installed in addition. How-To activate, check HACS setup guide at https://hacs.xyz/docs/configuration/basic/"
+			G_DIETPI-NOTIFY 2 "Home Assistant Community Store (HACS) has been installed in addition. To activate it, follow this guide: https://hacs.xyz/docs/configuration/basic/"
 
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12122,6 +12122,7 @@ _EOF_
 			# Download HACS
 			Download_Install 'https://github.com/hacs/integration/releases/latest/download/hacs.zip' hacs
 			[[ -d '/mnt/dietpi_userdata/homeassistant/custom_components/hacs' ]] && G_EXEC rm -R /mnt/dietpi_userdata/homeassistant/custom_components/hacs
+			[[ -d '/mnt/dietpi_userdata/homeassistant/custom_components' ]] || G_EXEC mkdir /mnt/dietpi_userdata/homeassistant/custom_components
 			G_EXEC mv hacs /mnt/dietpi_userdata/homeassistant/custom_components/
 			G_EXEC chown -R "$ha_user:$ha_user" /mnt/dietpi_userdata/homeassistant
 			G_DIETPI-NOTIFY 2 "Home Assistant Community Store (HACS) has been installed in addition. To activate it, follow this guide: https://hacs.xyz/docs/configuration/basic/"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12119,7 +12119,13 @@ _EOF_
 			fi
 			G_EXEC rm -Rf "$ha_home/.homeassistant"
 			G_EXEC ln -s /mnt/dietpi_userdata/homeassistant "$ha_home/.homeassistant"
+
+			# Download HACS
+			Download_Install 'https://github.com/hacs/integration/releases/latest/download/hacs.zip' hacs
+			[[ -d '/mnt/dietpi_userdata/homeassistant/custom_components/hacs' ]] && G_EXEC rm -Rf /mnt/dietpi_userdata/homeassistant/custom_components/hacs
+			G_EXEC mv hacs /mnt/dietpi_userdata/homeassistant/custom_components/
 			G_EXEC chown -R "$ha_user:$ha_user" /mnt/dietpi_userdata/homeassistant
+			G_DIETPI-NOTIFY 2 "Home Assistant Community Store has been installed in addition. How-To activate, check HACS setup guide at https://hacs.xyz/docs/configuration/basic/"
 
 		fi
 


### PR DESCRIPTION
DietPi-Software | Home Assistant - add HACS plugin by default to HA install

