### PR TITLE
DietPi-Software | Home Assistant: Bump pyenv Python version to 3.11.4

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,11 +7,13 @@ Removed software:
 
 Enhancements:
 - DietPi-Software | microblog.pub: On fresh installs and reinstalls, the pyenv Python version will be raised to 3.11.4, matching the version of the official Docker container.
+- DietPi-Software | Home Assistant: The pyenv Python version has been updated to 3.11.4 to maintain compatibility with Home Assistant and align with Home Assistant OS and containers. Many thanks to @whyisthisbroken and others for informing us about this: https://dietpi.com/forum/t/home-assistant-finally-integrates-python-3-11/17033
 
 Bug fixes:
 - Quartz64 | Resolved an issue where some iptables/nftables features did not work as of missing kernel features. Many thanks to @acelinkit for reporting the issue and pointing us at the solution: https://github.com/MichaIng/DietPi/issues/6389
 - DietPi-Software | Bazarr: Resolved an issue on Bookworm ARMv6/7 systems where the install failed because of missing dependencies.
 - DietPi-Software | microblog.pub: Resolved an issue where the install failed on x86_64 due to a missing new build dependency.
+- DietPi-Software | Home Assistant: Since latest Home Assistant requires more recent FFmpeg libraries than provided on Debian Bullseye, sadly it now requires at least Debian Bookworm. Your existing Home Assistant instance will remain functional, but you can only update/reinstall it after upgrading to Debian Bookworm: https://dietpi.com/blog/?p=2809, https://community.home-assistant.io/t/unable-to-install-package-ha-av/466286/39
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1514,6 +1514,8 @@ Available commands:
 		aSOFTWARE_DESC[$software_id]='Open source home automation platform'
 		aSOFTWARE_CATX[$software_id]=17
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/home_automation/#home-assistant'
+		# Bookworm only as it requires FFmpeg headers >=4.4: https://community.home-assistant.io/t/unable-to-install-package-ha-av/466286/39
+		(( $G_DISTRO > 6 )) || aSOFTWARE_AVAIL_G_DISTRO[$software_id,$G_DISTRO]=0
 		#------------------
 		software_id=140
 		aSOFTWARE_NAME[$software_id]='Domoticz'
@@ -11285,7 +11287,7 @@ _EOF_
 			local ha_user='homeassistant'
 			local ha_home="/home/$ha_user"
 			local ha_pyenv_activation=". $ha_home/pyenv-activate.sh"
-			local ha_python_version='3.10.11' # https://github.com/pyenv/pyenv/tree/master/plugins/python-build/share/python-build
+			local ha_python_version='3.11.4' # https://github.com/pyenv/pyenv/tree/master/plugins/python-build/share/python-build
 
 			G_DIETPI-NOTIFY 2 "Home Assistant user:  $ha_user"
 			G_DIETPI-NOTIFY 2 "Home Assistant home:  $ha_home"


### PR DESCRIPTION
https://dietpi.com/forum/t/home-assistant-finally-integrates-python-3-11/17033