### PR TITLE
Image | Add support for NanoPi R6S

### DIFF
--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -113,6 +113,7 @@ case $HW_MODEL in
 	76) iname='NanoPiR5S' HW_ARCH=3 root_size=752;; # Special case: Skips image file, partitioning and filesystem generation, but runs debootstrap only!
 	77) iname='ROCK3A' HW_ARCH=3 PTTYPE='gpt' partition_start=16 boot_size=128 root_size=688;;
 	78) iname='ROCK5B' HW_ARCH=3 PTTYPE='gpt' partition_start=16 boot_size=128 root_size=688;;
+	79) iname='NanoPiR6S' HW_ARCH=3 root_size=752;; # Special case: Skips image file, partitioning and filesystem generation, but runs debootstrap only!
 	*) G_DIETPI-NOTIFY 1 "Invalid hardware model \"$HW_MODEL\" passed, aborting..."; exit 1;;
 esac
 
@@ -219,15 +220,16 @@ G_EXIT_CUSTOM(){
 	(( $mask_dbus )) && G_EXEC systemctl mask --now dbus dbus.socket
 }
 
-if (( $HW_MODEL == 76 ))
+# NanoPi R5S/R6S: Base image download
+if [[ $HW_MODEL == 7[69] ]]
 then
-	G_EXEC curl -sSfO 'https://dietpi.com/downloads/nanopir5s.7z'
-	G_EXEC "$c7zz" x nanopir5s.7z
-	G_EXEC rm nanopir5s.7z
-	G_EXEC truncate -s "$(( 140 + $root_size ))M" nanopir5s.img
-	G_EXEC_OUTPUT=1 G_EXEC sgdisk -e nanopir5s.img
-	G_EXEC_OUTPUT=1 G_EXEC eval 'sfdisk -fN8 nanopir5s.img <<< '\'',+'\'
-	G_EXEC mv nanopir5s.img "$OUTPUT_IMG_NAME.img"
+	G_EXEC curl -sSfO "https://dietpi.com/downloads/${iname,,}.7z"
+	G_EXEC "$c7zz" x "${iname,,}.7z"
+	G_EXEC rm "${iname,,}.7z"
+	G_EXEC truncate -s "$(( 140 + $root_size ))M" "${iname,,}.img"
+	G_EXEC_OUTPUT=1 G_EXEC sgdisk -e "${iname,,}.img"
+	G_EXEC_OUTPUT=1 G_EXEC eval "sfdisk -fN8 '${iname,,}.img' <<< ',+'"
+	G_EXEC mv "${iname,,}.img" "$OUTPUT_IMG_NAME.img"
 else
 # Create image file
 G_EXEC fallocate -l "$((partition_start+efi_size+boot_size+root_size))M" "$OUTPUT_IMG_NAME.img"
@@ -276,8 +278,8 @@ G_EXEC partx -u "$FP_LOOP"
 
 # Create and mount filesystems and fstab
 G_EXEC mkdir rootfs
-# - NanoPi R5S with base image
-if (( $HW_MODEL == 76 ))
+# - NanoPi R5S/R6S with base image
+if [[ $HW_MODEL == 7[69] ]]
 then
 	FP_ROOT_DEV=8
 	G_EXEC_OUTPUT=1 G_EXEC e2fsck -fpD "${FP_LOOP}p8"

--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -374,6 +374,7 @@ _EOF_
 			'55' ': NanoPi R2S'
 			'47' ': NanoPi R4S'
 			'76' ': NanoPi R5S'
+			'79' ': NanoPi R6S'
 			'72' ': ROCK Pi 4'
 			'73' ': ROCK Pi S'
 			'74' ': Radxa Zero'
@@ -821,13 +822,13 @@ _EOF_
 			then
 				aPACKAGES_REQUIRED_INSTALL+=('tiny-initramfs')
 
-			elif (( $G_HW_MODEL > 9 && $G_HW_MODEL != 49 && $G_HW_MODEL != 61 && $G_HW_MODEL != 76 ))
+			elif (( $G_HW_MODEL > 9 && $G_HW_MODEL != 49 && $G_HW_MODEL != 61 && $G_HW_MODEL != 76 && $G_HW_MODEL != 79 ))
 			then
 				aPACKAGES_REQUIRED_INSTALL+=('initramfs-tools')
 			fi
 
 			# Entropy daemon: Use modern rng-tools5 on all devices where it has been proven to work, else haveged: https://github.com/MichaIng/DietPi/issues/2806
-			if [[ $G_HW_MODEL -lt 10 || $G_HW_MODEL =~ ^(14|15|16|24|29|42|46|49|58|68|72|74|76)$ ]] # RPi, S922X, Odroid C4, RK3399 - 47 NanoPi R4S, Quartz64, Radxa Zero, NanoPi R5S
+			if [[ $G_HW_MODEL -lt 10 || $G_HW_MODEL =~ ^(14|15|16|24|29|42|46|49|58|68|72|74|76|79)$ ]] # RPi, S922X, Odroid C4, RK3399 - 47 NanoPi R4S, Quartz64, Radxa Zero, NanoPi R5S, NanoPi R6S
 			then
 				aPACKAGES_REQUIRED_INSTALL+=('rng-tools5')
 			else
@@ -1138,6 +1139,13 @@ _EOF_
 			G_EXEC curl -sSfO 'https://dietpi.com/downloads/binaries/firmware-nanopi5.deb'
 			G_EXEC_OUTPUT=1 G_EXEC dpkg -i firmware-nanopi5.deb
 			G_EXEC rm firmware-nanopi5.deb
+
+		# - NanoPi R6S
+		elif (( $G_HW_MODEL == 79 )) && { [[ ! $(find /lib/modules -mindepth 1 -maxdepth 1 -type d) ]] || dpkg-query -s 'firmware-nanopi6' &> /dev/null; }
+		then
+			G_EXEC curl -sSfO 'https://dietpi.com/downloads/binaries/firmware-nanopi6.deb'
+			G_EXEC_OUTPUT=1 G_EXEC dpkg -i firmware-nanopi6.deb
+			G_EXEC rm firmware-nanopi6.deb
 
 		# - NanoPi M2/T2 Linux 4.4: Requires dedicated boot partition, starting at 4 MiB for U-Boot, with ext4 filesystem
 		elif [[ $G_HW_MODEL == 61 && $(findmnt -Ufnro FSTYPE -M /boot) == 'ext4' ]] && (( $(sfdisk -qlo Start "$BOOT_DEVICE" | mawk 'NR==2') >= 8192 ))
@@ -1684,8 +1692,8 @@ _EOF_'
 		then
 			/boot/dietpi/func/dietpi-set_hardware serialconsole enable ttyS1
 
-		# NanoPi R5S
-		elif (( $G_HW_MODEL == 76 ))
+		# NanoPi R5S/R6S
+		elif (( $G_HW_MODEL == 76 || $G_HW_MODEL == 79 ))
 		then
 			/boot/dietpi/func/dietpi-set_hardware serialconsole enable ttyFIQ0
 
@@ -1950,6 +1958,16 @@ _EOF_
 SUBSYSTEM=="leds", KERNEL=="wan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth0", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1"
 SUBSYSTEM=="leds", KERNEL=="lan1_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth1", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1"
 SUBSYSTEM=="leds", KERNEL=="lan2_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth2", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1"
+_EOF_
+		# NanoPi R6S
+		elif (( $G_HW_MODEL == 79 ))
+		then
+			G_DIETPI-NOTIFY 2 'Enabling NanoPi R6S Ethernet LEDs'
+			G_EXEC eval 'echo '\''ledtrig-netdev'\'' > /etc/modules-load.d/dietpi-eth-leds.conf'
+			cat << '_EOF_' > /etc/udev/rules.d/dietpi-eth-leds.rules
+SUBSYSTEM=="leds", KERNEL=="lan2_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth0", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1"
+SUBSYSTEM=="leds", KERNEL=="lan1_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth1", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1"
+SUBSYSTEM=="leds", KERNEL=="wan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth2", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1"
 _EOF_
 		fi
 

--- a/.github/workflows/dietpi-build.yml
+++ b/.github/workflows/dietpi-build.yml
@@ -71,7 +71,8 @@ jobs:
         '"-m 75 -a 1 -d 7", "-m 75 -a 2 -d 7", "-m 75 -a 3 -d 7", "-m 75 -a 10 -d 7", '\
         '"-m 76 -d 6", "-m 76 -d 7", '\
         '"-m 77 -d 6", "-m 77 -d 7", '\
-        '"-m 78 -d 6", "-m 78 -d 7"]' >> "$GITHUB_OUTPUT"
+        '"-m 78 -d 6", "-m 78 -d 7", '\
+        '"-m 79 -d 6", "-m 79 -d 7"]' >> "$GITHUB_OUTPUT"
         else
           echo buildargs='["${{ github.event.inputs.buildargs }}"]' >> "$GITHUB_OUTPUT"
         fi

--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -82,6 +82,7 @@ shopt -s extglob
 		[76]='NanoPi R5S'
 		[77]='ROCK 3A'
 		[78]='ROCK 5B'
+		[79]='NanoPi R6S'
 	)
 
 	## Benchmark data arrays: aBENCH_XX[$HW_MODEL,${aBENCH_XX_INDEX[$HW_MODEL]}]

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ v8.12
 
 New images:
 - ROCK 5B | Support for Radxa's new flagship SBC has been added to DietPi with hardware ID 78. Many thanks to @docgalaxyblock for doing this request: https://github.com/MichaIng/DietPi/discussions/5247
+- NanoPi R6S | Support for FriendlyELEC's new flagship router SBC has been added to DietPi with hardware ID 79. Many thanks to FriendlyELEC for sending us free developer samples.
 
 Enhancements:
 - General | Informational kernel logs to console are now omitted, to avoid overlaps with login banner and informational logs, like regular network state changes caused by Docker. Many thanks to @TRENT7 and @vontainment for reporting related inconveniences: https://dietpi.com/forum/t/unfinished-services-during-boot-at-login-prompt/15145, https://dietpi.com/forum/t/network-state-filling-up-terminal/14401

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -199,7 +199,7 @@ Available commands:
 	esac
 
 	# Available for (need to match highest value in dietpi-obtain_hw_model)
-	readonly MAX_G_HW_MODEL=78
+	readonly MAX_G_HW_MODEL=79
 	readonly MAX_G_HW_ARCH=10
 	#readonly MAX_G_DISTRO=7
 	# - 2D array (well, bash style)

--- a/dietpi/func/dietpi-obtain_hw_model
+++ b/dietpi/func/dietpi-obtain_hw_model
@@ -17,6 +17,7 @@
 	# - MAX_G_HW_ARCH=10
 	# - MAX_G_DISTRO=7
 	#
+	# G_HW_MODEL 79 NanoPi R6S
 	# G_HW_MODEL 78 ROCK 5B
 	# G_HW_MODEL 77 ROCK 3A
 	# G_HW_MODEL 76 NanoPi R5S
@@ -308,7 +309,12 @@
 
 			G_HW_MODEL=$(mawk 'NR==1' "$FP_G_HW_MODEL_IDENTIFIER")
 
-			if (( $G_HW_MODEL == 78 )); then
+			if (( $G_HW_MODEL == 79 )); then
+
+				G_HW_MODEL_NAME='NanoPi R6S'
+				G_HW_CPUID=11
+
+			elif (( $G_HW_MODEL == 78 )); then
 
 				G_HW_MODEL_NAME='ROCK 5B'
 				G_HW_CPUID=11

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -1509,18 +1509,18 @@ Do you want to continue and DISABLE Bluetooth now?' || return 1
 					old=$(cut -d \" -f 2 <<< "$old")
 					G_CONFIG_INJECT 'setenv[[:blank:]]+bootrootfs[[:blank:]]' "setenv bootrootfs \"$old console=$INPUT_ADDITIONAL,115200n8\"" /boot/boot.ini 'ODROIDXU-UBOOT-CONFIG'
 
-				# - dietpiEnv.txt and Quartz64
-				elif (( $DIETPIENV || $G_HW_MODEL == 49 )); then
+				# - dietpiEnv.txt, Quartz64, NanoPi R5S, NanoPi R6S
+				elif (( $DIETPIENV || $G_HW_MODEL == 49 || $G_HW_MODEL == 76 || $G_HW_MODEL == 79 )); then
 
 					local baudrate='115200'
-					if [[ $G_HW_MODEL =~ ^(42|43|46|47|49|55|56|58|68|72|73|77|78)$ && $INPUT_ADDITIONAL == 'ttyS2' ]]
+					if [[ $G_HW_MODEL =~ ^(42|43|46|47|49|55|56|58|68|72|73|77|78)$ && $INPUT_ADDITIONAL == 'ttyS2' ]] || [[ $G_HW_MODEL =~ ^(76|79)$ && $INPUT_ADDITIONAL == 'ttyFIQ0' ]]
 					then
 						baudrate='1500000'
 						[[ -d /etc/systemd/system/serial-getty@$INPUT_ADDITIONAL.service.d ]] || G_EXEC mkdir "/etc/systemd/system/serial-getty@$INPUT_ADDITIONAL.service.d"
 						cat << '_EOF_' > "/etc/systemd/system/serial-getty@$INPUT_ADDITIONAL.service.d/dietpi-baudrate.conf"
 [Service]
 ExecStart=
-ExecStart=-/sbin/agetty -o '-p -- \\u' --keep-baud 1500000,115200,57600,38400,9600 %I $TERM
+ExecStart=-/sbin/agetty -o '-p -- \\u' --keep-baud 1500000,115200,57600,38400,9600 - $TERM
 _EOF_
 						G_EXEC systemctl daemon-reload
 					fi


### PR DESCRIPTION
- NanoPi R6S | Support for FriendlyELEC's new flagship router SBC has been added to DietPi with hardware ID 79. Many thanks to FriendlyELEC for sending us free developer samples.