### PR TITLE
DietPi-Software | apache2 / NextCloud / ownCloud / Pi-hole: Disable deprecated X-XSS-Protection header, Enable in NextCloud to avoid admin panel warning

### DIFF
--- a/.conf/dps_114/apache.nextcloud.conf
+++ b/.conf/dps_114/apache.nextcloud.conf
@@ -8,6 +8,9 @@
 	<IfModule mod_dav.c>
 		Dav off
 	</IfModule>
+
+	# Mute outdated admin panel warning
+	Header set X-XSS-Protection "1; mode=block"
 </Directory>
 
 # Redirect webfinger and nodeinfo requests to Nextcloud endpoint

--- a/.conf/dps_47/lighttpd.owncloud.conf
+++ b/.conf/dps_47/lighttpd.owncloud.conf
@@ -17,7 +17,7 @@ $HTTP["url"] =~ "^/owncloud($|/)" {
 			"Cache-Control" => "public, max-age=15778463",
 			"X-Frame-Options" => "SAMEORIGIN",
 			"X-Content-Type-Options" => "nosniff",
-			"X-XSS-Protection" => "1; mode=block",
+			"X-XSS-Protection" => "0",
 			"X-Robots-Tag" => "noindex, nofollow",
 			"X-Download-Options" => "noopen",
 			"X-Permitted-Cross-Domain-Policies" => "none",

--- a/.conf/dps_47/nginx.owncloud.conf
+++ b/.conf/dps_47/nginx.owncloud.conf
@@ -9,7 +9,7 @@ location ^~ /owncloud {
 	#add_header Strict-Transport-Security "max-age=15768000; includeSubDomains" always;
 	add_header X-Content-Type-Options nosniff always;
 	add_header X-Frame-Options "SAMEORIGIN" always;
-	add_header X-XSS-Protection "1; mode=block" always;
+	add_header X-XSS-Protection "0" always;
 	add_header X-Robots-Tag "noindex, nofollow" always;
 	add_header X-Download-Options noopen always;
 	add_header X-Permitted-Cross-Domain-Policies none always;

--- a/.conf/dps_93/lighttpd.pihole.conf
+++ b/.conf/dps_93/lighttpd.pihole.conf
@@ -12,7 +12,7 @@ $HTTP["url"] =~ "^(/html)?/admin/" {
 		"X-Pi-hole" => "The Pi-hole Web interface is working!",
 		"X-Content-Type-Options" => "nosniff",
 		"X-Frame-Options" => "deny",
-		"X-XSS-Protection" => "1; mode=block",
+		"X-XSS-Protection" => "0",
 		"X-Robots-Tag" => "noindex, nofollow",
 		"X-Permitted-Cross-Domain-Policies" => "none",
 		"Referrer-Policy" => "same-origin",

--- a/.conf/dps_93/nginx.pihole.conf
+++ b/.conf/dps_93/nginx.pihole.conf
@@ -15,7 +15,7 @@ location ~ ^(?:/html|)/admin(?:$|/) {
 	add_header X-Content-Type-Options "nosniff";
 	set $frame_options "deny";
 	add_header X-Frame-Options "$frame_options";
-	add_header X-XSS-Protection "1; mode=block";
+	add_header X-XSS-Protection "0";
 	add_header X-Robots-Tag "noindex, nofollow";
 	add_header X-Permitted-Cross-Domain-Policies "none";
 	add_header Referrer-Policy "same-origin";

--- a/.update/patches
+++ b/.update/patches
@@ -17,7 +17,7 @@ then
 	then
 		echo 25 > /etc/.dietpi_hw_model_identifier # Generic Allwinner H3
 
-	elif [[  $G_HW_MODEL == 3[87] ]] # OPi PC2, OPi Prime
+	elif [[ $G_HW_MODEL == 3[87] ]] # OPi PC2, OPi Prime
 	then
 		echo 26 > /etc/.dietpi_hw_model_identifier # Generic Allwinner H5
 	fi
@@ -1390,7 +1390,31 @@ Release notes: https://github.com/BlitterStudio/amiberry/releases
 
 Patch_8_20()
 {
-	:
+	# Software updates and migrations
+	if [[ -f '/boot/dietpi/.installed' ]]
+	then
+		# Set deprecated X-XSS-Protection header to 0
+		# - Apache
+		if grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[83\]=2' /boot/dietpi/.installed
+		then
+			[[ -f '/etc/apache2/conf-available/dietpi.conf' ]] && G_EXEC sed -i '/^Header set X-XSS-Protection "/c\Header set X-XSS-Protection "0"' /etc/apache2/conf-available/dietpi.conf
+
+			# Nextcloud: Revert to mute Nextcloud's outdated admin panel warning
+			[[ -f '/etc/apache2/sites-available/dietpi-nextcloud.conf' ]] && G_EXEC sed -i '/<\/IfModule>/a\\n\t# Mute outdated admin panel warning\n\tHeader set X-XSS-Protection "1; mode=block"' /etc/apache2/sites-available/dietpi-nextcloud.conf
+		fi
+		# - ownCloud
+		if grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[47\]=2' /boot/dietpi/.installed
+		then
+			[[ -f '/etc/nginx/sites-dietpi/dietpi-owncloud.conf' ]] && G_EXEC sed -i 's/add_header X-XSS-Protection "1; mode=block" always;/add_header X-XSS-Protection "0" always;/' /etc/nginx/sites-dietpi/dietpi-owncloud.conf
+			[[ -f '/etc/lighttpd/conf-available/99-dietpi-owncloud.conf' ]] && G_EXEC sed -i 's/"X-XSS-Protection" => "1; mode=block"/"X-XSS-Protection" => "0"/' /etc/lighttpd/conf-available/99-dietpi-owncloud.conf
+		fi
+		# - Pi-hole
+		if grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[93\]=2' /boot/dietpi/.installed
+		then
+			[[ -f '/etc/nginx/sites-dietpi/dietpi-pihole.conf' ]] && G_EXEC sed -i 's/add_header X-XSS-Protection "1; mode=block";/add_header X-XSS-Protection "0";/' /etc/nginx/sites-dietpi/dietpi-pihole.conf
+			[[ -f '/etc/lighttpd/conf-enabled/99-dietpi-pihole.conf' ]] && G_EXEC sed -i 's/"X-XSS-Protection" => "1; mode=block"/"X-XSS-Protection" => "0"/' /etc/lighttpd/conf-enabled/99-dietpi-pihole.conf
+		fi
+	fi
 }
 
 # v6.35 => v7 migration

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ v8.20
 Enhancements:
 - DietPi-LetsEncrypt | Updated the Lighttpd SSL config syntax and options according to latest Mozilla SSL config generator recommendation with intermediate client compatibility. Many thanks to @JappeHallunken for implementing this enhancement: https://github.com/MichaIng/DietPi/pull/6481
 - DietPi-Software | WiFi Hotspot: The default DHCP server settings have been cleaned up and enhanced, with the default lease time increased from 10 minutes to 12 hours, the max lease time increased from 2 hours to 1 day, and the IP range extended up to 192.168.42.250.
+- DietPi-Software | Apache/ownCloud/Pi-hole: The X-XSS-Protection header is now set to "0" in default configs to match recent security recommendations. This change is also applied to all systems on next DietPi update. Many thanks to @Zer0x00 for implementing this enhancement: https://github.com/MichaIng/DietPi/pull/6491
 
 Bug fixes:
 - Raspberry Pi | Resolved an issue on Bookworm systems where FFmpeg and related A/V libraries and development headers could not be installed, since the raised epoch version of those from the Raspberry Pi repository is leading to conflicts with the newer ones from the Debian Bookworm repository.

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3532,7 +3532,7 @@ TraceEnable Off
 # Security headers
 Header set X-Content-Type-Options "nosniff"
 Header set X-Frame-Options "sameorigin"
-Header set X-XSS-Protection "1; mode=block"
+Header set X-XSS-Protection "0"
 Header set X-Robots-Tag "noindex, nofollow"
 Header set X-Permitted-Cross-Domain-Policies "none"
 Header set Referrer-Policy "no-referrer"


### PR DESCRIPTION
Just noticed that the X-XSS-Protection header is now disabled in the [base Pi-hole configuration](https://github.com/pi-hole/pi-hole/blob/development/advanced/pihole-admin.conf) since it was deprecated in all major browsers a while ago.

Since the DietPi Pi-hole webserver config files are based on the base configuration we should disable it also in DietPi.

The apache configuration file has not set the header, therefore it's not necessary to change anything there.

<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
