### PR TITLE
DietPi-Software | Docker: Fix install if nftables is not supported

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ Enhancements:
 
 Bug fixes:
 - DietPi-Software | Readarr: Resolved an issue where the installation failed because of a wrong download URL. Many thanks to @lambolighting for reporting this issue: https://github.com/MichaIng/DietPi/issues/5992
+- DietPi-Software | Docker: Resolved an issue where the install failed if the kernel did not support nftables. Since iptables is installed as dependency along with the Docker package, it cannot be configured first to use the legacy API where needed. The Docker service is now masked before the package is installed, to prevent it from starting during the package install, before we can configure iptables. Many thanks to @tggjifdhn for reporting this issue: https://github.com/MichaIng/DietPi/issues/6013
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: 
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10461,8 +10461,10 @@ _EOF_
 			G_AGUP
 
 			# APT package
+			# - Mask service to prevent iptables related startup failure: https://github.com/MichaIng/DietPi/issues/6013
+			G_EXEC systemctl mask --now docker
 			G_AGI docker-ce
-			G_EXEC systemctl stop docker
+			G_EXEC systemctl unmask docker
 
 			# Change Docker service type to "simple": https://github.com/MichaIng/DietPi/issues/2238#issuecomment-439474766
 			[[ -d '/lib/systemd/system/docker.service.d' ]] || G_EXEC mkdir /lib/systemd/system/docker.service.d


### PR DESCRIPTION
- DietPi-Software | Docker: Resolved an issue where the install failed if the kernel did not support nftables. Since iptables is installed as dependency along with the Docker package, it cannot be configured first to use the legacy API where needed. The Docker service is now masked before the package is installed, to prevent it from starting during the package install, before we can configure iptables. Many thanks to @tggjifdhn for reporting this issue: https://github.com/MichaIng/DietPi/issues/6013