### PR TITLE
DietPi-Build | Enable F2FS support for GitHub Actions runners

### DIFF
--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -161,11 +161,11 @@ case $PTTYPE in
 	*) G_DIETPI-NOTIFY 1 "Invalid partition table type \"$PTTYPE\" passed, aborting..."; exit 1;;
 esac
 
-apackages=() afs_opts=()
+apackages=() afs_opts=() afsck=() aresize=()
 case $FSTYPE in
-	'ext4') apackages+=('e2fsprogs') afs_opts=('-e' 'remount-ro');;
-	'f2fs') apackages+=('f2fs-tools'); uname -r | grep -q '-azure$' && apackages+=('linux-modules-extra-azure');;
-	'btrfs') apackages+=('btrfs-progs');;
+	'ext4') apackages+=('e2fsprogs') afs_opts=('-e' 'remount-ro') afsck=('e2fsck' '-fpD') aresize=('resize2fs');;
+	'f2fs') apackages+=('f2fs-tools') afsck=('fsck.f2fs' '-f') aresize=('resize.f2fs'); uname -r | grep -q '-azure$' && apackages+=('linux-modules-extra-azure');;
+	'btrfs') apackages+=('btrfs-progs') afsck=('btrfs' 'check' '--repair') aresize=('btrfs' 'filesystem' 'resize' 'max');;
 	*) G_DIETPI-NOTIFY 1 "Invalid filesystem type \"$FSTYPE\" passed, aborting..."; exit 1;;
 esac
 
@@ -285,8 +285,8 @@ G_EXEC mkdir rootfs
 if [[ $HW_MODEL == 7[69] ]]
 then
 	FP_ROOT_DEV=8
-	G_EXEC_OUTPUT=1 G_EXEC e2fsck -fpD "${FP_LOOP}p8"
-	G_EXEC_OUTPUT=1 G_EXEC resize2fs "${FP_LOOP}p8"
+	G_EXEC_OUTPUT=1 G_EXEC "${afsck[@]}" "${FP_LOOP}p8"
+	G_EXEC_OUTPUT=1 G_EXEC "${aresize[@]}" "${FP_LOOP}p8"
 	G_EXEC mount "${FP_LOOP}p8" rootfs
 	G_EXEC mkdir rootfs/etc
 	cat << _EOF_ > rootfs/etc/fstab
@@ -472,8 +472,8 @@ then
 	G_EXEC_OUTPUT=1 G_EXEC eval "sfdisk -fN2 '$FP_LOOP' <<< ',+'"
 	G_EXEC partprobe "$FP_LOOP"
 	G_EXEC partx -u "$FP_LOOP"
-	G_EXEC_OUTPUT=1 G_EXEC e2fsck -fpD "${FP_LOOP}p2"
-	G_EXEC_OUTPUT=1 G_EXEC resize2fs "${FP_LOOP}p2"
+	G_EXEC_OUTPUT=1 G_EXEC "${afsck[@]}" "${FP_LOOP}p2"
+	G_EXEC_OUTPUT=1 G_EXEC "${aresize[@]}" "${FP_LOOP}p2"
 
 	# Mount filesystems
 	G_EXEC mkdir rootfs

--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -164,7 +164,7 @@ esac
 apackages=() afs_opts=()
 case $FSTYPE in
 	'ext4') apackages+=('e2fsprogs') afs_opts=('-e' 'remount-ro');;
-	'f2fs') apackages+=('f2fs-tools');;
+	'f2fs') apackages+=('f2fs-tools'); uname -r | grep -q '-azure$' && apackages+=('linux-modules-extra-azure');;
 	'btrfs') apackages+=('btrfs-progs');;
 	*) G_DIETPI-NOTIFY 1 "Invalid filesystem type \"$FSTYPE\" passed, aborting..."; exit 1;;
 esac


### PR DESCRIPTION
- DietPi-Build | Enable F2FS support for GitHub Actions runners