### PR TITLE
DietPi-Config | Audio: Intel + firmware-sof-signed

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ Enhancements:
 Bug fixes:
 - General | Resolved an issue where our recent images had the cron service masked accidentally after first run setup. Many thanks to @Johannes for reporting this issue: https://dietpi.com/forum/t/cron-service-is-masked/16544
 - DietPi-Globals | Resolved a DietPi v8.16 regression where wrong CPU temperatures were shown on some devices. Many thanks to @duledxb for reporting this issue: https://github.com/MichaIng/DietPi/issues/6315
+- DietPi-Config | Audio: 'firmware-sof-signed' required for functionality on some Intel devices, is now installed when selecting 'intel-sst-dsp': https://github.com/MichaIng/DietPi/issues/6281#issuecomment-1500990841
 - DietPi-Software | Home Assistant: Resolved an issue where to installation on 32-bit ARM systems failed since Python cryptography source builds do now require pky-config. Many thanks to @retrofame for reporting this issue: https://dietpi.com/forum/t/unable-to-upgrade-home-assistant-to-2021-10-x/5823/7
 - DietPi-Software | HTPC Manager/Synapse: Resolved an issue where to installation on 32-bit ARM Bookworm systems failed since Python cryptography source builds do now require pky-config.
 - DietPi-Software | microblog.pub: Resolved an issue where the installation failed on 32-bit ARM devices since a Rust compiler is required for the cryptography Python module build. Many thanks to @kinoushe for reporting this issue: https://github.com/MichaIng/DietPi/issues/6304

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -3310,7 +3310,6 @@ Additional benchmarks:
 		if [[ $G_WHIP_RETURNED_VALUE == 'Disable' ]]; then
 
 			/boot/dietpi/func/dietpi-set_hardware soundcard none
-			G_AGP alsa-utils libasound2-plugin-equal firmware-intel-sound
 			[[ -d '/etc/systemd/system/alsa-state.service.d' ]] && G_EXEC rm -R /etc/systemd/system/alsa-state.service.d
 			[[ -f '/boot/dietpi/.installed' ]] && G_CONFIG_INJECT 'aSOFTWARE_INSTALL_STATE\[5\]=' 'aSOFTWARE_INSTALL_STATE[5]=0' /boot/dietpi/.installed
 

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -1896,8 +1896,14 @@ _EOF_
 				fi
 			;;
 
-			# Intel SST DSP
-			'intel-sst-dsp') G_AG_CHECK_INSTALL_PREREQ 'firmware-intel-sound';;
+                        # Intel SST DSP
+                        'intel-sst-dsp')
+
+                                local aPackages=('firmware-intel-sound')
+                                (( $G_DISTRO >= 6 )) && aPackages+=('firmware-sof-signed') #Buster additions
+                                G_AG_CHECK_INSTALL_PREREQ "${aPackages[@]}"
+
+                        ;;
 
 			# --------------- Sparky SBC ------------
 			# Allo Piano DAC (firmware + module)

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -1906,7 +1906,7 @@ _EOF_
                         'intel-sst-dsp')
 
                                 local aPackages=('firmware-intel-sound')
-                                (( $G_DISTRO >= 6 )) && aPackages+=('firmware-sof-signed') #Buster additions
+                                (( $G_DISTRO > 5 )) && aPackages+=('firmware-sof-signed') # Available since Bullseye
                                 G_AG_CHECK_INSTALL_PREREQ "${aPackages[@]}"
 
                         ;;

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -1819,13 +1819,13 @@ _EOF_
 		[[ $INPUT_DEVICE_VALUE ]] || Unknown_Input_Mode
 		#-----------------------------------------------------------------------------
                 # Remove all known audio based packages
-                if [[ $INPUT_DEVICE_VALUE == 'none' ]] 
+                if [[ $INPUT_DEVICE_VALUE == 'none' ]]
                 then
                         G_AGP alsa-utils libasound2-plugin-equal firmware-intel-sound firmware-sof-signed
-                # Install base alsa package 
+                # Install base alsa package
                 else
                         G_AG_CHECK_INSTALL_PREREQ alsa-utils
-                fi 
+                fi
 		# Always reset sound cards and revert back to defaults
 		Soundcard_Reset_All
 		# Print info

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -1818,8 +1818,14 @@ _EOF_
 		# An input is required
 		[[ $INPUT_DEVICE_VALUE ]] || Unknown_Input_Mode
 		#-----------------------------------------------------------------------------
-		# Failsafe: Assure installed alsa-utils, if sound card has been selected
-		[[ $INPUT_DEVICE_VALUE == 'none' ]] || G_AG_CHECK_INSTALL_PREREQ alsa-utils
+                # Remove all known audio based packages
+                if [[ $INPUT_DEVICE_VALUE == 'none' ]] 
+                then
+                        G_AGP alsa-utils libasound2-plugin-equal firmware-intel-sound firmware-sof-signed
+                # Install base alsa package 
+                else
+                        G_AG_CHECK_INSTALL_PREREQ alsa-utils
+                fi 
 		# Always reset sound cards and revert back to defaults
 		Soundcard_Reset_All
 		# Print info


### PR DESCRIPTION
Required for some Intel devices for audio functionality: https://github.com/MichaIng/DietPi/issues/6281#issuecomment-1500990841
- Moves package removals from DietPi-Config to ```dietpi_set-hardware soundcard none```