### PR TITLE
CI | Add Quartz64 kernel and U-Boot build workflow

### DIFF
--- a/.github/workflows/quartz64.yml
+++ b/.github/workflows/quartz64.yml
@@ -1,0 +1,81 @@
+name: quartz64
+on: workflow_dispatch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+permissions: {}
+jobs:
+  build:
+    # https://github.com/actions/virtual-environments
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: sh
+        working-directory: /dev/shm
+    env:
+      linux_version: '6.1.12'
+      uboot_branch: 'v2022.04-dietpi'
+      CROSS_COMPILE: 'aarch64-none-linux-gnu-'
+      ARCH: 'arm64'
+    steps:
+    # https://github.com/actions/setup-python/tags
+    - uses: actions/setup-python@v4
+      with:
+        # https://github.com/actions/python-versions/tags
+        python-version: '3.x'
+        check-latest: true
+    - name: Setup build
+      run: |
+        { sudo apt-get -q update; sudo apt-get -qq install make gcc libc6-dev bc bison flex libssl-dev libncurses5-dev libelf-dev wget time xz-utils device-tree-compiler kmod swig zip; } &
+        { python3 -m pip install --no-cache-dir -U pip setuptools wheel; python3 -m pip install --no-cache-dir -U pyelftools; } &
+        { curl -fO 'https://gitlab.com/MichaIng/quartz64_ci/-/archive/DietPi/quartz64_ci-DietPi.tar.bz2'; tar xf quartz64_ci-DietPi.tar.bz2; } &
+        { curl -fO "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/snapshot/linux-$linux_version.tar.gz"; tar xf "linux-$linux_version.tar.gz"; } &
+        { curl -fO "https://gitlab.com/MichaIng/u-boot/-/archive/$uboot_branch/u-boot-$uboot_branch.tar.bz2"; tar xf "u-boot-$uboot_branch.tar.bz2"; } &
+        wait
+        rm quartz64_ci-DietPi.tar.bz2 "linux-$linux_version.tar.gz" "u-boot-$uboot_branch.tar.bz2"
+        cd quartz64_ci-DietPi
+        md5sum -c gcc-arm-10.2-2020.11-x86_64-aarch64-none-linux-gnu.tar.xz.asc
+        tar xf gcc-arm-10.2-2020.11-x86_64-aarch64-none-linux-gnu.tar.xz
+        rm gcc-arm-10.2-2020.11-x86_64-aarch64-none-linux-gnu.tar.xz*
+        cd ..
+        mv quartz64_ci-DietPi/quartz64_defconfig "linux-$linux_version/arch/arm64/configs/quartz64_defconfig"
+        mkdir artefacts
+    - name: Build U-Boot
+      run: |
+        mkdir artefacts/mainline-u-boot
+        export PATH="$PWD/quartz64_ci-DietPi/gcc-arm-10.2-2020.11-x86_64-aarch64-none-linux-gnu/bin:$PATH" BL31='rk3568_bl31_v1.28.elf'
+        cd "u-boot-$uboot_branch"
+        curl -sSfO 'https://raw.githubusercontent.com/JeffyCN/rockchip_mirrors/6186debcac95553f6b311cee10669e12c9c9963d/bin/rk35/rk3568_bl31_v1.28.elf' &
+        curl -sSfo 'rk3568_ddr_1560MHz_v1.12.bin' 'https://raw.githubusercontent.com/JeffyCN/rockchip_mirrors/ddf03c1d80b33dac72a33c4f732fc5849b47ff99/bin/rk35/rk3568_ddr_1560MHz_v1.13.bin' &
+        wait
+        make quartz64-a-rk3566_defconfig
+        make -j$(nproc)
+        mv u-boot-rockchip.bin ../artefacts/mainline-u-boot/quartz64-a-u-boot-rockchip.bin
+        make quartz64-b-rk3566_defconfig
+        make -j$(nproc)
+        mv u-boot-rockchip.bin ../artefacts/mainline-u-boot/quartz64-b-u-boot-rockchip.bin
+        make soquartz-rk3566_defconfig
+        make -j$(nproc)
+        mv u-boot-rockchip.bin ../artefacts/mainline-u-boot/soquartz-u-boot-rockchip.bin
+    - name: Build Linux
+      run: |
+        mkdir modules
+        export PATH="$PWD/quartz64_ci-DietPi/gcc-arm-10.2-2020.11-x86_64-aarch64-none-linux-gnu/bin:$PATH" INSTALL_MOD_PATH="$PWD/modules"
+        cd "linux-$linux_version"
+        make quartz64_defconfig
+        make -j$(nproc)
+        mv arch/arm64/boot/Image arch/arm64/boot/dts/rockchip/rk356*.dtb ../artefacts/
+        make modules_install
+        cd ../modules
+        tar -czf kernel-modules.tar.gz lib
+        mv kernel-modules.tar.gz ../artefacts/
+    - name: Upload
+      run: |
+        [ -d ~/.ssh ] || mkdir ~/.ssh
+        umask 377
+        echo '${{ secrets.KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+        echo '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
+        zip -9r artefacts.zip artefacts
+        curl -T artefacts.zip --key ~/.ssh/id_ed25519 '${{ secrets.UPLOAD_URL }}all/'
+        curl 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE }}/purge_cache' -H 'Authorization: Bearer ${{ secrets.CF_TOKEN }}' -H 'Content-Type: application/json' \
+        --data '{"files":["https://dietpi.com/downloads/binaries/testing/","https://dietpi.com/downloads/binaries/testing/artefacts.zip"]}'


### PR DESCRIPTION
- CI | Move kernel and U-Boot builds for Quartz64 from GitLab to GitHub and use stable sources: https://gitlab.com/MichaIng/quartz64_ci/-/blob/DietPi/.gitlab-ci.yml