### PR TITLE
DietPi-Software | UrBackup: Several setup updates

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ Enhancements:
 - DietPi-Software | vaultwarden: Updated to latest version 1.27.0. The update can be applied via reinstall: dietpi-software reinstall 183
 - DietPi-Software | NoMachine: Updated to latest version 8.2.3. The update can be applied via reinstall: dietpi-software reinstall 30
 - DietPi-Software | Transmission: The "cache-size-mb" setting is not set to anymore on fresh installs. It was set to 10% of RAM size, which is often too much for a pure download cache. It now defaults to 4 MiB instead. If you experience inconsistent download speeds on an existing install, you may edit or remove the setting in "/etc/transmission-daemon/settings.json". Many thanks to @bbsixzz for bringing up this topic: https://github.com/MichaIng/DietPi/issues/5069
+- DietPi-Software | UrBackup: The backup path can now be pre-configured with a new SOFTWARE_URBACKUP_BACKUPPATH setting in dietpi.txt.
 
 Bug fixes:
 - NanoPi M2/T2/Fire2 | Updated our image with a device tree for the actual NanoPi M2 and a fixed device tree to allow boot on NanoPi 2 Fire. Many thanks to @NewbieOrange for reporting this issue: https://github.com/MichaIng/DietPi/issues/5555

--- a/dietpi.txt
+++ b/dietpi.txt
@@ -238,7 +238,6 @@ SOFTWARE_VNCSERVER_SHARE_DESKTOP=0
 # - Optional username for admin account, the default is 'admin', applied during install
 SOFTWARE_OWNCLOUD_NEXTCLOUD_USERNAME=admin
 # - Optional data directory, default is "/mnt/dietpi_userdata/owncloud_data" respectively "/mnt/dietpi_userdata/nextcloud_data", applied during install
-#	NB: This option is for advanced users. For full compatibility, please keep this options defaults, and, use dietpi-drive_manager to move the DietPi user data location.
 SOFTWARE_OWNCLOUD_DATADIR=/mnt/dietpi_userdata/owncloud_data
 SOFTWARE_NEXTCLOUD_DATADIR=/mnt/dietpi_userdata/nextcloud_data
 
@@ -290,6 +289,10 @@ SOFTWARE_DIETPI_DASHBOARD_BACKEND=0
 # Shairport Sync
 # - Uncomment and set to "2" to install experimental AirPlay 2 build: https://github.com/mikebrady/shairport-sync/blob/master/AIRPLAY2.md
 #SOFTWARE_SHAIRPORT_SYNC_AIRPLAY=2
+
+# UrBackup Server
+# - Backup path, optional, defaults to "/mnt/dietpi_userdata/urbackup", effective on fresh UrBackup Server installs only
+SOFTWARE_URBACKUP_BACKUPPATH=/mnt/dietpi_userdata/urbackup
 
 #------------------------------------------------------------------------------------------------------
 ##### Dev settings #####

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5352,45 +5352,26 @@ _EOF_
 
 		if To_Install 111 # UrBackup Server
 		then
-			# Grab latest version
-			local url='https://hndl.urbackup.org/Server/latest'
-			G_CHECK_URL "$url"
-
-			# Latest known version
-			local latest='2.5.27'
-
-			# ARMv7
-			local fallback_url="https://hndl.urbackup.org/Server/$latest/urbackup-server_${latest}_armhf.deb"
-			local file=$(curl -sSfL "$url" | mawk -F\" '/"urbackup-server_.*_armhf\.deb"/{print $8}')
-
-			# ARMv8
-			if (( $G_HW_ARCH == 3 )); then
-
-				fallback_url="https://hndl.urbackup.org/Server/$latest/urbackup-server_${latest}_arm64.deb"
-				file=$(curl -sSfL "$url" | mawk -F\" '/"urbackup-server_.*_arm64\.deb"/{print $8}')
-
-			# x86_64
-			elif (( $G_HW_ARCH == 10 )); then
-
-				fallback_url="https://hndl.urbackup.org/Server/$latest/urbackup-server_${latest}_amd64.deb"
-				file=$(curl -sSfL "$url" | mawk -F\" '/"urbackup-server_.*_amd64\.deb"/{print $8}')
-
+			# Pre-configure backup path: Read from database on reinstall and align all configs
+			if [[ -f '/var/urbackup/backup_server_settings.db' ]] && command -v sqlite3 > /dev/null
+			then
+				local backuppath=$(sqlite3 /var/urbackup/backup_server_settings.db 'select value from settings where key = "backupfolder"')
+			else
+				local backuppath=$(sed -n '/^[[:blank:]]*SOFTWARE_URBACKUP_BACKUPPATH=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			fi
+			[[ $backuppath ]] || backuppath='/mnt/dietpi_userdata/urbackup'
+			[[ -f '/etc/urbackup/backupfolder' ]] && G_EXEC eval "echo '$backuppath' > /etc/urbackup/backupfolder"
+			[[ -f '/var/urbackup/backupfolder' ]] && G_EXEC eval "echo '$backuppath' > /var/urbackup/backupfolder"
+			G_EXEC eval "debconf-set-selections <<< 'urbackup-server urbackup/backuppath string $backuppath'"
 
-			[[ $file ]] && url="$url/$file" || url=$fallback_url
-			unset -v file fallback_url latest
-
-			G_EXEC eval 'debconf-set-selections <<< '\''urbackup-server urbackup/backuppath string /mnt/dietpi_userdata/urbackup'\'
+			# Install latest version
+			local arch=$(dpkg --print-architecture)
+			local url=$(curl -sSfL 'https://hndl.urbackup.org/Server/latest' | mawk -F\" "/\"urbackup-server_.*_$arch\.deb\"/{print \$8}")
+			[[ $url ]] && url="https://hndl.urbackup.org/Server/latest/$url"
+			local fallback_url="https://hndl.urbackup.org/Server/2.5.27/urbackup-server_2.5.27_$arch.deb"
 			Download_Install "$url"
 			G_EXEC systemctl stop urbackupsrv
-
-			# As we have /tmp mounted to RAM, change tmp location
-			#   [[ -d '/mnt/dietpi_userdata/urbackup/urbackup_tmp_files' ]] || G_EXEC mkdir -p /mnt/dietpi_userdata/urbackup/urbackup_tmp_files
-			G_EXEC chown -R urbackup:urbackup /mnt/dietpi_userdata/urbackup
-			G_CONFIG_INJECT 'DAEMON_TMPDIR=' 'DAEMON_TMPDIR='\''/mnt/dietpi_userdata/urbackup/urbackup_tmp_files'\' /etc/default/urbackupsrv
-
-			# https://github.com/MichaIng/DietPi/issues/545#issuecomment-252419739
-			#sqlite3 /usr/local/var/urbackup/backup_server_settings.db "UPDATE settings SET value = '/mnt/dietpi_userdata/urbackup/' WHERE key = 'backupfolder'"
+			unset -v backuppath arch url
 		fi
 
 		if To_Install 51 # OpenTyrian
@@ -12125,11 +12106,6 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 			[[ -d '/etc/systemd/system/certbot.service.d' ]] && G_EXEC rmdir --ignore-fail-on-non-empty /etc/systemd/system/certbot.service.d
 		fi
 
-		if To_Uninstall 87 # SQLite
-		then
-			G_AGP sqlite3 'php*-sqlite3'
-		fi
-
 		if To_Uninstall 91 # Redis
 		then
 			G_AGP redis-server redis-tools 'php*-redis'
@@ -14175,24 +14151,35 @@ _EOF_
 
 		if To_Uninstall 111 # UrBackup Server
 		then
-			G_AGP urbackup-server
-
 			# Pre-v6.29: ARMv8 source build
 			if [[ -f '/etc/systemd/system/urbackupsrv.service' ]]
 			then
 				G_EXEC systemctl disable --now urbackupsrv
 				G_EXEC rm /etc/systemd/system/urbackupsrv.service
 			fi
-			[[ -d '/etc/systemd/system/urbackupsrv.service.d' ]] && G_EXEC rm -R /etc/systemd/system/urbackupsrv.service.d
-			[[ -d '/mnt/dietpi_userdata/urbackup' ]] && G_EXEC rm -R /mnt/dietpi_userdata/urbackup
+
+			if [[ -f '/var/urbackup/backup_server_settings.db' ]] && command -v sqlite3 > /dev/null
+			then
+				local backuppath=$(sqlite3 /var/urbackup/backup_server_settings.db 'select value from settings where key = "backupfolder"')
+			else
+				local backuppath=$(sed -n '/^[[:blank:]]*SOFTWARE_URBACKUP_BACKUPPATH=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+			fi
+			G_AGP urbackup-server
+			G_EXEC update-rc.d -f urbackupsrv remove # The package attempts to remove the non-existent "urbackup_srv" ...
+			G_EXEC rm -Rf /etc/systemd/system/urbackupsrv.service{.d,} /var/log/urbackup.log "${backuppath:-/mnt/dietpi_userdata/urbackup}"
+			unset -v backuppath
+			getent passwd urbackup > /dev/null && G_EXEC userdel urbackup
+			getent group urbackup > /dev/null && G_EXEC groupdel urbackup
+
+			# Pre-v6.29: ARMv8 source build
+			command -v urbackupsrv > /dev/null && G_EXEC rm "$(command -v urbackupsrv)"
+			command -v urbackup_mount_helper > /dev/null && G_EXEC rm "$(command -v urbackup_mount_helper)"
+			command -v urbackup_snapshot_helper > /dev/null && G_EXEC rm "$(command -v urbackup_snapshot_helper)"
 			[[ -d '/usr/share/urbackup' ]] && G_EXEC rm -R /usr/share/urbackup
 			[[ -d '/usr/local/share/urbackup' ]] && G_EXEC rm -R /usr/local/share/urbackup
 			[[ -d '/var/urbackup' ]] && G_EXEC rm -R /var/urbackup
 			[[ -f '/etc/default/urbackupsrv' ]] && G_EXEC rm /etc/default/urbackupsrv
 			[[ -f '/etc/logrotate.d/urbackupsrv' ]] && G_EXEC rm /etc/logrotate.d/urbackupsrv
-			command -v urbackupsrv > /dev/null && G_EXEC rm "$(command -v urbackupsrv)"
-			command -v urbackup_mount_helper > /dev/null && G_EXEC rm "$(command -v urbackup_mount_helper)"
-			command -v urbackup_snapshot_helper > /dev/null && G_EXEC rm "$(command -v urbackup_snapshot_helper)"
 		fi
 
 		if To_Uninstall 16 # Build-Essential
@@ -14415,6 +14402,11 @@ _EOF_
 			G_AGP postgresql 'postgresql-*'
 			G_EXEC rm -Rf /etc/postgresql*
 			[[ -d '/mnt/dietpi_userdata/postgresql' ]] && G_EXEC rm -R /mnt/dietpi_userdata/postgresql
+		fi
+
+		if To_Uninstall 87 # SQLite
+		then
+			G_AGP sqlite3 'php*-sqlite3'
 		fi
 
 		if To_Uninstall 202 # Rclone

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5385,7 +5385,7 @@ _EOF_
 			G_EXEC systemctl stop urbackupsrv
 
 			# As we have /tmp mounted to RAM, change tmp location
-			[[ -d '/mnt/dietpi_userdata/urbackup/urbackup_tmp_files' ]] || G_EXEC mkdir -p /mnt/dietpi_userdata/urbackup/urbackup_tmp_files
+			#   [[ -d '/mnt/dietpi_userdata/urbackup/urbackup_tmp_files' ]] || G_EXEC mkdir -p /mnt/dietpi_userdata/urbackup/urbackup_tmp_files
 			G_EXEC chown -R urbackup:urbackup /mnt/dietpi_userdata/urbackup
 			G_CONFIG_INJECT 'DAEMON_TMPDIR=' 'DAEMON_TMPDIR='\''/mnt/dietpi_userdata/urbackup/urbackup_tmp_files'\' /etc/default/urbackupsrv
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5385,9 +5385,9 @@ _EOF_
 			G_EXEC systemctl stop urbackupsrv
 
 			# As we have /tmp mounted to RAM, change tmp location
-			[[ -d '/mnt/dietpi_userdata/urbackup/tmp' ]] || G_EXEC mkdir -p /mnt/dietpi_userdata/urbackup/tmp
+			[[ -d '/mnt/dietpi_userdata/urbackup/urbackup_tmp_files' ]] || G_EXEC mkdir -p /mnt/dietpi_userdata/urbackup/urbackup_tmp_files
 			G_EXEC chown -R urbackup:urbackup /mnt/dietpi_userdata/urbackup
-			G_CONFIG_INJECT 'DAEMON_TMPDIR=' 'DAEMON_TMPDIR='\''/mnt/dietpi_userdata/urbackup/tmp'\' /etc/default/urbackupsrv
+			G_CONFIG_INJECT 'DAEMON_TMPDIR=' 'DAEMON_TMPDIR='\''/mnt/dietpi_userdata/urbackup/urbackup_tmp_files'\' /etc/default/urbackupsrv
 
 			# https://github.com/MichaIng/DietPi/issues/545#issuecomment-252419739
 			#sqlite3 /usr/local/var/urbackup/backup_server_settings.db "UPDATE settings SET value = '/mnt/dietpi_userdata/urbackup/' WHERE key = 'backupfolder'"


### PR DESCRIPTION
Changed the default tmp file directory from `/mnt/dietpi_userdata/urbackup/tmp` to `/mnt/dietpi_userdata/urbackup/urbackup_tmp_files`.   This helps for the default tmp path of the UrBackup server, which seems to generate this directory by default.

<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
