### PR TITLE
fix DietPi-Set_hardware > lcdpanel   (waveshare32)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,9 +4,10 @@ v9.12
 Enhancemnts:
 - DietPi-Software | WiringPi: Added support for Orange Pi boards, using the wiringOP sources from Xunlong: https://github.com/orangepi-xunlong/wiringOP
 - DietPi-Software | Spotifyd: Added support for ARMv8 and x86_64 Bookworm/Trixie systems, supported with the latest Spotifyd release.
-- DietPi-Software | O!MPD: Resolved an issue where changing the config.php from within the web UI and storing covers did not work due to missing permissions. Many thanks to @praveensg for reporting this issue: https://dietpi.com/forum/t/22993
 
 Bug fixes:
+- DietPi-Config | Resolved an issue where enabling the waveshare32 LCD panel failed on Raspberry Pi with new kernel/firmware stack. Many thanks to @guiksign for fixing this bug: https://github.com/MichaIng/DietPi/pull/7462
+- DietPi-Software | O!MPD: Resolved an issue where changing the config.php from within the web UI and storing covers did not work due to missing permissions. Many thanks to @praveensg for reporting this issue: https://dietpi.com/forum/t/22993
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/ADDME
 

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -728,7 +728,7 @@ _EOF_
 			dpkg-query -s 'raspi-firmware' &> /dev/null || fp_overlays='/boot/overlays'
 
 			# Check if destination folder overlays exist before running curl command
- 			[[ -d "$fp_overlay" ]] || G_EXEC mkdir -p $fp_overlay
+ 			[[ -d "$fp_overlays" ]] || G_EXEC mkdir -p $fp_overlays
 
 			G_EXEC curl -sSfL 'https://raw.githubusercontent.com/waveshare/LCD-show/master/waveshare32b-overlay.dtb' -o "$fp_overlays/waveshare32b.dtbo"
 

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -722,6 +722,9 @@ _EOF_
 
 		# RPi
 		if (( $G_HW_MODEL < 10 )); then
+		
+			# Check if destination folder overlays exist before running curl command
+			G_EXEC if ! [ -d /boot/overlays ]; then mkdir /boot/overlays; fi
 
 			# Check if destination folder overlays exist before running curl command
 			[[ -d '/boot/overlays' ]] || G_EXEC mkdir -p /boot/overlays

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -726,10 +726,6 @@ _EOF_
 			# Download overlay to correct dir based on legacy vs modern firmware
 			local fp_overlays='/boot/firmware/overlays'
 			dpkg-query -s 'raspi-firmware' &> /dev/null || fp_overlays='/boot/overlays'
-
-			# Check if destination folder overlays exist before running curl command
- 			[[ -d "$fp_overlays" ]] || G_EXEC mkdir -p "$fp_overlays"
-
 			G_EXEC curl -sSfL 'https://raw.githubusercontent.com/waveshare/LCD-show/master/waveshare32b-overlay.dtb' -o "$fp_overlays/waveshare32b.dtbo"
 
 			#consoleblank=0 no effect
@@ -806,6 +802,7 @@ _EOF_
 		if (( $G_HW_MODEL < 10 )); then
 
 			[[ -f '/boot/overlays/waveshare32b.dtbo' ]] && G_EXEC rm /boot/overlays/waveshare32b.dtbo
+			[[ -f '/boot/firmware/overlays/waveshare32b.dtbo' ]] && G_EXEC rm /boot/firmware/overlays/waveshare32b.dtbo
 			G_EXEC sed --follow-symlinks -i 's/ fbcon=map:10 fbcon=font:ProFont6x11 logo.nologo//' /boot/cmdline.txt
 
 			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*dtoverlay=waveshare32b/d' /boot/config.txt

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -722,6 +722,9 @@ _EOF_
 
 		# RPi
 		if (( $G_HW_MODEL < 10 )); then
+		
+			# Check if destination folder overlays exist before running curl command
+			G_EXEC if ! [ -d /boot/overlays ]; then mkdir /boot/overlays; fi
 
 			G_EXEC curl -sSfL 'https://raw.githubusercontent.com/waveshare/LCD-show/master/waveshare32b-overlay.dtb' -o /boot/overlays/waveshare32b.dtbo
 

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -723,13 +723,10 @@ _EOF_
 		# RPi
 		if (( $G_HW_MODEL < 10 )); then
 
-			# Check if destination folder overlays exist before running curl command
-			[[ -d '/boot/overlays' ]] || G_EXEC mkdir -p /boot/overlays
-
-			# Check if destination folder overlays exist before running curl command
-			[[ -d '/boot/overlays' ]] || G_EXEC mkdir -p /boot/overlays
-
-			G_EXEC curl -sSfL 'https://raw.githubusercontent.com/waveshare/LCD-show/master/waveshare32b-overlay.dtb' -o /boot/overlays/waveshare32b.dtbo
+			# Download overlay to correct dir based on legacy vs modern firmware
+			local fp_overlays='/boot/firmware/overlays'
+			dpkg-query -s 'raspi-firmware' &> /dev/null || fp_overlays='/boot/overlays'
+			G_EXEC curl -sSfL 'https://raw.githubusercontent.com/waveshare/LCD-show/master/waveshare32b-overlay.dtb' -o "$fp_overlays/waveshare32b.dtbo"
 
 			#consoleblank=0 no effect
 			G_EXEC sed --follow-symlinks -i 's/rootwait/rootwait fbcon=map:10 fbcon=font:ProFont6x11 logo.nologo/' /boot/cmdline.txt

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -724,7 +724,7 @@ _EOF_
 		if (( $G_HW_MODEL < 10 )); then
 		
 			# Check if destination folder overlays exist before running curl command
-			G_EXEC if ! [ -d /boot/overlays ]; then mkdir /boot/overlays; fi
+			[[ -d '/boot/overlays' ]] || G_EXEC mkdir -p /boot/overlays
 
 			G_EXEC curl -sSfL 'https://raw.githubusercontent.com/waveshare/LCD-show/master/waveshare32b-overlay.dtb' -o /boot/overlays/waveshare32b.dtbo
 

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -726,6 +726,10 @@ _EOF_
 			# Download overlay to correct dir based on legacy vs modern firmware
 			local fp_overlays='/boot/firmware/overlays'
 			dpkg-query -s 'raspi-firmware' &> /dev/null || fp_overlays='/boot/overlays'
+			
+			# Check if destination folder overlays exist before running curl command
+ 			[[ -d '$fp_overlay' ]] || G_EXEC mkdir -p $fp_overlay
+ 
 			G_EXEC curl -sSfL 'https://raw.githubusercontent.com/waveshare/LCD-show/master/waveshare32b-overlay.dtb' -o "$fp_overlays/waveshare32b.dtbo"
 
 			#consoleblank=0 no effect

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -728,7 +728,7 @@ _EOF_
 			dpkg-query -s 'raspi-firmware' &> /dev/null || fp_overlays='/boot/overlays'
 
 			# Check if destination folder overlays exist before running curl command
- 			[[ -d "$fp_overlays" ]] || G_EXEC mkdir -p $fp_overlays
+ 			[[ -d "$fp_overlays" ]] || G_EXEC mkdir -p "$fp_overlays"
 
 			G_EXEC curl -sSfL 'https://raw.githubusercontent.com/waveshare/LCD-show/master/waveshare32b-overlay.dtb' -o "$fp_overlays/waveshare32b.dtbo"
 

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -722,7 +722,7 @@ _EOF_
 
 		# RPi
 		if (( $G_HW_MODEL < 10 )); then
-		
+
 			# Check if destination folder overlays exist before running curl command
 			[[ -d '/boot/overlays' ]] || G_EXEC mkdir -p /boot/overlays
 

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -726,10 +726,10 @@ _EOF_
 			# Download overlay to correct dir based on legacy vs modern firmware
 			local fp_overlays='/boot/firmware/overlays'
 			dpkg-query -s 'raspi-firmware' &> /dev/null || fp_overlays='/boot/overlays'
-			
+
 			# Check if destination folder overlays exist before running curl command
- 			[[ -d '$fp_overlay' ]] || G_EXEC mkdir -p $fp_overlay
- 
+ 			[[ -d "$fp_overlay" ]] || G_EXEC mkdir -p $fp_overlay
+
 			G_EXEC curl -sSfL 'https://raw.githubusercontent.com/waveshare/LCD-show/master/waveshare32b-overlay.dtb' -o "$fp_overlays/waveshare32b.dtbo"
 
 			#consoleblank=0 no effect

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -724,7 +724,7 @@ _EOF_
 		if (( $G_HW_MODEL < 10 )); then
 		
 			# Check if destination folder overlays exist before running curl command
-			G_EXEC if ! [ -d /boot/overlays ]; then mkdir /boot/overlays; fi
+			[[ -d '/boot/overlays' ]] || G_EXEC mkdir -p /boot/overlays
 
 			# Check if destination folder overlays exist before running curl command
 			[[ -d '/boot/overlays' ]] || G_EXEC mkdir -p /boot/overlays


### PR DESCRIPTION
curl command will fail if destination folder does not exist

<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->

Note, this fix was written from master branch but no diff for that file with dev branch