### PR TITLE
DietPi-Software | motionEye: Update dependencies and switch to pre-release from PyPI

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ New images:
 - Orange Pi Zero 3 | New images for the 1.5 GB RAM variant are now available for testing, before they are added to our download page soon: https://dietpi.com/downloads/binaries/testing/
 
 Enhancements:
+- DietPi-Software | motionEye: Updated build dependencies for ARM and RISC-V, and switched to the recent pre-release from PyPI, instead of pulling from the repositories dev branch.
 
 Bug fixes:
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9274,10 +9274,10 @@ _EOF_
 		if To_Install 136 motioneye # motionEye
 		then
 			# APT deps
-			# - ARMv6/7 Bullseye/Bookworm + RISC-V: libjpeg62-turbo-dev and gcc for Pillow
-			if (( ( $G_HW_ARCH < 3 && $G_DISTRO > 5 ) || $G_HW_ARCH == 11 ))
+			# - RISC-V: libcurl4-openssl-dev, gcc and libssl-dev for pycurl, libjpeg62-turbo-dev for Pillow
+			if (( $G_HW_ARCH == 11 ))
 			then
-				G_AGI libjpeg62-turbo-dev gcc
+				G_AGI libcurl4-openssl-dev gcc libssl-dev libjpeg62-turbo-dev
 
 			# - ARMv8/x86_64: libcurl4-openssl-dev, gcc and libssl-dev for pycurl
 			elif (( $G_HW_ARCH > 2 ))
@@ -9289,7 +9289,7 @@ _EOF_
 			(( $G_HW_MODEL > 9 )) || /boot/dietpi/func/dietpi-set_hardware rpi-camera enable
 
 			# motionEye
-			G_EXEC_OUTPUT=1 G_EXEC pip3 install -U 'https://github.com/motioneye-project/motioneye/archive/dev.tar.gz'
+			G_EXEC_OUTPUT=1 G_EXEC pip3 install -U --pre motioneye
 			G_EXEC_OUTPUT=1 G_EXEC motioneye_init --skip-apt-update
 			G_EXEC systemctl stop motioneye
 			G_EXEC systemctl --no-reload disable --now motion # motionEye starts motion directly.


### PR DESCRIPTION
Tests: https://github.com/MichaIng/DietPi/actions/runs/7366371402