### PR TITLE
DietPi-Software | Domoticz: Enable for x86_64 Bookworm/Trixie systems

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ v9.1
 New images:
 
 Enhancements:
+- DietPi-Software | Domoticz: Enabled for x86_64 Bookworm and Trixie systems, since the latest x86_64 builds were compiled against libssl3.
 
 Bug fixes:
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1507,8 +1507,10 @@ Available commands:
 		aSOFTWARE_DESC[$software_id]='Open source home automation platform'
 		aSOFTWARE_CATX[$software_id]=17
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/home_automation/#domoticz'
-		# - Bookworm: No libssl3 support: https://github.com/domoticz/domoticz/issues/5233, https://github.com/MichaIng/DietPi/issues/6404
-		aSOFTWARE_AVAIL_G_DISTRO[$software_id,7]=0
+		# - RISC-V: Missing archive: https://github.com/domoticz/domoticz/releases, https://www.domoticz.com/downloads/
+		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,11]=0
+		# - Bookworm/Trixie ARM: https://github.com/domoticz/domoticz/issues/5233#issuecomment-1904906172
+		(( $G_HW_ARCH < 10 && $G_DISTRO > 6 )) && aSOFTWARE_AVAIL_G_DISTRO[$software_id,$G_DISTRO]=0
 		#------------------
 		software_id=27
 		aSOFTWARE_NAME[$software_id]='TasmoAdmin'
@@ -11422,7 +11424,15 @@ _EOF_
 			# APT deps
 			aDEPS=('libusb-0.1-4' 'libcurl3-gnutls') # https://github.com/MichaIng/DietPi/issues/6404
 
-			Download_Install "https://releases.domoticz.com/releases/release/domoticz_linux_${G_HW_ARCH_NAME/armv6l/armv7l}.tgz" ./domoticz
+			# x86_64 builds provided via GitHub differ from those provided via domoticz.com and were compiled against libssl3. Hence download those for Bookworm/Trixie systems, else the ones from domoticz.com, compiled against libssl1.1. Currently, there are not builds for ARM and libssl3.
+			if (( $G_HW_ARCH == 10 && $G_DISTRO > 6 ))
+			then
+				local fallback_url="https://github.com/domoticz/domoticz/releases/download/2024.1/domoticz_linux_2024.1_${G_HW_ARCH_NAME/armv6l/armv7l}.tgz"
+				Download_Install "$(curl -sSfL 'https://api.github.com/repos/domoticz/domoticz/releases/latest' | mawk -F\" "/^ *\"browser_download_url\": \".*\/domoticz_linux_[^\"\/]*_${G_HW_ARCH_NAME/armv6l/armv7l}.tgz\"$/{print \$4}")" ./domoticz
+			else
+				Download_Install "https://releases.domoticz.com/releases/release/domoticz_linux_${G_HW_ARCH_NAME/armv6l/armv7l}.tgz" ./domoticz
+			fi
+
 			# Reinstall: Clean old install dir
 			[[ -d '/opt/domoticz' ]] && G_EXEC rm -R /opt/domoticz
 			G_EXEC mv domoticz /opt/


### PR DESCRIPTION
This means it won't work on (Buster and) Bookworm anymore: https://github.com/MichaIng/DietPi/actions/runs/7618133516
So we need to pull an earlier version/builds there.

Okay strange, only the `x86_64` builds from GitHub were compiled against libssl3, the ones for ARM and all builds from `domoticz.com` were compiled against libssl1.1. So currently we can only enable it for `x86_64` on Bookworm/Trixie. We need to retest this regularly, as the build system seem to be volatile.