### PR TITLE
DietPi-Software | Koel: Install fixed v5.1.14 on PHP 7.x distro versions

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9352,6 +9352,7 @@ _EOF_
 				Download_Install "$(curl -sSfL 'https://api.github.com/repos/koel/koel/releases/latest' | mawk -F\" '/^ *"browser_download_url": ".*\/koel-[^"\/]*\.tar\.gz"$/{print $4}')"
 			else
 				aDEPS+=("php$PHP_VERSION-json")
+				local aphp_deps=('json')
 				Download_Install 'https://github.com/koel/koel/releases/download/v5.1.14/koel-v5.1.14.tar.gz'
 			fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9352,8 +9352,7 @@ _EOF_
 				Download_Install "$(curl -sSfL 'https://api.github.com/repos/koel/koel/releases/latest' | mawk -F\" '/^ *"browser_download_url": ".*\/koel-[^"\/]*\.tar\.gz"$/{print $4}')"
 			else
 				aDEPS+=("php$PHP_VERSION-json")
-				local fallback_url='https://github.com/koel/koel/releases/download/v5.1.14/koel-v5.1.14.tar.gz' aphp_deps=('json')
-				Download_Install "$(curl -sSfL 'https://api.github.com/repos/koel/koel/releases' | mawk -F\" '/^ *"browser_download_url": ".*\/koel-v5[^"\/]*\.tar\.gz"$/{print $4}' | head -1)"
+				Download_Install 'https://github.com/koel/koel/releases/download/v5.1.14/koel-v5.1.14.tar.gz'
 			fi
 
 			# Reinstall: Clear previous install, but keep existing config file


### PR DESCRIPTION
- use fixed version v5.1.14 on systems running PHP version below 8 as it is not possible to detect Koel v5 via api.github.com anymore