### PR TITLE
DietPi-Software | TasmoAdmin: Fixe firmware restriction error

### DIFF
--- a/.conf/dps_27/apache.tasmoadmin.conf
+++ b/.conf/dps_27/apache.tasmoadmin.conf
@@ -1,4 +1,4 @@
-<Directory /var/www/tasmoadmin/>
+<Directory /var/www/tasmoadmin>
 	Require all granted
 	AllowOverride All
 	Options FollowSymLinks

--- a/.conf/dps_27/lighttpd.tasmoadmin.conf
+++ b/.conf/dps_27/lighttpd.tasmoadmin.conf
@@ -1,10 +1,13 @@
 $HTTP["url"] =~ "^/tasmoadmin($|/)" {
-	# Restrict direct access to .htaccess and data directory
+	# Deny direct access to .htaccess and data directory
 	$HTTP["url"] =~ "^/tasmoadmin/(\.|data)" {
-		url.access-deny = ("")
+		# Allow direct access to firmwares
+		$HTTP["url"] !~ "^/tasmoadmin/data/firmwares" {
+			url.access-deny = ("")
+		}
 	}
 
-	# TasmoAdmin URL rewrite, required for sync clients
+	# TasmoAdmin URL rewrites required for sync clients
 	url.rewrite-if-not-file = (
 		"^/tasmoadmin/doAjax$" => "/tasmoadmin/index.php?doAjax=doAjax",
 		"^/tasmoadmin/doAjaxAll$" => "/tasmoadmin/index.php?doAjaxAll=doAjaxAll",

--- a/.conf/dps_27/nginx.tasmoadmin.conf
+++ b/.conf/dps_27/nginx.tasmoadmin.conf
@@ -1,10 +1,9 @@
 location ^~ /tasmoadmin {
-	# Allow access to firmwares
-	location ~ ^/tasmoadmin/data/firmwares {
-                allow all;
-        }
+	# Allow direct access to firmwares
+	location ^~ /tasmoadmin/data/firmwares {
+	}
 
-	# Deny access to .htaccess and data dir
+	# Deny direct access to .htaccess and data directory
 	location ~ ^/tasmoadmin/(?:\.|data) {
 		deny all;
 	}
@@ -21,6 +20,7 @@ location ^~ /tasmoadmin {
 	location ~* \.(css|js|gif||jpe?g|png|json|cache\.json)$ {
 	}
 
+	# TasmoAdmin URL rewrites required for sync clients
 	location /tasmoadmin {
 		rewrite ^/tasmoadmin/login$ /tasmoadmin/login.php last;
 		rewrite ^/tasmoadmin/logout$ /tasmoadmin/login.php?logout=logout last;

--- a/.conf/dps_27/nginx.tasmoadmin.conf
+++ b/.conf/dps_27/nginx.tasmoadmin.conf
@@ -1,6 +1,8 @@
 location ^~ /tasmoadmin {
-	location /tasmoadmin/firmwares {
-	}
+	# Allow access to firmwares
+	location ~ ^/tasmoadmin/data/firmwares {
+                allow all;
+        }
 
 	# Deny access to .htaccess and data dir
 	location ~ ^/tasmoadmin/(?:\.|data) {

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,6 +28,7 @@ Bug fixes:
 - DietPi-Software | SABnzbd: Resolved an issue where the service start failed on Buster systems since SABnzbd v4 does not support Python 3.7 anymore. The latest SABnzbd v3 is now installed instead on Buster systems. Many thanks to @githubchonger for reporting this issue: https://github.com/sabnzbd/sabnzbd/issues/2545
 - DietPi-Software | SABnzbd: Resolved an issue where the install failed on RISC-V and ARMv6/7 Bookworm systems due to missing dependencies for Python module builds.
 - DietPi-Software | UnRAR: Resolved an issue where the install failed on RISC-V systems, since the non-free "unrar" package is not available for this architecture yet. "unrar-free" is now installed instead.
+- DietPi-Software | TasmoAdmin: Resolved an issue with Nginx and Lighttpd webservers where firmware updates failed as direct web access to the firmwares path was denied. Many thanks to @SimonPHP for reporting and fixing this issue: https://github.com/MichaIng/DietPi/pull/6328
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/xxxx
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11232,7 +11232,7 @@ _EOF_
 				if (( $G_DISTRO > 6 ))
 				then
 					local fallback_url='https://github.com/TasmoAdmin/TasmoAdmin/releases/download/v3.0.2/tasmoadmin_v3.0.2.tar.gz'
-					Download_Install "$(curl -sSfL 'https://api.github.com/repos/TasmoAdmin/TasmoAdmin/releases/latest' | mawk -F\" '/"browser_download_url": ".*\/tasmoadmin_v[^"\/]*\.tar\.gz"$/{print $4}')"
+					Download_Install "$(curl -sSfL 'https://api.github.com/repos/TasmoAdmin/TasmoAdmin/releases/latest' | mawk -F\" '/^ *"browser_download_url": ".*\/tasmoadmin_v[^"\/]*\.tar\.gz"$/{print $4}')"
 
 				# v2 drops PHP <7.4 support: https://github.com/TasmoAdmin/TasmoAdmin/releases/tag/v2.0.0
 				elif (( $G_DISTRO > 5 ))


### PR DESCRIPTION
Tasmoadmin could not deploy update to clients because the `/tasmoadmin/data/firmwares` directory had restricted access. Additionally, the path given in this file was wrong. `/tasmoadmin/firmwares` doesn't exist.

<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
