### PR TITLE
DietPi-DDNS | Update FreeDNS API URL

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,7 +9,8 @@ Enhancements:
 - DietPi-Software | youtube-dl: Since the development of the original youtube-dl project stalled for some years, we migrated to the well known actively developed fork "yt-dlp": https://github.com/yt-dlp/yt-dlp. If you installed youtube-dl before, you can migrate via reinstall: "dietpi-software reinstall 195". For backwards compatibility, the "youtube-dl" command will stay valid as a symlink to "yt-dlp", but there are some differences you should be aware about when doing the migration on your system: https://github.com/yt-dlp/yt-dlp#differences-in-default-behavior. Many thanks to @rgabbo for suggestion and @pulpe for implementing this change: https://github.com/MichaIng/DietPi/discussions/5670, https://github.com/MichaIng/DietPi/pull/6380
 
 Bug fixes:
-- DietPi-Software | Restic: Resolved an issue where Restic was installed without executable flag. Many thanks to @ for reporting this issue: https://github.com/MichaIng/DietPi/pull/6350#issuecomment-1537656560
+- DietPi-DDNS | Resolved an issue where the IP sync failed because the API URL changed recently. Many thanks to @ma651851384 for implementing the update: https://github.com/MichaIng/DietPi/pull/6375
+- DietPi-Software | Restic: Resolved an issue where Restic was installed without executable flag. Many thanks to @lima1 for reporting this issue: https://github.com/MichaIng/DietPi/pull/6350#issuecomment-1537656560
 - DietPi-Software | Domoticz: Resolved an issue where the installation failed when trying to unpack the tarball. Many thanks to @mcnahum for reporting this issue: https://github.com/MichaIng/DietPi/issues/6369
 - DietPi-Software | motionEye: Resolved an issue where the installation failed on ARMv6, ARMv7 and RISC-V Bookworm systems due to missing build dependencies. Many thanks to @magicfoxt-magicfox for reporting this issue: https://github.com/MichaIng/DietPi/issues/6333
 

--- a/dietpi/dietpi-ddns
+++ b/dietpi/dietpi-ddns
@@ -169,7 +169,7 @@ Apply()
 	# - FreeDNS
 	elif [[ $PROVIDER == 'FreeDNS' ]]
 	then
-		url="https://sync.afraid.org/u/$PASSWORD/"
+		url="https://freedns.afraid.org/dynamic/update.php?$PASSWORD"
 		http_auth=
 
 	# - OVH


### PR DESCRIPTION
Recently, I tried to set up DynDNS via the substantiated provider "FreeDNS". After acceptance of the setting using the token, the error 404 was displayed. When I used the custom URL, it worked. That URL was provided, if the user was logged in into the freedns user portal.

I believe that in the meantime the URL has changed from "https://sync.afraid.org/u/<token>" to "http://freedns.afraid.org/dynamic/update.php?<token>".

The effected line would have to be changed from

`url="https://sync.afraid.org/u/$PASSWORD/"`
to
`url="https://freedns.afraid.org/dynamic/update.php?$PASSWORD"`