### PR TITLE
DietPi-Banner | Word wrap for small terminals

### DIFF
--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -128,9 +128,9 @@
         ## The description is typically very long, and is folded from the second line
         ## onwards into the remaining MAX_DESCP_LEN, with left padding.
 	    if (( $descp_len >= $MAX_DESCP_LEN )); then
-		    descp=$(echo "${stripped_descp}" \
-				        | fold -s -w $MAX_DESCP_LEN \
-				        | sed "2,\$s|^|${left_padding}|")
+            descp=$(echo "${stripped_descp}" \
+				        | fold -s -w $MAX_DESCP_LEN)
+            descp="${descp//$'\n'/\\n$left_padding}"
 	    fi
 
         echo -e "$title $descp"

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -77,18 +77,16 @@
 		'\e[91m'	# Red		| Update notifications
 	)
 
-    ## Parse the above colour strings and use them to generate an expression to match them
-    ## via bash substitution
-    __make_strip_color(){
-        # shellcheck disable=SC2124
-        local tmp="${aCOLOUR[@]} $COLOUR_RESET" ## convert array to string
-        tmp="+(${tmp// /|})"                    ## convert list into OR expression
-        tmp="${tmp//\\e/\\\\\\e}"               ## ensure '\e' exists
-        tmp="${tmp//\[/\\[}"                    ## ensure '\[' exists
-        echo "$tmp"
-    }
-    shopt -s extglob    ## globally enable multiple pattern matching, and disable at the end
-    COLOUR_STRIP="$(__make_strip_color)"
+	# Parse the above colour strings and use them to generate an expression to match them via bash substitution
+	__make_strip_color(){
+		local tmp="${aCOLOUR[*]} $COLOUR_RESET" # convert array to string
+		tmp="+(${tmp// /|})"                    # convert list into OR expression
+		tmp=${tmp//\\e/\\\\\\e}                 # ensure '\e' exists
+		tmp=${tmp//\[/\\[}                      # ensure '\[' exists
+		echo "$tmp"
+	}
+	shopt -s extglob # globally enable multiple pattern matching
+	COLOUR_STRIP=$(__make_strip_color)
 
 	# Load settings here, to have chosen ${aCOLOUR[0]} applied to below strings
 	# shellcheck disable=SC1090
@@ -101,42 +99,44 @@
 	GREEN_BULLET=" ${aCOLOUR[0]}-$COLOUR_RESET"
 	GREEN_SEPARATOR="${aCOLOUR[0]}:$COLOUR_RESET"
 
-    # Print a banner line split into title and description with word-wrapping
-	Print_Line(){
-	    local title="$1"  ## Bold part before ":"
-	    local descp="$2"  ## Normal part after ":"
+	# Print a banner line split into title and description with word-wrapping
+	Print_Line()
+	{
+		local title=$1 # Bold part before ":"
+		local descp=$2 # Normal part after ":"
 
-        if [[ $WORD_WRAP == 1 ]]; then
-            ## Strip invisible colour codes in order to accurately measure the visual length
-            ## of a sentence.
-	        local stripped_title="${title//$COLOUR_STRIP/}"
-	        local stripped_descp="${descp//$COLOUR_STRIP/}"
+		if (( ${aENABLED[16]} == 1 ))
+		then
+			# Strip invisible colour codes in order to accurately measure the visual length of a sentence.
+			local stripped_title=${title//$COLOUR_STRIP}
+			local stripped_descp=${descp//$COLOUR_STRIP}
+			local title_len=${#stripped_title}
+			local descp_len=${#stripped_descp}
 
-            local title_len=${#stripped_title}
-            local descp_len=${#stripped_descp}
+			# Sometimes the title is long, so a sanity check is performed to fold the title
+			# if it exceeds the window size. Because of the hyphen it receives 3 spaces padding.
+			if (( $title_len >= $TERM_WIDTH ))
+			then
+				title=$(echo "$stripped_title" | fold -s -w "$TERM_WIDTH")
+				title=${title//$'\n'/$'\n'   }
+				title="${aCOLOUR[1]}$title$COLOUR_RESET"
+				# Recalculate the title length based on the last line with padding
+				title_len=$(( (($title_len + 3) % $TERM_WIDTH) + 3 ))
+			fi
 
-            ## Sometimes the title is long, so a sanity check is performed to fold the title
-            ## if it exceeds the window size. Because of the hyphen it receives 3 spaces padding.
-	        if (( $title_len >= $TERM_WIDTH )); then
-                title=$(echo "$stripped_title" | fold -s -w "$TERM_WIDTH")
-                title="${title//$'\n'/$'\n'   }"
-		        title="${aCOLOUR[1]}${title}$COLOUR_RESET"
-                ## Recalculate the title length based on the last line with padding
-                title_len=$(( (($title_len + 3) % $TERM_WIDTH) + 3 ))
-	        fi
+			local avail_len=$(( $TERM_WIDTH - $title_len - 1))
+			local left_pad=$(printf -- ' %.0s' $(seq 0 "$title_len"))
 
-            local avail_len=$(( ($TERM_WIDTH - $title_len) - 1))
-            local left_pad=$(printf -- " %.0s" $(seq 0 "$title_len"))
+			# The description is typically very long, and is folded from the second line
+			# onwards into the remaining available space, with left padding.
+			if (( $descp_len >= $avail_len ))
+			then
+				descp=$(echo "$stripped_descp" | fold -s -w "$avail_len")
+				descp=${descp//$'\n'/$'\n'$left_pad}
+			fi
+		fi
 
-            ## The description is typically very long, and is folded from the second line
-            ## onwards into the remaining available space, with left padding.
-	        if (( $descp_len >= $avail_len )); then
-                descp=$(echo "$stripped_descp" | fold -s -w "$avail_len")
-                descp="${descp//$'\n'/$'\n'${left_pad}}"
-	        fi
-        fi
-
-        echo -e "$title $descp"
+		echo -e "$title $descp"
 	}
 
 	DIETPI_VERSION="$G_DIETPI_VERSION_CORE.$G_DIETPI_VERSION_SUB.$G_DIETPI_VERSION_RC"
@@ -286,8 +286,6 @@
 		G_TERM_CLEAR
 		Print_Header
 
-        # Word Wrap
-        (( ${aENABLED[16]} == 1 )) && WORD_WRAP=1
 		# Large Format Hostname
 		# shellcheck disable=SC1091
 		(( ${aENABLED[14]} == 1 )) && . /boot/dietpi/func/dietpi-print_large "$(</etc/hostname)" && echo
@@ -400,7 +398,6 @@ NB: It is executed as bash script, so it needs to be in bash compatible syntax.
 		Menu_Main
 		Print_Banner
 	fi
-    shopt -u extglob
 	#-----------------------------------------------------------------------------------
 	exit 0
 	#-----------------------------------------------------------------------------------

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -57,14 +57,15 @@
 		'Large hostname'
 		'Print credits'
 		'Let'\''s Encrypt cert status'
+		'Word wrap for small terminals?'
 	)
 
 	# Set defaults: Disable CPU temp by default in VMs
 	if (( $G_HW_MODEL == 20 ))
 	then
-		aENABLED=(1 0 0 0 0 1 0 1 0 0 0 1 1 0 0 1 0)
+		aENABLED=(1 0 0 0 0 1 0 1 0 0 0 1 1 0 0 1 0 0)
 	else
-		aENABLED=(1 0 1 0 0 1 0 0 0 0 0 1 1 0 0 1 0)
+		aENABLED=(1 0 1 0 0 1 0 0 0 0 0 1 1 0 0 1 0 0)
 	fi
 
 	COLOUR_RESET='\e[0m'
@@ -105,6 +106,7 @@
 	    local title="$1"  ## Bold part before ":"
 	    local descp="$2"  ## Normal part after ":"
 
+        if [ -v WORD_WRAP ]; then
             ## Strip invisible colour codes in order to accurately measure the visual length
             ## of a sentence.
 	        local stripped_title="${title//$COLOUR_STRIP/}"
@@ -131,6 +133,7 @@
                 descp=$(echo ""$stripped_descp"" | fold -s -w $avail_len)
                 descp="${descp//$'\n'/$'\n'${left_pad}}"
 	        fi
+        fi
 
         echo -e "$title $descp"
 	}
@@ -282,6 +285,8 @@
 		G_TERM_CLEAR
 		Print_Header
 
+        # Word Wrap
+        (( ${aENABLED[16]} == 1 )) && WORD_WRAP=1
 		# Large Format Hostname
 		# shellcheck disable=SC1091
 		(( ${aENABLED[14]} == 1 )) && . /boot/dietpi/func/dietpi-print_large "$(</etc/hostname)" && echo

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -210,9 +210,9 @@
 			local text_update_available_date=$(LC_ALL=${locale:-C.UTF-8} date '+%R - %a %x')
 		fi
 
-		echo -e "$GREEN_LINE
- ${aCOLOUR[1]}DietPi v$DIETPI_VERSION$COLOUR_RESET $GREEN_SEPARATOR $text_update_available_date$COLOUR_RESET
-$GREEN_LINE"
+		echo -e "$GREEN_LINE"
+		Print_Line " ${aCOLOUR[1]}DietPi v$DIETPI_VERSION$COLOUR_RESET $GREEN_SEPARATOR" "$text_update_available_date$COLOUR_RESET"
+		echo -e "$GREEN_LINE"
 	}
 
 	Print_Local_Ip()
@@ -220,19 +220,22 @@ $GREEN_LINE"
 		[[ ${aENABLED[5]} == 1 ]] || return 0
 		local iface=$(G_GET_NET -q iface)
 		local ip=$(G_GET_NET -q ip)
-		echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[5]} $GREEN_SEPARATOR ${ip:-Use dietpi-config to setup a connection} (${iface:-NONE})"
+		Print_Line "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[5]} $GREEN_SEPARATOR" "${ip:-Use dietpi-config to setup a connection} (${iface:-NONE})"
 	}
 
 	Print_Credits()
 	{
-		echo -e " ${aCOLOUR[2]}DietPi Team     : https://github.com/MichaIng/DietPi#the-dietpi-project-team"
+		Print_Line " ${aCOLOUR[2]}DietPi Team     :" "https://github.com/MichaIng/DietPi#the-dietpi-project-team"
 
-		[[ -f '/boot/dietpi/.prep_info' ]] && mawk 'NR==1 {sub(/^0$/,"DietPi Core Team");a=$0} NR==2 {print " Image by        : "a" (pre-image: "$0")"}' /boot/dietpi/.prep_info
+		if [[ -f '/boot/dietpi/.prep_info' ]]; then
+		    local info=$(mawk 'NR==1 {sub(/^0$/,"DietPi Core Team");a=$0} NR==2 {print " "a" (pre-image: "$0")"}' /boot/dietpi/.prep_info)
+		    Print_Line " Image by        :$info"
+		fi
 
-		echo -e " Patreon Legends : Camry2731, Chris Gelatt
- Website         : https://dietpi.com/ | https://twitter.com/DietPi_
- Contribute      : https://dietpi.com/contribute.html
- Web Hosting by  : https://myvirtualserver.com$COLOUR_RESET\n"
+		Print_Line " Patreon Legends :" "Camry2731, Chris Gelatt"
+		Print_Line " Website         :" "https://dietpi.com/ | https://twitter.com/DietPi_"
+		Print_Line " Contribute      :" "https://dietpi.com/contribute.html"
+		Print_Line " Web Hosting by  :" "https://myvirtualserver.com$COLOUR_RESET\n"
 	}
 
 	Print_Updates()
@@ -240,32 +243,32 @@ $GREEN_LINE"
 		# DietPi update available?
 		if [[ $AVAILABLE_UPDATE ]]
 		then
-			echo -e " ${aCOLOUR[1]}dietpi-update$COLOUR_RESET   $GREEN_SEPARATOR ${aCOLOUR[3]}Run now to update DietPi from v$DIETPI_VERSION to v$AVAILABLE_UPDATE$COLOUR_RESET\n"
+			Print_Line " ${aCOLOUR[1]}dietpi-update$COLOUR_RESET   $GREEN_SEPARATOR" "${aCOLOUR[3]}Run now to update DietPi from v$DIETPI_VERSION to v$AVAILABLE_UPDATE$COLOUR_RESET\n"
 
 		# New DietPi live patches available?
 		elif (( $LIVE_PATCHES ))
 		then
-			echo -e " ${aCOLOUR[1]}dietpi-update$COLOUR_RESET   $GREEN_SEPARATOR ${aCOLOUR[3]}Run now to check out new available DietPi live patches$COLOUR_RESET\n"
+			Print_Line " ${aCOLOUR[1]}dietpi-update$COLOUR_RESET   $GREEN_SEPARATOR" "${aCOLOUR[3]}Run now to check out new available DietPi live patches$COLOUR_RESET\n"
 
 		# APT updates available?
 		elif (( $PACKAGE_COUNT ))
 		then
-			echo -e " ${aCOLOUR[1]}apt upgrade$COLOUR_RESET     $GREEN_SEPARATOR ${aCOLOUR[3]}Run now to apply $PACKAGE_COUNT available APT package upgrades$COLOUR_RESET\n"
+			Print_Line " ${aCOLOUR[1]}apt upgrade$COLOUR_RESET     $GREEN_SEPARATOR" "${aCOLOUR[3]}Run now to apply $PACKAGE_COUNT available APT package upgrades$COLOUR_RESET\n"
 
 		# Reboot required to finalise kernel upgrade?
 		elif (( $REBOOT_REQUIRED ))
 		then
-			echo -e " ${aCOLOUR[1]}reboot$COLOUR_RESET          $GREEN_SEPARATOR ${aCOLOUR[3]}A reboot is required to finalise a recent kernel upgrade$COLOUR_RESET\n"
+			Print_Line " ${aCOLOUR[1]}reboot$COLOUR_RESET          $GREEN_SEPARATOR" "${aCOLOUR[3]}A reboot is required to finalise a recent kernel upgrade$COLOUR_RESET\n"
 		fi
 	}
 
 	Print_Useful_Commands()
 	{
-		echo -e " ${aCOLOUR[1]}dietpi-launcher$COLOUR_RESET $GREEN_SEPARATOR All the DietPi programs in one place
- ${aCOLOUR[1]}dietpi-config$COLOUR_RESET   $GREEN_SEPARATOR Feature rich configuration tool for your device
- ${aCOLOUR[1]}dietpi-software$COLOUR_RESET $GREEN_SEPARATOR Select optimised software for installation
- ${aCOLOUR[1]}htop$COLOUR_RESET            $GREEN_SEPARATOR Resource monitor
- ${aCOLOUR[1]}cpu$COLOUR_RESET             $GREEN_SEPARATOR Shows CPU information and stats\n"
+		Print_Line " ${aCOLOUR[1]}dietpi-launcher$COLOUR_RESET $GREEN_SEPARATOR" "All the DietPi programs in one place"
+		Print_Line " ${aCOLOUR[1]}dietpi-config$COLOUR_RESET   $GREEN_SEPARATOR" "Feature rich configuration tool for your device"
+		Print_Line " ${aCOLOUR[1]}dietpi-software$COLOUR_RESET $GREEN_SEPARATOR" "Select optimised software for installation"
+		Print_Line " ${aCOLOUR[1]}htop$COLOUR_RESET            $GREEN_SEPARATOR" "Resource monitor"
+		Print_Line " ${aCOLOUR[1]}cpu$COLOUR_RESET             $GREEN_SEPARATOR" "Shows CPU information and stats\n"
 	}
 
 	Print_Banner()
@@ -277,27 +280,25 @@ $GREEN_LINE"
 		# shellcheck disable=SC1091
 		(( ${aENABLED[14]} == 1 )) && . /boot/dietpi/func/dietpi-print_large "$(</etc/hostname)" && echo
 		# Device model
-		(( ${aENABLED[0]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[0]} $GREEN_SEPARATOR $G_HW_MODEL_NAME"
+		(( ${aENABLED[0]} == 1 )) && Print_Line "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[0]} $GREEN_SEPARATOR" "$G_HW_MODEL_NAME"
 		# Uptime
-		(( ${aENABLED[1]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[1]} $GREEN_SEPARATOR $(uptime -p 2>&1)"
+		(( ${aENABLED[1]} == 1 )) && Print_Line "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[1]} $GREEN_SEPARATOR" "$(uptime -p 2>&1)"
 		# CPU temp
-		(( ${aENABLED[2]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[2]} $GREEN_SEPARATOR $(print_full_info=1 G_OBTAIN_CPU_TEMP 2>&1)"
+		(( ${aENABLED[2]} == 1 )) && Print_Line "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[2]} $GREEN_SEPARATOR" "$(print_full_info=1 G_OBTAIN_CPU_TEMP 2>&1)"
 		# Hostname
-		(( ${aENABLED[3]} == 1 && ${aENABLED[14]} != 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[3]} $GREEN_SEPARATOR $(</etc/hostname)"
+		(( ${aENABLED[3]} == 1 && ${aENABLED[14]} != 1 )) && Print_Line "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[3]} $GREEN_SEPARATOR" "$(</etc/hostname)"
 		# NIS/YP domainname
-		(( ${aENABLED[4]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[4]} $GREEN_SEPARATOR $(hostname -y 2>&1)"
+		(( ${aENABLED[4]} == 1 )) && Print_Line "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[4]} $GREEN_SEPARATOR" "$(hostname -y 2>&1)"
 		# LAN IP
 		Print_Local_Ip
 		# WAN IP + location info
-		(( ${aENABLED[6]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[6]} $GREEN_SEPARATOR $(G_GET_WAN_IP 2>&1)"
+		(( ${aENABLED[6]} == 1 )) && Print_Line "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[6]} $GREEN_SEPARATOR" "$(G_GET_WAN_IP 2>&1)"
 		# DietPi-VPN connection status
-		(( ${aENABLED[13]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[13]} $GREEN_SEPARATOR $(/boot/dietpi/dietpi-vpn status 2>&1)"
+		(( ${aENABLED[13]} == 1 )) && Print_Line "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[13]} $GREEN_SEPARATOR" "$(/boot/dietpi/dietpi-vpn status 2>&1)"
 		# Freespace (RootFS)
-		(( ${aENABLED[7]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[7]} $GREEN_SEPARATOR $(df -h --output=avail / | mawk 'NR==2 {print $1}' 2>&1)"
+		(( ${aENABLED[7]} == 1 )) && Print_Line "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[7]} $GREEN_SEPARATOR" "$(df -h --output=avail / | mawk 'NR==2 {print $1}' 2>&1)"
 		# Freespace (DietPi userdata)
-		(( ${aENABLED[8]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[8]} $GREEN_SEPARATOR $(df -h --output=avail /mnt/dietpi_userdata | mawk 'NR==2 {print $1}' 2>&1)"
-		# Weather
-		(( ${aENABLED[9]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[9]} $GREEN_SEPARATOR $(curl -sSfLm 3 'https://wttr.in/?format=4' 2>&1)"
+		(( ${aENABLED[8]} == 1 )) && Print_Line "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[8]} $GREEN_SEPARATOR" "$(df -h --output=avail /mnt/dietpi_userdata | mawk 'NR==2 {print $1}' 2>&1)"
 		# Let's Encrypt cert status
 		if (( ${aENABLED[16]} == 1 ))
 		then
@@ -308,17 +309,19 @@ $GREEN_LINE"
 				certinfo=$(openssl x509 -enddate -noout -in "$i" | mawk '/notAfter=/{print "Valid until "$4"-"substr($1,10)"-"$2" "$3}' 2>&1)
 				break
 			done
-			echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[16]} $GREEN_SEPARATOR $certinfo"
+			Print_Line "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[16]} $GREEN_SEPARATOR" "$certinfo"
 		fi
+		# Weather
+		(( ${aENABLED[9]} == 1 )) && Print_Line "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[9]} $GREEN_SEPARATOR" "$(curl -sSfLm 3 'https://wttr.in/?format=4' 2>&1)"
 		# Custom
-		(( ${aENABLED[10]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[10]} $GREEN_SEPARATOR $(bash "$FP_CUSTOM" 2>&1)"
+		(( ${aENABLED[10]} == 1 )) && Print_Line "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[10]} $GREEN_SEPARATOR" "$(bash "$FP_CUSTOM" 2>&1)"
 		# MOTD
 		if (( ${aENABLED[12]} == 1 ))
 		then
 			local motd fp_motd='/run/dietpi/.dietpi_motd'
 			[[ -f $fp_motd ]] || curl -sSfLm 3 'https://dietpi.com/motd' -o "$fp_motd"
 			# shellcheck disable=SC1090
-			[[ -f $fp_motd ]] && . "$fp_motd" &> /dev/null && [[ $motd ]] && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[12]} $GREEN_SEPARATOR $motd"
+			[[ -f $fp_motd ]] && . "$fp_motd" &> /dev/null && [[ $motd ]] && Print_Line "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[12]} $GREEN_SEPARATOR" "$motd"
 		fi
 		echo -e "$GREEN_LINE\n"
 

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -115,22 +115,30 @@
 
         ## Left-pad the description based on the title length
         local left_padding=$(printf -- " %.0s" $(seq 0 $MAX_TITLE_LEN))
+        local offset
 
         ## Sometimes the title is long, so a sanity check is performed to fold the title
         ## if it exceeds MAX_TITLE_LEN. This takes up the left-side of the message and
         ## receives no padding.
 	    if (( $title_len >= $MAX_TITLE_LEN )); then
-		    title=$(echo -e "${stripped_title}" \
-			             | fold -s -w $MAX_TITLE_LEN)
+            title="${stripped_title:0:$MAX_TITLE_LEN}"
+            offset=$MAX_TITLE_LEN
+            while [[ $offset < $title_len ]]; do
+                title="${title}\n${left_padding}${stripped_title:${offset}:${MAX_TITLE_LEN}}"
+                offset=$(( $offset + $MAX_DESCP_LEN ))
+            done
 		    title="${aCOLOUR[1]}${title}$COLOUR_RESET"
 	    fi
 
         ## The description is typically very long, and is folded from the second line
         ## onwards into the remaining MAX_DESCP_LEN, with left padding.
 	    if (( $descp_len >= $MAX_DESCP_LEN )); then
-            descp=$(echo "${stripped_descp}" \
-				        | fold -s -w $MAX_DESCP_LEN)
-            descp="${descp//$'\n'/\\n$left_padding}"
+            descp="${stripped_descp:0:$MAX_DESCP_LEN}"
+            offset=$MAX_DESCP_LEN
+            while [[ $offset < $descp_len ]]; do
+                descp="${descp}\n${left_padding}${stripped_descp:${offset}:${MAX_DESCP_LEN}}"
+                offset=$(( $offset + $MAX_DESCP_LEN ))
+            done
 	    fi
 
         echo -e "$title $descp"

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -76,58 +76,65 @@
 		'\e[91m'	# Red		| Update notifications
 	)
 
+    ## Parse the above colour strings and use them to generate an expression to match them
+    ## via bash substitution
+    __make_strip_color(){
+        local tmp="${aCOLOUR[@]} $COLOUR_RESET"
+        tmp="+(${tmp// /|})"       ## convert list into OR expression
+        tmp="${tmp//\\e/\\\\\\e}"  ## ensure '\e' exists
+        tmp="${tmp//\[/\\[}"       ## ensure '\[' exists
+        echo "$tmp"
+    }
+    shopt -s extglob               ## globally enable multiple pattern matching
+    COLOUR_STRIP="$(__make_strip_color)"
+
 	# Load settings here, to have chosen ${aCOLOUR[0]} applied to below strings
 	# shellcheck disable=SC1090
 	[[ -f $FP_SAVEFILE ]] && . "$FP_SAVEFILE"
 
 	TERM_WIDTH=$(tput cols)
-	COLOR_STRIP="s/\x1B\[[0-9;]*m//g"
+    MAX_TITLE_LEN=18      ## Hard-coded
+    MAX_DESCP_LEN=$(( -1 + $TERM_WIDTH - MAX_TITLE_LEN ))
 
-	Print_Line(){
-	    ## Colour codes and other text have been expanded already
-	    ## at this point into '\eXYZ' symbols, emojis, and
-	    ## stylized text.
-	    local descrp="$1"
-	    local result="$2"
-
-	    ## We could also replace the emojis with single characters
-	    ##     via: iconv -f UTF-8 -t ASCII//TRANSLIT
-	    ## to better format the weather and CPU, but it's a little overkill.
-	    local stripped_descrp=$(echo -e "${descrp}" | sed -r ${COLOR_STRIP})
-	    local stripped_result=$(echo -e "${result}" | sed -r ${COLOR_STRIP})
-	    ## Lengths:
-	    #  - If description is long, then split description
-	    ## - If result or total length is long, then split result
-	    local descrp_len=$(echo -e "$stripped_descrp" | wc -c)
-	    local result_len=$(echo -e "$stripped_result" | wc -c)
-	    local total_len=$(( $descrp_len + $result_len ))
-	    ## result text is left padded, so we compensate for it when folding
-	    local padded_len=$(( $TERM_WIDTH - $SEPERATOR_OFFSET ))
-
-	    if [ $descrp_len -gt $TERM_WIDTH ]; then
-		descrp=$(echo -e "${stripped_descrp}" \
-			   | fold -s -w $TERM_WIDTH \
-			   | sed "2,\$s|^|${SEPERATOR_FILLER}|")
-		descrp="${aCOLOUR[1]}${descrp}$COLOUR_RESET"
-	    fi
-
-	    if [ $result_len -gt $(( $TERM_WIDTH - $descrp_len )) ] ||
-		   [ $total_len -gt $TERM_WIDTH ]; then
-		result="\n"$(echo "${stripped_result}" \
-				 | fold -s -w $padded_len \
-				 | sed "s|^|${SEPERATOR_FILLER}|")
-	    fi
-	    echo -e "$descrp $result"
-	}
-
-	## Automatically generated spacing
 	GREEN_LINE_FILLER=$(printf -- "─%.0s" $(seq 1 $(( $TERM_WIDTH - 2 ))))
-	SEPERATOR_OFFSET=3 ## Hardcoded '3', until better suggestion.
-	SEPERATOR_FILLER=$(printf -- " %.0s" $(seq 1 $SEPERATOR_OFFSET))
-
 	GREEN_LINE=" ${aCOLOUR[0]}${GREEN_LINE_FILLER}$COLOUR_RESET"
 	GREEN_BULLET=" ${aCOLOUR[0]}-$COLOUR_RESET"
 	GREEN_SEPARATOR="${aCOLOUR[0]}:$COLOUR_RESET"
+
+	Print_Line(){
+	    local title="$1"  ## Bold part before ":"
+	    local descp="$2"  ## Normal part after ":"
+
+        ## Strip invisible colour codes in order to accurately measure the visual length
+        ## of a sentence.
+	    local stripped_title="${title//$COLOUR_STRIP/}"
+	    local stripped_descp="${descp//$COLOUR_STRIP/}"
+
+	    local title_len=${#stripped_title}
+	    local descp_len=${#stripped_descp}
+
+        ## Left-pad the description based on the title length
+        local left_padding=$(printf -- " %.0s" $(seq 0 $MAX_TITLE_LEN))
+
+        ## Sometimes the title is long, so a sanity check is performed to fold the title
+        ## if it exceeds MAX_TITLE_LEN. This takes up the left-side of the message and
+        ## receives no padding.
+	    if (( $title_len >= $MAX_TITLE_LEN )); then
+		    title=$(echo -e "${stripped_title}" \
+			             | fold -s -w $MAX_TITLE_LEN)
+		    title="${aCOLOUR[1]}${title}$COLOUR_RESET"
+	    fi
+
+        ## The description is typically very long, and is folded from the second line
+        ## onwards into the remaining MAX_DESCP_LEN, with left padding.
+	    if (( $descp_len >= $MAX_DESCP_LEN )); then
+		    descp=$(echo "${stripped_descp}" \
+				        | fold -s -w $MAX_DESCP_LEN \
+				        | sed "2,\$s|^|${left_padding}|")
+	    fi
+
+        echo -e "$title $descp"
+	}
 
 	DIETPI_VERSION="$G_DIETPI_VERSION_CORE.$G_DIETPI_VERSION_SUB.$G_DIETPI_VERSION_RC"
 	[[ $G_GITBRANCH == 'master' ]] || DIETPI_VERSION+=" ($G_GITBRANCH)"

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -95,12 +95,32 @@
 	TERM_WIDTH=$(tput cols)
     MAX_TITLE_LEN=18      ## Hard-coded
     MAX_DESCP_LEN=$(( -1 + $TERM_WIDTH - MAX_TITLE_LEN ))
+    WRAP_LEFTPAD=$(printf -- " %.0s" $(seq 0 $MAX_TITLE_LEN))
 
 	GREEN_LINE_FILLER=$(printf -- "─%.0s" $(seq 1 $(( $TERM_WIDTH - 2 ))))
 	GREEN_LINE=" ${aCOLOUR[0]}${GREEN_LINE_FILLER}$COLOUR_RESET"
 	GREEN_BULLET=" ${aCOLOUR[0]}-$COLOUR_RESET"
 	GREEN_SEPARATOR="${aCOLOUR[0]}:$COLOUR_RESET"
 
+    ## Wrap unformatted text to a length with padding
+    __word_wrap(){
+        local text="$1"
+        local max_len="$2"
+        local left_pad="$3"
+
+        local offset=$max_len
+        local text_len=${#text}
+
+        local wrap_text="${text:0:$max_len}"
+        while [[ $offset < $text_len ]]; do
+            wrap_text="${wrap_text}\n${left_pad}"                 ## left pad
+            wrap_text="${wrap_text}${text:${offset}:${max_len}}"  ## append
+            offset=$(( $offset + $max_len ))
+        done
+        echo "$wrap_text"
+    }
+
+    # Print a banner line split into title and description with word-wrapping
 	Print_Line(){
 	    local title="$1"  ## Bold part before ":"
 	    local descp="$2"  ## Normal part after ":"
@@ -110,35 +130,18 @@
 	    local stripped_title="${title//$COLOUR_STRIP/}"
 	    local stripped_descp="${descp//$COLOUR_STRIP/}"
 
-	    local title_len=${#stripped_title}
-	    local descp_len=${#stripped_descp}
-
-        ## Left-pad the description based on the title length
-        local left_padding=$(printf -- " %.0s" $(seq 0 $MAX_TITLE_LEN))
-        local offset
-
         ## Sometimes the title is long, so a sanity check is performed to fold the title
         ## if it exceeds MAX_TITLE_LEN. This takes up the left-side of the message and
         ## receives no padding.
-	    if (( $title_len >= $MAX_TITLE_LEN )); then
-            title="${stripped_title:0:$MAX_TITLE_LEN}"
-            offset=$MAX_TITLE_LEN
-            while [[ $offset < $title_len ]]; do
-                title="${title}\n${left_padding}${stripped_title:${offset}:${MAX_TITLE_LEN}}"
-                offset=$(( $offset + $MAX_DESCP_LEN ))
-            done
+	    if (( ${#stripped_title} >= $MAX_TITLE_LEN )); then
+            title=$(__word_wrap "$stripped_title" "$MAX_TITLE_LEN" "")
 		    title="${aCOLOUR[1]}${title}$COLOUR_RESET"
 	    fi
 
         ## The description is typically very long, and is folded from the second line
         ## onwards into the remaining MAX_DESCP_LEN, with left padding.
-	    if (( $descp_len >= $MAX_DESCP_LEN )); then
-            descp="${stripped_descp:0:$MAX_DESCP_LEN}"
-            offset=$MAX_DESCP_LEN
-            while [[ $offset < $descp_len ]]; do
-                descp="${descp}\n${left_padding}${stripped_descp:${offset}:${MAX_DESCP_LEN}}"
-                offset=$(( $offset + $MAX_DESCP_LEN ))
-            done
+	    if (( ${#stripped_descp} >= $MAX_DESCP_LEN )); then
+            descp=$(__word_wrap "$stripped_descp" "$MAX_DESCP_LEN" "$WRAP_LEFTPAD")
 	    fi
 
         echo -e "$title $descp"

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -79,7 +79,8 @@
     ## Parse the above colour strings and use them to generate an expression to match them
     ## via bash substitution
     __make_strip_color(){
-        local tmp="${aCOLOUR[@]} $COLOUR_RESET"
+        # shellcheck disable=SC2124
+        local tmp="${aCOLOUR[@]} $COLOUR_RESET" ## convert array to string
         tmp="+(${tmp// /|})"       ## convert list into OR expression
         tmp="${tmp//\\e/\\\\\\e}"  ## ensure '\e' exists
         tmp="${tmp//\[/\\[}"       ## ensure '\[' exists

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -106,7 +106,7 @@
 	    local title="$1"  ## Bold part before ":"
 	    local descp="$2"  ## Normal part after ":"
 
-        if [ -v WORD_WRAP ]; then
+        if [[ $WORD_WRAP == 1 ]]; then
             ## Strip invisible colour codes in order to accurately measure the visual length
             ## of a sentence.
 	        local stripped_title="${title//$COLOUR_STRIP/}"
@@ -126,7 +126,7 @@
 	        fi
 
             local avail_len=$(( ($TERM_WIDTH - $title_len) - 1))
-            local left_pad=$(printf -- " %.0s" $(seq 0 $title_len))
+            local left_pad=$(printf -- " %.0s" $(seq 0 "$title_len"))
 
             ## The description is typically very long, and is folded from the second line
             ## onwards into the remaining available space, with left padding.

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -77,61 +77,50 @@
 		'\e[91m'	# Red		| Update notifications
 	)
 
-	# Parse the above colour strings and use them to generate an expression to match them via bash substitution
-	__make_strip_color(){
-		local tmp="${aCOLOUR[*]} $COLOUR_RESET" # convert array to string
-		tmp="+(${tmp// /|})"                    # convert list into OR expression
-		tmp=${tmp//\\e/\\\\\\e}                 # ensure '\e' exists
-		tmp=${tmp//\[/\\[}                      # ensure '\[' exists
-		echo "$tmp"
-	}
-	shopt -s extglob # globally enable multiple pattern matching
-	COLOUR_STRIP=$(__make_strip_color)
-
 	# Load settings here, to have chosen ${aCOLOUR[0]} applied to below strings
 	# shellcheck disable=SC1090
 	[[ -f $FP_SAVEFILE ]] && . "$FP_SAVEFILE"
 
 	TERM_WIDTH=$(tput cols)
-
-	GREEN_LINE_FILLER=$(printf -- "─%.0s" $(seq 1 $(( $TERM_WIDTH - 2 ))))
-	GREEN_LINE=" ${aCOLOUR[0]}${GREEN_LINE_FILLER}$COLOUR_RESET"
+	printf -v GREEN_LINE "%$(( $TERM_WIDTH - 2 ))s" # Separator line with 1 space left and right respectively
+	GREEN_LINE=" ${aCOLOUR[0]}${GREEN_LINE//?/─}$COLOUR_RESET"
 	GREEN_BULLET=" ${aCOLOUR[0]}-$COLOUR_RESET"
 	GREEN_SEPARATOR="${aCOLOUR[0]}:$COLOUR_RESET"
 
 	# Print a banner line split into title and description with word-wrapping
+	shopt -s extglob # globally extended globbing for "*(pattern)" syntax
 	Print_Line()
 	{
-		local title=$1 # Bold part before ":"
+		local title=$1 # Bold part before including ":"
 		local descp=$2 # Normal part after ":"
 
 		if (( ${aENABLED[16]} == 1 ))
 		then
-			# Strip invisible colour codes in order to accurately measure the visual length of a sentence.
-			local stripped_title=${title//$COLOUR_STRIP}
-			local stripped_descp=${descp//$COLOUR_STRIP}
+			# Strip control codes to accurately measure visual length
+			local stripped_title=${title//\\e[[0-9]*([;0-9])m}
+			local stripped_descp=${descp//\\e[[0-9]*([;0-9])m}
 			local title_len=${#stripped_title}
 			local descp_len=${#stripped_descp}
 
-			# Sometimes the title is long, so a sanity check is performed to fold the title
-			# if it exceeds the window size. Because of the hyphen it receives 3 spaces padding.
+			# Wrap title if required
 			if (( $title_len >= $TERM_WIDTH ))
 			then
 				title=$(echo "$stripped_title" | fold -s -w "$TERM_WIDTH")
-				title=${title//$'\n'/$'\n'   }
+				title=${title//$'\n'/$'\n'   } # Add 3 spaces padding for hyphen
 				title="${aCOLOUR[1]}$title$COLOUR_RESET"
 				# Recalculate the title length based on the last line with padding
-				title_len=$(( (($title_len + 3) % $TERM_WIDTH) + 3 ))
+				title_len=$(( ($title_len + 3) % $TERM_WIDTH + 3 ))
 			fi
 
+			# Obtain remaining length for description starting 1 space after title
 			local avail_len=$(( $TERM_WIDTH - $title_len - 1))
-			local left_pad=$(printf -- ' %.0s' $(seq 0 "$title_len"))
 
-			# The description is typically very long, and is folded from the second line
-			# onwards into the remaining available space, with left padding.
+			# Wrap description if required
 			if (( $descp_len >= $avail_len ))
 			then
 				descp=$(echo "$stripped_descp" | fold -s -w "$avail_len")
+				local left_pad
+				printf -v left_pad "%$(( $title_len + 1 ))s"
 				descp=${descp//$'\n'/$'\n'$left_pad}
 			fi
 		fi
@@ -235,17 +224,17 @@
 
 	Print_Credits()
 	{
-		Print_Line " ${aCOLOUR[2]}DietPi Team     :" "https://github.com/MichaIng/DietPi#the-dietpi-project-team"
+		Print_Line " ${aCOLOUR[2]}DietPi Team     :" 'https://github.com/MichaIng/DietPi#the-dietpi-project-team'
 
 		if [[ -f '/boot/dietpi/.prep_info' ]]; then
 		    local info=$(mawk 'NR==1 {sub(/^0$/,"DietPi Core Team");a=$0} NR==2 {print ""a" (pre-image: "$0")"}' /boot/dietpi/.prep_info)
-		    Print_Line " Image by        :" "$info"
+		    Print_Line ' Image by        :' "$info"
 		fi
 
-		Print_Line " Patreon Legends :" "Camry2731, Chris Gelatt"
-		Print_Line " Website         :" "https://dietpi.com/ | https://twitter.com/DietPi_"
-		Print_Line " Contribute      :" "https://dietpi.com/contribute.html"
-		Print_Line " Web Hosting by  :" "https://myvirtualserver.com$COLOUR_RESET\n"
+		Print_Line ' Patreon Legends :' 'Camry2731, Chris Gelatt'
+		Print_Line ' Website         :' 'https://dietpi.com/ | https://twitter.com/DietPi_'
+		Print_Line ' Contribute      :' 'https://dietpi.com/contribute.html'
+		Print_Line ' Web Hosting by  :' "https://myvirtualserver.com$COLOUR_RESET\n"
 	}
 
 	Print_Updates()
@@ -274,11 +263,11 @@
 
 	Print_Useful_Commands()
 	{
-		Print_Line " ${aCOLOUR[1]}dietpi-launcher$COLOUR_RESET $GREEN_SEPARATOR" "All the DietPi programs in one place"
-		Print_Line " ${aCOLOUR[1]}dietpi-config$COLOUR_RESET   $GREEN_SEPARATOR" "Feature rich configuration tool for your device"
-		Print_Line " ${aCOLOUR[1]}dietpi-software$COLOUR_RESET $GREEN_SEPARATOR" "Select optimised software for installation"
-		Print_Line " ${aCOLOUR[1]}htop$COLOUR_RESET            $GREEN_SEPARATOR" "Resource monitor"
-		Print_Line " ${aCOLOUR[1]}cpu$COLOUR_RESET             $GREEN_SEPARATOR" "Shows CPU information and stats\n"
+		Print_Line " ${aCOLOUR[1]}dietpi-launcher$COLOUR_RESET $GREEN_SEPARATOR" 'All the DietPi programs in one place'
+		Print_Line " ${aCOLOUR[1]}dietpi-config$COLOUR_RESET   $GREEN_SEPARATOR" 'Feature rich configuration tool for your device'
+		Print_Line " ${aCOLOUR[1]}dietpi-software$COLOUR_RESET $GREEN_SEPARATOR" 'Select optimised software for installation'
+		Print_Line " ${aCOLOUR[1]}htop$COLOUR_RESET            $GREEN_SEPARATOR" 'Resource monitor'
+		Print_Line " ${aCOLOUR[1]}cpu$COLOUR_RESET             $GREEN_SEPARATOR" 'Shows CPU information and stats\n'
 	}
 
 	Print_Banner()

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -94,32 +94,11 @@
 	[[ -f $FP_SAVEFILE ]] && . "$FP_SAVEFILE"
 
 	TERM_WIDTH=$(tput cols)
-    MAX_TITLE_LEN=18      ## Hard-coded
-    MAX_DESCP_LEN=$(( -1 + $TERM_WIDTH - MAX_TITLE_LEN ))
-    WRAP_LEFTPAD=$(printf -- " %.0s" $(seq 0 $MAX_TITLE_LEN))
 
 	GREEN_LINE_FILLER=$(printf -- "─%.0s" $(seq 1 $(( $TERM_WIDTH - 2 ))))
 	GREEN_LINE=" ${aCOLOUR[0]}${GREEN_LINE_FILLER}$COLOUR_RESET"
 	GREEN_BULLET=" ${aCOLOUR[0]}-$COLOUR_RESET"
 	GREEN_SEPARATOR="${aCOLOUR[0]}:$COLOUR_RESET"
-
-    ## Wrap unformatted text to a length with padding
-    __word_wrap(){
-        local text="$1"
-        local max_len="$2"
-        local left_pad="$3"
-
-        local offset=$max_len
-        local text_len=${#text}
-
-        local wrap_text="${text:0:$max_len}"
-        while [[ $offset < $text_len ]]; do
-            wrap_text="${wrap_text}\n${left_pad}"                 ## left pad
-            wrap_text="${wrap_text}${text:${offset}:${max_len}}"  ## append
-            offset=$(( $offset + $max_len ))
-        done
-        echo "$wrap_text"
-    }
 
     # Print a banner line split into title and description with word-wrapping
 	Print_Line(){
@@ -131,18 +110,24 @@
 	    local stripped_title="${title//$COLOUR_STRIP/}"
 	    local stripped_descp="${descp//$COLOUR_STRIP/}"
 
+        local title_len=${#stripped_title}
+        local descp_len=${#stripped_descp}
+
         ## Sometimes the title is long, so a sanity check is performed to fold the title
-        ## if it exceeds MAX_TITLE_LEN. This takes up the left-side of the message and
-        ## receives no padding.
-	    if (( ${#stripped_title} >= $MAX_TITLE_LEN )); then
-            title=$(__word_wrap "$stripped_title" "$MAX_TITLE_LEN" "")
+        ## if it exceeds the window size. Because of the hyphen it receives 3 spaces padding.
+	    if (( $title_len >= $TERM_WIDTH )); then
+            title=$(echo "$stripped_title" | fold -s -w $TERM_WIDTH | sed "2,\$s|^|   |")
 		    title="${aCOLOUR[1]}${title}$COLOUR_RESET"
+            title_len=$(( ($title_len % $TERM_WIDTH) + 3 ))   ## leftover minus paddding
 	    fi
 
+        local avail_len=$(( ($TERM_WIDTH - $title_len) - 1))
+        local left_pad=$(printf -- " %.0s" $(seq 0 $title_len))
+
         ## The description is typically very long, and is folded from the second line
-        ## onwards into the remaining MAX_DESCP_LEN, with left padding.
-	    if (( ${#stripped_descp} >= $MAX_DESCP_LEN )); then
-            descp=$(__word_wrap "$stripped_descp" "$MAX_DESCP_LEN" "$WRAP_LEFTPAD")
+        ## onwards into the remaining available space, with left padding.
+	    if (( $descp_len >= $avail_len )); then
+            descp=$(echo ""$stripped_descp"" | fold -s -w $avail_len | sed "2,\$s|^|$left_pad|")
 	    fi
 
         echo -e "$title $descp"
@@ -248,7 +233,7 @@
 
 		if [[ -f '/boot/dietpi/.prep_info' ]]; then
 		    local info=$(mawk 'NR==1 {sub(/^0$/,"DietPi Core Team");a=$0} NR==2 {print " "a" (pre-image: "$0")"}' /boot/dietpi/.prep_info)
-		    Print_Line " Image by        :$info"
+		    Print_Line " Image by        :" "$info"
 		fi
 
 		Print_Line " Patreon Legends :" "Camry2731, Chris Gelatt"
@@ -407,7 +392,7 @@ NB: It is executed as bash script, so it needs to be in bash compatible syntax.
 		Menu_Main
 		Print_Banner
 	fi
-
+    shopt -u extglob
 	#-----------------------------------------------------------------------------------
 	exit 0
 	#-----------------------------------------------------------------------------------

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -232,7 +232,7 @@
 		Print_Line " ${aCOLOUR[2]}DietPi Team     :" "https://github.com/MichaIng/DietPi#the-dietpi-project-team"
 
 		if [[ -f '/boot/dietpi/.prep_info' ]]; then
-		    local info=$(mawk 'NR==1 {sub(/^0$/,"DietPi Core Team");a=$0} NR==2 {print " "a" (pre-image: "$0")"}' /boot/dietpi/.prep_info)
+		    local info=$(mawk 'NR==1 {sub(/^0$/,"DietPi Core Team");a=$0} NR==2 {print ""a" (pre-image: "$0")"}' /boot/dietpi/.prep_info)
 		    Print_Line " Image by        :" "$info"
 		fi
 

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -121,7 +121,8 @@
                 title=$(echo "$stripped_title" | fold -s -w $TERM_WIDTH)
                 title="${title//$'\n'/$'\n'   }"
 		        title="${aCOLOUR[1]}${title}$COLOUR_RESET"
-                title_len=$(( (($title_len + 3) % $TERM_WIDTH) + 3 ))   ## leftover minus paddding
+                ## Recalculate the title length based on the last line with padding
+                title_len=$(( (($title_len + 3) % $TERM_WIDTH) + 3 ))
 	        fi
 
             local avail_len=$(( ($TERM_WIDTH - $title_len) - 1))
@@ -130,7 +131,7 @@
             ## The description is typically very long, and is folded from the second line
             ## onwards into the remaining available space, with left padding.
 	        if (( $descp_len >= $avail_len )); then
-                descp=$(echo ""$stripped_descp"" | fold -s -w $avail_len)
+                descp=$(echo "$stripped_descp" | fold -s -w $avail_len)
                 descp="${descp//$'\n'/$'\n'${left_pad}}"
 	        fi
         fi

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -118,7 +118,7 @@
             ## Sometimes the title is long, so a sanity check is performed to fold the title
             ## if it exceeds the window size. Because of the hyphen it receives 3 spaces padding.
 	        if (( $title_len >= $TERM_WIDTH )); then
-                title=$(echo "$stripped_title" | fold -s -w $TERM_WIDTH)
+                title=$(echo "$stripped_title" | fold -s -w "$TERM_WIDTH")
                 title="${title//$'\n'/$'\n'   }"
 		        title="${aCOLOUR[1]}${title}$COLOUR_RESET"
                 ## Recalculate the title length based on the last line with padding
@@ -131,7 +131,7 @@
             ## The description is typically very long, and is folded from the second line
             ## onwards into the remaining available space, with left padding.
 	        if (( $descp_len >= $avail_len )); then
-                descp=$(echo "$stripped_descp" | fold -s -w $avail_len)
+                descp=$(echo "$stripped_descp" | fold -s -w "$avail_len")
                 descp="${descp//$'\n'/$'\n'${left_pad}}"
 	        fi
         fi

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -80,7 +80,52 @@
 	# shellcheck disable=SC1090
 	[[ -f $FP_SAVEFILE ]] && . "$FP_SAVEFILE"
 
-	GREEN_LINE=" ${aCOLOUR[0]}─────────────────────────────────────────────────────$COLOUR_RESET"
+	TERM_WIDTH=$(tput cols)
+	COLOR_STRIP="s/\x1B\[[0-9;]*m//g"
+
+	Print_Line(){
+	    ## Colour codes and other text have been expanded already
+	    ## at this point into '\eXYZ' symbols, emojis, and
+	    ## stylized text.
+	    local descrp="$1"
+	    local result="$2"
+
+	    ## We could also replace the emojis with single characters
+	    ##     via: iconv -f UTF-8 -t ASCII//TRANSLIT
+	    ## to better format the weather and CPU, but it's a little overkill.
+	    local stripped_descrp=$(echo -e "${descrp}" | sed -r ${COLOR_STRIP})
+	    local stripped_result=$(echo -e "${result}" | sed -r ${COLOR_STRIP})
+	    ## Lengths:
+	    #  - If description is long, then split description
+	    ## - If result or total length is long, then split result
+	    local descrp_len=$(echo -e "$stripped_descrp" | wc -c)
+	    local result_len=$(echo -e "$stripped_result" | wc -c)
+	    local total_len=$(( $descrp_len + $result_len ))
+	    ## result text is left padded, so we compensate for it when folding
+	    local padded_len=$(( $TERM_WIDTH - $SEPERATOR_OFFSET ))
+
+	    if [ $descrp_len -gt $TERM_WIDTH ]; then
+		descrp=$(echo -e "${stripped_descrp}" \
+			   | fold -s -w $TERM_WIDTH \
+			   | sed "2,\$s|^|${SEPERATOR_FILLER}|")
+		descrp="${aCOLOUR[1]}${descrp}$COLOUR_RESET"
+	    fi
+
+	    if [ $result_len -gt $(( $TERM_WIDTH - $descrp_len )) ] ||
+		   [ $total_len -gt $TERM_WIDTH ]; then
+		result="\n"$(echo "${stripped_result}" \
+				 | fold -s -w $padded_len \
+				 | sed "s|^|${SEPERATOR_FILLER}|")
+	    fi
+	    echo -e "$descrp $result"
+	}
+
+	## Automatically generated spacing
+	GREEN_LINE_FILLER=$(printf -- "─%.0s" $(seq 1 $(( $TERM_WIDTH - 2 ))))
+	SEPERATOR_OFFSET=3 ## Hardcoded '3', until better suggestion.
+	SEPERATOR_FILLER=$(printf -- " %.0s" $(seq 1 $SEPERATOR_OFFSET))
+
+	GREEN_LINE=" ${aCOLOUR[0]}${GREEN_LINE_FILLER}$COLOUR_RESET"
 	GREEN_BULLET=" ${aCOLOUR[0]}-$COLOUR_RESET"
 	GREEN_SEPARATOR="${aCOLOUR[0]}:$COLOUR_RESET"
 

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -81,12 +81,12 @@
     __make_strip_color(){
         # shellcheck disable=SC2124
         local tmp="${aCOLOUR[@]} $COLOUR_RESET" ## convert array to string
-        tmp="+(${tmp// /|})"       ## convert list into OR expression
-        tmp="${tmp//\\e/\\\\\\e}"  ## ensure '\e' exists
-        tmp="${tmp//\[/\\[}"       ## ensure '\[' exists
+        tmp="+(${tmp// /|})"                    ## convert list into OR expression
+        tmp="${tmp//\\e/\\\\\\e}"               ## ensure '\e' exists
+        tmp="${tmp//\[/\\[}"                    ## ensure '\[' exists
         echo "$tmp"
     }
-    shopt -s extglob               ## globally enable multiple pattern matching
+    shopt -s extglob    ## globally enable multiple pattern matching, and disable at the end
     COLOUR_STRIP="$(__make_strip_color)"
 
 	# Load settings here, to have chosen ${aCOLOUR[0]} applied to below strings
@@ -105,30 +105,32 @@
 	    local title="$1"  ## Bold part before ":"
 	    local descp="$2"  ## Normal part after ":"
 
-        ## Strip invisible colour codes in order to accurately measure the visual length
-        ## of a sentence.
-	    local stripped_title="${title//$COLOUR_STRIP/}"
-	    local stripped_descp="${descp//$COLOUR_STRIP/}"
+            ## Strip invisible colour codes in order to accurately measure the visual length
+            ## of a sentence.
+	        local stripped_title="${title//$COLOUR_STRIP/}"
+	        local stripped_descp="${descp//$COLOUR_STRIP/}"
 
-        local title_len=${#stripped_title}
-        local descp_len=${#stripped_descp}
+            local title_len=${#stripped_title}
+            local descp_len=${#stripped_descp}
 
-        ## Sometimes the title is long, so a sanity check is performed to fold the title
-        ## if it exceeds the window size. Because of the hyphen it receives 3 spaces padding.
-	    if (( $title_len >= $TERM_WIDTH )); then
-            title=$(echo "$stripped_title" | fold -s -w $TERM_WIDTH | sed "2,\$s|^|   |")
-		    title="${aCOLOUR[1]}${title}$COLOUR_RESET"
-            title_len=$(( ($title_len % $TERM_WIDTH) + 3 ))   ## leftover minus paddding
-	    fi
+            ## Sometimes the title is long, so a sanity check is performed to fold the title
+            ## if it exceeds the window size. Because of the hyphen it receives 3 spaces padding.
+	        if (( $title_len >= $TERM_WIDTH )); then
+                title=$(echo "$stripped_title" | fold -s -w $TERM_WIDTH)
+                title="${title//$'\n'/$'\n'   }"
+		        title="${aCOLOUR[1]}${title}$COLOUR_RESET"
+                title_len=$(( (($title_len + 3) % $TERM_WIDTH) + 3 ))   ## leftover minus paddding
+	        fi
 
-        local avail_len=$(( ($TERM_WIDTH - $title_len) - 1))
-        local left_pad=$(printf -- " %.0s" $(seq 0 $title_len))
+            local avail_len=$(( ($TERM_WIDTH - $title_len) - 1))
+            local left_pad=$(printf -- " %.0s" $(seq 0 $title_len))
 
-        ## The description is typically very long, and is folded from the second line
-        ## onwards into the remaining available space, with left padding.
-	    if (( $descp_len >= $avail_len )); then
-            descp=$(echo ""$stripped_descp"" | fold -s -w $avail_len | sed "2,\$s|^|$left_pad|")
-	    fi
+            ## The description is typically very long, and is folded from the second line
+            ## onwards into the remaining available space, with left padding.
+	        if (( $descp_len >= $avail_len )); then
+                descp=$(echo ""$stripped_descp"" | fold -s -w $avail_len)
+                descp="${descp//$'\n'/$'\n'${left_pad}}"
+	        fi
 
         echo -e "$title $descp"
 	}


### PR DESCRIPTION
This PR implements word wrapping functionality in the DietPi-Banner, which helps small terminals format the text better.

**Screenshots**

_105 Columns_
![dietpi_tput_105](https://user-images.githubusercontent.com/20641402/196984207-a6bf6a18-e833-42c8-8049-1104f64530f1.png)

_33 Columns_
![dietpi_tput_33](https://user-images.githubusercontent.com/20641402/196984292-3c155092-4cc5-43c0-b961-a91cfde6c9f5.png)
