### PR TITLE
DietPi-Software | Amiberry: Add RPi 5 and RISC-V support

### DIFF
--- a/.build/software/Amiberry/container_build.bash
+++ b/.build/software/Amiberry/container_build.bash
@@ -46,10 +46,11 @@ do
 done
 [[ $DISTRO =~ ^('buster'|'bullseye'|'bookworm'|'trixie')$ ]] || Error_Exit "Invalid distro \"$DISTRO\" passed"
 case $PLATFORM in
-	'rpi1') image="ARMv6-${DISTRO^}" arch=1;;
-	'rpi'[234]|'c1'|'xu4'|'RK3288'|'sun8i'|'s812') image="ARMv7-${DISTRO^}" arch=2;;
-	'rpi'[34]'-64-dmx'|'AMLSM1'|'n2'|'a64'|'rk3588') image="ARMv8-${DISTRO^}" arch=3;;
+	'rpi1'*) image="ARMv6-${DISTRO^}" arch=1;;
+	'rpi'[345]'-64-'*|'AMLSM1'|'n2'|'a64'|'rk3588') image="ARMv8-${DISTRO^}" arch=3;;
+	'rpi'[2-5]*|'c1'|'xu4'|'RK3288'|'sun8i'|'s812') image="ARMv7-${DISTRO^}" arch=2;;
 	'x86-64') image="x86_64-${DISTRO^}" arch=10;;
+	'riscv64') image='RISC-V-Sid' arch=11;;
 	*) Error_Exit "Invalid platform \"$PLATFORM\" passed";;
 esac
 image="DietPi_Container-$image.img"
@@ -118,11 +119,11 @@ G_CONFIG_INJECT 'CONFIG_CHECK_CONNECTION_IP=' 'CONFIG_CHECK_CONNECTION_IP=127.0.
 # Avoid DietPi-Survey uploads to not mess with the statistics
 G_EXEC rm rootfs/root/.ssh/known_hosts
 
-# RPi 64-bit: Add RPi repo, ARMv6 container images contain it already
-if [[ $PLATFORM == 'rpi'[234]* ]]
+# RPi: Add RPi repo, ARMv6 container images contain it already
+if [[ $PLATFORM == 'rpi'[2-5]* ]]
 then
-	G_EXEC eval "echo 'deb https://archive.raspberrypi.org/debian/ ${DISTRO/trixie/bookworm} main' > rootfs/etc/apt/sources.list.d/raspi.list"
-	G_EXEC curl -sSf 'https://archive.raspberrypi.org/debian/pool/main/r/raspberrypi-archive-keyring/raspberrypi-archive-keyring_2021.1.1+rpt1_all.deb' -o keyring.deb
+	G_EXEC eval "echo 'deb https://archive.raspberrypi.com/debian/ ${DISTRO/trixie/bookworm} main' > rootfs/etc/apt/sources.list.d/raspi.list"
+	G_EXEC curl -sSf 'https://archive.raspberrypi.com/debian/pool/main/r/raspberrypi-archive-keyring/raspberrypi-archive-keyring_2021.1.1+rpt1_all.deb' -o keyring.deb
 	G_EXEC dpkg --root=rootfs -i keyring.deb
 	G_EXEC rm keyring.deb
 	# Enforce Debian Trixie FFmpeg packages over RPi repo ones

--- a/.github/workflows/amiberry.yml
+++ b/.github/workflows/amiberry.yml
@@ -6,7 +6,7 @@ on:
         description: 'Target platform'
         type: choice
         # https://github.com/BlitterStudio/amiberry/blob/master/Makefile
-        options: [rpi1, rpi2, rpi3, rpi4, rpi3-64-dmx, rpi4-64-dmx, c1, xu4, RK3288, sun8i, s812, AMLSM1, n2, a64, x86-64, rk3588, all]
+        options: [rpi1-sdl2, rpi2-sdl2, rpi3-sdl2, rpi4-sdl2, rpi5-sdl2, rpi3-64-sdl2, rpi4-64-sdl2, rpi5-64-sdl2, c1, xu4, RK3288, sun8i, s812, AMLSM1, n2, a64, x86-64, rk3588, riscv64, all]
         default: all
         required: true
       dist:
@@ -35,7 +35,7 @@ jobs:
       run: |
         if [ '${{ github.event.inputs.plat }}' = 'all' ]
         then
-          echo plat='["rpi1", "rpi2", "rpi3", "rpi4", "rpi3-64-dmx", "rpi4-64-dmx", "c1", "xu4", "RK3288", "sun8i", "s812", "AMLSM1", "n2", "a64", "x86-64", "rk3588"]' >> "$GITHUB_OUTPUT"
+          echo plat='["rpi1-sdl2", "rpi2-sdl2", "rpi3-sdl2", "rpi4-sdl2", "rpi5-sdl2", "rpi3-64-sdl2", "rpi4-64-sdl2", "rpi5-64-sdl2", "c1", "xu4", "RK3288", "sun8i", "s812", "AMLSM1", "n2", "a64", "x86-64", "rk3588", "riscv64"]' >> "$GITHUB_OUTPUT"
         else
           echo plat='["${{ github.event.inputs.plat }}"]' >> "$GITHUB_OUTPUT"
         fi
@@ -54,8 +54,16 @@ jobs:
         plat: ${{ fromJson(needs.prep.outputs.plat) }}
         dist: ${{ fromJson(needs.prep.outputs.dist) }}
         exclude:
-        - { plat: rpi1, dist: trixie }
-        - { plat: rk3588, dist: buster }
+        - { plat: rk3588, dist: buster }  # Compiler fails with: "g++: fatal error: unknown value ‘cortex-a76+fp’ for -mcpu"
+        - { plat: rpi1-sdl2, dist: buster }  # Compiler fails with: "list sub-command REMOVE_ITEM requires two or more arguments." and those builds are not picked by DietPi v8 and earlier, the latest which support Buster
+        - { plat: rpi2-sdl2, dist: buster }
+        - { plat: rpi3-sdl2, dist: buster }
+        - { plat: rpi4-sdl2, dist: buster }
+        - { plat: rpi5-sdl2, dist: buster }
+        - { plat: rpi5-64-sdl2, dist: buster }  # Compiler fails with: "g++: fatal error: unknown value ‘cortex-a76’ for -mcpu"
+        - { plat: riscv64, dist: buster }
+        - { plat: riscv64, dist: bullseye }
+        - { plat: riscv64, dist: bookworm }
       fail-fast: false
     name: "${{ matrix.plat }} - ${{ matrix.dist }}"
     runs-on: ubuntu-22.04

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -887,8 +887,6 @@ Available commands:
 		aSOFTWARE_CATX[$software_id]=5
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/gaming/#amiberry'
 		aSOFTWARE_DEPS[$software_id]='5'
-		# - RISC-V: Missing target
-		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,11]=0
 		#------------------
 		software_id=51
 		aSOFTWARE_NAME[$software_id]='OpenTyrian'
@@ -5331,13 +5329,13 @@ _EOF_
 		if To_Install 108 # Amiberry
 		then
 			# Obtain platform: https://github.com/BlitterStudio/amiberry/blob/master/Makefile
-			local platform='rpi1'
+			local platform='rpi1-sdl2'
 			if (( $G_HW_MODEL < 10 )) # RPi
 			then
-				(( $G_HW_MODEL > 1 )) && platform="rpi$G_HW_MODEL" # ID 0 is rpi1
+				(( $G_HW_MODEL > 1 )) && platform="rpi$G_HW_MODEL-sdl2" # ID 0 is rpi1
 				# 64-bit: For RPi 2 v1.2 use RPi 3 64-bit build
-				(( $G_HW_ARCH == 3 )) && platform="${platform/[12]/3}-64-dmx"
-				/boot/dietpi/func/dietpi-set_hardware rpi-opengl vc4-fkms-v3d
+				(( $G_HW_ARCH == 3 )) && platform="${platform/[12]/3}-64-sdl2"
+				/boot/dietpi/func/dietpi-set_hardware rpi-opengl vc4-kms-v3d
 
 			elif (( $G_HW_MODEL == 10 )) # Odroid C1
 			then
@@ -5378,6 +5376,10 @@ _EOF_
 			elif (( $G_HW_ARCH == 10 )) # x86_64
 			then
 				platform='x86-64'
+
+			elif (( $G_HW_ARCH == 11 )) # RISC-V
+			then
+				platform='riscv64'
 			fi
 
 			# Install Amiberry DEB package


### PR DESCRIPTION
- Amiberry | Switch from RPi DispmanX builds to SDL2-backend builds
- Amiberry | Add RPi 5 and RISC-V builds
- Amiberry | Add new v5.6.5 dependencies: https://github.com/BlitterStudio/amiberry/releases/tag/v5.6.5