### PR TITLE
DietPi-Software | NZBGet: Migrate to new project maintainer

### DIFF
--- a/.update/patches
+++ b/.update/patches
@@ -1558,6 +1558,14 @@ Release notes: https://github.com/BlitterStudio/amiberry/releases
 \nDo you want to apply the update now?
 \nYou can manually apply it any time via:
 # dietpi-software reinstall 108' && echo 108 >> /var/tmp/dietpi/dietpi-update_reinstalls
+
+		# NZBGet: Disable file logging
+		if grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[149\]=2' /boot/dietpi/.installed && [[ -f '/mnt/dietpi_userdata/nzbget/nzbget.conf' ]]
+		then
+			G_CONFIG_INJECT 'WriteLog=' 'WriteLog=none' /mnt/dietpi_userdata/nzbget/nzbget.conf
+			[[ -f '/etc/systemd/system/nzbget.service' ]] && G_EXEC sed -i -e '/^Type=/d' -e '/^ExecStart=/c\ExecStart=/mnt/dietpi_userdata/nzbget/nzbget -so OutputMode=log' /etc/systemd/system/nzbget.service
+			[[ -f '/var/log/nzbget.log' ]] && G_EXEC rm /var/log/nzbget.log
+		fi
 	fi
 }
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ New images:
 
 Enhancements:
 - Quartz64 | The kernel receives a major upgrade to Linux 6.6.3 and we switched to latest unmodified mainline U-Boot 2023.10. Among others changes, this implies a fixed onboard Ethernet MAC address, which was previously changing on every boot.
+- DietPi-Software | NZBGet: We migrated to the repository of the new project maintainer, since the original author stopped development: https://dietpi.com/forum/t/nzbget-new-maintainer-dietpi-software-already-updated/18425. Being on it, plain text file logging has been disabled in favour for journal logging, i.e. all NZBGet related logs are now combined in "journalct -u nzbget". The logging change will be applied on next DietPi update, the NZBGet upgrade itself can be done via reinstall: dietpi-software reinstall 149
 
 Bug fixes:
 - Proxmox | Now really resolved the issue where the QEMU guest agent was not always installed automatically on first boot.

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10131,25 +10131,26 @@ _EOF_
 		then
 			local reinstall=0
 			[[ -f '/mnt/dietpi_userdata/nzbget/nzbget.conf' ]] && reinstall=1
-			G_EXEC curl -sSfL 'https://nzbget.net/download/nzbget-latest-bin-linux.run' -o package.run
+
+			local fallback_url='https://github.com/nzbgetcom/nzbget/releases/download/v22.0/nzbget-22.0-bin-linux.run'
+			Download_Install "$(curl -sSfL 'https://api.github.com/repos/nzbgetcom/nzbget/releases/latest' | mawk -F\" '/^ *"browser_download_url": ".*\/nzbget-[^"/]*-bin-linux.run"$/{print $4}')" nzbget.run
 			G_EXEC mkdir -p /mnt/dietpi_userdata/nzbget
-			G_EXEC_OUTPUT=1 G_EXEC dash package.run --destdir /mnt/dietpi_userdata/nzbget
-			G_EXEC rm package.run
+			G_EXEC_OUTPUT=1 G_EXEC dash nzbget.run --destdir /mnt/dietpi_userdata/nzbget
+			G_EXEC rm nzbget.run
 
 			# User
 			Create_User -g dietpi -d /mnt/dietpi_userdata/nzbget nzbget
 
 			# Permissions
-			G_EXEC touch /var/log/nzbget.log
-			G_EXEC chown -R nzbget:root /mnt/dietpi_userdata/nzbget /var/log/nzbget.log
 			G_EXEC chmod 0600 /mnt/dietpi_userdata/nzbget/nzbget.conf
+			G_EXEC chown -R nzbget:root /mnt/dietpi_userdata/nzbget
 
 			# Config
 			if (( ! $reinstall ))
 			then
 				G_CONFIG_INJECT 'MainDir=' 'MainDir=/mnt/dietpi_userdata/downloads' /mnt/dietpi_userdata/nzbget/nzbget.conf
 				G_CONFIG_INJECT 'DestDir=' 'DestDir=/mnt/dietpi_userdata/downloads/complete' /mnt/dietpi_userdata/nzbget/nzbget.conf
-				G_CONFIG_INJECT 'LogFile=' 'LogFile=/var/log/nzbget.log' /mnt/dietpi_userdata/nzbget/nzbget.conf
+				G_CONFIG_INJECT 'WriteLog=' 'WriteLog=none' /mnt/dietpi_userdata/nzbget/nzbget.conf
 				G_CONFIG_INJECT 'ControlUsername=' 'ControlUsername=admin' /mnt/dietpi_userdata/nzbget/nzbget.conf
 				GCI_PASSWORD=1 G_CONFIG_INJECT 'ControlPassword=' "ControlPassword=$GLOBAL_PW" /mnt/dietpi_userdata/nzbget/nzbget.conf
 
@@ -10157,13 +10158,13 @@ _EOF_
 				G_CONFIG_INJECT 'UMask=' 'UMask=0002' /mnt/dietpi_userdata/nzbget/nzbget.conf
 
 				# Optimisations
-				G_CONFIG_INJECT 'Server1.Cipher=' 'Server1.Cipher=RC4-MD5' /mnt/dietpi_userdata/nzbget/nzbget.conf
+				G_CONFIG_INJECT 'Server1.Cipher=' 'Server1.Cipher=RC4-MD5' /mnt/dietpi_userdata/nzbget/nzbget.conf # RC4-MD5 is fastest: https://nzbget.com/documentation/choosing-cipher/
 				G_CONFIG_INJECT 'CrcCheck=' 'CrcCheck=no' /mnt/dietpi_userdata/nzbget/nzbget.conf
 				G_CONFIG_INJECT 'ParScan=' 'ParScan=limited' /mnt/dietpi_userdata/nzbget/nzbget.conf
 				G_CONFIG_INJECT 'ParThreads=' "ParThreads=$G_HW_CPU_CORES" /mnt/dietpi_userdata/nzbget/nzbget.conf
 				G_CONFIG_INJECT 'DebugTarget=' 'DebugTarget=none' /mnt/dietpi_userdata/nzbget/nzbget.conf
-				G_CONFIG_INJECT 'CrashTrace=' 'CrashTrace=no' /mnt/dietpi_userdata/nzbget/nzbget.conf
 				G_CONFIG_INJECT 'DetailTarget=' 'DetailTarget=none' /mnt/dietpi_userdata/nzbget/nzbget.conf
+				G_CONFIG_INJECT 'CrashTrace=' 'CrashTrace=no' /mnt/dietpi_userdata/nzbget/nzbget.conf
 				G_CONFIG_INJECT 'ParBuffer=' "ParBuffer=$(Optimise_BitTorrent 0)" /mnt/dietpi_userdata/nzbget/nzbget.conf
 				G_CONFIG_INJECT 'ArticleCache=' "ArticleCache=$(Optimise_BitTorrent 0)" /mnt/dietpi_userdata/nzbget/nzbget.conf
 				G_CONFIG_INJECT 'WriteBuffer=' "WriteBuffer=$(Optimise_BitTorrent 0)" /mnt/dietpi_userdata/nzbget/nzbget.conf
@@ -10177,10 +10178,9 @@ Wants=network-online.target
 After=network-online.target remote-fs.target
 
 [Service]
-Type=forking
 User=nzbget
 WorkingDirectory=/mnt/dietpi_userdata/nzbget
-ExecStart=/mnt/dietpi_userdata/nzbget/nzbget -D
+ExecStart=/mnt/dietpi_userdata/nzbget/nzbget -so OutputMode=log
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Update of the download URL due to a new project maintainer.

- https://dietpi.com/forum/t/nzbget-new-maintainer-dietpi-software-already-updated/18425
- https://www.reddit.com/r/usenet/comments/17k0tda/new_nzbget_project/
- https://nzbget.com/documentation/installation-on-linux/

It seems FQDN changed from `nzbget.net` to `nzbget.com`