### PR TITLE
DietPi-Software | Deluge: Fix listening port on Bullseye

### DIFF
--- a/.conf/dps_45/deluge.conf
+++ b/.conf/dps_45/deluge.conf
@@ -26,8 +26,8 @@
     "info_sent": 0.0,
     "listen_interface": "",
     "listen_ports": [
-        6881,
-        6881
+        6882,
+        6882
     ],
     "lsd": true,
     "max_active_downloading": 2,

--- a/.conf/dps_45/deluge.conf
+++ b/.conf/dps_45/deluge.conf
@@ -27,7 +27,7 @@
     "listen_interface": "",
     "listen_ports": [
         6881,
-        6891
+        6881
     ],
     "lsd": true,
     "max_active_downloading": 2,

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,7 @@ Bug fixes:
 - DietPi-Software | Go: Resolved an issue, introduced with DietPi v8.9, where the Go compiler and development tools were not added to PATH. Many thanks to @envious_jag for reporting this issue: https://dietpi.com/forum/t/installation-snowflake/6566/10
 - DietPi-Software | RoonBridge/RoonServer: Resolved an issue where the download fails as Roon downloads are now hosted on a different domain. Many thanks to @net-david for reporting this issue: https://github.com/MichaIng/DietPi/issues/5856
 - DietPi-Software | Koel: Resolved an issue where the install failed on Buster and Bullseye systems since Koel v6 requires PHP 8.0 or later.
+- DietPi-Software | Deluge: Resolved an issue on Bullseye and Bookworm, where Deluge by default did not listen on any port or torrent connections, since the port range feature seems to be broken. It does now listen on the single port 6882 only by default. Many thanks to @Tarrasque for reporting this issue: https://dietpi.com/forum/t/deluge-does-not-download-anything/14376
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 


### PR DESCRIPTION
- fix LISTEN port for deluge application