### PR TITLE
Add a separate function inside dietpi-globals to generate troubleshoot template for the forum

### DIFF
--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -803,6 +803,28 @@ $grey─────────────────────────
 		return "${result:-1}"
 	}
 
+	G_BUG_REPORT() {
+    local dietpi_version="v$G_DIETPI_VERSION_CORE.$G_DIETPI_VERSION_SUB.$G_DIETPI_VERSION_RC ($G_GITOWNER/$G_GITBRANCH)"
+    local image_creator preimage_name
+
+    if [[ -f '/boot/dietpi/.prep_info' ]]; then
+        image_creator=$(mawk 'NR==1' /boot/dietpi/.prep_info)
+        [[ $image_creator == 0 ]] && image_creator='DietPi Core Team'
+        preimage_name=$(mawk 'NR==2' /boot/dietpi/.prep_info)
+    fi
+
+    cat <<EOF
+#### Required Information
+- DietPi version | $dietpi_version
+- Distro version | $G_DISTRO_NAME (ID=$G_DISTRO${G_RASPBIAN:+,RASPBIAN=$G_RASPBIAN})
+- Kernel version |  \`$(uname -a)\`
+- Architecture	 | \`$(dpkg --print-architecture)\`
+- SBC model 	 | $G_HW_MODEL_NAME (ID=$G_HW_MODEL)
+- Image creator  | $image_creator
+- Pre-image      | $preimage_name
+EOF
+}
+
 	#-----------------------------------------------------------------------------------
 	# Error handled command execution wrapper
 	#-----------------------------------------------------------------------------------
@@ -873,18 +895,19 @@ $grey─────────────────────────
 			# Exit retry loop if $G_EXEC_NOHALT=1 is given
 			[[ $G_EXEC_NOHALT == 1 ]] && break
 
-			# Prepare error handler menu and GitHub issue template
-			local fp_error_report='/tmp/G_EXEC_ERROR_REPORT' log_content=$(<"$fp_log") image_creator preimage_name dietpi_version="v$G_DIETPI_VERSION_CORE.$G_DIETPI_VERSION_SUB.$G_DIETPI_VERSION_RC ($G_GITOWNER/$G_GITBRANCH)" last_whip_menu_item sent_bug_report
-			if [[ -f '/boot/dietpi/.prep_info' ]]; then
+			   # Prepare error handler menu and GitHub issue template
+        local fp_error_report='/tmp/G_EXEC_ERROR_REPORT' log_content=$(<"$fp_log") last_whip_menu_item sent_bug_report
+        if [[ -f '/boot/dietpi/.prep_info' ]]; then
+            image_creator=$(mawk 'NR==1' /boot/dietpi/.prep_info)
+            [[ $image_creator == 0 ]] && image_creator='DietPi Core Team'
+            preimage_name=$(mawk 'NR==2' /boot/dietpi/.prep_info)
+        fi
 
-				image_creator=$(mawk 'NR==1' /boot/dietpi/.prep_info)
-				[[ $image_creator == 0 ]] && image_creator='DietPi Core Team'
-				preimage_name=$(mawk 'NR==2' /boot/dietpi/.prep_info)
+        local dietpi_version="v$G_DIETPI_VERSION_CORE.$G_DIETPI_VERSION_SUB.$G_DIETPI_VERSION_RC ($G_GITOWNER/$G_GITBRANCH)"
+        local error_details=$(generate_error_details "$dietpi_version")
 
-			fi
-
-			# Create GitHub issue template if error was produced by one of our scripts
-			[[ ${G_PROGRAM_NAME,,} == 'dietpi-'* ]] && echo -e "\e[41m
+        cat <<EOF > "$fp_error_report"
+\e[41m
 ---------------------------------------------------------------------
 - DietPi has encountered an error                                   -
 - Please create a ticket: https://github.com/MichaIng/DietPi/issues -
@@ -892,15 +915,10 @@ $grey─────────────────────────
 ---------------------------------------------------------------------\e[44m
 #### Details:
 - Date           | $(date)
-- DietPi version | $dietpi_version
-- Image creator  | $image_creator
-- Pre-image      | $preimage_name
-- Hardware       | $G_HW_MODEL_NAME (ID=$G_HW_MODEL)
-- Kernel version | \`$(uname -a)\`
-- Distro         | $G_DISTRO_NAME (ID=$G_DISTRO${G_RASPBIAN:+,RASPBIAN=$G_RASPBIAN})
 - Command        | \`$ecommand\`
 - Exit code      | $exit_code
 - Software title | $G_PROGRAM_NAME
+$error_details
 #### Steps to reproduce:
 <!-- Explain how to reproduce the issue -->
 1. ...
@@ -918,7 +936,8 @@ $grey─────────────────────────
 \`\`\`
 $log_content
 \`\`\`\e[41m
----------------------------------------------------------------------\e[0m" > "$fp_error_report"
+---------------------------------------------------------------------\e[0m
+EOF
 
 			# Enter error handler menu loop in interactive mode
 			[[ $G_INTERACTIVE == 1 ]] && while :

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -817,7 +817,7 @@ $grey─────────────────────────
 #### Required Information
 - DietPi version | $dietpi_version
 - Distro version | $G_DISTRO_NAME (ID=$G_DISTRO${G_RASPBIAN:+,RASPBIAN=$G_RASPBIAN})
-- Kernel version |  \`$(uname -a)\`
+- Kernel version | \`$(uname -a)\`
 - Architecture	 | \`$(dpkg --print-architecture)\`
 - SBC model 	 | $G_HW_MODEL_NAME (ID=$G_HW_MODEL)
 - Image creator  | $image_creator
@@ -904,9 +904,9 @@ EOF
         fi
 
         local dietpi_version="v$G_DIETPI_VERSION_CORE.$G_DIETPI_VERSION_SUB.$G_DIETPI_VERSION_RC ($G_GITOWNER/$G_GITBRANCH)"
-        local error_details=$(generate_error_details "$dietpi_version")
+        local error_details=$(G_BUG_REPORT)
 
-        cat <<EOF > "$fp_error_report"
+        [[ ${G_PROGRAM_NAME,,} == 'dietpi-'* ]] && echo -e "\e[41m
 \e[41m
 ---------------------------------------------------------------------
 - DietPi has encountered an error                                   -
@@ -936,8 +936,7 @@ $error_details
 \`\`\`
 $log_content
 \`\`\`\e[41m
----------------------------------------------------------------------\e[0m
-EOF
+---------------------------------------------------------------------\e[0m" > "$fp_error_report"
 
 			# Enter error handler menu loop in interactive mode
 			[[ $G_INTERACTIVE == 1 ]] && while :
@@ -948,7 +947,8 @@ EOF
 				# Allow to open DietPi-Config if this error was not produced within DietPi-Config
 				pgrep -cf 'dietpi-config' &> /dev/null || G_WHIP_MENU_ARRAY+=('DietPi-Config' ': Edit network, APT/NTP mirror settings etc')
 				G_WHIP_MENU_ARRAY+=('Open subshell' ': Open a subshell to investigate or solve the issue')
-				# Allow to send bug report, if it was produced by one of our scripts
+
+                # Allow to send bug report, if it was produced by one of our scripts
 				[[ ${G_PROGRAM_NAME,,} == 'dietpi-'* && $G_PROGRAM_NAME != 'DietPi-Installer' ]] && G_WHIP_MENU_ARRAY+=('Send report' ': Uploads bugreport containing system info to DietPi')
 				G_WHIP_MENU_ARRAY+=('' '●─ Devs only ')
 				G_WHIP_MENU_ARRAY+=('Change command' ': Adjust and rerun the command')

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -803,27 +803,62 @@ $grey─────────────────────────
 		return "${result:-1}"
 	}
 
-	G_BUG_REPORT() {
-    local dietpi_version="v$G_DIETPI_VERSION_CORE.$G_DIETPI_VERSION_SUB.$G_DIETPI_VERSION_RC ($G_GITOWNER/$G_GITBRANCH)"
-    local image_creator preimage_name
+	# G_BUG_REPORT [-c COMMAND] [-? EXIT_CODE]
+	# - Print pre-filled bug report template
+	G_BUG_REPORT()
+	{
+		local command exit_code
+		while (( $# ))
+		do
+			case $1 in
+				'-c') shift; command=$1;;
+				'-?') shift; exit_code=$1;;
+				*) G_DIETPI-NOTIFY 1 "Invalid argument \"$1\""; return 1;;
+			esac
+			shift
+		done
 
-    if [[ -f '/boot/dietpi/.prep_info' ]]; then
-        image_creator=$(mawk 'NR==1' /boot/dietpi/.prep_info)
-        [[ $image_creator == 0 ]] && image_creator='DietPi Core Team'
-        preimage_name=$(mawk 'NR==2' /boot/dietpi/.prep_info)
-    fi
-
-    cat <<EOF
-#### Required Information
-- DietPi version | $dietpi_version
+		# Print bug report template
+		echo "#### Details:
+- Date           | $(date '+%F %T')"
+		# - Add program/script name, failed command and exit code if given
+		[[ $G_PROGRAM_NAME ]] && echo "- Program name   | $G_PROGRAM_NAME"
+		[[ $command ]] && echo "- Command        | \`$command\`"
+		[[ $exit_code ]] && echo "- Exit code      | $exit_code"
+		echo "- DietPi version | v$G_DIETPI_VERSION_CORE.$G_DIETPI_VERSION_SUB.$G_DIETPI_VERSION_RC ($G_GITOWNER/$G_GITBRANCH)
 - Distro version | $G_DISTRO_NAME (ID=$G_DISTRO${G_RASPBIAN:+,RASPBIAN=$G_RASPBIAN})
 - Kernel version | \`$(uname -a)\`
 - Architecture	 | \`$(dpkg --print-architecture)\`
-- SBC model 	 | $G_HW_MODEL_NAME (ID=$G_HW_MODEL)
-- Image creator  | $image_creator
-- Pre-image      | $preimage_name
-EOF
-}
+- Hardware model | $G_HW_MODEL_NAME (ID=$G_HW_MODEL)
+- Power supply   | (EG: RAVPower 5V 1A)
+- SD card        | (EG: SanDisk Ultra 16 GB)"
+		# - Add image creator and pre-image info if given
+		if [[ -f '/boot/dietpi/.prep_info' ]]
+		then
+			image_creator=$(mawk 'NR==1' /boot/dietpi/.prep_info)
+			[[ ${image_creator:-0} == 0 ]] || echo "- Image creator  | $image_creator"
+			preimage_name=$(mawk 'NR==2' /boot/dietpi/.prep_info)
+			[[ $preimage_name ]] && echo "- Pre-image      | $preimage_name"
+		fi
+		echo '#### Steps to reproduce:
+<!-- Explain how to reproduce the issue -->
+1. ...
+2. ...
+#### Expected behaviour:
+<!-- What SHOULD happen? -->
+- ...
+#### Actual behaviour:
+<!-- What IS happening? -->
+- ...
+#### Extra details:
+<!-- Please post any extra details that might help solve the issue -->
+- ...
+#### Additional logs:
+```'
+		# - Add log if given
+		[[ -f '/tmp/G_EXEC_LOG' ]] && cat '/tmp/G_EXEC_LOG' || echo '<!-- Please paste logs or related console output here -->'
+		echo '```'
+	}
 
 	#-----------------------------------------------------------------------------------
 	# Error handled command execution wrapper
@@ -889,56 +924,17 @@ EOF
 			# Retry non-interactively if current $attempt is <= $G_EXEC_RETRIES
 			[[ $attempt -le $G_EXEC_RETRIES ]] && { ((attempt++)) && continue; }
 
+			# Print command output if not done already
+			[[ $G_EXEC_OUTPUT != 1 ]] && cat "$fp_log"
+
 			# Print FAILED, append raw command string if $G_EXEC_DESC is given
 			G_DIETPI-NOTIFY 1 "${G_EXEC_DESC:+$G_EXEC_DESC\n - Command: }$ecommand"
 
 			# Exit retry loop if $G_EXEC_NOHALT=1 is given
 			[[ $G_EXEC_NOHALT == 1 ]] && break
 
-			   # Prepare error handler menu and GitHub issue template
-        local fp_error_report='/tmp/G_EXEC_ERROR_REPORT' log_content=$(<"$fp_log") last_whip_menu_item sent_bug_report
-        if [[ -f '/boot/dietpi/.prep_info' ]]; then
-            image_creator=$(mawk 'NR==1' /boot/dietpi/.prep_info)
-            [[ $image_creator == 0 ]] && image_creator='DietPi Core Team'
-            preimage_name=$(mawk 'NR==2' /boot/dietpi/.prep_info)
-        fi
-
-        local dietpi_version="v$G_DIETPI_VERSION_CORE.$G_DIETPI_VERSION_SUB.$G_DIETPI_VERSION_RC ($G_GITOWNER/$G_GITBRANCH)"
-        local error_details=$(G_BUG_REPORT)
-
-        [[ ${G_PROGRAM_NAME,,} == 'dietpi-'* ]] && echo -e "\e[41m
-\e[41m
----------------------------------------------------------------------
-- DietPi has encountered an error                                   -
-- Please create a ticket: https://github.com/MichaIng/DietPi/issues -
-- Copy and paste only the BLUE lines below into the ticket          -
----------------------------------------------------------------------\e[44m
-#### Details:
-- Date           | $(date)
-- Command        | \`$ecommand\`
-- Exit code      | $exit_code
-- Software title | $G_PROGRAM_NAME
-$error_details
-#### Steps to reproduce:
-<!-- Explain how to reproduce the issue -->
-1. ...
-2. ...
-#### Expected behaviour:
-<!-- What SHOULD happen? -->
-- ...
-#### Actual behaviour:
-<!-- What IS happening? -->
-- ...
-#### Extra details:
-<!-- Please post any extra details that might help solve the issue -->
-- ...
-#### Additional logs:
-\`\`\`
-$log_content
-\`\`\`\e[41m
----------------------------------------------------------------------\e[0m" > "$fp_error_report"
-
 			# Enter error handler menu loop in interactive mode
+			local last_whip_menu_item sent_bug_report fp_error_report='/tmp/G_EXEC_ERROR_REPORT' dietpi_version="v$G_DIETPI_VERSION_CORE.$G_DIETPI_VERSION_SUB.$G_DIETPI_VERSION_RC ($G_GITOWNER/$G_GITBRANCH)"
 			[[ $G_INTERACTIVE == 1 ]] && while :
 			do
 				G_WHIP_MENU_ARRAY=('Retry' ': Re-run the last command that failed')
@@ -948,8 +944,12 @@ $log_content
 				pgrep -cf 'dietpi-config' &> /dev/null || G_WHIP_MENU_ARRAY+=('DietPi-Config' ': Edit network, APT/NTP mirror settings etc')
 				G_WHIP_MENU_ARRAY+=('Open subshell' ': Open a subshell to investigate or solve the issue')
 
-                # Allow to send bug report, if it was produced by one of our scripts
-				[[ ${G_PROGRAM_NAME,,} == 'dietpi-'* && $G_PROGRAM_NAME != 'DietPi-Installer' ]] && G_WHIP_MENU_ARRAY+=('Send report' ': Uploads bugreport containing system info to DietPi')
+				# Allow to send bug report if it was produced by one of our scripts, excluding DietPi-Installer
+				[[ ${G_PROGRAM_NAME,,} == 'dietpi-'* && $G_PROGRAM_NAME != 'DietPi-Installer' ]] && G_WHIP_MENU_ARRAY+=('Send report' ': Upload bug report including system info to DietPi')
+
+				# Allow to print bug report template if it was produced by one of our scripts
+				[[ ${G_PROGRAM_NAME,,} == 'dietpi-'* ]] && G_WHIP_MENU_ARRAY+=('Print report' ': Print bug report template for GitHub or forum')
+
 				G_WHIP_MENU_ARRAY+=('' '●─ Devs only ')
 				G_WHIP_MENU_ARRAY+=('Change command' ': Adjust and rerun the command')
 
@@ -959,8 +959,8 @@ $log_content
 				G_WHIP_MENU "${G_EXEC_DESC:+$(mawk '{gsub("\\\e[[0-9][;0-9]*m","");print}' <<< "$G_EXEC_DESC")\n} - Command: ${acommand[*]}
  - Exit code: $exit_code
  - DietPi version: $dietpi_version | HW_MODEL: $G_HW_MODEL | HW_ARCH: $G_HW_ARCH | DISTRO: $G_DISTRO
-${image_creator:+ - Image creator: $image_creator\n}${preimage_name:+ - Pre-image: $preimage_name\n} - Error log:
-$log_content" || break # Exit error handler menu loop on cancel
+ - Error log:
+$(<"$fp_log")" || break # Exit error handler menu loop on cancel
 
 				last_whip_menu_item=$G_WHIP_RETURNED_VALUE
 
@@ -987,7 +987,31 @@ $log_content" || break # Exit error handler menu loop on cancel
 
 				elif [[ $G_WHIP_RETURNED_VALUE == 'Send report' ]]; then
 
+					# Store error details to append to bug report upload
+					G_BUG_REPORT -c "${acommand[*]}" -? "$exit_code" > "$fp_error_report"
+
+					# Send report
 					/boot/dietpi/dietpi-bugreport 1 && sent_bug_report=1
+					read -rp '
+Press any key to continue...'
+
+				elif [[ $G_WHIP_RETURNED_VALUE == 'Print report' ]]; then
+
+					echo -e '\e[41m---------------------------------------------------------------------
+- DietPi bug report template for GitHub or forum                    -
+- Please report at: https://github.com/MichaIng/DietPi/issues       -
+                or: https://dietpi.com/forum/c/troubleshooting/10   -
+- Copy and paste ONLY the BLUE lines below, replacing the template! -
+---------------------------------------------------------------------\e[44m'
+					# Add bug report ID if sent already
+					if [[ $sent_bug_report == 1 ]]
+					then
+						sed --follow-symlinks -i "/^- Date           | /a\- Bug report     | $G_HW_UUID" "$fp_error_report"
+						cat "$fp_error_report"
+					else
+						G_BUG_REPORT -c "${acommand[*]}" -? "$exit_code"
+					fi
+					echo -e '\e[41m---------------------------------------------------------------------\e[0m'
 					read -rp '
 Press any key to continue...'
 
@@ -1016,14 +1040,7 @@ Press any key to continue...'
 				fi
 			done
 
-			# Error has not been solved, print GitHub issue template if it was produced and exit error handler menu loop
-			if [[ -f $fp_error_report ]]; then
-
-				# Add bug report ID if it was sent
-				[[ $sent_bug_report == 1 ]] && sed --follow-symlinks -i "/^- Date           | /a\- Bug report     | $G_HW_UUID" "$fp_error_report"
-				cat "$fp_error_report"
-
-			fi
+			# Error has not been solved, exit error handler menu loop
 			break
 		done
 


### PR DESCRIPTION
Users then have to only run `G_BUG_REPORT` to get the informationen needed, they can just copy and paste it from terminal into the forum.

G_EXEC error handler should work like before.

I still need to figure out way to trigger an error in one of  `dietpi-*` functions to test this properly. I tried `dietpi-update` without internet access, but this triggers not the full error handler