### PR TITLE
DietPi-Config | Stress test log

### DIFF
--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -3686,7 +3686,7 @@ Additional benchmarks:
 				fi
 				log_text+=" | $(( $STRESS_TEST_DURATION + $start_time_epoch - $(date '+%s') )) seconds remaining"
 				echo "$log_text"
-				echo "$log_text" > "$fp_log"
+				echo "$log_text" >> "$fp_log"
 				G_SLEEP 1
 			done
 


### PR DESCRIPTION
keep a full stress test log instead of last line only.