### PR TITLE
DietPi-Build | Test VM images with initramfs-tools

### DIFF
--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -402,12 +402,12 @@ bash -c "\$(curl -sSf 'https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_G
 _EOF_
 
 # - VM: Generate tiny-initramfs with explicit kernel modules, as auto-detection doesn't work correctly within container and loop devices
-[[ $HW_MODEL == 20 ]] && cat << _EOF_ >> rootfs/etc/rc.local
-echo '[ INFO ] Rebuilding virtual machine initramfs to support all virtualizers...'
-version=\$(dpkg --get-selections | mawk '\$1~/^linux-image-.*-$parch\$/{print \$1;exit}') || poweroff
-version=\${version#linux-image-}
-mktirfs -m no -M no --include-modules='ahci,sd_mod,vmw_pvscsi,hv_storvsc,virtio_scsi,virtio_pci,$FSTYPE' -o "/boot/initrd.img-\$version" "\$version" || poweroff
-_EOF_
+#[[ $HW_MODEL == 20 ]] && cat << _EOF_ >> rootfs/etc/rc.local
+#echo '[ INFO ] Rebuilding virtual machine initramfs to support all virtualizers...'
+#version=\$(dpkg --get-selections | mawk '\$1~/^linux-image-.*-$parch\$/{print \$1;exit}') || poweroff
+#version=\${version#linux-image-}
+#mktirfs -m no -M no --include-modules='ahci,sd_mod,vmw_pvscsi,hv_storvsc,virtio_scsi,virtio_pci,$FSTYPE' -o "/boot/initrd.img-\$version" "\$version" || poweroff
+#_EOF_
 
 cat << '_EOF_' >> rootfs/etc/rc.local
 > /success

--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -902,15 +902,15 @@ setenv rootuuid "true"' /boot/boot.cmd
 			local apackages=('linux-image-amd64' 'os-prober')
 
 			# As linux-image-amd64 pulls initramfs, pre-install the intended implementation here already
-			if (( $G_HW_MODEL == 20 ))
-			then
+			#if (( $G_HW_MODEL == 20 ))
+			#then
 				# VM: Install tiny-initramfs with limited features but sufficient and much smaller + faster
-				apackages+=('tiny-initramfs')
-			else
+			#	apackages+=('tiny-initramfs')
+			#else
 				# Install and use zstd for better initramfs compression
 				apackages+=('initramfs-tools' 'zstd')
 				G_CONFIG_INJECT 'COMPRESS=' 'COMPRESS=zstd' /etc/initramfs-tools/initramfs.conf
-			fi
+			#fi
 
 			# Grub EFI with secure boot compatibility
 			if [[ -d '/boot/efi' ]] || dpkg-query -s 'grub-efi-amd64' &> /dev/null


### PR DESCRIPTION
To test whether this solves boot of VMX appliance on Parallels.