### PR TITLE
Update youtube-dl install url to nightly build fork

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5648,7 +5648,9 @@ _EOF_
 		if To_Install 195 # youtube-dl
 		then
 			aDEPS=('python3')
-			Download_Install 'https://yt-dl.org/downloads/latest/youtube-dl' /usr/local/bin/youtube-dl
+
+			# Until "official" youtube-dl release we will use nightly build fork
+			Download_Install 'https://github.com/ytdl-patched/youtube-dl/releases/latest/download/youtube-dl' /usr/local/bin/youtube-dl
 			G_EXEC chmod +x /usr/local/bin/youtube-dl
 
 			# youtube-dl supports Python 2 and Python 3, but its shebang calls Python 2, else fails: https://github.com/ytdl-org/youtube-dl/issues/27649


### PR DESCRIPTION
As stated in ytdl-org/youtube-dl#31585 new release depends on solving certain issues.

Until then they "recommend" to update with a few solutions https://github.com/ytdl-org/youtube-dl/issues/31530#issuecomment-1435975611

I think that simplest for us is to use nightly build fork. (it's one of the solutions)