### PR TITLE
DietPi-Config | Add SPI toggle for Orange Pi Zero 3

### DIFF
--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -1088,6 +1088,14 @@ Re-enabling HDMI requires a reboot. If you need emergency HDMI output, edit the 
 		[[ -f '/etc/modprobe.d/dietpi-disable_bluetooth.conf' ]] && bluetooth_state=0 bluetooth_state_text='Off'
 		G_WHIP_MENU_ARRAY+=('Bluetooth' ": [$bluetooth_state_text]")
 
+		# Orange Pi Zero 3 specific
+		if (( $G_HW_MODEL == 83 )); then
+			local spi_enabled=$(grep -cm1 '^[[:blank:]]*overlays=.*spi1-cs1-spidev' /boot/dietpiEnv.txt)
+			spi_text="Off"
+			(( $spi_enabled )) && spi_text='On'
+			G_WHIP_MENU_ARRAY+=('SPI state' ": [$spi_text]")
+		fi
+
 		# RPi specific
 		if (( $G_HW_MODEL < 10 )); then
 
@@ -1104,9 +1112,9 @@ Re-enabling HDMI requires a reboot. If you need emergency HDMI output, edit the 
 			G_WHIP_MENU_ARRAY+=('I2C frequency' ": [$rpi_i2c_baudrate kHz]")
 
 			# SPI state
-			local rpi_spi_enabled=$(grep -cm1 '^[[:blank:]]*dtparam=spi=on' /boot/config.txt)
+			local spi_enabled=$(grep -cm1 '^[[:blank:]]*dtparam=spi=on' /boot/config.txt)
 			local rpi_spi_text='Off'
-			(( $rpi_spi_enabled )) && rpi_spi_text='On'
+			(( $spi_enabled )) && rpi_spi_text='On'
 			G_WHIP_MENU_ARRAY+=('SPI state' ": [$rpi_spi_text]")
 
 			# USB boot option: RPi3 only and not required for RPi3+: https://www.raspberrypi.org/documentation/hardware/raspberrypi/bootmodes/msd.md
@@ -1275,7 +1283,7 @@ Latest release notes: https://github.com/starfive-tech/VisionFive2/releases
 
 		elif [[ $G_WHIP_RETURNED_VALUE == 'SPI state' ]]; then
 
-			/boot/dietpi/func/dietpi-set_hardware spi $(( ! $rpi_spi_enabled )) && REBOOT_REQUIRED=1
+			/boot/dietpi/func/dietpi-set_hardware spi $(( ! $spi_enabled )) && REBOOT_REQUIRED=1
 
 		elif [[ $G_WHIP_RETURNED_VALUE == 'Serial/UART' ]]; then
 

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -1089,16 +1089,17 @@ Re-enabling HDMI requires a reboot. If you need emergency HDMI output, edit the 
 		G_WHIP_MENU_ARRAY+=('Bluetooth' ": [$bluetooth_state_text]")
 
 		# Orange Pi Zero 3 specific
-		if (( $G_HW_MODEL == 83 )); then
-			local spi_enabled=$(grep -cm1 '^[[:blank:]]*overlays=.*spi1-cs1-spidev' /boot/dietpiEnv.txt)
-			spi_text="Off"
+		if (( $G_HW_MODEL == 83 ))
+		then
+			# SPI state
+			local spi_enabled=$(grep -Ecm1 '^[[:blank:]]*overlays=(.*[[:blank:]])?spi1-cs1-spidev([[:blank:]]|$)' /boot/dietpiEnv.txt)
+			local spi_text='Off'
 			(( $spi_enabled )) && spi_text='On'
 			G_WHIP_MENU_ARRAY+=('SPI state' ": [$spi_text]")
-		fi
 
 		# RPi specific
-		if (( $G_HW_MODEL < 10 )); then
-
+		elif (( $G_HW_MODEL < 10 ))
+		then
 			# I2C state
 			local rpi_i2c_enabled=$(grep -cm1 '^[[:blank:]]*dtparam=i2c_arm=on' /boot/config.txt)
 			local rpi_i2c_text='Off'
@@ -1113,20 +1114,18 @@ Re-enabling HDMI requires a reboot. If you need emergency HDMI output, edit the 
 
 			# SPI state
 			local spi_enabled=$(grep -cm1 '^[[:blank:]]*dtparam=spi=on' /boot/config.txt)
-			local rpi_spi_text='Off'
-			(( $spi_enabled )) && rpi_spi_text='On'
-			G_WHIP_MENU_ARRAY+=('SPI state' ": [$rpi_spi_text]")
+			local spi_text='Off'
+			(( $spi_enabled )) && spi_text='On'
+			G_WHIP_MENU_ARRAY+=('SPI state' ": [$spi_text]")
 
 			# USB boot option: RPi3 only and not required for RPi3+: https://www.raspberrypi.org/documentation/hardware/raspberrypi/bootmodes/msd.md
-			if [[ $G_HW_MODEL == 3 && $G_HW_MODEL_NAME != *'+'* ]]; then
-
+			if [[ $G_HW_MODEL == 3 && $G_HW_MODEL_NAME != *'+'* ]]
+			then
 				local rpi3_usb_boot_bit_enabled=$(vcgencmd otp_dump | grep -cm1 '17:3020000a')
 				local rpi3_usb_boot_bit_text='Off'
 				(( $rpi3_usb_boot_bit_enabled )) && rpi3_usb_boot_bit_text='On'
 				G_WHIP_MENU_ARRAY+=('USB boot support' ": [$rpi3_usb_boot_bit_text]")
-
 			fi
-
 		fi
 
 		G_WHIP_MENU 'Please select an option:' || { Back_or_Exit 0; return 0; } # Main menu

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -1136,55 +1136,50 @@ _EOF_
 	#/////////////////////////////////////////////////////////////////////////////////////
 	# SPI: https://github.com/raspberrypi/documentation/tree/master/hardware/raspberrypi/spi
 	#/////////////////////////////////////////////////////////////////////////////////////
-	SPI_Main(){
-
-		if (( $G_HW_MODEL < 10 )); then
-
-			if [[ $INPUT_DEVICE_VALUE == 'enable' ]]; then
-
+	SPI_Main()
+	{
+		# RPi
+		if (( $G_HW_MODEL < 10 ))
+		then
+			if [[ $INPUT_DEVICE_VALUE == 'enable' ]]
+			then
 				# config.txt
 				G_CONFIG_INJECT 'dtparam=spi=' 'dtparam=spi=on' /boot/config.txt
 
 				# Enable in runtime seems to be possible?
 				#dtparam spi=on
 
-			elif [[ $INPUT_DEVICE_VALUE == 'disable' ]]; then
-
+			elif [[ $INPUT_DEVICE_VALUE == 'disable' ]]
+			then
 				# config.txt
 				G_CONFIG_INJECT 'dtparam=spi=' 'dtparam=spi=off' /boot/config.txt
 				G_EXEC sed -i '/^[[:blank:]]*dtoverlay=spi[0-9]-[0-9]cs/d' /boot/config.txt # Alternative SPI interfaces and chip select lines
 
 				# Disable in runtime seems to be possible?
 				#dtparam spi=off
-
 			else
-
 				Unknown_Input_Mode
-
 			fi
 
-		elif (( $G_HW_MODEL == 83 )); then
+		# Orange Pi Zero 3
+		elif (( $G_HW_MODEL == 83 ))
+		then
+			if [[ $INPUT_DEVICE_VALUE == 'enable' ]]
+			then
+				# Add overlay to dietpiEnv.txt
+				grep -Eq '^[[:blank:]]*overlays=(.*[[:blank:]])?spi1-cs1-spidev([[:blank:]]|$)' "$FP_UENV" || G_EXEC sed -i '/^[[:blank:]]*overlays=/s/[[:blank:]]*$/ spi1-cs1-spidev/' "$FP_UENV"
 
-			if [[ $INPUT_DEVICE_VALUE == 'enable' ]]; then
-
-				G_EXEC sed -i '/^[[:blank:]]*overlays=/s/$/ spi1-cs1-spidev/' "$FP_UENV"
-
-			elif [[ $INPUT_DEVICE_VALUE == 'disable' ]]; then
-
-				G_EXEC sed -i '/^[[:blank:]]*overlays=/s/ *spi1-cs1-spidev//' "$FP_UENV"
-
+			elif [[ $INPUT_DEVICE_VALUE == 'disable' ]]
+			then
+				# Remove overlay from dietpiEnv.txt
+				grep -Eq '^[[:blank:]]*overlays=(.*[[:blank:]])?spi1-cs1-spidev([[:blank:]]|$)' "$FP_UENV" && G_EXEC sed -Ei '/^[[:blank:]]*overlays=/s/[[:blank:]]*spi1-cs1-spidev([[:blank:]]*$)?//g' "$FP_UENV"
 			else
-
 				Unknown_Input_Mode
-
 			fi
-
 		else
-
 			Unsupported_Input_Name
-			return 1;
+			return 1
 		fi
-
 	}
 
 	#/////////////////////////////////////////////////////////////////////////////////////
@@ -2177,7 +2172,7 @@ _EOF_
 				if (( $ARMBIAN || $DIETPIENV ))
 				then
 					# Add analogue 3.5mm jack device tree overlay
-					G_EXEC sed -i '/^[[:blank:]]*overlays=/s/$/ analog-codec/' "$FP_UENV"
+					G_EXEC sed -i '/^[[:blank:]]*overlays=/s/[[:blank:]]*$/ analog-codec/' "$FP_UENV"
 
 				# Legacy
 				else

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -1138,29 +1138,51 @@ _EOF_
 	#/////////////////////////////////////////////////////////////////////////////////////
 	SPI_Main(){
 
-		(( $G_HW_MODEL > 9 )) && { Unsupported_Input_Name; return 1; } # Exit path for non-RPi
+		if (( $G_HW_MODEL < 10 )); then
 
-		if [[ $INPUT_DEVICE_VALUE == 'enable' ]]; then
+			if [[ $INPUT_DEVICE_VALUE == 'enable' ]]; then
 
-			# config.txt
-			G_CONFIG_INJECT 'dtparam=spi=' 'dtparam=spi=on' /boot/config.txt
+				# config.txt
+				G_CONFIG_INJECT 'dtparam=spi=' 'dtparam=spi=on' /boot/config.txt
 
-			# Enable in runtime seems to be possible?
-			#dtparam spi=on
+				# Enable in runtime seems to be possible?
+				#dtparam spi=on
 
-		elif [[ $INPUT_DEVICE_VALUE == 'disable' ]]; then
+			elif [[ $INPUT_DEVICE_VALUE == 'disable' ]]; then
 
-			# config.txt
-			G_CONFIG_INJECT 'dtparam=spi=' 'dtparam=spi=off' /boot/config.txt
-			G_EXEC sed -i '/^[[:blank:]]*dtoverlay=spi[0-9]-[0-9]cs/d' /boot/config.txt # Alternative SPI interfaces and chip select lines
+				# config.txt
+				G_CONFIG_INJECT 'dtparam=spi=' 'dtparam=spi=off' /boot/config.txt
+				G_EXEC sed -i '/^[[:blank:]]*dtoverlay=spi[0-9]-[0-9]cs/d' /boot/config.txt # Alternative SPI interfaces and chip select lines
 
-			# Disable in runtime seems to be possible?
-			#dtparam spi=off
+				# Disable in runtime seems to be possible?
+				#dtparam spi=off
+
+			else
+
+				Unknown_Input_Mode
+
+			fi
+
+		elif (( $G_HW_MODEL == 83 )); then
+
+			if [[ $INPUT_DEVICE_VALUE == 'enable' ]]; then
+
+				G_EXEC sed -i '/^[[:blank:]]*overlays=/s/$/ spi1-cs1-spidev/' "$FP_UENV"
+
+			elif [[ $INPUT_DEVICE_VALUE == 'disable' ]]; then
+
+				G_EXEC sed -i '/^[[:blank:]]*overlays=/s/ *spi1-cs1-spidev//' "$FP_UENV"
+
+			else
+
+				Unknown_Input_Mode
+
+			fi
 
 		else
 
-			Unknown_Input_Mode
-
+			Unsupported_Input_Name
+			return 1;
 		fi
 
 	}


### PR DESCRIPTION
- Orange Pi Zero 3 | Add toggle to dietpi-config to enable SPI for Orange Pi Zero 3

Tested with `spidev-test` and this overlay seems to work. There are multiple configurations for CS pin in device tree overlay files, but this one aligns with pinout on the Orange PI site.