### PR TITLE
Orange Pi 5/ROCK 5B | Kernel update and migration

### DIFF
--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -155,7 +155,7 @@ case $DISTRO in
 		[[ $HW_ARCH == 11 ]] && distro='sid' # RISC-V architecture is available on Debian Sid/unstable only
 		# Raise root size where required
 		case $HW_MODEL in
-			1[256]|49.[123]|54|61|7[4569]) ((root_size+=128));;
+			1[256]|49.[123]|54|61|7[4569]|80) ((root_size+=128));;
 			21) ((root_size+=448));;
 			*) :;;
 		esac

--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -613,8 +613,7 @@ setenv rootuuid "true"' /boot/boot.cmd
 				case $G_HW_MODEL in
 					73) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rk3308' /boot/dietpiEnv.txt;;
 					77) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rk35xx' /boot/dietpiEnv.txt;;
-					78) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rk3588' /boot/dietpiEnv.txt;; # ToDo: There are multiple other prefixes used in the kernel package, "rock-5b", "rock-5ab", "rockchip" (for fixup), so the boot.cmd need heavy adjustments (eliminate the prefix entirely) to work with all overlays.
-					80) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rockchip-rk3588' /boot/dietpiEnv.txt;;
+					78|80) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rk3588' /boot/dietpiEnv.txt;; # ToDo: There are multiple other prefixes used in the kernel package, "rock-5b", "rock-5ab", "rockchip" (for fixup), so the boot.cmd need heavy adjustments (eliminate the prefix entirely) to work with all overlays.
 					*) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rockchip' /boot/dietpiEnv.txt;;
 				esac
 				case $G_HW_MODEL in
@@ -624,7 +623,6 @@ setenv rootuuid "true"' /boot/boot.cmd
 					73) G_CONFIG_INJECT 'fdtfile=' 'fdtfile=rockchip/rk3308-rock-pi-s.dtb' /boot/dietpiEnv.txt;; # U-Boot does not pass any ${fdtfile}
 					77) G_CONFIG_INJECT 'fdtfile=' 'fdtfile=rockchip/rk3568-rock-3a.dtb' /boot/dietpiEnv.txt;;
 					78) G_CONFIG_INJECT 'fdtfile=' 'fdtfile=rockchip/rk3588-rock-5b.dtb' /boot/dietpiEnv.txt;;
-					80) G_CONFIG_INJECT 'fdtfile=' 'fdtfile=rockchip/rk3588s-orangepi-5.dtb' /boot/dietpiEnv.txt;;
 					*) :;;
 				esac
 				case $G_HW_MODEL in
@@ -1014,17 +1012,18 @@ _EOF_
 				73) model='rockpi-s' kernel='rockchip64' dietpi_com=1;;
 				74) model='radxa-zero';;
 				77) model='rock-3a' kernel='rk35xx' branch='edge';;
-				78) model='rock-5b' kernel='rockchip-rk3588' branch='legacy';;
-				80) model='orangepi5' kernel='rockchip-rk3588' branch='legacy';;
+				78) model='rock-5b' kernel='rk35xx' branch='legacy';;
+				80) model='orangepi5' kernel='rk35xx' branch='legacy';;
 				*) :;;
 			esac
-			# Download and pre-install U-Boot hosted on dietpi.com where it has not been ported (and probably never will) to the Armbian Bookworm repo.
-			if (( $dietpi_com && $G_DISTRO > 6 || $G_HW_MODEL == 62 ))
+			# Download and pre-install U-Boot hosted on dietpi.com where it has not been ported (and probably never will) to the Armbian Bookworm repo or where it provides a too old version
+			if (( $dietpi_com && $G_DISTRO > 6 || $G_HW_MODEL == 62 || $G_HW_MODEL == 80 ))
 			then
-				G_EXEC curl -sSfO "https://dietpi.com/downloads/binaries/linux-u-boot-$model-$branch.deb"
-				G_EXEC_OUTPUT=1 G_EXEC dpkg -i "linux-u-boot-$model-$branch.deb"
-				G_EXEC rm "linux-u-boot-$model-$branch.deb"
+				G_EXEC curl -sSfo package.deb "https://dietpi.com/downloads/binaries/linux-u-boot-$model-$branch.deb"
+				G_EXEC_OUTPUT=1 G_EXEC dpkg -i package.deb
+				G_EXEC rm package.deb
 			fi
+
 			# NanoPi R2S/NEO3
 			if [[ $G_HW_MODEL =~ ^(55|56)$ ]]
 			then
@@ -1038,9 +1037,17 @@ blacklist rockchip_vdec
 _EOF_
 			fi
 			# Install initramfs-tools first to have an initramfs generated on kernel install, and configure it to use zstd if supported for better compression and faster decompression
-			[[ $kernel == 'rockchip64' || $kernel == 'rockchip-rk3588' || $kernel == 'meson64' || $kernel == 'sunxi64' || $kernel == 'sunxi' ]] && zstd=('zstd')
+			[[ $kernel == 'rockchip64' || $kernel == 'rk35xx' || $kernel == 'meson64' || $kernel == 'sunxi64' || $kernel == 'sunxi' ]] && zstd=('zstd')
 			G_AGI initramfs-tools u-boot-tools armbian-firmware "${zstd[@]}"
 			[[ ${zstd[0]} ]] && G_CONFIG_INJECT 'COMPRESS=' 'COMPRESS=zstd' /etc/initramfs-tools/initramfs.conf
+			# Download and pre-install kernel hosted on dietpi.com where the Armbian APT repo provides a too old version
+			if [[ $G_HW_MODEL =~ ^(78|80)$ ]]
+			then
+				G_EXEC curl -sSfo package.deb "https://dietpi.com/downloads/binaries/linux-image-$branch-$kernel.deb"
+				G_EXEC curl -sSfo package2.deb "https://dietpi.com/downloads/binaries/linux-dtb-$branch-$kernel.deb"
+				G_EXEC_OUTPUT=1 G_EXEC dpkg -i package.deb package2.deb
+				G_EXEC rm package.deb package2.deb
+			fi
 			G_AGI linux-{image,dtb}-"$branch-$kernel" "linux-u-boot-$model-$branch"
 			# Cleanup
 			[[ $G_HW_MODEL != 10 && -f '/boot/uImage' ]] && G_EXEC rm /boot/uImage
@@ -1910,7 +1917,7 @@ _EOF_
 			# For backwards compatibility with software compiled against older libraspberrypi0, create symlinks from old to new filenames
 			if (( $G_HW_ARCH < 3 ))
 			then
-				G_DIETPI-NOTIFY 2 'Applying workaround for compiled against older libraspberrypi0'
+				G_DIETPI-NOTIFY 2 'Applying workaround for software compiled against older libraspberrypi0'
 				G_EXEC cd /usr/lib/arm-linux-gnueabihf
 				while read -r line
 				do
@@ -1919,6 +1926,7 @@ _EOF_
 					G_EXEC ln -sf "$line" "${line%.0}"
 
 				done < <(dpkg -L 'libraspberrypi0' | grep '^/usr/lib/arm-linux-gnueabihf/.*\.so.0$')
+				G_EXEC cd "/tmp/$G_PROGRAM_NAME"
 			fi
 
 		# NanoPi M3/T3/Fire3

--- a/.update/patches
+++ b/.update/patches
@@ -1423,10 +1423,31 @@ Patch_8_20()
 	[[ -f '/etc/apt/apt.conf.d/dietpi-ffmpeg' ]] && G_EXEC rm /etc/apt/apt.conf.d/dietpi-ffmpeg
 }
 
-Patch_8_20()
+Patch_8_21()
 {
 	# Remove obsolete sysctl config
 	[[ -f '/etc/sysctl.d/dietpi.conf' ]] && G_EXEC rm /etc/sysctl.d/dietpi.conf
+
+	# Orange Pi 5: Update U-Boot to enable NVMe boot
+	if (( $G_HW_MODEL == 80 )) && dpkg --compare-versions "$(dpkg-query -Wf '${Version}' linux-u-boot-orangepi5-legacy 2> /dev/null)" lt-nl 23.08.0
+	then
+		G_DIETPI-NOTIFY 2 'Updating Orange Pi 5 U-Boot package ...'
+		G_EXEC curl -sSfo package.deb 'https://dietpi.com/downloads/binaries/linux-u-boot-orangepi5-legacy.deb'
+		G_EXEC_OUTPUT=1 G_EXEC dpkg -i package.deb
+		G_EXEC rm package.deb
+	fi
+	# Orange Pi 5/ROCK 5B: Update kernel to Linux 5.10.160 as Armbian didn't update their repos for half a year. The "legacy-rockchip-rk3588" and "legacy-rk35xx" kernel families have been merged below the second name: https://github.com/armbian/build/pull/5362
+	if [[ $G_HW_MODEL =~ ^(78|80)$ ]] && { dpkg-query -s 'linux-image-legacy-rockchip-rk3588' &> /dev/null || dpkg --compare-versions "$(dpkg-query -Wf '${Version}' linux-image-legacy-rk35xx 2> /dev/null)" lt-nl 23.08.0; }
+	then
+		G_DIETPI-NOTIFY 2 'Updating RK3588 kernel package ...'
+		G_EXEC curl -sSfo package.deb 'https://dietpi.com/downloads/binaries/linux-image-legacy-rk35xx.deb'
+		G_EXEC curl -sSfo package2.deb 'https://dietpi.com/downloads/binaries/linux-dtb-legacy-rk35xx.deb'
+		G_EXEC_OUTPUT=1 G_EXEC dpkg -i package.deb package2.deb
+		G_EXEC rm package.deb package2.deb
+		(( $G_HW_MODEL == 80 )) && G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rk3588' /boot/dietpiEnv.txt
+		dpkg-query -s 'linux-image-legacy-rockchip-rk3588' &> /dev/null && G_EXEC apt-mark auto linux-image-legacy-rockchip-rk3588
+		dpkg-query -s 'linux-dtb-legacy-rockchip-rk3588' &> /dev/null && G_EXEC apt-mark auto linux-dtb-legacy-rockchip-rk3588
+	fi
 }
 
 # v6.35 => v7 migration

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ v8.21
 (2023-07-26)
 
 Enhancements:
+- Orange Pi 5/ROCK 5B | An update of the kernel to Linux 5.10.160 will be applied automatically as part of the DietPi update.
 
 Bug fixes:
 - DietPi-Set_swapfile | Resolved an issue on Bookworm systems where zram swap space was not enabled automatically on boot due to missing syscall permissions, and the swappiness was not changed as intended. Many thanks to @magicfoxt-magicfox for reporting this issue: https://github.com/MichaIng/DietPi/issues/6511


### PR DESCRIPTION
- Orange Pi 5/ROCK 5B | An update of the kernel to Linux 5.10.160 will be applied automatically as part of the DietPi update.
