### PR TITLE
DietPi-Software | Fail2ban: Fix moving logs to systemd journal

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ v8.16
 Enhancements:
 
 Bug fixes:
+- DietPi-Software | Fail2Ban: Resolved a DietPi v8.11 regression where moving logs to systemd journal on install fails due to a typo.
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/xxxx
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7299,7 +7299,7 @@ action = %(banaction)s[blocktype=blackhole]
 #mode = normal
 _EOF_
 			# Log to systemd by default
-			E_EXEC eval 'echo -e '\''[Definition]\nlogtarget = SYSOUT'\'' > /etc/fail2ban/fail2ban.d/97_dietpi.conf'
+			G_EXEC eval 'echo -e '\''[Definition]\nlogtarget = SYSOUT'\'' > /etc/fail2ban/fail2ban.d/97_dietpi.conf'
 
 			G_AGI python3-systemd fail2ban
 


### PR DESCRIPTION
DietPi-Software | Fail2ban - typo

@MichaIng I guess a LivePatch should be quite easy.