### PR TITLE
NanoPi R5S/R5C/6 series | Update kernel to v5.10.160

### DIFF
--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -236,13 +236,18 @@ G_EXIT_CUSTOM(){
 # NanoPi 5/6: Base image download
 if [[ $HW_MODEL == 7[69] ]]
 then
-	G_EXEC curl -sSfO "https://dietpi.com/downloads/${iname,,}.7z"
-	G_EXEC "$c7zz" x "${iname,,}.7z"
-	G_EXEC rm "${iname,,}.7z"
-	G_EXEC truncate -s "$(( 140 + $root_size ))M" "${iname,,}.img"
-	G_EXEC_OUTPUT=1 G_EXEC sgdisk -e "${iname,,}.img"
-	G_EXEC_OUTPUT=1 G_EXEC eval "sfdisk -fN8 '${iname,,}.img' <<< ',+'"
-	G_EXEC mv "${iname,,}.img" "$OUTPUT_IMG_NAME.img"
+	case $HW_MODEL in
+		76) series=5;;
+		79) series=6;;
+		*) :;;
+	esac
+	G_EXEC curl -sSfO "https://dietpi.com/downloads/nanopi$series.7z"
+	G_EXEC "$c7zz" x "nanopi$series.7z"
+	G_EXEC rm "nanopi$series.7z"
+	G_EXEC truncate -s "$(( 140 + $root_size ))M" "nanopi$series.img"
+	G_EXEC_OUTPUT=1 G_EXEC sgdisk -e "nanopi$series.img"
+	G_EXEC_OUTPUT=1 G_EXEC eval "sfdisk -fN8 'nanopi$series.img' <<< ',+'"
+	G_EXEC mv "nanopi$series.img" "$OUTPUT_IMG_NAME.img"
 else
 # Create image file
 G_EXEC fallocate -l "$((partition_start+efi_size+boot_size+root_size))M" "$OUTPUT_IMG_NAME.img"

--- a/.update/patches
+++ b/.update/patches
@@ -1349,7 +1349,7 @@ Patch_8_20()
 	if [[ $series ]] && dpkg --compare-versions "$(dpkg-query -Wf '${Version}' "firmware-nanopi$series" 2> /dev/null)" lt-nl "$version"
 	then
 		G_DIETPI-NOTIFY 2 "Updating NanoPi $series series kernel ..."
-		G_EXEC curl -sSfO "https://dietpi.com/downloads/testing/nanopi$series.7z"
+		G_EXEC curl -sSfO "https://dietpi.com/downloads/nanopi$series.7z"
 		G_EXEC 7zr x "nanopi$series.7z"
 		G_EXEC rm "nanopi$series.7z"
 		local loopdev=$(losetup -f) rootdev=$(lsblk -npo PKNAME "$G_ROOTFS_DEV")
@@ -1364,7 +1364,7 @@ Patch_8_20()
 		then
 			G_DIETPI-NOTIFY 1 "Unsupported system: ${rootdev}p8 != $G_ROOTFS_DEV, aborting kernel upgrade ..."
 		else
-			G_EXEC curl -sSfO "https://dietpi.com/downloads/binaries/testing/firmware-nanopi$series.deb"
+			G_EXEC curl -sSfO "https://dietpi.com/downloads/binaries/firmware-nanopi$series.deb"
 			G_EXEC_OUTPUT=1 G_EXEC dpkg -i --force-confdef,confold "firmware-nanopi$series.deb"
 			for i in {1..7}
 			do

--- a/.update/patches
+++ b/.update/patches
@@ -1268,45 +1268,8 @@ Patch_8_18()
 
 Patch_8_19()
 {
-	# NanoPi R5S/R6S kernel upgrade
-	case $G_HW_MODEL in
-		76) local series=5 version='5.10.110-dietpi7';;
-		79) local series=6 version='5.10.110-dietpi5';;
-		*) local series='';;
-	esac
-
-	if [[ $series ]] && dpkg --compare-versions "$(dpkg-query -Wf '${Version}' "firmware-nanopi$series" 2> /dev/null)" lt-nl "$version"
-	then
-		G_DIETPI-NOTIFY 2 "Updating NanoPi R$series series kernel ..."
-		G_EXEC curl -sSfO "https://dietpi.com/downloads/nanopir${series}s.7z"
-		G_EXEC 7zr x "nanopir${series}s.7z"
-		G_EXEC rm "nanopir${series}s.7z"
-		local loopdev=$(losetup -f) rootdev=$(lsblk -npo PKNAME "$G_ROOTFS_DEV")
-		G_EXEC losetup "$loopdev" "nanopir${series}s.img"
-		G_EXEC partprobe "$loopdev"
-		G_EXEC partx -u "$loopdev"
-		if [[ ! -b ${loopdev}p8 ]]
-		then
-			G_DIETPI-NOTIFY 1 "Image invalid: ${loopdev}p8 does not exist, aborting kernel upgrade ..."
-
-		elif [[ ${rootdev}p8 != "$G_ROOTFS_DEV" ]]
-		then
-			G_DIETPI-NOTIFY 1 "Unsupported system: ${rootdev}p8 != $G_ROOTFS_DEV, aborting kernel upgrade ..."
-		else
-			G_EXEC curl -sSfO "https://dietpi.com/downloads/binaries/firmware-nanopi$series.deb"
-			G_EXEC_OUTPUT=1 G_EXEC dpkg -i --force-confdef,confold "firmware-nanopi$series.deb"
-			for i in {1..7}
-			do
-				G_EXEC dd if="${loopdev}p$i" of="${rootdev}p$i" bs=1M
-			done
-			G_EXEC sync
-			G_EXEC rm "firmware-nanopi$series.deb"
-		fi
-		G_EXEC losetup -d "$loopdev"
-		G_EXEC rm "nanopir${series}s.img"
-
 	# Quartz64
-	elif (( $G_HW_MODEL == 49 ))
+	if (( $G_HW_MODEL == 49 ))
 	then
 		if dpkg --compare-versions "$(dpkg-query -Wf '${Version}' firmware-quartz64a 2> /dev/null)" lt-nl 6.3.11-dietpi1
 		then
@@ -1376,6 +1339,44 @@ Release notes: https://github.com/BlitterStudio/amiberry/releases
 
 Patch_8_20()
 {
+	# NanoPi R5S/6 kernel upgrade
+	case $G_HW_MODEL in
+		76) local series=5 version='5.10.160-dietpi1';;
+		79) local series=6 version='5.10.160-dietpi1';;
+		*) local series='';;
+	esac
+
+	if [[ $series ]] && dpkg --compare-versions "$(dpkg-query -Wf '${Version}' "firmware-nanopi$series" 2> /dev/null)" lt-nl "$version"
+	then
+		G_DIETPI-NOTIFY 2 "Updating NanoPi $series series kernel ..."
+		G_EXEC curl -sSfO "https://dietpi.com/downloads/testing/nanopi$series.7z"
+		G_EXEC 7zr x "nanopi$series.7z"
+		G_EXEC rm "nanopi$series.7z"
+		local loopdev=$(losetup -f) rootdev=$(lsblk -npo PKNAME "$G_ROOTFS_DEV")
+		G_EXEC losetup "$loopdev" "nanopi$series.img"
+		G_EXEC partprobe "$loopdev"
+		G_EXEC partx -u "$loopdev"
+		if [[ ! -b ${loopdev}p8 ]]
+		then
+			G_DIETPI-NOTIFY 1 "Image invalid: ${loopdev}p8 does not exist, aborting kernel upgrade ..."
+
+		elif [[ ${rootdev}p8 != "$G_ROOTFS_DEV" ]]
+		then
+			G_DIETPI-NOTIFY 1 "Unsupported system: ${rootdev}p8 != $G_ROOTFS_DEV, aborting kernel upgrade ..."
+		else
+			G_EXEC curl -sSfO "https://dietpi.com/downloads/binaries/testing/firmware-nanopi$series.deb"
+			G_EXEC_OUTPUT=1 G_EXEC dpkg -i --force-confdef,confold "firmware-nanopi$series.deb"
+			for i in {1..7}
+			do
+				G_EXEC dd if="${loopdev}p$i" of="${rootdev}p$i" bs=1M
+			done
+			G_EXEC sync
+			G_EXEC rm "firmware-nanopi$series.deb"
+		fi
+		G_EXEC losetup -d "$loopdev"
+		G_EXEC rm "nanopi$series.img"
+	fi
+
 	# Software updates and migrations
 	if [[ -f '/boot/dietpi/.installed' ]]
 	then

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ New software:
 
 Enhancements:
 - Quartz64 | Enabled support for the NFS kernel server. Many thanks to @sewe75 for reporting this missing feature: https://github.com/MichaIng/DietPi/issues/6502
+- NanoPi R5S/R5C/6 series | An update of the kernel to Linux 5.10.160 will be applied as part of the DietPi update. Many thanks to @meco for informing us about this opportunity: https://dietpi.com/forum/t/new-kernel-for-nanopi-s-5-10-160/17325
 - DietPi-LetsEncrypt | Updated the Lighttpd SSL config syntax and options according to latest Mozilla SSL config generator recommendation with intermediate client compatibility. Many thanks to @JappeHallunken for implementing this enhancement: https://github.com/MichaIng/DietPi/pull/6481
 - DietPi-Software | WiFi Hotspot: The default DHCP server settings have been cleaned up and enhanced, with the default lease time increased from 10 minutes to 12 hours, the max lease time increased from 2 hours to 1 day, and the IP range extended up to 192.168.42.250.
 - DietPi-Software | Apache/ownCloud/Pi-hole: The X-XSS-Protection header is now set to "0" in default configs to match recent security recommendations. This change is also applied to all systems on next DietPi update. Many thanks to @Zer0x00 for implementing this enhancement: https://github.com/MichaIng/DietPi/pull/6491


### PR DESCRIPTION
- NanoPi R5S/R5C/6 series | An update of the kernel to Linux 5.10.160 will be applied as part of the DietPi update. Many thanks to @HeyMeco for informing us about this opportunity: https://dietpi.com/forum/t/new-kernel-for-nanopi-s-5-10-160/17325