### PR TITLE
Raspberry Pi | Resolve FFmpeg package conflicts on Bookworm

### DIFF
--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -758,12 +758,27 @@ setenv rootuuid "true"' /boot/boot.cmd
 		# (Re)create DietPi runtime and logs dir, used by G_AGx
 		G_EXEC mkdir -p /run/dietpi /var/tmp/dietpi/logs
 
-		# RPi/ARMv6 container: Bootstrap RPi repo when key is missing
-		if [[ ( $G_HW_MODEL -le 9 || ( $G_HW_MODEL == 75 && $G_RASPBIAN == 1 ) ) && ! $(apt-key list 'CF8A1AF502A2AA2D763BAE7E82B129927FA3303E' 2> /dev/null) ]]
+		# RPi/ARMv6 container
+		if [[ -f '/etc/apt/sources.list.d/raspi.list' ]]
 		then
-			G_EXEC curl -sSf 'https://archive.raspberrypi.org/debian/pool/main/r/raspberrypi-archive-keyring/raspberrypi-archive-keyring_2021.1.1+rpt1_all.deb' -o keyring.deb
-			G_EXEC dpkg -i keyring.deb
-			G_EXEC rm keyring.deb
+			# Bootstrap RPi repo if key is missing
+			if [[ ! $(apt-key list 'CF8A1AF502A2AA2D763BAE7E82B129927FA3303E' 2> /dev/null) ]]
+			then
+				G_EXEC curl -sSf 'https://archive.raspberrypi.org/debian/pool/main/r/raspberrypi-archive-keyring/raspberrypi-archive-keyring_2021.1.1+rpt1_all.deb' -o keyring.deb
+				G_EXEC dpkg -i keyring.deb
+				G_EXEC rm keyring.deb
+			fi
+
+			# Bookworm: Avoid conflict between RPi repo and Bookworm FFmpeg packages: https://github.com/MichaIng/DietPi/issues/6461
+			if (( $DISTRO_TARGET > 6 ))
+			then
+				G_DIETPI-NOTIFY 2 'Enforcing Debian Bookworm FFmpeg packages over RPi repo ones'
+				cat << '_EOF_' > /etc/apt/preferences.d/dietpi-ffmpeg
+Package: src:ffmpeg
+Pin: version 7:5*
+Pin-Priority: 1000
+_EOF_
+			fi
 		fi
 
 		G_AGUP

--- a/.meta/dietpi-bookworm-upgrade
+++ b/.meta/dietpi-bookworm-upgrade
@@ -64,10 +64,21 @@ G_DIETPI-NOTIFY 2 'Reverting some package lists to Bullseye which have no Bookwo
 [[ -f '/etc/apt/sources.list.d/influxdb.list' ]] && G_EXEC sed -i 's/bookworm/bullseye/' /etc/apt/sources.list.d/influxdb.list
 [[ -f '/etc/apt/sources.list.d/mopidy.list' ]] && G_EXEC sed -i 's/bookworm/bullseye/' /etc/apt/sources.list.d/mopidy.list
 
-if (( $G_HW_MODEL < 10 )) && grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[31\]=2' /boot/dietpi/.installed && dpkg-query -s kodi &> /dev/null
+# RPi/ARMv6 container Bookworm
+if [[ -f '/etc/apt/sources.list.d/raspi.list' ]]
 then
-	G_DIETPI-NOTIFY 2 'Temporarily removeing Kodi packages to avoid conflicts with Debian Bookworm packages'
-	G_EXEC_OUTPUT=1 G_EXEC apt-get -y autoremove kodi
+	# Avoid conflict between RPi repo and Bookworm FFmpeg packages: https://github.com/MichaIng/DietPi/issues/6461
+	G_DIETPI-NOTIFY 2 'Enforcing Debian Bookworm FFmpeg packages over RPi repo ones'
+	cat << '_EOF_' > /etc/apt/preferences.d/dietpi-ffmpeg
+Package: src:ffmpeg
+Pin: version 7:5*
+Pin-Priority: 1000
+_EOF_
+	if grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[31\]=2' /boot/dietpi/.installed && dpkg-query -s kodi &> /dev/null
+	then
+		G_DIETPI-NOTIFY 2 'Temporarily removeing Kodi packages to avoid conflicts with Debian Bookworm packages'
+		G_EXEC_OUTPUT=1 G_EXEC apt-get -y autoremove kodi
+	fi
 fi
 
 G_DIETPI-NOTIFY 2 'Applying the actual upgrade to Debian Bookworm'

--- a/.update/pre-patches
+++ b/.update/pre-patches
@@ -242,5 +242,20 @@ then
 	fi
 fi
 
+# v8.20
+if (( $G_DIETPI_VERSION_CORE < 8 || ( $G_DIETPI_VERSION_CORE == 8 && $G_DIETPI_VERSION_SUB < 20 ) ))
+then
+	# RPi/ARMv6 container Bookworm: Avoid conflict between RPi repo and Bookworm FFmpeg packages: https://github.com/MichaIng/DietPi/issues/6461
+	if [[ $G_DISTRO -ge 7 && -f '/etc/apt/sources.list.d/raspi.list' ]]
+	then
+		G_DIETPI-NOTIFY 2 'Enforcing Debian Bookworm FFmpeg packages over RPi repo ones'
+		cat << '_EOF_' > /etc/apt/preferences.d/dietpi-ffmpeg
+Package: src:ffmpeg
+Pin: version 7:5*
+Pin-Priority: 1000
+_EOF_
+	fi
+fi
+
 exit 0
 }

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ Enhancements:
 - DietPi-Software | WiFi Hotspot: The default DHCP server settings have been cleaned up and enhanced, with the default lease time increased from 10 minutes to 12 hours, the max lease time increased from 2 hours to 1 day, and the IP range extended up to 192.168.42.250.
 
 Bug fixes:
+- Raspberry Pi | Resolved an issue on Bookworm systems where FFmpeg and related A/V libraries and development headers could not be installed, since the raised epoch version of those from the Raspberry Pi repository is leading to conflicts with the newer ones from the Debian Bookworm repository.
 - DietPi-LetsEncrypt | Resolved a DietPi v8.19 regression where applying the HTTPS certificate for Lighttpd fails. Many thanks to @midniteca for reporting this issue: https://github.com/MichaIng/DietPi/issues/6460
 - DietPi-Config | Resolved an issue where enabling Bluetooth on SBCs with Armbian firmware failed, because of a conflict between armbian-firmware and bluez-firmware packages. bluez-firmware will not be tried to be installed anymore if armbian-firmware is. Many thanks to @innovodev for reporting this issue: https://dietpi.com/forum/t/upgrading-dietpi-from-bullseye-to-bookworm/15963/16
 - DietPi-Software | Lighttpd: Resolved a DietPi v8.19 regression where the installation of Pi-hole, ownCloud, Nextcloud, Pydio and WikiMedia failed if Lighttpd was selected as webserver and HTTPS not yet enabled via dietpi-letsencrypt. Many thanks to @bruno-briner for reporting this issue: https://github.com/MichaIng/DietPi/issues/6455


### PR DESCRIPTION
- Raspberry Pi | Resolved an issue on Bookworm systems where FFmpeg and related A/V libraries and development headers could not be installed, since the raised epoch version of those from the Raspberry Pi repository is leading to conflicts with the newer ones from the Debian Bookworm repository.
