### PR TITLE
DietPi-Build/Installer | Backport minor fixes to beta

### DIFF
--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -122,8 +122,8 @@ case $HW_MODEL in
 	'68.2') iname='NanoPCT4' HW_ARCH=3 partition_start=16 root_size=880;;
 	'68.3') iname='NanoPiNEO4' HW_ARCH=3 partition_start=16 root_size=880;;
 	70) iname='SparkySBC' HW_ARCH=2 partition_start=8 boot_size=48 root_size=712 boot_fstype='fat16';;
-	'72.1') iname='ROCKPi4' HW_ARCH=3 partition_start=16 root_size=880;;
-	'72.2') iname='ROCK4SE' HW_ARCH=3 partition_start=16 root_size=880;;
+	'72.1') iname='ROCKPi4' HW_ARCH=3 partition_start=16 root_size=1008;;
+	'72.2') iname='ROCK4SE' HW_ARCH=3 partition_start=16 root_size=1008;;
 	73) iname='ROCKPiS' HW_ARCH=3 partition_start=16 root_size=880;;
 	74) iname='RadxaZero' HW_ARCH=3 partition_start=4 root_size=892;;
 	75) iname='Container' HW_ARCH=${HW_ARCH:-10} root_size=447;;
@@ -137,8 +137,8 @@ case $HW_MODEL in
 	80) iname='OrangePi5' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size=880;;
 	81) iname='VisionFive2' HW_ARCH=11 root_size=639;;
 	82) iname='OrangePi5Plus' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size=880;;
-	'83.1') iname='OrangePiZero3' HW_ARCH=3 partition_start=4 root_size=892;;
-	'83.2') iname='OrangePiZero3-1.5G' HW_ARCH=3 partition_start=4 root_size=892;;
+	'83.1') iname='OrangePiZero3' HW_ARCH=3 partition_start=4 root_size=1020;;
+	'83.2') iname='OrangePiZero3-1.5G' HW_ARCH=3 partition_start=4 root_size=1020;;
 	84) iname='Star64' HW_ARCH=11 root_size=639;;
 	85) iname='ROCK5A' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size=880;;
 	86) iname='ASUSTB2' HW_ARCH=3 partition_start=16 root_size=880;;

--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -1538,11 +1538,11 @@ _EOF_
 		dpkg-query -s usrmerge &> /dev/null && G_AGP usrmerge
 
 		# Remove old gcc-*-base packages, e.g. accumulated on Raspberry Pi OS images
+		# shellcheck disable=SC2015
 		case $G_DISTRO in
 			5) mapfile -t apackages < <(dpkg --get-selections 'gcc-*-base' | mawk '$1!~/^gcc-8-/{print $1}');;
 			6) mapfile -t apackages < <(dpkg --get-selections 'gcc-*-base' | mawk '$1!~/^gcc-10-/{print $1}');;
 			7) mapfile -t apackages < <(dpkg --get-selections 'gcc-*-base' | mawk '$1!~/^gcc-12-/{print $1}');;
-			# shellcheck disable=SC2015
 			8) dpkg-query -s 'gcc-14-base' &> /dev/null && mapfile -t apackages < <(dpkg --get-selections 'gcc-*-base' | mawk '$1!~/^gcc-14-/{print $1}') || mapfile -t apackages < <(dpkg --get-selections 'gcc-*-base' | mawk '$1!~/^gcc-13-/{print $1}');; # Temporary workaround for Raspbian Trixie not shipping gcc-14-base yet
 			*) :;;
 		esac

--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -788,9 +788,6 @@ setenv rootuuid "true"' /boot/boot.cmd
 		G_CONFIG_INJECT 'DEV_GITOWNER=' "DEV_GITOWNER=$G_GITOWNER" /boot/dietpi.txt
 		G_VERSIONDB_SAVE
 
-		# Temporary fix for resizing on Bullseye until v9.1 has been released: https://github.com/MichaIng/DietPi/issues/6900
-		(( $G_DISTRO < 7 )) && G_EXEC sed -i 's/MOUNTPOINTS/MOUNTPOINT/' /var/lib/dietpi/services/fs_partition_resize.sh
-
 		# Apply live patches
 		G_DIETPI-NOTIFY 2 'Applying DietPi live patches to fix known bugs in this version'
 		for i in "${!G_LIVE_PATCH[@]}"
@@ -1545,7 +1542,7 @@ _EOF_
 			5) mapfile -t apackages < <(dpkg --get-selections 'gcc-*-base' | mawk '$1!~/^gcc-8-/{print $1}');;
 			6) mapfile -t apackages < <(dpkg --get-selections 'gcc-*-base' | mawk '$1!~/^gcc-10-/{print $1}');;
 			7) mapfile -t apackages < <(dpkg --get-selections 'gcc-*-base' | mawk '$1!~/^gcc-12-/{print $1}');;
-			8) mapfile -t apackages < <(dpkg --get-selections 'gcc-*-base' | mawk '$1!~/^gcc-14-/{print $1}');;
+			8) dpkg-query -s 'gcc-14-base' &> /dev/null && mapfile -t apackages < <(dpkg --get-selections 'gcc-*-base' | mawk '$1!~/^gcc-14-/{print $1}') || mapfile -t apackages < <(dpkg --get-selections 'gcc-*-base' | mawk '$1!~/^gcc-13-/{print $1}');; # Temporary workaround for Raspbian Trixie not shipping gcc-14-base yet
 			*) :;;
 		esac
 		[[ ${apackages[0]} ]] && G_AGP "${apackages[@]}"

--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -1542,6 +1542,7 @@ _EOF_
 			5) mapfile -t apackages < <(dpkg --get-selections 'gcc-*-base' | mawk '$1!~/^gcc-8-/{print $1}');;
 			6) mapfile -t apackages < <(dpkg --get-selections 'gcc-*-base' | mawk '$1!~/^gcc-10-/{print $1}');;
 			7) mapfile -t apackages < <(dpkg --get-selections 'gcc-*-base' | mawk '$1!~/^gcc-12-/{print $1}');;
+			# shellcheck disable=SC2015
 			8) dpkg-query -s 'gcc-14-base' &> /dev/null && mapfile -t apackages < <(dpkg --get-selections 'gcc-*-base' | mawk '$1!~/^gcc-14-/{print $1}') || mapfile -t apackages < <(dpkg --get-selections 'gcc-*-base' | mawk '$1!~/^gcc-13-/{print $1}');; # Temporary workaround for Raspbian Trixie not shipping gcc-14-base yet
 			*) :;;
 		esac


### PR DESCRIPTION
- DietPi-Build | Raise size of ROCK 4 and Orange Pi Zero 3 rootfs, required for armbian-firmware installation
- DietPi-Installer | Work around Raspbian Trixie being out of sync, shipping gcc-14 souce packages, but not gcc-14-base: https://bugs.launchpad.net/raspbian/+bug/2052306