### PR TITLE
CI | DietPi-Build: Re-enable Trixie/Sid builds

### DIFF
--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -207,8 +207,7 @@ fi
 (( $efi_size )) || [[ $boot_size -gt 0 && $boot_fstype == 'fat'* ]] && apackages+=('dosfstools')
 
 # Emulation support in case of incompatible architecture
-# - TEMPORARY: Early exit for Trixie/Sid until systemd + QEMU incompatibility fix has been released: https://github.com/systemd/systemd/pull/28954
-(( ( $G_HW_ARCH < 10 && $G_HW_ARCH < $HW_ARCH ) || ( ( $G_HW_ARCH == 10 || $G_HW_ARCH == 11 ) && $G_HW_ARCH != $HW_ARCH ) )) && { apackages+=('qemu-user-static' 'binfmt-support'); (( $DISTRO == 8 )) && { G_DIETPI-NOTIFY 1 'systemd on Trixie/Sid does currently not support QEMU emulation, aborting ...'; exit 0; } }
+(( ( $G_HW_ARCH < 10 && $G_HW_ARCH < $HW_ARCH ) || ( ( $G_HW_ARCH == 10 || $G_HW_ARCH == 11 ) && $G_HW_ARCH != $HW_ARCH ) )) && apackages+=('qemu-user-static' 'binfmt-support')
 
 # Virtual machine disk conversion
 [[ $VMTYPE && $VMTYPE != 'raw' ]] && apackages+=('qemu-utils')


### PR DESCRIPTION
systemd 254.4 has the issue solved, which has been merged into Sid, hence RISC-V builds and tests do work again. Awaiting a soon merge into Trixie.