### PR TITLE
ADS-B Feeder Image: adapt to v2.1.1

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11929,11 +11929,6 @@ _EOF_
 			# finally ensure that /run allows executables (this is needed for the containers to be able to not do excessive
 			# writes to physical storage - which might be an SD card)
 			G_EXEC mount -o remount,exec /run
-
-			# now that everything is in place, run the one time service to get the software pre-configured
-			# running this as a service allows it to do a bit of housekeeping in the background without disrupting
-			# the software install flow
-			G_EXEC systemctl start adsb-nonimage
 		fi
 
 		if To_Install 172 # WireGuard


### PR DESCRIPTION
Newer versions of the Feeder Image no longer have the adsb-nonimage service. So don't try to start it.

<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
