### PR TITLE
Quartz64 | Fix Rockchip DDR binary repo

### DIFF
--- a/.github/workflows/quartz64.yml
+++ b/.github/workflows/quartz64.yml
@@ -29,8 +29,8 @@ jobs:
         { curl -fO "https://gitlab.com/MichaIng/u-boot/-/archive/$uboot_branch/u-boot-$uboot_branch.tar.bz2"; tar xf "u-boot-$uboot_branch.tar.bz2"; rm "u-boot-$uboot_branch.tar.bz2"; } &
         { curl -fO 'https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/snapshot/linux-rolling-stable.tar.gz'; tar xf linux-rolling-stable.tar.gz; rm linux-rolling-stable.tar.gz; } &
         wait
-        curl -sSfo "u-boot-$uboot_branch/u-boot-spl-ddr.bin" 'https://raw.githubusercontent.com/JeffyCN/rockchip_mirrors/rkbin/bin/rk35/rk3568_ddr_1560MHz_v1.13.bin' &
-        curl -sSfo "u-boot-$uboot_branch/bl31.elf" 'https://raw.githubusercontent.com/JeffyCN/rockchip_mirrors/6186deb/bin/rk35/rk3568_bl31_v1.28.elf' &
+        curl -sSfo "u-boot-$uboot_branch/u-boot-spl-ddr.bin" 'https://raw.githubusercontent.com/JeffyCN/mirrors/ddf03c1/bin/rk35/rk3568_ddr_1560MHz_v1.13.bin' &
+        curl -sSfo "u-boot-$uboot_branch/bl31.elf" 'https://raw.githubusercontent.com/JeffyCN/mirrors/6186deb/bin/rk35/rk3568_bl31_v1.28.elf' &
         curl -sSfo linux-rolling-stable/arch/arm64/configs/quartz64_defconfig "https://raw.githubusercontent.com/$GITHUB_REPOSITORY_OWNER/DietPi/$GITHUB_REF_NAME/.build/images/Quartz64/quartz64_defconfig" &
         rm -Rf firmware-quartz64a/DEBIAN firmware-quartz64a/boot/extlinux firmware-quartz64a/lib/firmware/brcm
         mkdir -p firmware-quartz64a/DEBIAN firmware-quartz64a/boot/extlinux firmware-quartz64a/lib/firmware/brcm


### PR DESCRIPTION
- Quartz64 | Fix Rockchip DDR binary repo, as the rkbin branch in rockchip_mirrors repo have been removed