### PR TITLE
DietPi-Imager | Solve issues related to GPT backup partition table

### DIFF
--- a/.build/images/dietpi-imager
+++ b/.build/images/dietpi-imager
@@ -336,10 +336,7 @@
 		# Move GPT backup partition table to end of drive
 		elif [[ $PART_TABLE_TYPE == 'gpt' ]]
 		then
-			G_DIETPI-NOTIFY 2 'GPT partition table detected, moving GPT backup partition table to end of drive...'
-			G_AG_CHECK_INSTALL_PREREQ gdisk
-			G_EXEC_OUTPUT=1 G_EXEC sgdisk -e "$FP_SOURCE"
-			G_SLEEP 0.5 # Give the root filesystem a little time to be detected
+			G_DIETPI-NOTIFY 2 'GPT partition table detected'
 		else
 			Error_Exit "Unknown partition table type ($PART_TABLE_TYPE), aborting..."
 		fi
@@ -512,9 +509,16 @@
 		# - WARNING: this assumes that the partitions in the table are in order (which we do in other places as well)
 		local last_part_end=$(sfdisk -qlo End "$FP_SOURCE" | tail -1) # 512 byte sectors
 		IMAGE_SIZE=$last_part_end
-		# Add 34 sectors for GPT backup partition table and 1 sector for MBR
-		# shellcheck disable=SC2015
-		[[ $PART_TABLE_TYPE == 'gpt' ]] && ((IMAGE_SIZE+=34)) || ((IMAGE_SIZE++))
+		# Add space for GPT backup partition table, or 1 sector for MBR
+		if [[ $PART_TABLE_TYPE == 'gpt' ]]
+		then
+			# Obtain first usable LBA, which defines the size of the GPT backup, else use 34 sectors as default: https://github.com/MichaIng/DietPi/issues/7024
+			local gpt_size=$(sgdisk -p "$FP_SOURCE" 2>&1 | mawk -F[\ ,] '/^First usable sector/{print $5}')
+			# shellcheck disable=SC2015
+			(( $gpt_size )) && ((IMAGE_SIZE+=$gpt_size)) || ((IMAGE_SIZE+=34))
+		else
+			((IMAGE_SIZE++))
+		fi
 		((IMAGE_SIZE*=512)) # 512 byte sectors => bytes
 
 		# RPi: Move configs to boot FAT partition to allow easier edit from Windows/macOS

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ Enhancements:
 - DietPi-Software | Snapcast: 64-bit ARM and Debian Bookworm + Trixie will have the now available packages from Snapcast installed, instead of those from the Debian repository.
 
 Bug fixes:
+- DietPi-Imager | Resolved an issue where the imager could have failed on GPT partitioned images, if either the source image size did not leave space for the GPT backup partition table, or the first usable LBA/sector was above 34. The GPT backup partition table is now created only at the end of the image generation, not anymore additionally at the start, and the required size it takes is correctly obtained. Many thanks to @SelfhostedPro and @disablewong for reporting this issue: https://github.com/MichaIng/DietPi/issues/7024, https://dietpi.com/forum/t/18035
 - DietPi-Software | Snapcast: Resolved an issue where version 0.27.0 was installed, because since version 0.28.0, Snapcast is provided with client and server packages wrapped into one archive, instead having individual downloads for each package.
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/ADDME


### PR DESCRIPTION
- DietPi-Imager | Skip moving backup partition table before touching the image. parted/sfdisk may throw warnings, but the step can fail if the last partition reaches the end of the image, e.g. if the file was cut right after the last partition, ignoring the backup table. Additionally, obtain the size needed for the GPT backup correctly by the first usabe LBA/sector, instead of using the 34 sectors default GPT size. fdisk/sfdisk use 2048 by default, while parted defaults to the actual 34 sectors the GPT truly uses.
