### PR TITLE
ci: vaultwarden: switch back to armv6l build on aarch64

### DIFF
--- a/.build/software/dietpi-software-build.bash
+++ b/.build/software/dietpi-software-build.bash
@@ -149,6 +149,9 @@ G_EXEC eval 'echo '\''infocmp "$TERM" > /dev/null 2>&1 || { echo "[ WARN ] Unsup
 # Workaround for failing IPv4 network connectivity check as GitHub Actions runners do not receive external ICMP echo replies
 G_CONFIG_INJECT 'CONFIG_CHECK_CONNECTION_IP=' 'CONFIG_CHECK_CONNECTION_IP=127.0.0.1' rootfs/boot/dietpi.txt
 
+# vaultwarden for ARMv6 on ARMv8 host: https://github.com/rust-lang/rust/issues/60605
+[[ $NAME == 'vaultwarden' ]] && (( $arch == 1 && $G_HW_ARCH == 3 )) && G_EXEC sysctl -w 'abi.cp15_barrier=2'
+
 # Shutdown on failures before the custom script is executed
 G_EXEC sed --follow-symlinks -i 's|Prompt_on_Failure$|{ journalctl -n 50; ss -tulpn; df -h; free -h; systemctl start poweroff.target; }|' rootfs/boot/dietpi/dietpi-login
 

--- a/.github/workflows/dietpi-software-build.yml
+++ b/.github/workflows/dietpi-software-build.yml
@@ -73,8 +73,7 @@ jobs:
         - { arch: armv6l, name: amiberry-lite }
       fail-fast: false
     name: "${{ matrix.name }} - ${{ matrix.arch }} - ${{ matrix.dist }}"
-    # Use emulation for armv6l vaultwarden: https://github.com/rust-lang/rustup/issues/4189
-    runs-on: ${{ ( matrix.arch == 'x86_64' || ( matrix.arch == 'armv6l' && matrix.name == 'vaultwarden' ) ) && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    runs-on: ${{ matrix.arch == 'x86_64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     steps:
     - name: Build
       run: sudo bash -c "G_GITOWNER=$GITHUB_REPOSITORY_OWNER G_GITBRANCH=$GITHUB_REF_NAME; $(curl -sSf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY_OWNER/DietPi/$GITHUB_REF_NAME/.build/software/dietpi-software-build.bash")" -- -n '${{ matrix.name }}' -a '${{ matrix.arch }}' -d '${{ matrix.dist }}'


### PR DESCRIPTION
with a different workaround, that we found a year before in another context, before running into the same issue here.