### PR TITLE
Live patch 0 | Fix Nextcloud Nginx config, serving wrong MIME types

### DIFF
--- a/.conf/dps_114/nginx.nextcloud.conf
+++ b/.conf/dps_114/nginx.nextcloud.conf
@@ -79,7 +79,7 @@ location ^~ /nextcloud {
 
 	include mime.types;
 	types {
-		text/javascript js mjs;
+		text/javascript mjs;
 		application/wasm wasm;
 	}
 

--- a/.update/version
+++ b/.update/version
@@ -14,6 +14,6 @@ G_MIN_DEBIAN=6
 # Alternative Git branch to automatically migrate to when Debian version is too low
 G_OLD_DEBIAN_BRANCH='8'
 # Live patches
-G_LIVE_PATCH_DESC=()
-G_LIVE_PATCH_COND=()
-G_LIVE_PATCH=()
+G_LIVE_PATCH_DESC=('Fix Nextcloud Nginx config, serving wrong MIME types')
+G_LIVE_PATCH_COND=('[[ -f /etc/nginx/sites-dietpi/dietpi-nextcloud.conf ]] && ! grep -q '\''include mime.types;'\'' /etc/nginx/sites-dietpi/dietpi-nextcloud.conf')
+G_LIVE_PATCH=('sed -i '\''/types {/i\\tinclude mime.types;'\'' /etc/nginx/sites-dietpi/dietpi-nextcloud.conf; systemctl -q is-active nginx && systemctl restart nginx')


### PR DESCRIPTION
- https://dietpi.com/forum/t/nextcloud-theme-broken-after-upgrade-v9-1-1/19372
- Fix in `dev` and patch for next DietPi update: https://github.com/MichaIng/DietPi/commit/bd9b374
- Backport to `master`, required for those which install Nextcloud freshly when on v9.1 already. The live patch is applied or skipped on any DietPi update check. In both cases it is not considered anymore afterwards, hence fresh Nextcloud installs would be bugged: https://github.com/MichaIng/DietPi/commit/81b1509

Additionally solves a visual-only warning about duplicate `js` MIME type mapping.