### PR TITLE
DietPi-Software | ADS-B Feeder: Harden uninstall and fix beta tags

### DIFF
--- a/.update/patches
+++ b/.update/patches
@@ -1480,6 +1480,14 @@ Patch_8_23()
 		G_EXEC_OUTPUT=1 G_EXEC dpkg -i --force-confdef,confold package.deb
 		G_EXEC rm package.deb
 	fi
+	# ADS-B Feeder used to install two service files that aren't needed: https://github.com/MichaIng/DietPi/pull/6661
+	if [[ -f '/boot/dietpi/.installed' ]] && grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[141\]=2' /boot/dietpi/.installed
+	then
+		systemctl -q is-enabled adsb-update.timer && G_EXEC systemctl --no-reload disable --now adsb-update.timer
+		[[ -f '/etc/systemd/system/adsb-update.timer' ]] && G_EXEC rm /etc/systemd/system/adsb-update.timer
+		systemctl -q is-enabled adsb-update && G_EXEC systemctl --no-reload disable --now adsb-update
+		[[ -f '/etc/systemd/system/adsb-update.service' ]] && G_EXEC rm /etc/systemd/system/adsb-update.service
+	fi
 	# ADS-B Feeder used to install two service files that aren't needed
 	# the names should be specific enough to make an unconditional force remove acceptable
 	G_EXEC rm -f /etc/systemd/system/adsb-update.service

--- a/.update/patches
+++ b/.update/patches
@@ -1488,10 +1488,6 @@ Patch_8_23()
 		systemctl -q is-enabled adsb-update && G_EXEC systemctl --no-reload disable --now adsb-update
 		[[ -f '/etc/systemd/system/adsb-update.service' ]] && G_EXEC rm /etc/systemd/system/adsb-update.service
 	fi
-	# ADS-B Feeder used to install two service files that aren't needed
-	# the names should be specific enough to make an unconditional force remove acceptable
-	G_EXEC rm -f /etc/systemd/system/adsb-update.service
-	G_EXEC rm -f /etc/systemd/system/adsb-update.timer
 }
 
 # v6.35 => v7 migration

--- a/.update/patches
+++ b/.update/patches
@@ -1480,6 +1480,10 @@ Patch_8_23()
 		G_EXEC_OUTPUT=1 G_EXEC dpkg -i --force-confdef,confold package.deb
 		G_EXEC rm package.deb
 	fi
+	# ADS-B Feeder used to install two service files that aren't needed
+	# the names should be specific enough to make an unconditional force remove acceptable
+	G_EXEC rm -f /etc/systemd/system/adsb-update.service
+	G_EXEC rm -f /etc/systemd/system/adsb-update.timer
 }
 
 # v6.35 => v7 migration

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ v8.23
 Enhancements:
 - ROCK 5B | Added an option to dietpi-config "Advanced Option" to flash the SPI bootloader, which enables NVMe boot for DietPi images.
 - DietPi-Software | Firefox: Enabled the software option for RISC-V, since Debian provides packages now. But do not expect good performance, as GPU-acceleration is missing.
+- DietPi-Software | ADS-B Feeder: The uninstall has been hardened to rule out the removal of unused Docker images which were not created by ADS-B Feeder. Furthermore, beta tags are now correctly shown in the version string. Many thanks to @andreagdipaolo for reporting a related issue and @dirkhh for implementing the enhancement: https://github.com/MichaIng/DietPi/pull/6587#issuecomment-1743744008
 
 Bug fixes:
 - DietPi daily cron | Resolved an issue where daily APT update checks failed if daily DietPi update checks were disabled. Many thanks to @lz1aam for reporting this issue: https://github.com/MichaIng/DietPi/issues/6651

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12015,6 +12015,8 @@ _EOF_
 			# remove the service that isn't needed for an app install on DietPi and install the rest
 			G_EXEC cd /tmp/adsb-feeder/src/modules/adsb-feeder/filesystem/root
 			G_EXEC rm ./usr/lib/systemd/system/adsb-bootstrap.service
+			G_EXEC rm ./usr/lib/systemd/system/adsb-update.service
+			G_EXEC rm ./usr/lib/systemd/system/adsb-update.timer
 			G_EXEC mv ./usr/lib/systemd/system/* /etc/systemd/system/
 
 			# determine the version
@@ -12814,11 +12816,9 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 		if To_Uninstall 141 # ADS-B Feeder
 		then
 			G_EXEC_NOHALT=1 G_EXEC_OUTPUT=1 G_EXEC /opt/adsb/docker-compose-adsb down
-			Remove_Service adsb-bootstrap
+			Remove_Service adsb-docker
 			Remove_Service adsb-feeder-update
 			Remove_Service adsb-setup
-			Remove_Service adsb-update
-			command -v docker &> /dev/null && G_EXEC docker image prune -a -f
 			G_EXEC rm -Rf /opt/adsb /mnt/dietpi_userdata/adsb-feeder /opt/adsb-feeder-update
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12819,6 +12819,7 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 			Remove_Service adsb-docker
 			Remove_Service adsb-feeder-update
 			Remove_Service adsb-setup
+			[[ -f /opt/adsb/pre-uninstall-cleanup ]] && G_EXEC /opt/adsb/pre-uninstall-cleanup
 			G_EXEC rm -Rf /opt/adsb /mnt/dietpi_userdata/adsb-feeder /opt/adsb-feeder-update
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12021,7 +12021,7 @@ _EOF_
 
 			# determine the version
 			local ADSB_FEEDER_DATE_COMPONENT=$(git log -20 --date='format:%y%m%d' --format='%ad' | uniq -c | mawk '{print $2"."$1;exit}')
-			local ADSB_FEEDER_TAG_COMPONENT=$(git describe --match "v[0-9]*" --long | sed "s/-[0-9]*-g[0-9a-f]*//")
+			local ADSB_FEEDER_TAG_COMPONENT=$(git describe --match 'v[0-9]*' --long | sed 's/-[0-9]*-g[0-9a-f]*//')
 			local ADSB_FEEDER_VERSION="$ADSB_FEEDER_TAG_COMPONENT(dietpi)-$ADSB_FEEDER_DATE_COMPONENT"
 
 			# create the target directory for the app and populated with the code from the git checkout

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12019,7 +12019,7 @@ _EOF_
 
 			# determine the version
 			local ADSB_FEEDER_DATE_COMPONENT=$(git log -20 --date='format:%y%m%d' --format='%ad' | uniq -c | mawk '{print $2"."$1;exit}')
-			local ADSB_FEEDER_TAG_COMPONENT=$(git describe --match 'v[0-9]*' | cut -d- -f1)
+			local ADSB_FEEDER_TAG_COMPONENT=$(git describe --match "v[0-9]*" --long | sed "s/-[0-9]*-g[0-9a-f]*//")
 			local ADSB_FEEDER_VERSION="$ADSB_FEEDER_TAG_COMPONENT(dietpi)-$ADSB_FEEDER_DATE_COMPONENT"
 
 			# create the target directory for the app and populated with the code from the git checkout


### PR DESCRIPTION
This addresses the concern https://github.com/MichaIng/DietPi/pull/6587#issuecomment-1743756614 about the ADS-B Feeder app sometimes issuing a docker prune which potentially removes data that we didn't own. The corresponding change to the upstream code was submitted as well: https://github.com/dirkhh/adsb-feeder-image/commit/0136d44a2c771066d4f28eeb641765d9f699ea34

This also adapts to a recent change in the tag semantic in the ADS-B Feeder image upstream and cleans up the services handling.