### PR TITLE
DietPi-Software | Lemmy: A link aggregator for the fediverse

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -13267,10 +13267,8 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 
 		if To_Uninstall 210 # lemmy
 		then
-			Remove_Service lemmy-ui 1 1
+			Remove_Service lemmy-ui
 			Remove_Service lemmy 1 1
-			## Remove_Service postgres ??
-			G_EXEC userdel lemmy
 			G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "DROP DATABASE IF EXISTS lemmy;"
 			G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "DROP TABLESPACE IF EXISTS lemmydata;"
 			G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "DROP ROLE IF EXISTS lemmy;"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4501,16 +4501,16 @@ lemmy-update()
 {
 	case \$1 in
 		l*) ## Lemmy
-            sudo -u '$lemm_user' dash -c 'source "$lemm_home/.cargo/env"; cargo install lemmy_server --target-dir --features embed-pictrs'
+            sudo -u '$lemm_user' dash -c '. "$lemm_home/.cargo/env"; cargo install lemmy_server --locked --features embed-pictrs'
             sudo systemctl restart lemmy
             ;;
-		ui) ## UI
+		ui) ## UI (hardcoded to 0.17.3)
             sudo -u '$lemm_user' dash -c '\
-source "$lemm_home/.cargo/env"; \
+. "$lemm_home/.cargo/env"; \
 cd /var/lib/lemmy-ui; \
 git checkout main && \
 git pull --tags && \
-git checkout 0.12.2 && \
+git checkout 0.17.3 && \
 git submodule update && \
 yarn install --pure-lockfile && \
 yarn build:prod;';
@@ -4520,7 +4520,7 @@ yarn build:prod;';
             # check docker-compose.yml for pict-rs version used by lemmy
             # https://github.com/LemmyNet/lemmy-ansible/blob/main/templates/docker-compose.yml#L40
             sudo -u '$lemm_user' dash -c '\
-source "$lemm_home/.cargo/env"; \
+. "$lemm_home/.cargo/env"; \
 rustup update && \
 cd /var/lib/pictrs-source && \
 git checkout main && \

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1042,6 +1042,12 @@ Available commands:
 		aSOFTWARE_CATX[$software_id]=6
 		aSOFTWARE_DEPS[$software_id]='17'
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/social/#microblogpub'
+		#-----------------
+		software_id=210
+		aSOFTWARE_NAME[$software_id]='lemmy'
+		aSOFTWARE_DESC[$software_id]='A link aggregator for the fediverse'
+		aSOFTWARE_CATX[$software_id]=6
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/social/#lemmy'
 
 		# Camera & Surveillance
 		#--------------------------------------------------------------------------------
@@ -4332,6 +4338,166 @@ _EOF_
 			G_DIETPI-NOTIFY 0 'microblog.pub installation finished. In order to complete the setup, please run "microblog-pub configure" in a new bash session. Append the port ":8007" to the domain when being asked for it if you do not use a reverse proxy.'
 		fi
 
+		if To_Install 210 # lemmy
+			## Install up-to-date rustup (cargo version in debian is too old)
+			local lemm_user='lemmy'
+			local lemm_home="/home/$lemm_user"
+			local lemm_bin=$lemm_home/bin
+			# User
+			Create_User -G dialout,gpio,i2c -d "$lemm_home" "$lemm_user"
+			sudo su -u $lemm_user mkdir -p $lemm_bin
+
+			## Install Rust, cargo
+			## We assume users will want to upload images, so we enable pictrs
+			G_WHIP_MSG '[ INFO ] lemmy backend installation started'
+			sudo su -u $lemm_user dash -c '\
+curl https://sh.rustup.rs -sSf | sh;\
+source "$lemm_home/.cargo/env"; \
+cargo install lemmy_server --target-dir $lemm_bin --locked --features embed-pictrs;'
+			G_WHIP_MSG '[ INFO ] lemmy backend installation finished'
+
+			## TODO: Install lemmy front-end server
+## Deps
+# https://classic.yarnpkg.com/en/docs/install/#debian-stable
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+# https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions
+curl -fsSL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+sudo apt install nodejs yarn
+
+## Installation
+mkdir /var/lib/lemmy-ui
+cd /var/lib/lemmy-ui
+chown lemmy:lemmy .
+# dont compile as admin
+sudo -u lemmy bash
+git clone https://github.com/LemmyNet/lemmy-ui.git --recursive .
+git checkout 0.16.7 # replace with the version you want to install
+yarn install --pure-lockfile
+yarn build:prod
+exit
+
+			## Backend Config
+			cat << _EOF_ > /etc/lemmy/lemmy.hjson
+{
+  database: {
+    # put your db-passwd from above
+    password: "db-passwd"
+    port: 5432
+  }
+  # replace with your domain
+  hostname: "dietpi.lemmy"
+  bind: "127.0.0.1"
+  port: 5433
+  federation: {
+    enabled: true
+  }
+  # remove this block if you don't require image hosting
+  pictrs: {
+    url: "http://localhost:5434/"
+  }
+  ## Disable this if not a federated instance
+  tls_enabled: true
+}
+_EOF_
+			## Backend Service
+			cat << _EOF_ > /etc/systemd/system/lemmy.service
+[Unit]
+Description=Lemmy - A link aggregator for the fediverse
+After=network.target
+
+[Service]
+User=lemmy
+ExecStart=/usr/bin/lemmy_server
+Environment=LEMMY_CONFIG_LOCATION=/etc/lemmy/lemmy.hjson
+# remove these two lines if you don't need pict-rs
+Environment=PICTRS_PATH=/var/lib/pictrs
+Environment=PICTRS_ADDR=127.0.0.1:5434
+Restart=on-failure
+
+# Hardening
+ProtectSystem=yes
+PrivateTmp=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target
+_EOF_
+			## UI Service
+			cat << _EOF_ > /etc/systemd/system/lemmy-ui.service
+[Unit]
+Description=Lemmy UI - Web frontend for Lemmy
+After=lemmy.service
+Before=nginx.service
+
+[Service]
+User=lemmy
+WorkingDirectory=/var/lib/lemmy-ui
+ExecStart=/usr/bin/node dist/js/server.js
+Environment=LEMMY_INTERNAL_HOST=localhost:5433
+Environment=LEMMY_EXTERNAL_HOST="dietpi.lemmy"
+Environment=LEMMY_HTTPS=true
+Restart=on-failure
+
+# Hardening
+ProtectSystem=full
+PrivateTmp=true
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target
+_EOF_
+			## Upgrade Scripts
+    		cat << _EOF_ > /etc/bashrc.d/lemmy.sh
+#!/bin/dash
+lemmy-update()
+{
+	case \$1 in
+		l*) ## Lemmy
+            sudo -u '$lemm_user' dash -c 'source "$lemm_home/.cargo/env"; cargo install lemmy_server --target-dir '$lemm_bin' --features embed-pictrs'
+            sudo systemctl restart lemmy
+            ;;
+		ui) ## UI
+            sudo -u '$lemm_user' dash -c '\
+source "$lemm_home/.cargo/env"; \
+cd /var/lib/lemmy-ui; \
+git checkout main && \
+git pull --tags && \
+git checkout 0.12.2 && \
+git submodule update && \
+yarn install --pure-lockfile && \
+yarn build:prod;';
+            sudo systemctl restart lemmy-ui
+            ;;
+		pic*) ## PictRS
+            # check docker-compose.yml for pict-rs version used by lemmy
+            # https://github.com/LemmyNet/lemmy-ansible/blob/main/templates/docker-compose.yml#L40
+            sudo -u '$lemm_user' dash -c '\
+source "$lemm_home/.cargo/env"; \
+rustup update && \
+cd /var/lib/pictrs-source && \
+git checkout main && \
+git pull --tags && \
+git checkout v0.2.6-r2 &&\
+cargo build --release &&
+cp target/release/pict-rs "$lemm_bin" '
+            sudo systemctl restart pictrs
+            ;;
+		*) echo 'lemmy-update helper script
+
+usage: lemmy-update <lemmy|ui|pictrs>
+
+where:
+  lemmy   update and rebuild the backend server (via cargo)
+  ui      update and rebuilt the ui (via yarn)
+  pictrs  update and rebuild the picture service (via cargo)' && \
+           return 1;;
+	esac
+}
+_EOF_
+
+		fi
 		if To_Install 2 fahclient # Folding@Home
 		then
 			G_DIETPI-NOTIFY 2 'Pre-configuring FAHClient DEB package'
@@ -13039,6 +13205,11 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 			[[ -f '/etc/bashrc.d/microblog-pub.sh' ]] && G_EXEC rm /etc/bashrc.d/microblog-pub.sh
 			[[ -d '/opt/microblog-pub' ]] && G_EXEC rm -R /opt/microblog-pub
 			G_DIETPI-NOTIFY 2 'All microblog.pub data and settings are still retained.\n - You can remove these manually: rm -R /mnt/dietpi_userdata/microblog-pub'
+		fi
+
+		if To_Uninstall 210 # lemmy
+		then
+            ## TODO!
 		fi
 
 		if To_Uninstall 98 # HAProxy

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4459,7 +4459,7 @@ After=network.target
 User=lemmy
 ExecStart=$lemm_server_path/lemmy_server
 Environment=LEMMY_CONFIG_LOCATION="$lemmy_userdata/lemmy.hjson"
-Environment=PICTRS_PATH=$lemmy_userdata/picts  # /var/lib/pictrs
+Environment=PICTRS_PATH=$lemmy_userdata/pictrs
 Environment=PICTRS__REPO__PATH=$PICTRS_PATH/sled-repo
 Environment=PICTRS__STORE__PATH=$PICTRS_PATH/store
 Environment=PICTRS_ADDR=$host_bind:$port_pictrs

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4341,14 +4341,15 @@ _EOF_
 
 		if To_Install 210 # lemmy
         then
+            aDEPS=('make' 'gcc' 'libc6-dev' 'pkg-config' 'libssl-dev' 'protobuf-compiler' 'libprotobuf-dev' 'libpq-dev')
 			## Install up-to-date rustup (cargo version in debian is too old)
 			local lemm_user='lemmy'
             local lemm_home="/home/$lemm_user"
 			# User
             ##Create_User -G dialout,gpio,i2c -d "$lemm_home" "$lemm_user"
-            G_EXEC mkdir -p $lemm_home
-            Create_User -d $lemm_home $lemm_user
-            G_EXEC chown $lemm_user:$lemm_user -R $lemm_home
+            G_EXEC mkdir -p "$lemm_home"
+            Create_User -d "$lemm_home" "$lemm_user"
+            G_EXEC chown "$lemm_user":"$lemm_user" -R "$lemm_home"
 
             ##G_EXEC sudo su -u $lemm_user mkdir -p $lemm_bin
 
@@ -4373,11 +4374,11 @@ _EOF_
             G_AGI yarn nodejs
             # ## Installation
             G_EXEC mkdir -p /var/lib/lemmy-ui
-            G_EXEC chown $lemm_user:$lemm_user -R /var/lib/lemmy-ui
+            G_EXEC chown "$lemm_user":"$lemm_user" -R /var/lib/lemmy-ui
             # dont compile as admin
             G_EXEC cd /var/lib/lemmy-ui
             G_DIETPI-NOTIFY 0 '[ INFO ] lemmy UI installation started'
-            G_EXEC sudo -u $lemm_user dash -c '\
+            G_EXEC sudo -u "$lemm_user" dash -c '\
  git clone https://github.com/LemmyNet/lemmy-ui.git --recursive . && \
  git checkout 0.17.3 && \
  yarn install --pure-lockfile && \
@@ -4393,7 +4394,7 @@ _EOF_
             local port_pictrs=5434
             local port_frontend=5435  ## default:1234
 
-            G_DIETPI-NOTIFY 0 '[ INFO ] lemmy will be up and running at https://$host_broadcast:$port_frontend'
+            G_DIETPI-NOTIFY 0 "[ INFO ] lemmy will be up and running at https://$host_broadcast:$port_frontend"
             
 			cat << _EOF_ > /etc/lemmy/lemmy.hjson
 {
@@ -4471,7 +4472,7 @@ lemmy-update()
 {
 	case \$1 in
 		l*) ## Lemmy
-            sudo -u '$lemm_user' dash -c 'source "$lemm_home/.cargo/env"; cargo install lemmy_server --target-dir '$lemm_bin' --features embed-pictrs'
+            sudo -u '$lemm_user' dash -c 'source "$lemm_home/.cargo/env"; cargo install lemmy_server --target-dir --features embed-pictrs'
             sudo systemctl restart lemmy
             ;;
 		ui) ## UI

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4415,7 +4415,8 @@ cargo install lemmy_server --locked --features embed-pictrs'
 # https://join-lemmy.org/docs/en/administration/configuration.html#full-config-with-default-values
 {
   database: {
-    host: /var/run/postgresql
+    # For some reason, host needs to be blank.
+    host: ""
     password: "$pass_database"
     port: $port_database
   }
@@ -4472,7 +4473,7 @@ _EOF_
 [Unit]
 Description=Lemmy UI - Web frontend for Lemmy
 After=lemmy.service
-Before=nginx.service  ## Hey, do you think this is needed?
+##Before=nginx.service
 
 [Service]
 User=lemmy
@@ -4542,10 +4543,11 @@ where:
 }
 _EOF_
 
-            ## Fresh database and upgrade lemmy to sudo
-            ## Hey, maybe a reinstallation shouldn't drop the last database?
-            G_EXEC systemctl stop postgresql
-            G_EXEC systemctl start postgresql
+            # Postgres
+            ## We need to tell postgres that we're doing password auth (md5) and not peer.
+            G_EXEC sed -i -r '/^local\s+all\s+all\s+peer/i local   lemmy           lemmy                                   md5' /etc/postgresql/15/main/pg_hba.conf
+            G_EXEC systemctl restart postgresql
+
             local db_files=$lemmy_userdata/postgres
             G_EXEC mkdir -p $db_files
             G_EXEC chown postgres:postgres -R $db_files
@@ -4557,6 +4559,7 @@ _EOF_
             G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "CREATE DATABASE lemmy WITH OWNER lemmy ENCODING 'UTF8' TEMPLATE template0 LC_COLLATE 'C' LC_CTYPE 'C' TABLESPACE='lemmydata';"
             G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE lemmy TO lemmy;"
             G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "ALTER USER lemmy WITH SUPERUSER;"
+            G_EXEC systemctl restart postgresql
 		fi
            
 		if To_Install 2 fahclient # Folding@Home

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4342,7 +4342,13 @@ _EOF_
 		if To_Install 210 # lemmy
         then
             aDEPS=('make' 'gcc' 'libc6-dev' 'pkg-config' 'libssl-dev' 'protobuf-compiler' 'libprotobuf-dev' 'libpq-dev')
-			## Install up-to-date rustup (cargo version in debian is too old)
+
+            # This script creates the lemmy user, a dedicated postgres
+            # db in the dietpi userspace, the lemmy backend, the lemmy
+            # frontend, and apparently the pict-rs image server too
+            # (that last one is NOT clear).
+
+            ## Install up-to-date rustup (cargo version in debian is too old)
 			local lemm_user='lemmy'
             local lemm_home="/home/$lemm_user"
             local lemm_server_path=$lemm_home/.cargo/bin
@@ -13273,7 +13279,20 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 
 		if To_Uninstall 210 # lemmy
 		then
-            echo hi
+            Remove_Service lemmy-ui 1 1
+            Remove_Service lemmy 1 1
+            G_EXEC userdel lemmy
+            G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "DROP DATABASE IF EXISTS lemmy;"
+            G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "DROP TABLESPACE IF EXISTS lemmydata;"
+            G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "DROP ROLE IF EXISTS lemmy;"
+            ## Remove Lemmy config line
+            [[ -f '/etc/postgresql/15/main/pg_hba.conf' ]] && G_EXEC sed -i -r '/^local\s+lemmy\s+lemmy\s+md5/d'  /etc/postgresql/15/main/pg_hba.conf
+            ##
+            [[ -d '/var/lib/lemmy-ui' ]] && G_EXEC rm -rf /var/lib/lemmy-ui
+            [[ -d '/home/lemmy' ]] && G_EXEC rm -rf /home/lemmy
+            [[ -f '/etc/systemd/system/lemmy.service' ]] && G_EXEC rm /etc/systemd/system/lemmy.service
+            [[ -f '/etc/systemd/system/lemmy-ui.service' ]] && G_EXEC rm /etc/systemd/system/lemmy-ui.service
+            [[ -f '/etc/bashrc.d/lemmy.sh' ]] && G_EXEC rm /etc/bashrc.d/lemmy.sh
 		fi
 
 		if To_Uninstall 98 # HAProxy

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4340,6 +4340,7 @@ _EOF_
 		fi
 
 		if To_Install 210 # lemmy
+           then
 			## Install up-to-date rustup (cargo version in debian is too old)
 			local lemm_user='lemmy'
 			local lemm_home="/home/$lemm_user"
@@ -4391,9 +4392,9 @@ yarn build:prod'
             local host_broadcast=0.0.0.0
             local host_domain=dietpi.lemmy.com
             local port_database=5432
-            local port_backend=5433
+            local port_backend=5433   ## default:8536
             local port_pictrs=5434
-            local port_frontend=5435
+            local port_frontend=5435  ## default:1234
 
             G_WHIP_MSG '[ INFO ] lemmy is up and running at https://$host_broadcast:$port_frontend'
             
@@ -4441,7 +4442,7 @@ NoNewPrivileges=true
 [Install]
 WantedBy=multi-user.target
 _EOF_
-			## UI Service
+			## UI Service - https://github.com/LemmyNet/lemmy-ui#configuration
 			cat << _EOF_ > /etc/systemd/system/lemmy-ui.service
 [Unit]
 Description=Lemmy UI - Web frontend for Lemmy
@@ -4514,8 +4515,9 @@ where:
 	esac
 }
 _EOF_
-
+     
 		fi
+           
 		if To_Install 2 fahclient # Folding@Home
 		then
 			G_DIETPI-NOTIFY 2 'Pre-configuring FAHClient DEB package'
@@ -13227,7 +13229,7 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 
 		if To_Uninstall 210 # lemmy
 		then
-            ## TODO!
+            echo hi
 		fi
 
 		if To_Uninstall 98 # HAProxy

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4340,53 +4340,50 @@ _EOF_
 		fi
 
 		if To_Install 210 # lemmy
-           then
+        then
 			## Install up-to-date rustup (cargo version in debian is too old)
 			local lemm_user='lemmy'
-			local lemm_home="/home/$lemm_user"
-			local lemm_bin=$lemm_home/bin
+            local lemm_home="/home/$lemm_user"
 			# User
-			Create_User -G dialout,gpio,i2c -d "$lemm_home" "$lemm_user"
-			sudo su -u $lemm_user mkdir -p $lemm_bin
+            ##Create_User -G dialout,gpio,i2c -d "$lemm_home" "$lemm_user"
+            G_EXEC mkdir -p $lemm_home
+            Create_User -d $lemm_home $lemm_user
+            G_EXEC chown $lemm_user:$lemm_user -R $lemm_home
+
+            ##G_EXEC sudo su -u $lemm_user mkdir -p $lemm_bin
 
 			## Install Rust, cargo
 			## We assume users will want to upload images, so we enable pictrs
-			G_WHIP_MSG '[ INFO ] lemmy backend installation started'
+			G_DIETPI-NOTIFY 0 '[ INFO ] lemmy backend installation started'
             G_EXEC curl -sSf 'https://sh.rustup.rs/' -o rustup-init.sh
-			G_EXEC chmod +x rustup-init.sh
-			G_EXEC_OUTPUT=1 G_EXEC ./rustup-init.sh -y --profile minimal
-			G_EXEC rm rustup-init.sh
+            G_EXEC chmod +x rustup-init.sh
+            G_EXEC_OUTPUT=1 G_EXEC ./rustup-init.sh -y --profile minimal
+            G_EXEC rm rustup-init.sh
             export PATH="/root/.cargo/bin:$PATH"
-		    G_EXEC cargo install lemmy_server --target-dir $lemm_bin --locked --features embed-pictrs;
-			G_WHIP_MSG '[ INFO ] lemmy backend installation finished'
+            G_EXEC_OUTPUT=1 G_EXEC cargo install lemmy_server --locked --features embed-pictrs
+			G_DIETPI-NOTIFY 0 '[ INFO ] lemmy backend installation finished'
 
 			## Install lemmy front-end server
             ## Deps
             local url='https://dl.yarnpkg.com/debian/pubkey.gpg'
 			G_CHECK_URL "$url"
-			G_EXEC eval "curl -sSfL '$url' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-lemmy.gpg --yes"
+            G_EXEC eval "curl -sSfL '$url' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-lemmy.gpg --yes"
             G_EXEC eval "echo 'deb https://dl.yarnpkg.com/debian/ stable main' >  /etc/apt/sources.list.d/dietpi-yarn.list"
-			G_AGUP
+            G_AGUP
             G_AGI yarn nodejs
-            ## Installation
+            # ## Installation
             G_EXEC mkdir -p /var/lib/lemmy-ui
             G_EXEC chown $lemm_user:$lemm_user -R /var/lib/lemmy-ui
             # dont compile as admin
             G_EXEC cd /var/lib/lemmy-ui
-            G_WHIP_MSG '[ INFO ] lemmy UI installation started'
-            G_EXEC sudo -u dash .c '\
-git clone https://github.com/LemmyNet/lemmy-ui.git --recursive . && \
-git checkout 0.17.3 && \
-yarn install --pure-lockfile && \
-yarn build:prod'
-            G_WHIP_MSG '[ INFO ] lemmy UI installation finished'
-
-            ## Fresh database
-            ## Hey, maybe a reinstallation shouldn't drop the last database?
-            G_EXEC sudo -u postgres psql -c "DROP DATABASE lemmy;"
-            G_EXEC sudo -u postgres psql -c "CREATE DATABASE lemmy WITH OWNER lemmy ENCODING 'UTF8' TEMPLATE template0 LC_COLLATE 'C' LC_CTYPE 'C';"
-            G_EXEC sudo -u postgres psql -c "ALTER USER lemmy WITH SUPERUSER;"
-            
+            G_DIETPI-NOTIFY 0 '[ INFO ] lemmy UI installation started'
+            G_EXEC sudo -u $lemm_user dash -c '\
+ git clone https://github.com/LemmyNet/lemmy-ui.git --recursive . && \
+ git checkout 0.17.3 && \
+ yarn install --pure-lockfile && \
+ yarn build:prod'
+            G_DIETPI-NOTIFY 0 '[ INFO ] lemmy UI installation finished'
+          
 			# Config Section
             local host_bind=127.0.0.1
             local host_broadcast=0.0.0.0
@@ -4396,7 +4393,7 @@ yarn build:prod'
             local port_pictrs=5434
             local port_frontend=5435  ## default:1234
 
-            G_WHIP_MSG '[ INFO ] lemmy is up and running at https://$host_broadcast:$port_frontend'
+            G_DIETPI-NOTIFY 0 '[ INFO ] lemmy will be up and running at https://$host_broadcast:$port_frontend'
             
 			cat << _EOF_ > /etc/lemmy/lemmy.hjson
 {
@@ -4427,10 +4424,10 @@ After=network.target
 
 [Service]
 User=lemmy
-ExecStart=/home/lemmy/.cargo/bin/lemmy_server
+ExecStart=/root/.cargo/bin/lemmy_server
 Environment=LEMMY_CONFIG_LOCATION=/etc/lemmy/lemmy.hjson
 Environment=PICTRS_PATH=/var/lib/pictrs
-Environment=PICTRS_ADDR=$host_pictrs
+Environment=PICTRS_ADDR=$host_bind:$port_pictrs
 Restart=on-failure
 
 # Hardening
@@ -4515,7 +4512,13 @@ where:
 	esac
 }
 _EOF_
-     
+
+            ## Fresh database and upgrade lemmy to sudo
+            ## Hey, maybe a reinstallation shouldn't drop the last database?
+            G_EXEC systemctl start postgresql
+            G_EXEC sudo -u postgres psql -c "DROP DATABASE lemmy;"
+            G_EXEC sudo -u postgres psql -c "CREATE DATABASE lemmy WITH OWNER lemmy ENCODING 'UTF8' TEMPLATE template0 LC_COLLATE 'C' LC_CTYPE 'C';"
+            G_EXEC sudo -u postgres psql -c "ALTER USER lemmy WITH SUPERUSER;"            
 		fi
            
 		if To_Install 2 fahclient # Folding@Home

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4506,45 +4506,32 @@ _EOF_
 #!/bin/dash
 lemmy-update()
 {
-	case \$1 in
+	case "\$1" in
 		l*) ## Lemmy
 			sudo -u '$lemm_user' dash -c '. "$lemm_home/.cargo/env"; cargo install lemmy_server --locked --features embed-pictrs'
 			sudo systemctl restart lemmy
 			;;
-		ui) ## UI (hardcoded to 0.17.3)
+		ui) ## UI
 			sudo -u '$lemm_user' dash -c '\
 . "$lemm_home/.cargo/env"; \
 cd /var/lib/lemmy-ui; \
 git checkout main && \
 git pull --tags && \
-git checkout 0.17.3 && \
+git checkout main && \
 git submodule update && \
 yarn install --pure-lockfile && \
 yarn build:prod;';
 			sudo systemctl restart lemmy-ui
 			;;
-		pic*) ## PictRS
-			# check docker-compose.yml for pict-rs version used by lemmy
-			# https://github.com/LemmyNet/lemmy-ansible/blob/main/templates/docker-compose.yml#L40
-			sudo -u '$lemm_user' dash -c '\
-. "$lemm_home/.cargo/env"; \
-rustup update && \
-cd /var/lib/pictrs-source && \
-git checkout main && \
-git pull --tags && \
-git checkout v0.2.6-r2 &&\
-cargo build --release &&
-cp target/release/pict-rs /usr/bin/'
-			sudo systemctl restart pictrs
-			;;
 		*) echo 'lemmy-update helper script
 
-usage: lemmy-update <lemmy|ui|pictrs>
+usage: lemmy-update <lemmy|ui>
 
 where:
   lemmy   update and rebuild the backend server (via cargo)
-  ui      update and rebuilt the ui (via yarn)
-  pictrs  update and rebuild the picture service (via cargo)' && \
+  ui      update and rebuild the ui (via yarn)
+
+  branch  defaults to 'main'
 		   return 1;;
 	esac
 }

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4362,7 +4362,7 @@ _EOF_
 
 			## Install Rust, cargo
 			## We assume users will want to upload images, so we enable pictrs
-			G_DIETPI-NOTIFY 0 '[ INFO ] lemmy backend installation started'
+			G_DIETPI-NOTIFY 2 'Lemmy backend installation started'
 			G_EXEC cd "$lemm_home"
 			G_EXEC sudo -u lemmy dash -c '\
 curl -sSf "https://sh.rustup.rs/" -o rustup-init.sh && \

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1047,7 +1047,7 @@ Available commands:
 		aSOFTWARE_NAME[$software_id]='lemmy'
 		aSOFTWARE_DESC[$software_id]='A link aggregator for the fediverse'
 		aSOFTWARE_CATX[$software_id]=6
-        aSOFTWARE_DEPS[$software_id]='9 17 194'
+		aSOFTWARE_DEPS[$software_id]='9 17 194'
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/social/#lemmy'
 
 		# Camera & Surveillance
@@ -4340,31 +4340,31 @@ _EOF_
 		fi
 
 		if To_Install 210 # lemmy
-        then
-            aDEPS=('make' 'gcc' 'libc6-dev' 'pkg-config' 'libssl-dev' 'protobuf-compiler' 'libprotobuf-dev' 'libpq-dev')
+		then
+			aDEPS=('make' 'gcc' 'libc6-dev' 'pkg-config' 'libssl-dev' 'protobuf-compiler' 'libprotobuf-dev' 'libpq-dev')
 
-            # This script creates the lemmy user, a dedicated postgres
-            # db in the dietpi userspace, the lemmy backend, the lemmy
-            # frontend, and apparently the pict-rs image server too
-            # (that last one is NOT clear).
+			# This script creates the lemmy user, a dedicated postgres
+			# db in the dietpi userspace, the lemmy backend, the lemmy
+			# frontend, and apparently the pict-rs image server too
+			# (that last one is NOT clear).
 
-            ## Install up-to-date rustup (cargo version in debian is too old)
+			## Install up-to-date rustup (cargo version in debian is too old)
 			local lemm_user='lemmy'
-            local lemm_home="/home/$lemm_user"
-            local lemm_server_path=$lemm_home/.cargo/bin
+			local lemm_home="/home/$lemm_user"
+			local lemm_server_path=$lemm_home/.cargo/bin
 			# User
-            ##Create_User -G dialout,gpio,i2c -d "$lemm_home" "$lemm_user"
-            G_EXEC mkdir -p "$lemm_home"
-            Create_User -d "$lemm_home" "$lemm_user"
-            G_EXEC chown "$lemm_user":"$lemm_user" -R "$lemm_home"
+			##Create_User -G dialout,gpio,i2c -d "$lemm_home" "$lemm_user"
+			G_EXEC mkdir -p "$lemm_home"
+			Create_User -d "$lemm_home" "$lemm_user"
+			G_EXEC chown "$lemm_user":"$lemm_user" -R "$lemm_home"
 
-            ##G_EXEC sudo su -u $lemm_user mkdir -p $lemm_bin
+			##G_EXEC sudo su -u $lemm_user mkdir -p $lemm_bin
 
 			## Install Rust, cargo
 			## We assume users will want to upload images, so we enable pictrs
 			G_DIETPI-NOTIFY 0 '[ INFO ] lemmy backend installation started'
-            G_EXEC cd "$lemm_home"
-            G_EXEC sudo -u lemmy dash -c '\
+			G_EXEC cd "$lemm_home"
+			G_EXEC sudo -u lemmy dash -c '\
 curl -sSf "https://sh.rustup.rs/" -o rustup-init.sh && \
 chmod +x rustup-init.sh && \
 ./rustup-init.sh -y --profile minimal && \
@@ -4374,41 +4374,41 @@ cargo install lemmy_server --locked --features embed-pictrs'
 			G_DIETPI-NOTIFY 0 '[ INFO ] lemmy backend installation finished'
 
 			## Install lemmy front-end server
-            ## Deps
-            local url='https://dl.yarnpkg.com/debian/pubkey.gpg'
+			## Deps
+			local url='https://dl.yarnpkg.com/debian/pubkey.gpg'
 			G_CHECK_URL "$url"
-            G_EXEC eval "curl -sSfL '$url' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-lemmy.gpg --yes"
-            G_EXEC eval "echo 'deb https://dl.yarnpkg.com/debian/ stable main' >  /etc/apt/sources.list.d/dietpi-yarn.list"
-            G_AGUP
-            G_AGI yarn nodejs
-            # ## Installation
-            if ! [[ -e /var/lib/lemmy-ui ]]; then
-                G_EXEC mkdir -p /var/lib/lemmy-ui
-                G_EXEC chown "$lemm_user":"$lemm_user" -R /var/lib/lemmy-ui
-                # dont compile as admin
-                G_EXEC cd /var/lib/lemmy-ui
-                G_DIETPI-NOTIFY 0 '[ INFO ] lemmy UI installation started'
-                G_EXEC sudo -u "$lemm_user" dash -c 'git clone https://github.com/LemmyNet/lemmy-ui.git --recursive .'
-                G_EXEC sudo -u "$lemm_user" dash -c '\
+			G_EXEC eval "curl -sSfL '$url' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-lemmy.gpg --yes"
+			G_EXEC eval "echo 'deb https://dl.yarnpkg.com/debian/ stable main' >  /etc/apt/sources.list.d/dietpi-yarn.list"
+			G_AGUP
+			G_AGI yarn nodejs
+			# ## Installation
+			if ! [[ -e /var/lib/lemmy-ui ]]; then
+				G_EXEC mkdir -p /var/lib/lemmy-ui
+				G_EXEC chown "$lemm_user":"$lemm_user" -R /var/lib/lemmy-ui
+				# dont compile as admin
+				G_EXEC cd /var/lib/lemmy-ui
+				G_DIETPI-NOTIFY 0 '[ INFO ] lemmy UI installation started'
+				G_EXEC sudo -u "$lemm_user" dash -c 'git clone https://github.com/LemmyNet/lemmy-ui.git --recursive .'
+				G_EXEC sudo -u "$lemm_user" dash -c '\
  git checkout 0.17.3 && \
  yarn install --pure-lockfile && \
  yarn build:prod'
-            fi
-            G_DIETPI-NOTIFY 0 '[ INFO ] lemmy UI installation finished'
+			fi
+			G_DIETPI-NOTIFY 0 '[ INFO ] lemmy UI installation finished'
 
-            # Config Section
-            local host_bind=127.0.0.1
-            local host_broadcast=0.0.0.0
-            local host_domain=dietpi.lemmy.com
-            local pass_database="dblemmypassword"
-            local port_database=5432
-            local port_backend=5433   ## default:8536
-            local port_pictrs=5434
-            local port_frontend=5435  ## default:1234
+			# Config Section
+			local host_bind=127.0.0.1
+			local host_broadcast=0.0.0.0
+			local host_domain=dietpi.lemmy.com
+			local pass_database="dblemmypassword"
+			local port_database=5432
+			local port_backend=5433	  ## default:8536
+			local port_pictrs=5434
+			local port_frontend=5435  ## default:1234
 
-            local lemmy_userdata=/mnt/dietpi_userdata/lemmy/
+			local lemmy_userdata=/mnt/dietpi_userdata/lemmy
 
-            G_DIETPI-NOTIFY 0 "[ INFO ] lemmy will be up and running at https://$host_broadcast:$port_frontend"
+			G_DIETPI-NOTIFY 0 "[ INFO ] lemmy will be up and running at https://$host_broadcast:$port_frontend"
 
 			# Prepare our new config + data directory if not yet present
 			if [[ ! -f "$lemmy_userdata/lemmy.hjson" ]]
@@ -4448,9 +4448,9 @@ cargo install lemmy_server --locked --features embed-pictrs'
 }
 _EOF_
 			## Backend Service
-            # Pictrs options: https://git.asonix.dog/asonix/pict-rs/
-            G_EXEC mkdir -p "$lemmy_userdata/pictrs/sled-repo"
-            G_EXEC mkdir -p "$lemmy_userdata/pictrs/store"
+			# Pictrs options: https://git.asonix.dog/asonix/pict-rs/
+			G_EXEC mkdir -p "$lemmy_userdata/pictrs/sled-repo"
+			G_EXEC mkdir -p "$lemmy_userdata/pictrs/store"
 			cat << _EOF_ > /etc/systemd/system/lemmy.service
 [Unit]
 Description=Lemmy - A link aggregator for the fediverse
@@ -4508,11 +4508,11 @@ lemmy-update()
 {
 	case \$1 in
 		l*) ## Lemmy
-            sudo -u '$lemm_user' dash -c '. "$lemm_home/.cargo/env"; cargo install lemmy_server --locked --features embed-pictrs'
-            sudo systemctl restart lemmy
-            ;;
+			sudo -u '$lemm_user' dash -c '. "$lemm_home/.cargo/env"; cargo install lemmy_server --locked --features embed-pictrs'
+			sudo systemctl restart lemmy
+			;;
 		ui) ## UI (hardcoded to 0.17.3)
-            sudo -u '$lemm_user' dash -c '\
+			sudo -u '$lemm_user' dash -c '\
 . "$lemm_home/.cargo/env"; \
 cd /var/lib/lemmy-ui; \
 git checkout main && \
@@ -4521,12 +4521,12 @@ git checkout 0.17.3 && \
 git submodule update && \
 yarn install --pure-lockfile && \
 yarn build:prod;';
-            sudo systemctl restart lemmy-ui
-            ;;
+			sudo systemctl restart lemmy-ui
+			;;
 		pic*) ## PictRS
-            # check docker-compose.yml for pict-rs version used by lemmy
-            # https://github.com/LemmyNet/lemmy-ansible/blob/main/templates/docker-compose.yml#L40
-            sudo -u '$lemm_user' dash -c '\
+			# check docker-compose.yml for pict-rs version used by lemmy
+			# https://github.com/LemmyNet/lemmy-ansible/blob/main/templates/docker-compose.yml#L40
+			sudo -u '$lemm_user' dash -c '\
 . "$lemm_home/.cargo/env"; \
 rustup update && \
 cd /var/lib/pictrs-source && \
@@ -4535,8 +4535,8 @@ git pull --tags && \
 git checkout v0.2.6-r2 &&\
 cargo build --release &&
 cp target/release/pict-rs /usr/bin/'
-            sudo systemctl restart pictrs
-            ;;
+			sudo systemctl restart pictrs
+			;;
 		*) echo 'lemmy-update helper script
 
 usage: lemmy-update <lemmy|ui|pictrs>
@@ -4545,30 +4545,30 @@ where:
   lemmy   update and rebuild the backend server (via cargo)
   ui      update and rebuilt the ui (via yarn)
   pictrs  update and rebuild the picture service (via cargo)' && \
-           return 1;;
+		   return 1;;
 	esac
 }
 _EOF_
 
-            # Postgres
-            ## We need to tell postgres that we're doing password auth (md5) and not peer.
-            G_EXEC sed -i -r '/^local\s+all\s+all\s+peer/i local   lemmy           lemmy                                   md5' /etc/postgresql/15/main/pg_hba.conf
-            G_EXEC systemctl restart postgresql
+			# Postgres
+			## We need to tell postgres that we're doing password auth (md5) and not peer.
+			G_EXEC sed -i -r '/^local\s+all\s+all\s+peer/i local   lemmy		   lemmy								   md5' /etc/postgresql/15/main/pg_hba.conf
+			G_EXEC systemctl restart postgresql
 
-            local db_files="$lemmy_userdata/postgres"
-            G_EXEC mkdir -p "$db_files"
-            G_EXEC chown postgres:postgres -R "$db_files"
-            G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "DROP DATABASE IF EXISTS lemmy;"
-            G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "DROP TABLESPACE IF EXISTS lemmydata;"
-            G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "DROP ROLE IF EXISTS lemmy;"
-            G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "CREATE USER lemmy WITH PASSWORD '""$pass_database""';"
-            G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "CREATE TABLESPACE lemmydata OWNER lemmy LOCATION '""$db_files""';"
-            G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "CREATE DATABASE lemmy WITH OWNER lemmy ENCODING 'UTF8' TEMPLATE template0 LC_COLLATE 'C' LC_CTYPE 'C' TABLESPACE='lemmydata';"
-            G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE lemmy TO lemmy;"
-            G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "ALTER USER lemmy WITH SUPERUSER;"
-            G_EXEC systemctl restart postgresql
+			local db_files="$lemmy_userdata/postgres"
+			G_EXEC mkdir -p "$db_files"
+			G_EXEC chown postgres:postgres -R "$db_files"
+			G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "DROP DATABASE IF EXISTS lemmy;"
+			G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "DROP TABLESPACE IF EXISTS lemmydata;"
+			G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "DROP ROLE IF EXISTS lemmy;"
+			G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "CREATE USER lemmy WITH PASSWORD '""$pass_database""';"
+			G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "CREATE TABLESPACE lemmydata OWNER lemmy LOCATION '""$db_files""';"
+			G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "CREATE DATABASE lemmy WITH OWNER lemmy ENCODING 'UTF8' TEMPLATE template0 LC_COLLATE 'C' LC_CTYPE 'C' TABLESPACE='lemmydata';"
+			G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE lemmy TO lemmy;"
+			G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "ALTER USER lemmy WITH SUPERUSER;"
+			G_EXEC systemctl restart postgresql
 		fi
-           
+
 		if To_Install 2 fahclient # Folding@Home
 		then
 			G_DIETPI-NOTIFY 2 'Pre-configuring FAHClient DEB package'
@@ -13280,20 +13280,20 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 
 		if To_Uninstall 210 # lemmy
 		then
-            Remove_Service lemmy-ui 1 1
-            Remove_Service lemmy 1 1
-            G_EXEC userdel lemmy
-            G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "DROP DATABASE IF EXISTS lemmy;"
-            G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "DROP TABLESPACE IF EXISTS lemmydata;"
-            G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "DROP ROLE IF EXISTS lemmy;"
-            ## Remove Lemmy config line
-            [[ -f '/etc/postgresql/15/main/pg_hba.conf' ]] && G_EXEC sed -i -r '/^local\s+lemmy\s+lemmy\s+md5/d'  /etc/postgresql/15/main/pg_hba.conf
-            ##
-            [[ -d '/var/lib/lemmy-ui' ]] && G_EXEC rm -rf /var/lib/lemmy-ui
-            [[ -d '/home/lemmy' ]] && G_EXEC rm -rf /home/lemmy
-            [[ -f '/etc/systemd/system/lemmy.service' ]] && G_EXEC rm /etc/systemd/system/lemmy.service
-            [[ -f '/etc/systemd/system/lemmy-ui.service' ]] && G_EXEC rm /etc/systemd/system/lemmy-ui.service
-            [[ -f '/etc/bashrc.d/lemmy.sh' ]] && G_EXEC rm /etc/bashrc.d/lemmy.sh
+			Remove_Service lemmy-ui 1 1
+			Remove_Service lemmy 1 1
+			## Remove_Service postgres ??
+			G_EXEC userdel lemmy
+			G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "DROP DATABASE IF EXISTS lemmy;"
+			G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "DROP TABLESPACE IF EXISTS lemmydata;"
+			G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "DROP ROLE IF EXISTS lemmy;"
+			## Remove Lemmy config line
+			[[ -f '/etc/postgresql/15/main/pg_hba.conf' ]] && G_EXEC sed -i -r '/^local\s+lemmy\s+lemmy\s+md5/d'  /etc/postgresql/15/main/pg_hba.conf
+			[[ -d '/var/lib/lemmy-ui' ]] && G_EXEC rm -rf /var/lib/lemmy-ui
+			[[ -d '/home/lemmy' ]] && G_EXEC rm -rf /home/lemmy
+			[[ -f '/etc/systemd/system/lemmy.service' ]] && G_EXEC rm /etc/systemd/system/lemmy.service
+			[[ -f '/etc/systemd/system/lemmy-ui.service' ]] && G_EXEC rm /etc/systemd/system/lemmy-ui.service
+			[[ -f '/etc/bashrc.d/lemmy.sh' ]] && G_EXEC rm /etc/bashrc.d/lemmy.sh
 		fi
 
 		if To_Uninstall 98 # HAProxy

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1047,6 +1047,7 @@ Available commands:
 		aSOFTWARE_NAME[$software_id]='lemmy'
 		aSOFTWARE_DESC[$software_id]='A link aggregator for the fediverse'
 		aSOFTWARE_CATX[$software_id]=6
+        aSOFTWARE_DEPS[$software_id]='9 17'
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/social/#lemmy'
 
 		# Camera & Surveillance
@@ -4350,51 +4351,68 @@ _EOF_
 			## Install Rust, cargo
 			## We assume users will want to upload images, so we enable pictrs
 			G_WHIP_MSG '[ INFO ] lemmy backend installation started'
-			sudo su -u $lemm_user dash -c '\
-curl https://sh.rustup.rs -sSf | sh;\
-source "$lemm_home/.cargo/env"; \
-cargo install lemmy_server --target-dir $lemm_bin --locked --features embed-pictrs;'
+            G_EXEC curl -sSf 'https://sh.rustup.rs/' -o rustup-init.sh
+			G_EXEC chmod +x rustup-init.sh
+			G_EXEC_OUTPUT=1 G_EXEC ./rustup-init.sh -y --profile minimal
+			G_EXEC rm rustup-init.sh
+            export PATH="/root/.cargo/bin:$PATH"
+		    G_EXEC cargo install lemmy_server --target-dir $lemm_bin --locked --features embed-pictrs;
 			G_WHIP_MSG '[ INFO ] lemmy backend installation finished'
 
-			## TODO: Install lemmy front-end server
-## Deps
-# https://classic.yarnpkg.com/en/docs/install/#debian-stable
-curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-# https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions
-curl -fsSL https://deb.nodesource.com/setup_12.x | sudo -E bash -
-sudo apt install nodejs yarn
+			## Install lemmy front-end server
+            ## Deps
+            local url='https://dl.yarnpkg.com/debian/pubkey.gpg'
+			G_CHECK_URL "$url"
+			G_EXEC eval "curl -sSfL '$url' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-lemmy.gpg --yes"
+            G_EXEC eval "echo 'deb https://dl.yarnpkg.com/debian/ stable main' >  /etc/apt/sources.list.d/dietpi-yarn.list"
+			G_AGUP
+            G_AGI yarn nodejs
+            ## Installation
+            G_EXEC mkdir -p /var/lib/lemmy-ui
+            G_EXEC chown $lemm_user:$lemm_user -R /var/lib/lemmy-ui
+            # dont compile as admin
+            G_EXEC cd /var/lib/lemmy-ui
+            G_WHIP_MSG '[ INFO ] lemmy UI installation started'
+            G_EXEC sudo -u dash .c '\
+git clone https://github.com/LemmyNet/lemmy-ui.git --recursive . && \
+git checkout 0.17.3 && \
+yarn install --pure-lockfile && \
+yarn build:prod'
+            G_WHIP_MSG '[ INFO ] lemmy UI installation finished'
 
-## Installation
-mkdir /var/lib/lemmy-ui
-cd /var/lib/lemmy-ui
-chown lemmy:lemmy .
-# dont compile as admin
-sudo -u lemmy bash
-git clone https://github.com/LemmyNet/lemmy-ui.git --recursive .
-git checkout 0.16.7 # replace with the version you want to install
-yarn install --pure-lockfile
-yarn build:prod
-exit
+            ## Fresh database
+            ## Hey, maybe a reinstallation shouldn't drop the last database?
+            G_EXEC sudo -u postgres psql -c "DROP DATABASE lemmy;"
+            G_EXEC sudo -u postgres psql -c "CREATE DATABASE lemmy WITH OWNER lemmy ENCODING 'UTF8' TEMPLATE template0 LC_COLLATE 'C' LC_CTYPE 'C';"
+            G_EXEC sudo -u postgres psql -c "ALTER USER lemmy WITH SUPERUSER;"
+            
+			# Config Section
+            local host_bind=127.0.0.1
+            local host_broadcast=0.0.0.0
+            local host_domain=dietpi.lemmy.com
+            local port_database=5432
+            local port_backend=5433
+            local port_pictrs=5434
+            local port_frontend=5435
 
-			## Backend Config
+            G_WHIP_MSG '[ INFO ] lemmy is up and running at https://$host_broadcast:$port_frontend'
+            
 			cat << _EOF_ > /etc/lemmy/lemmy.hjson
 {
   database: {
-    # put your db-passwd from above
     password: "db-passwd"
-    port: 5432
+    port: $port_database
   }
   # replace with your domain
-  hostname: "dietpi.lemmy"
-  bind: "127.0.0.1"
-  port: 5433
+  hostname: "$host_domain"
+  bind: "$host_bind"
+  port: $port_backend
   federation: {
     enabled: true
   }
   # remove this block if you don't require image hosting
   pictrs: {
-    url: "http://localhost:5434/"
+    url: "$host_bind:$port_pictrs/"
   }
   ## Disable this if not a federated instance
   tls_enabled: true
@@ -4408,11 +4426,10 @@ After=network.target
 
 [Service]
 User=lemmy
-ExecStart=/usr/bin/lemmy_server
+ExecStart=/home/lemmy/.cargo/bin/lemmy_server
 Environment=LEMMY_CONFIG_LOCATION=/etc/lemmy/lemmy.hjson
-# remove these two lines if you don't need pict-rs
 Environment=PICTRS_PATH=/var/lib/pictrs
-Environment=PICTRS_ADDR=127.0.0.1:5434
+Environment=PICTRS_ADDR=$host_pictrs
 Restart=on-failure
 
 # Hardening
@@ -4429,15 +4446,16 @@ _EOF_
 [Unit]
 Description=Lemmy UI - Web frontend for Lemmy
 After=lemmy.service
-Before=nginx.service
+Before=nginx.service  ## Hey, do you think this is needed?
 
 [Service]
 User=lemmy
 WorkingDirectory=/var/lib/lemmy-ui
 ExecStart=/usr/bin/node dist/js/server.js
-Environment=LEMMY_INTERNAL_HOST=localhost:5433
-Environment=LEMMY_EXTERNAL_HOST="dietpi.lemmy"
-Environment=LEMMY_HTTPS=true
+Environment=LEMMY_UI_HOST=$host_broadcast:$port_frontend
+Environment=LEMMY_UI_LEMMY_INTERNAL_HOST=$host_bind:$port_backend
+Environment=LEMMY_UI_LEMMY_EXTERNAL_HOST="$host_domain"
+Environment=LEMMY_UI_HTTPS=true ## Hey, should this be enforced?
 Restart=on-failure
 
 # Hardening
@@ -4448,7 +4466,7 @@ NoNewPrivileges=true
 [Install]
 WantedBy=multi-user.target
 _EOF_
-			## Upgrade Scripts
+			## TODO: Upgrade Scripts. FIX THIS SO THAT IT WORKS WITH THE GLOBAL CARGO ENV
     		cat << _EOF_ > /etc/bashrc.d/lemmy.sh
 #!/bin/dash
 lemmy-update()

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4382,7 +4382,7 @@ cargo install lemmy_server --locked --features embed-pictrs'
             G_AGUP
             G_AGI yarn nodejs
             # ## Installation
-            if ! [ -e /var/lib/lemmy-ui ]; then
+            if ! [[ -e /var/lib/lemmy-ui ]]; then
                 G_EXEC mkdir -p /var/lib/lemmy-ui
                 G_EXEC chown "$lemm_user":"$lemm_user" -R /var/lib/lemmy-ui
                 # dont compile as admin
@@ -4395,8 +4395,8 @@ cargo install lemmy_server --locked --features embed-pictrs'
  yarn build:prod'
             fi
             G_DIETPI-NOTIFY 0 '[ INFO ] lemmy UI installation finished'
-          
-			# Config Section
+
+            # Config Section
             local host_bind=127.0.0.1
             local host_broadcast=0.0.0.0
             local host_domain=dietpi.lemmy.com
@@ -4413,10 +4413,9 @@ cargo install lemmy_server --locked --features embed-pictrs'
 			# Prepare our new config + data directory if not yet present
 			if [[ ! -f "$lemmy_userdata/lemmy.hjson" ]]
 			then
-				[[ -d '$lemmy_userdata' ]] || G_EXEC mkdir $lemmy_userdata
+				[[ -d "$lemmy_userdata" ]] || G_EXEC mkdir "$lemmy_userdata"
 			fi
-            
-            
+
 			cat << _EOF_ > "$lemmy_userdata/lemmy.hjson"
 # https://join-lemmy.org/docs/en/administration/configuration.html#full-config-with-default-values
 {
@@ -4450,6 +4449,8 @@ cargo install lemmy_server --locked --features embed-pictrs'
 _EOF_
 			## Backend Service
             # Pictrs options: https://git.asonix.dog/asonix/pict-rs/
+            G_EXEC mkdir -p "$lemmy_userdata/pictrs/sled-repo"
+            G_EXEC mkdir -p "$lemmy_userdata/pictrs/store"
 			cat << _EOF_ > /etc/systemd/system/lemmy.service
 [Unit]
 Description=Lemmy - A link aggregator for the fediverse
@@ -4460,8 +4461,8 @@ User=lemmy
 ExecStart=$lemm_server_path/lemmy_server
 Environment=LEMMY_CONFIG_LOCATION="$lemmy_userdata/lemmy.hjson"
 Environment=PICTRS_PATH=$lemmy_userdata/pictrs
-Environment=PICTRS__REPO__PATH=$PICTRS_PATH/sled-repo
-Environment=PICTRS__STORE__PATH=$PICTRS_PATH/store
+Environment=PICTRS__REPO__PATH=$lemmy_userdata/pictrs/sled-repo
+Environment=PICTRS__STORE__PATH=$lemmy_userdata/pictrs/store
 Environment=PICTRS_ADDR=$host_bind:$port_pictrs
 Restart=on-failure
 
@@ -4533,7 +4534,7 @@ git checkout main && \
 git pull --tags && \
 git checkout v0.2.6-r2 &&\
 cargo build --release &&
-cp target/release/pict-rs "$lemm_bin" '
+cp target/release/pict-rs /usr/bin/'
             sudo systemctl restart pictrs
             ;;
 		*) echo 'lemmy-update helper script
@@ -4554,9 +4555,9 @@ _EOF_
             G_EXEC sed -i -r '/^local\s+all\s+all\s+peer/i local   lemmy           lemmy                                   md5' /etc/postgresql/15/main/pg_hba.conf
             G_EXEC systemctl restart postgresql
 
-            local db_files=$lemmy_userdata/postgres
-            G_EXEC mkdir -p $db_files
-            G_EXEC chown postgres:postgres -R $db_files
+            local db_files="$lemmy_userdata/postgres"
+            G_EXEC mkdir -p "$db_files"
+            G_EXEC chown postgres:postgres -R "$db_files"
             G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "DROP DATABASE IF EXISTS lemmy;"
             G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "DROP TABLESPACE IF EXISTS lemmydata;"
             G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "DROP ROLE IF EXISTS lemmy;"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1047,7 +1047,7 @@ Available commands:
 		aSOFTWARE_NAME[$software_id]='lemmy'
 		aSOFTWARE_DESC[$software_id]='A link aggregator for the fediverse'
 		aSOFTWARE_CATX[$software_id]=6
-        aSOFTWARE_DEPS[$software_id]='9 17'
+        aSOFTWARE_DEPS[$software_id]='9 17 194'
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/social/#lemmy'
 
 		# Camera & Surveillance
@@ -4345,6 +4345,7 @@ _EOF_
 			## Install up-to-date rustup (cargo version in debian is too old)
 			local lemm_user='lemmy'
             local lemm_home="/home/$lemm_user"
+            local lemm_server_path=$lemm_home/.cargo/bin
 			# User
             ##Create_User -G dialout,gpio,i2c -d "$lemm_home" "$lemm_user"
             G_EXEC mkdir -p "$lemm_home"
@@ -4356,12 +4357,14 @@ _EOF_
 			## Install Rust, cargo
 			## We assume users will want to upload images, so we enable pictrs
 			G_DIETPI-NOTIFY 0 '[ INFO ] lemmy backend installation started'
-            G_EXEC curl -sSf 'https://sh.rustup.rs/' -o rustup-init.sh
-            G_EXEC chmod +x rustup-init.sh
-            G_EXEC_OUTPUT=1 G_EXEC ./rustup-init.sh -y --profile minimal
-            G_EXEC rm rustup-init.sh
-            export PATH="/root/.cargo/bin:$PATH"
-            G_EXEC_OUTPUT=1 G_EXEC cargo install lemmy_server --locked --features embed-pictrs
+            G_EXEC cd "$lemm_home"
+            G_EXEC sudo -u lemmy dash -c '\
+curl -sSf "https://sh.rustup.rs/" -o rustup-init.sh && \
+chmod +x rustup-init.sh && \
+./rustup-init.sh -y --profile minimal && \
+rm rustup-init.sh; \
+. /home/lemmy/.cargo/env
+cargo install lemmy_server --locked --features embed-pictrs'
 			G_DIETPI-NOTIFY 0 '[ INFO ] lemmy backend installation finished'
 
 			## Install lemmy front-end server
@@ -4373,33 +4376,47 @@ _EOF_
             G_AGUP
             G_AGI yarn nodejs
             # ## Installation
-            G_EXEC mkdir -p /var/lib/lemmy-ui
-            G_EXEC chown "$lemm_user":"$lemm_user" -R /var/lib/lemmy-ui
-            # dont compile as admin
-            G_EXEC cd /var/lib/lemmy-ui
-            G_DIETPI-NOTIFY 0 '[ INFO ] lemmy UI installation started'
-            G_EXEC sudo -u "$lemm_user" dash -c '\
- git clone https://github.com/LemmyNet/lemmy-ui.git --recursive . && \
+            if ! [ -e /var/lib/lemmy-ui ]; then
+                G_EXEC mkdir -p /var/lib/lemmy-ui
+                G_EXEC chown "$lemm_user":"$lemm_user" -R /var/lib/lemmy-ui
+                # dont compile as admin
+                G_EXEC cd /var/lib/lemmy-ui
+                G_DIETPI-NOTIFY 0 '[ INFO ] lemmy UI installation started'
+                G_EXEC sudo -u "$lemm_user" dash -c 'git clone https://github.com/LemmyNet/lemmy-ui.git --recursive .'
+                G_EXEC sudo -u "$lemm_user" dash -c '\
  git checkout 0.17.3 && \
  yarn install --pure-lockfile && \
  yarn build:prod'
+            fi
             G_DIETPI-NOTIFY 0 '[ INFO ] lemmy UI installation finished'
           
 			# Config Section
             local host_bind=127.0.0.1
             local host_broadcast=0.0.0.0
             local host_domain=dietpi.lemmy.com
+            local pass_database="dblemmypassword"
             local port_database=5432
             local port_backend=5433   ## default:8536
             local port_pictrs=5434
             local port_frontend=5435  ## default:1234
 
+            local lemmy_userdata=/mnt/dietpi_userdata/lemmy/
+
             G_DIETPI-NOTIFY 0 "[ INFO ] lemmy will be up and running at https://$host_broadcast:$port_frontend"
+
+			# Prepare our new config + data directory if not yet present
+			if [[ ! -f "$lemmy_userdata/lemmy.hjson" ]]
+			then
+				[[ -d '$lemmy_userdata' ]] || G_EXEC mkdir $lemmy_userdata
+			fi
             
-			cat << _EOF_ > /etc/lemmy/lemmy.hjson
+            
+			cat << _EOF_ > "$lemmy_userdata/lemmy.hjson"
+# https://join-lemmy.org/docs/en/administration/configuration.html#full-config-with-default-values
 {
   database: {
-    password: "db-passwd"
+    host: /var/run/postgresql
+    password: "$pass_database"
     port: $port_database
   }
   # replace with your domain
@@ -4411,13 +4428,21 @@ _EOF_
   }
   # remove this block if you don't require image hosting
   pictrs: {
-    url: "$host_bind:$port_pictrs/"
+    url: "https://$host_bind:$port_pictrs/"
+    api_key: "$pass_database"
+  }
+  setup: {
+    admin_username: "dietpi"
+    # Password for the admin user. It must be at least 10 characters.
+    admin_password: "dietpi-lemmy"
+    site_name: "My DietPi Lemmy Instance"
   }
   ## Disable this if not a federated instance
   tls_enabled: true
 }
 _EOF_
 			## Backend Service
+            # Pictrs options: https://git.asonix.dog/asonix/pict-rs/
 			cat << _EOF_ > /etc/systemd/system/lemmy.service
 [Unit]
 Description=Lemmy - A link aggregator for the fediverse
@@ -4425,9 +4450,11 @@ After=network.target
 
 [Service]
 User=lemmy
-ExecStart=/root/.cargo/bin/lemmy_server
-Environment=LEMMY_CONFIG_LOCATION=/etc/lemmy/lemmy.hjson
-Environment=PICTRS_PATH=/var/lib/pictrs
+ExecStart=$lemm_server_path/lemmy_server
+Environment=LEMMY_CONFIG_LOCATION="$lemmy_userdata/lemmy.hjson"
+Environment=PICTRS_PATH=$lemmy_userdata/picts  # /var/lib/pictrs
+Environment=PICTRS__REPO__PATH=$PICTRS_PATH/sled-repo
+Environment=PICTRS__STORE__PATH=$PICTRS_PATH/store
 Environment=PICTRS_ADDR=$host_bind:$port_pictrs
 Restart=on-failure
 
@@ -4454,6 +4481,7 @@ ExecStart=/usr/bin/node dist/js/server.js
 Environment=LEMMY_UI_HOST=$host_broadcast:$port_frontend
 Environment=LEMMY_UI_LEMMY_INTERNAL_HOST=$host_bind:$port_backend
 Environment=LEMMY_UI_LEMMY_EXTERNAL_HOST="$host_domain"
+Environment=LEMMY_UI_EXTRA_THEMES_FOLDER="$lemmy_userdata/extra-themes"
 Environment=LEMMY_UI_HTTPS=true ## Hey, should this be enforced?
 Restart=on-failure
 
@@ -4516,10 +4544,19 @@ _EOF_
 
             ## Fresh database and upgrade lemmy to sudo
             ## Hey, maybe a reinstallation shouldn't drop the last database?
+            G_EXEC systemctl stop postgresql
             G_EXEC systemctl start postgresql
-            G_EXEC sudo -u postgres psql -c "DROP DATABASE lemmy;"
-            G_EXEC sudo -u postgres psql -c "CREATE DATABASE lemmy WITH OWNER lemmy ENCODING 'UTF8' TEMPLATE template0 LC_COLLATE 'C' LC_CTYPE 'C';"
-            G_EXEC sudo -u postgres psql -c "ALTER USER lemmy WITH SUPERUSER;"            
+            local db_files=$lemmy_userdata/postgres
+            G_EXEC mkdir -p $db_files
+            G_EXEC chown postgres:postgres -R $db_files
+            G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "DROP DATABASE IF EXISTS lemmy;"
+            G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "DROP TABLESPACE IF EXISTS lemmydata;"
+            G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "DROP ROLE IF EXISTS lemmy;"
+            G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "CREATE USER lemmy WITH PASSWORD '""$pass_database""';"
+            G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "CREATE TABLESPACE lemmydata OWNER lemmy LOCATION '""$db_files""';"
+            G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "CREATE DATABASE lemmy WITH OWNER lemmy ENCODING 'UTF8' TEMPLATE template0 LC_COLLATE 'C' LC_CTYPE 'C' TABLESPACE='lemmydata';"
+            G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE lemmy TO lemmy;"
+            G_EXEC_OUTPUT=1 G_EXEC sudo -iu postgres psql -c "ALTER USER lemmy WITH SUPERUSER;"
 		fi
            
 		if To_Install 2 fahclient # Folding@Home


### PR DESCRIPTION
The Fediverse is really picking up steam since the latest Reddit drama and a lot of people are spawning their own Lemmy instances.

I’m impressed that Lemmy only needs [150 MB RAM and uses virtually no CPU](https://join-lemmy.org/docs/en/administration/administration.html?highlight=RAM#officialsupported-methods), so it seems ideal for DietPi

This is a WIP based on the in the [installation page](https://join-lemmy.org/docs/en/administration/from_scratch.html), using the "From Scratch" approach, since Docker and Ansible are no-nos.

Surprisingly there are no Deb packages of existing builds out there, so compilation is taking ~40mins on my Rpi4

The install encompasses two builds:
* Lemmy Backend
* Lemmy UI

If we should split them into seperate things, lemme know!