### PR TITLE
CI | DietPi-Software: Add an option to fake an RPi system on ARM

### DIFF
--- a/.github/workflows/dietpi-software.bash
+++ b/.github/workflows/dietpi-software.bash
@@ -35,12 +35,14 @@ G_EXEC cd "$FP_ORIGIN" # Process everything in origin dir instead of /tmp/$G_PRO
 DISTRO=
 ARCH=
 SOFTWARE=
+RPI=
 while (( $# ))
 do
 	case $1 in
 		'-d') shift; DISTRO=$1;;
 		'-a') shift; ARCH=$1;;
 		'-s') shift; SOFTWARE=$1;;
+		'-rpi') shift; RPI=$1;;
 		*) G_DIETPI-NOTIFY 1 "Invalid input \"$1\", aborting..."; exit 1;;
 	esac
 	shift
@@ -55,6 +57,7 @@ case $ARCH in
 	*) G_DIETPI-NOTIFY 1 "Invalid architecture \"$ARCH\" passed, aborting..."; exit 1;;
 esac
 [[ $SOFTWARE =~ ^[0-9\ ]+$ ]] || { G_DIETPI-NOTIFY 1 "Invalid software list \"$SOFTWARE\" passed, aborting..."; exit 1; }
+[[ $RPI =~ ^|'false'|'true'$ ]] || { G_DIETPI-NOTIFY 1 "Invalid RPi flag \"$RPI\" passed, aborting..."; exit 1; }
 
 ##########################################
 # Dependencies
@@ -87,7 +90,20 @@ G_EXEC mkdir rootfs
 G_EXEC mount "${FP_LOOP}p1" rootfs
 
 # Force ARMv6 arch on Raspbian
-(( $ARCH == 1 )) && echo 'sed -i -e '\''/^G_HW_ARCH=/c\G_HW_ARCH=1'\'' -e '\''/^G_HW_ARCH_NAME=/c\G_HW_ARCH_NAME=armv6l'\'' /boot/dietpi/.hw_model' > rootfs/boot/Automation_Custom_PreScript.sh
+[[ $ARCH == 'armv6l' ]] && echo 'sed -i -e '\''/^G_HW_ARCH=/c\G_HW_ARCH=1'\'' -e '\''/^G_HW_ARCH_NAME=/c\G_HW_ARCH_NAME=armv6l'\'' /boot/dietpi/.hw_model' > rootfs/boot/Automation_Custom_PreScript.sh
+
+# Force RPi on ARM systems if requested
+if [[ $RPI == 'true' && $ARCH == 'a'* ]]
+then
+	case $ARCH in
+		'armv6l') local model=1;;
+		'armv7l') local model=2;;
+		'aarch64') local model=4;;
+	esac
+	# Defining G_HW_MODEL < 10 leads to raspi.list being added automatically during DietPi-FirstBoot.
+	# The DietPi-FirstBoot script itself has .hw_model loaded already to is not affected by this, i.e. the network setup is still skipped, only external script calls like dietpi-set_software will load the new .hw_model.
+	echo "sed -i -e '/^G_HW_MODEL=/c\G_HW_MODEL=$model' -e '/^G_HW_MODEL_NAME=/c\G_HW_MODEL_NAME=\"RPi $model ($ARCH)\"' /boot/dietpi/.hw_model; > /boot/config.txt; > /boot/cmdline.txt" >> rootfs/boot/Automation_Custom_PreScript.sh
+fi
 
 # Workaround invalid TERM on login
 # shellcheck disable=SC2016

--- a/.github/workflows/dietpi-software.bash
+++ b/.github/workflows/dietpi-software.bash
@@ -90,19 +90,21 @@ G_EXEC mkdir rootfs
 G_EXEC mount "${FP_LOOP}p1" rootfs
 
 # Force ARMv6 arch on Raspbian
-[[ $ARCH == 'armv6l' ]] && echo 'sed -i -e '\''/^G_HW_ARCH=/c\G_HW_ARCH=1'\'' -e '\''/^G_HW_ARCH_NAME=/c\G_HW_ARCH_NAME=armv6l'\'' /boot/dietpi/.hw_model' > rootfs/boot/Automation_Custom_PreScript.sh
+[[ $ARCH == 'armv6l' ]] && G_EXEC sed -i '/# Start DietPi-Software/iG_EXEC sed -i -e '\''/^G_HW_ARCH=/cG_HW_ARCH=1'\'' -e '\''/^G_HW_ARCH_NAME=/cG_HW_ARCH_NAME=armv6l'\'' /boot/dietpi/.hw_model' rootfs/boot/dietpi/dietpi-login
 
 # Force RPi on ARM systems if requested
 if [[ $RPI == 'true' && $ARCH == 'a'* ]]
 then
 	case $ARCH in
-		'armv6l') local model=1;;
-		'armv7l') local model=2;;
-		'aarch64') local model=4;;
+		'armv6l') model=1;;
+		'armv7l') model=2;;
+		'aarch64') model=4;;
+		*) G_DIETPI-NOTIFY 1 "Invalid architecture $ARCH beginning with \"a\" but not being one of the known/accepted ARM architectures. This should never happen!"; exit 1;;
 	esac
-	# Defining G_HW_MODEL < 10 leads to raspi.list being added automatically during DietPi-FirstBoot.
-	# The DietPi-FirstBoot script itself has .hw_model loaded already to is not affected by this, i.e. the network setup is still skipped, only external script calls like dietpi-set_software will load the new .hw_model.
-	echo "sed -i -e '/^G_HW_MODEL=/c\G_HW_MODEL=$model' -e '/^G_HW_MODEL_NAME=/c\G_HW_MODEL_NAME=\"RPi $model ($ARCH)\"' /boot/dietpi/.hw_model; > /boot/config.txt; > /boot/cmdline.txt" >> rootfs/boot/Automation_Custom_PreScript.sh
+	G_EXEC sed -i "/# Start DietPi-Software/iG_EXEC sed -i -e '/^G_HW_MODEL=/cG_HW_MODEL=$model' -e '/^G_HW_MODEL_NAME=/cG_HW_MODEL_NAME=\"RPi $model ($ARCH)\"' /boot/dietpi/.hw_model; > /boot/config.txt; > /boot/cmdline.txt" rootfs/boot/dietpi/dietpi-login
+	G_EXEC curl -sSf 'https://archive.raspberrypi.org/debian/pool/main/r/raspberrypi-archive-keyring/raspberrypi-archive-keyring_2021.1.1+rpt1_all.deb' -o keyring.deb
+	G_EXEC dpkg --root=rootfs -i keyring.deb
+	G_EXEC rm keyring.deb
 fi
 
 # Workaround invalid TERM on login

--- a/.github/workflows/dietpi-software.yml
+++ b/.github/workflows/dietpi-software.yml
@@ -17,6 +17,10 @@ on:
       soft:
         description: 'Software ID(s) to install (space separated)'
         required: true
+      rpi:
+        description: 'Fake RPi system on ARM archs'
+        type: boolean
+        default: false
       branch:
         description: 'Change target repo branch (optional)'
       owner:
@@ -72,4 +76,4 @@ jobs:
         [ $owner ] || owner=$GITHUB_REPOSITORY_OWNER
         branch='${{ github.event.inputs.branch }}'
         [ $branch ] || branch=$GITHUB_REF_NAME
-        sudo bash -c "G_GITOWNER=$owner G_GITBRANCH=$branch; $(curl -sSf "https://raw.githubusercontent.com/$owner/DietPi/$branch/.github/workflows/dietpi-software.bash")" -- -a '${{ matrix.arch }}' -d '${{ matrix.dist }}' -s '${{ github.event.inputs.soft }}'
+        sudo bash -c "G_GITOWNER=$owner G_GITBRANCH=$branch; $(curl -sSf "https://raw.githubusercontent.com/$owner/DietPi/$branch/.github/workflows/dietpi-software.bash")" -- -a '${{ matrix.arch }}' -d '${{ matrix.dist }}' -s '${{ github.event.inputs.soft }}' -rpi '${{ github.event.inputs.rpi }}'

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -305,11 +305,12 @@
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Installing new DietPi code'
 		G_EXEC_DESC='Downloading update archive' G_EXEC curl -sSfLO "https://github.com/$GITOWNER_TARGET/DietPi/archive/$GITBRANCH_TARGET.tar.gz"
-		G_EXEC_DESC='Unpacking update archive' G_EXEC tar xf "$GITBRANCH_TARGET.tar.gz"
-		G_EXEC_DESC='Removing unused files' G_EXEC rm "$GITBRANCH_TARGET.tar.gz" "DietPi-$GITBRANCH_TARGET/dietpi/"{pre-patch_file,server_version-6}
-		G_EXEC_DESC='Hardening update archive mode' G_EXEC chmod -R g-w "DietPi-$GITBRANCH_TARGET"
-		G_EXEC_DESC='Installing new DietPi scripts' G_EXEC cp -a "DietPi-$GITBRANCH_TARGET/dietpi" /boot/
-		G_EXEC_DESC='Installing new DietPi system files' G_EXEC cp -a "DietPi-$GITBRANCH_TARGET/rootfs/." /
+		G_EXEC_DESC='Unpacking update archive' G_EXEC tar xf "${GITBRANCH_TARGET##*/}.tar.gz" # Support for Git branch names with forward slashes
+		local dir="DietPi-${GITBRANCH_TARGET//\//-}" # GitHub translates forward slashes into dashes
+		G_EXEC_DESC='Removing unused files' G_EXEC rm "${GITBRANCH_TARGET##*/}.tar.gz" "$dir/dietpi/"{pre-patch_file,server_version-6}
+		G_EXEC_DESC='Hardening update archive mode' G_EXEC chmod -R g-w "$dir"
+		G_EXEC_DESC='Installing new DietPi scripts' G_EXEC cp -a "$dir/dietpi" /boot/
+		G_EXEC_DESC='Installing new DietPi system files' G_EXEC cp -a "$dir/rootfs/." /
 
 		# Save version + Git info now for sub scripts to pull from correct branch
 		G_GITOWNER=$GITOWNER_TARGET
@@ -344,7 +345,7 @@
 		fi
 		rm /boot/dietpi/patch_file
 
-		if ! "DietPi-$G_GITBRANCH/.update/patches"; then
+		if ! "$dir/.update/patches"; then
 
 			G_DIETPI-NOTIFY 1 "An error occurred during incremental patching. Please check the above log or $FP_LOG for errors, and rerun \"dietpi-update\" after the cause has been solved."
 			exit 1


### PR DESCRIPTION
- CI | DietPi-Software: Add an option to fake an RPi system on ARM architectures to allow testing RPi-only software and possible effects of the RPi APT repository. Generic options to allow defining specific hardware models for specific architectures would be an idea as well, but also makes the inputs more complicated.
- DietPi-Update | Add support for Git branch names with forward slashes