### PR TITLE
Removing deprecated parameters from smb.conf

### DIFF
--- a/.conf/dps_96/conf
+++ b/.conf/dps_96/conf
@@ -5,13 +5,11 @@
 	dns proxy = no
 	log file = /var/log/samba/log.%m
 	max log size = 1000
-	syslog only = no
-	syslog = 0
+	logging = syslog@0
 
 	panic action = /usr/share/samba/panic-action %d
 
 	security = user
-	encrypt passwords = true
 	passdb backend = tdbsam
 	obey pam restrictions = yes
 	unix password sync = yes

--- a/.conf/dps_96/conf
+++ b/.conf/dps_96/conf
@@ -5,7 +5,7 @@
 	dns proxy = no
 	log file = /var/log/samba/log.%m
 	max log size = 1000
-	logging = syslog@0
+	logging = syslog@1
 
 	panic action = /usr/share/samba/panic-action %d
 


### PR DESCRIPTION
The dietpi-software script generates a samba configuration file `smb.conf` with outdated parameters. The `testparm` verification script displays the following warnings:
```bash
# testparm
Load smb config files from /etc/samba/smb.conf
lpcfg_do_global_parameter: WARNING: The "syslog only" option is deprecated
lpcfg_do_global_parameter: WARNING: The "syslog" option is deprecated
lpcfg_do_global_parameter: WARNING: The "encrypt passwords" option is deprecated
```
This fix removes deprecated parameters and replaces them with current ones.