### PR TITLE
 CI | DietPi-Software: Stop SSH and Mono XSP4 services

### DIFF
--- a/.github/workflows/dietpi-software.yml
+++ b/.github/workflows/dietpi-software.yml
@@ -76,4 +76,5 @@ jobs:
         [ $owner ] || owner=$GITHUB_REPOSITORY_OWNER
         branch='${{ github.event.inputs.branch }}'
         [ $branch ] || branch=$GITHUB_REF_NAME
+        sudo systemctl stop ssh mono-xsp4
         sudo bash -c "G_GITOWNER=$owner G_GITBRANCH=$branch; $(curl -sSf "https://raw.githubusercontent.com/$owner/DietPi/$branch/.github/workflows/dietpi-software.bash")" -- -a '${{ matrix.arch }}' -d '${{ matrix.dist }}' -s '${{ github.event.inputs.soft }}' -rpi '${{ github.event.inputs.rpi }}'


### PR DESCRIPTION
- CI | DietPi-Software: Stop SSH and Mono XSP4 services to allow SSH server and File Browser install tests