### PR TITLE
DietPi-Config | WiFi Hotspot: Do not allow to enter a <8 character key

### DIFF
--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -2134,7 +2134,8 @@ _EOF_
 			until [[ $G_WHIP_RETURNED_VALUE == [[:upper:]][[:upper:]] ]]
 			do
 				G_WHIP_INPUTBOX "${error}Please enter a 2 capital letter country code: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2" || return 0
-				error="[FAILED] Invalid country code ($G_WHIP_RETURNED_VALUE)"
+				error="[FAILED] Invalid country code ($G_WHIP_RETURNED_VALUE)\n\n"
+				G_WHIP_DEFAULT_ITEM=$G_WHIP_RETURNED_VALUE
 			done
 		fi
 		WIFI_COUNTRYCODE=$G_WHIP_RETURNED_VALUE
@@ -2704,8 +2705,15 @@ This is mainly aimed at PINE A64 which may have a hardware issue that causes uns
 
 			'Key')
 
+				local error
 				G_WHIP_DEFAULT_ITEM=$HOTSPOT_KEY
-				G_WHIP_INPUTBOX 'Please enter a key/password with a minimum of 8 characters for your WiFi hotspot:' && HOTSPOT_KEY=$G_WHIP_RETURNED_VALUE
+				until (( ${#G_WHIP_RETURNED_VALUE} > 7 ))
+				do
+					G_WHIP_INPUTBOX "${error}Please enter a key/password with a minimum of 8 characters for your WiFi hotspot:" || return 0
+					error='[FAILED] The entered key is too short.\n\n'
+					G_WHIP_DEFAULT_ITEM=$G_WHIP_RETURNED_VALUE
+				done
+				HOTSPOT_KEY=$G_WHIP_RETURNED_VALUE
 			;;
 
 			'SSID')
@@ -2762,7 +2770,7 @@ This is mainly aimed at PINE A64 which may have a hardware issue that causes uns
 
 			'Disable')
 
-				G_WHIP_YESNO 'Would you like to disable the WiFi adapter?\n - (NOTICE) All WiFi connections will be dropped.' || return
+				G_WHIP_YESNO 'Would you like to disable the WiFi adapter?\n - (NOTICE) All WiFi connections will be dropped.' || return 0
 				WIFI_DISABLED=1
 				G_EXEC systemctl disable --now dietpi-wifi-monitor
 				Network_ApplyChanges

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7949,6 +7949,7 @@ _EOF_
 			[[ $wifi4 == [01] ]] || wifi4=0
 			[[ $wifi5 == [01] ]] || wifi5=0
 			[[ $freq5 == [01] ]] || freq5=0
+			(( ${#key} > 8 )) || { G_DIETPI-NOTIFY 1 'WiFi key from dietpi.txt is too short (less than 8 characters), falling back to default: "dietpihotspot"'; key='dietpihotspot'; }
 			# - WiFi 5 implies 5 GHz and 5 GHz requires at least WiFi 4
 			(( $wifi5 )) && freq5=1
 			(( $freq5 && ! $wifi5 )) && wifi4=1
@@ -7982,7 +7983,7 @@ macaddr_acl=0
 auth_algs=1
 ignore_broadcast_ssid=0
 wpa=2
-wpa_passphrase=${key:-dietpihotspot}
+wpa_passphrase=$key
 wpa_key_mgmt=WPA-PSK
 wpa_pairwise=TKIP
 rsn_pairwise=CCMP


### PR DESCRIPTION
- DietPi-Config | WiFi Hotspot: Do not allow to enter a <8 character key, add an error message to the input box in this case