### PR TITLE
Release v9.3

### DIFF
--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -964,7 +964,7 @@ setenv rootuuid "true"' /boot/boot.cmd
 		fi
 
 		# Assure that dir for additional sources is present
-		[[ -d '/etc/apt/sources.list.d' ]] || G_EXEC mkdir /etc/apt/sources.list.d
+		G_EXEC mkdir -p /etc/apt/sources.list.d
 
 		### Kernel/bootloader/initramfs packages: We need to install those directly to allow G_AGA() autoremove possible older packages later: https://github.com/MichaIng/DietPi/issues/1285#issuecomment-354602594
 
@@ -1037,7 +1037,7 @@ _EOF_
 			# Remove obsolete lists
 			G_EXEC rm -Rf /etc/apt/sources.list.d/*
 			# Add Armbian repository
-			G_EXEC eval "echo 'deb https://apt.armbian.com/ ${DISTRO_TARGET_NAME/bullseye/bookworm} main' > /etc/apt/sources.list.d/dietpi-armbian.list"
+			G_EXEC eval "echo 'deb https://apt.armbian.com ${DISTRO_TARGET_NAME/bullseye/bookworm} main' > /etc/apt/sources.list.d/dietpi-armbian.list"
 			# Update APT lists
 			G_AGUP
 			# Install kernel, device tree, U-Boot, firmware and initramfs packages
@@ -1448,7 +1448,7 @@ _EOF_
 
 			# Remove obsolete components from Armbian list and connect via HTTPS
 			G_EXEC rm -Rf /etc/apt/sources.list.d/{,.??,.[^.]}*
-			G_EXEC eval "echo 'deb https://apt.armbian.com/ $DISTRO_TARGET_NAME main' > /etc/apt/sources.list.d/dietpi-armbian.list"
+			G_EXEC eval "echo 'deb https://apt.armbian.com $DISTRO_TARGET_NAME main' > /etc/apt/sources.list.d/dietpi-armbian.list"
 
 			# Skip creating kernel symlinks and remove existing ones
 			if [[ -L '/vmlinuz' ]]

--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -1194,7 +1194,7 @@ _EOF_
 			elif (( $G_HW_MODEL == 74 ))
 			then
 				G_AGI device-tree-compiler
-				[[ -d '/boot/overlay-user' ]] || G_EXEC mkdir /boot/overlay-user
+				G_EXEC mkdir -p /boot/overlay-user
 				cat << '_EOF_' > /boot/overlay-user/dietpi-usb-otg.dts
 /dts-v1/;
 /plugin/;
@@ -1284,6 +1284,14 @@ _EOF_
 			[[ -f '/usr/share/keyrings/raspbian-archive-keyring.gpg' ]] && G_EXEC ln -sf /usr/share/keyrings/raspbian-archive-keyring.gpg /etc/apt/trusted.gpg.d/raspbian-archive-keyring.gpg
 			[[ -f '/etc/apt/trusted.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg
 			[[ -f '/etc/apt/trusted.gpg~' ]] && G_EXEC rm '/etc/apt/trusted.gpg~'
+
+			# Skip creating kernel symlinks and remove existing ones
+			if [[ -L '/vmlinuz' ]]
+			then
+				G_DIETPI-NOTIFY 2 'Preventing obsolete kernel and initramfs symlink generation'
+				G_EXEC eval 'echo '\''do_symlinks=0'\'' > /etc/kernel-img.conf'
+				G_EXEC rm -f /{initrd.img,vmlinuz}{,.old}
+			fi
 
 		# Quartz64
 		elif [[ $G_HW_MODEL == 49 && $(findmnt -Ufnro TARGET -T /boot) == '/' ]]
@@ -1476,10 +1484,6 @@ _EOF_
 			if dpkg-query -s 'armbian-firmware' &> /dev/null
 			then
 				aPACKAGES_REQUIRED_INSTALL+=('armbian-firmware')
-
-			elif dpkg-query -s 'orangepi-firmware' &> /dev/null
-			then
-				aPACKAGES_REQUIRED_INSTALL+=('orangepi-firmware')
 			else
 				aPACKAGES_REQUIRED_INSTALL+=('firmware-linux-free')	# Free misc
 				aPACKAGES_REQUIRED_INSTALL+=('firmware-misc-nonfree')	# Non-free misc incl. Ralink and MediaTek WiFi/BT

--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -816,7 +816,7 @@ setenv rootuuid "true"' /boot/boot.cmd
 		G_DIETPI-NOTIFY 2 "Setting APT sources.list: $DISTRO_TARGET_NAME $DISTRO_TARGET"
 
 		# We need to forward $DISTRO_TARGET* to dietpi-set_software, as well as $G_HW_MODEL + $G_RASPBIAN for Debian vs Raspbian decision.
-		G_DISTRO=$DISTRO_TARGET G_DISTRO_NAME=$DISTRO_TARGET_NAME G_HW_ARCH=$G_HW_ARCH G_HW_MODEL=$G_HW_MODEL G_RASPBIAN=$G_RASPBIAN G_EXEC /boot/dietpi/func/dietpi-set_software apt-mirror default
+		G_DISTRO=$DISTRO_TARGET G_DISTRO_NAME=$DISTRO_TARGET_NAME G_HW_ARCH=$G_HW_ARCH G_HW_MODEL=$G_HW_MODEL G_RASPBIAN=$G_RASPBIAN HW_VARIANT=$HW_VARIANT G_EXEC /boot/dietpi/func/dietpi-set_software apt-mirror default
 
 		# (Re)create DietPi runtime and logs dir, used by G_AGx
 		G_EXEC mkdir -p /run/dietpi /var/tmp/dietpi/logs

--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -1151,14 +1151,13 @@ _EOF_
 			G_AGI initramfs-tools u-boot-tools armbian-firmware "${zstd[@]}"
 			[[ ${zstd[0]} ]] && G_CONFIG_INJECT 'COMPRESS=' 'COMPRESS=zstd' /etc/initramfs-tools/initramfs.conf
 			# Download and pre-install kernel hosted on dietpi.com where the Armbian APT repo provides a too old version
-			# - NanoPi R4S: Solve Ethernet adapter disappearing on soft reboot: https://github.com/MichaIng/DietPi/issues/6342
-			if [[ ( $G_HW_MODEL == 72 && $HW_VARIANT == 2 ) || $G_HW_MODEL =~ ^(47|76|83)$ ]]
+			if (( $G_HW_MODEL == 83 ))
 			then
 				G_EXEC_OUTPUT=1 G_EXEC curl -fo package1.deb "https://dietpi.com/downloads/binaries/linux-image-$branch-$kernel.deb"
 				G_EXEC_OUTPUT=1 G_EXEC curl -fo package2.deb "https://dietpi.com/downloads/binaries/linux-dtb-$branch-$kernel.deb"
 				G_EXEC_OUTPUT=1 G_EXEC curl -fo package3.deb 'https://dietpi.com/downloads/binaries/armbian-firmware.deb'
 				local uboot=()
-				[[ $G_HW_MODEL == 76 || ( $G_HW_MODEL == 83 && $HW_VARIANT == 1 ) ]] && { G_EXEC_OUTPUT=1 G_EXEC curl -fo package4.deb "https://dietpi.com/downloads/binaries/linux-u-boot-$model-$branch.deb"; uboot=('package4.deb'); }
+				#(( $G_HW_MODEL == 83 )) && (( $HW_VARIANT == 1 )) && { G_EXEC_OUTPUT=1 G_EXEC curl -fo package4.deb "https://dietpi.com/downloads/binaries/linux-u-boot-$model-$branch.deb"; uboot=('package4.deb'); }
 				G_EXEC_OUTPUT=1 G_EXEC dpkg -i package1.deb package2.deb package3.deb "${uboot[@]}"
 				G_EXEC rm package1.deb package2.deb package3.deb "${uboot[@]}"
 			fi

--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -1037,7 +1037,7 @@ _EOF_
 			# Remove obsolete lists
 			G_EXEC rm -Rf /etc/apt/sources.list.d/*
 			# Add Armbian repository
-			G_EXEC eval "echo 'deb https://apt.armbian.com/ $DISTRO_TARGET_NAME main' > /etc/apt/sources.list.d/dietpi-armbian.list"
+			G_EXEC eval "echo 'deb https://apt.armbian.com/ ${DISTRO_TARGET_NAME/bullseye/bookworm} main' > /etc/apt/sources.list.d/dietpi-armbian.list"
 			# Update APT lists
 			G_AGUP
 			# Install kernel, device tree, U-Boot, firmware and initramfs packages

--- a/.build/software/Amiberry/build.bash
+++ b/.build/software/Amiberry/build.bash
@@ -207,15 +207,12 @@ Package: amiberry
 Version: $v_ami
 Architecture: $(dpkg --print-architecture)
 Maintainer: MichaIng <micha@dietpi.com>
-Date: $(date -u '+%a, %d %b %Y %T %z')
-Standards-Version: 4.6.2.0
+Date: $(date -uR)
 Installed-Size: $(du -sk "$DIR" | mawk '{print $1}')
 Depends:$DEPS_APT_VERSIONED
 Section: games
 Priority: optional
 Homepage: https://amiberry.com/
-Vcs-Git: https://github.com/BlitterStudio/amiberry.git
-Vcs-Browser: https://github.com/BlitterStudio/amiberry
 Description: Optimized Amiga emulator for the Raspberry Pi and other ARM boards
  This package ships with optimized libSDL2 and capsimg builds.
 _EOF_

--- a/.build/software/gmediarender/build.bash
+++ b/.build/software/gmediarender/build.bash
@@ -182,15 +182,12 @@ Package: $name
 Version: $version-$suffix
 Architecture: $(dpkg --print-architecture)
 Maintainer: MichaIng <micha@dietpi.com>
-Date: $(date -u '+%a, %d %b %Y %T %z')
-Standards-Version: 4.6.2.0
+Date: $(date -uR)
 Installed-Size: $(du -sk "$DIR" | mawk '{print $1}')
 Depends:$DEPS_APT_VERSIONED
 Section: sound
 Priority: optional
 Homepage: $repo
-Vcs-Git: $repo.git
-Vcs-Browser: $repo
 Description: Minimalist UPNP AV renderer
  gmrender-resurrect is a minimalist UPNP AV renderer that can be used to
  play music controlled by a UPNP AV control point.  This package contains

--- a/.build/software/gmediarender/build.bash
+++ b/.build/software/gmediarender/build.bash
@@ -9,7 +9,8 @@ adeps=('libc6' 'gstreamer1.0-alsa' 'gstreamer1.0-libav' 'gstreamer1.0-plugins-go
 (( $G_DISTRO > 7 )) && adeps+=('libupnp17') || adeps+=('libupnp13')
 for i in "${adeps[@]}"
 do
-	dpkg-query -s "$i" &> /dev/null && continue
+	# Temporarily allow lib*t64 packages, while the 64-bit time_t transition is ongoing on Sid: https://bugs.debian.org/1065394
+	dpkg-query -s "$i" &> /dev/null || dpkg-query -s "${i}t64" &> /dev/null && continue
 	G_DIETPI-NOTIFY 1 "Expected dependency package was not installed: $i"
 	exit 1
 done
@@ -163,6 +164,8 @@ find "$DIR" ! \( -path "$DIR/DEBIAN" -prune \) -type f -exec md5sum {} + | sed "
 DEPS_APT_VERSIONED=
 for i in "${adeps[@]}"
 do
+	# Temporarily allow lib*t64 packages, while the 64-bit time_t transition is ongoing on Sid: https://bugs.debian.org/1065394
+	dpkg-query -s "$i" &> /dev/null || i+='t64'
 	DEPS_APT_VERSIONED+=" $i (>= $(dpkg-query -Wf '${VERSION}' "$i")),"
 done
 DEPS_APT_VERSIONED=${DEPS_APT_VERSIONED%,}

--- a/.build/software/raspberrypi-sys-mods/build.bash
+++ b/.build/software/raspberrypi-sys-mods/build.bash
@@ -54,14 +54,11 @@ Package: raspberrypi-sys-mods
 Version: 2:20230510-dietpi2
 Architecture: all
 Maintainer: MichaIng <micha@dietpi.com>
-Date: $(date -u '+%a, %d %b %Y %T %z')
-Standards-Version: 4.6.2.0
+Date: $(date -uR)
 Installed-Size: $(du -sk raspberrypi-sys-mods | mawk '{print $1}')
 Section: admin
 Priority: optional
 Homepage: https://github.com/RPi-Distro/raspberrypi-sys-mods
-Vcs-Git: https://github.com/RPi-Distro/raspberrypi-sys-mods.git
-Vcs-Browser: https://github.com/RPi-Distro/raspberrypi-sys-mods
 Description: System tweaks for the Raspberry Pi, DietPi edition
 _EOF_
 G_CONFIG_INJECT 'Installed-Size: ' "Installed-Size: $(du -sk raspberrypi-sys-mods | mawk '{print $1}')" raspberrypi-sys-mods/DEBIAN/control

--- a/.build/software/shairport-sync/build.bash
+++ b/.build/software/shairport-sync/build.bash
@@ -22,7 +22,8 @@ case $G_DISTRO in
 esac
 for i in "${adeps[@]}" "${adeps2[@]}"
 do
-	dpkg-query -s "$i" &> /dev/null && continue
+	# Temporarily allow lib*t64 packages, while the 64-bit time_t transition is ongoing on Sid: https://bugs.debian.org/1065394
+	dpkg-query -s "$i" &> /dev/null || dpkg-query -s "${i}t64" &> /dev/null && continue
 	G_DIETPI-NOTIFY 1 "Expected dependency package was not installed: $i"
 	exit 1
 done
@@ -348,6 +349,8 @@ find "$DIR" ! \( -path "$DIR/DEBIAN" -prune \) -type f -exec md5sum {} + | sed "
 DEPS_APT_VERSIONED=
 for i in "${adeps[@]}"
 do
+	# Temporarily allow lib*t64 packages, while the 64-bit time_t transition is ongoing on Sid: https://bugs.debian.org/1065394
+	dpkg-query -s "$i" &> /dev/null || i+='t64'
 	DEPS_APT_VERSIONED+=" $i (>= $(dpkg-query -Wf '${VERSION}' "$i")),"
 done
 DEPS_APT_VERSIONED=${DEPS_APT_VERSIONED%,}
@@ -528,6 +531,8 @@ find "$DIR" ! \( -path "$DIR/DEBIAN" -prune \) -type f -exec md5sum {} + | sed "
 # - Obtain DEB dependency versions
 for i in "${adeps2[@]}"
 do
+	# Temporarily allow lib*t64 packages, while the 64-bit time_t transition is ongoing on Sid: https://bugs.debian.org/1065394
+	dpkg-query -s "$i" &> /dev/null || i+='t64'
 	DEPS_APT_VERSIONED+=", $i (>= $(dpkg-query -Wf '${VERSION}' "$i"))"
 done
 # shellcheck disable=SC2001

--- a/.build/software/shairport-sync/build.bash
+++ b/.build/software/shairport-sync/build.bash
@@ -539,16 +539,13 @@ Package: $name-airplay2
 Version: $version-$suffix
 Architecture: $(dpkg --print-architecture)
 Maintainer: MichaIng <micha@dietpi.com>
-Date: $(date -u '+%a, %d %b %Y %T %z')
-Standards-Version: 4.6.2.0
+Date: $(date -uR)
 Installed-Size: $(du -sk "$DIR" | mawk '{print $1}')
 Depends:$DEPS_APT_VERSIONED
 Conflicts: $name
 Section: sound
 Priority: optional
 Homepage: $repo
-Vcs-Git: $repo.git
-Vcs-Browser: $repo
 Description: AirPlay audio player
  Plays audio streamed from iTunes, iOS devices and third-party AirPlay
  sources such as ForkedDaapd and others. Audio played by a Shairport

--- a/.build/software/squeezelite/build.bash
+++ b/.build/software/squeezelite/build.bash
@@ -164,16 +164,13 @@ Package: squeezelite
 Version: $version-$suffix
 Architecture: $(dpkg --print-architecture)
 Maintainer: MichaIng <micha@dietpi.com>
-Date: $(date -u '+%a, %d %b %Y %T %z')
-Standards-Version: 4.6.2.0
+Date: $(date -uR)
 Installed-Size: $(du -sk "$DIR" | mawk '{print $1}')
 Depends:$DEPS_APT_VERSIONED
 Conflicts: squeezelite-pa, squeezelite-pulseaudio
 Section: sound
 Priority: optional
 Homepage: https://github.com/ralph-irving/squeezelite
-Vcs-Git: https://github.com/ralph-irving/squeezelite.git
-Vcs-Browser: https://github.com/ralph-irving/squeezelite
 Description: lightweight headless Squeezebox emulator - ALSA version
  Squeezelite is a small headless Squeezebox emulator. It is aimed at
  supporting high quality audio including USB DAC based output at multiple

--- a/.build/software/vaultwarden/build.bash
+++ b/.build/software/vaultwarden/build.bash
@@ -227,15 +227,12 @@ Package: vaultwarden
 Version: $version
 Architecture: $(dpkg --print-architecture)
 Maintainer: MichaIng <micha@dietpi.com>
-Date: $(date -u '+%a, %d %b %Y %T %z')
-Standards-Version: 4.6.2.0
+Date: $(date -uR)
 Installed-Size: $(du -sk "$DIR" | mawk '{print $1}')
 Depends:$DEPS_APT_VERSIONED
 Section: misc
 Priority: optional
 Homepage: https://github.com/dani-garcia/vaultwarden
-Vcs-Git: https://github.com/dani-garcia/vaultwarden.git
-Vcs-Browser: https://github.com/dani-garcia/vaultwarden
 Description: Alternative implementation of the Bitwarden server API written in
  Rust and compatible with upstream Bitwarden clients, perfect for self-hosted
  deployment where running the official resource-heavy service might not be ideal.

--- a/.build/software/ympd/build.bash
+++ b/.build/software/ympd/build.bash
@@ -157,15 +157,12 @@ Package: ympd
 Version: $version-$suffix
 Architecture: $(dpkg --print-architecture)
 Maintainer: MichaIng <micha@dietpi.com>
-Date: $(date -u '+%a, %d %b %Y %T %z')
-Standards-Version: 4.6.2.0
+Date: $(date -uR)
 Installed-Size: $(du -sk "$DIR" | mawk '{print $1}')
 Depends:$DEPS_APT_VERSIONED
 Section: sound
 Priority: optional
 Homepage: https://github.com/SuperBFG7/ympd
-Vcs-Git: https://github.com/SuperBFG7/ympd.git
-Vcs-Browser: https://github.com/SuperBFG7/ympd
 Description: Standalone MPD Web GUI written in C, utilizing Websockets and Bootstrap/JS
 _EOF_
 G_CONFIG_INJECT 'Installed-Size: ' "Installed-Size: $(du -sk "$DIR" | mawk '{print $1}')" "$DIR/DEBIAN/control"

--- a/.build/software/ympd/build.bash
+++ b/.build/software/ympd/build.bash
@@ -15,7 +15,8 @@ case $G_DISTRO in
 esac
 for i in "${adeps[@]}"
 do
-	dpkg-query -s "$i" &> /dev/null && continue
+	# Temporarily allow lib*t64 packages, while the 64-bit time_t transition is ongoing on Sid: https://bugs.debian.org/1065394
+	dpkg-query -s "$i" &> /dev/null || dpkg-query -s "${i}t64" &> /dev/null && continue
 	G_DIETPI-NOTIFY 1 "Expected dependency package was not installed: $i"
 	exit 1
 done
@@ -137,6 +138,8 @@ find "$DIR" ! \( -path "$DIR/DEBIAN" -prune \) -type f -exec md5sum {} + | sed "
 DEPS_APT_VERSIONED=
 for i in "${adeps[@]}"
 do
+	# Temporarily allow lib*t64 packages, while the 64-bit time_t transition is ongoing on Sid: https://bugs.debian.org/1065394
+	dpkg-query -s "$i" &> /dev/null || i+='t64'
 	DEPS_APT_VERSIONED+=" $i (>= $(dpkg-query -Wf '${VERSION}' "$i")),"
 done
 DEPS_APT_VERSIONED=${DEPS_APT_VERSIONED%,}

--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -712,10 +712,11 @@ shopt -s extglob
 		aSOFTWARE_NAME9_0[i]=${aSOFTWARE_NAME8_25[i]}
 		aSOFTWARE_NAME9_1[i]=${aSOFTWARE_NAME9_0[i]}
 		aSOFTWARE_NAME9_2[i]=${aSOFTWARE_NAME9_1[i]}
+		aSOFTWARE_NAME9_3[i]=${aSOFTWARE_NAME9_2[i]}
 	done
 
 	# Pre-create software counter array so that we can see also software (available in newest version) with 0 installs
-	for i in "${aSOFTWARE_NAME9_2[@]}"
+	for i in "${aSOFTWARE_NAME9_3[@]}"
 	do
 		aSOFTWARE[$i]=0
 	done

--- a/.update/patches
+++ b/.update/patches
@@ -1560,7 +1560,7 @@ Patch_9_3()
 	[[ -f '/etc/default/vmtouch' ]] && grep -q '/boot/dietpi' /etc/default/vmtouch && G_AGP vmtouch
 
 	# Add DietPi APT repo
-	/boot/dietpi/dietpi-set_software apt-mirror dietpi
+	/boot/dietpi/func/dietpi-set_software apt-mirror dietpi
 	G_AGUP -v
 	# shellcheck disable=SC2154
 	(( $G_AGUP_COUNT )) && G_AGUG

--- a/.update/patches
+++ b/.update/patches
@@ -1494,7 +1494,7 @@ map $arg_v $asset_immutable {
 		if grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[163\]=2' /boot/dietpi/.installed && grep -q ' -f  -I ' /etc/default/gmediarender
 		then
 			G_DIETPI-NOTIFY 2 'Fixing default GMediaRender command arguments'
-			G_EXEC sed -i "s/ -f  -I / -f $HOSTNAME -I /" /etc/default/gmediarender
+			G_EXEC sed --follow-symlinks -i "s/ -f  -I / -f $HOSTNAME -I /" /etc/default/gmediarender
 		fi
 
 		# OctoPrint: https://github.com/MichaIng/DietPi/issues/6915
@@ -1502,7 +1502,7 @@ map $arg_v $asset_immutable {
 		then
 			G_DIETPI-NOTIFY 2 'Fixing OctoPrint sudoers rule'
 			# shellcheck disable=SC2230
-			G_EXEC sed -i "s|, reboot, poweroff|, $(which reboot), $(which poweroff)|" /etc/sudoers.d/octoprint
+			G_EXEC sed --follow-symlinks -i "s|, reboot, poweroff|, $(which reboot), $(which poweroff)|" /etc/sudoers.d/octoprint
 		fi
 	fi
 }
@@ -1559,7 +1559,7 @@ Patch_9_2()
 		if [[ -f '/etc/nginx/sites-dietpi/dietpi-nextcloud.conf' ]] && ! grep -q 'include mime.types;' /etc/nginx/sites-dietpi/dietpi-nextcloud.conf
 		then
 			G_DIETPI-NOTIFY 2 'Fixing Nextclound Nginx config ...'
-			G_EXEC sed -i '/types {/i\\tinclude mime.types;' /etc/nginx/sites-dietpi/dietpi-nextcloud.conf
+			G_EXEC sed --follow-symlinks -i '/types {/i\\tinclude mime.types;' /etc/nginx/sites-dietpi/dietpi-nextcloud.conf
 		fi
 
 		# PaperMC
@@ -1573,7 +1573,7 @@ Patch_9_2()
 			if [[ -f '/mnt/dietpi_userdata/papermc/plugins/Geyser-Spigot/config.yml' ]] && grep -q '^auth-type: floodgate' /mnt/dietpi_userdata/papermc/plugins/Geyser-Spigot/config.yml
 			then
 				G_DIETPI-NOTIFY 2 'Fixing Geyser plugin config ...'
-				G_EXEC sed -i 's/^auth-type: floodgate/  auth-type: floodgate/' /mnt/dietpi_userdata/papermc/plugins/Geyser-Spigot/config.yml
+				G_EXEC sed --follow-symlinks -i 's/^auth-type: floodgate/  auth-type: floodgate/' /mnt/dietpi_userdata/papermc/plugins/Geyser-Spigot/config.yml
 			fi
 		fi
 

--- a/.update/patches
+++ b/.update/patches
@@ -1610,6 +1610,12 @@ Patch_9_2()
 	fi
 }
 
+Patch_9_3()
+{
+	# Purge ancient vmtouch which prevents /boot from being unmounted e.g. for RPi firmware migration: https://github.com/MichaIng/DietPi/issues/6819, https://github.com/MichaIng/DietPi/issues/6976
+	[[ -f '/etc/default/vmtouch' ]] && grep -q '/boot/dietpi' /etc/default/vmtouch && G_AGP vmtouch
+}
+
 # v6.35 => v7 migration
 if (( $G_DIETPI_VERSION_CORE == 6 && $G_DIETPI_VERSION_SUB > 34 ))
 then

--- a/.update/patches
+++ b/.update/patches
@@ -1314,16 +1314,8 @@ _EOF_
 
 Patch_8_23()
 {
-	# RPi: Update raspberrypi-sys-mods: https://github.com/MichaIng/DietPi/issues/6666
-	if (( $G_HW_MODEL < 10 )) && dpkg --compare-versions "$(dpkg-query -Wf '${Version}' raspberrypi-sys-mods 2> /dev/null)" lt-nl 2:20230510-dietpi2
-	then
-		G_DIETPI-NOTIFY 2 'Updating raspberrypi-sys-mods package ...'
-		G_EXEC_OUTPUT=1 G_EXEC curl -fo package.deb 'https://dietpi.com/downloads/binaries/raspberrypi-sys-mods.deb'
-		G_EXEC_OUTPUT=1 G_EXEC dpkg -i --force-confdef,confold package.deb
-		G_EXEC rm package.deb
-
 	# VisionFive 2
-	elif (( $G_HW_MODEL == 81 )) && dpkg --compare-versions "$(dpkg-query -Wf '${Version}' linux-image-visionfive2 2> /dev/null)" lt-nl 6.1.59-dietpi1
+	if (( $G_HW_MODEL == 81 )) && dpkg --compare-versions "$(dpkg-query -Wf '${Version}' linux-image-visionfive2 2> /dev/null)" lt-nl 6.1.59-dietpi1
 	then
 		G_DIETPI-NOTIFY 2 'Updating RISC-V StarFive VisionFive 2 kernel ...'
 		G_EXEC_OUTPUT=1 G_EXEC curl -fo package.deb 'https://dietpi.com/downloads/binaries/linux-image-visionfive2.deb'
@@ -1403,19 +1395,6 @@ Patch_8_24()
 			G_EXEC eval 'echo '\''sprdwl_ng'\'' > /etc/modules-load.d/dietpi-enable_wifi.conf'
 		fi
 		[[ -f '/etc/modprobe.d/dietpi-disable_bluetooth.conf' ]] || G_EXEC eval 'echo '\''sprdbt_tty'\'' > /etc/modules-load.d/dietpi-enable_bluetooth.conf'
-	fi
-
-	# Software updates and migrations
-	if [[ -f '/boot/dietpi/.installed' ]]
-	then
-		# Shairport Sync
-		if grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[37\]=2' /boot/dietpi/.installed && dpkg --compare-versions "$(dpkg-query -Wf '${Version}' shairport-sync 2> /dev/null)" lt 4.3.2-dietpi2
-		then
-			G_DIETPI-NOTIFY 2 'Updating Shairport Sync package ...'
-			G_EXEC_OUTPUT=1 G_EXEC curl -fo package.deb "https://dietpi.com/downloads/binaries/$G_DISTRO_NAME/shairport-sync_$G_HW_ARCH_NAME.deb"
-			G_AGI ./package.deb
-			G_EXEC rm package.deb
-		fi
 	fi
 }
 
@@ -1509,36 +1488,6 @@ map $arg_v $asset_immutable {
 
 Patch_9_2()
 {
-	# Quartz64
-	if (( $G_HW_MODEL == 49 ))
-	then
-		for i in quartz64{a,b} soquartz
-		do
-			dpkg --compare-versions "$(dpkg-query -Wf '${Version}' "firmware-$i" 2> /dev/null)" lt-nl 6.7.4-dietpi1 || continue
-			G_DIETPI-NOTIFY 2 "Updating $i kernel and bootloader ..."
-			G_EXEC_OUTPUT=1 G_EXEC curl -fo package.deb "https://dietpi.com/downloads/binaries/firmware-$i.deb"
-			G_EXEC_OUTPUT=1 G_EXEC dpkg -i --force-confdef,confold package.deb
-			G_EXEC rm package.deb
-			break
-		done
-
-	# VisionFive 2
-	elif (( $G_HW_MODEL == 81 )) && dpkg --compare-versions "$(dpkg-query -Wf '${Version}' linux-image-visionfive2 2> /dev/null)" lt-nl 6.1.81-dietpi1
-	then
-		G_DIETPI-NOTIFY 2 'Updating RISC-V StarFive VisionFive 2 kernel ...'
-		G_EXEC_OUTPUT=1 G_EXEC curl -fo package.deb 'https://dietpi.com/downloads/binaries/linux-image-visionfive2.deb'
-		G_EXEC_OUTPUT=1 G_EXEC dpkg -i --force-confdef,confold package.deb
-		G_EXEC rm package.deb
-
-	# Star64
-	elif (( $G_HW_MODEL == 84 )) && dpkg --compare-versions "$(dpkg-query -Wf '${Version}' linux-image-star64 2> /dev/null)" lt-nl 6.1.81-dietpi1
-	then
-		G_DIETPI-NOTIFY 2 'Updating RISC-V PINE64 Star64 kernel ...'
-		G_EXEC_OUTPUT=1 G_EXEC curl -fo package.deb 'https://dietpi.com/downloads/binaries/linux-image-star64.deb'
-		G_EXEC_OUTPUT=1 G_EXEC dpkg -i --force-confdef,confold package.deb
-		G_EXEC rm package.deb
-	fi
-
 	# Software updates and migrations
 	if [[ -f '/boot/dietpi/.installed' ]]
 	then
@@ -1565,15 +1514,6 @@ Patch_9_2()
 			fi
 		fi
 
-		# Squeezelite
-		if grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[36\]=2' /boot/dietpi/.installed && dpkg --compare-versions "$(dpkg-query -Wf '${Version}' squeezelite 2> /dev/null)" lt 2.0.0-1468-dietpi1
-		then
-			G_DIETPI-NOTIFY 2 'Updating Squeezelite package ...'
-			G_EXEC_OUTPUT=1 G_EXEC curl -fo package.deb "https://dietpi.com/downloads/binaries/$G_DISTRO_NAME/squeezelite_$G_HW_ARCH_NAME.deb"
-			G_AGI ./package.deb
-			G_EXEC rm package.deb
-		fi
-
 		# vaultwarden
 		if grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[183\]=2' /boot/dietpi/.installed && dpkg --compare-versions "$(dpkg-query -Wf '${Version}' vaultwarden 2> /dev/null)" lt 1.30.5-dietpi1
 		then
@@ -1583,10 +1523,6 @@ Patch_9_2()
 				G_EXEC rm -R /opt/vaultwarden
 				[[ -f '/etc/systemd/system/vaultwarden.service' ]] && G_EXEC rm /etc/systemd/system/vaultwarden.service
 			fi
-			G_DIETPI-NOTIFY 2 'Updating vaultwarden package ...'
-			G_EXEC_OUTPUT=1 G_EXEC curl -fo package.deb "https://dietpi.com/downloads/binaries/$G_DISTRO_NAME/vaultwarden_$G_HW_ARCH_NAME.deb"
-			G_AGI ./package.deb
-			G_EXEC rm package.deb
 		fi
 
 		# Amiberry
@@ -1602,6 +1538,11 @@ Patch_9_3()
 {
 	# Purge ancient vmtouch which prevents /boot from being unmounted e.g. for RPi firmware migration: https://github.com/MichaIng/DietPi/issues/6819, https://github.com/MichaIng/DietPi/issues/6976
 	[[ -f '/etc/default/vmtouch' ]] && grep -q '/boot/dietpi' /etc/default/vmtouch && G_AGP vmtouch
+
+	# Add DietPi APT repo
+	/boot/dietpi/dietpi-set_software apt-mirror dietpi
+	G_AGUP -v
+	(( $G_AGUP_COUNT )) && G_AGUG
 }
 
 # v6.35 => v7 migration

--- a/.update/patches
+++ b/.update/patches
@@ -1509,20 +1509,8 @@ map $arg_v $asset_immutable {
 
 Patch_9_2()
 {
-	# NanoPi R4S: Solve Ethernet adapter disappearing on soft reboot: https://github.com/MichaIng/DietPi/issues/6342
-	if (( $G_HW_MODEL == 47 )) && dpkg --compare-versions "$(dpkg-query -Wf '${Version}' linux-image-current-rockchip64 2> /dev/null)" lt-nl 24.2.0
-	then
-		G_DIETPI-NOTIFY 2 'Updating NanoPi R4S kernel ...'
-		G_EXEC_OUTPUT=1 G_EXEC curl -fo package1.deb 'https://dietpi.com/downloads/binaries/linux-image-current-rockchip64.deb'
-		G_EXEC_OUTPUT=1 G_EXEC curl -fo package2.deb 'https://dietpi.com/downloads/binaries/linux-dtb-current-rockchip64.deb'
-		G_EXEC_OUTPUT=1 G_EXEC curl -fo package3.deb 'https://dietpi.com/downloads/binaries/armbian-firmware.deb'
-		local headers=()
-		dpkg-query -s 'linux-headers-current-rockchip64' &> /dev/null && { G_EXEC_OUTPUT=1 G_EXEC curl -fo package4.deb 'https://dietpi.com/downloads/binaries/linux-headers-current-rockchip64.deb'; headers=('package4.deb'); }
-		G_EXEC_OUTPUT=1 G_EXEC dpkg -i --force-confdef,confold package1.deb package2.deb package3.deb "${headers[@]}"
-		G_EXEC rm package1.deb package2.deb package3.deb "${headers[@]}"
-
 	# Quartz64
-	elif (( $G_HW_MODEL == 49 ))
+	if (( $G_HW_MODEL == 49 ))
 	then
 		for i in quartz64{a,b} soquartz
 		do

--- a/.update/patches
+++ b/.update/patches
@@ -713,6 +713,18 @@ Patch_8_7()
 		G_DIETPI-NOTIFY 2 'Removing duplicate "cgroup_enable=memory" kernel command-line argument...'
 		G_EXEC sed --follow-symlinks -i 's/ cgroup_enable=memory//' /boot/cmdline.txt
 	done
+
+	# vaultwarden
+	if [[ -f '/boot/dietpi/.installed' ]] && grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[183\]=2' /boot/dietpi/.installed && dpkg --compare-versions "$(dpkg-query -Wf '${Version}' vaultwarden 2> /dev/null)" lt 1.30.5-dietpi1
+	then
+		# Pre-v8.7 cleanup
+		[[ -f '/opt/vaultwarden/target/release/vaultwarden' ]] && G_EXEC rm -R /opt/vaultwarden
+		[[ -f '/etc/systemd/system/vaultwarden.service' ]] && G_EXEC rm /etc/systemd/system/vaultwarden.service
+		G_DIETPI-NOTIFY 2 'Updating vaultwarden package ...'
+		G_EXEC_OUTPUT=1 G_EXEC curl -fo package.deb "https://dietpi.com/downloads/binaries/$G_DISTRO_NAME/vaultwarden_$G_HW_ARCH_NAME.deb"
+		G_AGI ./package.deb
+		G_EXEC rm package.deb
+	fi
 }
 
 Patch_8_8(){ :; }
@@ -1397,6 +1409,15 @@ Patch_8_24()
 		fi
 		[[ -f '/etc/modprobe.d/dietpi-disable_bluetooth.conf' ]] || G_EXEC eval 'echo '\''sprdbt_tty'\'' > /etc/modules-load.d/dietpi-enable_bluetooth.conf'
 	fi
+
+	# Shairport Sync
+	if [[ -f '/boot/dietpi/.installed' ]] && grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[37\]=2' /boot/dietpi/.installed && dpkg --compare-versions "$(dpkg-query -Wf '${Version}' shairport-sync 2> /dev/null)" lt 4.3.2-dietpi2
+	then
+		G_DIETPI-NOTIFY 2 'Updating Shairport Sync package ...'
+		G_EXEC_OUTPUT=1 G_EXEC curl -fo package.deb "https://dietpi.com/downloads/binaries/$G_DISTRO_NAME/shairport-sync_$G_HW_ARCH_NAME.deb"
+		G_AGI ./package.deb
+		G_EXEC rm package.deb
+	fi
 }
 
 Patch_8_25()
@@ -1515,14 +1536,11 @@ Patch_9_2()
 			fi
 		fi
 
-		# vaultwarden
-		if grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[183\]=2' /boot/dietpi/.installed && dpkg --compare-versions "$(dpkg-query -Wf '${Version}' vaultwarden 2> /dev/null)" lt 1.30.5-dietpi1
+		# Squeezelite
+		if grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[36\]=2' /boot/dietpi/.installed && dpkg --compare-versions "$(dpkg-query -Wf '${Version}' squeezelite 2> /dev/null)" lt 2.0.0-1468-dietpi1
 		then
-			# Pre-v8.7 cleanup
-			[[ -f '/opt/vaultwarden/target/release/vaultwarden' ]] && G_EXEC rm -R /opt/vaultwarden
-			[[ -f '/etc/systemd/system/vaultwarden.service' ]] && G_EXEC rm /etc/systemd/system/vaultwarden.service
-			G_DIETPI-NOTIFY 2 'Updating vaultwarden package ...'
-			G_EXEC_OUTPUT=1 G_EXEC curl -fo package.deb "https://dietpi.com/downloads/binaries/$G_DISTRO_NAME/vaultwarden_$G_HW_ARCH_NAME.deb"
+			G_DIETPI-NOTIFY 2 'Updating Squeezelite package ...'
+			G_EXEC_OUTPUT=1 G_EXEC curl -fo package.deb "https://dietpi.com/downloads/binaries/$G_DISTRO_NAME/squeezelite_$G_HW_ARCH_NAME.deb"
 			G_AGI ./package.deb
 			G_EXEC rm package.deb
 		fi

--- a/.update/patches
+++ b/.update/patches
@@ -38,6 +38,7 @@ export G_SERVICE_CONTROL=0
 
 # ToDo: On RPi 4, the 64-bit kernel is now used by default, without "arm_64bit=1" set: https://forums.raspberrypi.com/viewtopic.php?p=2088935#p2088935
 # - We could set "arm_64bit=0", but for now lets assure that 32-bit software is installed and see how it goes. This enables general support for RPi with 64-bit kernel running 32-bit userland.
+# shellcheck disable=SC2034
 [[ $G_HW_MODEL == [2-9] && $G_HW_ARCH == 3 && $(dpkg --print-architecture) == 'armhf' ]] && G_HW_ARCH=2 G_HW_ARCH_NAME='armv7l'
 
 # Version-based incremental patches
@@ -1542,6 +1543,7 @@ Patch_9_3()
 	# Add DietPi APT repo
 	/boot/dietpi/dietpi-set_software apt-mirror dietpi
 	G_AGUP -v
+	# shellcheck disable=SC2154
 	(( $G_AGUP_COUNT )) && G_AGUG
 }
 

--- a/.update/patches
+++ b/.update/patches
@@ -1519,11 +1519,12 @@ Patch_9_2()
 		if grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[183\]=2' /boot/dietpi/.installed && dpkg --compare-versions "$(dpkg-query -Wf '${Version}' vaultwarden 2> /dev/null)" lt 1.30.5-dietpi1
 		then
 			# Pre-v8.7 cleanup
-			if [[ -f '/opt/vaultwarden/target/release/vaultwarden' ]]
-			then
-				G_EXEC rm -R /opt/vaultwarden
-				[[ -f '/etc/systemd/system/vaultwarden.service' ]] && G_EXEC rm /etc/systemd/system/vaultwarden.service
-			fi
+			[[ -f '/opt/vaultwarden/target/release/vaultwarden' ]] && G_EXEC rm -R /opt/vaultwarden
+			[[ -f '/etc/systemd/system/vaultwarden.service' ]] && G_EXEC rm /etc/systemd/system/vaultwarden.service
+			G_DIETPI-NOTIFY 2 'Updating vaultwarden package ...'
+			G_EXEC_OUTPUT=1 G_EXEC curl -fo package.deb "https://dietpi.com/downloads/binaries/$G_DISTRO_NAME/vaultwarden_$G_HW_ARCH_NAME.deb"
+			G_AGI ./package.deb
+			G_EXEC rm package.deb
 		fi
 
 		# Amiberry

--- a/.update/pre-patches
+++ b/.update/pre-patches
@@ -161,7 +161,7 @@ fi
 if (( $G_DIETPI_VERSION_CORE < 8 || ( $G_DIETPI_VERSION_CORE == 8 && $G_DIETPI_VERSION_SUB < 11 ) )) && [[ -f '/etc/apt/sources.list.d/grafana.list' ]]
 then
 	G_DIETPI-NOTIFY 2 'Updating Grafana APT list to use the new repository: https://grafana.com/docs/grafana/latest/setup-grafana/installation/debian/#repository-migration-november-8th-2022'
-	G_EXEC eval "echo 'deb https://apt.grafana.com/ stable main' > /etc/apt/sources.list.d/grafana.list"
+	G_EXEC eval "echo 'deb https://apt.grafana.com stable main' > /etc/apt/sources.list.d/grafana.list"
 fi
 
 # v8.13
@@ -283,14 +283,14 @@ then
 	if (( $G_HW_ARCH == 11 ))
 	then
 		G_DIETPI-NOTIFY 2 'Migrating from Debian ports to regular Debian Sid repository, which now supports RISC-V'
-		G_EXEC eval 'echo '\''deb https://deb.debian.org/debian/ sid main contrib non-free non-free-firmware'\'' > /etc/apt/sources.list'
+		G_EXEC eval 'echo '\''deb https://deb.debian.org/debian sid main contrib non-free non-free-firmware'\'' > /etc/apt/sources.list'
 		dpkg-query -s 'debian-ports-archive-keyring' &> /dev/null && G_EXEC apt-mark auto debian-ports-archive-keyring
 
 	# RPi/ARMv6 container Bookworm
 	elif [[ $G_DISTRO -ge 7 && -f '/etc/apt/sources.list.d/raspi.list' ]]
 	then
 		G_DIETPI-NOTIFY 2 'Migrating RPi APT repository to Bookworm'
-		G_EXEC eval 'echo '\''deb https://archive.raspberrypi.com/debian/ bookworm main'\'' > /etc/apt/sources.list.d/raspi.list'
+		G_EXEC eval 'echo '\''deb https://archive.raspberrypi.com/debian bookworm main'\'' > /etc/apt/sources.list.d/raspi.list'
 
 		G_DIETPI-NOTIFY 2 'Removing faulty non-free-firmware component if present'
 		(( $G_RASPBIAN )) && G_EXEC sed --follow-symlinks -i 's/ non-free-firmware$//' /etc/apt/sources.list
@@ -395,11 +395,11 @@ fi
 # v9.3
 if (( $G_DIETPI_VERSION_CORE < 9 || ( $G_DIETPI_VERSION_CORE == 9 && $G_DIETPI_VERSION_SUB < 3 ) ))
 then
-	# Update APT repo on Bullseye systems to Bookworm, but re-assure only kernel and firmware packages are pulled form it. Armbian dropped Bullseye support
+	# Update APT repo on Bullseye systems to Bookworm, but re-assure only kernel and firmware packages are pulled form it. Armbian dropped Bullseye support.
 	if [[ $G_DISTRO == 6 && -f '/etc/apt/sources.list.d/dietpi-armbian.list' ]]
 	then
 		G_DIETPI-NOTIFY 2 'Moving EOL Armbian Bullseye repo to Bookworm for Debian-version-agnostic firmware and kernel upgrades'
-		cat << '_EOF_' > /etc/apt/preferences.d/dietpi-armbian
+		cat << '_EOF_' > /etc/apt/preferences.d/dietpi-armbian || exit 1
 Package: *
 Pin: origin apt.armbian.com
 Pin-Priority: -1

--- a/.update/pre-patches
+++ b/.update/pre-patches
@@ -369,9 +369,9 @@ then
 	if (( $G_HW_MODEL < 10 || ( $G_HW_MODEL == 75 && ${G_RASPBIAN:-0} == 1 ) ))
 	then
 		G_DIETPI-NOTIFY 2 'Migrating from raspberrypi.org to raspberrypi.com'
-		G_EXEC sed -i 's/raspberrypi.org/raspberrypi.com/' /etc/apt/sources.list /boot/dietpi.txt
-		find /etc/apt/sources.list.d/* &> /dev/null && G_EXEC sed -i 's/raspberrypi.org/raspberrypi.com/' /etc/apt/sources.list.d/*.list
-		find /etc/apt/preferences.d/* &> /dev/null && G_EXEC sed -i 's/raspberrypi.org/raspberrypi.com/' /etc/apt/preferences.d/*
+		G_EXEC sed --follow-symlinks -i 's/raspberrypi.org/raspberrypi.com/' /etc/apt/sources.list /boot/dietpi.txt
+		find /etc/apt/sources.list.d/* &> /dev/null && G_EXEC sed --follow-symlinks -i 's/raspberrypi.org/raspberrypi.com/' /etc/apt/sources.list.d/*.list
+		find /etc/apt/preferences.d/* &> /dev/null && G_EXEC sed --follow-symlinks -i 's/raspberrypi.org/raspberrypi.com/' /etc/apt/preferences.d/*
 	fi
 	GITBRANCH_TARGET=$(sed -n '/^[[:blank:]]*DEV_GITBRANCH=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 	GITBRANCH_TARGET=${GITBRANCH_TARGET:-master}
@@ -389,6 +389,26 @@ then
 	then
 		G_DIETPI-NOTIFY 2 'Adding FFmpeg workaround for RPi Trixie systems'
 		G_EXEC eval 'echo -e '\''Package: src:ffmpeg\nPin: origin archive.raspberrypi.com\nPin-Priority: -1'\'' > /etc/apt/preferences.d/dietpi-ffmpeg'
+	fi
+fi
+
+# v9.3
+if (( $G_DIETPI_VERSION_CORE < 9 || ( $G_DIETPI_VERSION_CORE == 9 && $G_DIETPI_VERSION_SUB < 3 ) ))
+then
+	# Update APT repo on Bullseye systems to Bookworm, but re-assure only kernel and firmware packages are pulled form it. Armbian dropped Bullseye support
+	if [[ $G_DISTRO == 6 && -f '/etc/apt/sources.list.d/dietpi-armbian.list' ]]
+	then
+		G_DIETPI-NOTIFY 2 'Moving EOL Armbian Bullseye repo to Bookworm for Debian-version-agnostic firmware and kernel upgrades'
+		cat << '_EOF_' > /etc/apt/preferences.d/dietpi-armbian
+Package: *
+Pin: origin apt.armbian.com
+Pin-Priority: -1
+
+Package: armbian-firmware* linux-*
+Pin: origin apt.armbian.com
+Pin-Priority: 500
+_EOF_
+		G_EXEC sed --follow-symlinks -i 's/bullseye/bookworm/g' /etc/apt/sources.list.d/dietpi-armbian.list
 	fi
 fi
 

--- a/.update/version
+++ b/.update/version
@@ -3,7 +3,7 @@
 # Available DietPi version
 G_REMOTE_VERSION_CORE=9
 G_REMOTE_VERSION_SUB=3
-G_REMOTE_VERSION_RC=-1
+G_REMOTE_VERSION_RC=0
 # Minimum DietPi version to allow update
 G_MIN_VERSION_CORE=7
 G_MIN_VERSION_SUB=0

--- a/.update/version
+++ b/.update/version
@@ -2,8 +2,8 @@
 # shellcheck disable=SC2034
 # Available DietPi version
 G_REMOTE_VERSION_CORE=9
-G_REMOTE_VERSION_SUB=2
-G_REMOTE_VERSION_RC=1
+G_REMOTE_VERSION_SUB=3
+G_REMOTE_VERSION_RC=-1
 # Minimum DietPi version to allow update
 G_MIN_VERSION_CORE=7
 G_MIN_VERSION_SUB=0

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,5 @@
 v9.3
-(2024-04-13)
+(2024-04-14)
 
 Enhancements:
 - General | We added an own APT repository for own software and kernel/firmware builds. This simplifies updates for software packages like Squeezelite, vaultwarden and Amiberry, as well as allows us to provide own up-to-date kernel and bootloader packages, applied via regular "apt upgrade". A goal is also to become independent of some 3rd party repositories, which are regularly affected by network errors or provide packages updates too infrequently.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,8 +1,6 @@
 v9.3
 (2024-04-13)
 
-New images:
-
 Enhancements:
 - DietPi-Config | Removed the 3.5mm audio option on Raspberry Pi 5, as it does not have a 3.5mm jack. Additionally, the KMS graphics driver is enabled OOTB when HDMI audio is selected, as the snd_bcm2835 driver does not work on Raspberry Pi 5. Many thanks to @JRK0469 for making us aware of this: https://dietpi.com/forum/t/19760
 - DietPi-Software | Mosquitto: The official APT repository added support for 64-bit ARM on Bookworm, which is now used for our installation.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ New images:
 Enhancements:
 - DietPi-Config | Removed the 3.5mm audio option on Raspberry Pi 5, as it does not have a 3.5mm jack. Additionally, the KMS graphics driver is enabled OOTB when HDMI audio is selected, as the snd_bcm2835 driver does not work on Raspberry Pi 5. Many thanks to @JRK0469 for making us aware of this: https://dietpi.com/forum/t/19760
 - DietPi-Software | Mosquitto: The official APT repository added support for 64-bit ARM on Bookworm, which is now used for our installation.
+- DietPi-Software | UnRAR: Debian added unrar packages for RISC-V, which are now used for our installation.
 
 Bug fixes:
 - Raspberry Pi 5 | Fixed X11/desktop startup if KMS is enabled. Many thanks to @denguido for reporting the issue and solution: https://dietpi.com/forum/t/19760

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,8 +4,10 @@ v9.3
 New images:
 
 Enhancements:
+- DietPi-Config | Removed the 3.5mm audio option on Raspberry Pi 5, as it does not have a 3.5mm jack. Additionally, the KMS graphics driver is enabled OOTB when HDMI audio is selected, as the snd_bcm2835 driver does not work on Raspberry Pi 5. Many thanks to @JRK0469 for making us aware of this: https://dietpi.com/forum/t/19760
 
 Bug fixes:
+- Raspberry Pi 5 | Fixed X11/desktop startup if KMS is enabled. Many thanks to @denguido for reporting the issue and solution: https://dietpi.com/forum/t/19760
 - DietPi-Software | Logitech Media Server: Resolved an issue where the install failed due to a changed download URL. Many thanks to @JRK0469 for reporting this issue: https://github.com/MichaIng/DietPi/issues/6992
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/ADDME

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ v9.3
 (2024-04-13)
 
 Enhancements:
+- General | We added an own APT repository for own software and kernel/firmware builds. This simplifies updates for software packages like Squeezelite, vaultwarden and Amiberry, as well as allows us to provide own up-to-date kernel and bootloader packages, applied via regular "apt upgrade". A goal is also to become independent of some 3rd party repositories, which are regularly affected by network errors or provide packages updates too infrequently.
 - DietPi-Config | Removed the 3.5mm audio option on Raspberry Pi 5, as it does not have a 3.5mm jack. Additionally, the KMS graphics driver is enabled OOTB when HDMI audio is selected, as the snd_bcm2835 driver does not work on Raspberry Pi 5. Many thanks to @JRK0469 for making us aware of this: https://dietpi.com/forum/t/19760
 - DietPi-Software | Mosquitto: The official APT repository added support for 64-bit ARM on Bookworm, which is now used for our installation.
 - DietPi-Software | UnRAR: Debian added unrar packages for RISC-V, which are now used for our installation.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,7 +2,7 @@ v9.3
 (2024-04-14)
 
 Enhancements:
-- General | We added an own APT repository for own software and kernel/firmware builds. This simplifies updates for software packages like Squeezelite, vaultwarden and Amiberry, as well as allows us to provide own up-to-date kernel and bootloader packages, applied via regular "apt upgrade". A goal is also to become independent of some 3rd party repositories, which are regularly affected by network errors or provide packages updates too infrequently.
+- General | We added an own APT repository at https://dietpi.com/apt for own software and kernel/firmware builds. This simplifies updates for software packages like Squeezelite, vaultwarden and Amiberry, as well as allows us to provide own up-to-date kernel and bootloader packages, applied via regular "apt upgrade". A goal is also to become independent of some 3rd party repositories, which are regularly affected by network errors or provide packages updates too infrequently.
 - DietPi-Config | Removed the 3.5mm audio option on Raspberry Pi 5, as it does not have a 3.5mm jack. Additionally, the KMS graphics driver is enabled OOTB when HDMI audio is selected, as the snd_bcm2835 driver does not work on Raspberry Pi 5. Many thanks to @JRK0469 for making us aware of this: https://dietpi.com/forum/t/19760
 - DietPi-Software | Mosquitto: The official APT repository added support for 64-bit ARM on Bookworm, which is now used for our installation.
 - DietPi-Software | UnRAR: Debian added unrar packages for RISC-V, which are now used for our installation.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,16 @@
+v9.3
+(2024-04-13)
+
+New images:
+
+Enhancements:
+
+Bug fixes:
+
+As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/ADDME
+
+-----------------------------------------------------------------------------------------------------------
+
 v9.2
 (2024-03-16)
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,7 +11,7 @@ Bug fixes:
 - Raspberry Pi 5 | Fixed X11/desktop startup if KMS is enabled. Many thanks to @denguido for reporting the issue and solution: https://dietpi.com/forum/t/19760
 - DietPi-Software | Logitech Media Server: Resolved an issue where the install failed due to a changed download URL. Many thanks to @JRK0469 for reporting this issue: https://github.com/MichaIng/DietPi/issues/6992
 
-As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/ADDME
+As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/7016
 
 -----------------------------------------------------------------------------------------------------------
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ New images:
 
 Enhancements:
 - DietPi-Config | Removed the 3.5mm audio option on Raspberry Pi 5, as it does not have a 3.5mm jack. Additionally, the KMS graphics driver is enabled OOTB when HDMI audio is selected, as the snd_bcm2835 driver does not work on Raspberry Pi 5. Many thanks to @JRK0469 for making us aware of this: https://dietpi.com/forum/t/19760
+- DietPi-Software | Mosquitto: The official APT repository added support for 64-bit ARM on Bookworm, which is now used for our installation.
 
 Bug fixes:
 - Raspberry Pi 5 | Fixed X11/desktop startup if KMS is enabled. Many thanks to @denguido for reporting the issue and solution: https://dietpi.com/forum/t/19760

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ New images:
 Enhancements:
 
 Bug fixes:
+- DietPi-Software | Logitech Media Server: Resolved an issue where the install failed due to a changed download URL. Many thanks to @JRK0469 for reporting this issue: https://github.com/MichaIng/DietPi/issues/6992
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/ADDME
 

--- a/dietpi.txt
+++ b/dietpi.txt
@@ -226,9 +226,9 @@ CONFIG_APT_DEBIAN_MIRROR=https://deb.debian.org/debian/
 # NTP server(s) applied to /etc/systemd/timesyncd.conf
 # - "default": Use the NTP server(s) provided via DHCP, else the debian.pool.ntp.org NTP pool.
 # - "gateway": Use the router/gateway as NTP server. Recommended, if it does provide this functionality.
-# - To use a public NTP pool, see the full list at: https://www.ntppool.org/zone/@
+# - To use another public NTP pool, see the full list at: https://www.ntppool.org/zone/@
 #   Use the pool domain without leading integer and dot (without "0."), like "debian.pool.ntp.org", "pool.ntp.org" or "uk.pool.ntp.org".
-# - You can also use a custom IP address, hostname or any combination of space-separated IP addresses, hostnames and NTP pool domain.
+# - You can also use a custom IP address, hostname or any combination of space-separated IP addresses, hostnames and NTP pool domains.
 CONFIG_NTP_MIRROR=default
 
 #------------------------------------------------------------------------------------------------------

--- a/dietpi.txt
+++ b/dietpi.txt
@@ -219,9 +219,9 @@ CONFIG_ENABLE_IPV6=1
 
 # APT mirrors which are applied to /etc/apt/sources.list | Values here will also be applied during 1st run setup
 # - Raspbian: https://www.raspbian.org/RaspbianMirrors
-CONFIG_APT_RASPBIAN_MIRROR=http://raspbian.raspberrypi.com/raspbian/
+CONFIG_APT_RASPBIAN_MIRROR=http://raspbian.raspberrypi.com/raspbian
 # - Debian: https://www.debian.org/mirror/official#list
-CONFIG_APT_DEBIAN_MIRROR=https://deb.debian.org/debian/
+CONFIG_APT_DEBIAN_MIRROR=https://deb.debian.org/debian
 
 # NTP server(s) applied to /etc/systemd/timesyncd.conf
 # - "default": Use the NTP server(s) provided via DHCP, else the debian.pool.ntp.org NTP pool.

--- a/dietpi.txt
+++ b/dietpi.txt
@@ -223,10 +223,13 @@ CONFIG_APT_RASPBIAN_MIRROR=http://raspbian.raspberrypi.com/raspbian/
 # - Debian: https://www.debian.org/mirror/official#list
 CONFIG_APT_DEBIAN_MIRROR=https://deb.debian.org/debian/
 
-# NTP mirror, applied to /etc/ntp.conf
-# - For a full list, please see: https://www.ntppool.org/zone/@
-# - Please remove the initial integer and full stop from the value (removing "0."), eg: debian.pool.ntp.org
-CONFIG_NTP_MIRROR=debian.pool.ntp.org
+# NTP server(s) applied to /etc/systemd/timesyncd.conf
+# - "default": Use the NTP server(s) provided via DHCP, else the debian.pool.ntp.org NTP pool.
+# - "gateway": Use the router/gateway as NTP server. Recommended, if it does provide this functionality.
+# - To use a public NTP pool, see the full list at: https://www.ntppool.org/zone/@
+#   Use the pool domain without leading integer and dot (without "0."), like "debian.pool.ntp.org", "pool.ntp.org" or "uk.pool.ntp.org".
+# - You can also use a custom IP address, hostname or any combination of space-separated IP addresses, hostnames and NTP pool domain.
+CONFIG_NTP_MIRROR=default
 
 #------------------------------------------------------------------------------------------------------
 ##### DietPi-Software settings #####

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -3864,23 +3864,23 @@ Additional benchmarks:
 					if (( $G_RASPBIAN ))
 					then
 						local mirror_list='https://www.raspbian.org/RaspbianMirrors/'
-						G_WHIP_MENU_ARRAY+=('http://raspbian.raspberrypi.org/raspbian/' ': Global mirror director (default)')
-						G_WHIP_MENU_ARRAY+=('https://mirror.ox.ac.uk/sites/archive.raspbian.org/archive/raspbian/' ': UK')
-						G_WHIP_MENU_ARRAY+=('https://mirror.netcologne.de/raspbian/raspbian/' ': Germany')
-						G_WHIP_MENU_ARRAY+=('https://mirror.umd.edu/raspbian/raspbian/' ': USA')
-						G_WHIP_MENU_ARRAY+=('https://mirrors.ustc.edu.cn/raspbian/raspbian/' ': China')
-						G_WHIP_MENU_ARRAY+=('http://raspbian.mirror.digitalpacific.com.au/raspbian/' ': Australia')
+						G_WHIP_MENU_ARRAY+=('http://raspbian.raspberrypi.org/raspbian' ': Global mirror director (default)')
+						G_WHIP_MENU_ARRAY+=('https://mirror.ox.ac.uk/sites/archive.raspbian.org/archive/raspbian' ': UK')
+						G_WHIP_MENU_ARRAY+=('https://mirror.netcologne.de/raspbian/raspbian' ': Germany')
+						G_WHIP_MENU_ARRAY+=('https://mirror.umd.edu/raspbian/raspbian' ': USA')
+						G_WHIP_MENU_ARRAY+=('https://mirrors.ustc.edu.cn/raspbian/raspbian' ': China')
+						G_WHIP_MENU_ARRAY+=('http://raspbian.mirror.digitalpacific.com.au/raspbian' ': Australia')
 
 					# Debian
 					else
 						local mirror_list='https://www.debian.org/mirror/list'
-						G_WHIP_MENU_ARRAY+=('https://deb.debian.org/debian/' ': Global mirror director (default)')
-						G_WHIP_MENU_ARRAY+=('https://ftp.debian.org/debian/' ': Global')
-						G_WHIP_MENU_ARRAY+=('http://ftp.uk.debian.org/debian/' ': UK')
-						G_WHIP_MENU_ARRAY+=('http://ftp.de.debian.org/debian/' ': Germany')
-						G_WHIP_MENU_ARRAY+=('http://ftp.us.debian.org/debian/' ': USA')
-						G_WHIP_MENU_ARRAY+=('http://ftp.cn.debian.org/debian/' ': China')
-						G_WHIP_MENU_ARRAY+=('http://ftp.au.debian.org/debian/' ': Australia')
+						G_WHIP_MENU_ARRAY+=('https://deb.debian.org/debian' ': Global mirror director (default)')
+						G_WHIP_MENU_ARRAY+=('https://ftp.debian.org/debian' ': Global')
+						G_WHIP_MENU_ARRAY+=('http://ftp.uk.debian.org/debian' ': UK')
+						G_WHIP_MENU_ARRAY+=('http://ftp.de.debian.org/debian' ': Germany')
+						G_WHIP_MENU_ARRAY+=('http://ftp.us.debian.org/debian' ': USA')
+						G_WHIP_MENU_ARRAY+=('http://ftp.cn.debian.org/debian' ': China')
+						G_WHIP_MENU_ARRAY+=('http://ftp.au.debian.org/debian' ': Australia')
 					fi
 
 					G_WHIP_DEFAULT_ITEM=$apt_mirror_current
@@ -3889,7 +3889,7 @@ Additional benchmarks:
 					if [[ $G_WHIP_RETURNED_VALUE == 'Custom' ]]
 					then
 						G_WHIP_DEFAULT_ITEM=$apt_mirror_current
-						G_WHIP_INPUTBOX 'Please enter a new APT mirror, e.g. https://ftp.debian.org/debian/' || continue
+						G_WHIP_INPUTBOX 'Please enter a new APT mirror, e.g. https://ftp.debian.org/debian' || continue
 					fi
 
 					/boot/dietpi/func/dietpi-set_software apt-mirror "$G_WHIP_RETURNED_VALUE" || { failure='[FAILED] An internal error occurred, please report this issue to:\n - https://github.com/MichaIng/DietPi/issues\n\n'; continue; }

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -3442,39 +3442,41 @@ Additional benchmarks:
 			# RPi
 			if (( $G_HW_MODEL < 10 )); then
 
-				G_WHIP_MENU_ARRAY+=('rpi-bcm2835-auto' ': Onboard HDMI if plugged, else 3.5mm')
-				G_WHIP_MENU_ARRAY+=('rpi-bcm2835-3.5mm' ': Onboard 3.5mm output')
-				G_WHIP_MENU_ARRAY+=('rpi-bcm2835-hdmi' ': Onboard HDMI output')
-				G_WHIP_MENU_ARRAY+=('allo-boss-dac-pcm512x-audio' ': Allo Boss DAC')
-				G_WHIP_MENU_ARRAY+=('allo-boss2-dac-audio' ': Allo Boss2 DAC')
-				G_WHIP_MENU_ARRAY+=('allo-digione' ': Allo DigiOne')
-				G_WHIP_MENU_ARRAY+=('allo-katana-dac-audio' ': Allo Katana DAC')
-				G_WHIP_MENU_ARRAY+=('allo-piano-dac-pcm512x-audio' ': Allo Piano DAC')
-				G_WHIP_MENU_ARRAY+=('allo-piano-dac-plus-pcm512x-audio' ': Allo Piano DAC 2.1')
-				G_WHIP_MENU_ARRAY+=('applepi-dac' ': ApplePi DAC (Orchard Audio)')
-				G_WHIP_MENU_ARRAY+=('dionaudio-loco' ': Dion Audio LOCO')
-				G_WHIP_MENU_ARRAY+=('dionaudio-loco-v2' ': Dion Audio LOCO V2')
-				G_WHIP_MENU_ARRAY+=('googlevoicehat-soundcard' ': Google AIY voice kit')
-				G_WHIP_MENU_ARRAY+=('hifiberry-amp' ': HifiBerry AMP / AMP+')
-				G_WHIP_MENU_ARRAY+=('hifiberry-dac' ': HifiBerry DAC / MiniAMP')
-				G_WHIP_MENU_ARRAY+=('hifiberry-dacplus' ': HifiBerry DAC+ / DAC+ Pro / AMP2')
-				G_WHIP_MENU_ARRAY+=('hifiberry-dacplusadc' ': HifiBerry DAC+ADC')
-				G_WHIP_MENU_ARRAY+=('hifiberry-dacplusadcpro' ': HifiBerry DAC+ADC Pro')
-				G_WHIP_MENU_ARRAY+=('hifiberry-dacplusdsp' ': HifiBerry DAC+DSP')
-				G_WHIP_MENU_ARRAY+=('hifiberry-dacplushd' ': HifiBerry DAC+ HD')
-				G_WHIP_MENU_ARRAY+=('hifiberry-digi' ': HifiBerry Digi / Digi+')
-				G_WHIP_MENU_ARRAY+=('hifiberry-digi-pro' ': HifiBerry Digi+ Pro')
-				G_WHIP_MENU_ARRAY+=('i-sabre-q2m' ': AudioPhonics I-Sabre ES9028Q2M / ES9038Q2M')
-				G_WHIP_MENU_ARRAY+=('iqaudio-codec' ': IQaudIO Pi-Codec HAT')
-				G_WHIP_MENU_ARRAY+=('iqaudio-dac' ': IQaudIO DAC audio card')
-				G_WHIP_MENU_ARRAY+=('iqaudio-dacplus' ': Pi-DAC+, Pi-DACZero, Pi-DAC+ Pro, Pi-DigiAMP+')
-				G_WHIP_MENU_ARRAY+=('iqaudio-digi-wm8804-audio' ': Pi-Digi+')
-				G_WHIP_MENU_ARRAY+=('iqaudio-dacplus,auto_mute_amp' ': Pi-DigiAMP+')
-				G_WHIP_MENU_ARRAY+=('iqaudio-dacplus,unmute_amp' ': Pi-DigiAMP+')
-				G_WHIP_MENU_ARRAY+=('justboom-dac' ': JustBoom: DAC HAT, Amp HAT, DAC Zero and Amp Zero')
-				G_WHIP_MENU_ARRAY+=('justboom-digi' ': JustBoom: Digi HAT and Digi Zero')
-				G_WHIP_MENU_ARRAY+=('justboom-both' ': JustBoom: Simultaneous DAC and Digi usage')
-				G_WHIP_MENU_ARRAY+=('rpi-dac' ': Soekris DAM1021 (pcm1794a)')
+				# RPi 5 has no 3.5mm jack: https://dietpi.com/forum/t/19760
+				(( $G_HW_MODEL == 5 )) || G_WHIP_MENU_ARRAY+=('rpi-bcm2835-auto' ': Onboard HDMI if plugged, else 3.5mm' 'rpi-bcm2835-3.5mm' ': Onboard 3.5mm output')
+				G_WHIP_MENU_ARRAY+=(
+					'rpi-bcm2835-hdmi' ': Onboard HDMI output'
+					'allo-boss-dac-pcm512x-audio' ': Allo Boss DAC'
+					'allo-boss2-dac-audio' ': Allo Boss2 DAC'
+					'allo-digione' ': Allo DigiOne'
+					'allo-katana-dac-audio' ': Allo Katana DAC'
+					'allo-piano-dac-pcm512x-audio' ': Allo Piano DAC'
+					'allo-piano-dac-plus-pcm512x-audio' ': Allo Piano DAC 2.1'
+					'applepi-dac' ': ApplePi DAC (Orchard Audio)'
+					'dionaudio-loco' ': Dion Audio LOCO'
+					'dionaudio-loco-v2' ': Dion Audio LOCO V2'
+					'googlevoicehat-soundcard' ': Google AIY voice kit'
+					'hifiberry-amp' ': HifiBerry AMP / AMP+'
+					'hifiberry-dac' ': HifiBerry DAC / MiniAMP'
+					'hifiberry-dacplus' ': HifiBerry DAC+ / DAC+ Pro / AMP2'
+					'hifiberry-dacplusadc' ': HifiBerry DAC+ADC'
+					'hifiberry-dacplusadcpro' ': HifiBerry DAC+ADC Pro'
+					'hifiberry-dacplusdsp' ': HifiBerry DAC+DSP'
+					'hifiberry-dacplushd' ': HifiBerry DAC+ HD'
+					'hifiberry-digi' ': HifiBerry Digi / Digi+'
+					'hifiberry-digi-pro' ': HifiBerry Digi+ Pro'
+					'i-sabre-q2m' ': AudioPhonics I-Sabre ES9028Q2M / ES9038Q2M'
+					'iqaudio-codec' ': IQaudIO Pi-Codec HAT'
+					'iqaudio-dac' ': IQaudIO DAC audio card'
+					'iqaudio-dacplus' ': Pi-DAC+, Pi-DACZero, Pi-DAC+ Pro, Pi-DigiAMP+'
+					'iqaudio-digi-wm8804-audio' ': Pi-Digi+'
+					'iqaudio-dacplus,auto_mute_amp' ': Pi-DigiAMP+'
+					'iqaudio-dacplus,unmute_amp' ': Pi-DigiAMP+'
+					'justboom-dac' ': JustBoom: DAC HAT, Amp HAT, DAC Zero and Amp Zero'
+					'justboom-digi' ': JustBoom: Digi HAT and Digi Zero'
+					'justboom-both' ': JustBoom: Simultaneous DAC and Digi usage'
+					'rpi-dac' ': Soekris DAM1021 (pcm1794a)'
+				)
 
 			# Odroid C1/C2 legacy image
 			elif [[ $G_HW_MODEL == 1[12] ]]; then
@@ -3486,42 +3488,39 @@ Additional benchmarks:
 			# NanoPi M2/M3
 			elif [[ $G_HW_MODEL == 6[12] ]]; then
 
-				G_WHIP_MENU_ARRAY+=('default' ': 3.5mm Analogue')
-				G_WHIP_MENU_ARRAY+=('s5pxx18-hdmi' ': HDMI')
+				G_WHIP_MENU_ARRAY+=('default' ': 3.5mm Analogue' 's5pxx18-hdmi' ': HDMI')
 
 			# H3
 			elif (( $G_HW_CPUID == 1 )); then
 
-				G_WHIP_MENU_ARRAY+=('default' ': HDMI')
-				G_WHIP_MENU_ARRAY+=('h3-analogue' ': 3.5mm Analogue')
+				G_WHIP_MENU_ARRAY+=('default' ': HDMI' 'h3-analogue' ': 3.5mm Analogue')
 
 			# Sparky SBC
 			elif (( $G_HW_MODEL == 70 )); then
 
-				G_WHIP_MENU_ARRAY+=('default' ': HDMI')
-				G_WHIP_MENU_ARRAY+=('snd-soc-allo-piano-dac' ': Allo Piano DAC')
-				G_WHIP_MENU_ARRAY+=('snd-soc-allo-piano-dac-plus' ': Allo Piano DAC 2.1')
-				G_WHIP_MENU_ARRAY+=('allo-cheapo-analogue' ': Allo Cheapo (3.5mm / RCA output)')
-				G_WHIP_MENU_ARRAY+=('allo-cheapo-optical' ': Allo Cheapo (Optical output)')
-				G_WHIP_MENU_ARRAY+=('usb-dac-1.1' ': USB 1.1 Audio DAC (any)')
+				G_WHIP_MENU_ARRAY+=(
+					'default' ': HDMI'
+					'snd-soc-allo-piano-dac' ': Allo Piano DAC'
+					'snd-soc-allo-piano-dac-plus' ': Allo Piano DAC 2.1'
+					'allo-cheapo-analogue' ': Allo Cheapo (3.5mm / RCA output)'
+					'allo-cheapo-optical' ': Allo Cheapo (Optical output)'
+					'usb-dac-1.1' ': USB 1.1 Audio DAC (any)'
+				)
 
 			# ASUS TB
 			elif (( $G_HW_MODEL == 52 )); then
 
-				G_WHIP_MENU_ARRAY+=('default' ': HDMI')
-				G_WHIP_MENU_ARRAY+=('asus-tb-analogue' ': 3.5mm Analogue')
+				G_WHIP_MENU_ARRAY+=('default' ': HDMI' 'asus-tb-analogue' ': 3.5mm Analogue')
 
 			# Odroid N2: Modern image
 			elif [[ $G_HW_MODEL == 15 && -f '/boot/dietpiEnv.txt' ]]; then
 
-				G_WHIP_MENU_ARRAY+=('OdroidN2_HDMI' ': Onboard digital HDMI audio (default)')
-				G_WHIP_MENU_ARRAY+=('OdroidN2_3.5mm' ': Onboard analogue 3.5mm audio')
+				G_WHIP_MENU_ARRAY+=('OdroidN2_HDMI' ': Onboard digital HDMI audio (default)' 'OdroidN2_3.5mm' ': Onboard analogue 3.5mm audio')
 
 			# Odroid C4: Modern image
 			elif [[ $G_HW_MODEL == 16 && -f '/boot/dietpiEnv.txt' ]]; then
 
 				G_WHIP_MENU_ARRAY+=('OdroidC4_HDMI' ': Onboard digital HDMI audio (default)')
-
 			fi
 
 			# Intel SST DSP

--- a/dietpi/dietpi-login
+++ b/dietpi/dietpi-login
@@ -185,7 +185,7 @@ Please login again as user "root" with password "dietpi", respectively the one y
 			if (( $G_DIETPI_INSTALL_STAGE == 0 )); then
 
 				# Start DietPi-Update
-				/boot/dietpi/dietpi-update 1 # Sets /boot/dietpi/.install_stage > G_DIETPI_INSTALL_STAGE=1
+				/boot/dietpi/dietpi-update 1 2>&1 | tee "$FP_DIETPI_FIRSTRUNSETUP_LOG" # Sets /boot/dietpi/.install_stage > G_DIETPI_INSTALL_STAGE=1
 
 				# Prompt on failure
 				(( $(</boot/dietpi/.install_stage) == 1 )) || Prompt_on_Failure
@@ -194,7 +194,7 @@ Please login again as user "root" with password "dietpi", respectively the one y
 			elif (( $G_DIETPI_INSTALL_STAGE == 1 )); then
 
 				# Start DietPi-Software
-				/boot/dietpi/dietpi-software 2>&1 | tee "$FP_DIETPI_FIRSTRUNSETUP_LOG" # Sets /boot/dietpi/.install_stage > G_DIETPI_INSTALL_STAGE=2
+				/boot/dietpi/dietpi-software 2>&1 | tee -a "$FP_DIETPI_FIRSTRUNSETUP_LOG" # Sets /boot/dietpi/.install_stage > G_DIETPI_INSTALL_STAGE=2
 
 				# Prompt on failure
 				(( $(</boot/dietpi/.install_stage) == 2 )) || Prompt_on_Failure

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2662,7 +2662,15 @@ _EOF_
 			then
 				# Add fbdev display driver for legacy framebuffer graphics support, as modesetting requires KMS driver overlay for /dev/dri/card0 to exists.
 				aDEPS+=('xserver-xorg-video-fbdev')
-
+				# RPi 5: Add config to force X11 using the correct DRM device: https://forums.raspberrypi.com/viewtopic.php?t=358853
+				(( $G_HW_MODEL == 5 )) && cat << '_EOF_' > /etc/X11/xorg.conf.d/02-dietpi-rpi5.conf
+Section "OutputClass"
+	Identifier "vc4"
+	MatchDriver "vc4"
+	Driver "modesetting"
+	Option "PrimaryGPU" "true"
+EndSection
+_EOF_
 			# x86_64 VM
 			elif (( $G_HW_ARCH == 10 && $G_HW_MODEL == 20 ))
 			then
@@ -2675,20 +2683,20 @@ _EOF_
 			then
 				cat << '_EOF_' > /etc/X11/xorg.conf.d/02-dietpi-aml-s905.conf
 Section "OutputClass"
-    Identifier "Amlogic"
-    MatchDriver "meson"
-    Driver "modesetting"
-    Option "PrimaryGPU" "true"
+	Identifier "Amlogic"
+	MatchDriver "meson"
+	Driver "modesetting"
+	Option "PrimaryGPU" "true"
 EndSection
 Section "Screen"
-    Identifier "Default Screen"
-    Device "Meson"
-    Monitor "foo"
-    DefaultDepth 24
-    SubSection "Display"
-        Depth 24
-        Modes "1920x1080" "1440x900" "1280x720" "1280x1024" "1280x960" "1024x768" "800x600" "640x480" "720x400"
-    EndSubSection
+	Identifier "Default Screen"
+	Device "Meson"
+	Monitor "foo"
+	DefaultDepth 24
+	SubSection "Display"
+		Depth 24
+		Modes "1920x1080" "1440x900" "1280x720" "1280x1024" "1280x960" "1024x768" "800x600" "640x480" "720x400"
+	EndSubSection
 EndSection
 _EOF_
 			fi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4896,6 +4896,7 @@ The install script will now exit. After applying one of the the above, rerun die
 		if To_Install 32 ympd # ympd
 		then
 			Download_Install "https://dietpi.com/downloads/binaries/$G_DISTRO_NAME/ympd_$G_HW_ARCH_NAME.deb"
+			G_EXEC systemctl stop ympd
 		fi
 
 		if To_Install 148 mympd # myMPD
@@ -9260,8 +9261,6 @@ _EOF_
 
 		if To_Install 183 vaultwarden # vaultwarden
 		then
-			[[ -f '/opt/vaultwarden/target/release/vaultwarden' ]] && G_EXEC rm -R /opt/vaultwarden # Pre-v8.7
-			[[ -f '/etc/systemd/system/vaultwarden.service' ]] && G_EXEC rm /etc/systemd/system/vaultwarden.service # Pre-v8.7
 			Download_Install "https://dietpi.com/downloads/binaries/$G_DISTRO_NAME/vaultwarden_$G_HW_ARCH_NAME.deb"
 			G_EXEC systemctl stop vaultwarden
 		fi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11710,9 +11710,16 @@ _EOF_
 
 		if To_Install 198 filebrowser # File Browser
 		then
-			local arch=$(dpkg --print-architecture)
-			local fallback_url="https://github.com/filebrowser/filebrowser/releases/download/v2.28.0/linux-${arch%l}-filebrowser.tar.gz"
-			Download_Install "$(curl -sSfL 'https://api.github.com/repos/filebrowser/filebrowser/releases/latest' | mawk -F\" "/^ *\"browser_download_url\": \".*\/linux-${arch%l}-filebrowser\.tar\.gz\"$/{print \$4}")" ./filebrowser/
+			case $G_HW_ARCH in
+				1) local arch='armv6';;
+				2) local arch='armv7';;
+				3) local arch='arm64';;
+				11) local arch='riscv64';;
+				*) local arch='amd64';;
+			esac
+
+			local fallback_url="https://github.com/filebrowser/filebrowser/releases/download/v2.28.0/linux-$arch-filebrowser.tar.gz"
+			Download_Install "$(curl -sSfL 'https://api.github.com/repos/filebrowser/filebrowser/releases/latest' | mawk -F\" "/^ *\"browser_download_url\": \".*\/linux-$arch-filebrowser\.tar\.gz\"$/{print \$4}")" ./filebrowser/
 
 			# Reinstall
 			[[ -d '/opt/filebrowser' ]] && G_EXEC rm -R /opt/filebrowser

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7521,7 +7521,7 @@ _EOF_
 			local json=()
 			[[ $PHP_VERSION == 8* ]] || aDEPS+=("php$PHP_VERSION-json") json=('json')
 
-			local fallback_url="https://github.com/ampache/ampache/releases/download/6.3.0/ampache-6.3.0_all_php$PHP_VERSION.zip"
+			local fallback_url="https://github.com/ampache/ampache/releases/download/6.3.1/ampache-6.3.1_all_php$PHP_VERSION.zip"
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/ampache/ampache/releases/latest' | mawk -F\" "/^ *\"browser_download_url\": \".*\/ampache-[0-9\.]*_all_php$PHP_VERSION.zip\"$/{print \$4}")" ampache
 
 			# Reinstall: Preserve configs from old and new paths
@@ -9951,7 +9951,7 @@ _EOF_
 					*) local arch='x64';;
 				esac
 
-				local fallback_url="https://github.com/Prowlarr/Prowlarr/releases/download/v1.14.3.4333/Prowlarr.master.1.14.3.4333.linux-core-$arch.tar.gz"
+				local fallback_url="https://github.com/Prowlarr/Prowlarr/releases/download/v1.15.0.4361/Prowlarr.master.1.15.0.4361.linux-core-$arch.tar.gz"
 				Download_Install "$(curl -sSfL 'https://api.github.com/repos/Prowlarr/Prowlarr/releases/latest' | mawk -F\" "/^ *\"browser_download_url\": \".*linux-core-$arch\.tar\.gz\"$/{print \$4}")"
 				G_EXEC mv Prowlarr /opt/prowlarr
 			fi
@@ -10026,7 +10026,7 @@ _EOF_
 					*) local arch='x64';;
 				esac
 
-				local fallback_url="https://github.com/Readarr/Readarr/releases/download/v0.3.20.2452/Readarr.develop.0.3.20.2452.linux-core-$arch.tar.gz"
+				local fallback_url="https://github.com/Readarr/Readarr/releases/download/v0.3.21.2475/Readarr.develop.0.3.21.2475.linux-core-$arch.tar.gz"
 				Download_Install "$(curl -sSfL 'https://api.github.com/repos/Readarr/Readarr/releases' | mawk -F\" "/^ *\"browser_download_url\": \".*linux-core-$arch\.tar\.gz\"$/{print \$4}" | head -1)"
 				G_EXEC mv Readarr /opt/readarr
 			fi
@@ -10590,7 +10590,7 @@ _EOF_
 				*) local arch='arm-6';;
 			esac
 
-			local fallback_url="https://github.com/go-gitea/gitea/releases/download/v1.21.9/gitea-1.21.9-linux-$arch.xz"
+			local fallback_url="https://github.com/go-gitea/gitea/releases/download/v1.21.10/gitea-1.21.10-linux-$arch.xz"
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/go-gitea/gitea/releases/latest' | mawk -F\" "/\"browser_download_url\": \".*\/gitea-[^\"\/]*-linux-$arch\.xz\"/{print \$4}")" /mnt/dietpi_userdata/gitea/gitea
 
 			# User

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8913,7 +8913,7 @@ _EOF_
 					*) local arch='arm';;
 				esac
 
-				local fallback_url="https://github.com/syncthing/syncthing/releases/download/v1.27.4/syncthing-linux-$arch-v1.27.4.tar.gz"
+				local fallback_url="https://github.com/syncthing/syncthing/releases/download/v1.27.5/syncthing-linux-$arch-v1.27.5.tar.gz"
 				Download_Install "$(curl -sSfL 'https://api.github.com/repos/syncthing/syncthing/releases/latest' | mawk -F\" "/\"browser_download_url\": .*\/syncthing-linux-$arch-[^\"\/]*\.tar\.gz\"/{print \$4}")"
 				G_EXEC mv syncthing-* /opt/syncthing
 			fi
@@ -10034,7 +10034,7 @@ _EOF_
 					*) local arch='x64';;
 				esac
 
-				local fallback_url="https://github.com/Readarr/Readarr/releases/download/v0.3.21.2475/Readarr.develop.0.3.21.2475.linux-core-$arch.tar.gz"
+				local fallback_url="https://github.com/Readarr/Readarr/releases/download/v0.3.22.2499/Readarr.develop.0.3.22.2499.linux-core-$arch.tar.gz"
 				Download_Install "$(curl -sSfL 'https://api.github.com/repos/Readarr/Readarr/releases' | mawk -F\" "/^ *\"browser_download_url\": \".*linux-core-$arch\.tar\.gz\"$/{print \$4}" | head -1)"
 				G_EXEC mv Readarr /opt/readarr
 			fi
@@ -11710,15 +11710,7 @@ _EOF_
 
 		if To_Install 198 filebrowser # File Browser
 		then
-			case $G_HW_ARCH in
-				1) local arch='armv6';;
-				2) local arch='armv7';;
-				3) local arch='arm64';;
-				11) local arch='riscv64';;
-				*) local arch='amd64';;
-			esac
-
-			local fallback_url="https://github.com/filebrowser/filebrowser/releases/download/v2.27.0/linux-$arch-filebrowser.tar.gz"
+			local fallback_url="https://github.com/filebrowser/filebrowser/releases/download/v2.28.0/linux-${G_HW_ARCH_NAME%l}-filebrowser.tar.gz"
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/filebrowser/filebrowser/releases/latest' | mawk -F\" "/^ *\"browser_download_url\": \".*\/linux-$arch-filebrowser\.tar\.gz\"$/{print \$4}")" ./filebrowser/
 
 			# Reinstall

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6998,7 +6998,7 @@ _EOF_
 			(( $G_HW_ARCH == 10 )) && arch='amd64'
 
 			# Grab latest package URL
-			local fallback_url="https://downloads.lms-community.org/nightly/logitechmediaserver_8.5.1~1711624004_$arch.deb"
+			local fallback_url="https://downloads.lms-community.org/nightly/logitechmediaserver_8.5.1~1712473975_$arch.deb"
 			Download_Install "$(curl -sSf 'https://raw.githubusercontent.com/LMS-Community/lms-server-repository/master/stable.xml' | grep -om1 "https://[^\"]*_$arch.deb")"
 			G_EXEC systemctl stop logitechmediaserver
 			Remove_SysV logitechmediaserver
@@ -9172,8 +9172,8 @@ _EOF_
 		then
 			# APT deps
 			aDEPS=('par2' 'p7zip-full')
-			# - ARMv6/7 on Bookworm + RISC-V: gcc and libffi-dev for cffi; pkg-config, libssl-dev and Rust for cryptography, g++ for sabctools and ujson
-			if (( $G_DISTRO > 6 && $G_HW_ARCH < 3 || $G_HW_ARCH == 11 ))
+			# - RISC-V: gcc and libffi-dev for cffi; pkg-config, libssl-dev and Rust for cryptography, g++ for sabctools and ujson
+			if (( $G_HW_ARCH == 11 ))
 			then
 				aDEPS+=('g++' 'libffi-dev' 'libssl-dev' 'pkg-config')
 				G_EXEC curl -sSf 'https://sh.rustup.rs/' -o rustup-init.sh
@@ -9181,11 +9181,6 @@ _EOF_
 				G_EXEC_OUTPUT=1 G_EXEC ./rustup-init.sh -y --profile minimal
 				G_EXEC rm rustup-init.sh
 				export PATH="/root/.cargo/bin:$PATH"
-
-			# - ARMv6/7 temporary workaround: https://github.com/piwheels/packages/issues/358
-			elif (( $G_HW_ARCH < 3 ))
-			then
-				aDEPS+=('g++')
 			fi
 
 			Download_Install 'https://github.com/sabnzbd/sabnzbd/archive/master.tar.gz'

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3041,7 +3041,7 @@ unix_socket_directories = '/run/postgresql'" > "$i/00dietpi.conf"
 			# - On Raspbian use separate suite: https://github.com/MichaIng/DietPi/issues/1023
 			local suite='buster'
 			(( $G_RASPBIAN )) && suite='raspbianbuster'
-			G_EXEC eval "echo 'deb https://download.mono-project.com/repo/debian/ $suite main' > /etc/apt/sources.list.d/dietpi-mono.list"
+			G_EXEC eval "echo 'deb https://download.mono-project.com/repo/debian $suite main' > /etc/apt/sources.list.d/dietpi-mono.list"
 			G_AGUP
 
 			# APT package
@@ -5039,7 +5039,7 @@ _EOF_
 				G_EXEC eval "curl -sSfL '$url' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-mopidy.gpg --yes"
 
 				# APT list
-				G_EXEC eval "echo 'deb https://apt.mopidy.com/ ${G_DISTRO_NAME/bookworm/bullseye} main contrib non-free' > /etc/apt/sources.list.d/mopidy.list"
+				G_EXEC eval "echo 'deb https://apt.mopidy.com ${G_DISTRO_NAME/bookworm/bullseye} main contrib non-free' > /etc/apt/sources.list.d/mopidy.list"
 				G_AGUP
 			fi
 
@@ -6695,7 +6695,7 @@ _EOF_
 				G_EXEC eval "curl -sSfL '$url' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-mosquitto.gpg --yes"
 
 				# APT list
-				G_EXEC eval "echo 'deb https://repo.mosquitto.org/debian/ $G_DISTRO_NAME main' > /etc/apt/sources.list.d/dietpi-mosquitto.list"
+				G_EXEC eval "echo 'deb https://repo.mosquitto.org/debian $G_DISTRO_NAME main' > /etc/apt/sources.list.d/dietpi-mosquitto.list"
 				G_AGUP
 			fi
 
@@ -7293,7 +7293,7 @@ _EOF_
 			G_EXEC eval "curl -sSfL '$url' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-influxdb.gpg --yes"
 
 			# APT list
-			G_EXEC eval "echo 'deb https://repos.influxdata.com/debian/ ${G_DISTRO_NAME/bookworm/bullseye} stable' > /etc/apt/sources.list.d/influxdb.list"
+			G_EXEC eval "echo 'deb https://repos.influxdata.com/debian ${G_DISTRO_NAME/bookworm/bullseye} stable' > /etc/apt/sources.list.d/influxdb.list"
 			G_AGUP
 
 			# APT package
@@ -7331,7 +7331,7 @@ _EOF_
 				G_EXEC eval "curl -sSfL '$url' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-grafana.gpg --yes"
 
 				# APT list
-				G_EXEC eval "echo 'deb https://apt.grafana.com/ stable main' > /etc/apt/sources.list.d/grafana.list"
+				G_EXEC eval "echo 'deb https://apt.grafana.com stable main' > /etc/apt/sources.list.d/grafana.list"
 				G_AGUP
 
 				# APT package
@@ -7791,7 +7791,7 @@ _EOF_
 			G_EXEC eval "curl -sSfL '$url' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-zerotier.gpg --yes"
 
 			# APT list
-			G_EXEC eval "echo 'deb https://download.zerotier.com/debian/${G_DISTRO_NAME/trixie/bookworm}/ ${G_DISTRO_NAME/trixie/bookworm} main' > /etc/apt/sources.list.d/dietpi-zerotier.list"
+			G_EXEC eval "echo 'deb https://download.zerotier.com/debian/${G_DISTRO_NAME/trixie/bookworm} ${G_DISTRO_NAME/trixie/bookworm} main' > /etc/apt/sources.list.d/dietpi-zerotier.list"
 			G_AGUP
 
 			# APT package
@@ -8285,7 +8285,7 @@ location = /.well-known/caldav  { return 301 /baikal/html/dav.php; }' > /etc/ngi
 			G_EXEC eval "curl -sSfL '$url' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-plexmediaserver.gpg --yes"
 
 			# APT list
-			G_EXEC eval 'echo '\''deb https://downloads.plex.tv/repo/deb/ public main'\'' > /etc/apt/sources.list.d/plexmediaserver.list'
+			G_EXEC eval 'echo '\''deb https://downloads.plex.tv/repo/deb public main'\'' > /etc/apt/sources.list.d/plexmediaserver.list'
 			G_AGUP
 
 			# APT package
@@ -9408,7 +9408,7 @@ _EOF_
 			G_EXEC eval 'curl -sSf '\''https://keyserver.ubuntu.com/pks/lookup?search=0x2009837CBFFD68F45BC180471F4F90DE2A9B4BF8&op=get'\'' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-sonarr.gpg --yes'
 
 			# APT list: Buster is the latest available suite: https://apt.sonarr.tv/debian/dists/
-			G_EXEC eval 'echo '\''deb https://apt.sonarr.tv/debian/ buster main'\'' > /etc/apt/sources.list.d/sonarr.list'
+			G_EXEC eval 'echo '\''deb https://apt.sonarr.tv/debian buster main'\'' > /etc/apt/sources.list.d/sonarr.list'
 
 			# Update package lists
 			G_AGUP
@@ -10029,7 +10029,7 @@ _EOF_
 					*) local arch='x64';;
 				esac
 
-				local fallback_url="https://github.com/Readarr/Readarr/releases/download/v0.3.22.2499/Readarr.develop.0.3.22.2499.linux-core-$arch.tar.gz"
+				local fallback_url="https://github.com/Readarr/Readarr/releases/download/v0.3.23.2506/Readarr.develop.0.3.23.2506.linux-core-$arch.tar.gz"
 				Download_Install "$(curl -sSfL 'https://api.github.com/repos/Readarr/Readarr/releases' | mawk -F\" "/^ *\"browser_download_url\": \".*linux-core-$arch\.tar\.gz\"$/{print \$4}" | head -1)"
 				G_EXEC mv Readarr /opt/readarr
 			fi
@@ -10372,7 +10372,7 @@ _EOF_
 				G_EXEC eval "curl -sSfL '$url' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-docker.gpg --yes"
 
 				# APT list
-				G_EXEC eval "echo 'deb https://download.docker.com/linux/$distro/ ${G_DISTRO_NAME/trixie/bookworm} stable' > /etc/apt/sources.list.d/docker.list"
+				G_EXEC eval "echo 'deb https://download.docker.com/linux/$distro ${G_DISTRO_NAME/trixie/bookworm} stable' > /etc/apt/sources.list.d/docker.list"
 				G_AGUP
 
 				# APT package name
@@ -10766,7 +10766,7 @@ _EOF_
 				G_EXEC eval "curl -sSfL '$url' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-raspotify.gpg --yes"
 
 				# APT list
-				G_EXEC eval 'echo '\''deb https://dtcooper.github.io/raspotify/ raspotify main'\'' > /etc/apt/sources.list.d/raspotify.list'
+				G_EXEC eval 'echo '\''deb https://dtcooper.github.io/raspotify raspotify main'\'' > /etc/apt/sources.list.d/raspotify.list'
 				G_AGUP
 
 				# APT package
@@ -10927,7 +10927,7 @@ _EOF_
 			G_EXEC eval "curl -sSfL '$url' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-jellyfin.gpg --yes"
 
 			# APT list
-			G_EXEC eval "echo 'deb https://repo.jellyfin.org/debian/ $G_DISTRO_NAME main' > /etc/apt/sources.list.d/dietpi-jellyfin.list"
+			G_EXEC eval "echo 'deb https://repo.jellyfin.org/debian $G_DISTRO_NAME main' > /etc/apt/sources.list.d/dietpi-jellyfin.list"
 			G_AGUP
 
 			# APT meta package: Server, web component and FFmpeg implementation
@@ -11077,7 +11077,7 @@ _EOF_
 			G_EXEC eval "curl -sSfL '$url' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-moonlight.gpg --yes"
 
 			# APT list
-			G_EXEC eval "echo 'deb https://dl.cloudsmith.io/public/moonlight-game-streaming/moonlight-embedded/deb/raspbian/ ${G_DISTRO_NAME/trixie/bookworm} main' > /etc/apt/sources.list.d/dietpi-moonlight.list"
+			G_EXEC eval "echo 'deb https://dl.cloudsmith.io/public/moonlight-game-streaming/moonlight-embedded/deb/raspbian ${G_DISTRO_NAME/trixie/bookworm} main' > /etc/apt/sources.list.d/dietpi-moonlight.list"
 			G_AGUP
 
 			# APT deps
@@ -11099,7 +11099,7 @@ _EOF_
 			G_EXEC eval "curl -sSfL '$url' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-moonlight-qt.gpg --yes"
 
 			# APT list
-			G_EXEC eval "echo 'deb https://dl.cloudsmith.io/public/moonlight-game-streaming/moonlight-qt/deb/raspbian/ ${G_DISTRO_NAME/trixie/bookworm} main' > /etc/apt/sources.list.d/dietpi-moonlight-qt.list"
+			G_EXEC eval "echo 'deb https://dl.cloudsmith.io/public/moonlight-game-streaming/moonlight-qt/deb/raspbian ${G_DISTRO_NAME/trixie/bookworm} main' > /etc/apt/sources.list.d/dietpi-moonlight-qt.list"
 			G_AGUP
 
 			# Install: libgl1 required, else start from console prints "SDL Error: Can't load EGL/GL library on window creation.", the GUI says it cannot find a video decoder and streaming does not start.

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3082,8 +3082,8 @@ unix_socket_directories = '/run/postgresql'" > "$i/00dietpi.conf"
 
 		if To_Install 170 # UnRAR
 		then
-			# On Raspbian and for RISC-V, only "unrar-free" is available which does not support all RAR formats, thus we use "unrar" [non-free] from Debian on ARMv7+ models: http://raspbian.raspberrypi.com/raspbian/pool/non-free/u/unrar-nonfree/, https://deb.debian.org/debian-ports/pool/non-free/u/unrar-nonfree/
-			if (( $G_HW_ARCH == 1 || $G_HW_ARCH == 11 ))
+			# On Raspbian, only "unrar-free" is available which does not support all RAR formats, thus we use "unrar" [non-free] from Debian on ARMv7+ models: http://raspbian.raspberrypi.com/raspbian/pool/non-free/u/unrar-nonfree/
+			if (( $G_HW_ARCH == 1 ))
 			then
 				G_AGI unrar-free
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4140,8 +4140,8 @@ _EOF_
 			esac
 
 			# Download latest version
-			local version=$(curl -sSfL 'https://dist.ipfs.io/go-ipfs/versions' | tail -1)
-			[[ $version ]] || { version='v0.20.0'; G_DIETPI-NOTIFY 1 "Automatic latest ${aSOFTWARE_NAME[$software_id]} version detection failed. Version \"$version\" will be installed as fallback, but a newer version might be available. Please report this at: https://github.com/MichaIng/DietPi/issues"; }
+			local version=$(curl -sSfL 'https://dist.ipfs.io/go-ipfs/versions' | sed '/-rc[0-9]*$/d' | tail -1)
+			[[ $version ]] || { version='v0.27.0'; G_DIETPI-NOTIFY 1 "Automatic latest ${aSOFTWARE_NAME[$software_id]} version detection failed. Version \"$version\" will be installed as fallback, but a newer version might be available. Please report this at: https://github.com/MichaIng/DietPi/issues"; }
 			Download_Install "https://dist.ipfs.io/go-ipfs/$version/go-ipfs_${version}_linux-$arch.tar.gz"
 
 			# Install
@@ -4192,7 +4192,7 @@ _EOF_
 		if To_Install 16 # microblog.pub
 		then
 			local micro_name='microblog-pub'
-			local micro_python_version='3.11.4' # https://github.com/pyenv/pyenv/tree/master/plugins/python-build/share/python-build
+			local micro_python_version='3.12.3' # https://github.com/pyenv/pyenv/tree/master/plugins/python-build/share/python-build
 			local micro_pyenv_dir="/opt/$micro_name"
 			local micro_pyenv_activate_file="$micro_pyenv_dir/pyenv-activate.sh"
 			local micro_virtualenv="$micro_pyenv_dir/.virtual_path"
@@ -5287,7 +5287,7 @@ _EOF_
 			local arch=$(dpkg --print-architecture)
 			local version=$(curl -sSfL 'https://hndl.urbackup.org/Server/' | grep -Pwo '(?<=href=")[0-9.]+(?=/")' | sort -Vr | head -1)
 			local file=$(curl -sSfL "https://hndl.urbackup.org/Server/$version/" | grep -Pwom1 "(?<=href=\")urbackup-server_${version}_$arch\.deb(?=\")")
-			local fallback_url="https://hndl.urbackup.org/Server/2.5.31/urbackup-server_2.5.31_$arch.deb"
+			local fallback_url="https://hndl.urbackup.org/Server/2.5.33/urbackup-server_2.5.33_$arch.deb"
 			Download_Install "${file:+https://hndl.urbackup.org/Server/$version/$file}"
 			G_EXEC systemctl stop urbackupsrv
 			unset -v backuppath arch version file
@@ -6301,7 +6301,7 @@ _EOF_
 				*) local arch='x64';;
 			esac
 
-			local fallback_url="https://github.com/Kareadita/Kavita/releases/download/v0.7.14/kavita-linux-$arch.tar.gz"
+			local fallback_url="https://github.com/Kareadita/Kavita/releases/download/v0.8.0/kavita-linux-$arch.tar.gz"
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/Kareadita/Kavita/releases/latest' | mawk -F\" "/^ *\"browser_download_url\": \".*\/kavita-linux-$arch\.tar\.gz\"$/{print \$4}")"
 			G_EXEC chmod +x Kavita/Kavita
 
@@ -6509,7 +6509,7 @@ _EOF_
 			esac
 
 			# Download
-			local fallback_url="https://github.com/fatedier/frp/releases/download/v0.56.0/frp_0.56.0_linux_$arch.tar.gz"
+			local fallback_url="https://github.com/fatedier/frp/releases/download/v0.57.0/frp_0.57.0_linux_$arch.tar.gz"
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/fatedier/frp/releases/latest' | mawk -F\" "/\"browser_download_url\": .*\/frp_[0-9.]*_linux_$arch\.tar\.gz\"/{print \$4}")"
 
 			G_EXEC cd frp_*
@@ -6896,7 +6896,7 @@ _EOF_
 
 		if To_Install 98 haproxy # HAProxy
 		then
-			local version='2.8.3' # https://www.haproxy.org/download/
+			local version='2.9.7' # https://www.haproxy.org/download/
 			aDEPS=('make' 'gcc' 'libpcre3-dev' 'libssl-dev' 'zlib1g-dev' 'libsystemd-dev')
 			Download_Install "https://www.haproxy.org/download/${version%.*}/src/haproxy-$version.tar.gz"
 
@@ -8522,7 +8522,7 @@ _EOF_
 			# Install ruTorrent: Web UI for rTorrent
 			# - Grab current version
 			local version=$(curl -sSfL 'https://api.github.com/repos/Novik/ruTorrent/releases/latest' | mawk -F\" '/^ *"tag_name": "[^"]*",$/{print $4}')
-			[[ $version ]] || { version='v4.2.11'; G_DIETPI-NOTIFY 1 "Automatic latest ruTorrent version detection failed. Version \"$version\" will be installed as fallback, but a newer version might be available. Please report this at: https://github.com/MichaIng/DietPi/issues"; }
+			[[ $version ]] || { version='v4.3.0'; G_DIETPI-NOTIFY 1 "Automatic latest ruTorrent version detection failed. Version \"$version\" will be installed as fallback, but a newer version might be available. Please report this at: https://github.com/MichaIng/DietPi/issues"; }
 			Download_Install "https://github.com/Novik/ruTorrent/archive/$version.tar.gz"
 
 			# - Reinstall freshly with preserved configs and 3rd party plugins
@@ -8913,7 +8913,7 @@ _EOF_
 					*) local arch='arm';;
 				esac
 
-				local fallback_url="https://github.com/syncthing/syncthing/releases/download/v1.27.5/syncthing-linux-$arch-v1.27.5.tar.gz"
+				local fallback_url="https://github.com/syncthing/syncthing/releases/download/v1.27.6/syncthing-linux-$arch-v1.27.6.tar.gz"
 				Download_Install "$(curl -sSfL 'https://api.github.com/repos/syncthing/syncthing/releases/latest' | mawk -F\" "/\"browser_download_url\": .*\/syncthing-linux-$arch-[^\"\/]*\.tar\.gz\"/{print \$4}")"
 				G_EXEC mv syncthing-* /opt/syncthing
 			fi
@@ -9510,7 +9510,7 @@ _EOF_
 					esac
 
 					url=$(curl -sSfL 'https://api.github.com/repos/Radarr/Radarr/releases/latest' | mawk -F\" "/^ *\"browser_download_url\": \".*linux-core-$arch\.tar\.gz\"$/{print \$4}")
-					local fallback_url="https://github.com/Radarr/Radarr/releases/download/v5.3.6.8612/Radarr.master.5.3.6.8612.linux-core-$arch.tar.gz"
+					local fallback_url="https://github.com/Radarr/Radarr/releases/download/v5.4.6.8723/Radarr.master.5.4.6.8723.linux-core-$arch.tar.gz"
 				fi
 
 				Download_Install "$url"
@@ -9607,7 +9607,7 @@ _EOF_
 					esac
 
 					url=$(curl -sSfL 'https://api.github.com/repos/Lidarr/Lidarr/releases/latest' | mawk -F\" "/^ *\"browser_download_url\": \".*linux-core-$arch\.tar\.gz\"$/{print \$4}")
-					local fallback_url="https://github.com/Lidarr/Lidarr/releases/download/v2.1.7.4030/Lidarr.master.2.1.7.4030.linux-core-$arch.tar.gz"
+					local fallback_url="https://github.com/Lidarr/Lidarr/releases/download/v2.2.5.4141/Lidarr.master.2.2.5.4141.linux-core-$arch.tar.gz"
 				fi
 
 				Download_Install "$url"
@@ -11133,7 +11133,7 @@ _EOF_
 				# v3 drops PHP 7.4 support: https://github.com/TasmoAdmin/TasmoAdmin/releases/tag/v3.0.0
 				if (( $G_DISTRO > 6 ))
 				then
-					local fallback_url='https://github.com/TasmoAdmin/TasmoAdmin/releases/download/v4.0.1/tasmoadmin_v4.0.1.tar.gz'
+					local fallback_url='https://github.com/TasmoAdmin/TasmoAdmin/releases/download/v4.0.2/tasmoadmin_v4.0.2.tar.gz'
 					Download_Install "$(curl -sSfL 'https://api.github.com/repos/TasmoAdmin/TasmoAdmin/releases/latest' | mawk -F\" '/^ *"browser_download_url": ".*\/tasmoadmin_v[^"\/]*\.tar\.gz"$/{print $4}')"
 				else
 					Download_Install 'https://github.com/TasmoAdmin/TasmoAdmin/releases/download/v2.4.2/tasmoadmin_v2.4.2.tar.gz'
@@ -11230,7 +11230,7 @@ _EOF_
 			local ha_user='homeassistant'
 			local ha_home="/home/$ha_user"
 			local ha_pyenv_activation=". $ha_home/pyenv-activate.sh"
-			local ha_python_version='3.12.1' # https://github.com/pyenv/pyenv/tree/master/plugins/python-build/share/python-build
+			local ha_python_version='3.12.3' # https://github.com/pyenv/pyenv/tree/master/plugins/python-build/share/python-build
 
 			G_DIETPI-NOTIFY 2 "Home Assistant user:  $ha_user"
 			G_DIETPI-NOTIFY 2 "Home Assistant home:  $ha_home"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6687,7 +6687,7 @@ _EOF_
 		then
 			# Use official APT repository where available: https://repo.mosquitto.org/debian/pool/main/m/mosquitto/
 			# - Current builds are not ARMv6 compatible: https://github.com/MichaIng/DietPi/issues/5140
-			if (( $G_DISTRO < 8 )) && [[ $G_HW_ARCH == 2 || $G_HW_ARCH == 10 ]]
+			if (( $G_DISTRO < 8 )) && [[ $G_HW_ARCH == 2 || $G_HW_ARCH == 10 || ( $G_HW_ARCH == 3 && $G_DISTRO == 7 ) ]]
 			then
 				# APT key
 				local url='https://repo.mosquitto.org/debian/mosquitto-repo.gpg.key'

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11710,8 +11710,9 @@ _EOF_
 
 		if To_Install 198 filebrowser # File Browser
 		then
-			local fallback_url="https://github.com/filebrowser/filebrowser/releases/download/v2.28.0/linux-${G_HW_ARCH_NAME%l}-filebrowser.tar.gz"
-			Download_Install "$(curl -sSfL 'https://api.github.com/repos/filebrowser/filebrowser/releases/latest' | mawk -F\" "/^ *\"browser_download_url\": \".*\/linux-$arch-filebrowser\.tar\.gz\"$/{print \$4}")" ./filebrowser/
+			local arch=$(dpkg --print-architecture)
+			local fallback_url="https://github.com/filebrowser/filebrowser/releases/download/v2.28.0/linux-${arch%l}-filebrowser.tar.gz"
+			Download_Install "$(curl -sSfL 'https://api.github.com/repos/filebrowser/filebrowser/releases/latest' | mawk -F\" "/^ *\"browser_download_url\": \".*\/linux-${arch%l}-filebrowser\.tar\.gz\"$/{print \$4}")" ./filebrowser/
 
 			# Reinstall
 			[[ -d '/opt/filebrowser' ]] && G_EXEC rm -R /opt/filebrowser

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4192,7 +4192,7 @@ _EOF_
 		if To_Install 16 # microblog.pub
 		then
 			local micro_name='microblog-pub'
-			local micro_python_version='3.12.3' # https://github.com/pyenv/pyenv/tree/master/plugins/python-build/share/python-build
+			local micro_python_version='3.11.9' # https://github.com/pyenv/pyenv/tree/master/plugins/python-build/share/python-build
 			local micro_pyenv_dir="/opt/$micro_name"
 			local micro_pyenv_activate_file="$micro_pyenv_dir/pyenv-activate.sh"
 			local micro_virtualenv="$micro_pyenv_dir/.virtual_path"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6501,7 +6501,7 @@ _EOF_
 			esac
 
 			# Download
-			local fallback_url="https://github.com/fatedier/frp/releases/download/v0.55.1/frp_0.55.1_linux_$arch.tar.gz"
+			local fallback_url="https://github.com/fatedier/frp/releases/download/v0.56.0/frp_0.56.0_linux_$arch.tar.gz"
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/fatedier/frp/releases/latest' | mawk -F\" "/\"browser_download_url\": .*\/frp_[0-9.]*_linux_$arch\.tar\.gz\"/{print \$4}")"
 
 			G_EXEC cd frp_*
@@ -8176,7 +8176,7 @@ _EOF_
 			# APT deps: https://github.com/sabre-io/Baikal/wiki/Baïkal-dependencies
 			aDEPS=("php$PHP_VERSION-xml" "php$PHP_VERSION-mbstring" "php$PHP_VERSION-mysql")
 
-			local fallback_url='https://github.com/sabre-io/Baikal/releases/download/0.9.3/baikal-0.9.3.zip'
+			local fallback_url='https://github.com/sabre-io/Baikal/releases/download/0.9.5/baikal-0.9.5.zip'
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/sabre-io/Baikal/releases/latest' | mawk -F\" '/^ *"browser_download_url": ".*\/baikal-[^"\/]*\.zip"$/{print $4}')"
 
 			# Reinstall: https://sabre.io/baikal/upgrade/
@@ -9951,7 +9951,7 @@ _EOF_
 					*) local arch='x64';;
 				esac
 
-				local fallback_url="https://github.com/Prowlarr/Prowlarr/releases/download/v1.13.3.4273/Prowlarr.master.1.13.3.4273.linux-core-$arch.tar.gz"
+				local fallback_url="https://github.com/Prowlarr/Prowlarr/releases/download/v1.14.3.4333/Prowlarr.master.1.14.3.4333.linux-core-$arch.tar.gz"
 				Download_Install "$(curl -sSfL 'https://api.github.com/repos/Prowlarr/Prowlarr/releases/latest' | mawk -F\" "/^ *\"browser_download_url\": \".*linux-core-$arch\.tar\.gz\"$/{print \$4}")"
 				G_EXEC mv Prowlarr /opt/prowlarr
 			fi
@@ -10590,7 +10590,7 @@ _EOF_
 				*) local arch='arm-6';;
 			esac
 
-			local fallback_url="https://github.com/go-gitea/gitea/releases/download/v1.21.8/gitea-1.21.8-linux-$arch.xz"
+			local fallback_url="https://github.com/go-gitea/gitea/releases/download/v1.21.9/gitea-1.21.9-linux-$arch.xz"
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/go-gitea/gitea/releases/latest' | mawk -F\" "/\"browser_download_url\": \".*\/gitea-[^\"\/]*-linux-$arch\.xz\"/{print \$4}")" /mnt/dietpi_userdata/gitea/gitea
 
 			# User

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6990,8 +6990,8 @@ _EOF_
 			(( $G_HW_ARCH == 10 )) && arch='amd64'
 
 			# Grab latest package URL
-			local fallback_url="https://downloads.slimdevices.com/nightly/logitechmediaserver_8.3.2~1702911674_$arch.deb"
-			Download_Install "$(curl -sSf 'https://lms-community.github.io/lms-server-repository/stable.xml' | grep -om1 "https://[^\"]*_$arch.deb")"
+			local fallback_url="https://downloads.lms-community.org/nightly/logitechmediaserver_8.5.1~1711624004_$arch.deb"
+			Download_Install "$(curl -sSf 'https://raw.githubusercontent.com/LMS-Community/lms-server-repository/master/stable.xml' | grep -om1 "https://[^\"]*_$arch.deb")"
 			G_EXEC systemctl stop logitechmediaserver
 			Remove_SysV logitechmediaserver
 

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -55,7 +55,7 @@
 	# - Assign defaults/code version as fallback
 	[[ $G_DIETPI_VERSION_CORE ]] || G_DIETPI_VERSION_CORE=9
 	[[ $G_DIETPI_VERSION_SUB ]] || G_DIETPI_VERSION_SUB=3
-	[[ $G_DIETPI_VERSION_RC ]] || G_DIETPI_VERSION_RC=-1
+	[[ $G_DIETPI_VERSION_RC ]] || G_DIETPI_VERSION_RC=0
 	[[ $G_GITBRANCH ]] || G_GITBRANCH='master'
 	[[ $G_GITOWNER ]] || G_GITOWNER='MichaIng'
 	# - Save current version and Git branch

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -54,8 +54,8 @@
 	[[ -f '/boot/dietpi/.version' ]] && . /boot/dietpi/.version
 	# - Assign defaults/code version as fallback
 	[[ $G_DIETPI_VERSION_CORE ]] || G_DIETPI_VERSION_CORE=9
-	[[ $G_DIETPI_VERSION_SUB ]] || G_DIETPI_VERSION_SUB=2
-	[[ $G_DIETPI_VERSION_RC ]] || G_DIETPI_VERSION_RC=1
+	[[ $G_DIETPI_VERSION_SUB ]] || G_DIETPI_VERSION_SUB=3
+	[[ $G_DIETPI_VERSION_RC ]] || G_DIETPI_VERSION_RC=-1
 	[[ $G_GITBRANCH ]] || G_GITBRANCH='master'
 	[[ $G_GITOWNER ]] || G_GITOWNER='MichaIng'
 	# - Save current version and Git branch

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -1729,8 +1729,21 @@ _EOF_
 		local kms=$(grep -Em1 '^[[:blank:]]*dtoverlay=vc4-kms-v3d(-pi4)?(,|$)' /boot/config.txt)
 		[[ $kms && ! $kms =~ ',noaudio'(,|$) ]] && G_EXEC sed --follow-symlinks -Ei '/^[[:blank:]]*dtoverlay=vc4-kms-v3d(-pi4)?(,|$)/s/$/,noaudio/' /boot/config.txt
 
-		# Use "auto" as default
-		[[ $INPUT_DEVICE_VALUE == 'default' ]] && INPUT_DEVICE_VALUE='rpi-bcm2835-auto'
+		# On RPi 5, use "hdmi" by default, else "auto": https://dietpi.com/forum/t/19760
+		if [[ $INPUT_DEVICE_VALUE == 'default' ]]
+		then
+			if (( $G_HW_MODEL == 5 ))
+			then
+				INPUT_DEVICE_VALUE='rpi-bcm2835-hdmi'
+			else
+				INPUT_DEVICE_VALUE='rpi-bcm2835-auto'
+			fi
+
+		# RPi 5: Enforce HDMI audio if any onboard audio was selected, as it does not have a 3.5mm jack.
+		elif [[ $G_HW_MODEL == 5 && INPUT_DEVICE_VALUE == 'rpi-bcm2835-'* ]]
+		then
+			INPUT_DEVICE_VALUE='rpi-bcm2835-hdmi'
+		fi
 	}
 
 	Soundcard_Reset_Odroid()
@@ -1942,6 +1955,9 @@ _EOF_
 			#	rpi-bcm2835-3.5mm
 			#	rpi-bcm2835-hdmi
 			'rpi-bcm2835-'*)
+
+				# RPi 5: Enable KMS as the snd_bcm2835 driver does not work on Raspberry Pi 5. It has no 3.5mm jack, hence the only supported onboard audio is HDMI.
+				(( $G_HW_MODEL == 5 )) && INPUT_DEVICE_VALUE='vc4-kms-v3d' RPi_OpenGL_Main
 
 				# Enable VC4 HDMI audio if onboard HDMI is enabled and KMS used, as the bcm2835 HDMI audio driver and KMS conflict: https://dietpi.com/forum/t/19568, https://github.com/raspberrypi/linux/issues/4651
 				if [[ $INPUT_DEVICE_VALUE != *'3.5mm' ]] && grep -Eq '^[[:blank:]]*dtoverlay=vc4-kms-v3d(-pi4)?,(noaudio|.+,noaudio)(,|$)' /boot/config.txt

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -1740,7 +1740,7 @@ _EOF_
 			fi
 
 		# RPi 5: Enforce HDMI audio if any onboard audio was selected, as it does not have a 3.5mm jack.
-		elif [[ $G_HW_MODEL == 5 && INPUT_DEVICE_VALUE == 'rpi-bcm2835-'* ]]
+		elif [[ $G_HW_MODEL == 5 && $INPUT_DEVICE_VALUE == 'rpi-bcm2835-'* ]]
 		then
 			INPUT_DEVICE_VALUE='rpi-bcm2835-hdmi'
 		fi

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -119,7 +119,7 @@ $FP_SCRIPT	rpi_kernel_choice		<empty> Supported on Debian Bookworm or newer on R
 		local components='main' all_components=''
 		(( $G_HW_ARCH == 1 )) && components='main-armv6'
 		# - Additional components for SBC-specific packages and builds, some per distro version, some for all distro versions
-		[[ $G_HW_MODEL [2-5] ]] && components+=' rpi$G_HW_MODEL'
+		[[ $G_HW_MODEL == [2-5] ]] && components+=' rpi$G_HW_MODEL'
 		case $G_HW_MODEL in
 			[0-9]) all_components='rpi';;
 			10) all_components='odroidc1';;
@@ -166,7 +166,7 @@ $FP_SCRIPT	rpi_kernel_choice		<empty> Supported on Debian Bookworm or newer on R
 		esac
 		G_EXEC eval "echo 'deb https://dietpi.com/apt $G_DISTRO_NAME $components' > /etc/apt/sources.list.d/dietpi.list"
 		[[ $all_components ]] && G_EXEC eval "echo 'deb https://dietpi.com/apt all $all_components' >> /etc/apt/sources.list.d/dietpi.list"
-		
+
 		# Exit path for quick DietPi-only repo updates
 		[[ $INPUT_MODE_VALUE == 'dietpi' ]] && return 0
 

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -96,7 +96,7 @@ $FP_SCRIPT	rpi_kernel_choice		<empty> Supported on Debian Bookworm or newer on R
 
 			# Generate locales and set new default
 			# - 1. this calls "locale-gen" to regenerate a fresh locale cache based on /etc/locale.gen to /usr/lib/locale/locale-archive.
-			# - 2. this calls "update-locale LANG=<default>" to apply the new default locale form the debconf default assigned above.
+			# - 2. this calls "update-locale LANG=<default>" to apply the new default locale from the debconf default assigned above.
 			G_CHECK_OUTPUT=1 G_EXEC dpkg-reconfigure -f noninteractive locales
 
 			# Update dietpi.txt entry

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -114,17 +114,17 @@ $FP_SCRIPT	rpi_kernel_choice		<empty> Supported on Debian Bookworm or newer on R
 		[[ $INPUT_MODE_VALUE ]] || { Unknown_Input_Mode; return 1; }
 
 		# RPi Trixie: Suite does not exist yet: https://archive.raspberrypi.com/debian/dists/
-		(( $G_HW_MODEL < 10 || ( $G_HW_MODEL == 75 && ${G_RASPBIAN:-0} == 1 ) )) && G_EXEC eval "echo 'deb https://archive.raspberrypi.com/debian/ ${G_DISTRO_NAME/trixie/bookworm} main' > /etc/apt/sources.list.d/raspi.list"
+		(( $G_HW_MODEL < 10 || ( $G_HW_MODEL == 75 && ${G_RASPBIAN:-0} == 1 ) )) && G_EXEC eval "echo 'deb https://archive.raspberrypi.com/debian ${G_DISTRO_NAME/trixie/bookworm} main' > /etc/apt/sources.list.d/raspi.list"
 
 		# RISC-V: Provided via Sid only
 		if (( $G_HW_ARCH == 11 ))
 		then
-			G_EXEC eval 'echo '\''deb https://deb.debian.org/debian/ sid main contrib non-free non-free-firmware'\'' > /etc/apt/sources.list'
+			G_EXEC eval 'echo '\''deb https://deb.debian.org/debian sid main contrib non-free non-free-firmware'\'' > /etc/apt/sources.list'
 
 		# Raspbian
 		elif (( $G_RASPBIAN ))
 		then
-			[[ $INPUT_MODE_VALUE == 'default' ]] && INPUT_MODE_VALUE='http://raspbian.raspberrypi.com/raspbian/'
+			[[ $INPUT_MODE_VALUE == 'default' ]] && INPUT_MODE_VALUE='http://raspbian.raspberrypi.com/raspbian'
 
 			G_EXEC eval "echo 'deb $INPUT_MODE_VALUE $G_DISTRO_NAME main contrib non-free' > /etc/apt/sources.list"
 
@@ -137,7 +137,7 @@ $FP_SCRIPT	rpi_kernel_choice		<empty> Supported on Debian Bookworm or newer on R
 
 			G_EXEC eval "echo 'deb $INPUT_MODE_VALUE $G_DISTRO_NAME main contrib non-free
 deb $INPUT_MODE_VALUE $G_DISTRO_NAME-updates main contrib non-free
-deb https://deb.debian.org/debian-security/ $G_DISTRO_NAME-security main contrib non-free
+deb https://deb.debian.org/debian-security $G_DISTRO_NAME-security main contrib non-free
 deb $INPUT_MODE_VALUE $G_DISTRO_NAME-backports main contrib non-free' > /etc/apt/sources.list"
 
 			# Bookworm: non-free firmware has been moved to new component: https://deb.debian.org/debian/pool/

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -245,7 +245,7 @@ deb $INPUT_MODE_VALUE $G_DISTRO_NAME-backports main contrib non-free' > /etc/apt
 	#/////////////////////////////////////////////////////////////////////////////////////
 	TimeSync_Main()
 	{
-		if [[ ! $INPUT_MODE_VALUE || $INPUT_MODE_VALUE == [01234] ]]
+		if [[ ! $INPUT_MODE_VALUE || $INPUT_MODE_VALUE == [0-4] ]]
 		then
 			# If no input given, re-apply current dietpi.txt setting, else revert to default mode 2
 			[[ $INPUT_MODE_VALUE ]] || INPUT_MODE_VALUE=$(sed -n '/^[[:blank:]]*CONFIG_NTP_MODE=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -113,6 +113,63 @@ $FP_SCRIPT	rpi_kernel_choice		<empty> Supported on Debian Bookworm or newer on R
 	{
 		[[ $INPUT_MODE_VALUE ]] || { Unknown_Input_Mode; return 1; }
 
+		# DietPi repo
+		[[ -f '/etc/apt/trusted.gpg.d/dietpi.asc' ]] || G_EXEC curl -sSf 'https://dietpi.com/apt/key.asc' -o /etc/apt/trusted.gpg.d/dietpi.asc
+		# - ARMv6: Since Debian cannot distinguish between ARMv6hf and ARMv7, both armhf, we use a dedicated main component for those.
+		local components='main' all_components=''
+		(( $G_HW_ARCH == 1 )) && components='main-armv6'
+		# - Additional components for SBC-specific packages and builds, some per distro version, some for all distro versions
+		[[ $G_HW_MODEL [2-5] ]] && components+=' rpi$G_HW_MODEL'
+		case $G_HW_MODEL in
+			[0-9]) all_components='rpi';;
+			10) all_components='odroidc1';;
+			49)
+				# Detect variant either based on $HW_VARIANT environment variable, existing "all" components or installed kernel/firmware package
+				case $HW_VARIANT in
+					1) all_components='quartz64a';;
+					2) all_components='quartz64b';;
+					3) all_components='soquartz';;
+					*)
+						[[ -f '/etc/apt/sources.list.d/dietpi.list' ]] && all_components=$(sed -n '/ all /{s/^.* all //p;q}' /etc/apt/sources.list.d/dietpi.list)
+						[[ $all_components ]] || for i in quartz64{a,b} soquartz
+						do
+							dpkg-query -s "firmware-$i" &> /dev/null || continue
+							all_components=$i
+							break
+						done
+					;;
+				esac
+			;;
+			61) all_components='nanopi2';;
+			62)
+				# Detect variant either based on $HW_VARIANT environment variable, existing "all" components or installed U-Boot package
+				case $HW_VARIANT in
+					1) all_components='nanopim3';;
+					2) all_components='nanopifire3';;
+					*)
+						[[ -f '/etc/apt/sources.list.d/dietpi.list' ]] && all_components=$(sed -n '/ all /{s/^.* all //p;q}' /etc/apt/sources.list.d/dietpi.list)
+						[[ $all_components ]] || for i in nanopi{m,fire}3
+						do
+							dpkg-query -s "linux-u-boot-$i-legacy" &> /dev/null || continue
+							all_components=$i
+							break
+						done
+					;;
+				esac
+			;;
+			63) all_components='nanopim1';;
+			66) all_components='nanopim1plus';;
+			70) all_components='sparkysbc';;
+			81) all_components='visionfive2';;
+			84) all_components='star64';;
+			*) :;;
+		esac
+		G_EXEC eval "echo 'deb https://dietpi.com/apt $G_DISTRO_NAME $components' > /etc/apt/sources.list.d/dietpi.list"
+		[[ $all_components ]] && G_EXEC eval "echo 'deb https://dietpi.com/apt all $all_components' >> /etc/apt/sources.list.d/dietpi.list"
+		
+		# Exit path for quick DietPi-only repo updates
+		[[ $INPUT_MODE_VALUE == 'dietpi' ]] && return 0
+
 		# RPi Trixie: Suite does not exist yet: https://archive.raspberrypi.com/debian/dists/
 		(( $G_HW_MODEL < 10 || ( $G_HW_MODEL == 75 && ${G_RASPBIAN:-0} == 1 ) )) && G_EXEC eval "echo 'deb https://archive.raspberrypi.com/debian ${G_DISTRO_NAME/trixie/bookworm} main' > /etc/apt/sources.list.d/raspi.list"
 

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -119,12 +119,13 @@ $FP_SCRIPT	rpi_kernel_choice		<empty> Supported on Debian Bookworm or newer on R
 		local components='main' all_components=''
 		(( $G_HW_ARCH == 1 )) && components='main-armv6'
 		# - Additional components for SBC-specific packages and builds, some per distro version, some for all distro versions
-		[[ $G_HW_MODEL == [2-5] ]] && components+=' rpi$G_HW_MODEL'
+		[[ $G_HW_MODEL == [2-5] ]] && components+=" rpi$G_HW_MODEL"
 		case $G_HW_MODEL in
 			[0-9]) all_components='rpi';;
 			10) all_components='odroidc1';;
 			49)
 				# Detect variant either based on $HW_VARIANT environment variable, existing "all" components or installed kernel/firmware package
+				# shellcheck disable=SC2154
 				case $HW_VARIANT in
 					1) all_components='quartz64a';;
 					2) all_components='quartz64b';;
@@ -143,6 +144,7 @@ $FP_SCRIPT	rpi_kernel_choice		<empty> Supported on Debian Bookworm or newer on R
 			61) all_components='nanopi2';;
 			62)
 				# Detect variant either based on $HW_VARIANT environment variable, existing "all" components or installed U-Boot package
+				# shellcheck disable=SC2154
 				case $HW_VARIANT in
 					1) all_components='nanopim3';;
 					2) all_components='nanopifire3';;

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -300,7 +300,7 @@ deb $INPUT_MODE_VALUE $G_DISTRO_NAME-backports main contrib non-free' > /etc/apt
 			# Oneshot modes: Enable systemd-timesyncd to start early at boot, but stop it now
 			elif [[ $INPUT_MODE_VALUE == [123] ]]
 			then
-				[[ ${timesyncd[0]} ]] && G_AG_CHECK_INSTALL_PREREQ systemd-timesyncd
+				G_AG_CHECK_INSTALL_PREREQ systemd-timesyncd
 				G_EXEC systemctl unmask systemd-timesyncd # Failsafe
 				G_EXEC systemctl enable systemd-timesyncd
 				G_EXEC systemctl stop systemd-timesyncd


### PR DESCRIPTION
### Beta v9.3.0
_(2024-04-14)_

#### Enhancements
- General | We added an own APT repository at https://dietpi.com/apt/ for own software and kernel/firmware builds. This simplifies updates for software packages like Squeezelite, vaultwarden and Amiberry, as well as allows us to provide own up-to-date kernel and bootloader packages, applied via regular `apt upgrade`. A goal is also to become independent of some 3rd party repositories, which are regularly affected by network errors or provide packages updates too infrequently.
- DietPi-Config | Removed the 3.5mm audio option on Raspberry Pi 5, as it does not have a 3.5mm jack. Additionally, the KMS graphics driver is enabled OOTB when HDMI audio is selected, as the `snd_bcm2835` driver does not work on Raspberry Pi 5. Many thanks to `@JRK0469` for making us aware of this: https://dietpi.com/forum/t/19760
- DietPi-Software | Mosquitto: The official APT repository added support for 64-bit ARM on Bookworm, which is now used for our installation.
- DietPi-Software | UnRAR: Debian added `unrar` packages for RISC-V, which are now used for our installation.

#### Bug fixes
- Raspberry Pi 5 | Fixed X11/desktop startup if KMS is enabled. Many thanks to `@denguido` for reporting the issue and solution: https://dietpi.com/forum/t/19760
- DietPi-Software | Logitech Media Server: Resolved an issue where the install failed due to a changed download URL. Many thanks to @JRK0469 for reporting this issue: https://github.com/MichaIng/DietPi/issues/6992