### PR TITLE
DietPi-Software | Support Raspberry Pi with 64-bit kernel on 32-bit OS

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Enhancements:
 Bug fixes:
 - General | Added more generic support for obtaining the CPU temperature, covering some thin clients and potentially other systems where no CPU temperature was shown when running the "cpu" command or enabling it for the login banner.
 - Orange Pi 5/ROCK 5B | Resolved an issue where the wrong serial console device name was expected. The correct /dev/ttyFIQ0 will be enabled on DietPi update and patched for a baudrate of 1,500,000.
+- Raspberry Pi | With the recent official Raspberry Pi kernel upgrade, Raspberry Pi 4 systems do now boot with the 64-bit kernel by default, even if the underlying OS/userland is 32-bit. While we doubt in any practical benefits, dietpi-software has been patched to correctly deal with this case, i.e. installing 32-bit packages and binaries instead of relying on the "uname -m" kernel architecture output. Some 3rd party software installers may still fail to deal with this case, but we give it a chance for now and hope that affected installers can be relatively easily made compatible.
 - DietPi-Config | Resolved an issue where selecting the Nvidia driver on x86_64 systems did not actually install the needed kernel module if kernel headers were not installed before. Headers matching your kernel package are now installed automatically when selecting this option, to have the driver compiled and installed.
 - DietPi-Software | Fail2Ban: Resolved a DietPi v8.11 regression where moving logs to systemd journal on install fails due to a typo.
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -190,6 +190,12 @@ Available commands:
 	declare -A aSOFTWARE_AVAIL_G_HW_ARCH
 	declare -A aSOFTWARE_AVAIL_G_DISTRO
 
+	# ToDo: On RPi 4, the 64-bit kernel is now used by default, without "arm_64bit=1" set: https://forums.raspberrypi.com/viewtopic.php?p=2088935#p2088935
+	# - We could set "arm_64bit=0", but for now lets assure that 32-bit software is installed and see how it goes. This enables general support for RPi with 64-bit kernel running 32-bit userland.
+	# - Also set a little flag here for the "dietpi-software list" command to correctly show that a software title is disabled because of the userland architecture, not because of the kernel architecture.
+	RPI_64KERNEL_32OS=
+	[[ $G_HW_MODEL == [2-9] && $G_HW_ARCH == 3 && $(dpkg --print-architecture) == 'armhf' ]] && G_HW_ARCH=2 G_HW_ARCH_NAME='armv7l' RPI_64KERNEL_32OS='32-bit image'
+
 	# Generate arrays for all available software titles
 	Software_Arrays_Init()
 	{
@@ -14443,7 +14449,7 @@ _EOF_
 					# Available for G_HW_ARCH?
 					if (( ! ${aSOFTWARE_AVAIL_G_HW_ARCH[$i,$G_HW_ARCH]:=1} )); then
 
-						string+=" \e[31mDISABLED for $G_HW_ARCH_NAME\e[0m"
+						string+=" \e[31mDISABLED for ${RPI_64KERNEL_32OS:-$G_HW_ARCH_NAME}\e[0m"
 
 					# Available for G_HW_MODEL?
 					elif (( ! ${aSOFTWARE_AVAIL_G_HW_MODEL[$i,$G_HW_MODEL]:=1} )); then


### PR DESCRIPTION
A very quick and easy fix. There may be some cases where this causes confusion when outside of `dietpi-software` "aarch64" is shown and within "armv7l" is shown. It would be better to cleanly differentiate between kernel architecture and userland/dpkg architecture. But this requires a larger rework and we won't be able to make this difference clear for inexperienced users in small info boxes. Also I hope that with our recent download page layout there won't be many cases of RPi 4 running 32-bit DietPi images. So probably not worth the effort.