### PR TITLE
DietPi-Software | WiFi Hotspot: Cleanup and enhance deps and settings

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ v8.20
 (2023-07-29)
 
 Enhancements:
+- DietPi-Software | WiFi Hotspot: The default DHCP server settings have been cleaned up and enhanced, with the default lease time increased from 10 minutes to 12 hours, the max lease time increased from 2 hours to 1 day, and the IP range extended up to 192.168.42.250.
 
 Bug fixes:
 - DietPi-LetsEncrypt | Resolved a DietPi v8.19 regression where applying the HTTPS certificate for Lighttpd fails. Many thanks to @midniteca for reporting this issue: https://github.com/MichaIng/DietPi/issues/6460

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3507,7 +3507,7 @@ ServerName $(G_GET_NET ip)
 DocumentRoot /var/www
 
 # Logging to: journalctl -u apache2
-ErrorLog syslog:local7
+ErrorLog syslog
 
 # Allow unlimited Keep-Alive requests
 MaxKeepAliveRequests 0
@@ -6568,7 +6568,7 @@ _EOF_
 			esac
 
 			# Download
-			local fallback_url="https://github.com/fatedier/frp/releases/download/v0.50.0/frp_0.50.0_linux_$arch.tar.gz"
+			local fallback_url="https://github.com/fatedier/frp/releases/download/v0.51.0/frp_0.51.0_linux_$arch.tar.gz"
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/fatedier/frp/releases/latest' | mawk -F\" "/\"browser_download_url\": .*\/frp_[0-9.]*_linux_$arch\.tar\.gz\"/{print \$4}")"
 
 			G_EXEC cd frp_*
@@ -7868,7 +7868,7 @@ _EOF_
 
 		if To_Install 60 # WiFi Hotspot
 		then
-			local packages=('hostapd' 'isc-dhcp-server' 'iptables' 'libnl-3-200')
+			local packages=('hostapd' 'isc-dhcp-server' 'iptables')
 
 			G_AGI "${packages[@]}"
 			G_EXEC systemctl stop hostapd isc-dhcp-server
@@ -7887,18 +7887,16 @@ _EOF_
 			# DHCP server config
 			G_BACKUP_FP /etc/dhcp/dhcpd.conf
 			cat << '_EOF_' > /etc/dhcp/dhcpd.conf
-ddns-update-style none;
-default-lease-time 600;
-max-lease-time 7200;
 authoritative;
-log-facility local7;
+#default-lease-time 43200;
+#max-lease-time 86400;
 
 subnet 192.168.42.0 netmask 255.255.255.0 {
-        range 192.168.42.10 192.168.42.50;
-        option broadcast-address 192.168.42.255;
-        option routers 192.168.42.1;
-        option domain-name "local";
-        option domain-name-servers 9.9.9.9, 149.112.112.112;
+	range 192.168.42.10 192.168.42.250;
+	option broadcast-address 192.168.42.255;
+	option routers 192.168.42.1;
+	option domain-name "local";
+	option domain-name-servers 9.9.9.9, 149.112.112.112;
 }
 _EOF_
 			# Assign detected WLAN interface
@@ -9007,7 +9005,7 @@ _EOF_
 					*) local arch='arm';;
 				esac
 
-				local fallback_url="https://github.com/syncthing/syncthing/releases/download/v1.23.5/syncthing-linux-$arch-v1.23.5.tar.gz"
+				local fallback_url="https://github.com/syncthing/syncthing/releases/download/v1.23.6/syncthing-linux-$arch-v1.23.6.tar.gz"
 				Download_Install "$(curl -sSfL 'https://api.github.com/repos/syncthing/syncthing/releases/latest' | mawk -F\" "/\"browser_download_url\": .*\/syncthing-linux-$arch-[^\"\/]*\.tar\.gz\"/{print \$4}")"
 				G_EXEC mv syncthing-* /opt/syncthing
 			fi
@@ -9619,7 +9617,7 @@ _EOF_
 				# ARMv7
 				else
 					local url=$(curl -sSfL 'https://api.github.com/repos/Radarr/Radarr/releases/latest' | mawk -F\" '/"browser_download_url": .*linux-core-arm\.tar\.gz"/{print $4}')
-					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v4.5.2.7388/Radarr.master.4.5.2.7388.linux-core-arm.tar.gz'
+					local fallback_url='https://github.com/Radarr/Radarr/releases/download/v4.6.4.7568/Radarr.master.4.6.4.7568.linux-core-arm.tar.gz'
 				fi
 
 				# ARMv8
@@ -10651,7 +10649,7 @@ _EOF_
 				*) local arch='arm-6';;
 			esac
 
-			local fallback_url="https://github.com/go-gitea/gitea/releases/download/v1.19.3/gitea-1.19.3-linux-$arch.xz"
+			local fallback_url="https://github.com/go-gitea/gitea/releases/download/v1.19.4/gitea-1.19.4-linux-$arch.xz"
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/go-gitea/gitea/releases/latest' | mawk -F\" "/\"browser_download_url\": \".*\/gitea-[^\"\/]*-linux-$arch\.xz\"/{print \$4}")" /mnt/dietpi_userdata/gitea/gitea
 
 			# User


### PR DESCRIPTION
### Changes

- `libnl-3-200` is a dependency of `hostapd` on all supported Debian versions.
- The default lease time of the DHCP server is half/one day default/max, which seems much more reasonable than 10 minutes default/2 hours max, as long as it is not for a WiFi hotspot for customers in a coffee shop or similar. For at home I would even set it to a week or something, but the default seems to be a good compromise. It makes sense to leave the settings commented within the config file, as this is something admins may want to change for their use cases.
- `ddns-update-style` defaults to `none` and alone does not make sense. This DHCP server can inform a (local) DNS server automatically about its client's IP and hostname changes on leases, in a DDNS fashion. Quite handy on larger networks with several hotspots/DHCP servers but a central DNS server. But requires a lot of additional setup.
- The `log-facility` is a syslog parameter which can be used for sorting logs. E.g. `rsyslog` can be configured to forward logs with a certain facility to different log files. This is used by default to create the separate `daemon.log`, `kern.log`, `cron.log` files in `/var/log`. Also `journalctl` has an option to show only logs from a specific facility, but it is much easier to sort by service/unit via `--unit/-u` option. `local0` - `local7` are sort of unused facilities, hence free to be used by admins for anything: https://en.wikipedia.org/wiki/Syslog#Facility
    The default `dhcpd` facility is `daemon`, hence with `rsyslog` by default logs land in `daemon.log`, which is actually pretty fine. There is not really a point to change it, unless one wants to explicitly redirect those elsewhere and configures the syslog daemon accordingly.
    `local7` is sometimes misunderstood as network facility, as the facility with "code" 7 is indeed for network news. I found several wrong StackExchange answers about this. However, the facility code does not equal the "local" facility number, as `local7` actually has the facility code 23 (see Wikipedia article). I guess this misunderstanding is the reason why `local7` was used here.
- The log facility for Apache was removed in the same turn. It defaults to `local7` anyway, which is actually another reason to not use the same for the DHCP server.
- `authoritative` needs to remain to encourage misconfigured clients to release an IP. It is not set by default so that if this package is accidentally installed, it does not override authoritative DHCP server within the network. It can be seen as a "I know what I am doing!" flag.
- Fallback URL updates

For reference: https://manpages.debian.org/dhcpd.conf

### Questions

1. Shall we configure the DHCP server automatically to promote Pi-hole/AdGuard Home/Unbound as DNS server to clients, if installed or about to be installed? Could follow a similar logic like the auto-configuration of Unbound as upstream DNS in this combination: Who would install a DNS server and a WiFi hotspot on the same system, if the DNS server should not serve the DHCP clients as well?
2. Pi-hole as well as AdGuard Home both have an own optional DHCP server. So theoretically this should make the `isc-dhcp-server` redundant for the WiFi hotspot, or would even conflict if both were enabled. However, we configure it (via `/etc/default/isc-dhcp-server`) to only listen on the WiFi network, of course, while Pi-hole and AdGuard Home alone would usually listen on the Internet facing interface, hence the Ethernet interface in this case. So no conflict. I am not sure now whether Pi-hole and AdGuard Home can be configured to be DHCP server for the Ethernet side network as well as the dedicated WiFi network with each own IP ranges? Or whether they can be configured to only be DHCP server for WiFi clients if the router shall remain DHCP server for the Ethernet network, while answering DNS requests from both sides?