### PR TITLE
Dietpi-Software | microblog.pub

### DIFF
--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -651,6 +651,7 @@ shopt -s extglob
 	do
 		aSOFTWARE_NAME8_16[$i]=${aSOFTWARE_NAME8_15[$i]}
 	done
+	aSOFTWARE_NAME8_16[16]='microblog.pub'
 
 	# Pre-create software counter array so that we can see also software (available in newest version) with 0 installs
 	for i in "${aSOFTWARE_NAME8_16[@]}"

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,9 @@
 v8.16
 (2023-04-08)
 
+New software:
+- microblog.pub | A self-hosted, single-user, ActivityPub powered microblog has been added to our software catalogue. Many thanks to @mtekman for implementing this software option: https://github.com/MichaIng/DietPi/pull/6246
+
 Enhancements:
 - General | Reworked GPU driver installations for x86 systems. This provides better control of GPU drivers for DietPi, adding support for Vulkan and resolves issues with Steam Proton. Users will be prompted to select a driver package during DietPi-Update.: https://github.com/MichaIng/DietPi/issues/6262
 - NanoPi R5S/R6S | The kernel will be upgraded during the DietPi update to disable a writable clk DebugFS flag it was previously shipped with. Many thanks to @thinkpanzer for beinging this to our attention: https://github.com/MichaIng/DietPi/issues/6136

--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Links to hardware and software manufacturers, sources and build instructions use
 - [ZeroTier](https://github.com/zerotier/ZeroTierOne)
 - [Navidrome](https://github.com/navidrome/navidrome)
 - [Homer](https://github.com/bastienwirtz/homer)
+- [microblog.pub](https://git.sr.ht/~tsileo/microblog.pub)
 
 ---
 

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -230,6 +230,7 @@ _EOF_
 			# - Social/Search
 			'openbazaar'
 			'synapse'
+            'microblog-pub'
 
 			# - Hardware Projects
 			'pi-spc'

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -230,7 +230,7 @@ _EOF_
 			# - Social/Search
 			'openbazaar'
 			'synapse'
-            'microblog-pub'
+			'microblog-pub'
 
 			# - Hardware Projects
 			'pi-spc'

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4196,7 +4196,7 @@ poetry install
 ## - poetry run inv migrate-db
 poetry env info | grep -oP '(?<=^Path:\s).*/virtualenvs/.*' | xargs echo > $micro_virtualenv
 "
-			if [[ "$(cat  \"$micro_virtualenv\")" = "" ]]; then
+			if [[ $(cat "$micro_virtualenv") = "" ]]; then
 				echo "Unable to locate virtualenv" && exit 255
 			fi
 			## 3. Generate functions for later configuration and install to profile
@@ -4236,7 +4236,7 @@ User=dietpi
 SyslogIdentifier=Microblog.pub
 ExecStart=bash -c "source $micro_pyenv_activate_file; poetry run supervisord -c misc/supervisord.conf -n"
 WorkingDirectory=$micro_dir
-Environment="VENV_DIR=$(cat \"$micro_virtualenv\")"
+Environment="VENV_DIR=$(cat "$micro_virtualenv")"
 RestartForceExitStatus=100
 
 [Install]

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4154,17 +4154,17 @@ _EOF_
 			local micro_systemd="/etc/systemd/system/microblog-pub.service"
 			local micro_functions="/etc/bashrc.d/microblog_pub.sh"
 
-			if ! [ -d $micro_dir ]; then
-				G_EXEC_OUTPUT=1 G_EXEC git clone https://git.sr.ht/~tsileo/microblog.pub $micro_dir
+			if ! [[ -d "$micro_dir" ]]; then
+				G_EXEC_OUTPUT=1 G_EXEC git clone https://git.sr.ht/~tsileo/microblog.pub "$micro_dir"
 			fi
-			G_EXEC_OUTPUT=0 G_EXEC chown -R dietpi:dietpi $micro_dir
+			G_EXEC_OUTPUT=0 G_EXEC chown -R dietpi:dietpi "$micro_dir"
 
 			## 1. Clone the Repo into location, copy over default config
 			Download_Install 'https://github.com/pyenv/pyenv/archive/master.tar.gz'
 			# - Start with fresh instance, to allow clean pyenv and Python updates and fix broken instances.
 			[[ -d "$micro_pyenv_dir" ]] && G_EXEC rm -R "$micro_pyenv_dir"
-			G_EXEC mv pyenv-master $micro_pyenv_dir
-			G_EXEC chown -R dietpi:dietpi $micro_pyenv_dir
+			G_EXEC mv pyenv-master "$micro_pyenv_dir"
+			G_EXEC chown -R dietpi:dietpi "$micro_pyenv_dir"
 
 			# 2. Generate script to activate pyenv
 			echo "#!/bin/dash
@@ -4175,7 +4175,7 @@ eval \"\$(pyenv init --path)\"
 eval \"\$(pyenv init -)\"
 cd $micro_dir
 PS1=\"(microblog.pub) \$PS1\" " > "$micro_pyenv_activate_file"
-			G_EXEC chown dietpi:dietpi $micro_pyenv_activate_file
+			G_EXEC chown dietpi:dietpi "$micro_pyenv_activate_file"
 
 			## Install Python 3.10 and Poetry
 			G_EXEC_DESC='Installing Python with into pyenv'
@@ -4196,11 +4196,11 @@ poetry install
 ## - poetry run inv migrate-db
 poetry env info | grep -oP '(?<=^Path:\s).*/virtualenvs/.*' | xargs echo > $micro_virtualenv
 "
-			if [ "$(cat $micro_virtualenv)" = "" ]; then
+			if [[ "$(cat  \"$micro_virtualenv\")" = "" ]]; then
 				echo "Unable to locate virtualenv" && exit 255
 			fi
 			## 3. Generate functions for later configuration and install to profile
-			cat << _EOF_ > $micro_functions
+			cat << _EOF_ > "$micro_functions"
 #!/bin/bash
 
 microblog_pub (){
@@ -4225,7 +4225,7 @@ where:
 
 _EOF_
 			## 4. Generate systemd script
-			cat << _EOF_ > $micro_systemd
+			cat << _EOF_ > "$micro_systemd"
 [Unit]
 Description=Microblog.pub Web Service
 Wants=network-online.target
@@ -4236,7 +4236,7 @@ User=dietpi
 SyslogIdentifier=Microblog.pub
 ExecStart=bash -c "source $micro_pyenv_activate_file; poetry run supervisord -c misc/supervisord.conf -n"
 WorkingDirectory=$micro_dir
-Environment="VENV_DIR=$(cat $micro_virtualenv)"
+Environment="VENV_DIR=$(cat \"$micro_virtualenv\")"
 RestartForceExitStatus=100
 
 [Install]

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4251,8 +4251,8 @@ RestartForceExitStatus=100
 [Install]
 WantedBy=multi-user.target
 _EOF_
-			G_WHIP_MSG '[ INFO ] microblog.pub installation finished\n\nIn order to complete the setup, please run "microblog-pub configure" in a new bash session.'
-			G_DIETPI-NOTIFY 0 'microblog.pub installation finished. In order to complete the setup, please run "microblog-pub configure" in a new bash session.'
+			G_WHIP_MSG '[ INFO ] microblog.pub installation finished\n\nIn order to complete the setup, please run "microblog-pub configure" in a new bash session.\n\nNB: Append the port ":8007" to the domain when being asked for it if you do not use a reverse proxy.'
+			G_DIETPI-NOTIFY 0 'microblog.pub installation finished. In order to complete the setup, please run "microblog-pub configure" in a new bash session. Append the port ":8007" to the domain when being asked for it if you do not use a reverse proxy.'
 		fi
 
 		if To_Install 2 fahclient # Folding@Home

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1533,6 +1533,12 @@ Available commands:
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/distributed_projects/#ipfs-node'
 		# - RISC-V: Missing package
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,11]=0
+		#-----------------
+		software_id=206
+		aSOFTWARE_NAME[$software_id]='microblog.pub'
+		aSOFTWARE_DESC[$software_id]='A self-hosted, single-user, ActivityPub powered microblog.'
+		aSOFTWARE_CATX[$software_id]=19
+		aSOFTWARE_DOCS[$software_id]='https://docs.microblog.pub/'
 
 		# SSH Clients
 		#--------------------------------------------------------------------------------
@@ -4134,6 +4140,111 @@ _EOF_
 			# Raise packet receive buffer: https://github.com/lucas-clemente/quic-go/wiki/UDP-Receive-Buffer-Size
 			G_EXEC eval "echo 'net.core.rmem_max=2500000' > /etc/sysctl.d/dietpi-ipfs.conf"
 			G_EXEC sysctl -w net.core.rmem_max=2500000
+		fi
+
+		if To_Install 206 microblog-pub # microblog.pub
+		then
+			## 1. Create a python environment py3.10 via pyenc
+			##	  see: https://python-poetry.org/docs/managing-environments/
+			local micro_pyenv_dir="/home/dietpi/.pyenv_microblog"
+			local micro_pyenv_activate_file="$micro_pyenv_dir/pyenv-activate.sh"
+			local micro_python_version='3.10.7'
+			local micro_dir="/home/dietpi/microblog"
+			local micro_virtualenv="/home/dietpi/microblog/.virtual_path"
+			local micro_systemd="/etc/systemd/system/microblog-pub.service"
+			local micro_functions="/etc/bashrc.d/microblog_pub.sh"
+
+			if ! [ -d $micro_dir ]; then
+				G_EXEC_OUTPUT=1 G_EXEC git clone https://git.sr.ht/~tsileo/microblog.pub $micro_dir
+			fi
+			G_EXEC_OUTPUT=0 G_EXEC chown -R dietpi:dietpi $micro_dir
+
+			## 1. Clone the Repo into location, copy over default config
+			Download_Install 'https://github.com/pyenv/pyenv/archive/master.tar.gz'
+			# - Start with fresh instance, to allow clean pyenv and Python updates and fix broken instances.
+			[[ -d "$micro_pyenv_dir" ]] && G_EXEC rm -R "$micro_pyenv_dir"
+			G_EXEC mv pyenv-master $micro_pyenv_dir
+			G_EXEC chown -R dietpi:dietpi $micro_pyenv_dir
+
+			# 2. Generate script to activate pyenv
+			echo "#!/bin/dash
+cd $micro_pyenv_dir
+export PYENV_ROOT='$micro_pyenv_dir'
+export PATH=\"\$PYENV_ROOT/bin:\$PATH\"
+eval \"\$(pyenv init --path)\"
+eval \"\$(pyenv init -)\"
+cd $micro_dir
+PS1=\"(microblog.pub) \$PS1\" " > "$micro_pyenv_activate_file"
+			G_EXEC chown dietpi:dietpi $micro_pyenv_activate_file
+
+			## Install Python 3.10 and Poetry
+			G_EXEC_DESC='Installing Python with into pyenv'
+			G_EXEC_OUTPUT=1 G_EXEC sudo -u dietpi dash -c "
+source $micro_pyenv_activate_file
+pyenv install $micro_python_version
+pyenv local $micro_python_version
+pip3 install --no-cache-dir -U pip setuptools wheel
+exec pip3 install --no-cache-dir poetry"
+
+			G_EXEC_DESC='Installing Poetry dependencies (can take a while)'
+			G_EXEC_OUTPUT=0 G_EXEC sudo -u dietpi dash -c "
+source $micro_pyenv_activate_file
+pyenv local $micro_python_version
+poetry install
+## Skip these for now:
+## - poetry run inv configuration-wizard
+## - poetry run inv migrate-db
+poetry env info | grep -oP '(?<=^Path:\s).*/virtualenvs/.*' | xargs echo > $micro_virtualenv
+"
+			if [ "$(cat $micro_virtualenv)" = "" ]; then
+				echo "Unable to locate virtualenv" && exit 255
+			fi
+			## 3. Generate functions for later configuration and install to profile
+			cat << _EOF_ > $micro_functions
+#!/bin/bash
+
+microblog_pub (){
+	case \$1 in
+		v*) bash --init-file "$micro_pyenv_activate_file";;  ## venv
+		c*) bash -c "source $micro_pyenv_activate_file; poetry run inv configuration-wizard && poetry run inv migrate-db";; ## configure
+		u*) bash -c "source $micro_pyenv_activate_file; git pull && poetry run inv update";; ## update
+		*) echo "Micropub helper script
+
+    usage:  microblog_pub  <venv|configure|update>
+
+where:
+   configure   runs the configuration wizard and updates the microblog environment.
+   update      pulls the latest changes from the microblog repository and reconfigures.
+   venv        starts a virtual environment where the microblog can be configured.
+" && return;;
+	esac
+
+	sudo systemctl restart microblog-pub
+
+}
+
+_EOF_
+			## 4. Generate systemd script
+			cat << _EOF_ > $micro_systemd
+[Unit]
+Description=Microblog.pub Web Service
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=dietpi
+SyslogIdentifier=Microblog.pub
+ExecStart=bash -c "source $micro_pyenv_activate_file; poetry run supervisord -c misc/supervisord.conf -n"
+WorkingDirectory=$micro_dir
+Environment="VENV_DIR=$(cat $micro_virtualenv)"
+RestartForceExitStatus=100
+
+[Install]
+WantedBy=multi-user.target
+_EOF_
+
+			G_EXEC systemctl enable --now microblog-pub
+			G_EXEC_DESC="In order to complete the microblog-pub installation, you need to run 'microblog_pub configure' in a new bash shell!"
 		fi
 
 		if To_Install 2 fahclient # Folding@Home
@@ -12750,6 +12861,23 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 		then
 			Remove_Service ipfs 1 1
 			G_EXEC rm -Rf /usr/local/bin/ipfs /etc/bashrc.d/dietpi-ipfs.sh /etc/sysctl.d/dietpi-ipfs.conf /mnt/dietpi_userdata/ipfs
+		fi
+
+		if To_Uninstall 206 # microblog.pub
+		then
+			local micro_pyenv="/home/dietpi/.pyenv_microblog"
+			local micro_dir="/home/dietpi/microblog"
+			local micro_systemd="/etc/systemd/system/microblog-pub.service"
+			local micro_functions="/etc/bashrc.d/microblog_pub.sh"
+
+			if [[ -f "$micro_systemd" ]]
+			then
+				G_EXEC systemctl disable --now microblog-pub
+				G_EXEC rm "$micro_systemd"
+			fi
+			[[ -f "$micro_functions" ]] && G_EXEC rm "$micro_functions"
+			[[ -d "$micro_pyenv" ]] && G_EXEC rm -R "$micro_pyenv"
+			G_DIETPI-NOTIFY 2 "All microblog.pub data and settings are still retained.\n - You can remove these manually: rm -R $micro_dir"
 		fi
 
 		if To_Uninstall 98 # HAProxy

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1011,6 +1011,13 @@ Available commands:
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/social/#synapse'
 		aSOFTWARE_DEPS[$software_id]='130 194'
 		aSOFTWARE_INTERACTIVE[$software_id]=1
+		#-----------------
+		software_id=16
+		aSOFTWARE_NAME[$software_id]='microblog.pub'
+		aSOFTWARE_DESC[$software_id]='A self-hosted, single-user, ActivityPub powered microblog.'
+		aSOFTWARE_CATX[$software_id]=6
+		aSOFTWARE_DEPS[$software_id]='17'
+		aSOFTWARE_DOCS[$software_id]='https://docs.microblog.pub/'
 
 		# Camera & Surveillance
 		#--------------------------------------------------------------------------------
@@ -1533,12 +1540,6 @@ Available commands:
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/distributed_projects/#ipfs-node'
 		# - RISC-V: Missing package
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,11]=0
-		#-----------------
-		software_id=206
-		aSOFTWARE_NAME[$software_id]='microblog.pub'
-		aSOFTWARE_DESC[$software_id]='A self-hosted, single-user, ActivityPub powered microblog.'
-		aSOFTWARE_CATX[$software_id]=19
-		aSOFTWARE_DOCS[$software_id]='https://docs.microblog.pub/'
 
 		# SSH Clients
 		#--------------------------------------------------------------------------------
@@ -4142,14 +4143,16 @@ _EOF_
 			G_EXEC sysctl -w net.core.rmem_max=2500000
 		fi
 
-		if To_Install 206 microblog-pub # microblog.pub
+		if To_Install 16 microblog-pub # microblog.pub
 		then
-			## 1. Create a python environment py3.10 via pyenc
+			Create_User -g dietpi -d /home/microblog microblog
+			## 1. Create a python environment py3.10 via pyenv
 			##	  see: https://python-poetry.org/docs/managing-environments/
-			local micro_pyenv_dir="/home/dietpi/.pyenv_microblog"
+			local micro_user="microblog"
+			local micro_pyenv_dir="/opt/microblog-pub/.pyenv"
 			local micro_pyenv_activate_file="$micro_pyenv_dir/pyenv-activate.sh"
 			local micro_python_version='3.10.7'
-			local micro_dir="/home/dietpi/microblog"
+			local micro_dir="/mnt/dietpi_userdata/microblog-pub/"
 			local micro_virtualenv="/home/dietpi/microblog/.virtual_path"
 			local micro_systemd="/etc/systemd/system/microblog-pub.service"
 			local micro_functions="/etc/bashrc.d/microblog_pub.sh"
@@ -4157,14 +4160,14 @@ _EOF_
 			if ! [[ -d "$micro_dir" ]]; then
 				G_EXEC_OUTPUT=1 G_EXEC git clone https://git.sr.ht/~tsileo/microblog.pub "$micro_dir"
 			fi
-			G_EXEC_OUTPUT=0 G_EXEC chown -R dietpi:dietpi "$micro_dir"
+			G_EXEC_OUTPUT=0 G_EXEC chown -R "$micro_user":"$micro_user" "$micro_dir"
 
 			## 1. Clone the Repo into location, copy over default config
 			Download_Install 'https://github.com/pyenv/pyenv/archive/master.tar.gz'
 			# - Start with fresh instance, to allow clean pyenv and Python updates and fix broken instances.
 			[[ -d "$micro_pyenv_dir" ]] && G_EXEC rm -R "$micro_pyenv_dir"
 			G_EXEC mv pyenv-master "$micro_pyenv_dir"
-			G_EXEC chown -R dietpi:dietpi "$micro_pyenv_dir"
+			G_EXEC chown -R "$micro_user":"$micro_user" "$micro_pyenv_dir"
 
 			# 2. Generate script to activate pyenv
 			echo "#!/bin/dash
@@ -4175,11 +4178,11 @@ eval \"\$(pyenv init --path)\"
 eval \"\$(pyenv init -)\"
 cd $micro_dir
 PS1=\"(microblog.pub) \$PS1\" " > "$micro_pyenv_activate_file"
-			G_EXEC chown dietpi:dietpi "$micro_pyenv_activate_file"
+			G_EXEC chown "$micro_user":"$micro_user" "$micro_pyenv_activate_file"
 
 			## Install Python 3.10 and Poetry
 			G_EXEC_DESC='Installing Python with into pyenv'
-			G_EXEC_OUTPUT=1 G_EXEC sudo -u dietpi dash -c "
+			G_EXEC_OUTPUT=1 G_EXEC sudo -u "$micro_user" dash -c "
 source $micro_pyenv_activate_file
 pyenv install $micro_python_version
 pyenv local $micro_python_version
@@ -4187,7 +4190,7 @@ pip3 install --no-cache-dir -U pip setuptools wheel
 exec pip3 install --no-cache-dir poetry"
 
 			G_EXEC_DESC='Installing Poetry dependencies (can take a while)'
-			G_EXEC_OUTPUT=0 G_EXEC sudo -u dietpi dash -c "
+			G_EXEC_OUTPUT=0 G_EXEC sudo -u "$micro_user" dash -c "
 source $micro_pyenv_activate_file
 pyenv local $micro_python_version
 poetry install
@@ -4196,7 +4199,7 @@ poetry install
 ## - poetry run inv migrate-db
 poetry env info | grep -oP '(?<=^Path:\s).*/virtualenvs/.*' | xargs echo > $micro_virtualenv
 "
-			if [[ $(cat "$micro_virtualenv") = "" ]]; then
+			if [[ ! -s "$micro_virtualenv" ]]; then
 				echo "Unable to locate virtualenv" && exit 255
 			fi
 			## 3. Generate functions for later configuration and install to profile
@@ -4232,7 +4235,7 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-User=dietpi
+User=$micro_user
 SyslogIdentifier=Microblog.pub
 ExecStart=bash -c "source $micro_pyenv_activate_file; poetry run supervisord -c misc/supervisord.conf -n"
 WorkingDirectory=$micro_dir
@@ -4243,8 +4246,8 @@ RestartForceExitStatus=100
 WantedBy=multi-user.target
 _EOF_
 
-			G_EXEC systemctl enable --now microblog-pub
-			G_EXEC_DESC="In order to complete the microblog-pub installation, you need to run 'microblog_pub configure' in a new bash shell!"
+			G_WHIP_MSG '[ INFO] microblog.pub installation finished
+\nIn order to complete the setup, please run "microblog_pub configure" in a new bash.'
 		fi
 
 		if To_Install 2 fahclient # Folding@Home
@@ -12875,6 +12878,7 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 				G_EXEC systemctl disable --now microblog-pub
 				G_EXEC rm "$micro_systemd"
 			fi
+			[[ -d $micro_systemd.d ]] && G_EXEC rm -R "$micro_systemd.d"
 			[[ -f "$micro_functions" ]] && G_EXEC rm "$micro_functions"
 			[[ -d "$micro_pyenv" ]] && G_EXEC rm -R "$micro_pyenv"
 			G_DIETPI-NOTIFY 2 "All microblog.pub data and settings are still retained.\n - You can remove these manually: rm -R $micro_dir"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4198,6 +4198,7 @@ poetry install || exit 1
 poetry env info | grep -oP '(?<=^Path:\s).*/virtualenvs/.*' > '$micro_virtualenv'"
 
 			read -r VENV_DIR < "$micro_virtualenv"
+			# shellcheck disable=SC2016
 			G_EXEC_DESC='Checking for Poetry virtualenv' G_EXEC eval '[[ $VENV_DIR ]]'
 			G_EXEC rm "$micro_virtualenv"
 
@@ -4235,7 +4236,7 @@ User=$micro_name
 SyslogIdentifier=microblog.pub
 WorkingDirectory=$micro_data_dir
 Environment="VENV_DIR=$VENV_DIR"
-ExecStart=dash -c '. $micro_pyenv_activate_file; exec poetry run supervisord -c misc/supervisord.conf -n'
+ExecStart=/bin/dash -c '. $micro_pyenv_activate_file; exec poetry run supervisord -c misc/supervisord.conf -n'
 RestartForceExitStatus=100
 
 [Install]

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4145,109 +4145,99 @@ _EOF_
 
 		if To_Install 16 microblog-pub # microblog.pub
 		then
-			Create_User -g dietpi -d /home/microblog microblog
-			## 1. Create a python environment py3.10 via pyenv
-			##	  see: https://python-poetry.org/docs/managing-environments/
-			local micro_user="microblog"
-			local micro_pyenv_dir="/opt/microblog-pub/.pyenv"
+			local micro_name='microblog-pub'
+			local micro_python_version='3.10.9'
+			local micro_pyenv_dir="/opt/$micro_name"
 			local micro_pyenv_activate_file="$micro_pyenv_dir/pyenv-activate.sh"
-			local micro_python_version='3.10.7'
-			local micro_dir="/mnt/dietpi_userdata/microblog-pub/"
-			local micro_virtualenv="/home/dietpi/microblog/.virtual_path"
-			local micro_systemd="/etc/systemd/system/microblog-pub.service"
-			local micro_functions="/etc/bashrc.d/microblog_pub.sh"
+			local micro_virtualenv="$micro_pyenv_dir/.virtual_path"
+			local micro_data_dir="/mnt/dietpi_userdata/$micro_name"
+			local micro_systemd="/etc/systemd/system/$micro_name.service"
+			local micro_functions="/etc/bashrc.d/$micro_name.sh"
 
-			if ! [[ -d "$micro_dir" ]]; then
-				G_EXEC_OUTPUT=1 G_EXEC git clone https://git.sr.ht/~tsileo/microblog.pub "$micro_dir"
-			fi
-			G_EXEC_OUTPUT=0 G_EXEC chown -R "$micro_user":"$micro_user" "$micro_dir"
+			# User
+			Create_User -d "$micro_data_dir" "$micro_name"
 
-			## 1. Clone the Repo into location, copy over default config
+			# 1. Create a Python 3.10 environment via pyenv
+			# - https://python-poetry.org/docs/managing-environments/
 			Download_Install 'https://github.com/pyenv/pyenv/archive/master.tar.gz'
-			# - Start with fresh instance, to allow clean pyenv and Python updates and fix broken instances.
-			[[ -d "$micro_pyenv_dir" ]] && G_EXEC rm -R "$micro_pyenv_dir"
+			# - Start with fresh instance to allow clean pyenv and Python updates and fix broken instances.
+			[[ -d $micro_pyenv_dir ]] && G_EXEC rm -R "$micro_pyenv_dir"
 			G_EXEC mv pyenv-master "$micro_pyenv_dir"
-			G_EXEC chown -R "$micro_user":"$micro_user" "$micro_pyenv_dir"
 
-			# 2. Generate script to activate pyenv
+			# 2. Clone the repo into data dir
+			[[ -d $micro_data_dir ]] || G_EXEC_OUTPUT=1 G_EXEC git clone 'https://git.sr.ht/~tsileo/microblog.pub' "$micro_data_dir"
+			G_EXEC chown -R "$micro_name:$micro_name" "$micro_data_dir"
+
+			# 3. Generate script to activate pyenv
 			echo "#!/bin/dash
 cd $micro_pyenv_dir
 export PYENV_ROOT='$micro_pyenv_dir'
 export PATH=\"\$PYENV_ROOT/bin:\$PATH\"
 eval \"\$(pyenv init --path)\"
 eval \"\$(pyenv init -)\"
-cd $micro_dir
-PS1=\"(microblog.pub) \$PS1\" " > "$micro_pyenv_activate_file"
-			G_EXEC chown "$micro_user":"$micro_user" "$micro_pyenv_activate_file"
+cd $micro_data_dir
+PS1=\"(microblog.pub) \$PS1\"" > "$micro_pyenv_activate_file"
 
-			## Install Python 3.10 and Poetry
-			G_EXEC_DESC='Installing Python with into pyenv'
-			G_EXEC_OUTPUT=1 G_EXEC sudo -u "$micro_user" dash -c "
+			# 4. Install Python 3.10 and Poetry
+			G_EXEC chown -R "$micro_name:$micro_name" "$micro_pyenv_dir"
+			G_EXEC_DESC='Installing Python with Poetry into pyenv'
+			G_EXEC_OUTPUT=1 G_EXEC sudo -u "$micro_name" dash -c "
 source $micro_pyenv_activate_file
 pyenv install $micro_python_version
 pyenv local $micro_python_version
-pip3 install --no-cache-dir -U pip setuptools wheel
-exec pip3 install --no-cache-dir poetry"
-
-			G_EXEC_DESC='Installing Poetry dependencies (can take a while)'
-			G_EXEC_OUTPUT=0 G_EXEC sudo -u "$micro_user" dash -c "
-source $micro_pyenv_activate_file
-pyenv local $micro_python_version
+pip3 install -U pip setuptools wheel
+pip3 install poetry
 poetry install
-## Skip these for now:
-## - poetry run inv configuration-wizard
-## - poetry run inv migrate-db
-poetry env info | grep -oP '(?<=^Path:\s).*/virtualenvs/.*' | xargs echo > $micro_virtualenv
-"
-			if [[ ! -s "$micro_virtualenv" ]]; then
-				echo "Unable to locate virtualenv" && exit 255
-			fi
-			## 3. Generate functions for later configuration and install to profile
+# Skip these for now:
+#poetry run inv configuration-wizard
+#poetry run inv migrate-db
+poetry env info | grep -oP '(?<=^Path:\s).*/virtualenvs/.*' > '$micro_virtualenv'"
+
+			G_EXEC_DESC='Checking for Poetry virtualenv' G_EXEC eval "[[ -s $micro_virtualenv ]]"
+
+			# 5. Generate functions for later configuration and install to profile
 			cat << _EOF_ > "$micro_functions"
-#!/bin/bash
-
-microblog_pub (){
+#!/bin/dash
+microblog_pub()
+{
 	case \$1 in
-		v*) bash --init-file "$micro_pyenv_activate_file";;  ## venv
-		c*) bash -c "source $micro_pyenv_activate_file; poetry run inv configuration-wizard && poetry run inv migrate-db";; ## configure
-		u*) bash -c "source $micro_pyenv_activate_file; git pull && poetry run inv update";; ## update
-		*) echo "Micropub helper script
+		v*) bash --init-file '$micro_pyenv_activate_file';; # venv
+		c*) dash -c 'source $micro_pyenv_activate_file; poetry run inv configuration-wizard && poetry run inv migrate-db';; # configure
+		u*) dash -c 'source $micro_pyenv_activate_file; git pull && poetry run inv update';; # update
+		*) echo 'microblog.pub helper script
 
-    usage:  microblog_pub  <venv|configure|update>
+usage: microblog_pub <venv|configure|update>
 
 where:
-   configure   runs the configuration wizard and updates the microblog environment.
-   update      pulls the latest changes from the microblog repository and reconfigures.
-   venv        starts a virtual environment where the microblog can be configured.
-" && return;;
+  configure   runs the configuration wizard and updates the microblog environment.
+  update      pulls the latest changes from the microblog repository and reconfigures.
+  venv        starts a virtual environment where the microblog can be configured.' && return 1;;
 	esac
 
-	sudo systemctl restart microblog-pub
-
+sudo systemctl restart $micro_name
 }
-
 _EOF_
-			## 4. Generate systemd script
+			# 5. Generate systemd script
 			cat << _EOF_ > "$micro_systemd"
 [Unit]
-Description=Microblog.pub Web Service
+Description=microblog.pub (DietPi)
 Wants=network-online.target
 After=network-online.target
 
 [Service]
-User=$micro_user
-SyslogIdentifier=Microblog.pub
-ExecStart=bash -c "source $micro_pyenv_activate_file; poetry run supervisord -c misc/supervisord.conf -n"
-WorkingDirectory=$micro_dir
-Environment="VENV_DIR=$(cat "$micro_virtualenv")"
+User=$micro_name
+SyslogIdentifier=microblog.pub
+WorkingDirectory=$micro_data_dir
+Environment=VENV_DIR=$micro_virtualenv
+ExecStart=dash -c '. $micro_pyenv_activate_file; exec poetry run supervisord -c misc/supervisord.conf -n'
 RestartForceExitStatus=100
 
 [Install]
 WantedBy=multi-user.target
 _EOF_
 
-			G_WHIP_MSG '[ INFO] microblog.pub installation finished
-\nIn order to complete the setup, please run "microblog_pub configure" in a new bash.'
+			G_WHIP_MSG '[ INFO ] microblog.pub installation finished
+\nIn order to complete the setup, please run "microblog_pub configure" in a new bash session.'
 		fi
 
 		if To_Install 2 fahclient # Folding@Home
@@ -12866,22 +12856,12 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 			G_EXEC rm -Rf /usr/local/bin/ipfs /etc/bashrc.d/dietpi-ipfs.sh /etc/sysctl.d/dietpi-ipfs.conf /mnt/dietpi_userdata/ipfs
 		fi
 
-		if To_Uninstall 206 # microblog.pub
+		if To_Uninstall 16 # microblog.pub
 		then
-			local micro_pyenv="/home/dietpi/.pyenv_microblog"
-			local micro_dir="/home/dietpi/microblog"
-			local micro_systemd="/etc/systemd/system/microblog-pub.service"
-			local micro_functions="/etc/bashrc.d/microblog_pub.sh"
-
-			if [[ -f "$micro_systemd" ]]
-			then
-				G_EXEC systemctl disable --now microblog-pub
-				G_EXEC rm "$micro_systemd"
-			fi
-			[[ -d $micro_systemd.d ]] && G_EXEC rm -R "$micro_systemd.d"
-			[[ -f "$micro_functions" ]] && G_EXEC rm "$micro_functions"
-			[[ -d "$micro_pyenv" ]] && G_EXEC rm -R "$micro_pyenv"
-			G_DIETPI-NOTIFY 2 "All microblog.pub data and settings are still retained.\n - You can remove these manually: rm -R $micro_dir"
+			Remove_Service microblog-pub 1 1
+			[[ -f '/etc/bashrc.d/microblog-pub.sh' ]] && G_EXEC rm /etc/bashrc.d/microblog-pub.sh
+			[[ -d '/opt/microblog-pub' ]] && G_EXEC rm -R /opt/microblog-pub
+			G_DIETPI-NOTIFY 2 'All microblog.pub data and settings are still retained.\n - You can remove these manually: rm -R /mnt/dietpi_userdata/microblog-pub'
 		fi
 
 		if To_Uninstall 98 # HAProxy

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4157,6 +4157,10 @@ _EOF_
 			# User
 			Create_User -d "$micro_data_dir" "$micro_name"
 
+			# Dependencies
+			# - gcc, libc6-dev, make, libssl-dev, zlib1g-dev for Python build. libbz2-dev; libreadline-dev, libsqlite3-dev, liblzma-dev to suppress warnings; libffi-dev for ModuleNotFoundError: No module named '_ctypes'
+			aDEPS=('gcc' 'libc6-dev' 'make' 'libssl-dev' 'zlib1g-dev' 'libbz2-dev' 'libreadline-dev' 'libsqlite3-dev' 'liblzma-dev' 'libffi-dev')
+
 			# 1. Create a Python 3.10 environment via pyenv
 			# - https://python-poetry.org/docs/managing-environments/
 			Download_Install 'https://github.com/pyenv/pyenv/archive/master.tar.gz'
@@ -4170,11 +4174,11 @@ _EOF_
 
 			# 3. Generate script to activate pyenv
 			echo "#!/bin/dash
-cd $micro_pyenv_dir
-export PYENV_ROOT='$micro_pyenv_dir'
-export PATH=\"\$PYENV_ROOT/bin:\$PATH\"
-eval \"\$(pyenv init --path)\"
-eval \"\$(pyenv init -)\"
+cd $micro_pyenv_dir || return 1
+export PYENV_ROOT='$micro_pyenv_dir' || return 1
+export PATH=\"\$PYENV_ROOT/bin:\$PATH\" || return 1
+eval \"\$(pyenv init --path)\" || return 1
+eval \"\$(pyenv init -)\" || return 1
 cd $micro_data_dir
 PS1=\"(microblog.pub) \$PS1\"" > "$micro_pyenv_activate_file"
 
@@ -4182,12 +4186,12 @@ PS1=\"(microblog.pub) \$PS1\"" > "$micro_pyenv_activate_file"
 			G_EXEC chown -R "$micro_name:$micro_name" "$micro_pyenv_dir"
 			G_EXEC_DESC='Installing Python with Poetry into pyenv'
 			G_EXEC_OUTPUT=1 G_EXEC sudo -u "$micro_name" dash -c "
-source $micro_pyenv_activate_file
-pyenv install $micro_python_version
-pyenv local $micro_python_version
-pip3 install -U pip setuptools wheel
-pip3 install poetry
-poetry install
+. $micro_pyenv_activate_file || exit 1
+pyenv install $micro_python_version || exit 1
+pyenv local $micro_python_version || exit 1
+pip3 install -U pip setuptools wheel || exit 1
+pip3 install poetry || exit 1
+poetry install || exit 1
 # Skip these for now:
 #poetry run inv configuration-wizard
 #poetry run inv migrate-db
@@ -4202,8 +4206,8 @@ microblog_pub()
 {
 	case \$1 in
 		v*) bash --init-file '$micro_pyenv_activate_file';; # venv
-		c*) dash -c 'source $micro_pyenv_activate_file; poetry run inv configuration-wizard && poetry run inv migrate-db';; # configure
-		u*) dash -c 'source $micro_pyenv_activate_file; git pull && poetry run inv update';; # update
+		c*) dash -c '. $micro_pyenv_activate_file; poetry run inv configuration-wizard && poetry run inv migrate-db';; # configure
+		u*) dash -c '. $micro_pyenv_activate_file; git pull && poetry run inv update';; # update
 		*) echo 'microblog.pub helper script
 
 usage: microblog_pub <venv|configure|update>
@@ -4238,6 +4242,7 @@ _EOF_
 
 			G_WHIP_MSG '[ INFO ] microblog.pub installation finished
 \nIn order to complete the setup, please run "microblog_pub configure" in a new bash session.'
+			G_DIETPI-NOTIFY 0 'microblog.pub installation finished. In order to complete the setup, please run "microblog_pub configure" in a new bash session.'
 		fi
 
 		if To_Install 2 fahclient # Folding@Home

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4202,15 +4202,15 @@ poetry env info | grep -oP '(?<=^Path:\s).*/virtualenvs/.*' > '$micro_virtualenv
 			# 5. Generate functions for later configuration and install to profile
 			cat << _EOF_ > "$micro_functions"
 #!/bin/dash
-microblog_pub()
+microblog-pub()
 {
 	case \$1 in
-		v*) bash --init-file '$micro_pyenv_activate_file';; # venv
-		c*) dash -c '. $micro_pyenv_activate_file; poetry run inv configuration-wizard && poetry run inv migrate-db';; # configure
-		u*) dash -c '. $micro_pyenv_activate_file; git pull && poetry run inv update';; # update
+		v*) sudo -u '$micro_name' bash --init-file '$micro_pyenv_activate_file';; # venv
+		c*) sudo -u '$micro_name' dash -c '. $micro_pyenv_activate_file; poetry run inv configuration-wizard && poetry run inv migrate-db';; # configure
+		u*) sudo -u '$micro_name' dash -c '. $micro_pyenv_activate_file; git pull && poetry run inv update';; # update
 		*) echo 'microblog.pub helper script
 
-usage: microblog_pub <venv|configure|update>
+usage: microblog-pub <venv|configure|update>
 
 where:
   configure   runs the configuration wizard and updates the microblog environment.
@@ -4218,7 +4218,7 @@ where:
   venv        starts a virtual environment where the microblog can be configured.' && return 1;;
 	esac
 
-sudo systemctl restart $micro_name
+	sudo systemctl restart '$micro_name'
 }
 _EOF_
 			# 5. Generate systemd script
@@ -4241,8 +4241,8 @@ WantedBy=multi-user.target
 _EOF_
 
 			G_WHIP_MSG '[ INFO ] microblog.pub installation finished
-\nIn order to complete the setup, please run "microblog_pub configure" in a new bash session.'
-			G_DIETPI-NOTIFY 0 'microblog.pub installation finished. In order to complete the setup, please run "microblog_pub configure" in a new bash session.'
+\nIn order to complete the setup, please run "microblog-pub configure" in a new bash session.'
+			G_DIETPI-NOTIFY 0 'microblog.pub installation finished. In order to complete the setup, please run "microblog-pub configure" in a new bash session.'
 		fi
 
 		if To_Install 2 fahclient # Folding@Home

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4169,10 +4169,19 @@ _EOF_
 			G_EXEC mv pyenv-master "$micro_pyenv_dir"
 
 			# 2. Clone the repo into data dir
-			[[ -d $micro_data_dir ]] || G_EXEC_OUTPUT=1 G_EXEC git clone 'https://git.sr.ht/~tsileo/microblog.pub' "$micro_data_dir"
-			G_EXEC chown -R "$micro_name:$micro_name" "$micro_data_dir"
+			if [[ ! -d $micro_data_dir ]]
+			then
+				G_EXEC_OUTPUT=1 G_EXEC git clone 'https://git.sr.ht/~tsileo/microblog.pub' "$micro_data_dir"
+				# Enable remote access on port 8007
+				G_EXEC sed -i 's/uvicorn app/uvicorn --host 0.0.0.0 --port 8007 app/' "$micro_data_dir/misc/supervisord.conf"
+				G_EXEC sed -i 's/8000/8007/' "$micro_data_dir/data/tests.toml"
+			fi
 
-			# 3. Generate script to activate pyenv
+			# 3. Disable pip cache
+			G_EXEC mkdir -p "$micro_data_dir/.pip"
+			G_EXEC eval "echo -e '[global]\nno-cache-dir=true' > '$micro_data_dir/.pip/pip.conf'"
+
+			# 4. Generate script to activate pyenv
 			echo "#!/bin/dash
 cd $micro_pyenv_dir || return 1
 export PYENV_ROOT='$micro_pyenv_dir' || return 1
@@ -4182,8 +4191,8 @@ eval \"\$(pyenv init -)\" || return 1
 cd $micro_data_dir
 PS1=\"(microblog.pub) \$PS1\"" > "$micro_pyenv_activate_file"
 
-			# 4. Install Python 3.10 and Poetry
-			G_EXEC chown -R "$micro_name:$micro_name" "$micro_pyenv_dir"
+			# 5. Install Python 3.10 and Poetry
+			G_EXEC chown -R "$micro_name:$micro_name" "$micro_pyenv_dir" "$micro_data_dir"
 			G_EXEC_DESC='Installing Python with Poetry into pyenv'
 			G_EXEC_OUTPUT=1 G_EXEC sudo -u "$micro_name" dash -c "
 . $micro_pyenv_activate_file || exit 1
@@ -4202,7 +4211,7 @@ poetry env info | grep -oP '(?<=^Path:\s).*/virtualenvs/.*' > '$micro_virtualenv
 			G_EXEC_DESC='Checking for Poetry virtualenv' G_EXEC eval '[[ $VENV_DIR ]]'
 			G_EXEC rm "$micro_virtualenv"
 
-			# 5. Generate functions for later configuration and install to profile
+			# 6. Generate functions for later configuration and install to profile
 			cat << _EOF_ > "$micro_functions"
 #!/bin/dash
 microblog-pub()
@@ -4224,7 +4233,7 @@ where:
 	sudo systemctl restart '$micro_name'
 }
 _EOF_
-			# 5. Generate systemd script
+			# 7. Generate systemd service
 			cat << _EOF_ > "$micro_systemd"
 [Unit]
 Description=microblog.pub (DietPi)
@@ -4242,9 +4251,7 @@ RestartForceExitStatus=100
 [Install]
 WantedBy=multi-user.target
 _EOF_
-
-			G_WHIP_MSG '[ INFO ] microblog.pub installation finished
-\nIn order to complete the setup, please run "microblog-pub configure" in a new bash session.'
+			G_WHIP_MSG '[ INFO ] microblog.pub installation finished\n\nIn order to complete the setup, please run "microblog-pub configure" in a new bash session.'
 			G_DIETPI-NOTIFY 0 'microblog.pub installation finished. In order to complete the setup, please run "microblog-pub configure" in a new bash session.'
 		fi
 
@@ -11233,6 +11240,10 @@ _EOF_
 			# Reset and merge pyenv and HA Python environment to avoid version mismatches on Python upgrades: https://github.com/MichaIng/DietPi/issues/6117
 			[[ -d '/mnt/dietpi_userdata/homeassistant/deps' ]] && G_EXEC rm -R /mnt/dietpi_userdata/homeassistant/deps
 			G_EXEC ln -sf "$ha_home/.pyenv/versions/$ha_python_version" /mnt/dietpi_userdata/homeassistant/deps
+
+			# Disable pip cache
+			G_EXEC mkdir -p "$ha_home/.pip"
+			G_EXEC eval "echo -e '[global]\nno-cache-dir=true' > '$ha_home/.pip/pip.conf'"
 
 			# Generate script to activate pyenv: This must be sourced from the originating shell, hence it does not require execute permissions.
 			echo "#!/bin/dash

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4197,7 +4197,9 @@ poetry install || exit 1
 #poetry run inv migrate-db
 poetry env info | grep -oP '(?<=^Path:\s).*/virtualenvs/.*' > '$micro_virtualenv'"
 
-			G_EXEC_DESC='Checking for Poetry virtualenv' G_EXEC eval "[[ -s $micro_virtualenv ]]"
+			read -r VENV_DIR < "$micro_virtualenv"
+			G_EXEC_DESC='Checking for Poetry virtualenv' G_EXEC eval '[[ $VENV_DIR ]]'
+			G_EXEC rm "$micro_virtualenv"
 
 			# 5. Generate functions for later configuration and install to profile
 			cat << _EOF_ > "$micro_functions"
@@ -4232,7 +4234,7 @@ After=network-online.target
 User=$micro_name
 SyslogIdentifier=microblog.pub
 WorkingDirectory=$micro_data_dir
-Environment=VENV_DIR=$micro_virtualenv
+Environment="VENV_DIR=$VENV_DIR"
 ExecStart=dash -c '. $micro_pyenv_activate_file; exec poetry run supervisord -c misc/supervisord.conf -n'
 RestartForceExitStatus=100
 


### PR DESCRIPTION
Add [microblog.pub](https://microblog.pub/) , an activitypub powered microblog.

_Requirements:_

It requires Python3.10, so we create pyenv, and we clone the repo to the directory `~/microblog`

_Caveats_:

The installation is supposedly interactive, since it requires the user to enter a domain name, an admin password, but I can't make these interactive without significantly extending the app to generate the right hashes for all of the above.

Instead, it installs and starts default config, and then the user needs to re-configure it using a `microblog_pub configure` script, which loads the environment, and brings up the app's own configuration wizard.