### PR TITLE
DietPi-Software | Box86/Box64: Fix directory removal on install

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ v9.7
 Enhancements:
 
 Bug fixes:
+- DietPi-Software | Box86/Box64: Resolved an issue where the installation failed because of a false directory removal attempt. Many thanks to @lukaszsobala for fixing this issue: https://github.com/MichaIng/DietPi/pull/7149
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/ADDME
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11085,7 +11085,7 @@ _EOF_
 
 			# Cleanup
 			G_EXEC cd "$G_WORKING_DIR"
-			G_EXEC rm "box86-${version#v}"
+			G_EXEC rm -R "box86-${version#v}"
 
 			# Reload binfmt if kernel module is available to have i386 binaries executed via box86 automatically from now on
 			modprobe binfmt_misc 2> /dev/null && G_EXEC systemctl restart systemd-binfmt
@@ -11142,7 +11142,7 @@ _EOF_
 
 			# Cleanup
 			G_EXEC cd "$G_WORKING_DIR"
-			G_EXEC rm -r "box64-${version#v}"
+			G_EXEC rm -R "box64-${version#v}"
 
 			# Reload binfmt if kernel module is available to have x86_64 binaries executed via box64 automatically from now on
 			modprobe binfmt_misc 2> /dev/null && G_EXEC systemctl restart systemd-binfmt

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11142,7 +11142,7 @@ _EOF_
 
 			# Cleanup
 			G_EXEC cd "$G_WORKING_DIR"
-			G_EXEC rm "box64-${version#v}"
+			G_EXEC rm -r "box64-${version#v}"
 
 			# Reload binfmt if kernel module is available to have x86_64 binaries executed via box64 automatically from now on
 			modprobe binfmt_misc 2> /dev/null && G_EXEC systemctl restart systemd-binfmt


### PR DESCRIPTION
<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
This is the proper pull request to the proper branch. Fixes box64 directory removal post-install.