### PR TITLE
DietPi-Set_Hardware | Update 1st run setup on RPi4

### DIFF
--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -224,18 +224,7 @@ _EOF_
 		(( $G_HW_MODEL == 4 )) || { Unsupported_Input_Name; return 1; } # Exit path for non-RPi4
 
 		# Install required APT package
-		if (( $G_DISTRO > 6 ))
-		then
-			if ! dpkg-query -s rpi-eeprom &> /dev/null
-			then
-				G_EXEC_OUTPUT=1 G_EXEC curl -fO 'https://dietpi.com/downloads/binaries/rpi/rpi-eeprom.deb'
-				G_AGI ./rpi-eeprom.deb
-				G_EXEC rm rpi-eeprom.deb
-				G_EXEC apt-mark hold rpi-eeprom
-			fi
-		else
-			G_AG_CHECK_INSTALL_PREREQ rpi-eeprom
-		fi
+		G_AG_CHECK_INSTALL_PREREQ rpi-eeprom
 
 		# Update/flash new bootloader and VL805 USB firmware to EEPROM
 		rpi-eeprom-update -a


### PR DESCRIPTION
Undoes a change that blocks the package `rpi-eeprom` at the first start. This step is no longer required.