### PR TITLE
DietPi-Software | Transmission

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12019,6 +12019,12 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 
 		if To_Uninstall 44 # Transmission
 		then
+			# Stop Transmission service, as it may keep running on package removal
+			if [[ -f '/lib/systemd/system/transmission-daemon.service' ]]
+			then
+				G_EXEC systemctl unmask transmission-daemon
+				G_EXEC systemctl disable --now transmission-daemon
+			fi
 			G_AGP transmission-daemon
 			getent passwd debian-transmission > /dev/null && G_EXEC userdel debian-transmission
 			getent group debian-transmission > /dev/null && G_EXEC groupdel debian-transmission


### PR DESCRIPTION
Stop Transmission service before removal, as processes keeps running. Otherwise, it is blocking `userdel` leading to a failed uninstall.