### PR TITLE
DietPi-Imager | Add option to add FAT partition after rootfs to simplify setup

### DIFF
--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -122,7 +122,7 @@ case $HW_MODEL in
 	79) iname='NanoPi6' HW_ARCH=3 root_size=752;; # Special case: Skips image file, partitioning and filesystem generation, but runs debootstrap only!
 	80) iname='OrangePi5' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size=752;;
 	81) iname='VisionFive2' HW_ARCH=11 root_size=639;;
-	82) iname='OrangePi5Plus' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size=752;;
+	82) iname='OrangePi5Plus' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size=952;;
 	*) G_DIETPI-NOTIFY 1 "Invalid hardware model \"$HW_MODEL\" passed, aborting..."; exit 1;;
 esac
 

--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -197,6 +197,7 @@ fi
 ##########################################
 # EFI or FAT boot partition
 (( $efi_size )) || [[ $boot_size -gt 0 && $boot_fstype == 'fat'* ]] && apackages+=('dosfstools')
+[[ $boot_size -gt 0 && $boot_fstype == 'fat'* ]] && export ADD_DOS_PART=0
 
 # Emulation support in case of incompatible architecture
 (( ( $G_HW_ARCH < 10 && $G_HW_ARCH < $HW_ARCH ) || ( ( $G_HW_ARCH == 10 || $G_HW_ARCH == 11 ) && $G_HW_ARCH != $HW_ARCH ) )) && apackages+=('qemu-user-static' 'binfmt-support')

--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -94,7 +94,7 @@ case $HW_MODEL in
 	52) iname='ASUSTB' HW_ARCH=2 partition_start=4 root_size=764;;
 	54) iname='NanoPiK2' HW_ARCH=3 partition_start=4 root_size=764;;
 	55) iname='NanoPiR2S' HW_ARCH=3 partition_start=16 root_size=752;;
-	56) iname='NanoPiNEO3' HW_ARCH=3 partition_start=16 root_size=752;;
+	56) iname='NanoPiNEO3' HW_ARCH=3 partition_start=16 root_size=884;;
 	57) iname='NanoPiNEOPlus2' HW_ARCH=3 partition_start=4 root_size=764;;
 	58) iname='NanoPiM4V2' HW_ARCH=3 partition_start=16 root_size=752;;
 	59) iname='ZeroPi' HW_ARCH=2 partition_start=4 root_size=764;;

--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -463,7 +463,8 @@ G_EXEC losetup -d "$FP_LOOP"
 ##########################################
 # Do not pack and upload raw VM image if not explicitly requested
 [[ $VMTYPE && ! $VMTYPE =~ ^(raw|all)$ ]] && SKIP_ARCHIVE=1 || SKIP_ARCHIVE=0
-export FP_ROOT_DEV CLONING_TOOL OUTPUT_IMG_NAME MOUNT_IT='Off' SKIP_ARCHIVE SKIP_FIRSTBOOT_RESIZE=1
+export FP_ROOT_DEV CLONING_TOOL OUTPUT_IMG_NAME MOUNT_IT='Off' SKIP_ARCHIVE SKIP_FIRSTBOOT_RESIZE=1 ADD_DOS_PART
+G_DIETPI-NOTIFY 2 "getting dietpi-imager for $G_GITOWNER/$G_GITBRANCH"
 [[ $EDITION && $EDITION != 'all' ]] || bash -c "$(curl -sSf "https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.build/images/dietpi-imager")" 'DietPi-Imager' "$OUTPUT_IMG_NAME.img" || exit 1
 
 # Amiberry edition: Install automatically on first boot, enable autostart option and onboard audio on RPi

--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -197,7 +197,6 @@ fi
 ##########################################
 # EFI or FAT boot partition
 (( $efi_size )) || [[ $boot_size -gt 0 && $boot_fstype == 'fat'* ]] && apackages+=('dosfstools')
-[[ $boot_size -gt 0 && $boot_fstype == 'fat'* ]] && export ADD_DOS_PART=0
 
 # Emulation support in case of incompatible architecture
 (( ( $G_HW_ARCH < 10 && $G_HW_ARCH < $HW_ARCH ) || ( ( $G_HW_ARCH == 10 || $G_HW_ARCH == 11 ) && $G_HW_ARCH != $HW_ARCH ) )) && apackages+=('qemu-user-static' 'binfmt-support')
@@ -223,6 +222,13 @@ then
 	G_EXEC_OUTPUT=1 G_EXEC dpkg -i /tmp/keyring.deb
 	G_EXEC_NOHALT=1 G_EXEC rm /tmp/keyring.deb
 fi
+
+##########################################
+# Add FAT partition for boards without it
+##########################################
+export ADD_DOS_PART=1
+[[ $boot_size -gt 0 && $boot_fstype == 'fat'* ]] && ADD_DOS_PART=0
+[[ $HW_MODEL == 20 || $HW_MODEL == 75 || $ITYPE == 'Installer' ]] && ADD_DOS_PART=0
 
 ##########################################
 # Partitions and filesystems
@@ -464,7 +470,7 @@ G_EXEC losetup -d "$FP_LOOP"
 ##########################################
 # Do not pack and upload raw VM image if not explicitly requested
 [[ $VMTYPE && ! $VMTYPE =~ ^(raw|all)$ ]] && SKIP_ARCHIVE=1 || SKIP_ARCHIVE=0
-export FP_ROOT_DEV CLONING_TOOL OUTPUT_IMG_NAME MOUNT_IT='Off' SKIP_ARCHIVE SKIP_FIRSTBOOT_RESIZE=1 ADD_DOS_PART
+export FP_ROOT_DEV CLONING_TOOL OUTPUT_IMG_NAME MOUNT_IT='Off' SKIP_ARCHIVE SKIP_FIRSTBOOT_RESIZE=1
 G_DIETPI-NOTIFY 2 "getting dietpi-imager for $G_GITOWNER/$G_GITBRANCH"
 [[ $EDITION && $EDITION != 'all' ]] || bash -c "$(curl -sSf "https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.build/images/dietpi-imager")" 'DietPi-Imager' "$OUTPUT_IMG_NAME.img" || exit 1
 

--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -45,6 +45,7 @@ GITBRANCH='master'
 GITOWNER='MichaIng'
 EDITION=
 SUFFIX=
+ADD_DOS_PART=1
 while (( $# ))
 do
 	case $1 in
@@ -59,6 +60,7 @@ do
 		'-o') shift; GITOWNER=$1;;
 		'-e') shift; EDITION=$1;;
 		'-s') shift; SUFFIX=$1;;
+		'--no-dos-part') ADD_DOS_PART=0;;
 		*) G_DIETPI-NOTIFY 1 "Invalid input \"$1\", aborting..."; exit 1;;
 	esac
 	shift
@@ -170,6 +172,10 @@ case $PTTYPE in
 	*) G_DIETPI-NOTIFY 1 "Invalid partition table type \"$PTTYPE\" passed, aborting..."; exit 1;;
 esac
 
+# Do not add trailing FAT partitions for VM, container and (Clonezilla) installer images, and if there is a boot FAT partition already
+[[ $HW_MODEL == 20 || $HW_MODEL == 75 || $ITYPE == 'Installer' ]] && ADD_DOS_PART=0
+[[ $boot_size -gt 0 && $boot_fstype == 'fat'* ]] && ADD_DOS_PART=0
+
 fsname='' apackages=() afs_opts=() afsck=() aresize=()
 case $FSTYPE in
 	'ext4') apackages+=('e2fsprogs') afs_opts=('-e' 'remount-ro') afsck=('e2fsck' '-fyD') aresize=('resize2fs');;
@@ -222,13 +228,6 @@ then
 	G_EXEC_OUTPUT=1 G_EXEC dpkg -i /tmp/keyring.deb
 	G_EXEC_NOHALT=1 G_EXEC rm /tmp/keyring.deb
 fi
-
-##########################################
-# Add FAT partition for boards without it
-##########################################
-export ADD_DOS_PART=1
-[[ $boot_size -gt 0 && $boot_fstype == 'fat'* ]] && ADD_DOS_PART=0
-[[ $HW_MODEL == 20 || $HW_MODEL == 75 || $ITYPE == 'Installer' ]] && ADD_DOS_PART=0
 
 ##########################################
 # Partitions and filesystems
@@ -426,6 +425,7 @@ _EOF_
 
 cat << _EOF_ >> rootfs/etc/rc.local
 export GITOWNER='$GITOWNER' GITBRANCH='$GITBRANCH' HW_MODEL='$HW_MODEL' IMAGE_CREATOR=0 PREIMAGE_INFO=0 WIFI_REQUIRED=1 DISTRO_TARGET=$DISTRO
+echo '[ INFO ] Running DietPi-Installer for $G_GITOWNER/$G_GITBRANCH'
 bash -c "\$(curl -sSf 'https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.build/images/dietpi-installer')" || poweroff
 _EOF_
 
@@ -471,8 +471,13 @@ G_EXEC losetup -d "$FP_LOOP"
 # Do not pack and upload raw VM image if not explicitly requested
 [[ $VMTYPE && ! $VMTYPE =~ ^(raw|all)$ ]] && SKIP_ARCHIVE=1 || SKIP_ARCHIVE=0
 export FP_ROOT_DEV CLONING_TOOL OUTPUT_IMG_NAME MOUNT_IT='Off' SKIP_ARCHIVE SKIP_FIRSTBOOT_RESIZE=1
-G_DIETPI-NOTIFY 2 "getting dietpi-imager for $G_GITOWNER/$G_GITBRANCH"
-[[ $EDITION && $EDITION != 'all' ]] || bash -c "$(curl -sSf "https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.build/images/dietpi-imager")" 'DietPi-Imager' "$OUTPUT_IMG_NAME.img" || exit 1
+IMAGER_ARGS=("$OUTPUT_IMG_NAME.img")
+(( $ADD_DOS_PART )) && IMAGER_ARGS+=('--add-dos-part')
+if [[ ! $EDITION || $EDITION == 'all' ]]
+then
+	G_DIETPI-NOTIFY 2 "Running DietPi-Imager for $G_GITOWNER/$G_GITBRANCH"
+	bash -c "$(curl -sSf "https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.build/images/dietpi-imager")" 'DietPi-Imager' "${IMAGER_ARGS[@]}" || exit 1
+fi
 
 # Amiberry edition: Install automatically on first boot, enable autostart option and onboard audio on RPi
 if [[ $EDITION == 'Amiberry' || ( $EDITION == 'all' && $HW_MODEL == 0 ) ]]
@@ -485,6 +490,15 @@ then
 	G_EXEC losetup "$FP_LOOP" "$OUTPUT_IMG_NAME.img"
 	G_EXEC partprobe "$FP_LOOP"
 	G_EXEC partx -u "$FP_LOOP"
+
+	# Remove added DOS partition, it will be re-added by DietPi-Imager
+	if (( $ADD_DOS_PART )) && [[ $(lsblk -nrbo FSTYPE,LABEL "$FP_LOOP" | tail -1) == 'vfat DIETPISETUP' ]]
+	then
+		SETUP_PART=$(sfdisk -lqo DEVICE "$FP_LOOP" | tail -1)
+		G_EXEC_OUTPUT=1 G_EXEC sfdisk --no-reread --no-tell-kernel --delete "$FP_LOOP" "${SETUP_PART: -1}"
+		G_EXEC partprobe "$FP_LOOP"
+		G_EXEC partx -u "$FP_LOOP"
+	fi
 
 	# Mount filesystems
 	G_EXEC mkdir rootfs
@@ -510,7 +524,8 @@ then
 	G_EXEC rmdir rootfs
 	G_EXEC losetup -d "$FP_LOOP"
 
-	bash -c "$(curl -sSf "https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.build/images/dietpi-imager")" 'DietPi-Imager' "$OUTPUT_IMG_NAME.img" || exit 1
+	G_DIETPI-NOTIFY 2 "Running DietPi-Imager for $G_GITOWNER/$G_GITBRANCH"
+	bash -c "$(curl -sSf "https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.build/images/dietpi-imager")" 'DietPi-Imager' "${IMAGER_ARGS[@]}" || exit 1
 fi
 
 # AlloGUI edition: Pre-install Allo GUI with all managed audiophile software
@@ -525,7 +540,17 @@ then
 	G_EXEC losetup "$FP_LOOP" "$OUTPUT_IMG_NAME.img"
 	G_EXEC partprobe "$FP_LOOP"
 	G_EXEC partx -u "$FP_LOOP"
-	# Raise partition and filesystem size as well, since resize2fs within the image returns "Nothing to do!"
+
+	# Remove added DOS partition, it will be re-added by DietPi-Imager
+	if (( $ADD_DOS_PART )) && [[ $(lsblk -nrbo FSTYPE,LABEL "$FP_LOOP" | tail -1) == 'vfat DIETPISETUP' ]]
+	then
+		SETUP_PART=$(sfdisk -lqo DEVICE "$FP_LOOP" | tail -1)
+		G_EXEC_OUTPUT=1 G_EXEC sfdisk --no-reread --no-tell-kernel --delete "$FP_LOOP" "${SETUP_PART: -1}"
+		G_EXEC partprobe "$FP_LOOP"
+		G_EXEC partx -u "$FP_LOOP"
+	fi
+
+	# Raise partition and filesystem sizes as well, since partprobe cannot inform the host kernel about the changed size from within the container
 	G_EXEC_OUTPUT=1 G_EXEC eval "sfdisk -fN2 '$FP_LOOP' <<< ',+'"
 	G_EXEC partprobe "$FP_LOOP"
 	G_EXEC partx -u "$FP_LOOP"
@@ -633,7 +658,8 @@ _EOF_
 	G_EXEC rmdir rootfs
 	G_EXEC losetup -d "$FP_LOOP"
 
-	bash -c "$(curl -sSf "https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.build/images/dietpi-imager")" 'DietPi-Imager' "$OUTPUT_IMG_NAME.img" || exit 1
+	G_DIETPI-NOTIFY 2 "Running DietPi-Imager for $G_GITOWNER/$G_GITBRANCH"
+	bash -c "$(curl -sSf "https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.build/images/dietpi-imager")" 'DietPi-Imager' "${IMAGER_ARGS[@]}" || exit 1
 fi
 
 [[ $VMTYPE && $VMTYPE != 'raw' ]] || exit 0

--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -94,7 +94,7 @@ case $HW_MODEL in
 	52) iname='ASUSTB' HW_ARCH=2 partition_start=4 root_size=764;;
 	54) iname='NanoPiK2' HW_ARCH=3 partition_start=4 root_size=764;;
 	55) iname='NanoPiR2S' HW_ARCH=3 partition_start=16 root_size=752;;
-	56) iname='NanoPiNEO3' HW_ARCH=3 partition_start=16 root_size=884;;
+	56) iname='NanoPiNEO3' HW_ARCH=3 partition_start=16 root_size=752;;
 	57) iname='NanoPiNEOPlus2' HW_ARCH=3 partition_start=4 root_size=764;;
 	58) iname='NanoPiM4V2' HW_ARCH=3 partition_start=16 root_size=752;;
 	59) iname='ZeroPi' HW_ARCH=2 partition_start=4 root_size=764;;
@@ -122,7 +122,7 @@ case $HW_MODEL in
 	79) iname='NanoPi6' HW_ARCH=3 root_size=752;; # Special case: Skips image file, partitioning and filesystem generation, but runs debootstrap only!
 	80) iname='OrangePi5' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size=752;;
 	81) iname='VisionFive2' HW_ARCH=11 root_size=639;;
-	82) iname='OrangePi5Plus' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size=952;;
+	82) iname='OrangePi5Plus' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size=752;;
 	*) G_DIETPI-NOTIFY 1 "Invalid hardware model \"$HW_MODEL\" passed, aborting..."; exit 1;;
 esac
 

--- a/.build/images/dietpi-imager
+++ b/.build/images/dietpi-imager
@@ -338,15 +338,7 @@
 		# Remount image for any required edits
 		G_EXEC mkdir "$FP_MNT_TMP"
 		G_EXEC mount "$FP_ROOT_DEV" "$FP_MNT_TMP"
-		[[ -z ${ADD_DOS_PART+x} ]] && ADD_DOS_PART="0"
-		if [[ "$ADD_DOS_PART" == "1" ]]
-		then
-			# let's copy the two config files we want to add to the setup partition
-			TMP_DIETPI_CONF_DIR=$(mktemp -d)
-			cp "$FP_MNT_TMP"/boot/dietpi.txt "$TMP_DIETPI_CONF_DIR"/
-			cp "$FP_MNT_TMP"/boot/dietpi-wifi.txt "$TMP_DIETPI_CONF_DIR"/
-			G_EXEC_OUTPUT=1 G_EXEC ls -l "$TMP_DIETPI_CONF_DIR"/
-		fi
+
 		# - Remove bash history and DHCP leases, which are stored on shutdown, hence cannot be removed via DietPi-PREP
 		G_EXEC rm -f "$FP_MNT_TMP/"{root,home/*}/.bash_history "$FP_MNT_TMP/var/lib/dhcp/"*.leases
 		# - Enable DietPi-FS_partition_resize to have both, old and new image being resized on next boot automatically
@@ -502,33 +494,37 @@
 			G_EXEC partprobe "$FP_SOURCE"
 			G_EXEC partx -u "$FP_SOURCE"
 		fi
-		if [[ "$ADD_DOS_PART" == "1" &&  "$PART_TABLE_TYPE" == 'dos' ]]
+		[[ -z ${ADD_DOS_PART+x} ]] && ADD_DOS_PART="0"
+		if [[ $ADD_DOS_PART == 1 ]]
 		then
 			G_DIETPI-NOTIFY 2 'Adding a 4MB FAT partition to the DOS partition table'
-			G_EXEC_OUTPUT=1 G_EXEC dd if=/dev/zero bs=4M count=1 >> "$FP_SOURCE_IMG"
-			# first, methodically extract the starting point for that next partition
-			local old_table=$(sfdisk --json "$FP_SOURCE_IMG")
-			export lp_start=$(echo "$old_table" | jq ".partitiontable.partitions[].start" | sort -n | tail -1)
-			# jq syntax is a bit werid: pick the partition with the given start, and extract its size
-			local lp_size=$(echo "$old_table" | jq '.partitiontable.partitions|map(select(.start==(env.lp_start|tonumber)))[].size')
-			local np_start=$(( $lp_start + $lp_size ))
+			# figure out where the new partition starts
+			# WARNING: this assumes that the partitions in the table are in order (which we do in other places as well)
+			if [[ $SOURCE_TYPE == 'Image' ]]
+			then
+				G_DIETPI-NOTIFY 2 "working on a filesystem image, so adding 4MB to $FP_SOURCE_IMG"
+				G_EXEC_OUTPUT=1 G_EXEC dd if=/dev/zero bs=4M count=1 >> "$FP_SOURCE_IMG"
+			fi
+			local root_part=$(sfdisk -qlo DEVICE "$FP_SOURCE" | tail -1)
+			local np_start=$(($(sfdisk -qlo END "$FP_SOURCE" | tail -1) + 1))
+			local type='EBD0A0A2-B9E5-4433-87C0-68B6B72699C7'
+			[[ $PART_TABLE_TYPE == 'dos' ]] && type='c'
 			# now we know where the new partition needs to start... so let's add it to the partition table
-			echo "start=$np_start,size=8192,type=c" | sfdisk -a "$FP_SOURCE_IMG"
-			# we had to export a variable we really wanted to be local in order to make jq happy; undo that
-			export -n lp_start
+			G_DIETPI-NOTIFY 2 "/:${root_part}, np_start:${np_start}, FP_SOURCE:${FP_SOURCE}"
+			echo "start=$np_start,size=8192,type=$type" | sfdisk -a "$FP_SOURCE"
+			G_EXEC partprobe "$FP_SOURCE"
+			G_EXEC losetup -c "$FP_SOURCE"
 			# create a fat filesystem and add the two config files to it
-			Delete_Loopback # Prevent doubled loop device
-			FP_SOURCE=$(losetup -f)
-			G_EXEC losetup -P "$FP_SOURCE" "$FP_SOURCE_IMG"
 			local new_dos_part=$(sfdisk -l "$FP_SOURCE" | grep "$np_start" | mawk '{print $1}')
-			G_DIETPI-NOTIFY 2 "device is $new_dos_part: mkfs.vfat -v -n DIETPISETUP $new_dos_part"
 			G_EXE_OUTPUT=1 G_EXEC mkfs.vfat -v -n DIETPISETUP "$new_dos_part"
-			local mountpoint=$(mktemp -d)
-			G_EXEC mount "$new_dos_part" "$mountpoint"
-			G_EXEC cp "$TMP_DIETPI_CONF_DIR"/* "$mountpoint"/
-			G_EXE_OUTPUT=1 G_EXEC ls -l "$mountpoint"
-			G_EXEC umount "$mountpoint"
-			G_EXEC rmdir "$mountpoint"
+			local fat_mountpoint=$(mktemp -d)
+			local root_mountpoint=$(mktemp -d)
+			G_EXEC mount "$new_dos_part" "$fat_mountpoint"
+			G_EXEC mount "$root_part" "$root_mountpoint"
+			G_EXEC cp "${root_mountpoint}/boot/dietpi{,-wifi}.txt" "$fat_mountpoint"/
+			G_DIETPI_NOTIFY 2 "copied dietpi.txt and dietpi-wifi.txt to the FAT partition"
+			G_EXEC umount "$root_mountpoint" "$fat_mountpoint"
+			G_EXEC rmdir "$root_mountpoint" "$fat_mountpoint"
 		fi
 		# Exit now if source shall be shrunk only
 		(( $SHRINK_ONLY )) && exit 0

--- a/.build/images/dietpi-imager
+++ b/.build/images/dietpi-imager
@@ -338,6 +338,15 @@
 		# Remount image for any required edits
 		G_EXEC mkdir "$FP_MNT_TMP"
 		G_EXEC mount "$FP_ROOT_DEV" "$FP_MNT_TMP"
+		[[ -z ${ADD_DOS_PART+x} ]] && ADD_DOS_PART="0"
+		if [[ "$ADD_DOS_PART" == "1" ]]
+		then
+			# let's copy the two config files we want to add to the setup partition
+			TMP_DIETPI_CONF_DIR=$(mktemp -d)
+			cp "$FP_MNT_TMP"/boot/dietpi.txt "$TMP_DIETPI_CONF_DIR"/
+			cp "$FP_MNT_TMP"/boot/dietpi-wifi.txt "$TMP_DIETPI_CONF_DIR"/
+			G_EXEC_OUTPUT=1 G_EXEC ls -l "$TMP_DIETPI_CONF_DIR"/
+		fi
 		# - Remove bash history and DHCP leases, which are stored on shutdown, hence cannot be removed via DietPi-PREP
 		G_EXEC rm -f "$FP_MNT_TMP/"{root,home/*}/.bash_history "$FP_MNT_TMP/var/lib/dhcp/"*.leases
 		# - Enable DietPi-FS_partition_resize to have both, old and new image being resized on next boot automatically
@@ -493,7 +502,34 @@
 			G_EXEC partprobe "$FP_SOURCE"
 			G_EXEC partx -u "$FP_SOURCE"
 		fi
-
+		if [[ "$ADD_DOS_PART" == "1" &&  "$PART_TABLE_TYPE" == 'dos' ]]
+		then
+			G_DIETPI-NOTIFY 2 'Adding a 4MB FAT partition to the DOS partition table'
+			G_EXEC_OUTPUT=1 G_EXEC dd if=/dev/zero bs=4M count=1 >> "$FP_SOURCE_IMG"
+			# first, methodically extract the starting point for that next partition
+			local old_table=$(sfdisk --json "$FP_SOURCE_IMG")
+			export lp_start=$(echo "$old_table" | jq ".partitiontable.partitions[].start" | sort -n | tail -1)
+			# jq syntax is a bit werid: pick the partition with the given start, and extract its size
+			local lp_size=$(echo "$old_table" | jq '.partitiontable.partitions|map(select(.start==(env.lp_start|tonumber)))[].size')
+			local np_start=$(( $lp_start + $lp_size ))
+			# now we know where the new partition needs to start... so let's add it to the partition table
+			echo "start=$np_start,size=8192,type=c" | sfdisk -a "$FP_SOURCE_IMG"
+			# we had to export a variable we really wanted to be local in order to make jq happy; undo that
+			export -n lp_start
+			# create a fat filesystem and add the two config files to it
+			Delete_Loopback # Prevent doubled loop device
+			FP_SOURCE=$(losetup -f)
+			G_EXEC losetup -P "$FP_SOURCE" "$FP_SOURCE_IMG"
+			local new_dos_part=$(sfdisk -l "$FP_SOURCE" | grep "$np_start" | mawk '{print $1}')
+			G_DIETPI-NOTIFY 2 "device is $new_dos_part: mkfs.vfat -v -n DIETPISETUP $new_dos_part"
+			G_EXE_OUTPUT=1 G_EXEC mkfs.vfat -v -n DIETPISETUP "$new_dos_part"
+			local mountpoint=$(mktemp -d)
+			G_EXEC mount "$new_dos_part" "$mountpoint"
+			G_EXEC cp "$TMP_DIETPI_CONF_DIR"/* "$mountpoint"/
+			G_EXE_OUTPUT=1 G_EXEC ls -l "$mountpoint"
+			G_EXEC umount "$mountpoint"
+			G_EXEC rmdir "$mountpoint"
+		fi
 		# Exit now if source shall be shrunk only
 		(( $SHRINK_ONLY )) && exit 0
 

--- a/.build/images/dietpi-imager
+++ b/.build/images/dietpi-imager
@@ -510,6 +510,7 @@
 			local type='EBD0A0A2-B9E5-4433-87C0-68B6B72699C7'
 			[[ $PART_TABLE_TYPE == 'dos' ]] && type='c'
 			# now we know where the new partition needs to start... so let's add it to the partition table
+			G_EXEC losetup -c "$FP_SOURCE"
 			G_DIETPI-NOTIFY 2 "/:${root_part}, np_start:${np_start}, FP_SOURCE:${FP_SOURCE}"
 			echo "start=$np_start,size=8192,type=$type" | sfdisk -a "$FP_SOURCE"
 			G_EXEC partprobe "$FP_SOURCE"

--- a/.build/images/dietpi-imager
+++ b/.build/images/dietpi-imager
@@ -521,8 +521,8 @@
 			local root_mountpoint=$(mktemp -d)
 			G_EXEC mount "$new_dos_part" "$fat_mountpoint"
 			G_EXEC mount "$root_part" "$root_mountpoint"
-			G_EXEC cp "${root_mountpoint}/boot/dietpi{,-wifi}.txt" "$fat_mountpoint"/
-			G_DIETPI_NOTIFY 2 "copied dietpi.txt and dietpi-wifi.txt to the FAT partition"
+			G_EXEC cp "${root_mountpoint}"/boot/dietpi{,-wifi}.txt "$fat_mountpoint"/
+			G_DIETPI-NOTIFY 2 "copied dietpi.txt and dietpi-wifi.txt to the DIETPISETUP partition"
 			G_EXEC umount "$root_mountpoint" "$fat_mountpoint"
 			G_EXEC rmdir "$root_mountpoint" "$fat_mountpoint"
 		fi

--- a/.build/images/dietpi-imager
+++ b/.build/images/dietpi-imager
@@ -338,7 +338,6 @@
 		# Remount image for any required edits
 		G_EXEC mkdir "$FP_MNT_TMP"
 		G_EXEC mount "$FP_ROOT_DEV" "$FP_MNT_TMP"
-
 		# - Remove bash history and DHCP leases, which are stored on shutdown, hence cannot be removed via DietPi-PREP
 		G_EXEC rm -f "$FP_MNT_TMP/"{root,home/*}/.bash_history "$FP_MNT_TMP/var/lib/dhcp/"*.leases
 		# - Enable DietPi-FS_partition_resize to have both, old and new image being resized on next boot automatically
@@ -497,22 +496,17 @@
 		[[ -z ${ADD_DOS_PART+x} ]] && ADD_DOS_PART="0"
 		if [[ $ADD_DOS_PART == 1 ]]
 		then
-			G_DIETPI-NOTIFY 2 'Adding a 1MB FAT partition to the DOS partition table'
+			G_DIETPI-NOTIFY 2 'Adding a 1MB FAT partition to the partition table'
 			# figure out where the new partition starts
 			# WARNING: this assumes that the partitions in the table are in order (which we do in other places as well)
-			if [[ $SOURCE_TYPE == 'Image' ]]
-			then
-				G_DIETPI-NOTIFY 2 "working on a filesystem image, so adding 1MB to $FP_SOURCE_IMG"
-				G_EXEC_OUTPUT=1 G_EXEC dd if=/dev/zero bs=1M count=1 >> "$FP_SOURCE_IMG"
-			fi
+			[[ $SOURCE_TYPE == 'Image' ]] && G_EXEC_OUTPUT=1 G_EXEC dd if=/dev/zero bs=1M count=1 >> "$FP_SOURCE_IMG"
 			local root_part=$(sfdisk -qlo DEVICE "$FP_SOURCE" | tail -1)
 			local np_start=$(($(sfdisk -qlo END "$FP_SOURCE" | tail -1) + 1))
 			local type='EBD0A0A2-B9E5-4433-87C0-68B6B72699C7'
 			[[ $PART_TABLE_TYPE == 'dos' ]] && type='c'
 			# now we know where the new partition needs to start... so let's add it to the partition table
 			G_EXEC losetup -c "$FP_SOURCE"
-			G_DIETPI-NOTIFY 2 "/:${root_part}, np_start:${np_start}, FP_SOURCE:${FP_SOURCE}"
-			echo "start=$np_start,size=2048,type=$type" | sfdisk -a "$FP_SOURCE"
+			sfdisk -a "$FP_SOURCE" <<< "start=$np_start,size=2048,type=$type"
 			G_EXEC partprobe "$FP_SOURCE"
 			G_EXEC losetup -c "$FP_SOURCE"
 			# create a fat filesystem and add the two config files to it

--- a/.build/images/dietpi-imager
+++ b/.build/images/dietpi-imager
@@ -46,22 +46,11 @@
 		exit 1
 	}
 
-	# Inputs
+	##########################################
+	# Process inputs
+	##########################################
 	SOURCE_TYPE='Drive'
 	FP_SOURCE_IMG=
-	if [[ -b $1 ]]
-	then
-		FP_SOURCE=$1
-
-	elif [[ -f $1 ]]
-	then
-		SOURCE_TYPE='Image'
-		FP_SOURCE_IMG=$1
-
-	elif [[ $1 ]]
-	then
-		Error_Exit "Input source $1 does not exist, aborting..."
-	fi
 	PART_TABLE_TYPE=
 	#FP_ROOT_DEV=
 	ROOT_FS_TYPE=
@@ -69,9 +58,32 @@
 	OUTPUT_IMG_EXT='img'
 	#OUTPUT_IMG_NAME=
 	[[ $MOUNT_IT == 'On' ]] || MOUNT_IT='Off'
+	[[ $SKIP_FIRSTBOOT_RESIZE == 1 ]] || SKIP_FIRSTBOOT_RESIZE=0
 	[[ $SHRINK_ONLY == 1 ]] || SHRINK_ONLY=0
 	[[ $SKIP_ARCHIVE == 1 ]] || SKIP_ARCHIVE=0
-	[[ $SKIP_FIRSTBOOT_RESIZE == 1 ]] || SKIP_FIRSTBOOT_RESIZE=0
+	ADD_DOS_PART=0
+	while (( $# ))
+	do
+		case $1 in
+			'--add-dos-part') ADD_DOS_PART=1;;
+			*)
+				if [[ -b $1 ]]
+				then
+					FP_SOURCE=$1
+
+				elif [[ -f $1 ]]
+				then
+					SOURCE_TYPE='Image'
+					FP_SOURCE_IMG=$1
+
+				elif [[ $1 ]]
+				then
+					Error_Exit "Input source $1 does not exist, aborting..."
+				fi
+			;;
+		esac
+		shift
+	done
 
 	Unmount_tmp()
 	{
@@ -493,53 +505,58 @@
 			G_EXEC partprobe "$FP_SOURCE"
 			G_EXEC partx -u "$FP_SOURCE"
 		fi
-		[[ -z ${ADD_DOS_PART+x} ]] && ADD_DOS_PART="0"
-		if [[ $ADD_DOS_PART == 1 ]]
+
+		# Derive target image size from last partition end + 1 sector
+		IMAGE_SIZE=$(( ( $(sfdisk -qlo End "$FP_SOURCE" | tail -1) + 1 ) * 512 )) # 512 byte sectors => bytes
+
+		# Add trailing FAT partition to simplify first run setup if requested
+		# - WARNING: this assumes that the partitions in the table are in order (which we do in other places as well)
+		if (( $ADD_DOS_PART ))
 		then
-			G_DIETPI-NOTIFY 2 'Adding a 1MB FAT partition to the partition table'
-			# figure out where the new partition starts
-			# WARNING: this assumes that the partitions in the table are in order (which we do in other places as well)
-			[[ $SOURCE_TYPE == 'Image' ]] && G_EXEC_OUTPUT=1 G_EXEC dd if=/dev/zero bs=1M count=1 >> "$FP_SOURCE_IMG"
-			local root_part=$(sfdisk -qlo DEVICE "$FP_SOURCE" | tail -1)
-			local np_start=$(($(sfdisk -qlo END "$FP_SOURCE" | tail -1) + 1))
-			local type='EBD0A0A2-B9E5-4433-87C0-68B6B72699C7'
+			G_DIETPI-NOTIFY 2 'Adding a 1 MiB FAT partition to simplify first run setup'
+			# Increase source image size if required
+			[[ $SOURCE_TYPE == 'Image' ]] && (( $(stat -c '%s' "$FP_SOURCE_IMG") < $IMAGE_SIZE + 1048576 )) && G_EXEC truncate -s "$(( $IMAGE_SIZE + 1048576 ))" "$FP_SOURCE_IMG" && G_EXEC losetup -c "$FP_SOURCE"
+			# Add new DOS partition
+			local type='EBD0A0A2-B9E5-4433-87C0-68B6B72699C7' # https://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
 			[[ $PART_TABLE_TYPE == 'dos' ]] && type='c'
-			# now we know where the new partition needs to start... so let's add it to the partition table
-			G_EXEC losetup -c "$FP_SOURCE"
-			sfdisk -a "$FP_SOURCE" <<< "start=$np_start,size=2048,type=$type"
+			G_EXEC eval "sfdisk -a '$FP_SOURCE' <<< 'start=$IMAGE_SIZE,size=2048,type=$type'" # size in sectors
 			G_EXEC partprobe "$FP_SOURCE"
-			G_EXEC losetup -c "$FP_SOURCE"
-			# create a fat filesystem and add the two config files to it
-			local new_dos_part=$(sfdisk -l "$FP_SOURCE" | grep "$np_start" | mawk '{print $1}')
-			G_EXE_OUTPUT=1 G_EXEC mkfs.vfat -v -n DIETPISETUP "$new_dos_part"
+			G_EXEC partx -u "$FP_SOURCE"
+			# create a FAT filesystem and add config files to it
+			local new_dos_part=$(sfdisk -l "$FP_SOURCE" | mawk "/ $IMAGE_SIZE /{print \$1;exit}")
+			G_EXE_OUTPUT=1 G_EXEC mkfs.fat -F 16 -n DIETPISETUP "$new_dos_part"
 			local fat_mountpoint=$(mktemp -d)
 			local root_mountpoint=$(mktemp -d)
 			G_EXEC mount "$new_dos_part" "$fat_mountpoint"
-			G_EXEC mount "$root_part" "$root_mountpoint"
-			G_EXEC cp "${root_mountpoint}"/boot/dietpi{,-wifi,Env}.txt "$fat_mountpoint"/
-			cat << '_EOF_' > "$fat_mountpoint"/Readme-DietPi-Config.txt
+			G_EXEC mount "$FP_ROOT_DEV" "$root_mountpoint"
+			G_DIETPI-NOTIFY 2 'Copying dietpi.txt and other config files to the DIETPISETUP partition'
+			for f in 'dietpi.txt' 'dietpi-wifi.txt' 'dietpiEnv.txt' 'unattended_pivpn.conf' 'Automation_Custom_PreScript.sh' 'Automation_Custom_Script.sh'
+			do
+				[[ -f $root_mountpoint/boot/$f ]] && G_EXEC cp "$root_mountpoint/boot/$f" "$fat_mountpoint/"
+			done
+			cat << '_EOF_' > "$fat_mountpoint/Readme-DietPi-Config.txt"
 DietPi pre-boot configuration
 
 You can edit the files in this folder to setup some configuration options
-or even a completely automated install. Please check the documentation for
-details. https://dietpi.com/docs/install/
+or even a completely automated install. Please check the documentation and
+dietpi.txt for details: https://dietpi.com/docs/install/
 
 This folder also supports the following additional files. Please ensure that
-they have Unix style line endings:
+they have UNIX style LF line endings:
 - unattended_pivpn.conf
 - Automation_Custom_PreScript.sh
 - Automation_Custom_Script.sh
 _EOF_
-			G_DIETPI-NOTIFY 2 "copied dietpi.txt and dietpi-wifi.txt to the DIETPISETUP partition"
 			G_EXEC umount "$root_mountpoint" "$fat_mountpoint"
 			G_EXEC rmdir "$root_mountpoint" "$fat_mountpoint"
+			((IMAGE_SIZE+=1048576))
 		fi
+
 		# Exit now if source shall be shrunk only
 		(( $SHRINK_ONLY )) && exit 0
 
-		# Finished: Derive final image size from last partition end + 1 sector
-		IMAGE_SIZE=$(( ( $(sfdisk -qlo End "$FP_SOURCE" | tail -1) + 1 ) * 512 )) # 512 byte sectors => bytes
-		[[ $PART_TABLE_TYPE == 'gpt' ]] && IMAGE_SIZE=$(( $IMAGE_SIZE + 33*512 )) # Add 33 (34 overall) sectors for GPT backup partition table
+		# Add 33 (34 overall) sectors for GPT backup partition table
+		[[ $PART_TABLE_TYPE == 'gpt' ]] && IMAGE_SIZE=$(( $IMAGE_SIZE + 33*512 ))
 
 		# Image file source and dd target
 		if [[ $FP_SOURCE_IMG && $CLONING_TOOL == 'dd' ]]

--- a/.build/images/dietpi-imager
+++ b/.build/images/dietpi-imager
@@ -497,13 +497,13 @@
 		[[ -z ${ADD_DOS_PART+x} ]] && ADD_DOS_PART="0"
 		if [[ $ADD_DOS_PART == 1 ]]
 		then
-			G_DIETPI-NOTIFY 2 'Adding a 4MB FAT partition to the DOS partition table'
+			G_DIETPI-NOTIFY 2 'Adding a 1MB FAT partition to the DOS partition table'
 			# figure out where the new partition starts
 			# WARNING: this assumes that the partitions in the table are in order (which we do in other places as well)
 			if [[ $SOURCE_TYPE == 'Image' ]]
 			then
-				G_DIETPI-NOTIFY 2 "working on a filesystem image, so adding 4MB to $FP_SOURCE_IMG"
-				G_EXEC_OUTPUT=1 G_EXEC dd if=/dev/zero bs=4M count=1 >> "$FP_SOURCE_IMG"
+				G_DIETPI-NOTIFY 2 "working on a filesystem image, so adding 1MB to $FP_SOURCE_IMG"
+				G_EXEC_OUTPUT=1 G_EXEC dd if=/dev/zero bs=1M count=1 >> "$FP_SOURCE_IMG"
 			fi
 			local root_part=$(sfdisk -qlo DEVICE "$FP_SOURCE" | tail -1)
 			local np_start=$(($(sfdisk -qlo END "$FP_SOURCE" | tail -1) + 1))
@@ -512,7 +512,7 @@
 			# now we know where the new partition needs to start... so let's add it to the partition table
 			G_EXEC losetup -c "$FP_SOURCE"
 			G_DIETPI-NOTIFY 2 "/:${root_part}, np_start:${np_start}, FP_SOURCE:${FP_SOURCE}"
-			echo "start=$np_start,size=8192,type=$type" | sfdisk -a "$FP_SOURCE"
+			echo "start=$np_start,size=2048,type=$type" | sfdisk -a "$FP_SOURCE"
 			G_EXEC partprobe "$FP_SOURCE"
 			G_EXEC losetup -c "$FP_SOURCE"
 			# create a fat filesystem and add the two config files to it

--- a/.build/images/dietpi-imager
+++ b/.build/images/dietpi-imager
@@ -522,7 +522,20 @@
 			local root_mountpoint=$(mktemp -d)
 			G_EXEC mount "$new_dos_part" "$fat_mountpoint"
 			G_EXEC mount "$root_part" "$root_mountpoint"
-			G_EXEC cp "${root_mountpoint}"/boot/dietpi{,-wifi}.txt "$fat_mountpoint"/
+			G_EXEC cp "${root_mountpoint}"/boot/dietpi{,-wifi,Env}.txt "$fat_mountpoint"/
+			cat << '_EOF_' > "$fat_mountpoint"/Readme-DietPi-Config.txt
+DietPi pre-boot configuration
+
+You can edit the files in this folder to setup some configuration options
+or even a completely automated install. Please check the documentation for
+details. https://dietpi.com/docs/install/
+
+This folder also supports the following additional files. Please ensure that
+they have Unix style line endings:
+- unattended_pivpn.conf
+- Automation_Custom_PreScript.sh
+- Automation_Custom_Script.sh
+_EOF_
 			G_DIETPI-NOTIFY 2 "copied dietpi.txt and dietpi-wifi.txt to the DIETPISETUP partition"
 			G_EXEC umount "$root_mountpoint" "$fat_mountpoint"
 			G_EXEC rmdir "$root_mountpoint" "$fat_mountpoint"

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ New software:
 - ADS-B Feeder | Track airplanes using SDRs and feed the data to ADS-B aggregators. Many thanks to @dirkhh for maintaining and implementing this software option: https://github.com/MichaIng/DietPi/pull/6587
 
 Enhancements:
+- General | DietPi images are now shipped with a trailing FAT partition which contains dietpi.txt and other config files for easier pre-configuration and automation from Windows and macOS hosts. Related CLI flags have been added to our build scripts. Many thanks to @dirkhh for implementing this feature: https://github.com/MichaIng/DietPi/pull/6602
 - DietPi-Software | Docker: Enabled for Trixie and RISC-V via "docker.io" package from Debian repository.
 - DietPi-Software | Portainer: Enabled for RISC-V as Docker is now supported on RISC-V as well.
 

--- a/rootfs/var/lib/dietpi/services/dietpi-firstboot.bash
+++ b/rootfs/var/lib/dietpi/services/dietpi-firstboot.bash
@@ -88,54 +88,6 @@
 		fi
 	}
 
-	Apply_DietPiSetup(){
-		# Detect root device
-		# this code is a verbatim copy from the fs_resize code - I didn't quite know
-		# where to put common code for these scripts
-		ROOT_DEV=$(findmnt -Ufnro SOURCE -M /)
-
-		# Detect root partition and parent drive for supported naming schemes:
-		# - SCSI/SATA:	/dev/sd[a-z][1-9]
-		# - IDE:	/dev/hd[a-z][1-9]
-		# - VirtIO:	/dev/vd[a-z][1-9]
-		# - eMMC:	/dev/mmcblk[0-9]p[1-9]
-		# - NVMe:	/dev/nvme[0-9]n[0-9]p[1-9]
-		# - loop:	/dev/loop[0-9]p[1-9]
-		if [[ $ROOT_DEV == /dev/[shv]d[a-z][1-9] ]]
-		then
-			ROOT_DRIVE=${ROOT_DEV::-1}	# /dev/sda1 => /dev/sda
-
-		elif [[ $ROOT_DEV =~ ^/dev/(mmcblk|nvme[0-9]n|loop)[0-9]p[1-9]$ ]]
-		then
-			ROOT_DRIVE=${ROOT_DEV::-2}	# /dev/mmcblk0p1 => /dev/mmcblk0
-		else
-			echo "[FAILED] Unsupported root device naming scheme ($ROOT_DEV). Aborting..."
-			exit 1
-		fi
-
-		# check if the last partition is a 4MB partition with the Windows/FAT type
-		if sfdisk -l "$ROOT_DRIVE" | tail -1 | grep -E "\s4M\s+c\s" > /dev/null 2>&1
-		then
-			# the last partition is a 4M FAT filesystem - let's check if it is ours
-			local setup_part=$(sfdisk -l "$ROOT_DRIVE" | tail -1 | mawk '{print $1}')
-			if blkid "$setup_part" | grep 'LABEL="DIETPISETUP"'
-			then
-				# mount it and copy files
-				local temp_mount=$(mktemp -d)
-				mount "$setup_part" "$temp_mount"
-				[[ -f "$temp_mount"/dietpi.txt ]] && cp "$temp_mount"/dietpi.txt /boot/dietpi.txt
-				[[ -f "$temp_mount"/dietpi-wifi.txt ]] && cp "$temp_mount"/dietpi-wifi.txt /boot/dietpi-wifi.txt
-				umount "$setup_part"
-				rmdir "$temp_mount"
-				# finally delete the partition so the resizing works
-				sfdisk --no-tell --no-reread --delete "$ROOT_DRIVE" "${setup_part: -1}"
-				# Try to inform kernel about changed partition table
-				partprobe "$ROOT_DRIVE" || echo "partprobe failed" # I don't think we should bail here
-				partx -u "$ROOT_DRIVE" || echo "partx -u failed"   # I don't think we should bail here
-			fi
-		fi
-	}
-
 	Apply_DietPi_FirstRun_Settings(){
 
 		# RPi: Apply safe overclocking values or update comments to show model-specific defaults
@@ -391,9 +343,6 @@ _EOF_
 	# Failsafe: https://github.com/MichaIng/DietPi/issues/3646#issuecomment-653739919
 	chown root:root /
 	chmod 0755 /
-
-	# Check if there is a DIETPISETUP partition and extract the data from it
-	Apply_DietPiSetup
 
 	# Apply dietpi.txt settings and reset hardware ID + SSH host keys
 	Apply_DietPi_FirstRun_Settings

--- a/rootfs/var/lib/dietpi/services/fs_partition_resize.sh
+++ b/rootfs/var/lib/dietpi/services/fs_partition_resize.sh
@@ -39,8 +39,9 @@
 		exit 1
 	fi
 
-	# check if the last partition is a 4MB partition with the Windows/FAT type
-	if sfdisk -l "$ROOT_DRIVE" | tail -1 | grep -E "\s4M\s+c\s" > /dev/null 2>&1
+	# check if the last partition is a 4MB partition with a vfat filesystem
+	LAST_FS_TYPE=$(lsblk -no FSTYPE "$ROOT_DRIVE" | tail -1)
+	if sfdisk -l "$ROOT_DRIVE" | tail -1 | grep -E "\s4M\s" > /dev/null 2>&1 && [[ $LAST_FS_TYPE = 'vfat' ]]
 	then
 		# the last partition is a 4M FAT filesystem - let's check if it is ours
 		SETUP_PART=$(sfdisk -l "$ROOT_DRIVE" | tail -1 | mawk '{print $1}')


### PR DESCRIPTION
This isn't complete, yet (MBR only, only tested on one board), but I felt that this would be enough to maybe get some feedback on the code and the overall idea for implementation.

What this does right now is that if the corresponding environment variable `ADD_DOS_PART` is set, at image creation time a 4MB DOS partition named DIETPISETUP (yay for 11 character limit) is created at the end of the disk image and `dietpi.txt` and `dietpi-wifi.txt` are copied onto that partition.

During first boot, when such a partition is found, those two files (and ONLY those two files - not sure if that is the right choice, but it seemed better that way) get copied back over the ones that were in the `root` filesystem.

This way a user on a Mac or a Windows system can very easily make changes to the settings - I think the most important use case will be wifi setup on headless systems... and then of course fully automated setup.

Again, I'm curious to hear comments about everything. Coding style, decisions about how this is enabled, where I inserted the code, anything. I want to make sure that this is broadly useful and not just a fix for my use case.