### PR TITLE
General | Replace Armbian APT repo with our own

### DIFF
--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -412,8 +412,8 @@ packages='apt,bash-completion,bzip2,ca-certificates,cron,curl,fdisk,gpg,htop,ipu
 [[ $HW_MODEL == 75 ]] && packages+='iproute2' || packages+='console-setup,dropbear,ethtool,fake-hwclock,ifupdown,isc-dhcp-client,kmod,rfkill,systemd-timesyncd,usbutils'
 # - "--skip=check/empty" to ignore /etc/fstab, boot and tmpfs mounts we added above
 # - "--skip=check/qemu" to skip arch test, which requires the "arch-test" package. We however assure emulation support out end.
-# - Bullseye/Jammy host mmdebstrap seems to not support "--skip=check/empty,check/qemu".
-G_EXEC_OUTPUT=1 G_EXEC mmdebstrap --debug --mode=root --format=dir --skip=check/empty --skip=check/qemu --variant=minbase --include="$packages" --arch="$parch" --keyring="$keyring" "$distro" ./rootfs "$repo"
+# - Bullseye/Jammy host mmdebstrap does not support "--skip=check/empty,check/qemu".
+G_EXEC_OUTPUT=1 G_EXEC mmdebstrap --mode=root --format=dir --skip=check/empty --skip=check/qemu --variant=minbase --include="$packages" --arch="$parch" --keyring="$keyring" "$distro" ./rootfs "$repo"
 G_EXEC umount rootfs/dev rootfs/run rootfs/var/cache/apt rootfs/var/lib/apt/lists rootfs/var/log
 
 ##########################################
@@ -431,15 +431,15 @@ _EOF_
 cat << _EOF_ >> rootfs/etc/rc.local
 export GITOWNER='$GITOWNER' GITBRANCH='$GITBRANCH' HW_MODEL='$HW_MODEL' IMAGE_CREATOR=0 PREIMAGE_INFO=0 WIFI_REQUIRED=1 DISTRO_TARGET=$DISTRO TEST_KERNEL=$TEST_KERNEL TEST_UBOOT=$TEST_UBOOT
 echo '[ INFO ] Running DietPi-Installer for $G_GITOWNER/$G_GITBRANCH'
-bash -c "\$(curl -sSf 'https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.build/images/dietpi-installer')" || poweroff
+bash -c "\$(curl -sSf 'https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.build/images/dietpi-installer')" || { echo '[FAILED] DietPi-Installer failed, shutting down ...'; journalctl -n 25; df -h; free -h; poweroff; exit 1; }
 _EOF_
 
 # - VM: Generate tiny-initramfs with explicit kernel modules, as auto-detection doesn't work correctly within container and loop devices
 [[ $HW_MODEL == 20 ]] && cat << _EOF_ >> rootfs/etc/rc.local
 echo '[ INFO ] Rebuilding virtual machine initramfs to support all virtualizers...'
-version=\$(dpkg --get-selections | mawk '\$1~/^linux-image-.*-$parch\$/{print \$1;exit}') || poweroff
+version=\$(dpkg --get-selections | mawk '\$1~/^linux-image-.*-$parch\$/{print \$1;exit}') || { echo '[FAILED] Obtaining kernel version failed, shutting down ...'; journalctl -n 25; df -h; free -h; poweroff; exit 1; }
 version=\${version#linux-image-}
-mktirfs -m no -M no --include-modules='ahci,sd_mod,vmw_pvscsi,hv_storvsc,virtio_scsi,virtio_pci,BusLogic,$FSTYPE' -o "/boot/initrd.img-\$version" "\$version" || poweroff
+mktirfs -m no -M no --include-modules='ahci,sd_mod,vmw_pvscsi,hv_storvsc,virtio_scsi,virtio_pci,BusLogic,$FSTYPE' -o "/boot/initrd.img-\$version" "\$version" || { echo '[FAILED] Generating initramfs failed, shutting down ...'; journalctl -n 25; df -h; free -h; poweroff; exit 1; }
 _EOF_
 
 cat << '_EOF_' >> rootfs/etc/rc.local
@@ -459,9 +459,9 @@ then
 	abind=("--bind=$FP_LOOP" '--bind=/dev/disk')
 	for i in "${FP_LOOP}p"*; do abind+=("--bind=$i"); done
 fi
-systemd-nspawn -bD rootfs "${abind[@]}" || { G_DIETPI-NOTIFY 1 'systemd-nspawn failed, aborting...'; journalctl -n 25; ss -tlpn; df -h; free -h; exit 1; }
+systemd-nspawn -bD rootfs "${abind[@]}" || { G_DIETPI-NOTIFY 1 'systemd-nspawn failed, aborting ...'; journalctl -n 25; ss -tlpn; df -h; free -h; exit 1; }
 
-[[ -f 'rootfs/success' ]] || { G_DIETPI-NOTIFY 1 'The container setup did not finish successfully, aborting...'; journalctl -n 25; ss -tlpn; df -h; free -h; exit 1; }
+[[ -f 'rootfs/success' ]] || { G_DIETPI-NOTIFY 1 'The container setup did not finish successfully, aborting ...'; journalctl -n 25; ss -tlpn; df -h; free -h; exit 1; }
 G_EXEC rm rootfs/success
 G_EXEC rm -Rf rootfs/{dev,proc,run,sys,tmp,var/log}/{,.??,.[^.]}* # Failsafe: /var/log/journal was found despite tmpfs mount!
 G_EXEC sync

--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -598,7 +598,7 @@ _EOF_
 		G_DIETPI-NOTIFY 2 'Moving kernel and boot configuration to /boot'
 
 		# Hardware specific boot configs
-		local armbian_repo=0
+		local armbian_packages=0
 		if (( $G_HW_MODEL < 10 ))
 		then
 			if findmnt -M /boot/firmware &> /dev/null
@@ -615,7 +615,7 @@ _EOF_
 
 		elif [[ $G_HW_MODEL =~ ^(10|11)$ ]]
 		then
-			armbian_repo=1
+			armbian_packages=1
 			local model='OdroidC1'
 			(( $G_HW_MODEL == 11 )) && model='OdroidXU4'
 			G_EXEC mv "DietPi-$G_GITBRANCH/.build/images/$model/boot.ini" /boot/boot.ini
@@ -629,7 +629,7 @@ _EOF_
 
 		elif [[ $G_HW_MODEL =~ ^(12|15|16|40|42|43|44|45|46|47|48|52|54|55|56|57|58|59|60|62|63|64|65|66|67|68|72|73|74|76|77|78|79|80|82|83|85|86|87|88|89|90)$ ]]
 		then
-			armbian_repo=1
+			armbian_packages=1
 			G_EXEC mv "DietPi-$G_GITBRANCH/.build/images/U-Boot/boot.cmd" /boot/boot.cmd
 			G_EXEC mv "DietPi-$G_GITBRANCH/.build/images/U-Boot/dietpiEnv.txt" /boot/dietpiEnv.txt
 			G_CONFIG_INJECT 'rootdev=' "rootdev=UUID=$(findmnt -Ufnro UUID -M /)" /boot/dietpiEnv.txt
@@ -673,11 +673,7 @@ setenv rootuuid "true"' /boot/boot.cmd
 				G_EXEC sed --follow-symlinks -Ei '/^setenv (kernel|fdt)_addr_r/d' /boot/boot.cmd
 				G_CONFIG_INJECT 'setenv scriptaddr ' 'setenv scriptaddr "0x9000000"' /boot/boot.cmd
 				G_CONFIG_INJECT 'overlay_path=' 'overlay_path=rockchip' /boot/dietpiEnv.txt
-				case $G_HW_MODEL in
-					73) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rk3308' /boot/dietpiEnv.txt;;
-					78|79|80|82|85) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rk3588' /boot/dietpiEnv.txt;; # ToDo: There are multiple other prefixes used in the kernel package, "rock-5b", "rock-5ab", "rockchip" (for fixup), so the boot.cmd need heavy adjustments (eliminate the prefix entirely) to work with all overlays.
-					*) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rockchip' /boot/dietpiEnv.txt;;
-				esac
+				# Device tree
 				case $G_HW_MODEL in
 					46) G_CONFIG_INJECT 'fdtfile=' 'fdtfile=rockchip/rk3399-pinebook-pro.dtb' /boot/dietpiEnv.txt;;
 					55) G_CONFIG_INJECT 'fdtfile=' 'fdtfile=rockchip/rk3328-nanopi-r2-rev00.dtb' /boot/dietpiEnv.txt;; # Not necessarily needed as rk3328-nanopi-r2s.dtb is automatically chosen, but provides more consistent /sys/class/leds/{wan,lan}_led interface and blinking instead of steady lid power LED
@@ -697,6 +693,13 @@ setenv rootuuid "true"' /boot/boot.cmd
 					87) G_CONFIG_INJECT 'fdtfile=' 'fdtfile=rockchip/rk3566-orangepi-3b.dtb' /boot/dietpiEnv.txt;;
 					*) :;;
 				esac
+				# Overlay prefix
+				case $G_HW_MODEL in
+					73) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rk3308' /boot/dietpiEnv.txt;;
+					78|79|80|82|85) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rk3588' /boot/dietpiEnv.txt;; # ToDo: There are multiple other prefixes used in the kernel package, "rock-5b", "rock-5ab", "rockchip" (for fixup), so the boot.cmd need heavy adjustments (eliminate the prefix entirely) to work with all overlays.
+					*) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rockchip' /boot/dietpiEnv.txt;;
+				esac
+				# Console args
 				case $G_HW_MODEL in
 					73) G_CONFIG_INJECT 'consoleargs=' 'consoleargs=console=ttyS0,1500000' /boot/dietpiEnv.txt;; # headless
 					47|55|56) G_CONFIG_INJECT 'consoleargs=' 'consoleargs=console=ttyS2,1500000' /boot/dietpiEnv.txt;; # headless
@@ -761,12 +764,14 @@ setenv rootuuid "true"' /boot/boot.cmd
 				G_EXEC sed --follow-symlinks -i -e 's|\${prefix}Image|${prefix}zImage|' -e 's/booti/bootz/' -e 's|\${overlay_path}/||' /boot/boot.cmd
 				G_EXEC sed --follow-symlinks -i '/^overlay_path/d' /boot/dietpiEnv.txt
 				G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=sun8i-h3' /boot/dietpiEnv.txt
+				# Overlays
 				case $G_HW_MODEL in
 					48) G_CONFIG_INJECT 'overlays=' 'overlays=usbhost1 usbhost2 uart1' /boot/dietpiEnv.txt;;
 					59|60) G_CONFIG_INJECT 'overlays=' 'overlays=usbhost1 usbhost2' /boot/dietpiEnv.txt;;
 					64) G_CONFIG_INJECT 'overlays=' 'overlays=usbhost2 usbhost3' /boot/dietpiEnv.txt;;
 					*) :;;
 				esac
+				# Console args
 				case $G_HW_MODEL in
 					48) G_CONFIG_INJECT 'consoleargs=' 'consoleargs=console=ttyS1,115200' /boot/dietpiEnv.txt;; # headless
 					59|60|64) G_CONFIG_INJECT 'consoleargs=' 'consoleargs=console=ttyS0,115200' /boot/dietpiEnv.txt;; # headless
@@ -1033,10 +1038,19 @@ setenv rootuuid "true"' /boot/boot.cmd
 			[[ -f '/etc/apt/trusted.gpg~' ]] && G_EXEC rm '/etc/apt/trusted.gpg~'
 
 		# DietPi-Build with Armbian kernel/bootloader/firmware
-		elif (( $armbian_repo ))
+		elif (( $armbian_packages ))
 		then
-			# Prevent any unintended packages from being installed from Armbian's APT repository, like base-files: https://github.com/MichaIng/DietPi/issues/6227#issuecomment-1713688577
-			cat << '_EOF_' > /etc/apt/preferences.d/dietpi-armbian
+			# Remove obsolete combined keyring
+			[[ -f '/etc/apt/trusted.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg
+			[[ -f '/etc/apt/trusted.gpg~' ]] && G_EXEC rm '/etc/apt/trusted.gpg~'
+
+			# Remove obsolete lists
+			find /etc/apt/sources.list.d -mindepth 1 ! -name 'dietpi.list' -exec rm -Rf {} +
+
+			if [[ $G_GITBRANCH == 'master' ]]
+			then
+				# Prevent any unintended packages from being installed from Armbian's APT repository, like base-files: https://github.com/MichaIng/DietPi/issues/6227#issuecomment-1713688577
+				cat << '_EOF_' > /etc/apt/preferences.d/dietpi-armbian
 Package: *
 Pin: origin apt.armbian.com
 Pin-Priority: -1
@@ -1045,29 +1059,23 @@ Package: armbian-firmware* linux-*
 Pin: origin apt.armbian.com
 Pin-Priority: 500
 _EOF_
-			if dpkg --compare-versions "$(dpkg-query -Wf '${Version}' base-files)" gt 20
-			then
-				G_DIETPI-NOTIFY 2 'Enforcing downgrade of Armbian'\''s base-files package to Debian'\''s'
-				cat << '_EOF_' > /etc/apt/preferences.d/dietpi-armbian-tmp
+				if dpkg --compare-versions "$(dpkg-query -Wf '${Version}' base-files)" gt 20
+				then
+					G_DIETPI-NOTIFY 2 'Enforcing downgrade of Armbian'\''s base-files package to Debian'\''s'
+					cat << '_EOF_' > /etc/apt/preferences.d/dietpi-armbian-tmp
 Package: base-files
 Pin: release o=Debian
 Pin-Priority: 1000
 _EOF_
-				G_EXEC eval 'echo '\''APT::Get::Allow-Downgrades "1";'\'' > /etc/apt/apt.conf.d/dietpi-armbian'
+					G_EXEC eval 'echo '\''APT::Get::Allow-Downgrades "1";'\'' > /etc/apt/apt.conf.d/dietpi-armbian'
+				fi
+
+				# Bootstrap Armbian repository
+				G_EXEC_RETRIES=2 G_EXEC eval 'curl -sSfL '\''https://apt.armbian.com/armbian.key'\'' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-armbian.gpg --yes'
+
+				# Add Armbian repository
+				G_EXEC eval "echo 'deb https://apt.armbian.com ${DISTRO_TARGET_NAME/bullseye/bookworm} main' > /etc/apt/sources.list.d/dietpi-armbian.list"
 			fi
-
-			# Bootstrap Armbian repository
-			G_EXEC_RETRIES=2 G_EXEC eval 'curl -sSfL '\''https://apt.armbian.com/armbian.key'\'' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-armbian.gpg --yes'
-
-			# Remove obsolete combined keyring
-			[[ -f '/etc/apt/trusted.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg
-			[[ -f '/etc/apt/trusted.gpg~' ]] && G_EXEC rm '/etc/apt/trusted.gpg~'
-
-			# Remove obsolete lists
-			find /etc/apt/sources.list.d -mindepth 1 ! -name 'dietpi.list' -exec rm -Rf {} +
-
-			# Add Armbian repository
-			G_EXEC eval "echo 'deb https://apt.armbian.com ${DISTRO_TARGET_NAME/bullseye/bookworm} main' > /etc/apt/sources.list.d/dietpi-armbian.list"
 
 			# Select kernel, device tree and U-Boot packages
 			local model='odroidn2' kernel='meson64' arch='arm64' branch='current' zstd=()
@@ -1367,14 +1375,7 @@ _EOF_
 			systemctl stop armbian-*
 
 			# Keep currently installed kernel and bootloader packages
-			local apackages=(
-
-				'linux-image-'
-				'linux-dtb-'
-				'linux-u-boot-'
-			)
-
-			for i in "${apackages[@]}"
+			for i in linux-{image,dtb,u-boot}-
 			do
 				while read -r line
 				do
@@ -1383,7 +1384,6 @@ _EOF_
 
 				done < <(dpkg-query -Wf '${Package}\n' | mawk -v pat="^$i" '$0~pat')
 			done
-			unset -v apackages
 
 			# Add initramfs-tools and u-boot-tools, required to convert initramfs images into u-boot format
 			aPACKAGES_REQUIRED_INSTALL+=('initramfs-tools' 'u-boot-tools')
@@ -1433,6 +1433,21 @@ _EOF_
 				G_DIETPI-NOTIFY 2 'Preventing needless kernel and initramfs symlink generation'
 				G_EXEC eval 'echo '\''do_symlinks=0'\'' > /etc/kernel-img.conf'
 				G_EXEC rm -f /{initrd.img,vmlinuz}{,.old}
+			fi
+
+			if [[ -f '/boot/armbianEnv.txt' ]]
+			then
+				# Force legacy network interface names
+				G_CONFIG_INJECT 'extraargs=' 'extraargs=net.ifnames=0' /boot/armbianEnv.txt
+
+				# Disable bootsplash logo, as we removed the file above: https://github.com/MichaIng/DietPi/issues/3932#issuecomment-852376681
+				G_CONFIG_INJECT 'bootlogo=' 'bootlogo=false' /boot/armbianEnv.txt
+
+				# Reset default kernel log verbosity, reduced to "1" on most Armbian images
+				G_CONFIG_INJECT 'verbosity=' 'verbosity=4' /boot/armbianEnv.txt
+
+				# Disable Docker optimisations, since this has some performance drawbacks, enable on Docker install instead
+				G_CONFIG_INJECT 'docker_optimizations=' 'docker_optimizations=off' /boot/armbianEnv.txt
 			fi
 
 		# Generic kernel, device tree, bootloader and firmware package auto detect + initramfs-tools
@@ -2178,22 +2193,6 @@ _EOF_
 		elif [[ $G_HW_MODEL =~ ^(83|87|88)$ ]]
 		then
 			G_EXEC eval 'echo '\''sprdwl_ng'\'' > /etc/modules-load.d/dietpi-enable_wifi.conf'
-		fi
-
-		# Armbian
-		if [[ -f '/boot/armbianEnv.txt' ]]
-		then
-			# Force legacy network interface names
-			G_CONFIG_INJECT 'extraargs=' 'extraargs=net.ifnames=0' /boot/armbianEnv.txt
-
-			# Disable bootsplash logo, as we removed the file above: https://github.com/MichaIng/DietPi/issues/3932#issuecomment-852376681
-			G_CONFIG_INJECT 'bootlogo=' 'bootlogo=false' /boot/armbianEnv.txt
-
-			# Reset default kernel log verbosity, reduced to "1" on most Armbian images
-			G_CONFIG_INJECT 'verbosity=' 'verbosity=4' /boot/armbianEnv.txt
-
-			# Disable Docker optimisations, since this has some performance drawbacks, enable on Docker install instead
-			G_CONFIG_INJECT 'docker_optimizations=' 'docker_optimizations=off' /boot/armbianEnv.txt
 		fi
 
 		#------------------------------------------------------------------------------------------------

--- a/.update/patches
+++ b/.update/patches
@@ -1651,8 +1651,15 @@ Patch_9_5()
 
 Patch_9_6()
 {
+	# Update DietPi APT list for several SBCs we added components to our repo for
+	if [[ $PATCH_9_3_RAN == 0 && $G_HW_MODEL =~ ^(42|43|46|47|52|55|58|68|72|73|76|77|86|87)$ ]]
+	then
+		/boot/dietpi/func/dietpi-set_software apt-mirror dietpi
+		G_AGUP
+		G_AGUG
+
 	# Orange Pi 5: Offer to flash new U-Boot image to solve random Ethernet MAC address: https://github.com/MichaIng/DietPi/issues/6663
-	if (( $G_HW_MODEL == 80 ))
+	elif (( $G_HW_MODEL == 80 ))
 	then
 		if G_WHIP_YESNO '[ INFO ] U-Boot update available to solve random Ethernet MAC address
 \nIn case you are affected by a random Ethernet MAC address, which changes every boot, flashing the latest U-Boot image has shown to solve it: https://github.com/MichaIng/DietPi/issues/6663
@@ -1689,6 +1696,15 @@ Patch_9_6()
 	elif dpkg-query -s 'linux-image-current-odroidxu4' &> /dev/null || dpkg-query -s 'linux-image-edge-odroidxu4' &> /dev/null ||  dpkg-query -s 'linux-image-current-meson' &> /dev/null || dpkg-query -s 'linux-image-edge-meson' &> /dev/null
 	then
 		G_AGI zstd
+	fi
+
+	# Remove Armbian APT repository from all systems which have an "all" component for kernel/bootloader/firmware packages form our APT repository
+	if [[ -f '/etc/apt/sources.list.d/dietpi-armbian.list' && -f '/etc/apt/sources.list.d/dietpi.list' ]] && grep -q 'dietpi.com/apt all' /etc/apt/sources.list.d/dietpi.list
+	then
+		G_DIETPI-NOTIFY 2 'Removing obsolete Armbian APT repository'
+		G_EXEC rm /etc/apt/sources.list.d/dietpi-armbian.list
+		[[ -f '/etc/apt/preferences.d/dietpi-armbian' ]] && G_EXEC rm /etc/apt/preferences.d/dietpi-armbian
+		[[ -f '/etc/apt/trusted.gpg.d/dietpi-armbian.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-armbian.gpg
 	fi
 
 	# Remove obsolete drop-in config: https://github.com/MichaIng/DietPi/issues/7104

--- a/.update/pre-patches
+++ b/.update/pre-patches
@@ -211,12 +211,6 @@ then
 		G_DIETPI-NOTIFY 2 'Adding new non-free-firmware component to APT lists, to re-enable firmware upgrades'
 		G_EXEC sed --follow-symlinks -i '/non-free/s/$/ non-free-firmware/' /etc/apt/sources.list
 	fi
-	if (( $G_DISTRO > 6 )) && [[ -f '/etc/apt/sources.list.d/dietpi-armbian.list' || -f '/etc/apt/sources.list.d/armbian.list' ]]
-	then
-		G_DIETPI-NOTIFY 2 'Updating Armbian APT repo list with Bookworm suite'
-		[[ -f '/etc/apt/sources.list.d/dietpi-armbian.list' ]] && G_EXEC sed --follow-symlinks -i 's/bullseye/bookworm/' /etc/apt/sources.list.d/dietpi-armbian.list
-		[[ -f '/etc/apt/sources.list.d/armbian.list' ]] && G_EXEC sed --follow-symlinks -i 's/bullseye/bookworm/' /etc/apt/sources.list.d/armbian.list
-	fi
 fi
 
 # v8.21
@@ -240,7 +234,7 @@ then
 	if [[ -f '/etc/apt/sources.list.d/dietpi-armbian.list' ]]
 	then
 		G_DIETPI-NOTIFY 2 'Preventing any unintended packages from being installed from Armbian'\''s APT repository'
-		cat << '_EOF_' > /etc/apt/preferences.d/dietpi-armbian
+		cat << '_EOF_' > /etc/apt/preferences.d/dietpi-armbian || exit 1
 Package: *
 Pin: origin apt.armbian.com
 Pin-Priority: -1
@@ -382,7 +376,7 @@ fi
 if (( $G_DIETPI_VERSION_CORE < 9 || ( $G_DIETPI_VERSION_CORE == 9 && $G_DIETPI_VERSION_SUB < 3 ) ))
 then
 	# Update APT repo on Bullseye systems to Bookworm, but re-assure only kernel and firmware packages are pulled form it. Armbian dropped Bullseye support.
-	if [[ $G_DISTRO == 6 && -f '/etc/apt/sources.list.d/dietpi-armbian.list' ]]
+	if [[ -f '/etc/apt/sources.list.d/dietpi-armbian.list' ]] && grep -q 'bullseye' /etc/apt/sources.list.d/dietpi-armbian.list
 	then
 		G_DIETPI-NOTIFY 2 'Moving EOL Armbian Bullseye repo to Bookworm for Debian-version-agnostic firmware and kernel upgrades'
 		cat << '_EOF_' > /etc/apt/preferences.d/dietpi-armbian || exit 1
@@ -423,6 +417,15 @@ then
 		mapfile -t apackages < <(apt-mark showhold | grep -E '^linux-(image|dtb|headers}-(current|edge)-meson$')
 		[[ ${apackages[0]} ]] && G_EXEC apt-mark unhold "${apackages[@]}"
 		unset -v apackages
+	fi
+
+	# Remove Armbian APT repository from all systems which have an "all" component for kernel/bootloader/firmware packages form our APT repository
+	if [[ -f '/etc/apt/sources.list.d/dietpi-armbian.list' && -f '/etc/apt/sources.list.d/dietpi.list' ]] && grep -q 'dietpi.com/apt all' /etc/apt/sources.list.d/dietpi.list
+	then
+		G_DIETPI-NOTIFY 2 'Removing obsolete Armbian APT repository'
+		G_EXEC rm /etc/apt/sources.list.d/dietpi-armbian.list
+		[[ -f '/etc/apt/preferences.d/dietpi-armbian' ]] && G_EXEC rm /etc/apt/preferences.d/dietpi-armbian
+		[[ -f '/etc/apt/trusted.gpg.d/dietpi-armbian.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-armbian.gpg
 	fi
 fi
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ v9.6
 (2024-07-06)
 
 Enhancements:
+- General | Since we provide all kernel, bootloader and firmware packages from our own APT repository now, the Armbian APT repository is removed form all systems. In case you use an SBC which is not officially supported by DietPi, as generic device, it is however preserved.
 - Quartz64/Star64/VisionFive 2 | The extended attribute handler for ext4 security labels "CONFIG_EXT4_FS_SECURITY" has been enabled for these SBCs, required for some Docker containers. Many thanks to @gxsw for reporting this missing feature: https://github.com/MichaIng/DietPi/issues/7102
 - Quartz64/Star64/VisionFive 2 | eBPF functionality for firewall and network monitoring software like Cilium has been added to our kernel builds for these SBCs. Many thanks to @kbrighton for reporting these missing features: https://github.com/MichaIng/DietPi/issues/6834
 - Orange Pi 5 | Older U-Boot builds caused the Ethernet MAC address to be random and change on every boot. Recent U-Boot builds solve this, but they are not flashed automatically on package upgrades. We hence inform users and offer to flash the latest U-Boot image during the DietPi update. Many thanks to @thuehlinger for reporting and testing the case: https://github.com/MichaIng/DietPi/issues/6663

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -1499,9 +1499,6 @@ Press any key to continue...'
 
 		G_CHECK_ROOT_USER 1
 
-		# Workaround for Armbian mirrors being out of sync regularly or throwing 5xx errors
-		[[ -f '/etc/apt/sources.list.d/dietpi-armbian.list' ]] && G_EXEC_POST_FUNC(){ [[ $exit_code != 0 ]] && grep -q '^E: Failed to fetch .*armbian' "$fp_log" && G_EXEC_RETRIES=2 && unset -f G_EXEC_POST_FUNC; }
-
 		G_EXEC_DESC="\e[0mAPT install \e[33m$*\e[0m"
 		DEBIAN_FRONTEND=noninteractive G_EXEC_OUTPUT=1 G_EXEC_OUTPUT_COL='\e[90m' G_EXEC apt-get -y --allow-change-held-packages install "$@"
 		local exit_code=$?
@@ -1548,9 +1545,6 @@ Press any key to continue...'
 	{
 		G_CHECK_ROOT_USER 1
 
-		# Workaround for Armbian mirrors being out of sync regularly or throwing 5xx errors
-		[[ -f '/etc/apt/sources.list.d/dietpi-armbian.list' ]] && G_EXEC_POST_FUNC(){ [[ $exit_code != 0 ]] && grep -q '^E: Failed to fetch .*armbian' "$fp_log" && G_EXEC_RETRIES=2 && unset -f G_EXEC_POST_FUNC; }
-
 		G_EXEC_DESC="\e[0mAPT fix${*:+ \e[33m$*\e[0m}"
 		DEBIAN_FRONTEND=noninteractive G_EXEC_OUTPUT=1 G_EXEC_OUTPUT_COL='\e[90m' G_EXEC apt-get -y --allow-change-held-packages -f install "$@"
 		local exit_code=$?
@@ -1574,9 +1568,6 @@ Press any key to continue...'
 
 		# Clean cache before every update, which can corrupt and gets fully rewritten anyway
 		G_EXEC_PRE_FUNC(){ apt-get clean; }
-
-		# Workaround for Armbian mirrors being out of sync regularly or throwing 5xx errors
-		[[ -f '/etc/apt/sources.list.d/dietpi-armbian.list' ]] && G_EXEC_POST_FUNC(){ [[ $exit_code != 0 ]] && grep -q '^E: Failed to fetch .*armbian' "$fp_log" && G_EXEC_RETRIES=2 && unset -f G_EXEC_POST_FUNC; }
 
 		G_EXEC_DESC='\e[0mAPT update'
 		G_EXEC_OUTPUT=1 G_EXEC_OUTPUT_COL='\e[90m' G_EXEC apt-get -y -eany update
@@ -1620,9 +1611,6 @@ Press any key to continue...'
 	{
 		G_CHECK_ROOT_USER 1
 
-		# Workaround for Armbian mirrors being out of sync regularly or throwing 5xx errors
-		[[ -f '/etc/apt/sources.list.d/dietpi-armbian.list' ]] && G_EXEC_POST_FUNC(){ [[ $exit_code != 0 ]] && grep -q '^E: Failed to fetch .*armbian' "$fp_log" && G_EXEC_RETRIES=2 && unset -f G_EXEC_POST_FUNC; }
-
 		G_EXEC_DESC="\e[0mAPT upgrade${*:+ \e[33m$*\e[0m}"
 		DEBIAN_FRONTEND=noninteractive G_EXEC_OUTPUT=1 G_EXEC_OUTPUT_COL='\e[90m' G_EXEC apt-get -y --with-new-pkgs upgrade "$@"
 		local exit_code=$?
@@ -1638,9 +1626,6 @@ Press any key to continue...'
 	G_AGDUG()
 	{
 		G_CHECK_ROOT_USER 1
-
-		# Workaround for Armbian mirrors being out of sync regularly or throwing 5xx errors
-		[[ -f '/etc/apt/sources.list.d/dietpi-armbian.list' ]] && G_EXEC_POST_FUNC(){ [[ $exit_code != 0 ]] && grep -q '^E: Failed to fetch .*armbian' "$fp_log" && G_EXEC_RETRIES=2 && unset -f G_EXEC_POST_FUNC; }
 
 		G_EXEC_DESC="\e[0mAPT dist-upgrade${*:+ \e[33m$*\e[0m}"
 		DEBIAN_FRONTEND=noninteractive G_EXEC_OUTPUT=1 G_EXEC_OUTPUT_COL='\e[90m' G_EXEC apt-get -y dist-upgrade "$@"

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -128,8 +128,12 @@ $FP_SCRIPT	rpi_kernel_choice		<empty> Supported on Debian Bookworm or newer on R
 			15) all_components='odroidn2';;
 			16) all_components='odroidc4';;
 			40) all_components='pinea64';;
+			42) all_components='rockpro64';;
+			43) all_components='rock64';;
 			44) all_components='pinebook';;
 			45) all_components='pineh64';;
+			46) all_components='pinebookpro';;
+			47) all_components='nanopir4s';;
 			48) all_components='nanopir1';;
 			49)
 				# Detect variant either based on $HW_VARIANT environment variable, existing "all" components or installed kernel/firmware package
@@ -149,9 +153,12 @@ $FP_SCRIPT	rpi_kernel_choice		<empty> Supported on Debian Bookworm or newer on R
 					;;
 				esac
 			;;
+			52) all_components='tinkerboard';;
 			54) all_components='nanopik2';;
+			55) all_components='nanopir2s';;
 			56) all_components='nanopineo3';;
 			57) all_components='nanopineoplus2';;
+			58) all_components='nanopim4v2';;
 			59) all_components='zeropi';;
 			60) all_components='nanopineo';;
 			61) all_components='nanopi2';;
@@ -193,18 +200,16 @@ $FP_SCRIPT	rpi_kernel_choice		<empty> Supported on Debian Bookworm or newer on R
 			;;
 			66) all_components='nanopim1plus';;
 			67) all_components='nanopik1plus';;
-			70) all_components='sparkysbc';;
-			74) all_components='radxazero';;
-			76)
+			68)
 				# Detect variant either based on $HW_VARIANT environment variable, existing "all" components or installed U-Boot package
 				# shellcheck disable=SC2154
 				case $HW_VARIANT in
-					1) all_components='';; # no R5S component is available yet
-					2) all_components='nanopir5c';;
+					1) all_components='nanopim4';;
+					2) all_components='nanopct4';;
+					3) all_components='nanopineo4';;
 					*)
 						[[ -f '/etc/apt/sources.list.d/dietpi.list' ]] && all_components=$(sed -n '/ all /{s/^.* all //p;q}' /etc/apt/sources.list.d/dietpi.list)
-						# shellcheck disable=SC2043
-						[[ $all_components ]] || for i in nanopi-r5c
+						[[ $all_components ]] || for i in nano{pim4,pineo4,pct4}
 						do
 							dpkg-query -s "linux-u-boot-$i-current" &> /dev/null || continue
 							all_components=${i/-//}
@@ -213,6 +218,45 @@ $FP_SCRIPT	rpi_kernel_choice		<empty> Supported on Debian Bookworm or newer on R
 					;;
 				esac
 			;;
+			70) all_components='sparkysbc';;
+			72)
+				# Detect variant either based on $HW_VARIANT environment variable, existing "all" components or installed U-Boot package
+				# shellcheck disable=SC2154
+				case $HW_VARIANT in
+					1) all_components='rock4';;
+					2) all_components='rock4se';;
+					3) all_components='rock4cplus';;
+					*)
+						[[ -f '/etc/apt/sources.list.d/dietpi.list' ]] && all_components=$(sed -n '/ all /{s/^.* all //p;q}' /etc/apt/sources.list.d/dietpi.list)
+						[[ $all_components ]] || for i in rock{pi-4b,-4se,pi-4cplus}
+						do
+							dpkg-query -s "linux-u-boot-$i-current" &> /dev/null || continue
+							all_components=${i/-//}
+							break
+						done
+					;;
+				esac
+			;;
+			73) all_components='rockpis';;
+			74) all_components='radxazero';;
+			76)
+				# Detect variant either based on $HW_VARIANT environment variable, existing "all" components or installed U-Boot package
+				# shellcheck disable=SC2154
+				case $HW_VARIANT in
+					1) all_components='nanopir5s';;
+					2) all_components='nanopir5c';;
+					*)
+						[[ -f '/etc/apt/sources.list.d/dietpi.list' ]] && all_components=$(sed -n '/ all /{s/^.* all //p;q}' /etc/apt/sources.list.d/dietpi.list)
+						[[ $all_components ]] || for i in nanopi-r5{c,s}
+						do
+							dpkg-query -s "linux-u-boot-$i-current" &> /dev/null || continue
+							all_components=${i/-//}
+							break
+						done
+					;;
+				esac
+			;;
+			77) all_components='rock3a';;
 			78) all_components='rock5b';;
 			79)
 				# Detect variant either based on $HW_VARIANT environment variable, existing "all" components or installed U-Boot package
@@ -238,6 +282,8 @@ $FP_SCRIPT	rpi_kernel_choice		<empty> Supported on Debian Bookworm or newer on R
 			83) all_components='orangepizero3';;
 			84) all_components='star64';;
 			85) all_components='rock5a';;
+			86) all_components='tinkerboard2';;
+			87) all_components='orangepi3b';;
 			88) all_components='orangepizero2w';;
 			89) all_components='orangepi3lts';;
 			90) all_components='radxazero3';;


### PR DESCRIPTION
- General | Since we provide all kernel, bootloader and firmware packages from our own APT repository now, the Armbian APT repository is removed form all systems. In case you use an SBC which is not officially supported by DietPi, as generic device, it is however preserved.
