### PR TITLE
DietPi-Software | Mopidy: On Bullseye and above, migrate APT repo to (new) Bullseye suite

### DIFF
--- a/.meta/dietpi-bookworm-upgrade
+++ b/.meta/dietpi-bookworm-upgrade
@@ -43,6 +43,7 @@ G_DIETPI-NOTIFY 2 'Reverting some package lists to Bullseye which have no Bookwo
 [[ -f '/etc/apt/sources.list.d/dietpi-radxa.list' ]] && G_EXEC sed -i 's/bookworm/bullseye/g' /etc/apt/sources.list.d/dietpi-radxa.list
 [[ -f '/etc/apt/sources.list.d/dietpi-mosquitto.list' ]] && G_EXEC sed -i 's/bookworm/bullseye/' /etc/apt/sources.list.d/dietpi-mosquitto.list
 [[ -f '/etc/apt/sources.list.d/influxdb.list' ]] && G_EXEC sed -i 's/bookworm/bullseye/' /etc/apt/sources.list.d/influxdb.list
+[[ -f '/etc/apt/sources.list.d/mopidy.list' ]] && G_EXEC sed -i 's/bookworm/bullseye/' /etc/apt/sources.list.d/mopidy.list
 
 G_DIETPI-NOTIFY 2 'Applying the actual upgrade to Debian Bookworm'
 /boot/dietpi/dietpi-services stop

--- a/.update/patches
+++ b/.update/patches
@@ -1355,9 +1355,12 @@ Patch_8_19()
 		G_EXEC rm package.deb
 	fi
 
-	# Inform about and offer available software updates
+	# Software updates and migrations
 	if [[ -f '/boot/dietpi/.installed' ]]
 	then
+		# Mopidy: Bullseye suite now available in official APT repo
+		(( $G_DISTRO > 5 )) && [[ -f '/etc/apt/sources.list.d/mopidy.list' ]] && grep -q buster /etc/apt/sources.list.d/mopidy.list && G_EXEC sed -i 's/buster/bullseye/' /etc/apt/sources.list.d/mopidy.list
+
 		# vaultwarden
 		grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[183\]=2' /boot/dietpi/.installed && dpkg --compare-versions "$(dpkg-query -Wf '${Version}' vaultwarden 2> /dev/null)" lt 1.28.1-dietpi3 && G_WHIP_MSG '[ INFO ] vaultwarden update available
 \nAn update to vaultwarden 1.28.1 is available, including web vault v2023.5.0.

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5193,8 +5193,7 @@ _EOF_
 				G_EXEC eval "curl -sSfL '$url' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-mopidy.gpg --yes"
 
 				# APT list
-				local distro=${G_DISTRO_NAME/bookworm/bullseye}
-				G_EXEC eval "echo 'deb https://apt.mopidy.com/ ${distro/bullseye/buster} main contrib non-free' > /etc/apt/sources.list.d/mopidy.list"
+				G_EXEC eval "echo 'deb https://apt.mopidy.com/ ${G_DISTRO_NAME/bookworm/bullseye} main contrib non-free' > /etc/apt/sources.list.d/mopidy.list"
 				G_AGUP
 			fi
 


### PR DESCRIPTION
Test: https://github.com/MichaIng/DietPi/actions/runs/5236659255