### PR TITLE
NanoPi R series | Update Ethernet LED udev rules

### DIFF
--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -377,8 +377,8 @@ _EOF_
 			'55' ': NanoPi R2S'
 			'47' ': NanoPi R4S'
 			'76' ': NanoPi R5S/R5C'
-			'79' ': NanoPi R6S'
-			'72' ': ROCK Pi 4'
+			'79' ': NanoPi R6S/R6C'
+			'72' ': ROCK 4'
 			'73' ': ROCK Pi S'
 			'74' ': Radxa Zero'
 			'77' ': ROCK 3A'
@@ -856,7 +856,7 @@ setenv rootuuid "true"' /boot/boot.cmd
 			)
 
 			# Entropy daemon: Use modern rng-tools5 on all devices where it has been proven to work, else haveged: https://github.com/MichaIng/DietPi/issues/2806
-			if [[ $G_HW_MODEL -lt 10 || $G_HW_MODEL =~ ^14|15|16|24|29|42|46|58|68|72|74|76|78|79|80|81$ ]] # RPi, S922X, Odroid C4, RK3399 - 47 NanoPi R4S, Radxa Zero, NanoPi R5S, ROCK 5B, NanoPi R6S, Orange Pi 5, VisionFive 2
+			if [[ $G_HW_MODEL -lt 10 || $G_HW_MODEL =~ ^14|15|16|24|29|42|46|58|68|72|74|76|78|79|80|81$ ]] # RPi, S922X, Odroid C4, RK3399 - 47 NanoPi R4S, Radxa Zero, NanoPi R5S/R5C, ROCK 5B, NanoPi R6S/R6C, Orange Pi 5, VisionFive 2
 			then
 				aPACKAGES_REQUIRED_INSTALL+=('rng-tools5')
 			else
@@ -1715,7 +1715,7 @@ _EOF_'
 			/boot/dietpi/func/dietpi-set_hardware serialconsole enable ttySAC0
 			/boot/dietpi/func/dietpi-set_hardware serialconsole enable ttyGS0
 
-		# ROCKPro64, ROCK64, Pinebook Pro, NanoPi R4S, Quartz64, ASUS Tinker Board, NanoPi R2S, NanoPi NEO3, NanoPi M4V2, NanoPi M4/T4/NEO4, ROCK Pi 4, ROCK 3A
+		# ROCKPro64, ROCK64, Pinebook Pro, NanoPi R4S, Quartz64, ASUS Tinker Board, NanoPi R2S, NanoPi NEO3, NanoPi M4V2, NanoPi M4/T4/NEO4, ROCK 4, ROCK 3A
 		elif [[ $G_HW_MODEL =~ ^42|43|46|47|49|52|55|56|58|68|72|77$ ]]
 		then
 			/boot/dietpi/func/dietpi-set_hardware serialconsole enable ttyS2
@@ -1730,7 +1730,7 @@ _EOF_'
 		then
 			/boot/dietpi/func/dietpi-set_hardware serialconsole enable ttyS1
 
-		# NanoPi R5S, ROCK 5B, NanoPi R6S, Orange Pi 5
+		# NanoPi R5S/R5C, ROCK 5B, NanoPi R6S/R6C, Orange Pi 5
 		elif [[ $G_HW_MODEL =~ ^76|78|79|80$ ]]
 		then
 			/boot/dietpi/func/dietpi-set_hardware serialconsole enable ttyFIQ0
@@ -1965,8 +1965,8 @@ _EOF_
 			G_DIETPI-NOTIFY 2 'Enabling NanoPi R4S Ethernet LEDs'
 			G_EXEC eval 'echo '\''ledtrig-netdev'\'' > /etc/modules-load.d/dietpi-eth-leds.conf'
 			cat << '_EOF_' > /etc/udev/rules.d/dietpi-eth-leds.rules
-SUBSYSTEM=="leds", KERNEL=="lan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth0", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1"
-SUBSYSTEM=="leds", KERNEL=="wan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth1", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1"
+SUBSYSTEM=="leds", KERNEL=="lan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth0", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth0; /bin/ip l s down dev eth0"
+SUBSYSTEM=="leds", KERNEL=="wan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth1", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth1; /bin/ip l s down dev eth1"
 _EOF_
 		# NanoPi R2S
 		elif (( $G_HW_MODEL == 55 ))
@@ -1974,28 +1974,28 @@ _EOF_
 			G_DIETPI-NOTIFY 2 'Enabling NanoPi R2S Ethernet LEDs'
 			G_EXEC eval 'echo '\''ledtrig-netdev'\'' > /etc/modules-load.d/dietpi-eth-leds.conf'
 			cat << '_EOF_' > /etc/udev/rules.d/dietpi-eth-leds.rules
-SUBSYSTEM=="leds", KERNEL=="wan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth0", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1"
-SUBSYSTEM=="leds", KERNEL=="lan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth1", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1"
+SUBSYSTEM=="leds", KERNEL=="wan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth0", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth0; /bin/ip l s down dev eth0"
+SUBSYSTEM=="leds", KERNEL=="lan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth1", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth1; /bin/ip l s down dev eth1"
 _EOF_
-		# NanoPi R5S/R5C
+		# NanoPi R5S/R5C: In case, will be updated for R5C on first boot
 		elif (( $G_HW_MODEL == 76 ))
 		then
-			G_DIETPI-NOTIFY 2 'Enabling NanoPi R5S Ethernet LEDs'
+			G_DIETPI-NOTIFY 2 'Enabling NanoPi R5S/R5C Ethernet LEDs'
 			G_EXEC eval 'echo '\''ledtrig-netdev'\'' > /etc/modules-load.d/dietpi-eth-leds.conf'
 			cat << '_EOF_' > /etc/udev/rules.d/dietpi-eth-leds.rules
-SUBSYSTEM=="leds", KERNEL=="wan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth0", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1"
-SUBSYSTEM=="leds", KERNEL=="lan1_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth1", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1"
-SUBSYSTEM=="leds", KERNEL=="lan2_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth2", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1"
+SUBSYSTEM=="leds", KERNEL=="wan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth0", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth0; /bin/ip l s down dev eth0"
+SUBSYSTEM=="leds", KERNEL=="lan1_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth1", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth1; /bin/ip l s down dev eth1"
+SUBSYSTEM=="leds", KERNEL=="lan2_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth2", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth2; /bin/ip l s down dev eth2"
 _EOF_
-		# NanoPi R6S/R6C
+		# NanoPi R6S/R6C: In case, will be updated for R6C on first boot
 		elif (( $G_HW_MODEL == 79 ))
 		then
-			G_DIETPI-NOTIFY 2 'Enabling NanoPi R6S Ethernet LEDs'
+			G_DIETPI-NOTIFY 2 'Enabling NanoPi R6S/R6C Ethernet LEDs'
 			G_EXEC eval 'echo '\''ledtrig-netdev'\'' > /etc/modules-load.d/dietpi-eth-leds.conf'
 			cat << '_EOF_' > /etc/udev/rules.d/dietpi-eth-leds.rules
-SUBSYSTEM=="leds", KERNEL=="lan2_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth0", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1"
-SUBSYSTEM=="leds", KERNEL=="lan1_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth1", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1"
-SUBSYSTEM=="leds", KERNEL=="wan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth2", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1"
+SUBSYSTEM=="leds", KERNEL=="lan2_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth0", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth0; /bin/ip l s down dev eth0"
+SUBSYSTEM=="leds", KERNEL=="lan1_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth1", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth1; /bin/ip l s down dev eth1"
+SUBSYSTEM=="leds", KERNEL=="wan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth2", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth2; /bin/ip l s down dev eth2"
 _EOF_
 		fi
 

--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -75,14 +75,14 @@ shopt -s extglob
 		[69]='Firefly RK3399'
 		[70]='Sparky SBC'
 		[71]='BeagleBone Black'
-		[72]='ROCK Pi 4'
+		[72]='ROCK 4'
 		[73]='ROCK Pi S'
 		[74]='Radxa Zero'
 		[75]='Container'
 		[76]='NanoPi R5S/R5C'
 		[77]='ROCK 3A'
 		[78]='ROCK 5B'
-		[79]='NanoPi R6S'
+		[79]='NanoPi R6S/R6C'
 		[80]='Orange Pi 5'
 		[81]='StarFive VisionFive 2'
 	)
@@ -905,6 +905,8 @@ shopt -s extglob
 			[[ $i == 'Unknown Device (aarch64)' ]] && ((aDEVICE_NAME['Generic Device (aarch64)']+=aDEVICE_NAME["$i"])) && unset -v "aDEVICE_NAME[$i]"
 			[[ $i == 'NanoPi M1/T1 (armv7l)' ]] && ((aDEVICE_NAME['NanoPi M1 (armv7l)']+=aDEVICE_NAME["$i"])) && unset -v "aDEVICE_NAME[$i]" # v8.11
 			[[ $i == 'NanoPi R5S (aarch64)' ]] && ((aDEVICE_NAME['NanoPi R5S/R5C (aarch64)']+=aDEVICE_NAME["$i"])) && unset -v "aDEVICE_NAME[$i]" # v8.13
+			[[ $i == 'NanoPi R6S (aarch64)' ]] && ((aDEVICE_NAME['NanoPi R6S/R6C (aarch64)']+=aDEVICE_NAME["$i"])) && unset -v "aDEVICE_NAME[$i]" # v8.17
+			[[ $i == 'ROCK Pi 4 (aarch64)' ]] && ((aDEVICE_NAME['ROCK 4 (aarch64)']+=aDEVICE_NAME["$i"])) && unset -v "aDEVICE_NAME[$i]" # v8.17
 		done
 
 		# Process all results, for later use in HTML printout

--- a/.update/patches
+++ b/.update/patches
@@ -876,79 +876,10 @@ Patch_8_11()
 		G_EXEC chmod +x "${adesktop_items[@]}"
 	fi
 
-	if (( $G_HW_MODEL == 47 ))
+	if (( $G_HW_MODEL == 76 ))
 	then
-		G_DIETPI-NOTIFY 2 'Configuring NanoPi R4S Ethernet LEDs'
-		G_EXEC eval 'echo '\''ledtrig-netdev'\'' > /etc/modules-load.d/dietpi-eth-leds.conf'
-		cat << '_EOF_' > /etc/udev/rules.d/dietpi-eth-leds.rules
-SUBSYSTEM=="leds", KERNEL=="lan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth0", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1"
-SUBSYSTEM=="leds", KERNEL=="wan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth1", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1"
-_EOF_
-		if modprobe -nq ledtrig-netdev
-		then
-			G_EXEC modprobe ledtrig-netdev
-			G_EXEC_NOHALT=1 G_EXEC eval 'echo netdev > /sys/class/leds/lan_led/trigger'
-			G_EXEC_NOHALT=1 G_EXEC eval 'echo eth0 > /sys/class/leds/lan_led/device_name'
-			G_EXEC_NOHALT=1 G_EXEC eval 'echo 1 > /sys/class/leds/lan_led/link'
-			G_EXEC_NOHALT=1 G_EXEC eval 'echo 1 > /sys/class/leds/lan_led/rx'
-			G_EXEC_NOHALT=1 G_EXEC eval 'echo 1 > /sys/class/leds/lan_led/tx'
-			G_EXEC_NOHALT=1 G_EXEC eval 'echo netdev > /sys/class/leds/wan_led/trigger'
-			G_EXEC_NOHALT=1 G_EXEC eval 'echo eth1 > /sys/class/leds/wan_led/device_name'
-			G_EXEC_NOHALT=1 G_EXEC eval 'echo 1 > /sys/class/leds/wan_led/link'
-			G_EXEC_NOHALT=1 G_EXEC eval 'echo 1 > /sys/class/leds/wan_led/rx'
-			G_EXEC_NOHALT=1 G_EXEC eval 'echo 1 > /sys/class/leds/wan_led/tx'
-		fi
-
-	elif (( $G_HW_MODEL == 55 ))
-	then
-		G_DIETPI-NOTIFY 2 'Configuring NanoPi R2S Ethernet LEDs'
-		G_EXEC eval 'echo '\''ledtrig-netdev'\'' > /etc/modules-load.d/dietpi-eth-leds.conf'
-		cat << '_EOF_' > /etc/udev/rules.d/dietpi-eth-leds.rules
-SUBSYSTEM=="leds", KERNEL=="wan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth0", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1"
-SUBSYSTEM=="leds", KERNEL=="lan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth1", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1"
-_EOF_
-		if modprobe -nq ledtrig-netdev
-		then
-			G_EXEC modprobe ledtrig-netdev
-			G_EXEC_NOHALT=1 G_EXEC eval 'echo netdev > /sys/class/leds/wan_led/trigger'
-			G_EXEC_NOHALT=1 G_EXEC eval 'echo eth0 > /sys/class/leds/wan_led/device_name'
-			G_EXEC_NOHALT=1 G_EXEC eval 'echo 1 > /sys/class/leds/wan_led/link'
-			G_EXEC_NOHALT=1 G_EXEC eval 'echo 1 > /sys/class/leds/wan_led/rx'
-			G_EXEC_NOHALT=1 G_EXEC eval 'echo 1 > /sys/class/leds/wan_led/tx'
-			G_EXEC_NOHALT=1 G_EXEC eval 'echo netdev > /sys/class/leds/lan_led/trigger'
-			G_EXEC_NOHALT=1 G_EXEC eval 'echo eth1 > /sys/class/leds/lan_led/device_name'
-			G_EXEC_NOHALT=1 G_EXEC eval 'echo 1 > /sys/class/leds/lan_led/link'
-			G_EXEC_NOHALT=1 G_EXEC eval 'echo 1 > /sys/class/leds/lan_led/rx'
-			G_EXEC_NOHALT=1 G_EXEC eval 'echo 1 > /sys/class/leds/lan_led/tx'
-		fi
-
-	elif (( $G_HW_MODEL == 76 ))
-	then
-		G_DIETPI-NOTIFY 2 'Configuring NanoPi R5S Ethernet LEDs'
 		[[ -f '/etc/modules-load.d/dietpi-nanopi5.conf' ]] && G_EXEC mv /etc/modules-load.d/dietpi-{nanopi5,eth-leds}.conf
 		[[ -f '/etc/udev/rules.d/dietpi-nanopi5.rules' ]] && G_EXEC mv /etc/udev/rules.d/dietpi-{nanopi5,eth-leds}.rules
-		G_EXEC eval 'echo '\''ledtrig-netdev'\'' > /etc/modules-load.d/dietpi-eth-leds.conf'
-		cat << '_EOF_' > /etc/udev/rules.d/dietpi-eth-leds.rules
-SUBSYSTEM=="leds", KERNEL=="wan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth0", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1"
-SUBSYSTEM=="leds", KERNEL=="lan1_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth1", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1"
-SUBSYSTEM=="leds", KERNEL=="lan2_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth2", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1"
-_EOF_
-		G_EXEC modprobe ledtrig-netdev
-		G_EXEC_NOHALT=1 G_EXEC eval 'echo netdev > /sys/class/leds/wan_led/trigger'
-		G_EXEC_NOHALT=1 G_EXEC eval 'echo eth0 > /sys/class/leds/wan_led/device_name'
-		G_EXEC_NOHALT=1 G_EXEC eval 'echo 1 > /sys/class/leds/wan_led/link'
-		G_EXEC_NOHALT=1 G_EXEC eval 'echo 1 > /sys/class/leds/wan_led/rx'
-		G_EXEC_NOHALT=1 G_EXEC eval 'echo 1 > /sys/class/leds/wan_led/tx'
-		G_EXEC_NOHALT=1 G_EXEC eval 'echo netdev > /sys/class/leds/lan1_led/trigger'
-		G_EXEC_NOHALT=1 G_EXEC eval 'echo eth1 > /sys/class/leds/lan1_led/device_name'
-		G_EXEC_NOHALT=1 G_EXEC eval 'echo 1 > /sys/class/leds/lan1_led/link'
-		G_EXEC_NOHALT=1 G_EXEC eval 'echo 1 > /sys/class/leds/lan1_led/rx'
-		G_EXEC_NOHALT=1 G_EXEC eval 'echo 1 > /sys/class/leds/lan1_led/tx'
-		G_EXEC_NOHALT=1 G_EXEC eval 'echo netdev > /sys/class/leds/lan2_led/trigger'
-		G_EXEC_NOHALT=1 G_EXEC eval 'echo eth2 > /sys/class/leds/lan2_led/device_name'
-		G_EXEC_NOHALT=1 G_EXEC eval 'echo 1 > /sys/class/leds/lan2_led/link'
-		G_EXEC_NOHALT=1 G_EXEC eval 'echo 1 > /sys/class/leds/lan2_led/rx'
-		G_EXEC_NOHALT=1 G_EXEC eval 'echo 1 > /sys/class/leds/lan2_led/tx'
 
 	elif (( $G_HW_MODEL == 52 ))
 	then
@@ -1325,6 +1256,67 @@ Patch_8_17()
 {
 	# https://dietpi.com/forum/t/cron-service-is-masked/16544
 	[[ $(systemctl is-enabled cron) == 'masked' ]] && G_EXEC systemctl unmask cron
+
+	# NanoPi R4S
+	if (( $G_HW_MODEL == 47 ))
+	then
+		G_DIETPI-NOTIFY 2 'Updating udev rule for NanoPi R4S Ethernet LEDs'
+		G_EXEC eval 'echo '\''ledtrig-netdev'\'' > /etc/modules-load.d/dietpi-eth-leds.conf'
+		cat << '_EOF_' > /etc/udev/rules.d/dietpi-eth-leds.rules
+SUBSYSTEM=="leds", KERNEL=="lan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth0", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth0; /bin/ip l s down dev eth0"
+SUBSYSTEM=="leds", KERNEL=="wan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth1", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth1; /bin/ip l s down dev eth1"
+_EOF_
+	# NanoPi R2S
+	elif (( $G_HW_MODEL == 55 ))
+	then
+		G_DIETPI-NOTIFY 2 'Updating udev rule for NanoPi R2S Ethernet LEDs'
+		G_EXEC eval 'echo '\''ledtrig-netdev'\'' > /etc/modules-load.d/dietpi-eth-leds.conf'
+		cat << '_EOF_' > /etc/udev/rules.d/dietpi-eth-leds.rules
+SUBSYSTEM=="leds", KERNEL=="wan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth0", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth0; /bin/ip l s down dev eth0"
+SUBSYSTEM=="leds", KERNEL=="lan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth1", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth1; /bin/ip l s down dev eth1"
+_EOF_
+	# NanoPi R5S/R5C
+	elif (( $G_HW_MODEL == 76 ))
+	then
+		local model='R5S'
+		[[ $(</proc/device-tree/model) == *'R5C'* ]] 2> /dev/null && model='R5C'
+		G_DIETPI-NOTIFY 2 "Updating udev rule for NanoPi $model Ethernet LEDs"
+		G_EXEC eval 'echo '\''ledtrig-netdev'\'' > /etc/modules-load.d/dietpi-eth-leds.conf'
+		if [[ $model == 'R6S' ]]
+		then
+			cat << '_EOF_' > /etc/udev/rules.d/dietpi-eth-leds.rules
+SUBSYSTEM=="leds", KERNEL=="wan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth0", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth0; /bin/ip l s down dev eth0"
+SUBSYSTEM=="leds", KERNEL=="lan1_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth1", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth1; /bin/ip l s down dev eth1"
+SUBSYSTEM=="leds", KERNEL=="lan2_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth2", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth2; /bin/ip l s down dev eth2"
+_EOF_
+		else
+			cat << '_EOF_' > /etc/udev/rules.d/dietpi-eth-leds.rules
+SUBSYSTEM=="leds", KERNEL=="wan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth0", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth0; /bin/ip l s down dev eth0"
+SUBSYSTEM=="leds", KERNEL=="lan1_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth1", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth1; /bin/ip l s down dev eth1"
+_EOF_
+		fi
+
+	# NanoPi R6S/R6C
+	elif (( $G_HW_MODEL == 79 ))
+	then
+		local model='R6S'
+		[[ $(</proc/device-tree/model) == *'R6C'* ]] 2> /dev/null && model='R6C'
+		G_DIETPI-NOTIFY 2 "Updating udev rule for NanoPi $model Ethernet LEDs"
+		G_EXEC eval 'echo '\''ledtrig-netdev'\'' > /etc/modules-load.d/dietpi-eth-leds.conf'
+		if [[ $model == 'R6S' ]]
+		then
+			cat << '_EOF_' > /etc/udev/rules.d/dietpi-eth-leds.rules
+SUBSYSTEM=="leds", KERNEL=="lan2_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth0", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth0; /bin/ip l s down dev eth0"
+SUBSYSTEM=="leds", KERNEL=="lan1_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth1", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth1; /bin/ip l s down dev eth1"
+SUBSYSTEM=="leds", KERNEL=="wan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth2", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth2; /bin/ip l s down dev eth2"
+_EOF_
+		else
+			cat << '_EOF_' > /etc/udev/rules.d/dietpi-eth-leds.rules
+SUBSYSTEM=="leds", KERNEL=="wan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth0", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth0; /bin/ip l s down dev eth0"
+SUBSYSTEM=="leds", KERNEL=="lan1_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth1", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth1; /bin/ip l s down dev eth1"
+_EOF_
+		fi
+	fi
 }
 
 # v6.35 => v7 migration

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,9 @@ New images:
 New software:
 
 Enhancements:
+- NanoPi R series | Updated udev rules for the Ethernet LEDs to not lid the LEDs of disabled Ethernet devices. If an Ethernet device has been detected by the kernel/udev already and an LED is configured to light on link (connected cable), it lights until the interface is set up and no link is detected. So for disabled interfaces, some LEDs remained lit. The udev rules have now been changed to quickly set up and down the interfaces for the LEDs to remain off until an interface has been successfully configured.
+- NanoPi R6S | Since our image runs fine on NanoPi R6C as well, the device name in DietPi is now shown as "NanoPi R6S/R6C" to indicate this fact.
+- ROCK Pi 4 | We followed Radxa and renamed the device to "ROCK 4", i.e. removed the "Pi" from its name.
 - DietPi-Banner | Added a new option to show the Let's Encrypt certificate status (expiry date), when installed via dietpi-letsencrypt or Certbot. Many thanks to @gary2002 for implementing this option: https://github.com/MichaIng/DietPi/pull/6314
 
 Bug fixes:

--- a/dietpi/func/dietpi-obtain_hw_model
+++ b/dietpi/func/dietpi-obtain_hw_model
@@ -19,14 +19,14 @@
 	#
 	# G_HW_MODEL 81 StarFive VisionFive 2
 	# G_HW_MODEL 80 Orange Pi 5
-	# G_HW_MODEL 79 NanoPi R6S
+	# G_HW_MODEL 79 NanoPi R6S/R6C
 	# G_HW_MODEL 78 ROCK 5B
 	# G_HW_MODEL 77 ROCK 3A
 	# G_HW_MODEL 76 NanoPi R5S/R5C
 	# G_HW_MODEL 75 Container
 	# G_HW_MODEL 74 Radxa Zero
 	# G_HW_MODEL 73 ROCK Pi S
-	# G_HW_MODEL 72 ROCK Pi 4
+	# G_HW_MODEL 72 ROCK 4
 	# G_HW_MODEL 70 Sparky SBC
 	# G_HW_MODEL 68 NanoPi M4/T4/NEO4
 	# G_HW_MODEL 67 NanoPi K1 Plus
@@ -323,7 +323,7 @@
 
 			elif (( $G_HW_MODEL == 79 )); then
 
-				G_HW_MODEL_NAME='NanoPi R6S'
+				G_HW_MODEL_NAME='NanoPi R6S/R6C'
 				G_HW_CPUID=11
 
 			elif (( $G_HW_MODEL == 78 )); then
@@ -356,7 +356,7 @@
 
 			elif (( $G_HW_MODEL == 72 )); then
 
-				G_HW_MODEL_NAME='ROCK Pi 4'
+				G_HW_MODEL_NAME='ROCK 4'
 				G_HW_CPUID=3
 
 			elif (( $G_HW_MODEL == 70 )); then

--- a/rootfs/var/lib/dietpi/services/dietpi-firstboot.bash
+++ b/rootfs/var/lib/dietpi/services/dietpi-firstboot.bash
@@ -91,7 +91,24 @@
 	Apply_DietPi_FirstRun_Settings(){
 
 		# RPi: Apply safe overclocking values or update comments to show model-specific defaults
-		(( $G_HW_MODEL < 10 )) && RPi_Set_Clock_Speeds
+		if (( $G_HW_MODEL < 10 ))
+		then
+			RPi_Set_Clock_Speeds
+
+		# NanoPi R5S/R5C/R6S/R6C: Update udev rules for C variants
+		elif (( $G_HW_MODEL == 76 ))
+		then
+			[[ $(</proc/device-tree/model) == *'R5C'* ]] 2> /dev/null && cat << '_EOF_' > /etc/udev/rules.d/dietpi-eth-leds.rules
+SUBSYSTEM=="leds", KERNEL=="wan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth0", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth0; /bin/ip l s down dev eth0"
+SUBSYSTEM=="leds", KERNEL=="lan1_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth1", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth1; /bin/ip l s down dev eth1"
+_EOF_
+		elif (( $G_HW_MODEL == 79 ))
+		then
+			[[ $(</proc/device-tree/model) == *'R6C'* ]] 2> /dev/null && cat << '_EOF_' > /etc/udev/rules.d/dietpi-eth-leds.rules
+SUBSYSTEM=="leds", KERNEL=="wan_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth0", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth0; /bin/ip l s down dev eth0"
+SUBSYSTEM=="leds", KERNEL=="lan1_led", ACTION=="add", ATTR{trigger}="netdev", ATTR{device_name}="eth1", ATTR{link}="1", ATTR{rx}="1", ATTR{tx}="1", RUN+="/bin/ip l s up dev eth1; /bin/ip l s down dev eth1"
+_EOF_
+		fi
 
 		# End user automated script
 		if [[ -f '/boot/Automation_Custom_PreScript.sh' ]]; then


### PR DESCRIPTION
- NanoPi R series | Updated udev rules for the Ethernet LEDs to not lid the LEDs of disabled Ethernet devices. If an Ethernet device has been detected by the kernel/udev already and an LED is configured to light on link (connected cable), it lights until the interface is set up and no link is detected. So for disabled interfaces, some LEDs remained lit. The udev rules have now been changed to quickly set up and down the interfaces for the LEDs to remain off until an interface has been successfully configured.
- NanoPi R6S | Since our image runs fine on NanoPi R6C as well, the device name in DietPi is now shown as "NanoPi R6S/R6C" to indicate this fact.
- ROCK Pi 4 | We followed Radxa and renamed the device to "ROCK 4", i.e. removed the "Pi" from its name.
