### PR TITLE
DietPi-DDNS | Add provider YDNS

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Enhancements:
 Bug fixes:
 - Raspberry Pi | Resolved an issue where the /dev/serial* symlinks were missing if binutils was not installed, which broke Bluetooth support among other things. Many thanks to @Rhiz3K for reporting this issue: https://github.com/MichaIng/DietPi/issues/6666
 - DietPi daily cron | Resolved an issue where daily APT update checks failed if daily DietPi update checks were disabled. Many thanks to @lz1aam for reporting this issue: https://github.com/MichaIng/DietPi/issues/6651
+- DietPi-DDNS | YDNS has been added to the list of natively supported DDNS providers. Many thanks to @edmundlaugasson for requesting and @TDuffinNTU for implementing it: https://github.com/MichaIng/DietPi/issues/5128, https://github.com/MichaIng/DietPi/pull/6674
 - DietPi-Config | Resolved an issue where the WiFi channel selection was not possible with 5 GHz mode enabled. Many thanks to @lukaszsobala for reporting this issue: https://github.com/MichaIng/DietPi/issues/6636#issuecomment-1734427451
 - DietPi-Software | Resolved an issue where motionEye failed to build on Bullseye systems since piwheels currently have no wheel for the latest Pillow version.
 - DietPi-Software | frp: Resolved an issue where the frp client could not connect to the frp server, because of missing spaces around the equal sign for the token setting in /etc/frp/frpc.ini. Many thanks to @josemahj for reporting this issue: https://github.com/MichaIng/DietPi/issues/6647

--- a/dietpi/dietpi-ddns
+++ b/dietpi/dietpi-ddns
@@ -128,7 +128,7 @@ Read()
 	elif [[ $command == *'www.ydns.io'* ]]
 	then
 		[[ $PROVIDER ]] || PROVIDER='YDNS'
-		[[ $DOMAINS ]] || DOMAINS=${command#*hostname=} DOMAINS=${DOMAINS%\'*}
+		[[ $DOMAINS ]] || DOMAINS=${command#*host=} DOMAINS=${DOMAINS%\'*}
 		[[ $USERNAME ]] || USERNAME=${command#*\'} USERNAME=${USERNAME%%:*}
 		[[ $PASSWORD ]] || PASSWORD=${command#*:} PASSWORD=${PASSWORD%%\'*}
 

--- a/dietpi/dietpi-ddns
+++ b/dietpi/dietpi-ddns
@@ -40,8 +40,8 @@ Available providers:
                     Use the "-p" option to set the account token.
   OVH               Read more: https://docs.ovh.com/gb/en/domains/hosting_dynhost/
                     Use the "-d", "-u" and "-p" options to set domains, username and password.
-  YDNS				Read More https://ydns.io
-					Use the "-d", "-u" and "-p" options to set domains, username and password.
+  YDNS              Read More https://ydns.io
+                    Use the "-d", "-u" and "-p" options to set the domain, username and password.
 '
 
 # Load DietPi-Globals
@@ -125,7 +125,7 @@ Read()
 		[[ $PASSWORD ]] || PASSWORD=${command#*:} PASSWORD=${PASSWORD%%\'*}
 
 	# YDNS
-	elif [[ $command = *'www.ydns.io'*]]
+	elif [[ $command == *'www.ydns.io'* ]]
 	then
 		[[ $PROVIDER ]] || PROVIDER='YDNS'
 		[[ $DOMAINS ]] || DOMAINS=${command#*hostname=} DOMAINS=${DOMAINS%\'*}
@@ -305,8 +305,8 @@ Menu_Provider()
 		'No-IP' ': Read more: https://www.noip.com/about'
 		'Dynu' ': Read more: https://www.dynu.com/DynamicDNS'
 		'FreeDNS' ': Read more: https://freedns.afraid.org/'
-		'OVH' ': Read More: https://docs.ovh.com/gb/en/domains/hosting_dynhost/'
-		'YDNS' ': Read More https://ydns.io'
+		'OVH' ': Read more: https://docs.ovh.com/gb/en/domains/hosting_dynhost/'
+		'YDNS' ': Read more: https://ydns.io'
 		'Custom' ": $custom_text"
 	)
 	G_WHIP_MENU 'Please select your DDNS provider:' || return 1
@@ -328,7 +328,6 @@ Menu_Domains()
 	[[ $PROVIDER == 'DuckDNS' || $PROVIDER == 'No-IP' || $PROVIDER == 'Dynu' || $PROVIDER == 'OVH' ]] || return 0
 
 	G_WHIP_DEFAULT_ITEM=$DOMAINS
-	
 	# Hint that YDNS only allows one domain
 	if [[ $PROVIDER == 'YDNS' ]]
 	then

--- a/dietpi/dietpi-ddns
+++ b/dietpi/dietpi-ddns
@@ -324,8 +324,8 @@ Menu_Provider()
 
 Menu_Domains()
 {
-	# Skip with these providers
-	[[ $PROVIDER == 'FreeDNS' ]] && return 0
+	# Skip with FreeDNS/Custom providers
+	[[ $PROVIDER == 'DuckDNS' || $PROVIDER == 'No-IP' || $PROVIDER == 'Dynu' || $PROVIDER == 'OVH' || $Provider == 'YDNS' ]] || return 0
 
 	G_WHIP_DEFAULT_ITEM=$DOMAINS
 	# Hint that YDNS only allows one domain

--- a/dietpi/dietpi-ddns
+++ b/dietpi/dietpi-ddns
@@ -325,7 +325,7 @@ Menu_Provider()
 Menu_Domains()
 {
 	# Skip with FreeDNS/Custom providers
-	[[ $PROVIDER == 'DuckDNS' || $PROVIDER == 'No-IP' || $PROVIDER == 'Dynu' || $PROVIDER == 'OVH' || $Provider == 'YDNS' ]] || return 0
+	[[ $PROVIDER == 'DuckDNS' || $PROVIDER == 'No-IP' || $PROVIDER == 'Dynu' || $PROVIDER == 'OVH' || $PROVIDER == 'YDNS' ]] || return 0
 
 	G_WHIP_DEFAULT_ITEM=$DOMAINS
 	# Hint that YDNS only allows one domain

--- a/dietpi/dietpi-ddns
+++ b/dietpi/dietpi-ddns
@@ -130,7 +130,7 @@ Read()
 		[[ $PROVIDER ]] || PROVIDER='YDNS'
 		[[ $DOMAINS ]] || DOMAINS=${command#*hostname=} DOMAINS=${DOMAINS%\'*}
 		[[ $USERNAME ]] || USERNAME=${command#*\'} USERNAME=${USERNAME%%:*}
-		[[ $PASSWORD ]] || PASSWORD=${command#*token=} PASSWORD=${PASSWORD%\'*}
+		[[ $PASSWORD ]] || PASSWORD=${command#*:} PASSWORD=${PASSWORD%%\'*}
 
 	# Custom
 	else
@@ -319,13 +319,13 @@ Menu_Provider()
 	esac
 
 	# Update credentials names
-	[[ $PROVIDER == 'DuckDNS' || $PROVIDER == 'FreeDNS' || $PROVIDER == 'YDNS' ]] && password='Token' || password='Password'
+	[[ $PROVIDER == 'DuckDNS' || $PROVIDER == 'FreeDNS' ]] && password='Token' || password='Password'
 }
 
 Menu_Domains()
 {
 	# Skip with these providers
-	[[ $PROVIDER == 'DuckDNS' || $PROVIDER == 'No-IP' || $PROVIDER == 'Dynu' || $PROVIDER == 'OVH' ]] || return 0
+	[[ $PROVIDER == 'FreeDNS' ]] && return 0
 
 	G_WHIP_DEFAULT_ITEM=$DOMAINS
 	# Hint that YDNS only allows one domain

--- a/dietpi/dietpi-ddns
+++ b/dietpi/dietpi-ddns
@@ -40,6 +40,8 @@ Available providers:
                     Use the "-p" option to set the account token.
   OVH               Read more: https://docs.ovh.com/gb/en/domains/hosting_dynhost/
                     Use the "-d", "-u" and "-p" options to set domains, username and password.
+  YDNS				Read More https://ydns.io
+					Use the "-d", "-u" and "-p" options to set domains, username and password.
 '
 
 # Load DietPi-Globals
@@ -122,6 +124,14 @@ Read()
 		[[ $USERNAME ]] || USERNAME=${command#*\'} USERNAME=${USERNAME%%:*}
 		[[ $PASSWORD ]] || PASSWORD=${command#*:} PASSWORD=${PASSWORD%%\'*}
 
+	# YDNS
+	elif [[ $command = *'www.ydns.io'*]]
+	then	# TODO confirm correct
+		[[ $PROVIDER ]] || PROVIDER='YDNS'
+		[[ $DOMAINS ]] || DOMAINS=${command#*hostname=} DOMAINS=${DOMAINS%\'*}
+		[[ $USERNAME ]] || USERNAME=${command#*\'} USERNAME=${USERNAME%%:*}
+		[[ $PASSWORD ]] || PASSWORD=${command#*token=} PASSWORD=${PASSWORD%\'*}
+
 	# Custom
 	else
 		[[ $PROVIDER ]] || PROVIDER=${command%\'*} PROVIDER=${PROVIDER##*\'}
@@ -177,6 +187,11 @@ Apply()
 	then
 		url="https://www.ovh.com/nic/update?system=dyndns&hostname=$DOMAINS"
 
+	# - YDNS
+	elif [[ $PROVIDER == 'YDNS' ]]
+	then
+		url="https://ydns.io/api/v1/update/?host=$DOMAINS"
+
 	# - Custom
 	else
 		url=$PROVIDER
@@ -208,6 +223,7 @@ Apply()
 	# shellcheck disable=SC2086
 	if ! result=$(curl $ipfamily -sSfL ${http_auth:+ -u "$USERNAME:$PASSWORD"} "$url" 2>&1) ||
 		[[ $PROVIDER == 'DuckDNS' && $result == 'KO' ]] ||
+		[[ $PROVIDER == 'YDNS' && $result != 'ok' ]] ||
 		[[ $PROVIDER == 'Dynu' && $result != 'good'* && $result != 'nochg'* ]]
 	then
 		G_DIETPI-NOTIFY 1 "DDNS update test failed, please check your input${result:+:\n$result}"
@@ -278,7 +294,7 @@ Menu_Provider()
 	G_WHIP_DEFAULT_ITEM=${PROVIDER:-DuckDNS}
 
 	# Custom provider selected
-	if [[ $PROVIDER && $PROVIDER != 'DuckDNS' && $PROVIDER != 'No-IP' && $PROVIDER != 'Dynu' && $PROVIDER != 'FreeDNS' && $PROVIDER != 'OVH' ]]
+	if [[ $PROVIDER && $PROVIDER != 'DuckDNS' && $PROVIDER != 'No-IP' && $PROVIDER != 'Dynu' && $PROVIDER != 'FreeDNS' && $PROVIDER != 'OVH' && $PROVIDER != 'YDNS' ]]
 	then
 		G_WHIP_DEFAULT_ITEM='Custom'
 		custom_text="[$PROVIDER]"
@@ -290,6 +306,7 @@ Menu_Provider()
 		'Dynu' ': Read more: https://www.dynu.com/DynamicDNS'
 		'FreeDNS' ': Read more: https://freedns.afraid.org/'
 		'OVH' ': Read More: https://docs.ovh.com/gb/en/domains/hosting_dynhost/'
+		'YDNS' ': Read More https://ydns.io'
 		'Custom' ": $custom_text"
 	)
 	G_WHIP_MENU 'Please select your DDNS provider:' || return 1
@@ -302,22 +319,29 @@ Menu_Provider()
 	esac
 
 	# Update credentials names
-	[[ $PROVIDER == 'DuckDNS' || $PROVIDER == 'FreeDNS' ]] && password='Token' || password='Password'
+	[[ $PROVIDER == 'DuckDNS' || $PROVIDER == 'FreeDNS' || $PROVIDER == 'YNDS' ]] && password='Token' || password='Password'
 }
 
 Menu_Domains()
 {
-	# Skip with FreeDNS and custom provider
+	# Skip with these providers
 	[[ $PROVIDER == 'DuckDNS' || $PROVIDER == 'No-IP' || $PROVIDER == 'Dynu' || $PROVIDER == 'OVH' ]] || return 0
 
 	G_WHIP_DEFAULT_ITEM=$DOMAINS
-	G_WHIP_INPUTBOX 'Please enter a comma-separated list of domains that shall point to this system:' || return 1
+	
+	# Hint that YDNS only allows one domain
+	if [[ $PROVIDER == 'YDNS' ]]
+	then
+	 	G_WHIP_INPUTBOX 'Please enter the domain that shall point to this system:' || return 1
+	else
+		G_WHIP_INPUTBOX 'Please enter a comma-separated list of domains that shall point to this system:' || return 1
+	fi
 	DOMAINS=$G_WHIP_RETURNED_VALUE
 }
 
 Menu_Username()
 {
-	# Skip with DuckDNS, Dynu and FreeDNS
+	# Skip with these providers
 	[[ $PROVIDER == 'DuckDNS' || $PROVIDER == 'Dynu' || $PROVIDER == 'FreeDNS' ]] && return 0
 
 	# Add note for custom provider
@@ -336,14 +360,14 @@ Menu_Password()
 {
 	# Add note for custom provider
 	local text="Please enter the $password to update your dynamic IP against your DDNS provider.\n - The single quote character ' is currently not supported!"
-	[[ $PROVIDER == 'DuckDNS' || $PROVIDER == 'No-IP' || $PROVIDER == 'Dynu' || $PROVIDER == 'FreeDNS' || $PROVIDER == 'OVH' ]] || text+='\n\nThis is used for HTTP authentication. If no HTTP authentication is required, type in a \"0\" to skip the password.'
+	[[ $PROVIDER == 'DuckDNS' || $PROVIDER == 'No-IP' || $PROVIDER == 'Dynu' || $PROVIDER == 'FreeDNS' || $PROVIDER == 'OVH' || $PROVIDER == 'YDNS' ]] || text+='\n\nThis is used for HTTP authentication. If no HTTP authentication is required, type in a \"0\" to skip the password.'
 
 	G_WHIP_PASSWORD "$text" || return 1
 	PASSWORD=$result
 	unset -v result
 
 	# Unset with custom provider when "0" is given
-	[[ $PROVIDER == 'DuckDNS' || $PROVIDER == 'No-IP' || $PROVIDER == 'Dynu' || $PROVIDER == 'FreeDNS' || $PROVIDER == 'OVH' || $PASSWORD != 0 ]] || unset -v PASSWORD
+	[[ $PROVIDER == 'DuckDNS' || $PROVIDER == 'No-IP' || $PROVIDER == 'Dynu' || $PROVIDER == 'FreeDNS' || $PROVIDER == 'OVH' || $PROVIDER == 'YDNS' || $PASSWORD != 0 ]] || unset -v PASSWORD
 }
 
 Menu_IPfamily()
@@ -355,7 +379,7 @@ Menu_IPfamily()
 	)
 	G_WHIP_DEFAULT_ITEM=${IPFAMILY:--4} G_WHIP_DEFAULT_ITEM=${G_WHIP_DEFAULT_ITEM/-/IPv}
 	G_WHIP_MENU 'Please select whether you want to force an IP family to associate with your DDNS domain.
-\nFor best compatibility with all clients and networks, we recomment to use IPv4.
+\nFor best compatibility with all clients and networks, we recommend to use IPv4.
 \nIf you do not force any IP family, IPv6 is used, if enabled on this server and if the DDNS provider is reachable via IPv6, else IPv4 is used.
 \nIf IPv6 is used, only clients with IPv6 enabled and connected via networks which support IPv6 can reach your server.' || return 1
 	IPFAMILY=${G_WHIP_RETURNED_VALUE/IPv/-}
@@ -378,8 +402,8 @@ Menu_Main()
 	[[ $PROVIDER ]] || { G_WHIP_BUTTON_CANCEL_TEXT='Exit' Menu_Provider || exit 0 && Menu_Domains && Menu_Username && Menu_Password && NEXT_MENU_START='Apply'; }
 
 	G_WHIP_MENU_ARRAY=('Provider' ": [$PROVIDER]")
-	[[ $PROVIDER == 'DuckDNS' || $PROVIDER == 'No-IP' || $PROVIDER == 'Dynu' || $PROVIDER == 'OVH' ]] && G_WHIP_MENU_ARRAY+=('Domains' ": [$DOMAINS]")
-	[[ $PROVIDER == 'DuckDNS' || $PROVIDER == 'Dynu' || $PROVIDER == 'FreeDNS' ]] || G_WHIP_MENU_ARRAY+=("$username" ": [$USERNAME]")
+	[[ $PROVIDER == 'DuckDNS' || $PROVIDER == 'No-IP' || $PROVIDER == 'Dynu' || $PROVIDER == 'OVH' || $PROVIDER == 'YDNS' ]] && G_WHIP_MENU_ARRAY+=('Domains' ": [$DOMAINS]")
+	[[ $PROVIDER == 'DuckDNS' || $PROVIDER == 'Dynu' || $PROVIDER == 'FreeDNS' || $PROVIDER == 'YDNS' ]] || G_WHIP_MENU_ARRAY+=("$username" ": [$USERNAME]")
 	G_WHIP_MENU_ARRAY+=(
 		"$password" ": [${PASSWORD//?/*}]"
 		'IP family' ": [${IPFAMILY:--4}]"

--- a/dietpi/dietpi-ddns
+++ b/dietpi/dietpi-ddns
@@ -126,7 +126,7 @@ Read()
 
 	# YDNS
 	elif [[ $command = *'www.ydns.io'*]]
-	then	# TODO confirm correct
+	then
 		[[ $PROVIDER ]] || PROVIDER='YDNS'
 		[[ $DOMAINS ]] || DOMAINS=${command#*hostname=} DOMAINS=${DOMAINS%\'*}
 		[[ $USERNAME ]] || USERNAME=${command#*\'} USERNAME=${USERNAME%%:*}

--- a/dietpi/dietpi-ddns
+++ b/dietpi/dietpi-ddns
@@ -319,7 +319,7 @@ Menu_Provider()
 	esac
 
 	# Update credentials names
-	[[ $PROVIDER == 'DuckDNS' || $PROVIDER == 'FreeDNS' || $PROVIDER == 'YNDS' ]] && password='Token' || password='Password'
+	[[ $PROVIDER == 'DuckDNS' || $PROVIDER == 'FreeDNS' || $PROVIDER == 'YDNS' ]] && password='Token' || password='Password'
 }
 
 Menu_Domains()


### PR DESCRIPTION
Closes #5128 

As YDNS expects a single (one and only one) domain in its API request I've added a special case for it in Menu_Domains but this might not be correct (do we submit domains as a  _list_ or is it split by the commas and sent in multiple requests?

There are two options for YDNS updating - One uses an auth header and the other uses an "update link" which is a shortened variant of the update URI but with a random token. I opted for the former since I feel that's more secure and easier to fit into the UX of the application. 

Remaining in draft until I can spin up a dietpi VM to test this, but welcome to feedback ahead of that.