### PR TITLE
Add Forgejo to dietpi-software

### DIFF
--- a/.github/workflows/dietpi-software.bash
+++ b/.github/workflows/dietpi-software.bash
@@ -197,6 +197,7 @@ Process_Software()
 			172) aSERVICES[i]='wg-quick@wg0' aUDP[i]='51820';;
 			174) aCOMMANDS[i]='gimp -v';;
 			176) aSERVICES[i]='mycroft';;
+			177) aSERVICES[i]='forgejo' aTCP[i]='3000'; (( $arch < 10 )) && aDELAY[i]=30;;
 			178) aSERVICES[i]='jellyfin' aTCP[i]='8097'; [[ $arch == [23] ]] && aDELAY[i]=300;; # jellyfin[9983]: arm-binfmt-P: ../../target/arm/translate.c:9659: thumb_tr_translate_insn: Assertion `(dc->base.pc_next & 1) == 0' failed.   ###   jellyfin[9983]: qemu: uncaught target signal 6 (Aborted) - core dumped   ###   about 5 times
 			179) aSERVICES[i]='komga' aTCP[i]='2037'; (( $arch == 10 )) && aDELAY[i]=30; (( $arch < 10 )) && aDELAY[i]=300;;
 			180) aSERVICES[i]='bazarr' aTCP[i]='6767'; (( $arch == 10 )) && aDELAY[i]=30; (( $arch < 10 )) && aDELAY[i]=90;;

--- a/.github/workflows/dietpi-software.bash
+++ b/.github/workflows/dietpi-software.bash
@@ -245,7 +245,7 @@ do
 		8|33|131|179|206) Process_Software 196;;
 		32|148|119) Process_Software 128;;
 		129) Process_Software 88 89 128 webserver;;
-		49|165) Process_Software 88;;
+		49|165|177) Process_Software 0 17 88;;
 		#61) Process_Software 60;; # Cannot be installed in CI
 		125) Process_Software 194;;
 		#86|134|185) Process_Software 162;; # Docker does not start in systemd containers (without dedicated network)

--- a/.github/workflows/dietpi-software.bash
+++ b/.github/workflows/dietpi-software.bash
@@ -88,7 +88,7 @@ Process_Software()
 			7) aCOMMANDS[i]='ffmpeg -version';;
 			9) aCOMMANDS[i]='node -v';;
 			#16) aSERVICES[i]='microblog-pub' aTCP[i]='8007';; Service enters a CPU-intense internal error loop until it has been configured interactively via "microblog-pub configure", hence it is not enabled and started anymore after install but instead as part of "microblog-pub configure"
-			17) aCOMMANDS[i]='git -v';;
+			17) aCOMMANDS[i]='git --version';; # from Bookworm on, the shorthand "-v" is supported
 			28) aSERVICES[i]='vncserver' aTCP[i]='5901';;
 			29) aSERVICES[i]='xrdp' aTCP[i]='3389';;
 			30) aSERVICES[i]='nxserver' aTCP[i]='4000';;

--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -719,6 +719,7 @@ shopt -s extglob
 		aSOFTWARE_NAME9_4[i]=${aSOFTWARE_NAME9_3[i]}
 		aSOFTWARE_NAME9_5[i]=${aSOFTWARE_NAME9_4[i]}
 	done
+	aSOFTWARE_NAME9_5[177]='Forgejo'
 
 	# Pre-create software counter array so that we can see also software (available in newest version) with 0 installs
 	for i in "${aSOFTWARE_NAME9_5[@]}"

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,9 @@
 v9.5
 (2024-06-08)
 
+New software:
+- Forgejo | This Gitea fork has been added to our software library. Read about the background of this fork here: https://forgejo.org/2022-12-15-hello-forgejo/. Many thanks to @Cs137 for requesting and @jcnils for implementing this software option: https://github.com/MichaIng/DietPi/discussions/6133, https://github.com/MichaIng/DietPi/pull/7071
+
 Enhancements:
 - Images | New DietPi images won't contain the "gnupg" package anymore, but "gpg" only, since other features of the suite are not required for our scripts anymore. E.g. "dirmngr" for interacting with keyservers, and "gpg-agent" for key passphrase inputs are hence missing. "gpg" however prints very clear error messages about what is missing. Let us know whether you find one of those GnuPG features too essential to not be pre-installed.
 - Radxa ZERO 3 | Onboard WiFi does now work OOTB on early ZERO 3W revisions with AP6212 WiFi chip.

--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ Links to hardware and software manufacturers, sources and build instructions use
 - [Homebridge](https://github.com/homebridge/homebridge)
 - [ADS-B Feeder](https://github.com/dirkhh/adsb-feeder-image)
 - [Kavita](https://github.com/Kareadita/Kavita)
+- [Forgejo](https://codeberg.org/forgejo/forgejo)
 
 ---
 

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -207,6 +207,7 @@ _EOF_
 			'urbackupsrv'
 			'gogs'
 			'gitea'
+			'forgejo'
 			'vaultwarden'
 			'filebrowser'
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10650,7 +10650,7 @@ _EOF_
 			esac
 
 			local fallback_url="https://codeberg.org/forgejo/forgejo/releases/download/v7.0.2/forgejo-7.0.2-linux-$arch.xz"
-			Download_Install "$(curl -sSfL 'https://codeberg.org/api/v1/repos/forgejo/forgejo/releases/latest' | mawk -F:\" -v RS=, '/"browser_download_url":".*\/forgejo-[^\"\/]*-linux-$arch\.xz"/{gsub("\"|}| ]","",$2);print $2}')" /mnt/dietpi_userdata/forgejo/forgejo
+			Download_Install "$(curl -sSfL 'https://codeberg.org/api/v1/repos/forgejo/forgejo/releases/latest' | mawk -F:\" -v RS=, '/"browser_download_url":".*\/forgejo-[^\"\/]*-linux-'"$arch"'\.xz"/{gsub("\"|}|]","",$2);print $2}')" /mnt/dietpi_userdata/forgejo/forgejo
 
 			# User
 			Create_User -d /mnt/dietpi_userdata/forgejo -s /bin/dash forgejo

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10686,6 +10686,7 @@ WantedBy=multi-user.target
 _EOF_
 			# Pre-v7.9: Migrate run user setting: https://github.com/MichaIng/DietPi/issues/5516
 			[[ -f '/mnt/dietpi_userdata/forgejo/custom/conf/app.ini' ]] && G_CONFIG_INJECT 'RUN_USER[[:blank:]]' 'RUN_USER = forgejo' /mnt/dietpi_userdata/forgejo/custom/conf/app.ini
+			G_EXEC systemctl start forgejo
 		fi
 
 		if To_Install 163 gmediarender # GMediaRender

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -806,7 +806,7 @@ Available commands:
 		aSOFTWARE_CATX[$software_id]=4
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/cloud/#gogs'
 		aSOFTWARE_DEPS[$software_id]='17 88 0'
-		aSOFTWARE_CONFLICTS[$software_id]='165'
+		aSOFTWARE_CONFLICTS[$software_id]='165 177'
 		#------------------
 		software_id=50
 		aSOFTWARE_NAME[$software_id]='Syncthing'
@@ -838,8 +838,18 @@ Available commands:
 		aSOFTWARE_CATX[$software_id]=4
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/cloud/#gitea'
 		aSOFTWARE_DEPS[$software_id]='17 88 0'
-		aSOFTWARE_CONFLICTS[$software_id]='49'
+		aSOFTWARE_CONFLICTS[$software_id]='49 177'
 		# - RISC-V: Missing binary: https://github.com/go-gitea/gitea/releases
+		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,11]=0
+		#------------------
+		software_id=177
+		aSOFTWARE_NAME[$software_id]='Forgejo'
+		aSOFTWARE_DESC[$software_id]='Self-hosted lightweight software forge. Fork of Gitea.'
+		aSOFTWARE_CATX[$software_id]=4
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/cloud/#forgejo'
+		aSOFTWARE_DEPS[$software_id]='17 88 0'
+		aSOFTWARE_CONFLICTS[$software_id]='49 165'
+		# - RISC-V: Missing binary: https://codeberg.org/forgejo/forgejo/releases
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,11]=0
 		#------------------
 		software_id=183
@@ -10630,6 +10640,54 @@ _EOF_
 			[[ -f '/mnt/dietpi_userdata/gitea/custom/conf/app.ini' ]] && G_CONFIG_INJECT 'RUN_USER[[:blank:]]' 'RUN_USER = gitea' /mnt/dietpi_userdata/gitea/custom/conf/app.ini
 		fi
 
+		if To_Install 177 forgejo # Forgejo
+		then
+			# ARMv7: Fork of gitea, do not support ARMv7 - https://github.com/go-gitea/gitea/issues/6700
+			case $G_HW_ARCH in
+				3) local arch='arm64';;
+				10) local arch='amd64';;
+				*) local arch='arm-6';;
+			esac
+
+			local fallback_url="https://codeberg.org/forgejo/forgejo/releases/download/v7.0.2/forgejo-7.0.2-linux-$arch.xz"
+			Download_Install "$(curl -sSfL 'https://codeberg.org/api/v1/repos/forgejo/forgejo/releases/latest' | jq '.' | mawk -F\" "/\"browser_download_url\": \".*\/forgejo-[^\"\/]*-linux-$arch\.xz\"/{print \$4}")" /mnt/dietpi_userdata/forgejo/forgejo
+
+			# User
+			Create_User -d /mnt/dietpi_userdata/forgejo -s /bin/dash forgejo
+
+			# Permissions
+			G_EXEC chown -R forgejo:forgejo /mnt/dietpi_userdata/forgejo
+			G_EXEC chmod +x /mnt/dietpi_userdata/forgejo/forgejo
+
+			# Database
+			/boot/dietpi/func/create_mysql_db forgejo forgejo "$GLOBAL_PW"
+
+			# Service
+			cat << '_EOF_' > /etc/systemd/system/forgejo.service
+[Unit]
+Description=Forgejo (DietPi)
+Wants=network-online.target
+After=network-online.target mariadb.service
+
+[Service]
+User=forgejo
+LogsDirectory=forgejo
+WorkingDirectory=/mnt/dietpi_userdata/forgejo
+ExecStart=/mnt/dietpi_userdata/forgejo/forgejo web
+
+# Hardening
+ProtectSystem=full
+PrivateDevices=yes
+PrivateTmp=yes
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target
+_EOF_
+			# Pre-v7.9: Migrate run user setting: https://github.com/MichaIng/DietPi/issues/5516
+			[[ -f '/mnt/dietpi_userdata/forgejo/custom/conf/app.ini' ]] && G_CONFIG_INJECT 'RUN_USER[[:blank:]]' 'RUN_USER = forgejo' /mnt/dietpi_userdata/forgejo/custom/conf/app.ini
+		fi
+
 		if To_Install 163 gmediarender # GMediaRender
 		then
 			G_AGI gmediarender
@@ -13555,6 +13613,17 @@ _EOF_
 			[[ -d '/var/log/gitea' ]] && G_EXEC rm -R /var/log/gitea
 
 			Remove_Database gitea
+		fi
+
+		if To_Uninstall 177 # Forgejo
+		then
+			Remove_Service forgejo 1 1
+
+			# Data
+			[[ -d '/mnt/dietpi_userdata/forgejo' ]] && G_EXEC rm -R /mnt/dietpi_userdata/forgejo
+			[[ -d '/var/log/forgejo' ]] && G_EXEC rm -R /var/log/forgejo
+
+			Remove_Database forgejo
 		fi
 
 		if To_Uninstall 166 # Audiophonics PI-SPC

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10650,7 +10650,7 @@ _EOF_
 			esac
 
 			local fallback_url="https://codeberg.org/forgejo/forgejo/releases/download/v7.0.2/forgejo-7.0.2-linux-$arch.xz"
-			Download_Install "$(curl -sSfL 'https://codeberg.org/api/v1/repos/forgejo/forgejo/releases/latest' | mawk -F:\" -v RS=, '/"browser_download_url":".*\/forgejo-[^\"\/]*-linux-'"$arch"'\.xz"/{gsub("\"|}|]","",$2);print $2}')" /mnt/dietpi_userdata/forgejo/forgejo
+			Download_Install "$(curl -sSfL 'https://codeberg.org/api/v1/repos/forgejo/forgejo/releases/latest' | mawk -v RS=, -F\" "/^\"browser_download_url\":\".*-linux-$arch\.xz\"/{print \$4;exit}")" /mnt/dietpi_userdata/forgejo/forgejo
 
 			# User
 			Create_User -d /mnt/dietpi_userdata/forgejo -s /bin/dash forgejo

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10650,7 +10650,7 @@ _EOF_
 			esac
 
 			local fallback_url="https://codeberg.org/forgejo/forgejo/releases/download/v7.0.2/forgejo-7.0.2-linux-$arch.xz"
-			Download_Install "$(curl -sSfL 'https://codeberg.org/api/v1/repos/forgejo/forgejo/releases/latest' | jq '.' | mawk -F\" "/\"browser_download_url\": \".*\/forgejo-[^\"\/]*-linux-$arch\.xz\"/{print \$4}")" /mnt/dietpi_userdata/forgejo/forgejo
+			Download_Install "$(curl -sSfL 'https://codeberg.org/api/v1/repos/forgejo/forgejo/releases/latest' | mawk -F:\" -v RS=, '/"browser_download_url":".*\/forgejo-[^\"\/]*-linux-$arch\.xz"/{gsub("\"|}| ]","",$2);print $2}')" /mnt/dietpi_userdata/forgejo/forgejo
 
 			# User
 			Create_User -d /mnt/dietpi_userdata/forgejo -s /bin/dash forgejo

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10642,14 +10642,14 @@ _EOF_
 
 		if To_Install 177 forgejo # Forgejo
 		then
-			# ARMv7: Fork of gitea, do not support ARMv7 - https://github.com/go-gitea/gitea/issues/6700
+			# ARMv7: Dedicated binaries are not provided: https://codeberg.org/forgejo/forgejo/releases
 			case $G_HW_ARCH in
 				3) local arch='arm64';;
 				10) local arch='amd64';;
 				*) local arch='arm-6';;
 			esac
 
-			local fallback_url="https://codeberg.org/forgejo/forgejo/releases/download/v7.0.2/forgejo-7.0.2-linux-$arch.xz"
+			local fallback_url="https://codeberg.org/forgejo/forgejo/releases/download/v7.0.3/forgejo-7.0.3-linux-$arch.xz"
 			Download_Install "$(curl -sSfL 'https://codeberg.org/api/v1/repos/forgejo/forgejo/releases/latest' | mawk -v RS=, -F\" "/^\"browser_download_url\":\".*-linux-$arch\.xz\"/{print \$4;exit}")" /mnt/dietpi_userdata/forgejo/forgejo
 
 			# User
@@ -10684,9 +10684,6 @@ NoNewPrivileges=true
 [Install]
 WantedBy=multi-user.target
 _EOF_
-			# Pre-v7.9: Migrate run user setting: https://github.com/MichaIng/DietPi/issues/5516
-			[[ -f '/mnt/dietpi_userdata/forgejo/custom/conf/app.ini' ]] && G_CONFIG_INJECT 'RUN_USER[[:blank:]]' 'RUN_USER = forgejo' /mnt/dietpi_userdata/forgejo/custom/conf/app.ini
-			G_EXEC systemctl start forgejo
 		fi
 
 		if To_Install 163 gmediarender # GMediaRender


### PR DESCRIPTION
It works similar to Gitea. The docs can be reused.
https://github.com/MichaIng/DietPi/discussions/6133

1 - I need to confirm if `jq` comes with dietpi. It was on mine, but my installation is ancient, and I do not remember.

I used it to get the release url from the codeberg repo, as the returning json is different from github used by gitea. Line [10662]

2 - I wonder if there are any tags for `ssh server` dependencies like 'browser' show in 
https://github.com/MichaIng/DietPi/wiki/How-to-add-a-new-software-title#asoftware_depssoftware_id

I noticed that there is also Dropbear besides OpenSSH. 