### PR TITLE
DietPi-Software | UrBackup: Fix for obtaining latest version

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,6 +24,7 @@ Bug fixes:
 - DietPi-Software | Home Assistant/HTPC Manager/microblog-pub/Synapse: Resolved an issue where the install on RPi 4 with 32-bit image failed since rustup/cargo tried to compile for 64-bit. The issue occurred since the 64-bit kernel is used on RPi 4 by default since Linux 6.1, even if the OS/userland is 32-bit. Many thanks to @josh3003 for reporting this issue: https://github.com/MichaIng/DietPi/issues/6306
 - DietPi-Software | Home Assistant: Resolved an issue where the installation failed on 32-bit ARM systems due to newly required C++ compiler and FFmpeg libraries for compiling all required Python modules.
 - DietPi-Software | Google AIY: Resolved an issue where the install failed on ARMv7 systems due to conflicting Python module dependencies.
+- DietPi-Software | UrBackup: Resolved an issue where the installation failed since the use "latest" directory has been removed the download server. Many thanks to @mikeruss1 for reporting this issue: https://dietpi.com/forum/t/404-on-trying-to-install-urbackup/16744
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/xxxx
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5422,12 +5422,12 @@ _EOF_
 
 			# Install latest version
 			local arch=$(dpkg --print-architecture)
-			local url=$(curl -sSfL 'https://hndl.urbackup.org/Server/latest' | mawk -F\" "/\"urbackup-server_.*_$arch\.deb\"/{print \$8}")
-			[[ $url ]] && url="https://hndl.urbackup.org/Server/latest/$url"
-			local fallback_url="https://hndl.urbackup.org/Server/2.5.30/urbackup-server_2.5.27_$arch.deb"
-			Download_Install "$url"
+			local version=$(curl -sSfL 'https://hndl.urbackup.org/Server/' | grep -Pwo '(?<=href=")[0-9.]+(?=/")' | sort -Vr | head -1)
+			local file=$(curl -sSfL "https://hndl.urbackup.org/Server/$version/" | grep -Pwom1 "(?<=href=\")urbackup-server_${version}_$arch\.deb(?=\")")
+			local fallback_url="https://hndl.urbackup.org/Server/2.5.31/urbackup-server_2.5.31_$arch.deb"
+			Download_Install "${file:+https://hndl.urbackup.org/Server/$version/$file}"
 			G_EXEC systemctl stop urbackupsrv
-			unset -v backuppath arch url
+			unset -v backuppath arch version file
 		fi
 
 		if To_Install 51 # OpenTyrian


### PR DESCRIPTION
Correct a typo and bump to latest version. Furthermore, URL `https://hndl.urbackup.org/Server/latest` seems not to exist anymore.

Reported at our forum https://dietpi.com/forum/t/404-on-trying-to-install-urbackup/16744/2