### PR TITLE
Fix dietpi-logclear fails when ARRAY_LOGFILE_TRUNCATE empty

### DIFF
--- a/dietpi/func/dietpi-logclear
+++ b/dietpi/func/dietpi-logclear
@@ -144,7 +144,7 @@
 		done
 
 		# Truncate files to be cleared
-		truncate -cs0 "${ARRAY_LOGFILE_TRUNCATE[@]}"
+		(( ${#ARRAY_LOGFILE_TRUNCATE[@]} )) && truncate -cs0 "${ARRAY_LOGFILE_TRUNCATE[@]}"
 
 	}
 


### PR DESCRIPTION
We unfortunately missed this during our PR:
https://github.com/MichaIng/DietPi/pull/6507#discussion_r1278143854

<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
