### PR TITLE
fix AUTO_SETUP_HEADLESS warning in dietpi-config

### DIFF
--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -642,7 +642,7 @@ A long (or insufficiently manufactured) cable may required a higher boost settin
  - Improve RAM performance by 1-5% (VideoCore shares RAM bandwidth)
    Source: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p105008\n
 Re-enabling HDMI requires a reboot. If you need emergency HDMI output, edit the following files on first partition of the SDcard from external system:
- - In config.txt, set "hdmi_ignore_hotplug=0" and comment/remove all (max_)framebuffer_(width/height) lines.
+ - In config.txt, set "hdmi_ignore_hotplug=0" and comment/remove the "max_framebuffers=0" line.
  - In dietpi.txt, set "AUTO_SETUP_HEADLESS=0".' || { REBOOT_REQUIRED=0; return; }
 
 				/boot/dietpi/func/dietpi-set_hardware headless 1

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -643,7 +643,7 @@ A long (or insufficiently manufactured) cable may required a higher boost settin
    Source: https://www.raspberrypi.org/forums/viewtopic.php?p=105008#p105008\n
 Re-enabling HDMI requires a reboot. If you need emergency HDMI output, edit the following files on first partition of the SDcard from external system:
  - In config.txt, set "hdmi_ignore_hotplug=0" and comment/remove all (max_)framebuffer_(width/height) lines.
- - In dietpi.txt, set "AUTO_SETUP_HEADLESS=1".' || { REBOOT_REQUIRED=0; return; }
+ - In dietpi.txt, set "AUTO_SETUP_HEADLESS=0".' || { REBOOT_REQUIRED=0; return; }
 
 				/boot/dietpi/func/dietpi-set_hardware headless 1
 


### PR DESCRIPTION
In order to Re-enabling HDMI, shouldn't the message advice to set `AUTO_SETUP_HEADLESS=0` instead of `AUTO_SETUP_HEADLESS=1`?

That is at least my experience.

<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
