### PR TITLE
DietPi-Config -> WiFi-Hotspot: IP address was always changed to 192.168.42.1 in /etc/network/interfaces

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ New images:
 
 Enhancements:
 - Orange Pi 5/ROCK 5B | An update of the kernel to Linux 5.10.160 will be applied automatically as part of the DietPi update.
+- DietPi-Config | When applying WiFi hotspot settings, manually changed IP addresses in /etc/network/interfaces will now be preserved.
 
 Bug fixes:
 - DietPi-Set_swapfile | Resolved an issue on Bookworm systems where zram swap space was not enabled automatically on boot due to missing syscall permissions, and the swappiness was not changed as intended. Many thanks to @magicfoxt-magicfox for reporting this issue: https://github.com/MichaIng/DietPi/issues/6511

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -1986,8 +1986,8 @@ _EOF_
 
 			cat << _EOF_ >> /etc/network/interfaces
 iface $WIFI_DEV_IFACE inet static
-address 192.168.42.1
-netmask 255.255.255.0
+address $WIFI_IP_STATIC
+netmask $WIFI_MASK_STATIC
 #gateway 192.168.0.1
 #dns-nameservers 9.9.9.9 149.112.112.112
 pre-up iw dev $WIFI_DEV_IFACE set power_save off


### PR DESCRIPTION
DietPi-Config can activate the WiFi settings for the WiFi-Hotspot (via `Network_ApplyChanges()`).
The IP address and netmask were set to fixed values, independent of what the user may have changed within the files `/etc/dhcp/dhcp.conf`, `/etc/network/interfaces` and `/etc/iptables.ipv4.nat`.

I'm not sure, whether there are other side effects of this change, at least with the WiFi-Hotspot function it seems to work.