### PR TITLE
Odroid N2 | Revert to Armbian U-Boot

### DIFF
--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -1065,14 +1065,6 @@ _EOF_
 				G_CONFIG_INJECT 'user_overlays=' 'user_overlays=dietpi-usb-otg' /boot/dietpiEnv.txt
 				G_EXEC apt-mark auto device-tree-compiler
 
-			# Workaround for Odroid N2 failing to boot from eMMC: https://forum.armbian.com/topic/20206-odroid-n2-issues-with-recent-firmware-and-emmc-modules/#comment-142409
-			elif (( $G_HW_MODEL == 15 ))
-			then
-				G_EXEC curl -sSfO 'https://dietpi.com/downloads/binaries/u-boot-odroidn2.bin.gz'
-				G_EXEC gzip -d u-boot-odroidn2.bin.gz
-				G_EXEC dd if=u-boot-odroidn2.bin "of=$BOOT_DEVICE" bs=512 seek=1 conv=notrunc,fdatasync
-				G_EXEC rm u-boot-odroidn2.bin
-
 			# Workaround for NanoPi R1 failing boot: https://github.com/MichaIng/DietPi/issues/5927
 			elif (( $G_HW_MODEL == 48 ))
 			then


### PR DESCRIPTION
In attempt to fix https://dietpi.com/forum/t/cant-get-dietpi-to-boot-on-odroid-n2/15390 without breaking other eMMC boots.