### PR TITLE
Parallels | Fix boot by adding the BusLogic driver to initramfs

### DIFF
--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -403,7 +403,7 @@ _EOF_
 echo '[ INFO ] Rebuilding virtual machine initramfs to support all virtualizers...'
 version=\$(dpkg --get-selections | mawk '\$1~/^linux-image-.*-$parch\$/{print \$1;exit}') || poweroff
 version=\${version#linux-image-}
-mktirfs -m no -M no --include-modules='ahci,sd_mod,vmw_pvscsi,hv_storvsc,virtio_scsi,virtio_pci,$FSTYPE' -o "/boot/initrd.img-\$version" "\$version" || poweroff
+mktirfs -m no -M no --include-modules='ahci,sd_mod,vmw_pvscsi,hv_storvsc,virtio_scsi,virtio_pci,BusLogic,$FSTYPE' -o "/boot/initrd.img-\$version" "\$version" || poweroff
 _EOF_
 
 cat << '_EOF_' >> rootfs/etc/rc.local


### PR DESCRIPTION
It works with the current `hda` image. On new Parallels after renaming and converting to `hdd`. However, it is much nicer to have a full VMX appliance, which requires the BusLogic driver when using the preferred SCSI controller.