### PR TITLE
Orange Pi 5 Ultra: switch to vendor branch

### DIFF
--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -752,7 +752,7 @@ setenv rootuuid "true"' /boot/boot.cmd
 					92) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=nanopi-m6 rockchip-rk3588 rk3588' /boot/dietpiEnv.txt;;
 					93) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=orangepi-5-pro rockchip-rk3588 rk3588' /boot/dietpiEnv.txt;;
 					79|91) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rockchip-rk3588 rk3588' /boot/dietpiEnv.txt;;
-					94) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rockchip-rk3588 rockchip' /boot/dietpiEnv.txt;;
+					94) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=orangepi-5-ultra rockchip-rk3588 rk3588' /boot/dietpiEnv.txt;;
 					*) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rockchip' /boot/dietpiEnv.txt;;
 				esac
 				# Overlays
@@ -764,7 +764,7 @@ setenv rootuuid "true"' /boot/boot.cmd
 				case $G_HW_MODEL in
 					73) G_CONFIG_INJECT 'consoleargs=' 'consoleargs=console=ttyS0,1500000' /boot/dietpiEnv.txt;; # headless
 					47|55|56) G_CONFIG_INJECT 'consoleargs=' 'consoleargs=console=ttyS2,1500000' /boot/dietpiEnv.txt;; # headless
-					78|79|80|82|85|90|91|92|93) G_EXEC sed --follow-symlinks -i 's/ttyAML0,115200/ttyFIQ0,1500000/' /boot/dietpiEnv.txt;; # Rockchip vendor
+					78|79|80|82|85|90|91|92|93|94) G_EXEC sed --follow-symlinks -i 's/ttyAML0,115200/ttyFIQ0,1500000/' /boot/dietpiEnv.txt;; # Rockchip vendor
 					*) G_EXEC sed --follow-symlinks -i 's/ttyAML0,115200/ttyS2,1500000/' /boot/dietpiEnv.txt;;
 				esac
 
@@ -1190,7 +1190,7 @@ _EOF_
 				91) model='orangepi5-max' kernel='rk35xx' branch='vendor';;
 				92) model='nanopi-m6' kernel='rk35xx' branch='vendor';;
 				93) model='orangepi5pro' kernel='rk35xx' branch='vendor';;
-				94) model='orangepi5-ultra' kernel='rockchip64';;
+				94) model='orangepi5-ultra' kernel='rk35xx' branch='vendor';;
 				*) :;;
 			esac
 


### PR DESCRIPTION
HDMI does not work with current branch, and boot regularly hangs when HDMI/DRM driver is reached.

Edge works much better, but it lacks many features. We added vendor kernel support to our Armbian fork, so let's go with that for now, providing edge kernel as well via repo.