### PR TITLE
Removed software "Network Tools"

### DIFF
--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -742,6 +742,12 @@ shopt -s extglob
 		aSOFTWARE_NAME9_9[i]=${aSOFTWARE_NAME9_8[i]}
 		aSOFTWARE_NAME9_10[i]=${aSOFTWARE_NAME9_9[i]}
 	done
+	unset -v 'aSOFTWARE_NAME9_10[10]' # iftop
+	unset -v 'aSOFTWARE_NAME9_10[11]' # IPTraf
+	unset -v 'aSOFTWARE_NAME9_10[12]' # Iperf
+	unset -v 'aSOFTWARE_NAME9_10[13]' # MTR-Tiny
+	unset -v 'aSOFTWARE_NAME9_10[14]' # nLoad
+	unset -v 'aSOFTWARE_NAME9_10[15]' # tcpdump
 
 	# Pre-create software counter array so that we can see also software (available in newest version) with 0 installs
 	for i in "${aSOFTWARE_NAME9_10[@]}"

--- a/.update/patches
+++ b/.update/patches
@@ -2091,6 +2091,12 @@ Patch_9_10()
 				G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-raspotify.gpg
 			fi
 		fi
+
+		# Remove obsolete install states: https://github.com/MichaIng/DietPi/pull/7351
+		for i in {10..15}
+		do
+			grep -q "^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[$i\]=" /boot/dietpi/.installed && G_EXEC sed --follow-symlinks -i "/^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[$i\]=/d" /boot/dietpi/.installed
+		done
 	fi
 }
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,12 +9,7 @@ Enhancements:
 - DietPi-Software | myMPD: We enabled the software option for ARMv6 Bookworm systems, since packages for Raspbian Bookworm are now available. Many thanks to @hackslikeus for bringing up the topic: https://github.com/MichaIng/DietPi/issues/7345
 
 Removed software:
-- DietPi-Software| iftop: Removed software package. Can be installed easily via `apt install iftop`, because there are no dependencies to other packages. Usage of this software was very rare.
-- DietPi-Software| IPTraf: Removed software package. Can be installed easily via `apt install iptraf`, because there are no dependencies to other packages. Usage of this software was very rare.
-- DietPi-Software| Iperf: Removed software package. Can be installed easily via `apt install iperf`, because there are no dependencies to other packages. Usage of this software was very rare.
-- DietPi-Software| MTR-Tiny: Removed software package. Can be installed easily via `apt install mtr`, because there are no dependencies to other packages. Usage of this software was very rare.
-- DietPi-Software| nLoad: Removed software package. Can be installed easily via `apt install nload`, because there are no dependencies to other packages. Usage of this software was very rare.
-- DietPi-Software| tcpdump: Removed software package. Can be installed easily via `apt install tcpdump`, because there are no dependencies to other packages. Usage of this software was very rare.
+- DietPi-Software | A number of software options have been removed, which were installed just as single APT package, without any configuration or dependant. Running `dietpi-software` for such is overkill, as one can just use the native Debian package manager directly, like "apt install tcpdump". Affected software titles: iftop, IPTraf, Iperf, MTR-Tiny, nLoad, tcpdump
 
 Bug fixes:
 - DietPi-Software | Sonarr: Resolved an issue where the internal updater did not work due to permission limits in the systemd unit. Many thanks to @tellice for reporting this issue: https://github.com/MichaIng/DietPi/issues/7321

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,14 @@ Enhancements:
 - RISC-V | Additional software options have been enabled for RISC-V systems: NZBGet, MicroK8s and AdGuard Home
 - DietPi-Software | myMPD: We enabled the software option for ARMv6 Bookworm systems, since packages for Raspbian Bookworm are now available. Many thanks to @hackslikeus for bringing up the topic: https://github.com/MichaIng/DietPi/issues/7345
 
+Removed software:
+- DietPi-Software| iftop: Removed software package. Can be installed easily via `apt install iftop`, because there are no dependencies to other packages. Usage of this software was very rare.
+- DietPi-Software| IPTraf: Removed software package. Can be installed easily via `apt install iptraf`, because there are no dependencies to other packages. Usage of this software was very rare.
+- DietPi-Software| Iperf: Removed software package. Can be installed easily via `apt install iperf`, because there are no dependencies to other packages. Usage of this software was very rare.
+- DietPi-Software| MTR-Tiny: Removed software package. Can be installed easily via `apt install mtr`, because there are no dependencies to other packages. Usage of this software was very rare.
+- DietPi-Software| nLoad: Removed software package. Can be installed easily via `apt install nload`, because there are no dependencies to other packages. Usage of this software was very rare.
+- DietPi-Software| tcpdump: Removed software package. Can be installed easily via `apt install tcpdump`, because there are no dependencies to other packages. Usage of this software was very rare.
+
 Bug fixes:
 - DietPi-Software | Sonarr: Resolved an issue where the internal updater did not work due to permission limits in the systemd unit. Many thanks to @tellice for reporting this issue: https://github.com/MichaIng/DietPi/issues/7321
 - DietPi-Software | Fail2Ban: Resolved an issue where a fixed Dropbear filter could not be installed, because the directory did not exist yet. Many thanks to @augustresende for reporting this issue: https://github.com/MichaIng/DietPi/issues/7325

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -232,10 +232,9 @@ Available commands:
 			'●─ File Managers ' #22
 			'●─ System ' #23
 			'●─ Databases & Data Stores ' #24
-			'●─ Network Tools ' #25
-			'●─ Development & Programming ' #26
-			'●─ Text Editors ' #27
-			'●─ Desktop Utilities ' #28
+			'●─ Development & Programming ' #25
+			'●─ Text Editors ' #26
+			'●─ Desktop Utilities ' #27
 		)
 
 		#--------------------------------------------------------------------------------
@@ -1512,6 +1511,11 @@ Available commands:
 		aSOFTWARE_CATX[$software_id]=16
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/advanced_networking/#haproxy'
 		#------------------
+		software_id=152
+		aSOFTWARE_NAME[$software_id]='Avahi-Daemon'
+		aSOFTWARE_DESC[$software_id]='Hostname broadcast via mDNS (Zeroconf, Bonjour)'
+		aSOFTWARE_CATX[$software_id]=25
+		#------------------
 		software_id=171
 		aSOFTWARE_NAME[$software_id]='frp'
 		aSOFTWARE_DESC[$software_id]='reverse proxy'
@@ -1717,60 +1721,23 @@ Available commands:
 		aSOFTWARE_CATX[$software_id]=24
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/databases/#postgresql'
 
-		# Network Tools
-		#--------------------------------------------------------------------------------
-		software_id=10
-		aSOFTWARE_NAME[$software_id]='iftop'
-		aSOFTWARE_DESC[$software_id]='displays bandwidth usage information'
-		aSOFTWARE_CATX[$software_id]=25
-		#------------------
-		software_id=11
-		aSOFTWARE_NAME[$software_id]='IPTraf'
-		aSOFTWARE_DESC[$software_id]='interactive colorful IP LAN monitor'
-		aSOFTWARE_CATX[$software_id]=25
-		#------------------
-		software_id=12
-		aSOFTWARE_NAME[$software_id]='Iperf'
-		aSOFTWARE_DESC[$software_id]='internet protocol bandwidth measuring tool'
-		aSOFTWARE_CATX[$software_id]=25
-		#------------------
-		software_id=13
-		aSOFTWARE_NAME[$software_id]='MTR-Tiny'
-		aSOFTWARE_DESC[$software_id]='full screen ncurses traceroute tool'
-		aSOFTWARE_CATX[$software_id]=25
-		#------------------
-		software_id=14
-		aSOFTWARE_NAME[$software_id]='nLoad'
-		aSOFTWARE_DESC[$software_id]='realtime console network usage monitor'
-		aSOFTWARE_CATX[$software_id]=25
-		#------------------
-		software_id=15
-		aSOFTWARE_NAME[$software_id]='tcpdump'
-		aSOFTWARE_DESC[$software_id]='command-line network traffic analyzer'
-		aSOFTWARE_CATX[$software_id]=25
-		#------------------
-		software_id=152
-		aSOFTWARE_NAME[$software_id]='Avahi-Daemon'
-		aSOFTWARE_DESC[$software_id]='Hostname broadcast via mDNS (Zeroconf, Bonjour)'
-		aSOFTWARE_CATX[$software_id]=25
-
 		# Development & Programming
 		#--------------------------------------------------------------------------------
 		software_id=17
 		aSOFTWARE_NAME[$software_id]='Git'
 		aSOFTWARE_DESC[$software_id]='Clone and manage Git repositories locally'
-		aSOFTWARE_CATX[$software_id]=26
+		aSOFTWARE_CATX[$software_id]=25
 		#------------------
 		software_id=130
 		aSOFTWARE_NAME[$software_id]='Python 3'
 		aSOFTWARE_DESC[$software_id]='Runtime system, pip package installer and development headers'
-		aSOFTWARE_CATX[$software_id]=26
+		aSOFTWARE_CATX[$software_id]=25
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/programming/#python-3'
 		#------------------
 		software_id=189
 		aSOFTWARE_NAME[$software_id]='VSCodium'
 		aSOFTWARE_DESC[$software_id]='FLOSS version of MS VSCode'
-		aSOFTWARE_CATX[$software_id]=26
+		aSOFTWARE_CATX[$software_id]=25
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/programming/#vscodium'
 		aSOFTWARE_DEPS[$software_id]='5 6 17'
 		# - RISC-V: https://paulcarroty.gitlab.io/vscodium-deb-rpm-repo/debs/dists/vscodium/Release
@@ -1779,14 +1746,14 @@ Available commands:
 		software_id=188
 		aSOFTWARE_NAME[$software_id]='Go'
 		aSOFTWARE_DESC[$software_id]='Runtime environment and package installer'
-		aSOFTWARE_CATX[$software_id]=26
+		aSOFTWARE_CATX[$software_id]=25
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/programming/#go'
 		aSOFTWARE_DEPS[$software_id]='17'
 		#------------------
 		software_id=8
 		aSOFTWARE_NAME[$software_id]='Java JDK'
 		aSOFTWARE_DESC[$software_id]='OpenJDK Development Kit'
-		aSOFTWARE_CATX[$software_id]=26
+		aSOFTWARE_CATX[$software_id]=25
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/programming/#java'
 		aSOFTWARE_DEPS[$software_id]='196'
 		# - ARMv6: No functional Java available
@@ -1795,7 +1762,7 @@ Available commands:
 		software_id=196
 		aSOFTWARE_NAME[$software_id]='Java JRE'
 		aSOFTWARE_DESC[$software_id]='OpenJDK Runtime Environment'
-		aSOFTWARE_CATX[$software_id]=26
+		aSOFTWARE_CATX[$software_id]=25
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/programming/#java'
 		# - ARMv6: No functional Java available
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
@@ -1803,13 +1770,13 @@ Available commands:
 		software_id=9
 		aSOFTWARE_NAME[$software_id]='Node.js'
 		aSOFTWARE_DESC[$software_id]='JavaScript runtime environment'
-		aSOFTWARE_CATX[$software_id]=26
+		aSOFTWARE_CATX[$software_id]=25
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/webserver_stack/#nodejs'
 		#------------------
 		software_id=150
 		aSOFTWARE_NAME[$software_id]='Mono'
 		aSOFTWARE_DESC[$software_id]='Runtime libraries and repository'
-		aSOFTWARE_CATX[$software_id]=26
+		aSOFTWARE_CATX[$software_id]=25
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/programming/#mono'
 		# - RISC-V: https://download.mono-project.com/repo/debian/dists/buster/main/, https://packages.debian.org/trixie/mono-runtime
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,11]=0
@@ -1817,7 +1784,7 @@ Available commands:
 		software_id=34
 		aSOFTWARE_NAME[$software_id]='PHP Composer'
 		aSOFTWARE_DESC[$software_id]='Package manager for PHP'
-		aSOFTWARE_CATX[$software_id]=26
+		aSOFTWARE_CATX[$software_id]=25
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/webserver_stack/#php-composer'
 		aSOFTWARE_DEPS[$software_id]='89'
 
@@ -1826,41 +1793,41 @@ Available commands:
 		software_id=18
 		aSOFTWARE_NAME[$software_id]='Emacs'
 		aSOFTWARE_DESC[$software_id]='GNU Emacs editor'
-		aSOFTWARE_CATX[$software_id]=27
+		aSOFTWARE_CATX[$software_id]=26
 		#------------------
 		software_id=19
 		aSOFTWARE_NAME[$software_id]='Jed'
 		aSOFTWARE_DESC[$software_id]='editor for programmers'
-		aSOFTWARE_CATX[$software_id]=27
+		aSOFTWARE_CATX[$software_id]=26
 		#------------------
 		software_id=20
 		aSOFTWARE_NAME[$software_id]='Vim'
 		aSOFTWARE_DESC[$software_id]='vi enhanced text editor'
-		aSOFTWARE_CATX[$software_id]=27
+		aSOFTWARE_CATX[$software_id]=26
 		#------------------
 		software_id=21
 		aSOFTWARE_NAME[$software_id]='Vim-Tiny'
 		aSOFTWARE_DESC[$software_id]='compact release of vim'
-		aSOFTWARE_CATX[$software_id]=27
+		aSOFTWARE_CATX[$software_id]=26
 		#------------------
 		software_id=127
 		aSOFTWARE_NAME[$software_id]='Neovim'
 		aSOFTWARE_DESC[$software_id]='heavily refactored vim fork'
-		aSOFTWARE_CATX[$software_id]=27
+		aSOFTWARE_CATX[$software_id]=26
 
 		# Desktop Utilities
 		#--------------------------------------------------------------------------------
 		software_id=22
 		aSOFTWARE_NAME[$software_id]='QuiteRSS'
 		aSOFTWARE_DESC[$software_id]='cross-platform, free rss reader'
-		aSOFTWARE_CATX[$software_id]=28
+		aSOFTWARE_CATX[$software_id]=27
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/desktop/#quiterss'
 		aSOFTWARE_DEPS[$software_id]='6'
 		#------------------
 		software_id=113
 		aSOFTWARE_NAME[$software_id]='Chromium'
 		aSOFTWARE_DESC[$software_id]='web browser for desktop or autostart'
-		aSOFTWARE_CATX[$software_id]=28
+		aSOFTWARE_CATX[$software_id]=27
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/desktop/#chromium'
 		aSOFTWARE_DEPS[$software_id]='5 6'
 		# - ARMv6: https://github.com/RPi-Distro/chromium-browser/issues/21
@@ -1871,7 +1838,7 @@ Available commands:
 		software_id=67
 		aSOFTWARE_NAME[$software_id]='Firefox'
 		aSOFTWARE_DESC[$software_id]='web browser for desktop'
-		aSOFTWARE_CATX[$software_id]=28
+		aSOFTWARE_CATX[$software_id]=27
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/desktop/#firefox'
 		aSOFTWARE_DEPS[$software_id]='5 6'
 		# - ARMv6: https://github.com/RPi-Distro/chromium-browser/issues/21#issuecomment-997044303
@@ -1880,14 +1847,14 @@ Available commands:
 		software_id=174
 		aSOFTWARE_NAME[$software_id]='GIMP'
 		aSOFTWARE_DESC[$software_id]='mspaint on steroids'
-		aSOFTWARE_CATX[$software_id]=28
+		aSOFTWARE_CATX[$software_id]=27
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/desktop/#gimp'
 		aSOFTWARE_DEPS[$software_id]='6'
 		#------------------
  		software_id=175
  		aSOFTWARE_NAME[$software_id]='Xfce Power Manager'
  		aSOFTWARE_DESC[$software_id]='with brightness control, recommended for LXDE/LXQt'
- 		aSOFTWARE_CATX[$software_id]=28
+ 		aSOFTWARE_CATX[$software_id]=27
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/desktop/#xfce-power-manager'
  		aSOFTWARE_DEPS[$software_id]='6'
 
@@ -2773,11 +2740,6 @@ _EOF_
 			G_AGI emacs
 		fi
 
-		if To_Install 12
-		then
-			G_AGI iperf
-		fi
-
 		if To_Install 3 # Midnight Commander
 		then
 			G_AGI mc
@@ -2786,31 +2748,6 @@ _EOF_
 		if To_Install 19
 		then
 			G_AGI jed
-		fi
-
-		if To_Install 10
-		then
-			G_AGI iftop
-		fi
-
-		if To_Install 11
-		then
-			G_AGI iptraf
-		fi
-
-		if To_Install 13
-		then
-			G_AGI mtr-tiny
-		fi
-
-		if To_Install 14
-		then
-			G_AGI nload
-		fi
-
-		if To_Install 15
-		then
-			G_AGI tcpdump
 		fi
 
 		if To_Install 0 # OpenSSH Client
@@ -14012,31 +13949,6 @@ _EOF_
 			[[ -f '/etc/apt/trusted.gpg.d/dietpi-jellyfin.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-jellyfin.gpg
 			[[ -d '/etc/systemd/system/jellyfin.service.d' ]] && G_EXEC rm -R /etc/systemd/system/jellyfin.service.d
 			[[ -d '/mnt/dietpi_userdata/jellyfin' ]] && G_EXEC rm -R /mnt/dietpi_userdata/jellyfin
-		fi
-
-		if To_Uninstall 15
-		then
-			G_AGP tcpdump
-		fi
-
-		if To_Uninstall 14
-		then
-			G_AGP nload
-		fi
-
-		if To_Uninstall 13
-		then
-			G_AGP mtr-tiny
-		fi
-
-		if To_Uninstall 11
-		then
-			G_AGP iptraf
-		fi
-
-		if To_Uninstall 10
-		then
-			G_AGP iftop
 		fi
 
 		if To_Uninstall 19


### PR DESCRIPTION
Removed `iftop`, `IPTraf`, `Iperf`, `MTR-Tiny`, `nLoad`, `tcpdump` from dietpi-software
- Very rare usage.
- Software is removed, otherwise documentation would be needed.
- See also https://github.com/MichaIng/DietPi-Docs/issues/649

Removed Software category "Network Tools"

Software `Avahi Daemon` moved to category "Advanced Networking"


Remark: Uninstall procedure from Iperf was missing (`G_AGP iperf`) in `dietpi-software`.

ToDo: 
- DietPi software list has to be updated (https://github.com/MichaIng/DietPi/wiki/DietPi-Software-list, IDs 10..15)
- Avahi Daemon needs to be described (see https://github.com/MichaIng/DietPi-Docs/issues/649#issuecomment-2572435380)

