### PR TITLE
DietPi-Build/Installer | Add support for RPi with new kernel/firmware

### DIFF
--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -47,6 +47,7 @@ EDITION=
 SUFFIX=
 ADD_DOS_PART=1
 SIGN_PASS=
+RPI_NEW=0
 while (( $# ))
 do
 	case $1 in
@@ -63,6 +64,7 @@ do
 		'-s') shift; SUFFIX=$1;;
 		'--no-dos-part') ADD_DOS_PART=0;;
 		'--sign') shift; SIGN_PASS=$1;;
+		'--rpi-new') RPI_NEW=1;;
 		*) G_DIETPI-NOTIFY 1 "Invalid input \"$1\", aborting..."; exit 1;;
 	esac
 	shift
@@ -77,6 +79,10 @@ boot_fstype='fat32'
 CLONING_TOOL='dd'
 case $HW_MODEL in
 	0) iname='RPi' HW_ARCH=${HW_ARCH:-1} boot_size=128 root_size=895;;
+	1) iname='RPi1' HW_ARCH=1 boot_size=128 root_size=895;;
+	2) iname='RPi2' HW_ARCH=2 boot_size=128 root_size=895;;
+	4) iname='RPi234' HW_ARCH=3 boot_size=128 root_size=895;;
+	5) iname='RPi5' HW_ARCH=3 boot_size=128 root_size=895;;
 	10) iname='OdroidC1' HW_ARCH=2 partition_start=4 boot_size=128 root_size=700 boot_fstype='fat16';;
 	11) iname='OdroidXU4' HW_ARCH=2 partition_start=4 root_size=764;;
 	12) iname='OdroidC2' HW_ARCH=3 partition_start=4 root_size=892;;
@@ -178,6 +184,16 @@ case $PTTYPE in
 	'gpt') [[ $HW_MODEL == 21 ]] && efi_size=64 iname='NativePC-UEFI' ITYPE='Installer';;
 	*) G_DIETPI-NOTIFY 1 "Invalid partition table type \"$PTTYPE\" passed, aborting..."; exit 1;;
 esac
+
+if (( $RPI_NEW ))
+then
+	(( $HW_MODEL < 10 && $DISTRO > 6 )) || { G_DIETPI-NOTIFY 1 "Invalid flag \"--rpi-new\" passed for hardware model \"$HW_MODEL\" or distro \"$DISTRO\" (${distro^}), aborting..."; exit 1; }
+
+elif (( $HW_MODEL && $HW_MODEL < 10 ))
+then
+	G_DIETPI-NOTIFY 1 "Invalid hardware model \"$HW_MODEL\" passed without flag \"--rpi-new\", aborting..."
+	exit 1
+fi
 
 # Do not add trailing FAT partitions for VM, container and (Clonezilla) installer images, and if there is a boot FAT partition already
 [[ $HW_MODEL == 20 || $HW_MODEL == 75 || $ITYPE == 'Installer' ]] && ADD_DOS_PART=0
@@ -367,12 +383,14 @@ then
 	fi
 	G_EXEC "mkfs.$FSTYPE" "${afs_opts[@]}" "${FP_LOOP}p2"
 	G_EXEC mount "${FP_LOOP}p2" rootfs
-	G_EXEC mkdir rootfs/boot
-	G_EXEC mount "${FP_LOOP}p1" rootfs/boot
+	fp_boot='boot'
+	(( $RPI_NEW )) && fp_boot+='/firmware'
+	G_EXEC mkdir -p "rootfs/$fp_boot"
+	G_EXEC mount "${FP_LOOP}p1" "rootfs/$fp_boot"
 	G_EXEC mkdir rootfs/etc
 	cat << _EOF_ > rootfs/etc/fstab
 PARTUUID=$(lsblk -no PARTUUID "${FP_LOOP}p2") / $FSTYPE noatime,lazytime 0 1
-PARTUUID=$(lsblk -no PARTUUID "${FP_LOOP}p1") /boot $boot_fstype noatime,lazytime 0 2
+PARTUUID=$(lsblk -no PARTUUID "${FP_LOOP}p1") /$fp_boot $boot_fstype noatime,lazytime 0 2
 _EOF_
 # - single partition
 else
@@ -470,6 +488,7 @@ G_EXEC losetup -d "$FP_LOOP"
 export FP_ROOT_DEV CLONING_TOOL OUTPUT_IMG_NAME MOUNT_IT='Off' SKIP_ARCHIVE SKIP_FIRSTBOOT_RESIZE=1
 IMAGER_ARGS=("$OUTPUT_IMG_NAME.img")
 (( $ADD_DOS_PART )) && IMAGER_ARGS+=('--add-dos-part')
+(( $RPI_NEW )) && IMAGER_ARGS+=('--configs-to-boot')
 [[ $SIGN_PASS ]] && IMAGER_ARGS+=('--sign' "$SIGN_PASS")
 if [[ ! $EDITION || $EDITION == 'all' ]]
 then
@@ -501,7 +520,11 @@ then
 
 	# Mount filesystems
 	G_EXEC mkdir rootfs
-	if (( $boot_size ))
+	if (( $RPI_NEW ))
+	then
+		G_EXEC mount "${FP_LOOP}p2" rootfs
+
+	elif (( $boot_size ))
 	then
 		G_EXEC mount "${FP_LOOP}p2" rootfs
 		G_EXEC mount "${FP_LOOP}p1" rootfs/boot
@@ -559,7 +582,11 @@ then
 
 	# Mount filesystems
 	G_EXEC mkdir rootfs
-	if (( $boot_size ))
+	if (( $RPI_NEW ))
+	then
+		G_EXEC mount "${FP_LOOP}p2" rootfs
+
+	elif (( $boot_size ))
 	then
 		G_EXEC mount "${FP_LOOP}p2" rootfs
 		G_EXEC mount "${FP_LOOP}p1" rootfs/boot

--- a/.build/images/dietpi-imager
+++ b/.build/images/dietpi-imager
@@ -62,11 +62,13 @@
 	[[ $SHRINK_ONLY == 1 ]] || SHRINK_ONLY=0
 	[[ $SKIP_ARCHIVE == 1 ]] || SKIP_ARCHIVE=0
 	ADD_DOS_PART=0
+	CONFIGS_TO_BOOT=0
 	SIGN_PASS=
 	while (( $# ))
 	do
 		case $1 in
 			'--add-dos-part') ADD_DOS_PART=1;;
+			'--configs-to-boot') CONFIGS_TO_BOOT=1;;
 			'--sign') shift; SIGN_PASS=$1;;
 			*)
 				if [[ -b $1 ]]
@@ -515,8 +517,23 @@
 		[[ $PART_TABLE_TYPE == 'gpt' ]] && ((IMAGE_SIZE+=34)) || ((IMAGE_SIZE++))
 		((IMAGE_SIZE*=512)) # 512 byte sectors => bytes
 
+		# RPi: Move configs to boot FAT partition to allow easier edit from Windows/macOS
+		if (( $CONFIGS_TO_BOOT ))
+		then
+			local fat_mountpoint=$(mktemp -d)
+			local root_mountpoint=$(mktemp -d)
+			G_EXEC mount "${FP_ROOT_DEV::-1}1" "$fat_mountpoint"
+			G_EXEC mount "$FP_ROOT_DEV" "$root_mountpoint"
+			G_DIETPI-NOTIFY 2 'Copying dietpi.txt and other config files to the DIETPISETUP partition'
+			for f in 'dietpi.txt' 'dietpi-wifi.txt' 'dietpiEnv.txt' 'unattended_pivpn.conf' 'Automation_Custom_PreScript.sh' 'Automation_Custom_Script.sh'
+			do
+				[[ -f $root_mountpoint/boot/$f ]] && G_EXEC cp "$root_mountpoint/boot/$f" "$fat_mountpoint/"
+			done
+			G_EXEC umount "$root_mountpoint" "$fat_mountpoint"
+			G_EXEC rmdir "$root_mountpoint" "$fat_mountpoint"
+
 		# Add trailing FAT partition to simplify first run setup if requested
-		if (( $ADD_DOS_PART ))
+		elif (( $ADD_DOS_PART ))
 		then
 			G_DIETPI-NOTIFY 2 'Adding a 1 MiB FAT partition to simplify first run setup'
 			((IMAGE_SIZE+=1048576))

--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -322,14 +322,35 @@ _EOF_
 		G_WHIP_BUTTON_CANCEL_TEXT='Exit'
 		G_WHIP_DEFAULT_ITEM=0
 		case $G_HW_ARCH in
-			1) G_WHIP_MENU_ARRAY=('0' ': Raspberry Pi (all models)');;
+			1)
+				if findmnt -M /boot/firmware &> /dev/null
+				then
+					G_WHIP_MENU_ARRAY=(
+						'0' ': Raspberry Pi (all models)'
+						'1' ': Raspberry Pi 1+Zero (1)'
+						'2' ': Raspberry Pi 2+3'
+						'4' ': Raspberry Pi 4+5'
+					)
+				else
+					G_WHIP_MENU_ARRAY=('0' ': Raspberry Pi 1-4')
+				fi
+			;;
 			2|3)
 				userland_arch=$(dpkg --print-architecture)
 				G_DIETPI-NOTIFY 2 "Detected target userland/OS architecture: $userland_arch"
 				if [[ $userland_arch == 'armhf' ]]
 				then
-					G_WHIP_MENU_ARRAY=(
-						'0' ': Raspberry Pi 2 - 4'
+					if findmnt -M /boot/firmware &> /dev/null
+					then
+						G_WHIP_MENU_ARRAY=(
+							'0' ': Raspberry Pi 2-5'
+							'2' ': Raspberry Pi 2+3'
+							'4' ': Raspberry Pi 4+5'
+						)
+					else
+						G_WHIP_MENU_ARRAY=('0' ': Raspberry Pi 2-4')
+					fi
+					G_WHIP_MENU_ARRAY+=(
 						'10' ': Odroid C1'
 						'11' ': Odroid XU3/XU4/MC1/HC1/HC2'
 						'13' ': Odroid U3'
@@ -347,8 +368,17 @@ _EOF_
 
 				elif [[ $userland_arch == 'arm64' ]]
 				then
-					G_WHIP_MENU_ARRAY=(
-						'0' ': Raspberry Pi 2 (v1.2) - 4'
+					if findmnt -M /boot/firmware &> /dev/null
+					then
+						G_WHIP_MENU_ARRAY=(
+							'0' ': Raspberry Pi 2-5 (page size: 4k and 16k)'
+							'4' ': Raspberry Pi 2-5 (page size: 4k only)'
+							'5' ': Raspberry Pi 5 (page size: 16k only)'
+						)
+					else
+						G_WHIP_MENU_ARRAY=('0' ': Raspberry Pi 2-4')
+					fi
+					G_WHIP_MENU_ARRAY+=(
 						'12' ': Odroid C2'
 						'15' ': Odroid N2'
 						'16' ': Odroid C4/HC4'
@@ -558,10 +588,17 @@ _EOF_
 		local armbian_repo=0
 		if (( $G_HW_MODEL < 10 ))
 		then
+			if findmnt -M /boot/firmware &> /dev/null
+			then
+				G_EXEC ln -sf firmware/cmdline.txt /boot/cmdline.txt
+				G_EXEC ln -sf firmware/config.txt /boot/config.txt
+				G_EXEC mv "DietPi-$G_GITBRANCH/.build/images/RPi/config.txt" /boot/firmware/
+			else
+				G_EXEC mv "DietPi-$G_GITBRANCH/.build/images/RPi/config.txt" /boot/
+			fi
 			echo "root=PARTUUID=$(findmnt -Ufnro PARTUUID -M /) rootfstype=$(findmnt -Ufnro FSTYPE -M /) rootwait net.ifnames=0 logo.nologo console=serial0,115200 console=tty1" > /boot/cmdline.txt
-			G_EXEC mv "DietPi-$G_GITBRANCH/.build/images/RPi/config.txt" /boot/
 			# Boot in 64-bit mode if this is a 64-bit image
-			[[ $G_HW_ARCH == 3 ]] && G_CONFIG_INJECT 'arm_64bit=' 'arm_64bit=1' /boot/config.txt
+			[[ $userland_arch == 'arm64' ]] && G_CONFIG_INJECT 'arm_64bit=' 'arm_64bit=1' /boot/config.txt
 
 		elif [[ $G_HW_MODEL =~ ^(10|11)$ ]]
 		then
@@ -1192,7 +1229,34 @@ _EOF_
 			(( $G_HW_ARCH == 3 )) || a32bit=('raspi-copies-and-fills')
 			# Install our own raspberrypi-sys-mods
 			G_EXEC curl -sSfO 'https://dietpi.com/downloads/binaries/raspberrypi-sys-mods.deb'
-			G_AGI raspberrypi-bootloader raspberrypi-kernel libraspberrypi0 libraspberrypi-bin ./raspberrypi-sys-mods.deb raspberrypi-archive-keyring "${a32bit[@]}"
+			if findmnt -M /boot/firmware &> /dev/null
+			then
+				local kernel=()
+				case $G_HW_MODEL in
+					0)
+						[[ $userland_arch == 'arm64' ]] || G_EXEC dpkg --add-architecture arm64
+						case $G_HW_ARCH in
+							1) kernel=('linux-image-rpi-v6' 'linux-image-rpi-v7' 'linux-image-rpi-v8');;
+							*)
+								if [[ $userland_arch == 'armhf' ]]
+								then
+									kernel=('linux-image-rpi-v7' 'linux-image-rpi-v8')
+								else
+									kernel=('linux-image-rpi-v8' 'linux-image-rpi-2712')
+								fi
+							;;
+						esac
+					;;
+					1) kernel=('linux-image-rpi-v6');;
+					2) kernel=('linux-image-rpi-v7');;
+					4) kernel=('linux-image-rpi-v8');;
+					5) kernel=('linux-image-rpi-2712');;
+					*) { G_DIETPI-NOTIFY 1 "Unexpected hardware model passed: \"$G_HW_MODEL\". Aborting ..."; exit 1; };;
+				esac
+				G_AGI raspi-firmware "${kernel[@]}" raspi-utils ./raspberrypi-sys-mods.deb raspberrypi-archive-keyring "${a32bit[@]}"
+			else
+				G_AGI raspberrypi-bootloader raspberrypi-kernel libraspberrypi0 libraspberrypi-bin ./raspberrypi-sys-mods.deb raspberrypi-archive-keyring "${a32bit[@]}"
+			fi
 			G_EXEC rm raspberrypi-sys-mods.deb
 
 			# https://github.com/RPi-Distro/raspberrypi-sys-mods/pull/60
@@ -2008,49 +2072,49 @@ _EOF_'
 			/boot/dietpi/func/dietpi-set_hardware rpi-camera disable
 			/boot/dietpi/func/dietpi-set_hardware rpi-codec disable
 
-			# Update USBridgeSig Ethernet driver via postinst kernel script, until it has been merged into official RPi kernel: https://github.com/allocom/USBridgeSig/tree/master/ethernet
-			cat << '_EOF_' > /etc/kernel/postinst.d/dietpi-USBridgeSig
-#!/bin/bash
-# Only available for v7+
-[[ $1 == *'-v7+' ]] || exit 0
-# Only reasonable for USBridgeSig = CM 3+
-grep -q '^Revision.*10.$' /proc/cpuinfo || exit 0
-echo "[ INFO ] Updating ASIX AX88179 driver for kernel $1 with ARM-optimised build"
-echo '[ INFO ] - by Allo: https://github.com/allocom/USBridgeSig/tree/master/ethernet'
-echo '[ INFO ] Estimating required module layout...'
-module_layout=$(modprobe --dump-modversions /lib/modules/$1/kernel/drivers/net/usb/asix.ko | mawk '/module_layout/{print $1;exit}') || exit 0
-echo '[ INFO ] Downloading stable branch driver...'
-if ! curl -#fL "http://3.230.113.73:9011/Allocom/USBridgeSig/stable_rel/rpi-usbs-$1/ax88179_178a.ko" -o /tmp/ax88179_178a.ko ||
-	[[ $module_layout != $(modprobe --dump-modversions /tmp/ax88179_178a.ko | mawk '/module_layout/{print $1;exit}') ]]
-then
-	echo '[ INFO ] No matching stable branch driver found, trying master branch driver...'
-	if ! curl -#fL "http://3.230.113.73:9011/Allocom/USBridgeSig/rpi-usbs-$1/ax88179_178a.ko" -o /tmp/ax88179_178a.ko ||
-		[[ $module_layout != $(modprobe --dump-modversions /tmp/ax88179_178a.ko | mawk '/module_layout/{print $1;exit}') ]]
-	then
-		echo '[ INFO ] No matching driver found, cleaning up and aborting...'
-		rm -fv /tmp/ax88179_178a.ko || :
-		echo '[ INFO ] The default RPi kernel driver will be used instead, which might result in pops and ticks in your audio stream. If so, please try to rerun this script later:'
-		echo " - /etc/kernel/postinst.d/dietpi-USBridgeSig $1"
-		exit 0
-	fi
-fi
-echo '[ INFO ] Installing driver...'
-install -vpm 644 /tmp/ax88179_178a.ko /lib/modules/$1/kernel/drivers/net/usb || exit 0
-echo '[ INFO ] Running depmod...'
-depmod $1 || exit 0
-echo '[ INFO ] All succeeded, cleaning up...'
-rm -v /tmp/ax88179_178a.ko || exit 0
-_EOF_
-			G_EXEC chmod +x /etc/kernel/postinst.d/dietpi-USBridgeSig
-			# Force upgrade now, regardless of current host machine
-			G_EXEC sed --follow-symlinks -i 's/^grep/#grep/' /etc/kernel/postinst.d/dietpi-USBridgeSig
-			for i in /lib/modules/*-v7+
-			do
-				[[ -d $i ]] || continue
-				i=${i##*/}
-				/etc/kernel/postinst.d/dietpi-USBridgeSig "$i"
-			done
-			G_EXEC sed --follow-symlinks -i 's/^#grep/grep/' /etc/kernel/postinst.d/dietpi-USBridgeSig
+			# # Update USBridgeSig Ethernet driver via postinst kernel script, until it has been merged into official RPi kernel: https://github.com/allocom/USBridgeSig/tree/master/ethernet
+			# cat << '_EOF_' > /etc/kernel/postinst.d/dietpi-USBridgeSig
+# #!/bin/bash
+# # Only available for v7+
+# [[ $1 == *'-v7+' ]] || exit 0
+# # Only reasonable for USBridgeSig = CM 3+
+# grep -q '^Revision.*10.$' /proc/cpuinfo || exit 0
+# echo "[ INFO ] Updating ASIX AX88179 driver for kernel $1 with ARM-optimised build"
+# echo '[ INFO ] - by Allo: https://github.com/allocom/USBridgeSig/tree/master/ethernet'
+# echo '[ INFO ] Estimating required module layout...'
+# module_layout=$(modprobe --dump-modversions /lib/modules/$1/kernel/drivers/net/usb/asix.ko | mawk '/module_layout/{print $1;exit}') || exit 0
+# echo '[ INFO ] Downloading stable branch driver...'
+# if ! curl -#fL "http://3.230.113.73:9011/Allocom/USBridgeSig/stable_rel/rpi-usbs-$1/ax88179_178a.ko" -o /tmp/ax88179_178a.ko ||
+	# [[ $module_layout != $(modprobe --dump-modversions /tmp/ax88179_178a.ko | mawk '/module_layout/{print $1;exit}') ]]
+# then
+	# echo '[ INFO ] No matching stable branch driver found, trying master branch driver...'
+	# if ! curl -#fL "http://3.230.113.73:9011/Allocom/USBridgeSig/rpi-usbs-$1/ax88179_178a.ko" -o /tmp/ax88179_178a.ko ||
+		# [[ $module_layout != $(modprobe --dump-modversions /tmp/ax88179_178a.ko | mawk '/module_layout/{print $1;exit}') ]]
+	# then
+		# echo '[ INFO ] No matching driver found, cleaning up and aborting...'
+		# rm -fv /tmp/ax88179_178a.ko || :
+		# echo '[ INFO ] The default RPi kernel driver will be used instead, which might result in pops and ticks in your audio stream. If so, please try to rerun this script later:'
+		# echo " - /etc/kernel/postinst.d/dietpi-USBridgeSig $1"
+		# exit 0
+	# fi
+# fi
+# echo '[ INFO ] Installing driver...'
+# install -vpm 644 /tmp/ax88179_178a.ko /lib/modules/$1/kernel/drivers/net/usb || exit 0
+# echo '[ INFO ] Running depmod...'
+# depmod $1 || exit 0
+# echo '[ INFO ] All succeeded, cleaning up...'
+# rm -v /tmp/ax88179_178a.ko || exit 0
+# _EOF_
+			# G_EXEC chmod +x /etc/kernel/postinst.d/dietpi-USBridgeSig
+			# # Force upgrade now, regardless of current host machine
+			# G_EXEC sed --follow-symlinks -i 's/^grep/#grep/' /etc/kernel/postinst.d/dietpi-USBridgeSig
+			# for i in /lib/modules/*-v7+
+			# do
+				# [[ -d $i ]] || continue
+				# i=${i##*/}
+				# /etc/kernel/postinst.d/dietpi-USBridgeSig "$i"
+			# done
+			# G_EXEC sed --follow-symlinks -i 's/^#grep/grep/' /etc/kernel/postinst.d/dietpi-USBridgeSig
 
 			# For backwards compatibility with software compiled against older libraspberrypi0, create symlinks from old to new filenames
 			if (( $G_HW_ARCH < 3 ))

--- a/rootfs/var/lib/dietpi/services/fs_partition_resize.sh
+++ b/rootfs/var/lib/dietpi/services/fs_partition_resize.sh
@@ -57,6 +57,20 @@
 		rmdir -v "$TMP_MOUNT"
 		# Finally delete the partition so the resizing works
 		sfdisk --no-reread --no-tell-kernel --delete "$ROOT_DRIVE" "${SETUP_PART: -1}"
+
+	elif grep -q '[[:blank:]]/boot/firmware[[:blank:]][[:blank:]]*vfat[[:blank:]]' /etc/fstab
+	then
+		BOOT_PART=$(mawk '/[[:blank:]]\/boot\/firmware[[:blank:]][[:blank:]]*vfat[[:blank:]]/{print $1}' /etc/fstab)
+		echo "[ INFO ] Detected RPi boot/firmware partition $BOOT_PART"
+		# Mount it and copy files if present and newer
+		TMP_MOUNT=$(mktemp -d)
+		mount -v "$BOOT_PART" "$TMP_MOUNT"
+		for f in 'dietpi.txt' 'dietpi-wifi.txt' 'dietpiEnv.txt' 'unattended_pivpn.conf' 'Automation_Custom_PreScript.sh' 'Automation_Custom_Script.sh'
+		do
+			[[ -f $TMP_MOUNT/$f ]] && cp -uv "$TMP_MOUNT/$f" /boot/
+		done
+		umount -v "$BOOT_PART"
+		rmdir -v "$TMP_MOUNT"
 	else
 		echo "[ INFO ] No DietPi setup partition found, last partition is: \"$LAST_PART\""
 		lsblk -po NAME,LABEL,SIZE,TYPE,FSTYPE,MOUNTPOINT "$ROOT_DRIVE"


### PR DESCRIPTION
- DietPi-Build/Installer | Start adding support for building RPi images with new firmware packages
- DietPi-Image/FS_partition_resize | Add support for DietPi config files and firstboot scripts on new RPi boot/firmware partition. Since the new RPi firmware packages require the boot FAT partition to be mounted at /boot/firmware, RPi firstboot automation does not work anymore. It is hence now handled similar to the trailing setup FAT partition used on other SBCs: With a related flag, the DietPi-Imager copies related files from /boot (rootfs) to the boot FAT partition, expected to be partition 1. The DietPi-FS_partition_resize script mounts this partition and copies all files over to /boot, replacing the ones there, if older.

First RPi 5 build test: https://github.com/MichaIng/DietPi/actions/runs/7702912169