### PR TITLE
Dietpi-Software | Raspotify: Add Avahi-Daemon as new librespot dependency

### DIFF
--- a/.update/patches
+++ b/.update/patches
@@ -2067,6 +2067,25 @@ Patch_9_9()
 	fi
 }
 
+Patch_9_10()
+{
+	# Software updates, migrations and patches
+	if [[ -f '/boot/dietpi/.installed' ]]
+	then
+		# Raspotify
+		if grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[167\]=2' /boot/dietpi/.installed
+		then
+			G_DIETPI-NOTIFY 2 'Migrating to new Raspotify APT list name and key format ...'
+			[[ -f '/etc/apt/sources.list.d/raspotify.list' ]] && G_EXEC mv /etc/apt/sources.list.d/{,dietpi-}raspotify.list
+			if [[ -f '/etc/apt/trusted.gpg.d/dietpi-raspotify.gpg' ]]
+			then
+				G_EXEC curl -sSfo /etc/apt/trusted.gpg.d/dietpi-raspotify.asc 'https://dtcooper.github.io/raspotify/key.asc'
+				G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-raspotify.gpg
+			fi
+		fi
+	fi
+}
+
 # v6.35 => v7 migration
 if (( $G_DIETPI_VERSION_CORE == 6 && $G_DIETPI_VERSION_SUB > 34 ))
 then

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Enhancements:
 Bug fixes:
 - DietPi-Software | Sonarr: Resolved an issue where the internal updater did not work due to permission limits in the systemd unit. Many thanks to @tellice for reporting this issue: https://github.com/MichaIng/DietPi/issues/7321
 - DietPi-Software | Fail2Ban: Resolved an issue where a fixed Dropbear filter could not be installed, because the directory did not exist yet. Many thanks to @augustresende for reporting this issue: https://github.com/MichaIng/DietPi/issues/7325
+- DietPi-Software | Raspotify: Resolved an issue where the service failed to start, if Avahi-Daemon was not installed. librespot has it as new default DNS discovery backend, and official pre-compiled Raspotify binaries are not compiled with the old DNS-SD backend anymore. Avahi-Daemon is hence installed now by DietPi-Software as well. Many thanks to @gergokis for reporting this issue: https://github.com/MichaIng/DietPi/issues/7323
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/ADDME
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -517,7 +517,7 @@ Available commands:
 		aSOFTWARE_DESC[$software_id]='Spotify connect client'
 		aSOFTWARE_CATX[$software_id]=2
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#raspotify'
-		aSOFTWARE_DEPS[$software_id]='5'
+		aSOFTWARE_DEPS[$software_id]='5 152'
 		# - RISC-V: No package: https://github.com/dtcooper/raspotify/releases
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,11]=0
 		# - Bookworm/Trixie on ARMv6 (older package): "/usr/bin/librespot: error while loading shared libraries: ld-linux.so.3: cannot open shared object file: No such file or directory"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -517,7 +517,7 @@ Available commands:
 		aSOFTWARE_DESC[$software_id]='Spotify connect client'
 		aSOFTWARE_CATX[$software_id]=2
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#raspotify'
-		aSOFTWARE_DEPS[$software_id]='5'
+		aSOFTWARE_DEPS[$software_id]='5 152'
 		# - RISC-V: No package: https://github.com/dtcooper/raspotify/releases
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,11]=0
 		# - Bookworm/Trixie on ARMv6 (older package): "/usr/bin/librespot: error while loading shared libraries: ld-linux.so.3: cannot open shared object file: No such file or directory"
@@ -10911,9 +10911,6 @@ _EOF_
 
 				# APT package
 				G_AGI raspotify
-
-				# Switch to old DNS-SD backend, to avoid Avahi-Daemon dependency: https://github.com/MichaIng/DietPi/issues/7323
-				GGI_PRESERVE=1 G_CONFIG_INJECT 'LIBRESPOT_ZEROCONF_BACKEND=' 'LIBRESPOT_ZEROCONF_BACKEND="dns-sd"' /etc/raspotify/conf
 			fi
 
 			# Stop service

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -517,7 +517,7 @@ Available commands:
 		aSOFTWARE_DESC[$software_id]='Spotify connect client'
 		aSOFTWARE_CATX[$software_id]=2
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#raspotify'
-		aSOFTWARE_DEPS[$software_id]='5 152'
+		aSOFTWARE_DEPS[$software_id]='5'
 		# - RISC-V: No package: https://github.com/dtcooper/raspotify/releases
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,11]=0
 		# - Bookworm/Trixie on ARMv6 (older package): "/usr/bin/librespot: error while loading shared libraries: ld-linux.so.3: cannot open shared object file: No such file or directory"
@@ -10903,16 +10903,17 @@ _EOF_
 			# ARMv7/ARMv8/x86_64
 			else
 				# APT key
-				local url='https://dtcooper.github.io/raspotify/key.asc'
-				G_CHECK_URL "$url"
-				G_EXEC eval "curl -sSfL '$url' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-raspotify.gpg --yes"
+				Download_Install 'https://dtcooper.github.io/raspotify/key.asc' /etc/apt/trusted.gpg.d/dietpi-raspotify.asc
 
 				# APT list
-				G_EXEC eval 'echo '\''deb https://dtcooper.github.io/raspotify raspotify main'\'' > /etc/apt/sources.list.d/raspotify.list'
+				G_EXEC eval 'echo '\''deb https://dtcooper.github.io/raspotify raspotify main'\'' > /etc/apt/sources.list.d/dietpi-raspotify.list'
 				G_AGUP
 
 				# APT package
 				G_AGI raspotify
+
+				# Switch to old DNS-SD backend, to avoid Avahi-Daemon dependency: https://github.com/MichaIng/DietPi/issues/7323
+				GGI_PRESERVE=1 G_CONFIG_INJECT 'LIBRESPOT_ZEROCONF_BACKEND=' 'LIBRESPOT_ZEROCONF_BACKEND="dns-sd"' /etc/raspotify/conf
 			fi
 
 			# Stop service
@@ -13793,8 +13794,8 @@ _EOF_
 		if To_Uninstall 167 # Raspotify
 		then
 			G_AGP raspotify
-			[[ -f '/etc/apt/sources.list.d/raspotify.list' ]] && G_EXEC rm /etc/apt/sources.list.d/raspotify.list
-			[[ -f '/etc/apt/trusted.gpg.d/dietpi-raspotify.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-raspotify.gpg
+			[[ -f '/etc/apt/sources.list.d/dietpi-raspotify.list' ]] && G_EXEC rm /etc/apt/sources.list.d/dietpi-raspotify.list
+			[[ -f '/etc/apt/trusted.gpg.d/dietpi-raspotify.asc' ]] && G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-raspotify.asc
 		fi
 
 		if To_Uninstall 169 # Google AIY


### PR DESCRIPTION
- add avahi-daemon as dependency 

Avahi seems to be required now, based on https://github.com/MichaIng/DietPi/issues/7323