### PR TITLE
DietPi-Software | Enable Portainer to use services using certs issued by a private CA #7215

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ v9.8
 
 Enhancements:
 - DietPi-Software | NoMachine: Our install option will now always download the latest NoMachine version, instead of a hardcoded one depending on the DietPi version. Many thanks to @tzvi208 for for figuring it out to version-agnostic download URLs: https://github.com/MichaIng/DietPi/issues/7198
+- DietPi-Software | Portainer: It has been enabled to accept private/custom CA certificates by using the trusted CA certificates of the host, instead of the ones shipped with the container image. Many thanks to @oldboys92 for implementing this enhancement: https://github.com/MichaIng/DietPi/pull/7217
 
 Bug fixes:
 - NanoPi M3/T3 | Resolved an issue where our recent image did not boot because the bootloader did not define a default device tree path anymore. Many thanks to @rozcietrzewiacz for reporting this issue: https://github.com/MichaIng/DietPi/issues/2630#issuecomment-2322085507

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11913,7 +11913,7 @@ _EOF_
 
 			# Deploy the Portainer container
 			G_DIETPI-NOTIFY 2 'Portainer will be deployed now. This could take a while...'
-			G_EXEC_OUTPUT=1 G_EXEC docker run -d -p '9002:9000' --name=portainer --restart=always -v '/run/docker.sock:/var/run/docker.sock' -v 'portainer_data:/data' 'portainer/portainer-ce'
+			G_EXEC_OUTPUT=1 G_EXEC docker run -d -p '9002:9000' --name=portainer --restart=always -v '/run/docker.sock:/var/run/docker.sock' -v '/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro' -v 'portainer_data:/data' 'portainer/portainer-ce'
 		fi
 
 		if To_Install 141 adsb-setup adsb-docker # ADS-B Feeder


### PR DESCRIPTION
fixes #7215. Tested on a local installation.
