### PR TITLE
keep networking packages for containers

### DIFF
--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -872,7 +872,7 @@ setenv rootuuid "true"' /boot/boot.cmd
 				'isc-dhcp-client'
 			)
 			apackages_string="${apackages[*]}"
-			for pkg in "${apackages[@]}"
+			for pkg in "${rpackages[@]}"
 			do
 				apackages_string=$(echo "$apackages_string" | sed "s/\b$pkg\b//g" | tr -s ' ')
 			done

--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -863,6 +863,22 @@ setenv rootuuid "true"' /boot/boot.cmd
 		G_DIETPI-NOTIFY 2 'Marking all packages as auto-installed first, to allow effective autoremove afterwards'
 		local apackages
 		mapfile -t apackages < <(apt-mark showmanual)
+
+		# Containers: keep necessary packages to avoid losing network connectivity
+		if [[ ${apackages[0]} && $G_HW_MODEL == 75 ]]
+		then
+			rpackages=(
+				'ifupdown'
+				'isc-dhcp-client'
+			)
+			apackages_string="${apackages[*]}"
+			for pkg in "${apackages[@]}"
+			do
+				apackages_string=$(echo "$apackages_string" | sed "s/\b$pkg\b//g" | tr -s ' ')
+			done
+			IFS=' ' read -r -a apackages <<< "$apackages_string"
+		fi
+
 		[[ ${apackages[0]} ]] && G_EXEC apt-mark auto "${apackages[@]}"
 		unset -v apackages
 

--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -450,7 +450,8 @@ _EOF_
 		esac
 		G_WHIP_MENU_ARRAY+=(
 			'' '●─ Other '
-			'75' ': Container image'
+			'75.1' ': Container image without network'
+			'75.2' ': Container image with network'
 			'22' ': Generic device'
 		)
 
@@ -864,8 +865,8 @@ setenv rootuuid "true"' /boot/boot.cmd
 		local apackages
 		mapfile -t apackages < <(apt-mark showmanual)
 
-		# Containers: keep necessary packages to avoid losing network connectivity
-		if [[ ${apackages[0]} && $G_HW_MODEL == 75 ]]
+		# Containers with network: keep necessary packages to avoid losing network connectivity
+		if [[ ${apackages[0]} && $G_HW_MODEL == 75 && $HW_VARIANT == 2 ]]
 		then
 			rpackages=(
 				'ifupdown'


### PR DESCRIPTION
<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
Hi,
I wanted to use a default debian lxc container in proxmox and convert it to DietPi.
The main problem was that the container was losing network connectivity during the installation procedure and could not reinstall required packages.
This fix keeps the required packages and the convertion succeeds.

I have tested it with debian 11 with dhcp and fixed ip, both works well now ;)