### PR TITLE
Raspberry Pi | Fix analogue onboard audio selection

### DIFF
--- a/.update/patches
+++ b/.update/patches
@@ -1257,8 +1257,25 @@ Patch_8_17()
 	# https://dietpi.com/forum/t/cron-service-is-masked/16544
 	[[ $(systemctl is-enabled cron) == 'masked' ]] && G_EXEC systemctl unmask cron
 
+	# RPi: Patch onboard audio
+	if (( $G_HW_MODEL < 10 ))
+	then
+		[[ -f '/etc/modprobe.d/dietpi-disable_rpi_sound.conf' ]] && G_EXEC mv /etc/modprobe.d/dietpi-disable_rpi_{sound,audio}.conf
+		if grep -q '^[[:blank:]]*dtoverlay=dietpi-disable_hdmi_audio' /boot/config.txt
+		then
+			G_EXEC sed -i '/^[[:blank:]]*dtoverlay=dietpi-disable_hdmi_audio/d' /boot/config.txt
+			G_EXEC sed -i '/root=/s/$/ snd_bcm2835.enable_hdmi=0/' /boot/cmdline.txt
+		fi
+		if grep -q '^[[:blank:]]*dtoverlay=dietpi-disable_headphones' /boot/config.txt
+		then
+			G_EXEC sed -i '/^[[:blank:]]*dtoverlay=dietpi-disable_headphones/d' /boot/config.txt
+			G_EXEC sed -i '/root=/s/$/ snd_bcm2835.enable_headphones=0/' /boot/cmdline.txt
+		fi
+		[[ -f '/boot/overlays/dietpi-disable_hdmi_audio.dtbo' ]] && G_EXEC rm /boot/overlays/dietpi-disable_hdmi_audio.dtbo
+		[[ -f '/boot/overlays/dietpi-disable_headphones.dtbo' ]] && G_EXEC rm /boot/overlays/dietpi-disable_headphones.dtbo
+
 	# NanoPi R4S
-	if (( $G_HW_MODEL == 47 ))
+	elif (( $G_HW_MODEL == 47 ))
 	then
 		G_DIETPI-NOTIFY 2 'Updating udev rule for NanoPi R4S Ethernet LEDs'
 		G_EXEC eval 'echo '\''ledtrig-netdev'\'' > /etc/modules-load.d/dietpi-eth-leds.conf'

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Enhancements:
 
 Bug fixes:
 - General | Resolved an issue where our recent images had the cron service masked accidentally after first run setup. Many thanks to @Johannes for reporting this issue: https://dietpi.com/forum/t/cron-service-is-masked/16544
+- Raspberry Pi | Resolved an issue where enabling the 3.5mm analogue onboard audio jack did not work if a HDMI device was attached, since due to a change with Linux 6.1 HDMI audio was not disabled correctly. Many thanks to @Gale for reporting this issue: https://dietpi.com/forum/t/no-audio-from-rpi-4b-headphone-jack/16538
 - DietPi-Globals | Resolved a DietPi v8.16 regression where wrong CPU temperatures were shown on some devices. Many thanks to @duledxb for reporting this issue: https://github.com/MichaIng/DietPi/issues/6315
 - DietPi-Config | Audio: 'firmware-sof-signed' required for functionality on some Intel devices, is now installed when selecting 'intel-sst-dsp': https://github.com/MichaIng/DietPi/issues/6281#issuecomment-1500990841
 - DietPi-Software | Resolved an issue where it was possible to install software titles via AUTO_SETUP_INSTALL_SOFTWARE_ID dietpi.txt entries on unsupported platforms.

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -18,7 +18,7 @@ $FP_SCRIPT	eth-forcespeed		10/100/1000/disable
 $FP_SCRIPT	wifimodules		enable/disable/onboard_enable/onboard_disable
 $FP_SCRIPT	wificountrycode		GB/US/DE/...
 $FP_SCRIPT	bluetooth		enable/disable
-$FP_SCRIPT	serialconsole		enable/disable		[(tty(S|AMA|SAC|AML|SC|GS|FIQ|MV)|hvc)[0-9]] (optional Serial/UART device)
+$FP_SCRIPT	serialconsole		enable/disable	[(tty(S|AMA|SAC|AML|SC|GS|FIQ|MV)|hvc)[0-9]] (optional Serial/UART device)
 $FP_SCRIPT	i2c			enable/disable/khz
 $FP_SCRIPT	spi			enable/disable
 $FP_SCRIPT	soundcard		target_card (non-matching name for reset to default). Add '-eq' to target_card string to enable ALSA equalizer on card. HW:x,x (specify target card and device index eg: HW:9,1)
@@ -39,14 +39,13 @@ $FP_SCRIPT	gpudriver		none|intel|nvidia|amd|custom
 	INPUT_DEVICE_NAME=${1,,}
 	INPUT_DEVICE_VALUE=${2,,}
 	# - Support for 1/0 inputs to enable/disable.
-	if [[ $INPUT_DEVICE_VALUE == '1' ]]; then
-
+	if [[ $INPUT_DEVICE_VALUE == '1' ]]
+	then
 		INPUT_DEVICE_VALUE='enable'
 
-	elif [[ $INPUT_DEVICE_VALUE == '0' ]]; then
-
+	elif [[ $INPUT_DEVICE_VALUE == '0' ]]
+	then
 		INPUT_DEVICE_VALUE='disable'
-
 	fi
 	INPUT_ADDITIONAL=$3
 
@@ -80,32 +79,28 @@ $FP_SCRIPT	gpudriver		none|intel|nvidia|amd|custom
 
 	EXIT_CODE=0
 
-	Unknown_Input_Name(){
-
+	Unknown_Input_Name()
+	{
 		G_DIETPI-NOTIFY 2 "Unknown input name ($INPUT_DEVICE_NAME). Nothing has been applied."
 		echo "$AVAIABLE_COMMANDS"
 		EXIT_CODE=1
-
 	}
 
-	Unknown_Input_Mode(){
-
+	Unknown_Input_Mode()
+	{
 		G_DIETPI-NOTIFY 2 "Unknown input value ($INPUT_DEVICE_VALUE). Nothing has been applied."
 		echo "$AVAIABLE_COMMANDS"
 		EXIT_CODE=1
-
 	}
 
-	Unsupported_Input_Name(){
-
+	Unsupported_Input_Name()
+	{
 		G_DIETPI-NOTIFY 2 "Input name ($INPUT_DEVICE_NAME) is not supported on your system. Nothing has been applied."
-
 	}
 
-	Unsupported_Input_Mode(){
-
+	Unsupported_Input_Mode()
+	{
 		G_DIETPI-NOTIFY 2 "Input value ($INPUT_DEVICE_VALUE) is not supported on your system. Nothing has been applied."
-
 	}
 
 	#/////////////////////////////////////////////////////////////////////////////////////
@@ -655,7 +650,7 @@ _EOF_
 				[[ $params ]] && params=$(mawk -F, '{for(i=1; i<=NF; i++) {if($i~/^cma-*/){print $i;exit}}}' <<< "$params")
 			else
 				# Disable full KMS HDMI audio if onboard HDMI is disabled
-				[[ $params != *',noaudio'* ]] && { ! grep -q '^[[:blank:]]*dtparam=audio=on' /boot/config.txt || grep -q '^[[:blank:]]*dtoverlay=dietpi-disable_hdmi_audio' /boot/config.txt; } && params+=',noaudio'
+				[[ $params != *',noaudio'* ]] && { ! grep -q '^[[:blank:]]*dtparam=audio=on' /boot/config.txt || grep -Eq '(^|[[:blank:]])snd_bcm2835.enable_hdmi=0([[:blank:]]|$)' /boot/cmdline.txt; } && params+=',noaudio'
 			fi
 
 			# Use additional argument for CMA size
@@ -682,49 +677,29 @@ _EOF_
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# lcdpanel: All non-HDMI/VGA based displays and monitors
 	#/////////////////////////////////////////////////////////////////////////////////////
-	Lcd_Panel_Main(){
+	Lcd_Panel_Main()
+	{
+		case $INPUT_DEVICE_VALUE in
+			'odroid-lcd35') Lcd_Panel_OdroidLCD35_Enable;;
+			'waveshare32') Lcd_Panel_Waveshare32_Enable;;
+			'odroid-cloudshell') Lcd_Panel_Odroidcloudshell_Enable;;
+			'esp01215e') Lcd_Panel_ESP01215E_Enable;;
+			'allo-boss2-oled') OLED_Allo_Boss2_Enable;;
+			'none')
+				Lcd_Panel_Waveshare32_Disable
+				Lcd_Panel_Odroidcloudshell_Disable
+				Lcd_Panel_OdroidLCD35_Disable
+				Lcd_Panel_ESP01215E_Disable
+				OLED_Allo_Boss2_Disable
+			;;
+			*)
+				Unknown_Input_Mode
+				return 1
+			;;
+		esac
 
-		local update_dietpitxt=1
-
-		if [[ $INPUT_DEVICE_VALUE == 'odroid-lcd35' ]]; then
-
-			Lcd_Panel_OdroidLCD35_Enable
-
-		elif [[ $INPUT_DEVICE_VALUE == 'waveshare32' ]]; then
-
-			Lcd_Panel_Waveshare32_Enable
-
-		elif [[ $INPUT_DEVICE_VALUE == 'odroid-cloudshell' ]]; then
-
-			Lcd_Panel_Odroidcloudshell_Enable
-
-		elif [[ ${INPUT_DEVICE_VALUE,,} == 'esp01215e' ]]; then
-
-			Lcd_Panel_ESP01215E_Enable
-
-		elif [[ ${INPUT_DEVICE_VALUE,,} == 'allo-boss2-oled' ]]; then
-
-			OLED_Allo_Boss2_Enable
-
-		# Disable all
-		elif [[ $INPUT_DEVICE_VALUE == 'none' ]]; then
-
-			Lcd_Panel_Waveshare32_Disable
-			Lcd_Panel_Odroidcloudshell_Disable
-			Lcd_Panel_OdroidLCD35_Disable
-			Lcd_Panel_ESP01215E_Disable
-			OLED_Allo_Boss2_Disable
-
-		else
-
-			update_dietpitxt=0
-			Unknown_Input_Mode
-
-		fi
-
-		# Update dietpi.txt entry?
-		(( $update_dietpitxt )) && G_CONFIG_INJECT 'CONFIG_LCDPANEL=' "CONFIG_LCDPANEL=$INPUT_DEVICE_VALUE" /boot/dietpi.txt
-
+		# Update dietpi.txt entry
+		G_CONFIG_INJECT 'CONFIG_LCDPANEL=' "CONFIG_LCDPANEL=$INPUT_DEVICE_VALUE" /boot/dietpi.txt
 	}
 
 	Lcd_Panel_ESP01215E_Enable(){
@@ -743,7 +718,7 @@ _EOF_
 
 	Lcd_Panel_ESP01215E_Disable(){
 
-		(( $G_HW_MODEL > 9 )) && return # Skip on non-RPi
+		(( $G_HW_MODEL > 9 )) && return 0 # Skip on non-RPi
 
 		G_EXEC sed -i '/^[[:blank:]]*hdmi_force_hotplug=/c\#hdmi_force_hotplug=1' /boot/config.txt
 		G_EXEC sed -i '/^[[:blank:]]*hdmi_group=/c\#hdmi_group=2' /boot/config.txt
@@ -759,9 +734,6 @@ _EOF_
 		G_AG_CHECK_INSTALL_PREREQ fbset xinput-calibrator xserver-xorg-input-evdev
 
 		G_EXEC mkdir -p /etc/X11/xorg.conf.d
-
-		# Create desktop icon for xcalibration
-		# - NB: libinput replaces this in start menu
 
 	}
 
@@ -1512,7 +1484,7 @@ _EOF_
 				# - RPi
 				elif (( $G_HW_MODEL < 10 ))
 				then
-					grep -q "console=$INPUT_ADDITIONAL" /boot/cmdline.txt || sed -i "/root=/s/[[:blank:]]*$/ console=$INPUT_ADDITIONAL,115200/" /boot/cmdline.txt
+					grep -q "console=$INPUT_ADDITIONAL" /boot/cmdline.txt || sed -i "/root=/s/$/ console=$INPUT_ADDITIONAL,115200/" /boot/cmdline.txt
 
 				# - Odroid C1/C2 legacy
 				elif [[ $G_HW_MODEL == 1[02] && -f '/boot/boot.ini' ]]
@@ -1734,17 +1706,16 @@ _EOF_
 	Soundcard_Reset_RPi()
 	{
 		# Remove device tree overlays which disable HDMI audio and 3.5mm jack and those for known sound card, disable I2S and HDMI drive
-		G_EXEC sed -Ei -e '/^[[:blank:]]*(dtoverlay=(dietpi-disable_(hdmi_audio|headphones)|allo-|applepi-dac|dionaudio-|googlevoicehat-soundcard|hifiberry-|i-sabre-q2m|iqaudio-|justboom-|rpi-dac)|dtparam=i2s)/d' -e 's/^[[:blank:]]*(hdmi_drive(:[01])?=.*$)/#\1/' /boot/config.txt
-
-		# Remove overlay files which disable HDMI audio and 3.5mm jack
-		[[ -f '/boot/overlays/dietpi-disable_hdmi_audio.dtbo' ]] && G_EXEC rm /boot/overlays/dietpi-disable_hdmi_audio.dtbo
-		[[ -f '/boot/overlays/dietpi-disable_headphones.dtbo' ]] && G_EXEC rm /boot/overlays/dietpi-disable_headphones.dtbo
+		G_EXEC sed -Ei -e '/^[[:blank:]]*(dtoverlay=(allo-|applepi-dac|dionaudio-|googlevoicehat-soundcard|hifiberry-|i-sabre-q2m|iqaudio-|justboom-|rpi-dac)|dtparam=i2s)/d' -e 's/^[[:blank:]]*(hdmi_drive(:[01])?=.*$)/#\1/' /boot/config.txt
 
 		# Disable onboard sound
 		G_CONFIG_INJECT 'dtparam=audio=' 'dtparam=audio=off' /boot/config.txt
 
 		# Blacklist onboard sound kernel module
-		G_EXEC eval 'echo '\''blacklist snd_bcm2835'\'' > /etc/modprobe.d/dietpi-disable_rpi_sound.conf'
+		G_EXEC eval 'echo '\''blacklist snd_bcm2835'\'' > /etc/modprobe.d/dietpi-disable_rpi_audio.conf'
+
+		# Remove kernel module options
+		G_EXEC sed -Ei '/root=/s/[[:blank:]]*snd_bcm2835.enable_[^[:blank:]]*([[:blank:]]*$)?//g' /boot/cmdline.txt
 
 		# Disable full KMS HDMI audio
 		local kms=$(grep -Em1 '^[[:blank:]]*dtoverlay=vc4-kms-v3d(-pi4)?(,|$)' /boot/config.txt)
@@ -1962,46 +1933,23 @@ _EOF_
 			'rpi-bcm2835-'*)
 
 				# Remove blacklist for onboard audio kernel module
-				G_EXEC rm /etc/modprobe.d/dietpi-disable_rpi_sound.conf
+				G_EXEC rm /etc/modprobe.d/dietpi-disable_rpi_audio.conf
 
 				# Enable onboard audio
 				G_CONFIG_INJECT 'dtparam=audio=' 'dtparam=audio=on' /boot/config.txt
 
-				# Force 3.5mm out?
+				# Force 3.5mm output?
 				if [[ $INPUT_DEVICE_VALUE == *'3.5mm' ]]
 				then
-					# Disable HDMI audio via dtoverlay
-					G_EXEC_DESC='Compiling device tree overlay: /boot/overlays/dietpi-disable_hdmi_audio.dtbo'
-					G_EXEC eval 'dtc -I dts -O dtb -o /boot/overlays/dietpi-disable_hdmi_audio.dtbo <<< '\''/dts-v1/;
-/plugin/;
-/ {
-	compatible = "brcm,bcm2835";
-	fragment@0 {
-		target = <&audio>;
-		__overlay__ {
-			brcm,disable-hdmi = <1>;
-		};
-	};
-};'\'
-					G_CONFIG_INJECT 'dtoverlay=dietpi-disable_hdmi_audio' 'dtoverlay=dietpi-disable_hdmi_audio' /boot/config.txt
+					# Disable HDMI audio via kernel module option
+					G_EXEC G_EXEC sed -i '/root=/s/$/ snd_bcm2835.enable_hdmi=0/' /boot/cmdline.txt
 
 				# Force HDMI output?
 				elif [[ $INPUT_DEVICE_VALUE == *'hdmi' ]]
 				then
-					# Disable headphones via dtoverlay
-					G_EXEC_DESC='Compiling device tree overlay: /boot/overlays/dietpi-disable_headphones.dtbo'
-					G_EXEC eval 'dtc -I dts -O dtb -o /boot/overlays/dietpi-disable_headphones.dtbo <<< '\''/dts-v1/;
-/plugin/;
-/ {
-	compatible = "brcm,bcm2835";
-	fragment@0 {
-		target = <&audio>;
-		__overlay__ {
-			brcm,disable-headphones = <1>;
-		};
-	};
-};'\'
-					G_CONFIG_INJECT 'dtoverlay=dietpi-disable_headphones' 'dtoverlay=dietpi-disable_headphones' /boot/config.txt
+					# Disable headphones via kernel module option
+					G_EXEC G_EXEC sed -i '/root=/s/$/ snd_bcm2835.enable_headphones=0/' /boot/cmdline.txt
+					# Force HDMI audio via config.txt option
 					G_CONFIG_INJECT 'hdmi_drive=' 'hdmi_drive=2' /boot/config.txt
 					(( $G_HW_MODEL == 4 )) && G_CONFIG_INJECT 'hdmi_drive:1=' 'hdmi_drive:1=2' /boot/config.txt 'hdmi_drive='
 				fi
@@ -2351,94 +2299,30 @@ _EOF_
 	#/////////////////////////////////////////////////////////////////////////////////////
 	#-----------------------------------------------------------------------------------
 	G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" "$INPUT_DEVICE_NAME ($INPUT_DEVICE_VALUE)"
-
 	#-----------------------------------------------------------------------------------
-	if [[ $INPUT_DEVICE_NAME == 'soundcard' ]]; then
-
-		Soundcard_Main
-
-	elif [[ $INPUT_DEVICE_NAME == 'serialconsole' ]]; then
-
-		Serial_Main
-
-	elif [[ $INPUT_DEVICE_NAME == 'bluetooth' ]]; then
-
-		Bluetooth_Main || EXIT_CODE=1
-
-	elif [[ $INPUT_DEVICE_NAME == 'wifimodules' ]]; then
-
-		Wifi_Modules_Main
-
-	elif [[ $INPUT_DEVICE_NAME == 'enableipv6' ]]; then
-
-		Enable_IPv6
-
-	elif [[ $INPUT_DEVICE_NAME == 'wificountrycode' ]]; then
-
-		Wifi_Countrycode_Main
-
-	elif [[ $INPUT_DEVICE_NAME == 'i2c' ]]; then
-
-		I2c_Main
-
-	elif [[ $INPUT_DEVICE_NAME == 'spi' ]]; then
-
-		SPI_Main
-
-	elif [[ $INPUT_DEVICE_NAME == 'lcdpanel' ]]; then
-
-		Lcd_Panel_Main
-
-	elif [[ $INPUT_DEVICE_NAME == 'rpi-opengl' ]]; then
-
-		RPi_OpenGL_Main
-
-	elif [[ $INPUT_DEVICE_NAME == 'eth-forcespeed' ]]; then
-
-		Eth_Force_Speed_Main
-
-	elif [[ $INPUT_DEVICE_NAME == 'remoteir' ]]; then
-
-		RemoteIR_Main
-
-	elif [[ $INPUT_DEVICE_NAME == 'gpumemsplit' ]]; then
-
-		Gpu_Memory_Split_Main
-
-	elif [[ $INPUT_DEVICE_NAME == 'rpi-camera' ]]; then
-
-		RPi_Camera_Main
-
-	elif [[ $INPUT_DEVICE_NAME == 'rpi-codec' ]]; then
-
-		RPi_Codec_Main
-
-	elif [[ $INPUT_DEVICE_NAME == 'rpi3_usb_boot' ]]; then
-
-		RPi_USB_Boot_Main
-
-	elif [[ $INPUT_DEVICE_NAME == 'rpi-eeprom' ]]; then
-
-		RPi_EEPROM
-
-	elif [[ $INPUT_DEVICE_NAME == 'vf2-spi-update' ]]; then
-
-		VF2_SPI_Update
-
-	elif [[ $INPUT_DEVICE_NAME == 'headless' ]]; then
-
-		Headless_Main
-
-	elif [[ $INPUT_DEVICE_NAME == 'gpudriver' ]]; then
-
-		GPUDriver_Main
-
-	else
-
-		Unknown_Input_Name
-
-	fi
-
+	case $INPUT_DEVICE_NAME in
+		'soundcard') Soundcard_Main;;
+		'serialconsole') Serial_Main;;
+		'bluetooth') Bluetooth_Main || EXIT_CODE=1;;
+		'wifimodules') Wifi_Modules_Main;;
+		'enableipv6') Enable_IPv6;;
+		'wificountrycode') Wifi_Countrycode_Main;;
+		'i2c') I2c_Main;;
+		'spi') SPI_Main;;
+		'lcdpanel') Lcd_Panel_Main;;
+		'rpi-opengl') RPi_OpenGL_Main;;
+		'eth-forcespeed') Eth_Force_Speed_Main;;
+		'remoteir') RemoteIR_Main;;
+		'gpumemsplit') Gpu_Memory_Split_Main;;
+		'rpi-camera') RPi_Camera_Main;;
+		'rpi-codec') RPi_Codec_Main;;
+		'rpi3_usb_boot') RPi_USB_Boot_Main;;
+		'rpi-eeprom') RPi_EEPROM;;
+		'vf2-spi-update') VF2_SPI_Update;;
+		'headless') Headless_Main;;
+		'gpudriver') GPUDriver_Main;;
+		*) Unknown_Input_Name;;
+	esac
 	#-----------------------------------------------------------------------------------
 	G_DIETPI-NOTIFY -1 "$EXIT_CODE" "$INPUT_DEVICE_NAME $INPUT_DEVICE_VALUE"
 	exit "$EXIT_CODE"


### PR DESCRIPTION
- Raspberry Pi | Resolved an issue where enabling the 3.5mm analogue onboard audio jack did not work if a HDMI device was attached, since due to a change with Linux 6.1 HDMI audio was not disabled correctly. Many thanks to `@Gale` for reporting this issue: https://dietpi.com/forum/t/no-audio-from-rpi-4b-headphone-jack/16538