### PR TITLE
DietPi-Banner: Display total space and space used in % for the freespace option

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ New images:
 - Orange Pi Zero 3 | New images for the 1.5 GB RAM variant are now available for testing, before they are added to our download page soon: https://dietpi.com/downloads/binaries/testing/
 
 Enhancements:
+- DietPi-Banner | Instead of "Freespace", the "Disk usage" is now shown, including the total disk size and used percent. Many thanks to @Andr3Carvalh0 for implementing this change: https://github.com/MichaIng/DietPi/pull/6837
 - DietPi-Software | motionEye: Updated build dependencies for ARM and RISC-V, and switched to the recent pre-release from PyPI, instead of pulling from the repositories dev branch.
 
 Bug fixes:

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -248,9 +248,9 @@ $GREEN_LINE"
 		# DietPi-VPN connection status
 		(( ${aENABLED[13]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[13]} $GREEN_SEPARATOR $(/boot/dietpi/dietpi-vpn status 2>&1)"
 		# Freespace (RootFS)
-		(( ${aENABLED[7]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[7]} $GREEN_SEPARATOR $(df -h --output=avail / | mawk 'NR==2 {print $1}' 2>&1)"
+		(( ${aENABLED[7]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[7]} $GREEN_SEPARATOR $(df -h / | mawk 'NR==2 {printf "%s / %s (%s)", $4, $2, $5}' 2>&1)"
 		# Freespace (DietPi userdata)
-		(( ${aENABLED[8]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[8]} $GREEN_SEPARATOR $(df -h --output=avail /mnt/dietpi_userdata | mawk 'NR==2 {print $1}' 2>&1)"
+		(( ${aENABLED[8]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[8]} $GREEN_SEPARATOR $(df -h /mnt/dietpi_userdata | mawk 'NR==2 {printf "%s / %s (%s)", $4, $2, $5}' 2>&1)"
 		# Weather
 		(( ${aENABLED[9]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[9]} $GREEN_SEPARATOR $(curl -sSfLm 3 'https://wttr.in/?format=4' 2>&1)"
 		# Let's Encrypt cert status

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -47,8 +47,8 @@
 		'NIS domainname'
 		'LAN IP'
 		'WAN IP'
-		'Freespace (RootFS)'
-		'Freespace (userdata)'
+		'Disk usage (RootFS)'
+		'Disk usage (userdata)'
 		'Weather (wttr.in)'
 		'Custom banner entry'
 		'Display DietPi useful commands?'
@@ -247,10 +247,10 @@ $GREEN_LINE"
 		(( ${aENABLED[6]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[6]} $GREEN_SEPARATOR $(G_GET_WAN_IP 2>&1)"
 		# DietPi-VPN connection status
 		(( ${aENABLED[13]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[13]} $GREEN_SEPARATOR $(/boot/dietpi/dietpi-vpn status 2>&1)"
-		# Freespace (RootFS)
-		(( ${aENABLED[7]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[7]} $GREEN_SEPARATOR $(df -h --output=avail,size / | mawk 'NR==2 {print $1" / "$2}' 2>&1)"
-		# Freespace (DietPi userdata)
-		(( ${aENABLED[8]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[8]} $GREEN_SEPARATOR $(df -h --output=avail,size /mnt/dietpi_userdata | mawk 'NR==2 {print $1" / "$2}' 2>&1)"
+		# Disk usage (RootFS)
+		(( ${aENABLED[7]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[7]} $GREEN_SEPARATOR $(df -h --output=used,size,pcent / | mawk 'NR==2 {printf $1" of "$2" ("$3"%)"}' 2>&1)"
+		# Disk usage (DietPi userdata)
+		(( ${aENABLED[8]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[8]} $GREEN_SEPARATOR $(df -h --output=used,size,pcent /mnt/dietpi_userdata | mawk 'NR==2 {printf $1" of "$2" ("$3"%)"}' 2>&1)"
 		# Weather
 		(( ${aENABLED[9]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[9]} $GREEN_SEPARATOR $(curl -sSfLm 3 'https://wttr.in/?format=4' 2>&1)"
 		# Let's Encrypt cert status

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -248,9 +248,9 @@ $GREEN_LINE"
 		# DietPi-VPN connection status
 		(( ${aENABLED[13]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[13]} $GREEN_SEPARATOR $(/boot/dietpi/dietpi-vpn status 2>&1)"
 		# Freespace (RootFS)
-		(( ${aENABLED[7]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[7]} $GREEN_SEPARATOR $(df -h / | mawk 'NR==2 {printf "%s / %s (%s)", $4, $2, $5}' 2>&1)"
+		(( ${aENABLED[7]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[7]} $GREEN_SEPARATOR $(df -h --output=avail,size / | mawk 'NR==2 {print $1" / "$2}' 2>&1)"
 		# Freespace (DietPi userdata)
-		(( ${aENABLED[8]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[8]} $GREEN_SEPARATOR $(df -h /mnt/dietpi_userdata | mawk 'NR==2 {printf "%s / %s (%s)", $4, $2, $5}' 2>&1)"
+		(( ${aENABLED[8]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[8]} $GREEN_SEPARATOR $(df -h --output=avail,size /mnt/dietpi_userdata | mawk 'NR==2 {print $1" / "$2}' 2>&1)"
 		# Weather
 		(( ${aENABLED[9]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[9]} $GREEN_SEPARATOR $(curl -sSfLm 3 'https://wttr.in/?format=4' 2>&1)"
 		# Let's Encrypt cert status


### PR DESCRIPTION
Simple change... Instead of only showing the available space for rootfs/userdata also indicate the total amount and the percentage thats in use.

<img width="682" alt="Screenshot 2024-01-05 at 13 31 19" src="https://github.com/MichaIng/DietPi/assets/6016433/b0d9c128-704e-445d-bf85-28292b711d9f">
