### PR TITLE
DietPi-Software | MineOS: Fix install on Bookworm and login

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ New software:
 Enhancements:
 - DietPi-Software | NFS Server: The "fsid=0" option has been removed from the /mnt/dietpi_userdata default export. As it is uncommon and not respected in "showmount -e" export lists, it caused confusion and issues.
 - DietPi-Software | YaCy: The latest YaCy version will now be installed, and the global software password will be set as default admin password on fresh installs.
+- DietPi-Software | MineOS: As a security enhancement and workaround for a web UI login issue, a dedicated "mineos" user is created again. For new MineOS installs or after reinstall, one can login with this user, and the global software password. It has permissions to install and manage Minecraft instances.
 
 Bug fixes:
 - NanoPi M1 Plus | Resolved an issue where Ethernet did not work because of a faulty kernel patch. Many thanks to @InnovoMagicCube and @InnovoDeveloper for reporting this issue: https://github.com/MichaIng/DietPi/issues/6974
@@ -13,6 +14,8 @@ Bug fixes:
 - DietPi-Software | InfluxDB: Resolved an issue where the service did not start up after the recent package upgrade. The package upgrade removes the symlink /var/lib/influxdb => /mnt/dietpi_userdata/influxdb, which is recreated with this DietPi update. Many thanks to @uwjhn for reporting this issue: https://dietpi.com/forum/t/influxdb-not-working-after-update/21868
 - DietPi-Software | Node-RED: Resolved an issue where the service failed on ARMv6 systems, since a dependency module of Node-RED v4 does not support this architecture. Node-RED v3 will now be installed on those old RPi models. Many thanks to @mvanbrab for reporting this issue: https://github.com/MichaIng/DietPi/issues/7252
 - DietPi-Software | Chromium: Resolved an issue where optional Chromium flags via "CHROMIUM_OPTS+=" line in /var/lib/dietpi/dietpi-software/installed/chromium-autostart.sh did not have any effect, as "+=" is bash-only syntax, while the script is executed with dash (bourne shell). Many thanks to @Nurgak for reporting this issue: https://github.com/MichaIng/DietPi/issues/7263#issuecomment-2463626660
+- DietPi-Software | MineOS: Worked around an issue where the install failed on Bookworm systems, as one of the Node.js modules failed to compile for unknown reasons. Many thanks to @mikedebian for reporting this issue: https://github.com/MichaIng/DietPi/issues/7265
+- DietPi-Software | MineOS: Worked around an issue where login into the web interface failed since Bullseye, as MineOS does not support the new default yescrypt password hash algorithm for UNIX users. A new dedicated "mineos" user is now created, and its password set explicitly with SHA512 hash algorithm. Many thanks to @maybaxstv for reporting this issue: https://github.com/MichaIng/DietPi/issues/5759
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/ADDME
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,7 @@ Bug fixes:
 - DietPi-Software | Chromium: Resolved an issue where optional Chromium flags via "CHROMIUM_OPTS+=" line in /var/lib/dietpi/dietpi-software/installed/chromium-autostart.sh did not have any effect, as "+=" is bash-only syntax, while the script is executed with dash (bourne shell). Many thanks to @Nurgak for reporting this issue: https://github.com/MichaIng/DietPi/issues/7263#issuecomment-2463626660
 - DietPi-Software | MineOS: Worked around an issue where the install failed on Bookworm systems, as one of the Node.js modules failed to compile for unknown reasons. Many thanks to @mikedebian for reporting this issue: https://github.com/MichaIng/DietPi/issues/7265
 - DietPi-Software | MineOS: Worked around an issue where login into the web interface failed since Bullseye, as MineOS does not support the new default yescrypt password hash algorithm for UNIX users. A new dedicated "mineos" user is now created, and its password set explicitly with SHA512 hash algorithm. Many thanks to @maybaxstv for reporting this issue: https://github.com/MichaIng/DietPi/issues/5759
+- DietPi-Software | Node.js: Resolved an issue where node failed on ARMv7 Bullseye systems, since the latest version for this architecture requires a newer C++ standard library than provided on Bullseye.
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/ADDME
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8433,6 +8433,9 @@ _EOF_
 			G_EXEC git config core.filemode false
 			G_EXEC chmod +x mineos_console.js webui.js update_webui.sh reset_webui.sh generate-sslcert.sh
 
+			# Bookworm: Workaround for failing userid 1.0.0-beta.9 build on weirdly Bookworm only. Latest stable 1.2.5 seems to work well: https://github.com/MichaIng/DietPi/issues/7265
+			G_CONFIG_INJECT '"userid"' '    "userid": "1.2.5",' package.json
+
 			# Workaround: Node.js posix needs to be installed alone first: https://github.com/MichaIng/DietPi/issues/5181
 			G_EXEC_OUTPUT=1 G_EXEC npm i --no-audit --no-package-lock posix@latest
 
@@ -8453,7 +8456,7 @@ _EOF_
 			G_EXEC cd "$G_WORKING_DIR"
 
 			# Service
-			cat << _EOF_ > /etc/systemd/system/mineos.service
+			cat << '_EOF_' > /etc/systemd/system/mineos.service
 [Unit]
 Description=MineOS (DietPi)
 Wants=network-online.target
@@ -8463,12 +8466,19 @@ After=network-online.target
 SyslogIdentifier=MineOS
 WorkingDirectory=/mnt/dietpi_userdata/mineos/minecraft
 Environment="SHELL=/bin/bash" "HOME=/root"
-ExecStart=$(command -v node) webui.js
+ExecStart=/usr/local/bin/node webui.js
 KillMode=process
 
 [Install]
 WantedBy=multi-user.target
 _EOF_
+			# User and permissions
+			local new_user=0
+			getent passwd mineos &> /dev/null || new_user=1
+			Create_User -d /mnt/dietpi_userdata/mineos/serverdata -p "$GLOBAL_PW" mineos
+			G_EXEC chown -R mineos /mnt/dietpi_userdata/mineos/serverdata
+			# - Assure SHA512 password hash algorithm, as MineOS does not support yescrypt, default since Bullseye: https://github.com/hexparrot/mineos-node/issues/441
+			(( $new_user )) && G_EXEC eval "chpasswd --crypt-method SHA512 <<< 'mineos:$GLOBAL_PW'"
 		fi
 
 		if To_Install 46 qbittorrent # qBittorrent
@@ -13598,10 +13608,10 @@ _EOF_
 
 		if To_Uninstall 53 # MineOS
 		then
-			Remove_Service mineos 1 1 # User and group for pre-v6.34
+			Remove_Service mineos 1 1
 			[[ -d '/mnt/dietpi_userdata/mineos' ]] && G_EXEC rm -R /mnt/dietpi_userdata/mineos
 			[[ -f '/etc/mineos.conf' ]] && G_EXEC rm /etc/mineos.conf
-			G_EXEC rm -Rf /var/games/minecraft /usr/local/bin/mineos # Symlinks
+			G_EXEC rm -Rf /var/games/minecraft /usr/local/bin/mineos /etc/ssl/certs/mineos.* # Symlinks and SSL cert
 			[[ -d '/home/mineos' ]] && G_EXEC rm -R /home/mineos # pre-v6.34
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3017,9 +3017,11 @@ unix_socket_directories = '/run/postgresql'" > "$i/00dietpi.conf"
 			G_EXEC chmod +x node-install.sh
 
 			# ARMv6/RISC-V: Use unofficial builds to get the latest version: https://github.com/MichaIng/nodejs-linux-installer/pull/2, https://github.com/MichaIng/nodejs-linux-installer/commit/cd952fe
-			local unofficial=()
-			(( $G_HW_ARCH == 1 || $G_HW_ARCH == 11 )) && unofficial=('-u')
-			G_EXEC_OUTPUT=1 G_EXEC ./node-install.sh "${unofficial[@]}"
+			local options=()
+			(( $G_HW_ARCH == 1 || $G_HW_ARCH == 11 )) && options=('-u')
+			# ARMv7 Bullseye: node: /usr/lib/arm-linux-gnueabihf/libstdc++.so.6: version `GLIBCXX_3.4.30'/'0/GLIBCXX_3.4.39' not found (required by node)
+			(( $G_HW_ARCH == 2 && $G_DISTRO < 7 )) && options=('-v' 'v22.11.0')
+			G_EXEC_OUTPUT=1 G_EXEC ./node-install.sh "${options[@]}"
 			G_EXEC rm node-install.sh
 		fi
 


### PR DESCRIPTION
- DietPi-Software | MineOS: Fix install on Bookworm by using latest userid Node module version. The defined v1.0.0-beta.9 fails to build on all Bookworm systems, for unknown reasons, the latest stable v1.2.5 however builds fine.
- DietPi-Software | Create again a dedicated mineos login user to manage the Minecraft servers. We switched to root, due to insufficient permissions, but I could not replicate any issues, after changing owner of /mnt/dietpi_userdata/mineos/serverdata accordingly. Apply SHA512 password algorithm for this user explicitly, as MineOS does not support the new default yescrypt: https://github.com/MichaIng/DietPi/issues/5759