### PR TITLE
linux-headers-generic: Required for Nvidia GPU.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ v8.16
 Enhancements:
 
 Bug fixes:
+- DietPi-Config | Resolved an issue where selecting the Nvidia driver on x86_64 systems did not actually install the needed kernel module if kernel headers were not installed before. Headers matching your kernel package are now installed automatically when selecting this option, to have the driver compiled and installed.
 - DietPi-Software | Fail2Ban: Resolved a DietPi v8.11 regression where moving logs to systemd journal on install fails due to a typo.
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/xxxx

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -539,7 +539,7 @@ A long (or insufficiently manufactured) cable may required a higher boost settin
 			dpkg-query -s nvidia-driver &> /dev/null && nvidia_installed=1 nvidia_text='[Installed] Uninstall'
 
 			local intel_installed=0 intel_text='Install'
-			dpkg-query -s xserver-xorg-video-intel &> /dev/null && intel_installed=1 intel_text='[Installed] Uninstall'
+			dpkg-query -s i965-va-driver &> /dev/null && intel_installed=1 intel_text='[Installed] Uninstall'
 
 			local amd_installed=0 amd_text='Install'
 			dpkg-query -s xserver-xorg-video-amdgpu &> /dev/null && amd_installed=1 amd_text='[Installed] Uninstall'
@@ -557,9 +557,13 @@ A long (or insufficiently manufactured) cable may required a higher boost settin
 			then
 				if (( $nvidia_installed ))
 				then
-					G_AGP nvidia-driver nvidia-xconfig nvidia-driver-libs-i386 libgl1-nvidia-glx
+					G_AGP nvidia-driver nvidia-driver-libs nvidia-xconfig libgl1-nvidia-glx
 				else
-					G_AGI nvidia-driver
+					local headers=()
+					dpkg-query -s 'linux-image-amd64' &> /dev/null && headers+=('linux-headers-amd64')
+					dpkg-query -s 'linux-image-cloud-amd64' &> /dev/null && headers+=('linux-headers-cloud-amd64')
+					dpkg-query -s 'linux-image-rt-amd64' &> /dev/null && headers+=('linux-headers-rt-amd64')
+					G_AGI "${headers[@]}" nvidia-driver
 				fi
 
 			elif [[ $G_WHIP_RETURNED_VALUE == 'Intel' ]]
@@ -568,7 +572,7 @@ A long (or insufficiently manufactured) cable may required a higher boost settin
 				then
 					G_AGP i965-va-driver xserver-xorg-video-intel
 				else
-					G_AG_CHECK_INSTALL_PREREQ i965-va-driver xserver-xorg-video-intel libgl1-mesa-dri
+					G_AG_CHECK_INSTALL_PREREQ i965-va-driver libgl1-mesa-dri
 				fi
 
 			elif [[ $G_WHIP_RETURNED_VALUE == 'AMD' ]]


### PR DESCRIPTION
Hello :)

Headers are required for building DKMS modules.
Tested on 1660ti. Desktop fails to load without headers pre-installed during Nvidia driver install.

Not had time to test with ```dietpi-software install 16``` (build-essential). However, both methods should end in same result?

With headers installed:
```
Building for 5.10.0-21-amd64
Building initial module for 5.10.0-21-amd64
Done.

nvidia-current.ko:
Running module version sanity check.
 - Original module
   - No original module exists within this kernel
 - Installation
   - Installing to /lib/modules/5.10.0-21-amd64/updates/dkms/

nvidia-current-modeset.ko:
Running module version sanity check.
 - Original module
   - No original module exists within this kernel
 - Installation
   - Installing to /lib/modules/5.10.0-21-amd64/updates/dkms/

nvidia-current-drm.ko:
Running module version sanity check.
 - Original module
   - No original module exists within this kernel
 - Installation
   - Installing to /lib/modules/5.10.0-21-amd64/updates/dkms/

nvidia-current-uvm.ko:
Running module version sanity check.
 - Original module
   - No original module exists within this kernel
 - Installation
   - Installing to /lib/modules/5.10.0-21-amd64/updates/dkms/

nvidia-current-peermem.ko:
Running module version sanity check.
 - Original module
   - No original module exists within this kernel
 - Installation
   - Installing to /lib/modules/5.10.0-21-amd64/updates/dkms/

depmod....

DKMS: install completed.
Setting up nvidia-driver (470.161.03-1) ...
```

<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
