### PR TITLE
dietpi-banner: Adds support for displaying ram usage

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ v9.2
 (2024-03-16)
 
 Enhancements:
+- DietPi-Banner | Support for showing the current RAM usage was added. Many thanks to @Andr3Carvalh0 for the implementation: https://github.com/MichaIng/DietPi/pull/6844
 - DietPi-Software | It is now possible to run "dietpi-software list" concurrent to other dietpi-software instances, and as non-root user. This avoids an issue in DietPi-Dashboard, where opening dietpi-software in the Terminal and switching to the Software page, caused an infinite hang.
 - DietPi-Software | Gogs/Gitea: Using repositories via SSH should now work OOTB with new installs and reinstalls. If pull or push operations via SSH fail in your case, try to give the respective user a default shell: "sudo usermod -s /bin/dash gogs" respectively "sudo usermod -s /bin/dash gitea". This is now included in our default setup. Many thanks to @din14970 for reporting this missing feature: https://github.com/MichaIng/DietPi/discussions/6964#discussioncomment-8813390
 

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -241,11 +241,8 @@ $GREEN_LINE"
 		# RAM usage
 		if (( ${aENABLED[17]} == 1 ))
 		then
-			ramused="$(free -h --si | mawk 'NR==2 {printf $3}' 2>&1)"
-			ramtotal="$(free -h --si | mawk 'NR==2 {printf $2}' 2>&1)"
-			ramperc="$(free -b | mawk 'NR==2 {printf "%.0f", 100*$3/$2}' 2>&1)"
-
-			echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[17]} $GREEN_SEPARATOR $ramused of $ramtotal (${ramperc}%)"
+			ramusage=$(free -b | mawk 'NR==2 {CONVFMT="%.0f"; print $3/1024^2" MiB of "$2/1024^2" MiB ("$3/$2*100"%)"}')
+			echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[17]} $GREEN_SEPARATOR $ramusage"
 		fi
 		# Hostname
 		(( ${aENABLED[3]} == 1 && ${aENABLED[14]} != 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[3]} $GREEN_SEPARATOR $(</etc/hostname)"

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -57,14 +57,15 @@
 		'Large hostname'
 		'Print credits'
 		'Let'\''s Encrypt cert status'
+		'RAM usage'
 	)
 
 	# Set defaults: Disable CPU temp by default in VMs
 	if (( $G_HW_MODEL == 20 ))
 	then
-		aENABLED=(1 0 0 0 0 1 0 1 0 0 0 1 1 0 0 1 0)
+		aENABLED=(1 0 0 0 0 1 0 1 0 0 0 1 1 0 0 1 0 0)
 	else
-		aENABLED=(1 0 1 0 0 1 0 0 0 0 0 1 1 0 0 1 0)
+		aENABLED=(1 0 1 0 0 1 0 0 0 0 0 1 1 0 0 1 0 0)
 	fi
 
 	COLOUR_RESET='\e[0m'
@@ -237,6 +238,15 @@ $GREEN_LINE"
 		(( ${aENABLED[1]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[1]} $GREEN_SEPARATOR $(uptime -p 2>&1)"
 		# CPU temp
 		(( ${aENABLED[2]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[2]} $GREEN_SEPARATOR $(print_full_info=1 G_OBTAIN_CPU_TEMP 2>&1)"
+		# RAM usage
+		if (( ${aENABLED[17]} == 1 ))
+		then
+			ramused="$(free -h --si | mawk 'NR==2 {printf $3}' 2>&1)"
+			ramtotal="$(free -h --si | mawk 'NR==2 {printf $2}' 2>&1)"
+			ramperc="$(free -b | mawk 'NR==2 {printf "%.0f", 100*$3/$2}' 2>&1)"
+
+			echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[17]} $GREEN_SEPARATOR $ramused of $ramtotal (${ramperc}%)"
+		fi
 		# Hostname
 		(( ${aENABLED[3]} == 1 && ${aENABLED[14]} != 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[3]} $GREEN_SEPARATOR $(</etc/hostname)"
 		# NIS/YP domainname

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -239,11 +239,7 @@ $GREEN_LINE"
 		# CPU temp
 		(( ${aENABLED[2]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[2]} $GREEN_SEPARATOR $(print_full_info=1 G_OBTAIN_CPU_TEMP 2>&1)"
 		# RAM usage
-		if (( ${aENABLED[17]} == 1 ))
-		then
-			ramusage=$(free -b | mawk 'NR==2 {CONVFMT="%.0f"; print $3/1024^2" MiB of "$2/1024^2" MiB ("$3/$2*100"%)"}')
-			echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[17]} $GREEN_SEPARATOR $ramusage"
-		fi
+		(( ${aENABLED[17]} == 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[17]} $GREEN_SEPARATOR $(free -b | mawk 'NR==2 {CONVFMT="%.0f"; print $3/1024^2" of "$2/1024^2" MiB ("$3/$2*100"%)"}')"
 		# Hostname
 		(( ${aENABLED[3]} == 1 && ${aENABLED[14]} != 1 )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[3]} $GREEN_SEPARATOR $(</etc/hostname)"
 		# NIS/YP domainname


### PR DESCRIPTION
Adds support for displaying how much ram the system is using (doesnt account for swap)

<img width="682" alt="Screenshot 2024-01-09 at 09 42 49" src="https://github.com/MichaIng/DietPi/assets/6016433/d43cd4e3-b693-4ddb-a3bd-a0c2eae2f367">
