### PR TITLE
Update dietpi-letsencrypt, since the upgrade to bookworm Lighttpd is now …

### DIFF
--- a/.update/version
+++ b/.update/version
@@ -14,6 +14,6 @@ G_MIN_DEBIAN=5
 # Alternative Git branch to automatically migrate to when Debian version is too low
 G_OLD_DEBIAN_BRANCH='stretch'
 # Live patches
-G_LIVE_PATCH_DESC=()
-G_LIVE_PATCH_COND=()
-G_LIVE_PATCH=()
+G_LIVE_PATCH_DESC=('Fix Pi-hole, ownCloud, Nextcloud, Pydio and WikiMedia install if Lighttpd is selected as webserver')
+G_LIVE_PATCH_COND=('grep -q '\''setenv.*dietpi-https'\'' /boot/dietpi/dietpi-software')
+G_LIVE_PATCH=('sed -i '\''/setenv.*dietpi-https/s/dietpi-https/setenv/'\'' /boot/dietpi/dietpi-software')

--- a/.update/version
+++ b/.update/version
@@ -14,6 +14,15 @@ G_MIN_DEBIAN=5
 # Alternative Git branch to automatically migrate to when Debian version is too low
 G_OLD_DEBIAN_BRANCH='stretch'
 # Live patches
-G_LIVE_PATCH_DESC=('Fix Pi-hole, ownCloud, Nextcloud, Pydio and WikiMedia install if Lighttpd is selected as webserver')
-G_LIVE_PATCH_COND=('grep -q '\''setenv.*dietpi-https'\'' /boot/dietpi/dietpi-software')
-G_LIVE_PATCH=('sed -i '\''/setenv.*dietpi-https/s/dietpi-https/setenv/'\'' /boot/dietpi/dietpi-software')
+G_LIVE_PATCH_DESC=(
+	[0]='Fix Pi-hole, ownCloud, Nextcloud, Pydio and WikiMedia install if Lighttpd is selected as webserver'
+	[1]='Fix applying dietpi-letsencrypt certificate for Lighttpd'
+)
+G_LIVE_PATCH_COND=(
+	[0]='grep -q '\''setenv.*dietpi-https'\'' /boot/dietpi/dietpi-software'
+	[1]='grep -q '\''setenv.*dietpi-https'\'' /boot/dietpi/dietpi-letsencrypt'
+)
+G_LIVE_PATCH=(
+	[0]='sed -i '\''/setenv.*dietpi-https/s/dietpi-https/setenv/'\'' /boot/dietpi/dietpi-software'
+	[1]='sed -i '\''/setenv.*dietpi-https/s/dietpi-https/setenv/'\'' /boot/dietpi/dietpi-letsencrypt'
+)

--- a/.update/version
+++ b/.update/version
@@ -14,15 +14,6 @@ G_MIN_DEBIAN=5
 # Alternative Git branch to automatically migrate to when Debian version is too low
 G_OLD_DEBIAN_BRANCH='stretch'
 # Live patches
-G_LIVE_PATCH_DESC=(
-	[0]='Fix Pi-hole, ownCloud, Nextcloud, Pydio and WikiMedia install if Lighttpd is selected as webserver'
-	[1]='Fix applying dietpi-letsencrypt certificate for Lighttpd'
-)
-G_LIVE_PATCH_COND=(
-	[0]='grep -q '\''setenv.*dietpi-https'\'' /boot/dietpi/dietpi-software'
-	[1]='grep -q '\''setenv.*dietpi-https'\'' /boot/dietpi/dietpi-letsencrypt'
-)
-G_LIVE_PATCH=(
-	[0]='sed -i '\''/setenv.*dietpi-https/s/dietpi-https/setenv/'\'' /boot/dietpi/dietpi-software'
-	[1]='sed -i '\''/setenv.*dietpi-https/s/dietpi-https/setenv/'\'' /boot/dietpi/dietpi-letsencrypt'
-)
+G_LIVE_PATCH_DESC=()
+G_LIVE_PATCH_COND=()
+G_LIVE_PATCH=()

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ v8.20
 (2023-07-29)
 
 Enhancements:
+- DietPi-LetsEncrypt | Updated the Lighttpd SSL config syntax and options according to latest Mozilla SSL config generator recommendation with intermediate client compatibility. Many thanks to @JappeHallunken for implementing this enhancement: https://github.com/MichaIng/DietPi/pull/6481
 - DietPi-Software | WiFi Hotspot: The default DHCP server settings have been cleaned up and enhanced, with the default lease time increased from 10 minutes to 12 hours, the max lease time increased from 2 hours to 1 day, and the IP range extended up to 192.168.42.250.
 
 Bug fixes:

--- a/dietpi/dietpi-letsencrypt
+++ b/dietpi/dietpi-letsencrypt
@@ -125,19 +125,15 @@ server.modules += ( "mod_openssl" )
 	ssl.pemfile = "$fp_cert_dir/fullchain.pem"
 	ssl.privkey = "$fp_cert_dir/privkey.pem"
 
-	# For DH/DHE ciphers, dhparam should be >= 2048-bit
-	#ssl.dh-file = "/path/to/dhparam.pem"
-	# ECDH/ECDHE ciphers curve strength, see "openssl ecparam -list_curves"
-	ssl.ec-curve = "secp384r1"
 
 	# Environment flag for HTTPS enabled
 	setenv.add-environment = ( "HTTPS" => "on" )
 
 	# Intermediate configuration, tweak to your needs
 	ssl.openssl.ssl-conf-cmd = ("MinProtocol" => "TLSv1.2", "Options" => "-SessionTicket")
-	ssl.cipher-list = "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384"
-	ssl.honor-cipher-order = "disable"
-	ssl.disable-client-renegotiation = "enable"
+	ssl.openssl.ssl-conf-cmd += ("Options" => "-ServerPreference")
+	ssl.openssl.ssl-conf-cmd += ("CipherString" => "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384")
+
 }
 # IPv6
 \$SERVER["socket"] == "[::]:443" {
@@ -146,19 +142,13 @@ server.modules += ( "mod_openssl" )
 	ssl.pemfile = "$fp_cert_dir/fullchain.pem"
 	ssl.privkey = "$fp_cert_dir/privkey.pem"
 
-	# For DH/DHE ciphers, dhparam should be >= 2048-bit
-	#ssl.dh-file = "/path/to/dhparam.pem"
-	# ECDH/ECDHE ciphers curve strength, see "openssl ecparam -list_curves"
-	ssl.ec-curve = "secp384r1"
-
 	# Environment flag for HTTPS enabled
 	setenv.add-environment = ( "HTTPS" => "on" )
 
 	# Intermediate configuration, tweak to your needs
 	ssl.openssl.ssl-conf-cmd = ("MinProtocol" => "TLSv1.2", "Options" => "-SessionTicket")
-	ssl.cipher-list = "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384"
-	ssl.honor-cipher-order = "disable"
-	ssl.disable-client-renegotiation = "enable"
+	ssl.openssl.ssl-conf-cmd += ("Options" => "-ServerPreference")
+	ssl.openssl.ssl-conf-cmd += ("CipherString" => "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384")
 }
 _EOF_
 			# Bullseye: Install dedicated TLS module package and keep session tickets enabled, which is safe since Lighttpd v1.4.56: https://github.com/MichaIng/DietPi/issues/4294#issuecomment-826802056

--- a/dietpi/dietpi-letsencrypt
+++ b/dietpi/dietpi-letsencrypt
@@ -129,10 +129,12 @@ server.modules += ( "mod_openssl" )
 	setenv.add-environment = ( "HTTPS" => "on" )
 
 	# Intermediate configuration, tweak to your needs
-	ssl.openssl.ssl-conf-cmd = ("MinProtocol" => "TLSv1.2", "Options" => "-SessionTicket")
-	ssl.openssl.ssl-conf-cmd += ("Options" => "-ServerPreference")
-	ssl.openssl.ssl-conf-cmd += ("CipherString" => "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384")
-
+	ssl.openssl.ssl-conf-cmd = (
+		"MinProtocol" => "TLSv1.2",
+		"Options" => "-SessionTicket",
+		"Options" => "-ServerPreference",
+		"CipherString" => "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305"
+	)
 }
 # IPv6
 \$SERVER["socket"] == "[::]:443" {
@@ -145,9 +147,12 @@ server.modules += ( "mod_openssl" )
 	setenv.add-environment = ( "HTTPS" => "on" )
 
 	# Intermediate configuration, tweak to your needs
-	ssl.openssl.ssl-conf-cmd = ("MinProtocol" => "TLSv1.2", "Options" => "-SessionTicket")
-	ssl.openssl.ssl-conf-cmd += ("Options" => "-ServerPreference")
-	ssl.openssl.ssl-conf-cmd += ("CipherString" => "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384")
+	ssl.openssl.ssl-conf-cmd = (
+		"MinProtocol" => "TLSv1.2",
+		"Options" => "-SessionTicket",
+		"Options" => "-ServerPreference",
+		"CipherString" => "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305"
+	)
 }
 _EOF_
 			# Bullseye: Install dedicated TLS module package and keep session tickets enabled, which is safe since Lighttpd v1.4.56: https://github.com/MichaIng/DietPi/issues/4294#issuecomment-826802056

--- a/dietpi/dietpi-letsencrypt
+++ b/dietpi/dietpi-letsencrypt
@@ -125,7 +125,6 @@ server.modules += ( "mod_openssl" )
 	ssl.pemfile = "$fp_cert_dir/fullchain.pem"
 	ssl.privkey = "$fp_cert_dir/privkey.pem"
 
-
 	# Environment flag for HTTPS enabled
 	setenv.add-environment = ( "HTTPS" => "on" )
 


### PR DESCRIPTION
…on 1.4.69; depcrecated some SSL/TSL features and changed also default config for SSL

See https://ssl-config.mozilla.org/#server=lighttpd and http://www.lighttpd.net/2022/8/7/1.4.66/

Also some more features of other modules are deprecated, I will have a look into them later.

Probably this needs to be implemented with a version check, for users with older debian base image? The deprecated features could be kept, ligtthpd just throws a warning at startup about them. But what with CipherString? IDK if this is compatible with older lighttpd versions.

