### PR TITLE
Live patch 3 | Fix Sonarr v4 permissions for updater for installed Sonarr v4 instances

### DIFF
--- a/.update/version
+++ b/.update/version
@@ -15,18 +15,21 @@ G_MIN_DEBIAN=6
 G_OLD_DEBIAN_BRANCH='8'
 # Live patches
 G_LIVE_PATCH_DESC=(
-	[0]='Fix Sonarr v4 permissions for updater. Only needed if you plan to install or migrate to Sonarr v4 via dietpi-software.'
+	[0]='Fix Sonarr v4 permissions for updater in dietpi-software. Only needed if you plan to install or migrate to Sonarr v4 via dietpi-software.'
 	[1]='Fix install of patches Fail2Ban Dropbear filter: https://github.com/MichaIng/DietPi/issues/7325'
 	[2]='Install patched Fail2Ban Dropbear filter: https://github.com/fail2ban/fail2ban/pull/3597'
+	[3]='Fix Sonarr v4 permissions for updater for installed Sonarr v4 instances'
 )
 G_LIVE_PATCH_COND=(
 	[0]='grep -q '\''^ReadWritePaths=-/usr/lib/sonarr'\'' /boot/dietpi/dietpi-software'
-	[1]='[[ ! -d /etc/fail2ban/filter.d ]] && grep -q '\''^			G_EXEC mkdir -p /etc/fail2ban/fail2ban.d'\'' /boot/dietpi/dietpi-software'
+	[1]='[[ ! -d /etc/fail2ban/filter.d ]] && grep -q '\''mkdir -p /etc/fail2ban/fail2ban.d'\'' /boot/dietpi/dietpi-software'
 	[2]='[[ -d /etc/fail2ban/filter.d && ! -f /etc/fail2ban/filter.d/dropbear.local ]]'
+	[3]='[[ -f /opt/sonarr/Sonarr ]] && grep -q '\''/usr/lib/sonarr'\'' /etc/systemd/system/sonarr.service 2> /dev/null'
 )
 # shellcheck disable=SC2016
 G_LIVE_PATCH=(
 	[0]='sed -i '\''s|^ReadWritePaths=-/usr/lib/sonarr|ReadWritePaths=-$install_dir|'\'' /boot/dietpi/dietpi-software'
-	[1]='sed -i '\''s|^			G_EXEC mkdir -p /etc/fail2ban/fail2ban.d|			G_EXEC mkdir -p /etc/fail2ban/{fail2ban,filter}.d|'\'' /boot/dietpi/dietpi-software'
-	[2]='curl -sSf https://raw.githubusercontent.com/fail2ban/fail2ban/eb8b443/config/filter.d/dropbear.conf -o /etc/fail2ban/filter.d/dropbear.local'
+	[1]='sed -i '\''s|mkdir -p /etc/fail2ban/fail2ban.d|mkdir -p /etc/fail2ban/{fail2ban,filter}.d|'\'' /boot/dietpi/dietpi-software'
+	[2]='curl -sSf https://raw.githubusercontent.com/fail2ban/fail2ban/master/config/filter.d/dropbear.conf -o /etc/fail2ban/filter.d/dropbear.local'
+	[3]='sed -i '\''s|/usr/lib/sonarr|/opt/sonarr|'\'' /etc/systemd/system/sonarr.service && systemctl daemon-reload'
 )


### PR DESCRIPTION
We shipped a live patch to fix it in `dietpi-software`, but this one fixes it for those who installed/migrated to Sonarr v4 already, before the first patch was released/applied.