### PR TITLE
DietPi-Software | Domoticz: Fix install due to missing new dependency

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Bug fixes:
 - DietPi-DDNS | Resolved an issue where the IP sync failed because the API URL changed recently. Many thanks to @ma651851384 for implementing the update: https://github.com/MichaIng/DietPi/pull/6375
 - DietPi-Software | Restic: Resolved an issue where Restic was installed without executable flag. Many thanks to @lima1 for reporting this issue: https://github.com/MichaIng/DietPi/pull/6350#issuecomment-1537656560
 - DietPi-Software | Domoticz: Resolved an issue where the installation failed when trying to unpack the tarball. Many thanks to @mcnahum for reporting this issue: https://github.com/MichaIng/DietPi/issues/6369
+- DietPi-Software | Domoticz: Resolved an issue where the service start failed because the new version of Domoticz depends on the GnuTLS variant of libcurl instead of the OpenSSL one. Many thanks to @IgrekLg for reporting this issue: https://github.com/MichaIng/DietPi/issues/6404
 - DietPi-Software | motionEye: Resolved an issue where the installation failed on ARMv6, ARMv7 and RISC-V Bookworm systems due to missing build dependencies. Many thanks to @magicfoxt-magicfox for reporting this issue: https://github.com/MichaIng/DietPi/issues/6333
 - DietPi-Software | LXQt: Resolved an issue on Bookworm systems where the install failed since configs were missing.
 - DietPi-Software | TigerVNC: Resolved an issue on Bookworm systems where the VNC password was not set as expected since the tigervncpasswd command became a dedicated DEB package "tigervnc-tools".

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1521,7 +1521,7 @@ Available commands:
 		aSOFTWARE_DESC[$software_id]='Open source home automation platform'
 		aSOFTWARE_CATX[$software_id]=17
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/home_automation/#domoticz'
-		# - Bookworm: No libssl3 support: https://github.com/domoticz/domoticz/issues/5233
+		# - Bookworm: No libssl3 support: https://github.com/domoticz/domoticz/issues/5233, https://github.com/MichaIng/DietPi/issues/6404
 		aSOFTWARE_AVAIL_G_DISTRO[$software_id,7]=0
 		#------------------
 		software_id=27
@@ -11569,7 +11569,7 @@ _EOF_
 		if To_Install 140 domoticz # Domoticz
 		then
 			# APT deps
-			aDEPS=('libusb-0.1-4')
+			aDEPS=('libusb-0.1-4' 'libcurl3-gnutls') # https://github.com/MichaIng/DietPi/issues/6404
 
 			Download_Install "https://releases.domoticz.com/releases/release/domoticz_linux_${G_HW_ARCH_NAME/armv6l/armv7l}.tgz" ./domoticz
 			# Reinstall: Clean old install dir


### PR DESCRIPTION
- DietPi-Software | Domoticz: Resolved an issue where the service start failed because the new version of Domoticz depends on the GnuTLS variant of libcurl instead of the OpenSSL one. Many thanks to @IgrekLg for reporting this issue: https://github.com/MichaIng/DietPi/issues/6404