### PR TITLE
DietPi-Software | Ampache: Fix for Ampache v6 on Bullseye and Bookworm

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Enhancements:
 
 Bug fixes:
 - DietPi-Update | Resolved an issue on RPi 4 systems with 32-bit userland/OS (but 64-bit kernel enabled) where wrong package variants could have been installed during patch stages. Many thanks to @diment08 for reporting this issue: https://github.com/MichaIng/DietPi/issues/6768
+- DietPi-Software | Ampache: Resolved an issue on Bullseye and Bookworm systems where the initial web UI access failed because our pre-generated database was too old. A template shipped with Ampache will now be used, the initial admin user and music catalogue added via CLI. Many thanks to @mostly_offline for reporting this issue: https://dietpi.com/forum/t/bypassing-ampache-update-page/17367
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/ADDME
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4581,8 +4581,6 @@ The install script will now exit. After applying one of the the above, rerun die
 				# For MariaDB, temporary database admin user needs to be created, as 'root' uses unix_socket login, which cannot be accessed by sudo -u www-data.
 				# - Create random temporary alphanumeric 30 characters password
 				local oc_password=$(tr -dc '[:alnum:]' < /dev/random | head -c30)
-				# - Failsafe: Use non-blocking entropy source, if /dev/random fails
-				(( ${#oc_password} == 30 )) || oc_password=$(tr -dc '[:alnum:]' < /dev/urandom | head -c30)
 				G_EXEC mysql -e "grant all privileges on *.* to tmp_root@localhost identified by '$oc_password' with grant option;"
 
 				G_EXEC_DESC='ownCloud occ install'
@@ -4848,8 +4846,6 @@ The install script will now exit. After applying one of the the above, rerun die
 				# For MariaDB, temporary database admin user needs to be created, as 'root' uses unix_socket login, which cannot be accessed by sudo -u www-data.
 				# - Create random temporary alphanumeric 30 characters password
 				local nc_password=$(tr -dc '[:alnum:]' < /dev/random | head -c30)
-				# - Failsafe: Use non-blocking entropy source, if /dev/random fails
-				(( ${#nc_password} == 30 )) || nc_password=$(tr -dc '[:alnum:]' < /dev/urandom | head -c30)
 				G_EXEC mysql -e "grant all privileges on *.* to tmp_root@localhost identified by '$nc_password' with grant option;"
 
 				G_EXEC_DESC='Nextcloud ncc install'
@@ -7668,7 +7664,7 @@ _EOF_
 			local json=()
 			[[ $PHP_VERSION == 8* ]] || aDEPS+=("php$PHP_VERSION-json") json=('json')
 
-			# Bullseye+
+			# Bullseye and above
 			if (( $G_DISTRO > 5 ))
 			then
 				local fallback_url="https://github.com/ampache/ampache/releases/download/6.1.0/ampache-6.1.0_all_php$PHP_VERSION.zip"
@@ -7676,7 +7672,7 @@ _EOF_
 				# Ampache is installed to /mnt/dietpi_userdata/ampache and the "public" directory linked to /var/www/ampache: https://github.com/MichaIng/DietPi/pull/5205
 				local fp_install='/mnt/dietpi_userdata' fp_public='ampache/public'
 
-			# Ampache v5 requires PHP7.4, hence pull latest Ampache v4 on Buster: https://github.com/ampache/ampache/wiki/Ampache-Next-Changes
+			# Buster: Ampache v5 requires PHP7.4, hence pull latest Ampache v4: https://github.com/ampache/ampache/wiki/Ampache-Next-Changes
 			else
 				Download_Install 'https://github.com/ampache/ampache/releases/download/4.4.3/ampache-4.4.3_all.zip' ampache
 				# Ampache is installed to /var/www/ampache.
@@ -7702,30 +7698,20 @@ _EOF_
 			# Enable required PHP modules: https://github.com/ampache/ampache/wiki/Installation#prerequisites
 			G_EXEC phpenmod curl intl xml "${json[@]}"
 
-			# Import our pre-made Ampache database, if not existent already
-			if [[ ! -d '/mnt/dietpi_userdata/mysql/ampache' ]]
-			then
-				/boot/dietpi/func/create_mysql_db ampache ampache "$GLOBAL_PW"
-				Download_Install 'https://dietpi.com/downloads/mysql_databases/ampache_mysql_3.8.2-v6.0.zip'
-				G_EXEC mysql ampache < ampache.sql
-				G_EXEC rm ampache.sql
-				# Also update password here for rare but possible case that database was lost but config file still exists
-				[[ -f $fp_install/ampache/config/ampache.cfg.php ]] && G_CONFIG_INJECT 'database_password[[:blank:]]+=' "database_password = \"$GLOBAL_PW\"" "$fp_install/ampache/config/ampache.cfg.php"
-			fi
+			# Create random temporary alphanumeric 30 characters database password
+			local password=$(tr -dc '[:alnum:]' < /dev/random | head -c30)
 
-			# Create new config, if not existent already
+			# Fresh install: Create new config
 			if [[ ! -f $fp_install/ampache/config/ampache.cfg.php ]]
 			then
-				G_EXEC mv "$fp_install/ampache/config/ampache.cfg.php"{.dist,}
+				G_EXEC cp "$fp_install/ampache/config/ampache.cfg.php"{.dist,}
 				G_CONFIG_INJECT 'web_path[[:blank:]]+=' 'web_path = "/ampache"' "$fp_install/ampache/config/ampache.cfg.php"
 				G_CONFIG_INJECT 'database_hostname[[:blank:]]+=' 'database_hostname = /run/mysqld/mysqld.sock' "$fp_install/ampache/config/ampache.cfg.php"
 				G_CONFIG_INJECT 'database_name[[:blank:]]+=' 'database_name = ampache' "$fp_install/ampache/config/ampache.cfg.php"
 				G_CONFIG_INJECT 'database_username[[:blank:]]+=' 'database_username = ampache' "$fp_install/ampache/config/ampache.cfg.php"
-				G_CONFIG_INJECT 'database_password[[:blank:]]+=' "database_password = \"$GLOBAL_PW\"" "$fp_install/ampache/config/ampache.cfg.php"
-				G_CONFIG_INJECT 'waveform[[:blank:]]+=' 'waveform = "true"' "$fp_install/ampache/config/ampache.cfg.php"
+				GCI_PASSWORD=1 G_CONFIG_INJECT 'database_password[[:blank:]]+=' "database_password = \"$password\"" "$fp_install/ampache/config/ampache.cfg.php"
 				G_CONFIG_INJECT 'tmp_dir_path[[:blank:]]+=' 'tmp_dir_path = "/tmp"' "$fp_install/ampache/config/ampache.cfg.php"
-				G_CONFIG_INJECT 'generate_video_preview[[:blank:]]+=' 'generate_video_preview = "true"' "$fp_install/ampache/config/ampache.cfg.php"
-				G_CONFIG_INJECT 'channel[[:blank:]]+=' 'channel = "true"' "$fp_install/ampache/config/ampache.cfg.php"
+				G_CONFIG_INJECT 'transcode_cmd[[:blank:]]+=' 'transcode_cmd = "ffmpeg"' "$fp_install/ampache/config/ampache.cfg.php"
 				G_CONFIG_INJECT 'transcode_m4a[[:blank:]]+=' 'transcode_m4a = "required"' "$fp_install/ampache/config/ampache.cfg.php"
 				G_CONFIG_INJECT 'transcode_flac[[:blank:]]+=' 'transcode_flac = "required"' "$fp_install/ampache/config/ampache.cfg.php"
 				G_CONFIG_INJECT 'transcode_mpc[[:blank:]]+=' 'transcode_mpc = "required"' "$fp_install/ampache/config/ampache.cfg.php"
@@ -7736,11 +7722,55 @@ _EOF_
 				G_CONFIG_INJECT 'transcode_mpg[[:blank:]]+=' 'transcode_mpg = "allowed"' "$fp_install/ampache/config/ampache.cfg.php"
 				G_CONFIG_INJECT 'encode_target[[:blank:]]+=' 'encode_target = mp3' "$fp_install/ampache/config/ampache.cfg.php"
 				G_CONFIG_INJECT 'encode_video_target[[:blank:]]+=' 'encode_video_target = webm' "$fp_install/ampache/config/ampache.cfg.php"
-				G_CONFIG_INJECT 'transcode_cmd[[:blank:]]+=' 'transcode_cmd = "ffmpeg"' "$fp_install/ampache/config/ampache.cfg.php"
+				G_CONFIG_INJECT 'generate_video_preview[[:blank:]]+=' 'generate_video_preview = "true"' "$fp_install/ampache/config/ampache.cfg.php"
+				G_CONFIG_INJECT 'waveform[[:blank:]]+=' 'waveform = "true"' "$fp_install/ampache/config/ampache.cfg.php"
+
+			# Update password as well in rare but possible case that config file still exists but database was lost
+			elif [[ ! -d '/mnt/dietpi_userdata/mysql/ampache' ]]
+			then
+				GCI_PASSWORD=1 G_CONFIG_INJECT 'database_password[[:blank:]]+=' "database_password = \"$password\"" "$fp_install/ampache/config/ampache.cfg.php"
 			fi
 
-			# Permissions: Ampache can automatically migrate old configs to the new config file
-			G_EXEC chown www-data "$fp_install/ampache/config/ampache.cfg.php"
+			# Permissions: Permit config file updates via web UI
+			G_EXEC chown www-data "$fp_install/ampache/config/ampache.cfg.php"{.dist,}
+
+			# Fresh install: Generate database
+			G_EXEC systemctl start mariadb
+			if [[ ! -d '/mnt/dietpi_userdata/mysql/ampache' ]]
+			then
+				/boot/dietpi/func/create_mysql_db ampache ampache "$password"
+				if (( $G_DISTRO > 5 ))
+				then
+					# Import template
+					G_EXEC mysql ampache < /mnt/dietpi_userdata/ampache/resources/sql/ampache.sql
+					# Generate admin user: Replace password string internally to avoid printing it to console
+					G_EXEC_PRE_FUNC(){ acommand[6]=$GLOBAL_PW; }
+					G_EXEC php /mnt/dietpi_userdata/ampache/bin/cli admin:addUser -l 100 -p "${GLOBAL_PW//?/X}" dietpi
+					# Generate local music catalogue
+					G_EXEC_OUTPUT=1 G_EXEC php /mnt/dietpi_userdata/ampache/bin/cli run:addCatalog Music /mnt/dietpi_userdata/Music music
+					# Scan for music files
+					G_EXEC_OUTPUT=1 G_EXEC php /mnt/dietpi_userdata/ampache/bin/cli run:updateCatalog
+				else
+					# Import template
+					G_EXEC mysql ampache < /var/www/ampache/sql/ampache.sql
+					# Generate admin user: Replace password string internally to avoid printing it to console
+					G_EXEC_PRE_FUNC(){ acommand[7]=$GLOBAL_PW; }
+					G_EXEC php /var/www/ampache/bin/install/add_user.inc -u dietpi -l 100 -p "${GLOBAL_PW//?/X}"
+					# Generate local music catalogue
+					# shellcheck disable=SC2016
+					G_EXEC_OUTPUT=1 G_EXEC mysql -e 'use ampache; insert into `catalog` values (1,'\''Music'\'','\''local'\'',0,null,0,1,'\''%T - %t'\'','\''%a/%A'\'','\''music'\''); insert into `catalog_local` values (1,'\''/mnt/dietpi_userdata/Music'\'',1)'
+					# Scan for music files
+					G_EXEC_OUTPUT=1 G_EXEC php /var/www/ampache/bin/catalog_update.inc
+				fi
+
+			# Reinstall: Update database
+			elif (( $G_DISTRO > 5 ))
+			then
+				G_EXEC_OUTPUT=1 G_EXEC php /mnt/dietpi_userdata/ampache/bin/cli admin:updateDatabase
+			else
+				G_EXEC_OUTPUT=1 G_EXEC php /var/www/ampache/bin/install/update_db.inc
+			fi
+			unset -v password
 		fi
 
 		if To_Install 58 tailscaled # Tailscale
@@ -10182,7 +10212,7 @@ _EOF_
 					*) local arch='x64';;
 				esac
 
-				local fallback_url="https://github.com/Prowlarr/Prowlarr/releases/download/v1.9.4.4039/Prowlarr.master.1.9.4.4039.linux-core-$arch.tar.gz"
+				local fallback_url="https://github.com/Prowlarr/Prowlarr/releases/download/v1.10.5.4116/Prowlarr.master.1.10.5.4116.linux-core-$arch.tar.gz"
 				Download_Install "$(curl -sSfL 'https://api.github.com/repos/Prowlarr/Prowlarr/releases/latest' | mawk -F\" "/^ *\"browser_download_url\": \".*linux-core-$arch\.tar\.gz\"$/{print \$4}")"
 				G_EXEC mv Prowlarr /opt/prowlarr
 			fi
@@ -10836,7 +10866,7 @@ _EOF_
 			unset -v db_password
 
 			# Apply new app key
-			GCI_PASSWORD=1 G_CONFIG_INJECT 'APP_KEY=' "APP_KEY=base64:$(base64 < <(tr -dc '[:graph:]' < /dev/urandom | head -c32))" allo/.env
+			GCI_PASSWORD=1 G_CONFIG_INJECT 'APP_KEY=' "APP_KEY=base64:$(base64 < <(tr -dc '[:graph:]' < /dev/random | head -c32))" allo/.env
 
 			# Install cleanly
 			[[ -d '/opt/allo' ]] && G_EXEC rm -R /opt/allo
@@ -11743,7 +11773,7 @@ _EOF_
 					*) local arch='amd64';;
 				esac
 
-				local fallback_url="https://github.com/rclone/rclone/releases/download/v1.64.2/rclone-v1.64.2-linux-$arch.deb"
+				local fallback_url="https://github.com/rclone/rclone/releases/download/v1.65.0/rclone-v1.65.0-linux-$arch.deb"
 				Download_Install "$(curl -sSfL 'https://api.github.com/repos/rclone/rclone/releases/latest' | mawk -F\" "/^ *\"browser_download_url\": \".*\/rclone-v[^\"\/]*-linux-$arch.deb\"$/{print \$4}")"
 			fi
 		fi

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -825,7 +825,8 @@ $grey─────────────────────────
 	# - $G_EXEC_ARRAY_ACTION[]	| Associative array, containing uneven $G_EXEC_ARRAY_TEXT[] values as keys and related commands as values
 	G_EXEC(){
 
-		local exit_code fp_log='/tmp/G_EXEC_LOG' attempt=1 acommand=("$@") ecommand
+		local exit_code fp_log='/tmp/G_EXEC_LOG' attempt=1 acommand=("$@")
+		local ecommand=${acommand[*]//\\/\\\\}
 
 		# Enter retry loop
 		while :
@@ -835,7 +836,6 @@ $grey─────────────────────────
 			[[ $exit_code == 0 ]] && break
 
 			# Execute command, store output to $fp_log file and store exit code to $exit_code variable
-			ecommand=${acommand[*]//\\/\\\\}
 			# - Print full command output if $G_EXEC_OUTPUT=1 is given
 			if [[ $G_EXEC_OUTPUT == 1 ]]; then
 
@@ -899,7 +899,7 @@ $grey─────────────────────────
 - Hardware       | $G_HW_MODEL_NAME (ID=$G_HW_MODEL)
 - Kernel version | \`$(uname -a)\`
 - Distro         | $G_DISTRO_NAME (ID=$G_DISTRO${G_RASPBIAN:+,RASPBIAN=$G_RASPBIAN})
-- Command        | \`${acommand[*]}\`
+- Command        | \`$ecommand\`
 - Exit code      | $exit_code
 - Software title | $G_PROGRAM_NAME
 #### Steps to reproduce:


### PR DESCRIPTION
In addition to the linked issue, this has first been reported on the forum: https://dietpi.com/forum/t/bypassing-ampache-update-page/17367

Additionally:
- Remove usage of `/dev/urandom` in general. New Linux versions have reliable internal entropy generation, so that `/dev/random` does not block. On SBCs with old kernel versions (Sparky SBC, NanoPi M2, NanoPi M3/T3/Fire3), we use entropy daemons to achieve this. If `/dev/random` really blocks for a long time when generating random passwords, this must be addressed better earlier than later anyway, as it can lead to various much more critical issues. Hence we intentionally do not use fallbacks to non-blocking `/dev/urandom` now.
- For the Ampache database, we use a random password now as well. The user does not need to know it, and never needs to enter it manually anywhere.
- Skip "channel" setting. It has been removed with Ampache v6.
- Assure that passwords are never printed to console, including a fix for the method we use to hide passwords in G_EXEC commands. Some recent code change broke that, so that the password was printed regardless.
- GUI admin user name changed to `dietpi`. We decided recently to not use "root" or "admin" anymore, as this is a too typical brute-force target. => requires docs change
- A fix for a workaround for MariaDB startup failures on Buster, only within QEMU-emulated Buster containers on GitHub (I could never replicate this locally) where suddenly our previously flawlessly working workaround caused another issue now, which I am able to perfectly replicate even on a native (non-emulated) Buster VM 😄.

For Buster/Ampache v4 we keep using our pre-generated database for now, as it does still work there. However, would be good to switch to CLI usage there as well. Should be possible, but the commands are provided via multiple CLI scripts there.

CI install tests: https://github.com/MichaIng/DietPi/actions/runs/6997610699