### PR TITLE
Image | Add Radxa ROCK 5B support

### DIFF
--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -110,6 +110,7 @@ case $HW_MODEL in
 	75) iname='Container' HW_ARCH=${HW_ARCH:-10} root_size=447;;
 	76) iname='NanoPiR5S' HW_ARCH=3 partition_start=16 root_size=752;;
 	77) iname='ROCK3A' HW_ARCH=3 PTTYPE='gpt' partition_start=16 boot_size=128 root_size=688;;
+	78) iname='ROCK5B' HW_ARCH=3 PTTYPE='gpt' partition_start=16 boot_size=128 root_size=688;;
 	*) G_DIETPI-NOTIFY 1 "Invalid hardware model \"$HW_MODEL\" passed, aborting..."; exit 1;;
 esac
 

--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -378,6 +378,7 @@ _EOF_
 			'73' ': ROCK Pi S'
 			'74' ': Radxa Zero'
 			'77' ': ROCK 3A'
+			'78' ': ROCK 5B'
 			'23' ': Generic Rockchip RK3328'
 			'24' ': Generic Rockchip RK3399'
 			'25' ': Generic Allwinner H3'
@@ -556,7 +557,7 @@ _EOF_
 			G_EXEC mv "DietPi-$G_GITBRANCH/.build/images/U-Boot/99-dietpi-uboot" /etc/initramfs/post-update.d/99-dietpi-uboot
 			G_EXEC sed -i 's/arm64/arm/' /etc/initramfs/post-update.d/99-dietpi-uboot
 
-		elif [[ $G_HW_MODEL =~ ^(12|15|16|40|42|43|44|46|47|48|52|54|55|56|57|58|59|60|63|64|65|66|67|68|72|73|74)$ && $(findmnt -Ufnro TARGET -T /boot) == '/' || ( $G_HW_MODEL == 77 && $(findmnt -t vfat -M /boot) ) ]]
+		elif [[ $G_HW_MODEL =~ ^(12|15|16|40|42|43|44|46|47|48|52|54|55|56|57|58|59|60|63|64|65|66|67|68|72|73|74)$ && $(findmnt -Ufnro TARGET -T /boot) == '/' || ( $G_HW_MODEL =~ ^(77|78)$ && $(findmnt -t vfat -M /boot) ) ]]
 		then
 			G_EXEC mv "DietPi-$G_GITBRANCH/.build/images/U-Boot/boot.cmd" /boot/boot.cmd
 			G_EXEC mv "DietPi-$G_GITBRANCH/.build/images/U-Boot/dietpiEnv.txt" /boot/dietpiEnv.txt
@@ -567,13 +568,14 @@ _EOF_
 			G_EXEC ln -sf /etc/kernel/post{inst,rm}.d/dietpi-initramfs_cleanup
 			G_EXEC mv "DietPi-$G_GITBRANCH/.build/images/U-Boot/99-dietpi-uboot" /etc/initramfs/post-update.d/99-dietpi-uboot
 			# Rockchip 64-bit (configs work with Amlogic OOTB)
-			if [[ $G_HW_MODEL =~ ^(42|43|46|47|55|56|58|68|72|73|77)$ ]]
+			if [[ $G_HW_MODEL =~ ^(42|43|46|47|55|56|58|68|72|73|77|78)$ ]]
 			then
 				G_EXEC sed -Ei '/^setenv (kernel|fdt)_addr_r/d' /boot/boot.cmd
 				G_CONFIG_INJECT 'setenv scriptaddr ' 'setenv scriptaddr "0x9000000"' /boot/boot.cmd
 				G_CONFIG_INJECT 'overlay_path=' 'overlay_path=rockchip' /boot/dietpiEnv.txt
 				case $G_HW_MODEL in
 					77) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rk35xx' /boot/dietpiEnv.txt;;
+					78) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rk3588' /boot/dietpiEnv.txt;; # ToDo: There are multiple other prefixes used in the kernel package, "rock-5b", "rock-5ab", "rockchip" (for fixup), so the boot.cmd need heavy adjustments (eliminate the prefix entirely) to work with all overlays.
 					*) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rockchip' /boot/dietpiEnv.txt;;
 				esac
 				case $G_HW_MODEL in
@@ -583,6 +585,7 @@ _EOF_
 					72) G_CONFIG_INJECT 'fdtfile=' 'fdtfile=rockchip/rk3399-rock-pi-4b.dtb' /boot/dietpiEnv.txt;;
 					73) G_CONFIG_INJECT 'fdtfile=' 'fdtfile=rockchip/rk3308-rock-pi-s.dtb' /boot/dietpiEnv.txt;;
 					77) G_CONFIG_INJECT 'fdtfile=' 'fdtfile=rockchip/rk3568-rock-3a.dtb' /boot/dietpiEnv.txt;;
+					78) G_CONFIG_INJECT 'fdtfile=' 'fdtfile=rockchip/rk3588-rock-5b.dtb' /boot/dietpiEnv.txt;;
 					*) :;;
 				esac
 				case $G_HW_MODEL in
@@ -901,7 +904,7 @@ _EOF_
 		fi
 
 		# - DietPi-Build with Armbian kernel/bootloader/firmware
-		if [[ ( $G_HW_MODEL =~ ^(12|15|16|40|42|43|44|45|46|47|48|52|54|55|56|57|58|59|60|63|64|65|66|67|68|72|73|74|77)$ && -f '/boot/dietpiEnv.txt' ) || ( $G_HW_MODEL == 11 && $(findmnt -Ufnro TARGET -T /boot) == '/' ) || ( $G_HW_MODEL == 10 && $(findmnt -t vfat -M /boot) ) ]]
+		if [[ ( $G_HW_MODEL =~ ^(12|15|16|40|42|43|44|45|46|47|48|52|54|55|56|57|58|59|60|63|64|65|66|67|68|72|73|74|77|78)$ && -f '/boot/dietpiEnv.txt' ) || ( $G_HW_MODEL == 11 && $(findmnt -Ufnro TARGET -T /boot) == '/' ) || ( $G_HW_MODEL == 10 && $(findmnt -t vfat -M /boot) ) ]]
 		then
 			# Bootstrap Armbian repository
 			G_EXEC eval "curl -sSfL 'https://apt.armbian.com/armbian.key' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-armbian.gpg --yes"
@@ -957,6 +960,7 @@ _EOF_
 				73) model='rockpi-s' kernel='rockchip64';;
 				74) model='radxa-zero';;
 				77) model='rock-3a' kernel='rk35xx' branch='edge';;
+				78) model='rock-5b' kernel='rockchip-rk3588' branch='legacy';;
 				*) :;;
 			esac
 			G_AGI linux-{image,dtb}-"$branch-$kernel" "linux-u-boot-$model-$branch" u-boot-tools armbian-firmware
@@ -1633,8 +1637,8 @@ _EOF_'
 		then
 			/boot/dietpi/func/dietpi-set_hardware serialconsole enable ttySAC0
 
-		# ROCKPro64, ROCK64, Pinebook Pro, NanoPi R4S, Quartz64, ASUS Tinker Board, NanoPi R2S, NanoPi NEO3, NanoPi M4V2, NanoPi M4/T4/NEO4, ROCK Pi 4, ROCK 3A
-		elif [[ $G_HW_MODEL =~ ^(42|43|46|47|49|52|55|56|58|68|72|77)$ ]]
+		# ROCKPro64, ROCK64, Pinebook Pro, NanoPi R4S, Quartz64, ASUS Tinker Board, NanoPi R2S, NanoPi NEO3, NanoPi M4V2, NanoPi M4/T4/NEO4, ROCK Pi 4, ROCK 3A, ROCK 5B
+		elif [[ $G_HW_MODEL =~ ^(42|43|46|47|49|52|55|56|58|68|72|77|78)$ ]]
 		then
 			/boot/dietpi/func/dietpi-set_hardware serialconsole enable ttyS2
 

--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -81,6 +81,7 @@ shopt -s extglob
 		[75]='Container'
 		[76]='NanoPi R5S'
 		[77]='ROCK 3A'
+		[78]='ROCK 5B'
 	)
 
 	## Benchmark data arrays: aBENCH_XX[$HW_MODEL,${aBENCH_XX_INDEX[$HW_MODEL]}]

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,7 +2,7 @@ v8.12
 (2022-12-17)
 
 New images:
-- 
+- ROCK 5B | Support for Radxa's new flagship SBC has been added to DietPi with hardware ID 78. Many thanks to @docgalaxyblock for doing this request: https://github.com/MichaIng/DietPi/discussions/5247
 
 New software:
 - 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -199,7 +199,7 @@ Available commands:
 	esac
 
 	# Available for (need to match highest value in dietpi-obtain_hw_model)
-	readonly MAX_G_HW_MODEL=76
+	readonly MAX_G_HW_MODEL=78
 	readonly MAX_G_HW_ARCH=10
 	#readonly MAX_G_DISTRO=7
 	# - 2D array (well, bash style)

--- a/dietpi/func/dietpi-obtain_hw_model
+++ b/dietpi/func/dietpi-obtain_hw_model
@@ -17,6 +17,7 @@
 	# - MAX_G_HW_ARCH=10
 	# - MAX_G_DISTRO=7
 	#
+	# G_HW_MODEL 78 ROCK 5B
 	# G_HW_MODEL 77 ROCK 3A
 	# G_HW_MODEL 76 NanoPi R5S
 	# G_HW_MODEL 75 Container
@@ -88,6 +89,7 @@
 	# G_HW_CPUID 8 Allwinner A64
 	# G_HW_CPUID 9 Rockchip RK3566
 	# G_HW_CPUID 10 Rockchip RK3568
+	# G_HW_CPUID 11 Rockchip RK3588
 	# ----------------
 	# G_DISTRO 5 Buster
 	# G_DISTRO 6 Bullseye
@@ -306,7 +308,12 @@
 
 			G_HW_MODEL=$(mawk 'NR==1' "$FP_G_HW_MODEL_IDENTIFIER")
 
-			if (( $G_HW_MODEL == 77 )); then
+			if (( $G_HW_MODEL == 78 )); then
+
+				G_HW_MODEL_NAME='ROCK 5B'
+				G_HW_CPUID=11
+
+			elif (( $G_HW_MODEL == 77 )); then
 
 				G_HW_MODEL_NAME='ROCK 3A'
 				G_HW_CPUID=10

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -1513,7 +1513,7 @@ Do you want to continue and DISABLE Bluetooth now?' || return 1
 				elif (( $DIETPIENV || $G_HW_MODEL == 49 )); then
 
 					local baudrate='115200'
-					if [[ $G_HW_MODEL =~ ^(42|43|46|47|49|55|56|58|68|72|73|77)$ && $INPUT_ADDITIONAL == 'ttyS2' ]]
+					if [[ $G_HW_MODEL =~ ^(42|43|46|47|49|55|56|58|68|72|73|77|78)$ && $INPUT_ADDITIONAL == 'ttyS2' ]]
 					then
 						baudrate='1500000'
 						[[ -d /etc/systemd/system/serial-getty@$INPUT_ADDITIONAL.service.d ]] || G_EXEC mkdir "/etc/systemd/system/serial-getty@$INPUT_ADDITIONAL.service.d"


### PR DESCRIPTION
- ROCK 5B | Support for Radxa's new flagship SBC has been added to DietPi with hardware ID 78. Many thanks to @docgalaxyblock for doing this request: https://github.com/MichaIng/DietPi/discussions/5247