### PR TITLE
DietPi-Software | openHAB: Disable plain HTTP change change HTTPS port

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11287,8 +11287,9 @@ _EOF_
 			G_AGI openhab
 			G_EXEC systemctl stop openhab
 
-			# Change TCP port to avoid conflict with SABnzbd and Airsonic-Advanced
-			G_CONFIG_INJECT 'OPENHAB_HTTP_PORT=' 'OPENHAB_HTTP_PORT=8089' /etc/default/openhab
+			# Disable plain HTTP and change HTTPS TCP port to avoid conflicts with SABnzbd, Airsonic-Advanced (8000) and MineOS (8443)
+			G_CONFIG_INJECT 'OPENHAB_HTTPS_PORT=' 'OPENHAB_HTTPS_PORT=8444' /etc/default/openhab
+			G_CONFIG_INJECT 'OPENHAB_HTTP_PORT=' 'OPENHAB_HTTP_PORT=0' /etc/default/openhab
 
 			# Do all logs to STDOUT => journalctl -u openhab
 			G_EXEC sed -i 's|<AppenderRef ref=".*"/>|<AppenderRef ref="STDOUT"/>|' /var/lib/openhab/etc/log4j2.xml

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11293,6 +11293,13 @@ _EOF_
 
 			# Do all logs to STDOUT => journalctl -u openhab
 			G_EXEC sed -i 's|<AppenderRef ref=".*"/>|<AppenderRef ref="STDOUT"/>|' /var/lib/openhab/etc/log4j2.xml
+			local line='' last=''
+			grep -n '<AppenderRef ref="STDOUT"/>' /var/lib/openhab/etc/log4j2.xml | while read -r line
+			do
+				line=${line%%:*}
+				(( $line == ${last:-$line} + 1 )) && G_EXEC sed -i "${last}d" /var/lib/openhab/etc/log4j2.xml
+				last=$line
+			done
 			G_EXEC rm -f /var/log/openhab/*
 		fi
 


### PR DESCRIPTION
Since HTTPS is enabled OOTB, change port to 8444 to avoid conflict with MineOS. Disable plain HTTP completely, as there is not really any point to use it.