### PR TITLE
DietPi-Software | openHAB: Switch to stable suite which provides v4 now

### DIFF
--- a/.update/pre-patches
+++ b/.update/pre-patches
@@ -352,6 +352,12 @@ then
 		G_DIETPI-NOTIFY 2 'Removing obsolete FFmpeg workaround from RPi Bookworm systems'
 		G_EXEC rm /etc/apt/preferences.d/dietpi-ffmpeg
 	fi
+	if [[ -f '/etc/apt/sources.list.d/dietpi-openhab.list' ]]
+	then
+		G_DIETPI-NOTIFY 2 'Migrating openHAB APT repository from testing suite to stable suite'
+		G_EXEC sed -i 's/ testing / stable /' /etc/apt/sources.list.d/dietpi-openhab.list
+		(( $G_DISTRO < 6 )) && G_EXEC eval 'echo -e '\''Package: openhab*\nPin: version 3.*\nPin-Priority: 501'\'' > /etc/apt/preferences.d/dietpi-openhab'
+	fi
 fi
 
 exit 0

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ New images:
 
 Enhancements:
 - ROCK 3A | A kernel upgrade from "edge-rk35xx" (Linux 6.1.11) to "current-rockchip64" (Linux 6.1.50 at time of writing) will be applied, which solves e.g. missing 3.5mm audio output. Many thanks to @wahono77 for testing the kernel upgrade: https://github.com/MichaIng/DietPi/issues/6710
+- DietPi-Software | openHAB: The openHAB APT repository will be migrated from testing to stable suite. Previously "testing" was used, as "stable" shipped openHAB 3, which does not support Java 17. In the meantime "stable" ships openHAB 4 as well. Many thanks to @twikedk for bringing this back to our attention: https://github.com/MichaIng/DietPi/issues/6731
 
 Bug fixes:
 - DietPi-Software | Resolved and issue where auto setup failed in case of trailing (non-integer) characters behind the "AUTO_SETUP_AUTOMATED=1" dietpi.txt setting. In this case, an automatic login was performed, but dietpi-software ran in interactive mode. It has been align now so that any trailing characters are ignored and either autologin and automated setup happens both or none. Many thanks to @inis17 for reporting a related issue: https://github.com/MichaIng/DietPi/issues/6719

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11359,10 +11359,14 @@ _EOF_
 
 			# APT list
 			# - Enable RISC-V support by explicitly defining arch=all, which contains exactly the same packages (well, it's Java...)
-			local arch=''
+			local arch=
 			(( $G_HW_ARCH == 11 )) && arch=' [arch=all]'
 			G_EXEC eval "echo 'deb$arch https://openhab.jfrog.io/artifactory/openhab-linuxpkg stable main' > /etc/apt/sources.list.d/dietpi-openhab.list"
 			G_AGUP
+
+			# Buster: Limit to v3 since v4 requires Java 17
+			(( $G_DISTRO < 6 )) && G_EXEC eval 'echo -e '\''Package: openhab*\nPin: version 3.*\nPin-Priority: 501'\'' > /etc/apt/preferences.d/dietpi-openhab'
+			[[ $G_DISTRO -ge 6 && -f '/etc/apt/preferences.d/dietpi-openhab' ]] && G_EXEC rm /etc/apt/preferences.d/dietpi-openhab
 
 			# APT package
 			G_AGI openhab
@@ -12576,6 +12580,7 @@ If no WireGuard (auto)start is included, but you require it, please do the follo
 			G_AGP openhab
 			[[ -f '/etc/apt/sources.list.d/dietpi-openhab.list' ]] && G_EXEC rm /etc/apt/sources.list.d/dietpi-openhab.list
 			[[ -f '/etc/apt/trusted.gpg.d/dietpi-openhab.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-openhab.gpg
+			[[ -f '/etc/apt/preferences.d/dietpi-openhab' ]] && G_EXEC rm /etc/apt/preferences.d/dietpi-openhab
 		fi
 
 		if To_Uninstall 83 # Apache

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11364,7 +11364,7 @@ _EOF_
 			G_EXEC eval "echo 'deb$arch https://openhab.jfrog.io/artifactory/openhab-linuxpkg stable main' > /etc/apt/sources.list.d/dietpi-openhab.list"
 			G_AGUP
 
-			# Buster: Limit to v3 since v4 requires Java 17
+			# Buster: Limit to v3, as v4 requires Java 17
 			(( $G_DISTRO < 6 )) && G_EXEC eval 'echo -e '\''Package: openhab*\nPin: version 3.*\nPin-Priority: 501'\'' > /etc/apt/preferences.d/dietpi-openhab'
 			[[ $G_DISTRO -ge 6 && -f '/etc/apt/preferences.d/dietpi-openhab' ]] && G_EXEC rm /etc/apt/preferences.d/dietpi-openhab
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11359,11 +11359,9 @@ _EOF_
 
 			# APT list
 			# - Enable RISC-V support by explicitly defining arch=all, which contains exactly the same packages (well, it's Java...)
-			# - Use testing suite == openHAB 4 from Bullseye on since openHAB 3 does not fully support Java 17: https://github.com/MichaIng/DietPi/pull/6334#issuecomment-1528729163
-			local arch='' suite='testing'
+			local arch=''
 			(( $G_HW_ARCH == 11 )) && arch=' [arch=all]'
-			(( $G_DISTRO < 6 )) && suite='stable'
-			G_EXEC eval "echo 'deb$arch https://openhab.jfrog.io/artifactory/openhab-linuxpkg $suite main' > /etc/apt/sources.list.d/dietpi-openhab.list"
+			G_EXEC eval "echo 'deb$arch https://openhab.jfrog.io/artifactory/openhab-linuxpkg stable main' > /etc/apt/sources.list.d/dietpi-openhab.list"
 			G_AGUP
 
 			# APT package


### PR DESCRIPTION
Install tests: https://github.com/MichaIng/DietPi/actions/runs/6763538446