### PR TITLE
DietPi-Pre-patches | Avoid error if /etc/apt/trusted.gpg.d/dietpi-mympd.gpg does not exist

### DIFF
--- a/.update/pre-patches
+++ b/.update/pre-patches
@@ -179,7 +179,7 @@ then
 fi
 
 # v8.13
-if (( $G_DIETPI_VERSION_CORE < 8 || ( $G_DIETPI_VERSION_CORE == 8 && $G_DIETPI_VERSION_SUB < 13 ) )) && [[ $(date -u '+%Y%m%d' -r '/etc/apt/trusted.gpg.d/dietpi-mympd.gpg') -lt 20221223 ]]
+if (( $G_DIETPI_VERSION_CORE < 8 || ( $G_DIETPI_VERSION_CORE == 8 && $G_DIETPI_VERSION_SUB < 13 ) )) && [[ -f '/etc/apt/trusted.gpg.d/dietpi-mympd.gpg' && $(date -u '+%Y%m%d' -r '/etc/apt/trusted.gpg.d/dietpi-mympd.gpg') -lt 20221223 ]]
 then
 	G_DIETPI-NOTIFY 2 'Updating myMPD APT repo key'
 	# Distro: https://download.opensuse.org/repositories/home:/jcorporation/


### PR DESCRIPTION
- DietPi-Pre-patches | Avoid error if /etc/apt/trusted.gpg.d/dietpi-mympd.gpg does not exist