### PR TITLE
Live patch 2 | Fix Python software uninstalls due to changes in pip

### DIFF
--- a/.update/version
+++ b/.update/version
@@ -16,14 +16,17 @@ G_OLD_DEBIAN_BRANCH='stretch'
 # Live patches
 G_LIVE_PATCH_DESC=(
 	[0]='Fix serial getty baudrate override'
-	[1]='Fix Python installs due to changes in pip'
+	[1]='Fix Python software installs due to changes in pip'
+	[2]='Fix Python software uninstalls due to changes in pip'
 )
 # shellcheck disable=SC2016
 G_LIVE_PATCH_COND=(
 	[0]='(( $G_DISTRO < 7 )) && grep -q '\''9600 -'\'' /etc/systemd/system/serial-getty@*.service.d/dietpi-baudrate.conf 2> /dev/null'
 	[1]='! grep -q '\''break-system-packages'\'' /boot/dietpi/dietpi-software'
+	[2]='grep -q '\''pip3 uninstall -y'\'' /boot/dietpi/dietpi-software'
 )
 G_LIVE_PATCH=(
 	[0]='sed -i '\''s/9600 -/9600 %I/'\'' /boot/dietpi/func/dietpi-set_hardware /etc/systemd/system/serial-getty@*.service.d/dietpi-baudrate.conf'
 	[1]='sed -Ei '\''s/^(\t\t\tG_EXEC_OUTPUT=1 G_EXEC (python3 get-pip.py|pip3 install))/\1 --break-system-packages/'\'' /boot/dietpi/dietpi-software'
+	[2]='sed -i '\''s/pip3 uninstall -y/pip3 uninstall --break-system-packages -y/'\'' /boot/dietpi/dietpi-software'
 )


### PR DESCRIPTION
- DietPi-Software | Python 3: Fix Python software uninstalls due to changes in pip