### PR TITLE
CI | DietPi-Software: Further fixes and workarounds

### DIFF
--- a/.github/workflows/dietpi-software.yml
+++ b/.github/workflows/dietpi-software.yml
@@ -59,7 +59,7 @@ jobs:
         - { arch: riscv64, dist: buster }
         - { arch: riscv64, dist: bullseye }
       fail-fast: false
-    name: "Install: ${{ matrix.arch }} - ${{ matrix.dist }} - ${{ github.event.inputs.soft }}"
+    name: "${{ matrix.arch }} - ${{ matrix.dist }} - ${{ github.event.inputs.soft }}"
     runs-on: ubuntu-22.04
     steps:
     - name: Install

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3631,7 +3631,8 @@ _EOF_
 			Remove_SysV mysql 1
 
 			# Assure correct owner in case the database dir got migrated from a different system: https://github.com/MichaIng/DietPi/issues/4721#issuecomment-917051930
-			[[ $(stat -c '%U' /mnt/dietpi_userdata/mysql/mysql) == 'mysql' ]] || G_EXEC chown -R mysql:mysql /mnt/dietpi_userdata/mysql
+			# - The group is correctly recursively fixed by the preinst script already.
+			[[ -d '/mnt/dietpi_userdata/mysql/mysql' && $(stat -c '%U' /mnt/dietpi_userdata/mysql/mysql) != 'mysql' ]] && find /mnt/dietpi_userdata/mysql ! -user root ! -user mysql -exec chown mysql {} +
 
 			# Force service to start before cron
 			G_EXEC mkdir -p /etc/systemd/system/mariadb.service.d


### PR DESCRIPTION
1. The isolated network does not work because `systemd-networkd` cannot be executed via `qemu-user`: https://gitlab.com/qemu-project/qemu/-/issues/348. Reverted.
2. The failing Redis server was not due to some port conflict, but because of `PrivateUsers=true` which fails within systemd containers in general. Workaround applied.
3. We still want to see whether port conflicts were an issue in case of a failure, hence `ss -tlpn` output added.
4. We at least want to see whether all installed services start, now done before the shutdown after successful installs.
5. On Buster, MariaDB service start fails. With our usual symlink applied, it fails with write permission issues, already during package `postinst`, while everything is owned correctly. When skipping the symlink, it however still does not work, the service start seems to hang forever.
    Issues cannot be replicated in systemd container with or without QEMU locally, so it seems to be an issue with the GitHub Actions runners in particular.
    There was another warning in the logs about the platform not supporting AIO, but disabling it explicitly + some other related settings doesn't help either: https://stackoverflow.com/questions/56160301/cant-restart-mysql-caused-by-innodb#62888364
6. Finally `Type=exec` solves it. With `Type=notify` (the way the service is shipped upstream and on Debian) for some reason never finishes. `mysqld` fully starts up and prints "ready to take connections", the final version info + which port/socket it is listening, but ExecStartPost is not running and the command queue does not continue, i.e. systemd does not receive the expected notify signal. The whole thing times out after 900 seconds.