### PR TITLE
go(188) software install path problem

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3199,7 +3199,7 @@ unix_socket_directories = '/run/postgresql'" > "$i/00dietpi.conf"
 
 			# Add to PATH, but do not overwrite existing script since we did set GOPATH until v8.9 and do not want to cause a breaking change for existing installs
 			# shellcheck disable=SC2016
-			[[ -f '/etc/bashrc.d/go.sh' ]] || echo 'export PATH="$PATH:/usr/local/go/bin"' /etc/bashrc.d/go.sh
+			[[ -f '/etc/bashrc.d/go.sh' ]] || echo 'export PATH="$PATH:/usr/local/go/bin"' > /etc/bashrc.d/go.sh
 			# shellcheck disable=SC1091
 			. /etc/bashrc.d/go.sh
 


### PR DESCRIPTION
Go(188) software install doesn't export path. Line 3202 was missing redirection to go.sh file, so file wasn't created.

<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
