### PR TITLE
dietpi-software: Google AIY: remove software option

### DIFF
--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -552,6 +552,7 @@ shopt -s extglob # +(expr) syntax
 	do
 		aSOFTWARE_NAME9_13[i]=${aSOFTWARE_NAME9_12[i]}
 	done
+	unset -v 'aSOFTWARE_NAME9_13[169]' # Google AIY
 
 	# Pre-create software counter array so that we can see also software (available in newest version) with 0 installs
 	for i in "${aSOFTWARE_NAME9_13[@]}"

--- a/.update/patches
+++ b/.update/patches
@@ -2196,6 +2196,9 @@ _EOF_
 
 		# Update motionEye: https://github.com/motioneye-project/motioneye/security/advisories/GHSA-g5mq-prx7-c588
 		command -v pip3 > /dev/null && pip3 freeze | grep -iq '^motioneye==0\.43\..*' && G_EXEC pip3 install --upgrade --pre motioneye
+
+		# Remove Google AIY
+		grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[169\]=' /boot/dietpi/.installed && G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[169\]=/d' /boot/dietpi/.installed
 	fi
 
 	# RPi firmware migration: Do after all other patches

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,9 @@
 v9.13
 (2025-05-17)
 
+Removed software:
+- Google AIY | The Google AIY Voice Kit is not produced or sold anymore, and the related software repositories have been archived years ago. Furthermore we used install steps which were deprecated even years before the repository has been archived, and no sample to test whether it still works or not. If you still have an instance running, or aim to still try to get one running, here are uninstall instructions, as well as a link to the latest install instructions: https://github.com/MichaIng/DietPi/pull/7533
+
 Enhancements:
 - Orange Pi 3B | Added support for the PWM fan connector to mainline kernel builds. Many thanks to @Vyacheslav-S for reporting this missing kernel feature: https://github.com/MichaIng/DietPi/issues/7490#issuecomment-2829426560
 - ASUS Tinker Board 2 | Resolved an issue where the onboard Ethernet MAC address changed each boot with the new Linux 6.12 based kernel. Many thanks to @briney83 for reporting this issue: https://github.com/MichaIng/DietPi/issues/7522

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -3325,7 +3325,6 @@ Additional benchmarks:
 					'applepi-dac' ': ApplePi DAC (Orchard Audio)'
 					'dionaudio-loco' ': Dion Audio LOCO'
 					'dionaudio-loco-v2' ': Dion Audio LOCO V2'
-					'googlevoicehat-soundcard' ': Google AIY voice kit'
 					'hifiberry-amp' ': HifiBerry AMP / AMP+'
 					'hifiberry-dac' ': HifiBerry DAC / MiniAMP'
 					'hifiberry-dacplus' ': HifiBerry DAC+ / DAC+ Pro / AMP2'

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1285,15 +1285,6 @@ Available commands:
 		# RPi only
 		(( $G_HW_MODEL > 9 )) && aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,$G_HW_MODEL]=0
 		#------------------
-		software_id=169
-		aSOFTWARE_NAME[$software_id]='Google AIY'
-		aSOFTWARE_DESC[$software_id]='Voice Kit'
-		aSOFTWARE_CATX[$software_id]=10
-		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/hardware_projects/#google-aiy'
-		aSOFTWARE_DEPS[$software_id]='5 17 69 130'
-		# RPi only
-		(( $G_HW_MODEL > 9 )) && aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,$G_HW_MODEL]=0
-		#------------------
 		software_id=176
 		aSOFTWARE_NAME[$software_id]='Mycroft AI'
 		aSOFTWARE_DESC[$software_id]='Open Source Voice Assistant'
@@ -7317,7 +7308,7 @@ _EOF_
 
 		if To_Install 179 komga # Komga
 		then
-			local fallback_url='https://github.com/gotson/komga/releases/download/1.21.2/komga-1.21.2.jar'
+			local fallback_url='https://github.com/gotson/komga/releases/download/1.21.3/komga-1.21.3.jar'
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/gotson/komga/releases/latest' | mawk -F\" '/^ *"browser_download_url": ".*\/komga-[^"\/]*\.jar"$/{print $4}')" /mnt/dietpi_userdata/komga/komga.jar
 
 			# User
@@ -10743,41 +10734,6 @@ _EOF_
 			G_EXEC systemctl stop raspotify
 		fi
 
-		if To_Install 169 alsa-init voice-recognizer # Google AIY: https://github.com/google/aiyprojects-raspbian/blob/voicekit/HACKING.md
-		then
-			G_EXEC_OUTPUT=1 G_EXEC git clone -b voicekit 'https://github.com/google/aiyprojects-raspbian.git' /mnt/dietpi_userdata/voice-recognizer-raspi
-			G_EXEC cd /mnt/dietpi_userdata/voice-recognizer-raspi
-
-			G_EXEC_OUTPUT=1 G_EXEC pip3 install -U virtualenv
-			G_EXEC_OUTPUT=1 G_EXEC virtualenv --system-site-packages -p python3 env
-			G_EXEC_OUTPUT=1 G_EXEC env/bin/pip install -Ur requirements.txt
-
-			# ARMv7 only: https://pypi.org/project/google-assistant-library/
-			(( $G_HW_ARCH == 2 )) && G_EXEC_OUTPUT=1 G_EXEC env/bin/pip install 'google-assistant-library~=1.0'
-
-			# Services
-			G_EXEC sed --follow-symlinks -i 's|/home/pi|/mnt/dietpi_userdata|g' systemd/voice-recognizer.service
-			G_CONFIG_INJECT 'User=' 'User=dietpi' systemd/voice-recognizer.service '\[Service\]'
-			G_EXEC cp systemd/{alsa-init,voice-recognizer}.service /etc/systemd/system/
-
-			# Enable default app for service start if not done yet
-			[[ -f 'src/main.py' ]] || G_EXEC cp src/assistant_library_with_button_demo.py src/main.py
-
-			G_EXEC cd "$G_WORKING_DIR"
-
-			# Symlink userdata location for assistant.json
-			G_EXEC ln -sf /mnt/dietpi_userdata/voice-recognizer-raspi/assistant.json /home/dietpi/assistant.json
-
-			# Generate cache dir
-			G_EXEC mkdir -p /home/dietpi/.cache/voice-recognizer
-
-			# Setup sound card
-			/boot/dietpi/func/dietpi-set_hardware soundcard googlevoicehat-soundcard
-
-			# Permissions
-			getent passwd dietpi > /dev/null && G_EXEC chown -R dietpi:dietpi /mnt/dietpi_userdata/voice-recognizer-raspi
-		fi
-
 		if To_Install 176 mycroft # Mycroft AI
 		then
 			# Git clone to DietPi userdata
@@ -13656,15 +13612,6 @@ _EOF_
 			G_AGP raspotify
 			[[ -f '/etc/apt/sources.list.d/dietpi-raspotify.list' ]] && G_EXEC rm /etc/apt/sources.list.d/dietpi-raspotify.list
 			[[ -f '/etc/apt/trusted.gpg.d/dietpi-raspotify.asc' ]] && G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-raspotify.asc
-		fi
-
-		if To_Uninstall 169 # Google AIY
-		then
-			Remove_Service voice-recognizer
-			Remove_Service alsa-init
-
-			[[ -d '/mnt/dietpi_userdata/voice-recognizer-raspi' ]] && G_EXEC rm -R /mnt/dietpi_userdata/voice-recognizer-raspi
-			G_EXEC rm -Rf /home/dietpi/assistant.json
 		fi
 
 		if To_Uninstall 176 # Mycroft AI

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -2043,15 +2043,6 @@ _EOF_
 				G_CONFIG_INJECT "dtoverlay=$INPUT_DEVICE_VALUE" "dtoverlay=$INPUT_DEVICE_VALUE" /boot/config.txt
 			;;
 
-			# dtoverlay + I2S
-			#	googlevoicehat-soundcard
-			'googlevoicehat-soundcard'*)
-
-				# Enable dtoverlay + I2S
-				G_CONFIG_INJECT 'dtparam=i2s=' 'dtparam=i2s=on' /boot/config.txt
-				G_CONFIG_INJECT "dtoverlay=$INPUT_DEVICE_VALUE" "dtoverlay=$INPUT_DEVICE_VALUE" /boot/config.txt
-			;;
-
 			# --------------- Odroid ----------------
 			'odroid-hifishield-plus')
 
@@ -2169,40 +2160,8 @@ _EOF_
 		esac
 
 		# - Apply asound.conf
-		if [[ $INPUT_DEVICE_VALUE == 'googlevoicehat-soundcard'* ]]; then
-
-			cat << '_EOF_' > /etc/asound.conf
-pcm.softvol {
-	type softvol
-	slave.pcm dmix
-	control {
-		name Master
-		card 0
-	}
-}
-
-pcm.micboost {
-	type route
-	slave.pcm dsnoop
-	ttable {
-		0.0 30.0
-		1.1 30.0
-	}
-}
-
-pcm.!default {
-	type asym
-	playback.pcm "plug:softvol"
-	capture.pcm "plug:micboost"
-}
-
-ctl.!default {
-	type hw
-	card 0
-}
-_EOF_
-		elif (( $ALSA_EQ_ENABLED )); then
-
+		if (( $ALSA_EQ_ENABLED ))
+		then
 			G_AG_CHECK_INSTALL_PREREQ libasound2-plugin-equal
 			# Pre-create config dir
 			[[ -d '/var/lib/dietpi/dietpi-config' ]] || G_EXEC mkdir -p /var/lib/dietpi/dietpi-config
@@ -2235,8 +2194,8 @@ ctl.!default {
 	card $SOUNDCARD_TARGET_CARD
 }
 _EOF_
-		elif (( $ALSA_PLUG_ENABLED )); then
-
+		elif (( $ALSA_PLUG_ENABLED ))
+		then
 			cat << _EOF_ > /etc/asound.conf
 pcm.!default {
 	type plug
@@ -2253,7 +2212,6 @@ ctl.!default {
 }
 _EOF_
 		else
-
 			cat << _EOF_ > /etc/asound.conf
 pcm.!default {
 	type hw


### PR DESCRIPTION
To **uninstall** an instance of Google AYI from your DietPi system:
```sh
systemctl unmask voice-recognizer alsa-init
systemctl disable --now voice-recognizer alsa-init
rm -Rf /etc/systemd/system/{voice-recognizer,alsa-init}.service{,.d}
rm -Rf /mnt/dietpi_userdata/voice-recognizer-raspi
rm -Rf /home/dietpi/assistant.json /home/dietpi/.cache/voice-recognizer
```
You may also want to change the sound card, or disable audio if not needed anymore via `dietpi-config`.
____________
If you want to **update** the software for your Voice Kit, probably as it does not work anymore with the way it was setup with `dietpi-software`, you can try to uninstall it as above, then install it following the more recent instructions as linked below.
____________
If you want to **install** the software needed to run a Voice Kit instead, check out the latest install instructions:
- https://github.com/google/aiyprojects-raspbian/blob/aiyprojects/HACKING.md#install-aiy-software-on-an-existing-raspbian-system
- Skip the part for the [Vision Kit](https://github.com/google/aiyprojects-raspbian/blob/aiyprojects/HACKING.md#install-vision-bonnet-packages) (which most likely won't work on Bookworm anymore in any case) and jump to the [Voice Kit part](https://github.com/google/aiyprojects-raspbian/blob/aiyprojects/HACKING.md#install-voice-bonnethat-packages).
- Note that installing/configuring PulseAudio as suggested in these instructions conflicts with the plain ALSA setup in `dietpi-config`, as well as with the Pipewire setup found on Raspberry Pi OS. Be sure to configure and use only one audio backend.