### PR TITLE
DietPi-Software | Domoticz: Fix failing tarball unpacking

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Enhancements:
 
 Bug fixes:
 - DietPi-Software | Restic: Resolved an issue where Restic was installed without executable flag. Many thanks to @ for reporting this issue: https://github.com/MichaIng/DietPi/pull/6350#issuecomment-1537656560
+- DietPi-Software | Domoticz: Resolved an issue where the installation failed when trying to unpack the tarball. Many thanks to @mcnahum for reporting this issue: https://github.com/MichaIng/DietPi/issues/6369
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11552,7 +11552,7 @@ _EOF_
 			# APT deps
 			aDEPS=('libusb-0.1-4')
 
-			Download_Install "https://releases.domoticz.com/releases/release/domoticz_linux_${G_HW_ARCH_NAME/armv6l/armv7l}.tgz" domoticz
+			Download_Install "https://releases.domoticz.com/releases/release/domoticz_linux_${G_HW_ARCH_NAME/armv6l/armv7l}.tgz" ./domoticz
 			# Reinstall: Clean old install dir
 			[[ -d '/opt/domoticz' ]] && G_EXEC rm -R /opt/domoticz
 			G_EXEC mv domoticz /opt/


### PR DESCRIPTION
- Fixing an error during the installation of domoticz

