### PR TITLE
DietPi-Software | myMPD

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12221,7 +12221,9 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 			[[ -f '/etc/apt/sources.list.d/dietpi-mympd.list' ]] && G_EXEC rm /etc/apt/sources.list.d/dietpi-mympd.list
 			[[ -f '/etc/apt/trusted.gpg.d/dietpi-mympd.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-mympd.gpg
 			[[ -d '/var/lib/mympd' ]] && G_EXEC rm -R /var/lib/mympd
+			[[ -d '/var/lib/private/mympd' ]] && G_EXEC rm -R /var/lib/private/mympd
 			[[ -d '/var/cache/mympd' ]] && G_EXEC rm -R /var/cache/mympd
+			[[ -d '/var/cache/private/mympd' ]] && G_EXEC rm -R /var/cache/private/mympd
 			# pre-v8.12
 			getent passwd mympd > /dev/null && G_EXEC userdel mympd # myMPD pre-v10.1.0
 			getent group mympd > /dev/null && G_EXEC groupdel mympd # myMPD pre-v10.1.0


### PR DESCRIPTION
@MichaIng 
we would need to cleanup `/var/lib/private/mympd` and `/var/cache/private/mympd` as well. Otherwise a new installation will fail.