### PR TITLE
DietPi-Software | myMPD: Update for upstream change

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,10 +13,12 @@ Enhancements:
 - DietPi-Software | Java 17 is now installed on ARMv7/8 Raspberry Pi hardware with ARMv6 (Raspbian) image. The binary packages are now provided by Raspbian, as well as via Raspberry Pi repository.
 - DietPi-Software | Koel: Updated dependencies, especially removed redundant PHP Composer call and dependency.
 - DietPi-Software | Grafana: For ARMv6 RPi models, RPi 1 and Zero (1), bumped version to latest stable v9.3.0, update via reinstall: dietpi-software reinstall 77
+- DietPi-Software | myMPD: On fresh installs, SSL is now enabled by default on the same port 1333 which was previously used for plain HTTP. For plain HTTP, now port 1332 is used, which redirects to HTTPS automatically, but currently cannot be disabled completely.
 
 Bug fixes:
 - DietPi-Software | PaperMC: Resolved an issue where the installation failed on Raspberry Pi ARMv6 images (with ARMv7/8 hardware), since latest PaperMC cannot run on Java 11. Since Java 17 binary packages are finally available via Raspbian and Raspberry Pi repositories, those can be installed now, allowing PaperMC to run. Many thanks to @blueyshark for reporting this issue: https://github.com/MichaIng/DietPi/issues/5668
 - DietPi-Software | Grafana: Resolved an issue where the uninstall failed when trying to remove the "grafana" user. Many thanks to @enviousjag for reporting this issue: https://github.com/MichaIng/DietPi/issues/5935
+- DietPi-Software | myMPD: Resolved an issue where the installation as well as the service start after latest myMPD release failed. Many thanks to @jalsco and @sofad for reporting these issues: https://github.com/MichaIng/DietPi/issues/5936, https://github.com/MichaIng/DietPi/issues/5919
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -351,21 +351,21 @@ Available commands:
 		aSOFTWARE_DESC[$software_id]='lightweight web interface music player for mpd'
 		aSOFTWARE_CATX[$software_id]=2
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#ympd'
-		aSOFTWARE_DEPS[$software_id]='5 128'
+		aSOFTWARE_DEPS[$software_id]='128'
 		#------------------
 		software_id=148
 		aSOFTWARE_NAME[$software_id]='myMPD'
 		aSOFTWARE_DESC[$software_id]='fork of ympd with improved features'
 		aSOFTWARE_CATX[$software_id]=2
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#mympd'
-		aSOFTWARE_DEPS[$software_id]='5 128'
+		aSOFTWARE_DEPS[$software_id]='128'
 		#------------------
 		software_id=119
 		aSOFTWARE_NAME[$software_id]='CAVA'
-		aSOFTWARE_DESC[$software_id]='optional: console audio vis for mpd'
+		aSOFTWARE_DESC[$software_id]='optional: console audio vis for MPD'
 		aSOFTWARE_CATX[$software_id]=2
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#cava'
-		aSOFTWARE_DEPS[$software_id]='5 128'
+		aSOFTWARE_DEPS[$software_id]='128'
 		#------------------
 		software_id=33
 		aSOFTWARE_NAME[$software_id]='Airsonic-Advanced'
@@ -463,7 +463,7 @@ Available commands:
 		aSOFTWARE_DESC[$software_id]='Feature-rich, web interface audio player for MPD'
 		aSOFTWARE_CATX[$software_id]=2
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#ompd'
-		aSOFTWARE_DEPS[$software_id]='5 88 89 128 195 webserver'
+		aSOFTWARE_DEPS[$software_id]='88 89 128 195 webserver'
 		#------------------
 		software_id=135
 		aSOFTWARE_NAME[$software_id]='IceCast'
@@ -517,7 +517,7 @@ Available commands:
 		aSOFTWARE_DESC[$software_id]='Audiophile web interface with all dependencies'
 		aSOFTWARE_CATX[$software_id]=-1
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/forum/t/dietpi-allo-com-web-gui-image/1523'
-		aSOFTWARE_DEPS[$software_id]='5 36 37 65 88 89 96 124 128 129 152 160 163 webserver'
+		aSOFTWARE_DEPS[$software_id]='36 37 65 88 89 96 124 128 129 152 160 163 webserver'
 		# Roon Bridge is not supported on ARMv6
 		(( $G_HW_ARCH == 1 )) || aSOFTWARE_DEPS[$software_id]+=' 121'
 		#------------------
@@ -5178,27 +5178,20 @@ _EOF_
 			G_AGI mympd
 			G_EXEC systemctl stop mympd
 
-			# User: Switch to primary group "dietpi" to allow media access and create media files as "dietpi" group: https://github.com/MichaIng/DietPi/issues/3382
-			# - Leave "mympd" group in place, as it is recreated on package upgrades
-			G_EXEC usermod -g dietpi mympd
-
 			# Config: Create on fresh install
 			# - On reinstall /var/lib/mympd exists, so use its existence as reinstall flag
 			if [[ ! -d '/var/lib/mympd' ]]
 			then
-				export MYMPD_HTTP_PORT=1333
-				export MYMPD_SSL=false
-				export MYMPD_MPD_HOST='/run/mpd/socket'
-				export MYMPD_LOGLEVEL=4
-				G_EXEC mympd -c
-				G_EXEC mkdir -pm 0700 /var/lib/mympd/state
-				echo '/mnt/dietpi_userdata/Music' > /var/lib/mympd/state/playlist_directory
-				echo '/mnt/dietpi_userdata/Music' > /var/lib/mympd/state/music_directory
-				G_EXEC chmod 0600 /var/lib/mympd/state/*
-				G_EXEC chown -R mympd:root /var/lib/mympd/state
+				G_EXEC export MYMPD_LOGLEVEL=4 MYMPD_MPD_HOST='/run/mpd/socket' MYMPD_HTTP_PORT=1332 MYMPD_SSL_PORT=1333
+				G_EXEC_OUTPUT=1 G_EXEC mympd -c
+				G_EXEC umask 0077
+				G_EXEC mkdir /var/lib/mympd/state
+				G_EXEC eval 'echo '\''/mnt/dietpi_userdata/Music'\'' > /var/lib/mympd/state/playlist_directory'
+				G_EXEC eval 'echo '\''/mnt/dietpi_userdata/Music'\'' > /var/lib/mympd/state/music_directory'
+				G_EXEC umask 0022
 			fi
 
-			# myMPD pre-v8.0.0 migration: Remove obsolete files
+			# myMPD pre-v8.0.0 cleanup
 			[[ -f '/etc/mympd.conf' ]] && G_EXEC_NOEXIT=1 G_EXEC rm /etc/mympd.conf
 			[[ -f '/etc/mympd.conf.dist' ]] && G_EXEC_NOEXIT=1 G_EXEC rm /etc/mympd.conf.dist
 			command -v mympd-config > /dev/null && G_EXEC_NOEXIT=1 G_EXEC rm "$(command -v mympd-config)"
@@ -12465,8 +12458,8 @@ NB: This port needs to be forwarded by your router and/or opened in your firewal
 				# Create everything inside WireGuard config dir
 				G_EXEC cd /etc/wireguard
 
-				# For security reasons set umask to 077
-				umask 077
+				# For security reasons set umask to 0077
+				G_EXEC umask 0077
 
 				# Create server and client keys
 				[[ -f 'server_private.key' ]] || wg genkey > server_private.key
@@ -12537,8 +12530,8 @@ Endpoint = $domain:$port
 # Uncomment the following, if you're behind a NAT and want the connection to be kept alive.
 #PersistentKeepalive = 25
 _EOF_
-				# Set umask back to default 022
-				umask 022
+				# Set umask back to default 0022
+				G_EXEC umask 0022
 
 				# Navigate back to DietPi-Software working dir
 				G_EXEC cd "$G_WORKING_DIR"
@@ -13079,30 +13072,30 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 		fi
 
 		software_id=148 # myMPD
-		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 )); then
-
+		if (( ${aSOFTWARE_INSTALL_STATE[$software_id]} == -1 ))
+		then
 			Banner_Uninstalling
 			if [[ -f '/lib/systemd/system/mympd.service' ]]
 			then
 				G_EXEC systemctl unmask mympd
 				G_EXEC systemctl disable --now mympd
-				G_EXEC rm /lib/systemd/system/mympd.service
 			fi
 			[[ -d '/etc/systemd/system/mympd.service.d' ]] && G_EXEC rm -R /etc/systemd/system/mympd.service.d
 			G_AGP mympd
-			getent passwd mympd > /dev/null && G_EXEC userdel mympd
-			getent group mympd > /dev/null && G_EXEC groupdel mympd
-			[[ -d '/var/lib/mympd' ]] && G_EXEC rm -R /var/lib/mympd
-			[[ -d '/var/cache/mympd' ]] && G_EXEC rm -R /var/cache/mympd
 			[[ -f '/etc/apt/sources.list.d/dietpi-mympd.list' ]] && G_EXEC rm /etc/apt/sources.list.d/dietpi-mympd.list
 			[[ -f '/etc/apt/trusted.gpg.d/dietpi-mympd.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-mympd.gpg
-			# Pre-v8.0
+			[[ -d '/var/lib/mympd' ]] && G_EXEC rm -R /var/lib/mympd
+			[[ -d '/var/cache/mympd' ]] && G_EXEC rm -R /var/cache/mympd
+			# pre-v8.12
+			getent passwd mympd > /dev/null && G_EXEC userdel mympd # myMPD pre-v10.1.0
+			getent group mympd > /dev/null && G_EXEC groupdel mympd # myMPD pre-v10.1.0
+			# pre-v8.0
+			[[ -f '/lib/systemd/system/mympd.service' ]] && G_EXEC rm /lib/systemd/system/mympd.service
 			command -v mympd > /dev/null && G_EXEC rm "$(command -v mympd)"
 			command -v mympd-config > /dev/null && G_EXEC rm "$(command -v mympd-config)" # myMPD pre-v8.0.0
 			command -v mympd-script > /dev/null && G_EXEC rm "$(command -v mympd-script)"
 			[[ -d '/usr/share/doc/mympd' ]] && G_EXEC rm -R /usr/share/doc/mympd
 			G_EXEC rm -f /usr/share/man/man1/mympd* /etc/mympd.conf* # /etc: myMPD pre-v8.0.0
-
 		fi
 
 		software_id=128 # MPD
@@ -13123,7 +13116,7 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 			[[ -d '/var/log/mpd' ]] && G_EXEC rm -R /var/log/mpd
 			[[ -d '/mnt/dietpi_userdata/.mpd_cache' ]] && G_EXEC rm -R /mnt/dietpi_userdata/.mpd_cache
 			[[ -f '/etc/mpd.conf' ]] && G_EXEC rm /etc/mpd.conf
-			[[ -f '/usr/local/etc/mpd.conf' ]] && G_EXEC rm /usr/local/etc/mpd.conf && G_EXEC rmdir --ignore-fail-on-non-empty /usr/local/etc # Pre-v6.29
+			[[ -f '/usr/local/etc/mpd.conf' ]] && G_EXEC rm /usr/local/etc/mpd.conf && G_EXEC rmdir --ignore-fail-on-non-empty /usr/local/etc # pre-v6.29
 			[[ -f '/etc/default/mpd' ]] && G_EXEC rm /etc/default/mpd # pre-v6.20
 
 		fi


### PR DESCRIPTION
- DietPi-Software | myMPD: On fresh installs, SSL is now enabled by default on the same port 1333 which was previously used for plain HTTP. For plain HTTP, now port 1332 is used, which redirects to HTTPS automatically, but currently cannot be disabled completely.
- DietPi-Software | myMPD: Resolved an issue where the installation as well as the service start after latest myMPD release failed. Many thanks to @jalsco and @sofad for reporting these issues: https://github.com/MichaIng/DietPi/issues/5936, https://github.com/MichaIng/DietPi/issues/5919