### PR TITLE
Backup fstab when using drive manager

### DIFF
--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -103,6 +103,12 @@
 		# Swap file location
 		FP_SWAPFILE_CURRENT=$(sed -n '/^[[:blank:]]*AUTO_SETUP_SWAPFILE_LOCATION=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 
+        	# Backup current fstab
+     		local fstab_hash=$(md5sum /etc/fstab | cut -d ' ' -f 1)
+		if [[ ! -f "/etc/fstab.${fstab_hash}" ]]; then
+		    cp -a /etc/fstab /etc/"fstab.${fstab_hash}"
+		fi
+
 		# Create tmp fstab
 		local fp_fstab_tmp='.fstab'
 		cp -a /etc/fstab "$fp_fstab_tmp"


### PR DESCRIPTION
Create a fstab backup so we don't loose manual changes if any. I don't normally use this tool only for nfs mounts and I always forget that I have manual entries and I lose them.

But I think it's a good practice to have a backup of fstab.

<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
