### PR TITLE
Update dietpi-letsencrypt, bug introduced with my last commit

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ Enhancements:
 
 Bug fixes:
 - DietPi-Set_swapfile | Resolved an issue on Bookworm systems where zram swap space was not enabled automatically on boot due to missing syscall permissions, and the swappiness was not changed as intended. Many thanks to @magicfoxt-magicfox for reporting this issue: https://github.com/MichaIng/DietPi/issues/6511
+- DietPi-LetsEncrypt | Resolved a v8.20 regression where Lighttpd did not start after applying or renewing the certificate due to a syntax error. Many thanks to @JappeHallunken for fixing this issue: https://github.com/MichaIng/DietPi/pull/6517
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-letsencrypt
+++ b/dietpi/dietpi-letsencrypt
@@ -131,7 +131,7 @@ server.modules += ( "mod_openssl" )
 	# Intermediate configuration, tweak to your needs
 	ssl.openssl.ssl-conf-cmd = (
 		"MinProtocol" => "TLSv1.2",
-		"Options" => "-ServerPreference",
+		"Options" => "-ServerPreference,-SessionTicket",
 		"CipherString" => "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305"
 	)
 }
@@ -148,7 +148,7 @@ server.modules += ( "mod_openssl" )
 	# Intermediate configuration, tweak to your needs
 	ssl.openssl.ssl-conf-cmd = (
 		"MinProtocol" => "TLSv1.2",
-		"Options" => "-ServerPreference",
+		"Options" => "-ServerPreference,-SessionTicket",
 		"CipherString" => "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305"
 	)
 }
@@ -157,7 +157,7 @@ _EOF_
 			if (( $G_DISTRO > 5 ))
 			then
 				G_AG_CHECK_INSTALL_PREREQ lighttpd-mod-openssl
-				G_EXEC sed -i 's/, "Options" => "-SessionTicket"//' /etc/lighttpd/conf-available/50-dietpi-https.conf
+				G_EXEC sed -i 's/,-SessionTicket//' /etc/lighttpd/conf-available/50-dietpi-https.conf
 			fi
 			[[ -f '/etc/lighttpd/conf-enabled/50-dietpi-https.conf' ]] || G_EXEC lighty-enable-mod dietpi-https
 

--- a/dietpi/dietpi-letsencrypt
+++ b/dietpi/dietpi-letsencrypt
@@ -131,7 +131,6 @@ server.modules += ( "mod_openssl" )
 	# Intermediate configuration, tweak to your needs
 	ssl.openssl.ssl-conf-cmd = (
 		"MinProtocol" => "TLSv1.2",
-		"Options" => "-SessionTicket",
 		"Options" => "-ServerPreference",
 		"CipherString" => "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305"
 	)
@@ -149,7 +148,6 @@ server.modules += ( "mod_openssl" )
 	# Intermediate configuration, tweak to your needs
 	ssl.openssl.ssl-conf-cmd = (
 		"MinProtocol" => "TLSv1.2",
-		"Options" => "-SessionTicket",
 		"Options" => "-ServerPreference",
 		"CipherString" => "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305"
 	)


### PR DESCRIPTION
there can only be one "options" line, otherwise lighttpd fails to restart after running dietpi-letsencrypt

https://dietpi.com/forum/t/lighttpd-fails-after-renewing-letsencrypt/17510/6
