### PR TITLE
DietPi-Installer | Fix ARMv7 image creations on ARMv8 hosts

### DIFF
--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -228,7 +228,7 @@ _EOF_
 			exit 1
 		fi
 	fi
-	G_DIETPI-NOTIFY 2 "Detected target CPU architecture: $G_HW_ARCH_NAME (ID: $G_HW_ARCH)"
+	G_DIETPI-NOTIFY 2 "Detected host CPU architecture: $G_HW_ARCH_NAME (ID: $G_HW_ARCH)"
 
 	Main()
 	{
@@ -328,25 +328,79 @@ _EOF_
 		G_WHIP_DEFAULT_ITEM=0
 		case $G_HW_ARCH in
 			1) G_WHIP_MENU_ARRAY=('0' ': Raspberry Pi (all models)');;
-			2) G_WHIP_MENU_ARRAY=(
-				'0' ': Raspberry Pi 2 - 4'
-				'' '●─ ARMv7 '
-				'10' ': Odroid C1'
-				'11' ': Odroid XU3/XU4/MC1/HC1/HC2'
-				'13' ': Odroid U3'
-				'70' ': Sparky SBC'
-				'52' ': ASUS Tinker Board'
-				'59' ': ZeroPi'
-				'60' ': NanoPi NEO'
-				'64' ': NanoPi NEO Air'
-				'63' ': NanoPi M1'
-				'66' ': NanoPi M1 Plus'
-				'48' ': NanoPi R1'
-				'61' ': NanoPi M2/T2/Fire2'
-				'25' ': Generic Allwinner H3'
-				'' '●─ ARMv8 '
-			);;
-			3) G_WHIP_MENU_ARRAY=('0' ': Raspberry Pi 2 (v1.2) - 4');;
+			2|3)
+				userland_arch=$(dpkg --print-architecture)
+				G_DIETPI-NOTIFY 2 "Detected target userland/OS architecture: $userland_arch"
+				if [[ $userland_arch == 'armhf' ]]
+				then
+					G_WHIP_MENU_ARRAY=(
+						'0' ': Raspberry Pi 2 - 4'
+						'10' ': Odroid C1'
+						'11' ': Odroid XU3/XU4/MC1/HC1/HC2'
+						'13' ': Odroid U3'
+						'70' ': Sparky SBC'
+						'52' ': ASUS Tinker Board'
+						'59' ': ZeroPi'
+						'60' ': NanoPi NEO'
+						'64' ': NanoPi NEO Air'
+						'63' ': NanoPi M1'
+						'66' ': NanoPi M1 Plus'
+						'48' ': NanoPi R1'
+						'61' ': NanoPi M2/T2/Fire2'
+						'25' ': Generic Allwinner H3'
+					)
+
+				elif [[ $userland_arch == 'arm64' ]]
+				then
+					G_WHIP_MENU_ARRAY=(
+						'0' ': Raspberry Pi 2 (v1.2) - 4'
+						'12' ': Odroid C2'
+						'15' ': Odroid N2'
+						'16' ': Odroid C4/HC4'
+						'40' ': PINE A64'
+						'45' ': PINE H64'
+						'43' ': ROCK64'
+						'42' ': ROCKPro64'
+						'44' ': Pinebook'
+						'46' ': Pinebook Pro'
+						'49.1' ': Quartz64 Model A'
+						'49.2' ': Quartz64 Model B'
+						'49.3' ': SOQuartz'
+						'65.1' ': NanoPi NEO2'
+						'65.2' ': NanoPi NEO2 Black'
+						'56' ': NanoPi NEO3'
+						'57' ': NanoPi NEO Plus2'
+						'62.1' ': NanoPi M3/T3'
+						'62.2' ': NanoPi Fire3'
+						'68.1' ': NanoPi M4'
+						'68.2' ': NanoPC T4'
+						'68.3' ': NanoPi NEO4'
+						'58' ': NanoPi M4V2'
+						'67' ': NanoPi K1 Plus'
+						'54' ': NanoPi K2'
+						'55' ': NanoPi R2S'
+						'47' ': NanoPi R4S'
+						'76' ': NanoPi R5S/R5C'
+						'79' ': NanoPi 6 series'
+						'72' ': ROCK 4'
+						'73' ': ROCK Pi S'
+						'74' ': Radxa Zero'
+						'77' ': ROCK 3A'
+						'78' ': ROCK 5B'
+						'80' ': Orange Pi 5'
+						'82' ': Orange Pi 5 Plus'
+						'23' ': Generic Rockchip RK3328'
+						'24' ': Generic Rockchip RK3399'
+						'26' ': Generic Allwinner H5'
+						'27' ': Generic Allwinner H6'
+						'28' ': Generic Amlogic S905'
+						'29' ': Generic Amlogic S922X'
+					)
+				else
+					G_DIETPI-NOTIFY 1 "Unsupported userland/OS architecture: \"$userland_arch\". Aborting...\n"
+					exit 1
+				fi
+			;;
 			10) G_WHIP_DEFAULT_ITEM=21 G_WHIP_MENU_ARRAY=(
 				'20' ': Virtual machine'
 				'21' ': Native PC'
@@ -354,49 +408,6 @@ _EOF_
 			11) G_WHIP_DEFAULT_ITEM=81 G_WHIP_MENU_ARRAY=('81' ': StarFive VisionFive 2');;
 			*) :;;
 		esac
-		[[ $G_HW_ARCH == [23] ]] && G_WHIP_MENU_ARRAY+=(
-			'12' ': Odroid C2'
-			'15' ': Odroid N2'
-			'16' ': Odroid C4/HC4'
-			'40' ': PINE A64'
-			'45' ': PINE H64'
-			'43' ': ROCK64'
-			'42' ': ROCKPro64'
-			'44' ': Pinebook'
-			'46' ': Pinebook Pro'
-			'49.1' ': Quartz64 Model A'
-			'49.2' ': Quartz64 Model B'
-			'49.3' ': SOQuartz'
-			'65.1' ': NanoPi NEO2'
-			'65.2' ': NanoPi NEO2 Black'
-			'56' ': NanoPi NEO3'
-			'57' ': NanoPi NEO Plus2'
-			'62.1' ': NanoPi M3/T3'
-			'62.2' ': NanoPi Fire3'
-			'68.1' ': NanoPi M4'
-			'68.2' ': NanoPC T4'
-			'68.3' ': NanoPi NEO4'
-			'58' ': NanoPi M4V2'
-			'67' ': NanoPi K1 Plus'
-			'54' ': NanoPi K2'
-			'55' ': NanoPi R2S'
-			'47' ': NanoPi R4S'
-			'76' ': NanoPi R5S/R5C'
-			'79' ': NanoPi 6 series'
-			'72' ': ROCK 4'
-			'73' ': ROCK Pi S'
-			'74' ': Radxa Zero'
-			'77' ': ROCK 3A'
-			'78' ': ROCK 5B'
-			'80' ': Orange Pi 5'
-			'82' ': Orange Pi 5 Plus'
-			'23' ': Generic Rockchip RK3328'
-			'24' ': Generic Rockchip RK3399'
-			'26' ': Generic Allwinner H5'
-			'27' ': Generic Allwinner H6'
-			'28' ': Generic Amlogic S905'
-			'29' ': Generic Amlogic S922X'
-		)
 		G_WHIP_MENU_ARRAY+=(
 			'' '●─ Other '
 			'75' ': Container image'

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Enhancements:
 - DietPi-Config | When applying WiFi hotspot settings, manually changed IP addresses in /etc/network/interfaces will now be preserved.
 
 Bug fixes:
+- DietPi-Installer | Resolved an issue where building images for ARMv7 hardware was not possible on a ARMv8 host. Offered/accepted ARM hardware IDs are not based on the userland/OS architecture of the image instead of the CPU/kernel architecture returned via "uname -m". Many thanks to @dirkhh for reporting this issue: https://github.com/MichaIng/DietPi/discussions/6541
 - DietPi-Set_swapfile | Resolved an issue on Bookworm systems where zram swap space was not enabled automatically on boot due to missing syscall permissions, and the swappiness was not changed as intended. Many thanks to @magicfoxt-magicfox for reporting this issue: https://github.com/MichaIng/DietPi/issues/6511
 - DietPi-LetsEncrypt | Resolved a v8.20 regression where Lighttpd did not start after applying or renewing the certificate due to a syntax error. Many thanks to @JappeHallunken for fixing this issue: https://github.com/MichaIng/DietPi/pull/6517
 - DietPi-Config | Resolved an issue where /etc/network/interfaces was created with missing key values if lines were previously manually removed. Defaults are now applied in this case. Many thanks to @huettenwirt for reporting this issue: https://dietpi.com/forum/t/ifup-error-due-to-faulty-etc-network-interfaces/17605


### PR DESCRIPTION
@dirkhh
In the hope that you were not concurrently working on a new PR. Would be great if you could test whether this solves your issue. With `-b installer` you can tell `dietpi-build` to use this branch.

Btw, I could not find the original issue/discussion we had about this. Could you link it? Nice to have the original report in changelog.