### PR TITLE
Live patch 0 | Migrate to new U-Boot package on NanoPi R6C

### DIFF
--- a/.update/version
+++ b/.update/version
@@ -14,6 +14,7 @@ G_MIN_DEBIAN=6
 # Alternative Git branch to automatically migrate to when Debian version is too low
 G_OLD_DEBIAN_BRANCH='8'
 # Live patches
-G_LIVE_PATCH_DESC=()
-G_LIVE_PATCH_COND=()
-G_LIVE_PATCH=()
+G_LIVE_PATCH_DESC=('Migrate to new U-Boot package on NanoPi R6C')
+# shellcheck disable=SC2016
+G_LIVE_PATCH_COND=('(( $G_HW_MODEL == 79 )) && grep -q '\''^[[:blank:]]*fdtfile=rockchip/rk3588s-nanopi-r6c.dtb$'\'' /boot/dietpiEnv.txt')
+G_LIVE_PATCH=('sed -i '\''s/r6s/r6c/'\'' /etc/apt/sources.list.d/dietpi.list && G_AGUP && G_AGI linux-u-boot-nanopi-r6c-legacy')


### PR DESCRIPTION
While an APT upgrade of the U-Boot package does not break anything, since the U-Boot binary is not flashed, flashing via `dietpi-config` afterwards does. This live patch prevents it.