### PR TITLE
Live patch 0 | Fix some software installs after recent kernel upgrade on RPi 4 with 32-bit OS/userland

### DIFF
--- a/.update/version
+++ b/.update/version
@@ -14,6 +14,8 @@ G_MIN_DEBIAN=5
 # Alternative Git branch to automatically migrate to when Debian version is too low
 G_OLD_DEBIAN_BRANCH='stretch'
 # Live patches
-G_LIVE_PATCH_DESC=()
-G_LIVE_PATCH_COND=()
-G_LIVE_PATCH=()
+G_LIVE_PATCH_DESC=('Fix some software installs after recent kernel upgrade on RPi 4 with 32-bit OS/userland')
+# shellcheck disable=SC2016
+G_LIVE_PATCH_COND=('[[ $G_HW_MODEL == 4 && $(dpkg --print-architecture) == armhf ]] && ! grep -q '\''\[\[ $G_HW_ARCH == 3 && $(dpkg --print-architecture) == armhf ]] && G_HW_ARCH=2 G_HW_ARCH_NAME=armv7l'\'' /boot/dietpi/dietpi-software')
+# shellcheck disable=SC2016
+G_LIVE_PATCH=('sed -i '\''/declare -A aSOFTWARE_AVAIL_G_DISTRO/a\\t[[ $G_HW_ARCH == 3 && $(dpkg --print-architecture) == armhf ]] && G_HW_ARCH=2 G_HW_ARCH_NAME=armv7l'\'' /boot/dietpi/dietpi-software')


### PR DESCRIPTION
As of this change: https://forums.raspberrypi.com/viewtopic.php?p=2088935#p2088935

Luckily we replaced quite a bunch of 3rd party installers in the meantime, so at least `dietpi-software` installs should be otherwise fine. Pi-hole supports this case already, PiVPN does not install any binary, but I need to go again through all of them.

The alternative would have been to add `arm_64bit=0`, but since, while I doubt it, some say it had performance benefits, and the CMA raise to 512 MiB seems to have issues with the 32-bit kernel, I want to give it a chance. The patch is only for RPi 4, on [dev](https://github.com/MichaIng/DietPi/pull/6274) I want to support `arm_64bit=1` on 32-bit userland for all RPi models.