### PR TITLE
DietPi-Software | Home Assistant/HTPC Manager: Add pkg-config for cryptography source builds

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ New software:
 Enhancements:
 
 Bug fixes:
+- DietPi-Software | Home Assistant: Resolved an issue where to installation on 32-bit ARM systems failed since Python cryptography source builds do now require pky-config. Many thanks to @retrofame for reporting this issue: https://dietpi.com/forum/t/unable-to-upgrade-home-assistant-to-2021-10-x/5823/7
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/xxxx
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Enhancements:
 
 Bug fixes:
 - DietPi-Software | Home Assistant: Resolved an issue where to installation on 32-bit ARM systems failed since Python cryptography source builds do now require pky-config. Many thanks to @retrofame for reporting this issue: https://dietpi.com/forum/t/unable-to-upgrade-home-assistant-to-2021-10-x/5823/7
+- DietPi-Software | HTPC Manager: Resolved an issue where to installation on 32-bit ARM Bookworm systems failed since Python cryptography source builds do now require pky-config.
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/xxxx
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10206,8 +10206,8 @@ _EOF_
 					then
 						G_AGI libtiff5 libopenjp2-7 libxcb1 # ARMv6/7: Runtime libs for Pillow from piwheels (libtiff5 pulls libjpeg62-turbo)
 					else
-						# Bookworm: Most wheels need to be compiled: gcc and libffi-dev for cffi, libssl-dev and Rust for cryptography and bcrypt, make for PyNaCl, libjpeg62-turbo-dev for Pillow
-						G_AGI gcc libffi-dev libssl-dev make libjpeg62-turbo-dev
+						# Bookworm: Most wheels need to be compiled: gcc and libffi-dev for cffi, libssl-dev and Rust for cryptography and bcrypt, make for PyNaCl, libjpeg62-turbo-dev for Pillow, pkg-config for cryptography
+						G_AGI gcc libffi-dev libssl-dev make libjpeg62-turbo-dev pkg-config
 						G_EXEC curl -sSf 'https://sh.rustup.rs/' -o rustup-init.sh
 						G_EXEC chmod +x rustup-init.sh
 						G_EXEC_OUTPUT=1 G_EXEC ./rustup-init.sh -y --profile minimal

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11204,8 +11204,8 @@ _EOF_
 			G_EXEC chown "$ha_user:$ha_user" "$ha_home"
 			if [[ $G_HW_ARCH == [12] ]]
 			then
-				# libjpeg62-turbo-dev for Pillow, libatlas-base-dev for numpy
-				aDEPS+=('libjpeg62-turbo-dev' 'libatlas-base-dev')
+				# libjpeg62-turbo-dev for Pillow, libatlas-base-dev for numpy, pkg-config for cryptography
+				aDEPS+=('libjpeg62-turbo-dev' 'libatlas-base-dev' 'pkg-config')
 				# Rust for cryptography
 				G_EXEC curl -sSf 'https://sh.rustup.rs/' -o rustup-init.sh
 				G_EXEC chmod +x rustup-init.sh


### PR DESCRIPTION
DietPi-Software | Home Assistant - add package `pkg-config` as dependency for 32bit systems as it is required for building wheel for cryptography.

https://dietpi.com/forum/t/unable-to-upgrade-home-assistant-to-2021-10-x/5823/7