### PR TITLE
install stage0: log to firstrunsetup

### DIFF
--- a/dietpi/dietpi-login
+++ b/dietpi/dietpi-login
@@ -185,7 +185,7 @@ Please login again as user "root" with password "dietpi", respectively the one y
 			if (( $G_DIETPI_INSTALL_STAGE == 0 )); then
 
 				# Start DietPi-Update
-				/boot/dietpi/dietpi-update 1 # Sets /boot/dietpi/.install_stage > G_DIETPI_INSTALL_STAGE=1
+				/boot/dietpi/dietpi-update 1 2>&1 | tee "$FP_DIETPI_FIRSTRUNSETUP_LOG" # Sets /boot/dietpi/.install_stage > G_DIETPI_INSTALL_STAGE=1
 
 				# Prompt on failure
 				(( $(</boot/dietpi/.install_stage) == 1 )) || Prompt_on_Failure
@@ -194,7 +194,7 @@ Please login again as user "root" with password "dietpi", respectively the one y
 			elif (( $G_DIETPI_INSTALL_STAGE == 1 )); then
 
 				# Start DietPi-Software
-				/boot/dietpi/dietpi-software 2>&1 | tee "$FP_DIETPI_FIRSTRUNSETUP_LOG" # Sets /boot/dietpi/.install_stage > G_DIETPI_INSTALL_STAGE=2
+				/boot/dietpi/dietpi-software 2>&1 | tee -a "$FP_DIETPI_FIRSTRUNSETUP_LOG" # Sets /boot/dietpi/.install_stage > G_DIETPI_INSTALL_STAGE=2
 
 				# Prompt on failure
 				(( $(</boot/dietpi/.install_stage) == 2 )) || Prompt_on_Failure


### PR DESCRIPTION
When debugging firstrun issues, stage0 doesn't have any logs which makes it hard to debug.

Log stage0 to /var/tmp/dietpi/logs/dietpi-firstrun-setup.log
Change stage1 logging to append to this log instead of clobbering it.

This could probably be also fixed to improving logging to dietpi-update.log (it only starts with 'Applying pre-patches' and doesn't include the requirement check / checking for available updates)
But in case of install stage 0 / 1 failure, the user is asked to provide the firstrun-setup.log so it seems somewhat logical to just use that.