### PR TITLE
Added remote debugging option to the Chromium settings in DietPi.

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9050,6 +9050,9 @@ RES_Y=$(sed -n '/^[[:blank:]]*SOFTWARE_CHROMIUM_RES_Y=/{s/^[^=]*=//p;q}' /boot/d
 # - Review and add custom flags in: /etc/chromium.d
 CHROMIUM_OPTS="--kiosk --window-size=${RES_X:-1280},${RES_Y:-720} --window-position=0,0"
 
+# If you want to enable remote debugging, uncomment the next line.
+#CHROMIUM_OPTS+=' --remote-debugging-port=9222'
+
 # If you want tablet mode, uncomment the next line.
 #CHROMIUM_OPTS+=' --force-tablet-mode --tablet-ui'
 


### PR DESCRIPTION
Hi,
I've tested and added a new option (enable remote debugging) to the Chromium settings in DietPi. I tested it on a Raspberry Pi 5.