### PR TITLE
ADS-B Feeder Image: fix install issues

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,7 @@ Bug fixes:
 - DietPi-Software | Shairport Sync: Resolved a DietPi v9.4 regression, where the AirPlay 2 choice did not have an effect, but the AirPlay 1 package was always installed. Additionally, uninstalling Shairport Sync will now also purge the AirPlay 2 package. Many thanks to @pulpe for fixing this bug: https://github.com/MichaIng/DietPi/pull/7082
 - DietPi-Software | Box64: Resolved an issue where an invalid build target was used on Raspberry Pi 5 with 16k page size kernel. This target was removed with latest Box64, as page size handling is now done at runtime.
 - DietPi-Software | Jellyfin: Resolved an issue where the intended HTTP port change could not be applied, since the network config file is not created anymore at service start. We do now pre-create a minimal one, which is complemented with defaults automatically.
+- DietPi-Software | ADS-B Feeder: Resolved an issue where the service start could have failed because of a missing Python module. Many thanks to @moonraka for reporting the issue and @dirkhh sending a fix quickly: https://dietpi.com/forum/t/ads-b-feeder-not-working/20601
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/7098
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11913,27 +11913,18 @@ _EOF_
 			G_EXEC mkdir -p /mnt/dietpi_userdata/adsb-feeder/config
 			G_EXEC ln -s /mnt/dietpi_userdata/adsb-feeder/config .
 
-			# set the 'image name' and version that are shown in the footer of the Web UI
+			# set the 'image name' and version that are shown in the footer of the Web UI and mark as app, not image
 			G_EXEC eval 'echo '\''ADSB Feeder app running on DietPi'\'' > feeder-image.name'
 			G_EXEC eval "echo '$ADSB_FEEDER_VERSION' > adsb.im.version"
+			G_EXEC rm -f os.adsb.feeder.image
+			G_EXEC touch app.adsb.feeder.image
 
-			# get the Python module
-			# for older distros we need to install via pip in order to get flask 2
-			if (( $G_DISTRO < 7 ))
-			then
-				G_EXEC_OUTPUT=1 G_EXEC pip3 install -U flask
-			else
-				G_AGI python3-flask
-			fi
+			# get the Python modules
+			G_EXEC_OUTPUT=1 G_EXEC pip3 install -U flask requests
 
 			# finally ensure that /run allows executables (this is needed for the containers to be able to not do excessive
 			# writes to physical storage - which might be an SD card)
 			G_EXEC mount -o remount,exec /run
-
-			# now that everything is in place, run the one time service to get the software pre-configured
-			# running this as a service allows it to do a bit of housekeeping in the background without disrupting
-			# the software install flow
-			G_EXEC systemctl start adsb-nonimage
 		fi
 
 		if To_Install 172 # WireGuard


### PR DESCRIPTION
Add the missing python requests library and the app flag file.

This includes changes that I had submitted previously - I still want to remove the adsb-nonimage service so I can remove the dummy service from the adsb-feeder-image repo, eventually

<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
