### PR TITLE
dietpi-software: motionEye: update dependencies

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8938,10 +8938,10 @@ _EOF_
 			then
 				G_AGI libcurl4-openssl-dev gcc libssl-dev libjpeg62-turbo-dev
 
-			# - ARMv8/x86_64: libcurl4-openssl-dev, gcc and libssl-dev for pycurl
-			elif (( $G_HW_ARCH > 2 ))
+			# - ARMv6/7: gcc and libjpeg62-turbo-dev for Pillow, until piwheels provides the latest version: https://piwheels.org/project/pillow/
+			elif (( $G_HW_ARCH < 3 ))
 			then
-				G_AGI libcurl4-openssl-dev gcc libssl-dev
+				G_AGI gcc libjpeg62-turbo-dev
 			fi
 
 			# RPi: Enable camera module


### PR DESCRIPTION
Recent PycURL is available as pre-compiled wheels for most architectures.