### PR TITLE
DietPi-Software | MinIO: Use fixed web UI port and solve conflict with LMS

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Enhancements:
 - ROCK Pi 4 | We followed Radxa and renamed the device to "ROCK 4", i.e. removed the "Pi" from its name.
 - DietPi-Banner | Added a new option to show the Let's Encrypt certificate status (expiry date), when installed via dietpi-letsencrypt or Certbot. Many thanks to @gary2002 for implementing this option: https://github.com/MichaIng/DietPi/pull/6314
 - DietPi-LetsEncrypt | HTTP/2 is now enabled OOTB on Nginx when enabling HTTPS via dietpi-letsencrypt. Many thanks to @Isti6github for bringing up this topic: https://dietpi.com/forum/t/nextcloud-memories-http-2-or-http-3-is-strongly-recommended-http-1-1-detected-nginx/16753
+- DietPi-Software | MinIO: On fresh installs, the S3 API port will be 9004 from now on, to resolve a port conflict with Logitech Media Server. Furthermore the web access port (aka console port) will be set to 9001, as otherwise it will be randomly applied from a high port range, making reverse proxy and container setups impossible. Many thanks to @din14970 for reporting this issue: https://dietpi.com/forum/t/configuring-https-for-minio-through-nginx/16775
 
 Bug fixes:
 - General | Resolved an issue where our recent images had the cron service masked accidentally after first run setup. Many thanks to @Johannes for reporting this issue: https://dietpi.com/forum/t/cron-service-is-masked/16544

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10522,7 +10522,7 @@ _EOF_
 # Default file path
 MINIO_VOLUMES="/mnt/dietpi_userdata/minio-data"
 # Use if you want to run MinIO on a custom port.
-MINIO_OPTS="--console-address :9001"
+MINIO_OPTS="--address :9004 --console-address :9001"
 # Access key of the server.
 #MINIO_ACCESS_KEY=Server-Access-Key
 # Secret key of the server.

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10522,7 +10522,7 @@ _EOF_
 # Default file path
 MINIO_VOLUMES="/mnt/dietpi_userdata/minio-data"
 # Use if you want to run MinIO on a custom port.
-#MINIO_OPTS="--address :9199"
+MINIO_OPTS="--console-address :9001"
 # Access key of the server.
 #MINIO_ACCESS_KEY=Server-Access-Key
 # Secret key of the server.


### PR DESCRIPTION
- using a static port assignment of 9001 for the MinIO Console

https://dietpi.com/forum/t/configuring-https-for-minio-through-nginx/16775