### PR TITLE
Live patches for Fail2Ban Dropbear filter

### DIFF
--- a/.update/version
+++ b/.update/version
@@ -14,7 +14,19 @@ G_MIN_DEBIAN=6
 # Alternative Git branch to automatically migrate to when Debian version is too low
 G_OLD_DEBIAN_BRANCH='8'
 # Live patches
-G_LIVE_PATCH_DESC=('Fix Sonarr v4 permissions for updater. Only needed if you plan to install or migrate to Sonarr v4 via dietpi-software.')
-G_LIVE_PATCH_COND=('grep -q '\''^ReadWritePaths=-/usr/lib/sonarr'\'' /boot/dietpi/dietpi-software')
+G_LIVE_PATCH_DESC=(
+	[0]='Fix Sonarr v4 permissions for updater. Only needed if you plan to install or migrate to Sonarr v4 via dietpi-software.'
+	[1]='Fix install of patches Fail2Ban Dropbear filter: https://github.com/MichaIng/DietPi/issues/7325'
+	[2]='Install patched Fail2Ban Dropbear filter: https://github.com/fail2ban/fail2ban/pull/3597'
+)
+G_LIVE_PATCH_COND=(
+	[0]='grep -q '\''^ReadWritePaths=-/usr/lib/sonarr'\'' /boot/dietpi/dietpi-software'
+	[1]='[[ ! -d /etc/fail2ban/filter.d ]] && grep -q '\''^			G_EXEC mkdir -p /etc/fail2ban/fail2ban.d'\'' /boot/dietpi/dietpi-software'
+	[2]='[[ -d /etc/fail2ban/filter.d && ! -f /etc/fail2ban/filter.d/dropbear.local ]]'
+)
 # shellcheck disable=SC2016
-G_LIVE_PATCH=('sed -i '\''s|^ReadWritePaths=-/usr/lib/sonarr|ReadWritePaths=-$install_dir|'\'' /boot/dietpi/dietpi-software')
+G_LIVE_PATCH=(
+	[0]='sed -i '\''s|^ReadWritePaths=-/usr/lib/sonarr|ReadWritePaths=-$install_dir|'\'' /boot/dietpi/dietpi-software'
+	[1]='sed -i '\''s|^			G_EXEC mkdir -p /etc/fail2ban/fail2ban.d|			G_EXEC mkdir -p /etc/fail2ban/{fail2ban,filter}.d|'\'' /boot/dietpi/dietpi-software'
+	[2]='curl -sSf https://raw.githubusercontent.com/fail2ban/fail2ban/eb8b443/config/filter.d/dropbear.conf -o /etc/fail2ban/filter.d/dropbear.local'
+)


### PR DESCRIPTION
- Live patch 1 | Fix install of patches Fail2Ban Dropbear filter: https://github.com/MichaIng/DietPi/issues/7325
- Live patch 2 | Install patched Fail2Ban Dropbear filter: https://github.com/fail2ban/fail2ban/pull/3597

<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
