### PR TITLE
DietPi-Software | Home Assistant

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11197,7 +11197,8 @@ _EOF_
 			local custom_pip_deps=$(sed -n '/^[[:blank:]]*SOFTWARE_HOMEASSISTANT_PIP_DEPS=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			# - All: gcc, libc6-dev, make, libssl-dev, zlib1g-dev for Python build and libbz2-dev, libreadline-dev, libsqlite3-dev, liblzma-dev to suppress warnings
 			# - All: libffi-dev to solve "ModuleNotFoundError: No module named '_ctypes'", for python-slugify==4.0.1 build on ARMv8/x86_64 and cffi build on ARMv6/7 Bookworm
-			aDEPS=('gcc' 'libc6-dev' 'make' 'libssl-dev' 'zlib1g-dev' 'libbz2-dev' 'libreadline-dev' 'libsqlite3-dev' 'liblzma-dev' 'libffi-dev')
+			# - All: xz-utils for Python build as the archive is compressed with xz now
+			aDEPS=('gcc' 'libc6-dev' 'make' 'libssl-dev' 'zlib1g-dev' 'libbz2-dev' 'libreadline-dev' 'libsqlite3-dev' 'liblzma-dev' 'libffi-dev' 'xz-utils')
 			mapfile -t -d' ' -O "${#aDEPS[@]}" aDEPS < <(echo -n "$custom_apt_deps")
 			# - ARMv6/7
 			G_EXEC mkdir -p "$ha_home"


### PR DESCRIPTION
DietPi-Software | Home Assistant - add package `xz-utils` as dependency.