### PR TITLE
DietPi-Software | Add openHAB to software catalogue

### DIFF
--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -658,6 +658,7 @@ shopt -s extglob
 	do
 		aSOFTWARE_NAME8_17[$i]=${aSOFTWARE_NAME8_16[$i]}
 	done
+	aSOFTWARE_NAME8_17[206]='openHAB'
 
 	# Pre-create software counter array so that we can see also software (available in newest version) with 0 installs
 	for i in "${aSOFTWARE_NAME8_17[@]}"

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,9 +1,8 @@
 v8.17
 (2023-05-06)
 
-New images:
-
 New software:
+- openHAB | This long requested vendor and technology agnostic FLOSS home automation software has been finally added to DietPi. Many thanks to @just-jason and many others for requesting it and @MDAR for providing install instructions and valuable information: https://github.com/MichaIng/DietPi/issues/3857
 
 Enhancements:
 - NanoPi R series | Updated udev rules for the Ethernet LEDs to not lid the LEDs of disabled Ethernet devices. If an Ethernet device has been detected by the kernel/udev already and an LED is configured to light on link (connected cable), it lights until the interface is set up and no link is detected. So for disabled interfaces, some LEDs remained lit. The udev rules have now been changed to quickly set up and down the interfaces for the LEDs to remain off until an interface has been successfully configured.

--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ Links to hardware and software manufacturers, sources and build instructions use
 - [Homer](https://github.com/bastienwirtz/homer)
 - [microblog.pub](https://git.sr.ht/~tsileo/microblog.pub)
 - [Nukkit](https://github.com/CloudburstMC/Nukkit)
+- [openHAB](https://github.com/openhab)
 
 ---
 

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -245,6 +245,7 @@ _EOF_
 			# - Home Automation
 			'home-assistant'
 			'domoticz'
+			'openhab'
 
 			# - Network
 			'noip2'

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1490,6 +1490,15 @@ Available commands:
 		aSOFTWARE_CATX[$software_id]=17
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/home_automation/#tasmoadmin'
 		aSOFTWARE_DEPS[$software_id]='89 webserver'
+		#------------------
+		software_id=206
+		aSOFTWARE_NAME[$software_id]='openHAB'
+		aSOFTWARE_DESC[$software_id]='Vendor and technology agnostic FLOSS home automation software'
+		aSOFTWARE_CATX[$software_id]=17
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/home_automation/#openhab'
+		aSOFTWARE_DEPS[$software_id]='196'
+		# - ARMv6: Requires at least Java 11
+		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
 
 		# Printing
 		#--------------------------------------------------------------------------------
@@ -11192,6 +11201,31 @@ _EOF_
 			fi
 		fi
 
+		if To_Install 206 openhab # openHAB
+		then
+			# APT key
+			local url='https://openhab.jfrog.io/artifactory/api/gpg/key/public'
+			G_CHECK_URL "$url"
+			G_EXEC eval "curl -sSfL '$url' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-openhab.gpg --yes"
+
+			# APT list: Enable RISC-V support by explicitly defining arch=all, which contains exactly the same packages (well, it's Java...)
+			local riscv=
+			(( $G_HW_ARCH == 11 )) && riscv=' [arch=all]'
+			G_EXEC eval "echo 'deb$riscv https://openhab.jfrog.io/artifactory/openhab-linuxpkg stable main' > /etc/apt/sources.list.d/dietpi-openhab.list"
+			G_AGUP
+
+			# APT package
+			G_AGI openhab
+			G_EXEC systemctl stop openhab
+
+			# Change TCP port to avoid conflict with SABnzbd and Airsonic-Advanced
+			G_CONFIG_INJECT 'OPENHAB_HTTP_PORT=' 'OPENHAB_HTTP_PORT=8089' /etc/default/openhab
+
+			# Do all logs to STDOUT => journalctl -u openhab
+			G_EXEC sed -i 's|<AppenderRef ref=".*"/>|<AppenderRef ref="STDOUT"/>|' /var/lib/openhab/etc/log4j2.xml
+			G_EXEC rm -f /var/log/openhab/*
+		fi
+
 		if To_Install 157 home-assistant # Home Assistant
 		then
 			local ha_user='homeassistant'
@@ -12199,6 +12233,13 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 			[[ -f '/etc/nginx/sites-dietpi/dietpi-tasmoadmin.conf' ]] && G_EXEC rm /etc/nginx/sites-dietpi/dietpi-tasmoadmin.conf
 			command -v lighty-disable-mod > /dev/null && lighty-disable-mod dietpi-tasmoadmin
 			[[ -f '/etc/lighttpd/conf-available/99-dietpi-tasmoadmin.conf' ]] && G_EXEC rm /etc/lighttpd/conf-available/99-dietpi-tasmoadmin.conf
+		fi
+
+		if To_Uninstall 206 # openHAB
+		then
+			G_AGP openhab
+			[[ -f '/etc/apt/sources.list.d/dietpi-openhab.list' ]] && G_EXEC rm /etc/apt/sources.list.d/dietpi-openhab.list
+			[[ -f '/etc/apt/trusted.gpg.d/dietpi-openhab.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-openhab.gpg
 		fi
 
 		if To_Uninstall 83 # Apache


### PR DESCRIPTION
- openHAB | This long requested vendor and technology agnostic FLOSS home automation software has been finally added to DietPi. Many thanks to @just-jason and many others for requesting it and @MDAR for providing install instructions and valuable information: https://github.com/MichaIng/DietPi/issues/3857