### PR TITLE
DietPi-Software | Fix Rust installs on RPi 4 with 32-bit image

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,7 @@ Bug fixes:
 - DietPi-Software | Home Assistant: Resolved an issue where to installation on 32-bit ARM systems failed since Python cryptography source builds do now require pky-config. Many thanks to @retrofame for reporting this issue: https://dietpi.com/forum/t/unable-to-upgrade-home-assistant-to-2021-10-x/5823/7
 - DietPi-Software | HTPC Manager/Synapse: Resolved an issue where to installation on 32-bit ARM Bookworm systems failed since Python cryptography source builds do now require pky-config.
 - DietPi-Software | microblog.pub: Resolved an issue where the installation failed on 32-bit ARM devices since a Rust compiler is required for the cryptography Python module build. Many thanks to @kinoushe for reporting this issue: https://github.com/MichaIng/DietPi/issues/6304
+- DietPi-Software | Home Assistant/HTPC Manager/microblog-pub/Synapse: Resolved an issue where the install on RPi 4 with 32-bit image failed since rustup/cargo tried to compile for 64-bit. The issue occurred since the 64-bit kernel is used on RPi 4 by default since Linux 6.1, even if the OS/userland is 32-bit. Many thanks to @josh3003 for reporting this issue: https://github.com/MichaIng/DietPi/issues/6306
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/xxxx
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3848,7 +3848,8 @@ _EOF_
 						G_AGI gcc libffi-dev libpq-dev make libjpeg62-turbo-dev libssl-dev pkg-config
 						G_EXEC curl -sSf 'https://sh.rustup.rs/' -o rustup-init.sh
 						G_EXEC chmod +x rustup-init.sh
-						G_EXEC_OUTPUT=1 G_EXEC ./rustup-init.sh -y --profile minimal
+						# RPi with 64-bit kernel on 32-bit image: Enforce 32-bit toolchain: https://github.com/MichaIng/DietPi/issues/6306
+						G_EXEC_OUTPUT=1 G_EXEC ./rustup-init.sh -y --profile minimal ${RPI_64KERNEL_32OS:+'--default-host' 'armv7-unknown-linux-gnueabihf'}
 						G_EXEC rm rustup-init.sh
 						export PATH="/root/.cargo/bin:$PATH"
 					fi
@@ -4187,7 +4188,8 @@ _EOF_
 				# Rust for cryptography
 				G_EXEC curl -sSf 'https://sh.rustup.rs/' -o rustup-init.sh
 				G_EXEC chmod +x rustup-init.sh
-				G_EXEC_OUTPUT=1 G_EXEC sudo -u "$micro_name" ./rustup-init.sh -y --profile minimal
+				# RPi with 64-bit kernel on 32-bit image: Enforce 32-bit toolchain: https://github.com/MichaIng/DietPi/issues/6306
+				G_EXEC_OUTPUT=1 G_EXEC sudo -u "$micro_name" ./rustup-init.sh -y --profile minimal ${RPI_64KERNEL_32OS:+'--default-host' 'armv7-unknown-linux-gnueabihf'}
 				G_EXEC rm rustup-init.sh
 			fi
 
@@ -10224,7 +10226,8 @@ _EOF_
 						G_AGI gcc libffi-dev libssl-dev make libjpeg62-turbo-dev pkg-config
 						G_EXEC curl -sSf 'https://sh.rustup.rs/' -o rustup-init.sh
 						G_EXEC chmod +x rustup-init.sh
-						G_EXEC_OUTPUT=1 G_EXEC ./rustup-init.sh -y --profile minimal
+						# RPi with 64-bit kernel on 32-bit image: Enforce 32-bit toolchain: https://github.com/MichaIng/DietPi/issues/6306
+						G_EXEC_OUTPUT=1 G_EXEC ./rustup-init.sh -y --profile minimal ${RPI_64KERNEL_32OS:+'--default-host' 'armv7-unknown-linux-gnueabihf'}
 						G_EXEC rm rustup-init.sh
 						export PATH="/root/.cargo/bin:$PATH"
 					fi
@@ -11223,7 +11226,8 @@ _EOF_
 				# Rust for cryptography
 				G_EXEC curl -sSf 'https://sh.rustup.rs/' -o rustup-init.sh
 				G_EXEC chmod +x rustup-init.sh
-				G_EXEC_OUTPUT=1 G_EXEC sudo -u "$ha_user" ./rustup-init.sh -y --profile minimal
+				# RPi with 64-bit kernel on 32-bit image: Enforce 32-bit toolchain: https://github.com/MichaIng/DietPi/issues/6306
+				G_EXEC_OUTPUT=1 G_EXEC sudo -u "$ha_user" ./rustup-init.sh -y --profile minimal ${RPI_64KERNEL_32OS:+'--default-host' 'armv7-unknown-linux-gnueabihf'}
 				G_EXEC rm rustup-init.sh
 			fi
 


### PR DESCRIPTION
If the Rust install hangs forever on
```
info: syncing channel updates
```
then this is required as well:
```sh
echo 'abi.cp15_barrier=2' > /etc/sysctl.d/98-dietpi-cp15_barrier.conf
sysctl -p /etc/sysctl.d/98-dietpi-cp15_barrier.conf
```
Was needed on Odroid N2 with 32-bit image, but might be different on RPi. Would be great if someone could test this.