### PR TITLE
allow armv7 builds on arm64 machines when not raw iron

### DIFF
--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -322,30 +322,37 @@ _EOF_
 		G_DIETPI-NOTIFY 2 "Entered pre-image info: $PREIMAGE_INFO"
 
 		# Hardware selection
+		# if running in a container or vm, allow armv7 if on arm64
+		NON_NATIVE=0
+		hash systemd-detect-virt 2> /dev/null && systemd-detect-virt -q && NON_NATIVE=1
+		G_DIETPI-NOTIFY 2 "NON_NATIVE: $NON_NATIVE"
+
+		ARMV7_BOARDS=(
+			'' '●─ ARMv7 '
+			'10' ': Odroid C1'
+			'11' ': Odroid XU3/XU4/MC1/HC1/HC2'
+			'13' ': Odroid U3'
+			'70' ': Sparky SBC'
+			'52' ': ASUS Tinker Board'
+			'59' ': ZeroPi'
+			'60' ': NanoPi NEO'
+			'64' ': NanoPi NEO Air'
+			'63' ': NanoPi M1'
+			'66' ': NanoPi M1 Plus'
+			'48' ': NanoPi R1'
+			'61' ': NanoPi M2/T2/Fire2'
+			'25' ': Generic Allwinner H3'
+			)
 		# - NB: PLEASE ENSURE HW_MODEL INDEX ENTRIES MATCH dietpi-obtain_hw_model and dietpi-survey_report
 		# - NBB: DO NOT REORDER INDICES. These are now fixed and will never change (due to survey results etc)
 		G_WHIP_BUTTON_CANCEL_TEXT='Exit'
 		G_WHIP_DEFAULT_ITEM=0
 		case $G_HW_ARCH in
 			1) G_WHIP_MENU_ARRAY=('0' ': Raspberry Pi (all models)');;
-			2) G_WHIP_MENU_ARRAY=(
-				'0' ': Raspberry Pi 2 - 4'
-				'' '●─ ARMv7 '
-				'10' ': Odroid C1'
-				'11' ': Odroid XU3/XU4/MC1/HC1/HC2'
-				'13' ': Odroid U3'
-				'70' ': Sparky SBC'
-				'52' ': ASUS Tinker Board'
-				'59' ': ZeroPi'
-				'60' ': NanoPi NEO'
-				'64' ': NanoPi NEO Air'
-				'63' ': NanoPi M1'
-				'66' ': NanoPi M1 Plus'
-				'48' ': NanoPi R1'
-				'61' ': NanoPi M2/T2/Fire2'
-				'25' ': Generic Allwinner H3'
-				'' '●─ ARMv8 '
-			);;
+			2) G_WHIP_MENU_ARRAY=('0' ': Raspberry Pi 2 - 4')
+				G_WHIP_MENU_ARRAY+=("${ARMV7_BOARDS[@]}")
+				G_WHIP_MENU_ARRAY+=('' '●─ ARMv8 ')
+				;;
 			3) G_WHIP_MENU_ARRAY=('0' ': Raspberry Pi 2 (v1.2) - 4');;
 			10) G_WHIP_DEFAULT_ITEM=21 G_WHIP_MENU_ARRAY=(
 				'20' ': Virtual machine'
@@ -354,6 +361,7 @@ _EOF_
 			11) G_WHIP_DEFAULT_ITEM=81 G_WHIP_MENU_ARRAY=('81' ': StarFive VisionFive 2');;
 			*) :;;
 		esac
+		[[ $G_HW_ARCH == 3 ]] && [[ $NON_NATIVE == 1 ]] && G_WHIP_MENU_ARRAY+=("${ARMV7_BOARDS[@]}")
 		[[ $G_HW_ARCH == [23] ]] && G_WHIP_MENU_ARRAY+=(
 			'12' ': Odroid C2'
 			'15' ': Odroid N2'
@@ -431,6 +439,8 @@ _EOF_
 
 		G_HW_MODEL=$HW_MODEL
 		unset -v HW_MODEL
+		unset -v ARMV7_BOARDS
+		unset -v NON_NATIVE
 
 		G_DIETPI-NOTIFY 2 "Selected hardware model ID: $G_HW_MODEL"
 


### PR DESCRIPTION
If you are using an arm64 system to build, but are not running natively (so you are in a VM, a container, or a chroot) to build, then you might just be taking advantage of non-emulated build speed - so allow armv7 board models to be selected.


THIS IS A DRAFT FOR COMMENTS... I ran this and it seemed to work for me, but this has NOT been extensively tested.
<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
