### PR TITLE
DietPi-Software | ADS-B Feeder: track airplanes using SDRs and feed the data to ADS-B aggregators

### DIFF
--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -689,7 +689,7 @@ shopt -s extglob
 		aSOFTWARE_NAME8_21[i]=${aSOFTWARE_NAME8_20[i]}
 		aSOFTWARE_NAME8_22[i]=${aSOFTWARE_NAME8_21[i]}
 	done
-	aSOFTWARE_NAME8_22[141]='ADSB Feeder'
+	aSOFTWARE_NAME8_22[141]='ADS-B Feeder'
 
 	# Pre-create software counter array so that we can see also software (available in newest version) with 0 installs
 	for i in "${aSOFTWARE_NAME8_22[@]}"

--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -689,6 +689,7 @@ shopt -s extglob
 		aSOFTWARE_NAME8_21[i]=${aSOFTWARE_NAME8_20[i]}
 		aSOFTWARE_NAME8_22[i]=${aSOFTWARE_NAME8_21[i]}
 	done
+	aSOFTWARE_NAME8_22[141]='ADSB Feeder'
 
 	# Pre-create software counter array so that we can see also software (available in newest version) with 0 installs
 	for i in "${aSOFTWARE_NAME8_22[@]}"

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,7 +2,7 @@ v8.22
 (2023-09-23)
 
 New software:
-- ADSB Feeder | Track airplanes using SDRs and feed the data to ADS-B aggregators. Many thanks to @dirkhh for maintaining and implementing this software option: https://github.com/MichaIng/DietPi/pull/6587
+- ADS-B Feeder | Track airplanes using SDRs and feed the data to ADS-B aggregators. Many thanks to @dirkhh for maintaining and implementing this software option: https://github.com/MichaIng/DietPi/pull/6587
 
 Enhancements:
 - DietPi-Software | Docker: Enabled for Trixie and RISC-V via "docker.io" package from Debian repository.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,9 @@
 v8.22
 (2023-09-23)
 
+New software:
+- ADSB Feeder | Track airplanes using SDRs and feed the data to ADS-B aggregators. Many thanks to @dirkhh for maintaining and implementing this software option: https://github.com/MichaIng/DietPi/pull/6587
+
 Enhancements:
 - DietPi-Software | Docker: Enabled for Trixie and RISC-V via "docker.io" package from Debian repository.
 - DietPi-Software | Portainer: Enabled for RISC-V as Docker is now supported on RISC-V as well.

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ Links to hardware and software manufacturers, sources and build instructions use
 - [Restic](https://github.com/restic/restic)
 - [MediaWiki](https://github.com/wikimedia/mediawiki)
 - [Homebridge](https://github.com/homebridge/homebridge)
-- [ADSB Feeder](https://github.com/dirkhh/adsb-feeder-image)
+- [ADS-B Feeder](https://github.com/dirkhh/adsb-feeder-image)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ Links to hardware and software manufacturers, sources and build instructions use
 - [Restic](https://github.com/restic/restic)
 - [MediaWiki](https://github.com/wikimedia/mediawiki)
 - [Homebridge](https://github.com/homebridge/homebridge)
+- [ADSB Feeder](https://github.com/dirkhh/adsb-feeder-image)
 
 ---
 

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -268,11 +268,12 @@ _EOF_
 			'fahclient'
 			'ipfs'
 			'yacy'
+			'adsb-setup'
+			'adsb-docker'
 		)
 
 		# Additional services: https://github.com/MichaIng/DietPi/issues/1869#issuecomment-401017251
 		[[ -f '/etc/rsyncd.conf' ]] && aSERVICE_NAME+=('rsync')
-		[[ -d '/opt/adsb' ]] && aSERVICE_NAME+=('adsb-docker' 'adsb-setup')
 
 		# Non-controlled services: Show only in menu and status mode!
 		if [[ ! $INPUT_CMD || $INPUT_CMD == 'status' ]]

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -272,6 +272,7 @@ _EOF_
 
 		# Additional services: https://github.com/MichaIng/DietPi/issues/1869#issuecomment-401017251
 		[[ -f '/etc/rsyncd.conf' ]] && aSERVICE_NAME+=('rsync')
+		[[ -d '/opt/adsb' ]] && aSERVICE_NAME+=('adsb-docker' 'adsb-setup')
 
 		# Non-controlled services: Show only in menu and status mode!
 		if [[ ! $INPUT_CMD || $INPUT_CMD == 'status' ]]

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12747,11 +12747,13 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 
 		if To_Uninstall 141 # ADSB Feeder
 		then
+			G_EXEC /opt/adsb/docker-compose-adsb down || true
+			G_EXEC docker image prune -a -f
 			Remove_Service adsb-bootstrap
 			Remove_Service adsb-feeder-update
 			Remove_Service adsb-setup
 			Remove_Service adsb-update
-			G_EXEC rm -rf /opt/adsb /mnt/dietpi_userdata/adsb-feeder
+			G_EXEC rm -rf /opt/adsb /mnt/dietpi_userdata/adsb-feeder /opt/feeder-update
 		fi
 
 		if To_Uninstall 2 # Folding@Home

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4212,9 +4212,14 @@ _EOF_
 			# writes to physical storage - which might be an SDcard)
 			G_EXEC mount -o remount,exec /run
 
+			# now that everything is in place, run the one time service to get the software pre-configured
+			# running this as a service allows it to do a bit of housekeeping in the background without disrupting
+			# the software install flow
+			G_EXEC systemctl start adsb-nonimage
+
 			# last but not least, register the services needed with DietPi
-			aENABLE_SERVICES+=('adsb-setup' 'adsb-nonimage' 'adsb-docker')
-			aSTART_SERVICES+=('adsb-setup' 'adsb-nonimage' 'adsb-docker')
+			aENABLE_SERVICES+=('adsb-setup' 'adsb-docker')
+			aSTART_SERVICES+=('adsb-setup' 'adsb-docker')
 		fi
 
 		if To_Install 186 ipfs # IPFS Node

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4206,7 +4206,13 @@ _EOF_
 			echo "$ADSB_FEEDER_VERSION" > adsb.im.version
 
 			# get the Python module
-			G_AGI python3-flask
+			# for older distros we need to install via pip in order to get flask 2
+			if (( $G_DISTRO < 7 ))
+			then
+				G_EXEC_OUTPUT=1 G_EXEC pip3 install -U flask
+			else
+				G_AGI python3-flask
+			fi
 
 			# finally ensure that /run allows executables (this is needed for the containers to be able to not do excessive
 			# writes to physical storage - which might be an SDcard)

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4179,9 +4179,8 @@ _EOF_
 			G_EXEC mkdir -p /mnt/dietpi_userdata/adsb-feeder
 			G_EXEC_OUTPUT=1 G_EXEC git clone -b dietpi 'https://github.com/dirkhh/adsb-feeder-image.git' /tmp/adsb-feeder
 
-			# remove the services that aren't needed for an app install on DietPi and install the rest
+			# remove the service that isn't needed for an app install on DietPi and install the rest
 			G_EXEC cd /tmp/adsb-feeder/src/modules/adsb-feeder/filesystem/root
-			G_EXEC rm -rf ./usr/lib/systemd/system/adsb-docker.service
 			G_EXEC rm -rf ./usr/lib/systemd/system/adsb-bootstrap.service
 			G_EXEC cp -a ./usr/lib/systemd/system/* /etc/systemd/system/
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4173,57 +4173,6 @@ WantedBy=multi-user.target
 _EOF_
 		fi
 
-		if To_Install 141 adsb-feeder # ADSB Feeder
-		then
-			# create the userdata directory and clone the adsb-feeder repo into /tmp
-			G_EXEC mkdir -p /mnt/dietpi_userdata/adsb-feeder
-			G_EXEC_OUTPUT=1 G_EXEC git clone -b dietpi 'https://github.com/dirkhh/adsb-feeder-image.git' /tmp/adsb-feeder
-
-			# remove the service that isn't needed for an app install on DietPi and install the rest
-			G_EXEC cd /tmp/adsb-feeder/src/modules/adsb-feeder/filesystem/root
-			G_EXEC rm -rf ./usr/lib/systemd/system/adsb-bootstrap.service
-			G_EXEC cp -a ./usr/lib/systemd/system/* /etc/systemd/system/
-
-			# determine the version
-			ADSB_FEEDER_DATE_COMPONENT=$(git log -20 --date=format:%y%m%d --format="%ad" | uniq -c | head -1 | awk '{ print $2"."$1 }')
-			ADSB_FEEDER_TAG_COMPONENT=$(git describe --match "v[0-9]*" | cut -d- -f1)
-			ADSB_FEEDER_VERSION="${ADSB_FEEDER_TAG_COMPONENT}(dietpi)-${ADSB_FEEDER_DATE_COMPONENT}"
-
-			# create the target directory for the app and populated with the code from the git checkout
-			[[ -d '/opt/adsb' ]] && G_EXEC rm -R /opt/adsb
-			G_EXEC cp -a /tmp/adsb-feeder/src/modules/adsb-feeder/filesystem/root/opt/adsb /opt
-			G_EXEC cd /opt/adsb
-
-			# remove the git clone of the repo we installed from
-			G_EXEC rm -rf /tmp/adsb-feeder
-
-			# create a symlink so the config files reside where they should be in /mnt/dietpi_userdata/adsb-feeder
-			G_EXEC mkdir -p /mnt/dietpi_userdata/adsb-feeder/config
-			G_EXEC ln -s /mnt/dietpi_userdata/adsb-feeder/config .
-
-			# set the 'image name' and version that are shown in the footer of the Web UI
-			echo "ADSB Feeder app running on DietPi" > feeder-image.name
-			echo "$ADSB_FEEDER_VERSION" > adsb.im.version
-
-			# get the Python module
-			# for older distros we need to install via pip in order to get flask 2
-			if (( $G_DISTRO < 7 ))
-			then
-				G_EXEC_OUTPUT=1 G_EXEC pip3 install -U flask
-			else
-				G_AGI python3-flask
-			fi
-
-			# finally ensure that /run allows executables (this is needed for the containers to be able to not do excessive
-			# writes to physical storage - which might be an SDcard)
-			G_EXEC mount -o remount,exec /run
-
-			# now that everything is in place, run the one time service to get the software pre-configured
-			# running this as a service allows it to do a bit of housekeeping in the background without disrupting
-			# the software install flow
-			G_EXEC systemctl start adsb-nonimage
-		fi
-
 		if To_Install 186 ipfs # IPFS Node
 		then
 			case $G_HW_ARCH in
@@ -11991,6 +11940,57 @@ _EOF_
 			# Deploy the Portainer container
 			G_DIETPI-NOTIFY 2 'Portainer will be deployed now. This could take a while...'
 			G_EXEC_OUTPUT=1 G_EXEC docker run -d -p '9002:9000' --name=portainer --restart=always -v '/run/docker.sock:/var/run/docker.sock' -v 'portainer_data:/data' 'portainer/portainer-ce'
+		fi
+
+		if To_Install 141 adsb-setup adsb-docker # ADSB Feeder
+		then
+			# create the userdata directory and clone the adsb-feeder repo into /tmp
+			G_EXEC mkdir -p /mnt/dietpi_userdata/adsb-feeder
+			G_EXEC_OUTPUT=1 G_EXEC git clone -b dietpi 'https://github.com/dirkhh/adsb-feeder-image.git' /tmp/adsb-feeder
+
+			# remove the service that isn't needed for an app install on DietPi and install the rest
+			G_EXEC cd /tmp/adsb-feeder/src/modules/adsb-feeder/filesystem/root
+			G_EXEC rm -rf ./usr/lib/systemd/system/adsb-bootstrap.service
+			G_EXEC cp -a ./usr/lib/systemd/system/* /etc/systemd/system/
+
+			# determine the version
+			ADSB_FEEDER_DATE_COMPONENT=$(git log -20 --date=format:%y%m%d --format="%ad" | uniq -c | head -1 | awk '{ print $2"."$1 }')
+			ADSB_FEEDER_TAG_COMPONENT=$(git describe --match "v[0-9]*" | cut -d- -f1)
+			ADSB_FEEDER_VERSION="${ADSB_FEEDER_TAG_COMPONENT}(dietpi)-${ADSB_FEEDER_DATE_COMPONENT}"
+
+			# create the target directory for the app and populated with the code from the git checkout
+			[[ -d '/opt/adsb' ]] && G_EXEC rm -R /opt/adsb
+			G_EXEC cp -a /tmp/adsb-feeder/src/modules/adsb-feeder/filesystem/root/opt/adsb /opt
+			G_EXEC cd /opt/adsb
+
+			# remove the git clone of the repo we installed from
+			G_EXEC rm -rf /tmp/adsb-feeder
+
+			# create a symlink so the config files reside where they should be in /mnt/dietpi_userdata/adsb-feeder
+			G_EXEC mkdir -p /mnt/dietpi_userdata/adsb-feeder/config
+			G_EXEC ln -s /mnt/dietpi_userdata/adsb-feeder/config .
+
+			# set the 'image name' and version that are shown in the footer of the Web UI
+			echo "ADSB Feeder app running on DietPi" > feeder-image.name
+			echo "$ADSB_FEEDER_VERSION" > adsb.im.version
+
+			# get the Python module
+			# for older distros we need to install via pip in order to get flask 2
+			if (( $G_DISTRO < 7 ))
+			then
+				G_EXEC_OUTPUT=1 G_EXEC pip3 install -U flask
+			else
+				G_AGI python3-flask
+			fi
+
+			# finally ensure that /run allows executables (this is needed for the containers to be able to not do excessive
+			# writes to physical storage - which might be an SDcard)
+			G_EXEC mount -o remount,exec /run
+
+			# now that everything is in place, run the one time service to get the software pre-configured
+			# running this as a service allows it to do a bit of housekeeping in the background without disrupting
+			# the software install flow
+			G_EXEC systemctl start adsb-nonimage
 		fi
 
 		if To_Install 172 # WireGuard

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1596,7 +1596,7 @@ Available commands:
 		aSOFTWARE_DESC[$software_id]='track airplanes using SDRs and feed the data to ADS-B aggregators'
 		aSOFTWARE_CATX[$software_id]=19
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/distributed_projects/#adsb-feeder'
-		aSOFTWARE_DEPS[$software_id]='17 130 134 162' # git, Python, dockers & docker compose
+		aSOFTWARE_DEPS[$software_id]='17 130 134 162' # Git, Python, Docker & Docker Compose
 		#------------------
 		software_id=184
 		aSOFTWARE_NAME[$software_id]='Tor Relay'
@@ -11942,37 +11942,36 @@ _EOF_
 			G_EXEC_OUTPUT=1 G_EXEC docker run -d -p '9002:9000' --name=portainer --restart=always -v '/run/docker.sock:/var/run/docker.sock' -v 'portainer_data:/data' 'portainer/portainer-ce'
 		fi
 
-		if To_Install 141 adsb-setup adsb-docker # ADSB Feeder
+		if To_Install 141 adsb-setup adsb-docker # ADS-B Feeder
 		then
-			# create the userdata directory and clone the adsb-feeder repo into /tmp
-			G_EXEC mkdir -p /mnt/dietpi_userdata/adsb-feeder
+			# clone the adsb-feeder repo into /tmp
 			G_EXEC_OUTPUT=1 G_EXEC git clone -b dietpi 'https://github.com/dirkhh/adsb-feeder-image.git' /tmp/adsb-feeder
 
 			# remove the service that isn't needed for an app install on DietPi and install the rest
 			G_EXEC cd /tmp/adsb-feeder/src/modules/adsb-feeder/filesystem/root
-			G_EXEC rm -rf ./usr/lib/systemd/system/adsb-bootstrap.service
-			G_EXEC cp -a ./usr/lib/systemd/system/* /etc/systemd/system/
+			G_EXEC rm ./usr/lib/systemd/system/adsb-bootstrap.service
+			G_EXEC mv ./usr/lib/systemd/system/* /etc/systemd/system/
 
 			# determine the version
-			ADSB_FEEDER_DATE_COMPONENT=$(git log -20 --date=format:%y%m%d --format="%ad" | uniq -c | head -1 | awk '{ print $2"."$1 }')
-			ADSB_FEEDER_TAG_COMPONENT=$(git describe --match "v[0-9]*" | cut -d- -f1)
-			ADSB_FEEDER_VERSION="${ADSB_FEEDER_TAG_COMPONENT}(dietpi)-${ADSB_FEEDER_DATE_COMPONENT}"
+			local ADSB_FEEDER_DATE_COMPONENT=$(git log -20 --date='format:%y%m%d' --format='%ad' | uniq -c | mawk '{print $2"."$1;exit}')
+			local ADSB_FEEDER_TAG_COMPONENT=$(git describe --match 'v[0-9]*' | cut -d- -f1)
+			local ADSB_FEEDER_VERSION="$ADSB_FEEDER_TAG_COMPONENT(dietpi)-$ADSB_FEEDER_DATE_COMPONENT"
 
 			# create the target directory for the app and populated with the code from the git checkout
 			[[ -d '/opt/adsb' ]] && G_EXEC rm -R /opt/adsb
-			G_EXEC cp -a /tmp/adsb-feeder/src/modules/adsb-feeder/filesystem/root/opt/adsb /opt
+			G_EXEC mv /tmp/adsb-feeder/src/modules/adsb-feeder/filesystem/root/opt/adsb /opt/
 			G_EXEC cd /opt/adsb
 
 			# remove the git clone of the repo we installed from
-			G_EXEC rm -rf /tmp/adsb-feeder
+			G_EXEC rm -R /tmp/adsb-feeder
 
 			# create a symlink so the config files reside where they should be in /mnt/dietpi_userdata/adsb-feeder
 			G_EXEC mkdir -p /mnt/dietpi_userdata/adsb-feeder/config
 			G_EXEC ln -s /mnt/dietpi_userdata/adsb-feeder/config .
 
 			# set the 'image name' and version that are shown in the footer of the Web UI
-			echo "ADSB Feeder app running on DietPi" > feeder-image.name
-			echo "$ADSB_FEEDER_VERSION" > adsb.im.version
+			G_EXEC eval 'echo '\''ADSB Feeder app running on DietPi'\'' > feeder-image.name'
+			G_EXEC eval "echo '$ADSB_FEEDER_VERSION' > adsb.im.version"
 
 			# get the Python module
 			# for older distros we need to install via pip in order to get flask 2
@@ -11984,7 +11983,7 @@ _EOF_
 			fi
 
 			# finally ensure that /run allows executables (this is needed for the containers to be able to not do excessive
-			# writes to physical storage - which might be an SDcard)
+			# writes to physical storage - which might be an SD card)
 			G_EXEC mount -o remount,exec /run
 
 			# now that everything is in place, run the one time service to get the software pre-configured
@@ -12747,15 +12746,15 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 			[[ -d '/etc/yacy' ]] && G_EXEC rm -R /etc/yacy
 		fi
 
-		if To_Uninstall 141 # ADSB Feeder
+		if To_Uninstall 141 # ADS-B Feeder
 		then
-			G_EXEC /opt/adsb/docker-compose-adsb down || true
-			G_EXEC docker image prune -a -f
+			G_EXEC_NOHALT=1 G_EXEC_OUTPUT=1 G_EXEC /opt/adsb/docker-compose-adsb down
 			Remove_Service adsb-bootstrap
 			Remove_Service adsb-feeder-update
 			Remove_Service adsb-setup
 			Remove_Service adsb-update
-			G_EXEC rm -rf /opt/adsb /mnt/dietpi_userdata/adsb-feeder /opt/adsb-feeder-update
+			command -v docker &> /dev/null && G_EXEC docker image prune -a -f
+			G_EXEC rm -Rf /opt/adsb /mnt/dietpi_userdata/adsb-feeder /opt/adsb-feeder-update
 		fi
 
 		if To_Uninstall 2 # Folding@Home

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1592,7 +1592,7 @@ Available commands:
 		aSOFTWARE_DEPS[$software_id]='196'
 		#------------------
 		software_id=141
-		aSOFTWARE_NAME[$software_id]='adsb-feeder'
+		aSOFTWARE_NAME[$software_id]='ADS-B Feeder'
 		aSOFTWARE_DESC[$software_id]='track airplanes using SDRs and feed the data to ADS-B aggregators'
 		aSOFTWARE_CATX[$software_id]=19
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/distributed_projects/#adsb-feeder'
@@ -4190,7 +4190,7 @@ _EOF_
 			ADSB_FEEDER_VERSION="${ADSB_FEEDER_TAG_COMPONENT}(dietpi)-${ADSB_FEEDER_DATE_COMPONENT}"
 
 			# create the target directory for the app and populated with the code from the git checkout
-			G_EXEC mkdir -p /opt
+			[[ -d '/opt/adsb' ]] && G_EXEC rm -R /opt/adsb
 			G_EXEC cp -a /tmp/adsb-feeder/src/modules/adsb-feeder/filesystem/root/opt/adsb /opt
 			G_EXEC cd /opt/adsb
 
@@ -4216,10 +4216,6 @@ _EOF_
 			# running this as a service allows it to do a bit of housekeeping in the background without disrupting
 			# the software install flow
 			G_EXEC systemctl start adsb-nonimage
-
-			# last but not least, register the services needed with DietPi
-			aENABLE_SERVICES+=('adsb-setup' 'adsb-docker')
-			aSTART_SERVICES+=('adsb-setup' 'adsb-docker')
 		fi
 
 		if To_Install 186 ipfs # IPFS Node

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12755,7 +12755,7 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 			Remove_Service adsb-feeder-update
 			Remove_Service adsb-setup
 			Remove_Service adsb-update
-			G_EXEC rm -rf /opt/adsb /mnt/dietpi_userdata/adsb-feeder /opt/feeder-update
+			G_EXEC rm -rf /opt/adsb /mnt/dietpi_userdata/adsb-feeder /opt/adsb-feeder-update
 		fi
 
 		if To_Uninstall 2 # Folding@Home

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1591,6 +1591,13 @@ Available commands:
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/distributed_projects/#yacy'
 		aSOFTWARE_DEPS[$software_id]='196'
 		#------------------
+		software_id=141
+		aSOFTWARE_NAME[$software_id]='adsb-feeder'
+		aSOFTWARE_DESC[$software_id]='track airplanes using SDRs and feed the data to ADS-B aggregators'
+		aSOFTWARE_CATX[$software_id]=19
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/distributed_projects/#adsb-feeder'
+		aSOFTWARE_DEPS[$software_id]='17 130 134 162' # git, Python, dockers & docker compose
+		#------------------
 		software_id=184
 		aSOFTWARE_NAME[$software_id]='Tor Relay'
 		aSOFTWARE_DESC[$software_id]='add a node to the Tor network'
@@ -4164,6 +4171,51 @@ ExecStop=/etc/yacy/stopYACY.sh
 [Install]
 WantedBy=multi-user.target
 _EOF_
+		fi
+
+		if To_Install 141 adsb-feeder # ADSB Feeder
+		then
+			# create the userdata directory and clone the adsb-feeder repo into /tmp
+			G_EXEC mkdir -p /mnt/dietpi_userdata/adsb-feeder
+			G_EXEC_OUTPUT=1 G_EXEC git clone -b dietpi 'https://github.com/dirkhh/adsb-feeder-image.git' /tmp/adsb-feeder
+
+			# remove the services that aren't needed for an app install on DietPi and install the rest
+			G_EXEC cd /tmp/adsb-feeder/src/modules/adsb-feeder/filesystem/root
+			G_EXEC rm -rf ./usr/lib/systemd/system/adsb-docker.service
+			G_EXEC rm -rf ./usr/lib/systemd/system/adsb-bootstrap.service
+			G_EXEC cp -a ./usr/lib/systemd/system/* /etc/systemd/system/
+
+			# determine the version
+			ADSB_FEEDER_DATE_COMPONENT=$(git log -20 --date=format:%y%m%d --format="%ad" | uniq -c | head -1 | awk '{ print $2"."$1 }')
+			ADSB_FEEDER_TAG_COMPONENT=$(git describe --match "v[0-9]*" | cut -d- -f1)
+			ADSB_FEEDER_VERSION="${ADSB_FEEDER_TAG_COMPONENT}(dietpi)-${ADSB_FEEDER_DATE_COMPONENT}"
+
+			# create the target directory for the app and populated with the code from the git checkout
+			G_EXEC mkdir -p /opt
+			G_EXEC cp -a /tmp/adsb-feeder/src/modules/adsb-feeder/filesystem/root/opt/adsb /opt
+			G_EXEC cd /opt/adsb
+
+			# remove the git clone of the repo we installed from
+			G_EXEC rm -rf /tmp/adsb-feeder
+
+			# create a symlink so the config files reside where they should be in /mnt/dietpi_userdata/adsb-feeder
+			G_EXEC mkdir -p /mnt/dietpi_userdata/adsb-feeder/config
+			G_EXEC ln -s /mnt/dietpi_userdata/adsb-feeder/config .
+
+			# set the 'image name' and version that are shown in the footer of the Web UI
+			echo "ADSB Feeder app running on DietPi" > feeder-image.name
+			echo "$ADSB_FEEDER_VERSION" > adsb.im.version
+
+			# get the Python module
+			G_AGI python3-flask
+
+			# finally ensure that /run allows executables (this is needed for the containers to be able to not do excessive
+			# writes to physical storage - which might be an SDcard)
+			G_EXEC mount -o remount,exec /run
+
+			# last but not least, register the services needed with DietPi
+			aENABLE_SERVICES+=('adsb-setup' 'adsb-nonimage' 'adsb-update')
+			aSTART_SERVICES+=('adsb-setup' 'adsb-nonimage' 'adsb-update')
 		fi
 
 		if To_Install 186 ipfs # IPFS Node
@@ -12687,6 +12739,15 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 		then
 			Remove_Service yacy
 			[[ -d '/etc/yacy' ]] && G_EXEC rm -R /etc/yacy
+		fi
+
+		if To_Uninstall 141 # ADSB Feeder
+		then
+			Remove_Service adsb-bootstrap
+			Remove_Service adsb-feeder-update
+			Remove_Service adsb-setup
+			Remove_Service adsb-update
+			G_EXEC rm -rf /opt/adsb /mnt/dietpi_userdata/adsb-feeder
 		fi
 
 		if To_Uninstall 2 # Folding@Home

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4213,8 +4213,8 @@ _EOF_
 			G_EXEC mount -o remount,exec /run
 
 			# last but not least, register the services needed with DietPi
-			aENABLE_SERVICES+=('adsb-setup' 'adsb-nonimage' 'adsb-update')
-			aSTART_SERVICES+=('adsb-setup' 'adsb-nonimage' 'adsb-update')
+			aENABLE_SERVICES+=('adsb-setup' 'adsb-nonimage' 'adsb-docker')
+			aSTART_SERVICES+=('adsb-setup' 'adsb-nonimage' 'adsb-docker')
 		fi
 
 		if To_Install 186 ipfs # IPFS Node


### PR DESCRIPTION
DietPi-Software | add ADSB-Feeder app that allows feeding ADSB data from one (or more) SDRs to various aggregators (based on https://adsb.im)

Please consider this a draft - I would love feedback on all aspects of this. Did I pick the right category? Any issues with the code? I tried to follow the guidelines I could fine and the comments that you made in our discussions today. But as this is my first time adding code to DietPi, I'm sure there are things that I missed.

This has been tested both in a VM and on an RPi and appears to work ok. I assume there are features in the Web UI that will need tweaking since some things work differently when installed like this.

<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
