### PR TITLE
live-patch-0: skip sysctl calls on container systems

### DIFF
--- a/.update/patches
+++ b/.update/patches
@@ -2187,7 +2187,7 @@ Patch_9_13()
 		grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[176\]=' /boot/dietpi/.installed && G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[176\]=/d' /boot/dietpi/.installed
 
 		# Redis
-		if grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[91\]=2' /boot/dietpi/.installed
+		if (( $G_HW_MODEL != 75 )) && grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[91\]=2' /boot/dietpi/.installed
 		then
 			G_DIETPI-NOTIFY 2 'Enabling memory overcomit for Redis server'
 			G_EXEC eval 'echo '\''vm.overcommit_memory=1'\'' > /etc/sysctl.d/98-dietpi-redis.conf'

--- a/.update/version
+++ b/.update/version
@@ -14,6 +14,7 @@ G_MIN_DEBIAN=6
 # Alternative Git branch to automatically migrate to when Debian version is too low
 G_OLD_DEBIAN_BRANCH='8'
 # Live patches
-G_LIVE_PATCH_DESC=()
-G_LIVE_PATCH_COND=()
-G_LIVE_PATCH=()
+G_LIVE_PATCH_DESC=('Fix Redis, Syncthing, and IPFS Node installs on container systems')
+# shellcheck disable=SC2016
+G_LIVE_PATCH_COND=('(( $G_HW_MODEL == 75 ))')
+G_LIVE_PATCH=('sed -i '\''/^[[:blank:]]*G_EXEC sysctl /d'\'' /boot/dietpi/dietpi-software')


### PR DESCRIPTION
as this cannot work, but must be applied at the host.

<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
