### PR TITLE
DietPi-Software | SABnzbd: Fix startup on Buster and install on RISC-V

### DIFF
--- a/.github/workflows/dietpi-software.bash
+++ b/.github/workflows/dietpi-software.bash
@@ -142,7 +142,7 @@ then
 fi
 
 # Workaround for failing 32-bit ARM Rust builds on ext4 in QEMU emulated container on 64-bit host: https://github.com/rust-lang/cargo/issues/9545
-(( $ARCH < 3 && $G_HW_ARCH > 9 )) && G_EXEC eval 'echo '\''tmpfs /mnt/dietpi_userdata tmpfs size=3G,noatime,lazytime'\'' >> rootfs/etc/fstab'
+(( $ARCH < 3 && $G_HW_ARCH > 9 )) && G_EXEC eval 'echo -e '\''tmpfs /mnt/dietpi_userdata tmpfs size=3G,noatime,lazytime\ntmpfs /root tmpfs size=3G,noatime,lazytime'\'' >> rootfs/etc/fstab'
 
 # Success flag and shutdown
 G_EXEC eval 'echo -e '\''#!/bin/dash\n/boot/dietpi/dietpi-services start\n> /success\npoweroff'\'' > rootfs/boot/Automation_Custom_Script.sh'

--- a/.github/workflows/dietpi-software.yml
+++ b/.github/workflows/dietpi-software.yml
@@ -31,7 +31,7 @@ concurrency:
 permissions: {}
 defaults:
   run:
-    #working-directory: /dev/shm # attempt to fix OOM kills
+    #working-directory: /dev/shm # uses too much RAM which can lead to OOM kills
     shell: sh
 jobs:
   prep:

--- a/.github/workflows/dietpi-software.yml
+++ b/.github/workflows/dietpi-software.yml
@@ -31,7 +31,7 @@ concurrency:
 permissions: {}
 defaults:
   run:
-    working-directory: /dev/shm
+    #working-directory: /dev/shm # attempt to fix OOM kills
     shell: sh
 jobs:
   prep:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,6 +26,7 @@ Bug fixes:
 - DietPi-Software | Google AIY: Resolved an issue where the install failed on ARMv7 systems due to conflicting Python module dependencies.
 - DietPi-Software | UrBackup: Resolved an issue where the installation failed since the use "latest" directory has been removed the download server. Many thanks to @mikeruss1 for reporting this issue: https://dietpi.com/forum/t/404-on-trying-to-install-urbackup/16744
 - DietPi-Software | SABnzbd: Resolved an issue where the service start failed on Buster systems since SABnzbd v4 does not support Python 3.7 anymore. The latest SABnzbd v3 is now installed instead on Buster systems. Many thanks to @githubchonger for reporting this issue: https://github.com/sabnzbd/sabnzbd/issues/2545
+- DietPi-Software | SABnzbd: Resolved an issue where the install failed on RISC-V due to missing dependencies for Python module builds.
 - DietPi-Software | UnRAR: Resolved an issue where the install failed on RISC-V systems, since the non-free "unrar" package is not available for this architecture yet. "unrar-free" is now installed instead.
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/xxxx

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -25,6 +25,8 @@ Bug fixes:
 - DietPi-Software | Home Assistant: Resolved an issue where the installation failed on 32-bit ARM systems due to newly required C++ compiler and FFmpeg libraries for compiling all required Python modules.
 - DietPi-Software | Google AIY: Resolved an issue where the install failed on ARMv7 systems due to conflicting Python module dependencies.
 - DietPi-Software | UrBackup: Resolved an issue where the installation failed since the use "latest" directory has been removed the download server. Many thanks to @mikeruss1 for reporting this issue: https://dietpi.com/forum/t/404-on-trying-to-install-urbackup/16744
+- DietPi-Software | SABnzbd: Resolved an issue where the service start failed on Buster systems since SABnzbd v4 does not support Python 3.7 anymore. The latest SABnzbd v3 is now installed instead on Buster systems. Many thanks to @githubchonger for reporting this issue: https://github.com/sabnzbd/sabnzbd/issues/2545
+- DietPi-Software | UnRAR: Resolved an issue where the install failed on RISC-V systems, since the non-free "unrar" package is not available for this architecture yet. "unrar-free" is now installed instead.
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/xxxx
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,7 +26,7 @@ Bug fixes:
 - DietPi-Software | Google AIY: Resolved an issue where the install failed on ARMv7 systems due to conflicting Python module dependencies.
 - DietPi-Software | UrBackup: Resolved an issue where the installation failed since the use "latest" directory has been removed the download server. Many thanks to @mikeruss1 for reporting this issue: https://dietpi.com/forum/t/404-on-trying-to-install-urbackup/16744
 - DietPi-Software | SABnzbd: Resolved an issue where the service start failed on Buster systems since SABnzbd v4 does not support Python 3.7 anymore. The latest SABnzbd v3 is now installed instead on Buster systems. Many thanks to @githubchonger for reporting this issue: https://github.com/sabnzbd/sabnzbd/issues/2545
-- DietPi-Software | SABnzbd: Resolved an issue where the install failed on RISC-V due to missing dependencies for Python module builds.
+- DietPi-Software | SABnzbd: Resolved an issue where the install failed on RISC-V and ARMv6/7 Bookworm systems due to missing dependencies for Python module builds.
 - DietPi-Software | UnRAR: Resolved an issue where the install failed on RISC-V systems, since the non-free "unrar" package is not available for this architecture yet. "unrar-free" is now installed instead.
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/xxxx

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9249,22 +9249,30 @@ _EOF_
 			# ARMv8: No sabyenc3 wheels available: https://pypi.org/project/sabyenc3/#files
 			(( $G_HW_ARCH == 3 )) && aDEPS+=('gcc')
 
-			# Reinstall: Remove old install dir
-			if [[ -d '/etc/sabnzbd' ]]
-			then
-				# Preserve old config file
-				[[ -f '/etc/sabnzbd/sabnzbd.ini' ]] && G_EXEC mv /etc/sabnzbd/sabnzbd.ini sabnzbd-master/sabnzbd.ini
-				G_EXEC rm -R /etc/sabnzbd
-			fi
-
 			if (( $G_DISTRO == 5 ))
 			then
-				# Buster Install
+				# Buster download
 				Download_Install 'https://github.com/sabnzbd/sabnzbd/archive/refs/tags/3.7.2.tar.gz'
+				# Reinstall: Remove old install dir
+				if [[ -d '/etc/sabnzbd' ]]
+				then
+					# Preserve old config file
+					[[ -f '/etc/sabnzbd/sabnzbd.ini' ]] && G_EXEC mv /etc/sabnzbd/sabnzbd.ini sabnzbd-3.7.2/sabnzbd.ini
+					G_EXEC rm -R /etc/sabnzbd
+				fi
+				# install
 				G_EXEC mv sabnzbd-3.7.2 /etc/sabnzbd
 			else
-				# Bullseye/Bookworm Install
+				# Bullseye/Bookworm download
 				Download_Install 'https://github.com/sabnzbd/sabnzbd/archive/master.tar.gz'
+				# Reinstall: Remove old install dir
+				if [[ -d '/etc/sabnzbd' ]]
+				then
+					# Preserve old config file
+					[[ -f '/etc/sabnzbd/sabnzbd.ini' ]] && G_EXEC mv /etc/sabnzbd/sabnzbd.ini sabnzbd-master/sabnzbd.ini
+					G_EXEC rm -R /etc/sabnzbd
+				fi
+				# install
 				G_EXEC mv sabnzbd-master /etc/sabnzbd
 			fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9241,15 +9241,14 @@ _EOF_
 			[[ -f '/var/log/virtualhere.log' ]] && G_EXEC rm /var/log/virtualhere.log
 		fi
 
-		if To_Install 139 sabnzbd # SABnzbd
+		if To_Install 139 sabnzbd # SABnzbd: https://sabnzbd.org/wiki/installation/install-off-modules
 		then
-			# https://sabnzbd.org/wiki/installation/install-off-modules
 			# APT deps
 			aDEPS=('par2' 'p7zip-full')
-			# RISC-V: gcc and libffi-dev for cffi; pkg-config, libssl-dev and Rust for cryptography, g++ for sabctools and ujson
-			if (( $G_HW_ARCH == 11 ))
+			# - ARMv6/7 on Bookworm + RISC-V: gcc and libffi-dev for cffi; pkg-config, libssl-dev and Rust for cryptography, g++ for sabctools and ujson
+			if (( $G_DISTRO > 6 && $G_HW_ARCH < 3 || $G_HW_ARCH == 11 ))
 			then
-				G_AGI g++ libffi-dev libssl-dev pkg-config
+				aDEPS+=('g++' 'libffi-dev' 'libssl-dev' 'pkg-config')
 				G_EXEC curl -sSf 'https://sh.rustup.rs/' -o rustup-init.sh
 				G_EXEC chmod +x rustup-init.sh
 				G_EXEC_OUTPUT=1 G_EXEC ./rustup-init.sh -y --profile minimal
@@ -9257,7 +9256,7 @@ _EOF_
 				export PATH="/root/.cargo/bin:$PATH"
 			fi
 
-			# Download: SABnzbd v4 does not support Buster anymore: https://github.com/sabnzbd/sabnzbd/issues/2545
+			# Download: SABnzbd v4 does not support Python 3.7 (Buster) anymore: https://github.com/sabnzbd/sabnzbd/issues/2545
 			if (( $G_DISTRO < 6 ))
 			then
 				Download_Install 'https://github.com/sabnzbd/sabnzbd/archive/3.7.2.tar.gz'
@@ -9290,7 +9289,7 @@ _EOF_
 			# Service: https://github.com/sabnzbd/sabnzbd/blob/master/linux/sabnzbd%40.service
 			# - Options: https://sabnzbd.org/wiki/advanced/command-line-parameters
 			#	"-OO":	Optimise code and remove doc lines (default shebang of SABnzbd.py, but we run python3 explicitly to avoid version conflicts)
-			#	"-d":	Run in daemon mode without terminal and browser start (requires "-f </path/to/config.ini>")
+			#	"-d":	Run in daemon mode without terminal and browser start (requires "-f /path/to/config.ini")
 			#		NB: In systemd unit leads to unreliable long taking webserver start. A new process is forked which allows web access, but sometimes after very long time, sometimes never: https://github.com/sabnzbd/sabnzbd/issues/1283
 			#	"-n":	Do no start browser with daemon
 			cat << '_EOF_' > /etc/systemd/system/sabnzbd.service

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9249,9 +9249,6 @@ _EOF_
 			# ARMv8: No sabyenc3 wheels available: https://pypi.org/project/sabyenc3/#files
 			(( $G_HW_ARCH == 3 )) && aDEPS+=('gcc')
 
-			# Download
-			Download_Install 'https://github.com/sabnzbd/sabnzbd/archive/master.tar.gz'
-
 			# Reinstall: Remove old install dir
 			if [[ -d '/etc/sabnzbd' ]]
 			then
@@ -9260,8 +9257,16 @@ _EOF_
 				G_EXEC rm -R /etc/sabnzbd
 			fi
 
-			# Install
-			G_EXEC mv sabnzbd-master /etc/sabnzbd
+			if (( $G_DISTRO == 5 ))
+			then
+				# Buster Install
+				Download_Install 'https://github.com/sabnzbd/sabnzbd/archive/refs/tags/3.7.2.tar.gz'
+				G_EXEC mv sabnzbd-3.7.2 /etc/sabnzbd
+			else
+				# Bullseye/Bookworm Install
+				Download_Install 'https://github.com/sabnzbd/sabnzbd/archive/master.tar.gz'
+				G_EXEC mv sabnzbd-master /etc/sabnzbd
+			fi
 
 			# Python deps
 			G_EXEC cd /etc/sabnzbd

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3053,8 +3053,8 @@ unix_socket_directories = '/run/postgresql'" > "$i/00dietpi.conf"
 
 		if To_Install 170 # UnRAR
 		then
-			# On Raspbian, only "unrar-free" is available which does not support all RAR formats, thus we use "unrar" [non-free] from Debian on ARMv7+ models: http://raspbian.raspberrypi.org/raspbian/pool/non-free/u/unrar-nonfree/
-			if (( $G_HW_ARCH == 1 ))
+			# On Raspbian and for RISC-V, only "unrar-free" is available which does not support all RAR formats, thus we use "unrar" [non-free] from Debian on ARMv7+ models: http://raspbian.raspberrypi.org/raspbian/pool/non-free/u/unrar-nonfree/, https://deb.debian.org/debian-ports/pool/non-free/u/unrar-nonfree/
+			if (( $G_HW_ARCH == 1 || $G_HW_ARCH == 11 ))
 			then
 				G_AGI unrar-free
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9246,8 +9246,16 @@ _EOF_
 			# https://sabnzbd.org/wiki/installation/install-off-modules
 			# APT deps
 			aDEPS=('par2' 'p7zip-full')
-			# ARMv8: No sabyenc3 wheels available: https://pypi.org/project/sabyenc3/#files
-			(( $G_HW_ARCH == 3 )) && aDEPS+=('gcc')
+			# RISC-V: gcc and libffi-dev for cffi; pkg-config, libssl-dev and Rust for cryptography, g++ for sabctools and ujson
+			if (( $G_HW_ARCH == 11 ))
+			then
+				G_AGI g++ libffi-dev libssl-dev pkg-config
+				G_EXEC curl -sSf 'https://sh.rustup.rs/' -o rustup-init.sh
+				G_EXEC chmod +x rustup-init.sh
+				G_EXEC_OUTPUT=1 G_EXEC ./rustup-init.sh -y --profile minimal
+				G_EXEC rm rustup-init.sh
+				export PATH="/root/.cargo/bin:$PATH"
+			fi
 
 			# Download: SABnzbd v4 does not support Buster anymore: https://github.com/sabnzbd/sabnzbd/issues/2545
 			if (( $G_DISTRO < 6 ))

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9254,6 +9254,11 @@ _EOF_
 				G_EXEC_OUTPUT=1 G_EXEC ./rustup-init.sh -y --profile minimal
 				G_EXEC rm rustup-init.sh
 				export PATH="/root/.cargo/bin:$PATH"
+
+			# - ARMv6/7 temporary workaround: https://github.com/piwheels/packages/issues/358
+			elif (( $G_HW_ARCH < 3 ))
+			then
+				aDEPS+=('g++')
 			fi
 
 			# Download: SABnzbd v4 does not support Python 3.7 (Buster) anymore: https://github.com/sabnzbd/sabnzbd/issues/2545

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9249,32 +9249,25 @@ _EOF_
 			# ARMv8: No sabyenc3 wheels available: https://pypi.org/project/sabyenc3/#files
 			(( $G_HW_ARCH == 3 )) && aDEPS+=('gcc')
 
-			if (( $G_DISTRO == 5 ))
+			# Download: SABnzbd v4 does not support Buster anymore: https://github.com/sabnzbd/sabnzbd/issues/2545
+			if (( $G_DISTRO < 6 ))
 			then
-				# Buster download
-				Download_Install 'https://github.com/sabnzbd/sabnzbd/archive/refs/tags/3.7.2.tar.gz'
-				# Reinstall: Remove old install dir
-				if [[ -d '/etc/sabnzbd' ]]
-				then
-					# Preserve old config file
-					[[ -f '/etc/sabnzbd/sabnzbd.ini' ]] && G_EXEC mv /etc/sabnzbd/sabnzbd.ini sabnzbd-3.7.2/sabnzbd.ini
-					G_EXEC rm -R /etc/sabnzbd
-				fi
-				# install
-				G_EXEC mv sabnzbd-3.7.2 /etc/sabnzbd
+				Download_Install 'https://github.com/sabnzbd/sabnzbd/archive/3.7.2.tar.gz'
+				G_EXEC mv sabnzbd-3.7.2 sabnzbd-master
 			else
-				# Bullseye/Bookworm download
 				Download_Install 'https://github.com/sabnzbd/sabnzbd/archive/master.tar.gz'
-				# Reinstall: Remove old install dir
-				if [[ -d '/etc/sabnzbd' ]]
-				then
-					# Preserve old config file
-					[[ -f '/etc/sabnzbd/sabnzbd.ini' ]] && G_EXEC mv /etc/sabnzbd/sabnzbd.ini sabnzbd-master/sabnzbd.ini
-					G_EXEC rm -R /etc/sabnzbd
-				fi
-				# install
-				G_EXEC mv sabnzbd-master /etc/sabnzbd
 			fi
+
+			# Reinstall: Remove old install dir
+			if [[ -d '/etc/sabnzbd' ]]
+			then
+				# Preserve old config file
+				[[ -f '/etc/sabnzbd/sabnzbd.ini' ]] && G_EXEC mv /etc/sabnzbd/sabnzbd.ini sabnzbd-master/sabnzbd.ini
+				G_EXEC rm -R /etc/sabnzbd
+			fi
+
+			# Install
+			G_EXEC mv sabnzbd-master /etc/sabnzbd
 
 			# Python deps
 			G_EXEC cd /etc/sabnzbd


### PR DESCRIPTION
lock version on Buster systems as SABnzbd 4 require Python version above 3.8.

Related to https://github.com/sabnzbd/sabnzbd/issues/2545