### PR TITLE
images: generate most new images without uInitrd

### DIFF
--- a/.build/images/OdroidXU4/boot.ini
+++ b/.build/images/OdroidXU4/boot.ini
@@ -126,14 +126,12 @@ setenv bootrootfs "root=/dev/mmcblk0p1 rootfstype=ext4 rootwait ro console=ttySA
 
 ### DO NOT EDIT ANYTHING BELOW THIS LINE ###
 
-# Load kernel, initrd and dtb in that sequence
-load mmc 0:1 0x40008000 /boot/zImage || load mmc 0:1 0x40008000 zImage
-load mmc 0:1 0x42000000 /boot/uInitrd || load mmc 0:1 0x42000000 uInitrd
+# Load device tree
 if test "${board_name}" = "xu4"; then setenv fdtfile "exynos5422-odroidxu4.dtb"; fi
 if test "${board_name}" = "xu3"; then setenv fdtfile "exynos5422-odroidxu3.dtb"; fi
 if test "${board_name}" = "xu3l"; then setenv fdtfile "exynos5422-odroidxu3-lite.dtb"; fi
 if test "${board_name}" = "hc1"; then setenv fdtfile "exynos5422-odroidhc1.dtb"; fi
-load mmc 0:1 0x44000000 /boot/dtb/${fdtfile} || load mmc 0:1 0x44000000 dtb/${fdtfile}
+load mmc 0:1 0x44000000 "/boot/dtb/${fdtfile}" || load mmc 0:1 0x44000000 "dtb/${fdtfile}"
 
 # Set FDT address
 fdt addr 0x44000000
@@ -156,7 +154,7 @@ fi
 if test "x${overlays}" != "x"; then
     fdt resize 8192
     for overlay in ${overlays}; do
-        load mmc 0:1 0x60000000 /boot/dtb/${overlay}.dtbo || load mmc 0:1 0x60000000 /boot/dtb/overlays/${overlay}.dtbo || load mmc 0:1 0x60000000 dtb/${overlay}.dtbo || load mmc 0:1 0x60000000 dtb/overlays/${overlay}.dtbo
+        load mmc 0:1 0x60000000 "/boot/dtb/${overlay}.dtbo" || load mmc 0:1 0x60000000 "/boot/dtb/overlays/${overlay}.dtbo" || load mmc 0:1 0x60000000 "dtb/${overlay}.dtbo" || load mmc 0:1 0x60000000 "dtb/overlays/${overlay}.dtbo"
         fdt apply 0x60000000
     done
 fi
@@ -167,5 +165,9 @@ if test "x${ddr_freq}" != "x"; then dmc "${ddr_freq}"; fi
 # Final boot args (DRM debugging: drm.debug=0xff)
 setenv bootargs "${bootrootfs} ${videoconfig} ${hid_quirks}"
 
+# Load kernel and initramfs last, for U-Boot to set ${filesize}, needed to load raw initrd
+load mmc 0:1 0x40008000 /boot/zImage || load mmc 0:1 0x40008000 zImage
+load mmc 0:1 0x42000000 /boot/initrd.img || load mmc 0:1 0x42000000 initrd.img
+
 # Boot the board
-bootz 0x40008000 0x42000000 0x44000000
+bootz 0x40008000 "0x42000000:${filesize}" 0x44000000

--- a/.build/images/U-Boot/99-dietpi-uboot
+++ b/.build/images/U-Boot/99-dietpi-uboot
@@ -1,5 +1,3 @@
 #!/bin/dash -e
-echo 'update-initramfs: Converting to U-Boot format'
-mkimage -A arm64 -O linux -T ramdisk -C gzip -n uInitrd -d "$2" "/boot/uInitrd-$1"
-ln -sfv "uInitrd-$1" /boot/uInitrd
+ln -sfv "initrd.img-$1" /boot/initrd.img
 exit 0

--- a/.build/images/U-Boot/99-dietpi-uboot-legacy
+++ b/.build/images/U-Boot/99-dietpi-uboot-legacy
@@ -1,0 +1,5 @@
+#!/bin/dash -e
+echo 'update-initramfs: Converting to U-Boot format'
+mkimage -A arm -O linux -T ramdisk -C gzip -n uInitrd -d "$2" "/boot/uInitrd-$1"
+mv -v "/boot/uInitrd-$1" /boot/uInitrd
+exit 0

--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -633,8 +633,14 @@ _EOF_
 		G_EXEC_DESC='Removing unused files' G_EXEC rm -f "${G_GITBRANCH##*/}.tar.gz" "$dir/"{pre-patch_file,patch_file,server_version-6}
 		G_EXEC_DESC='Hardening update archive mode' G_EXEC chmod -R g-w "$dir"
 
-		# Pre-v9.14: Download new boot.cmd for multi-overlay-prefix support
-		[[ $G_GITBRANCH == 'dev' ]] || G_EXEC curl -sSfo "$dir/.build/images/U-Boot/boot.cmd" 'https://raw.githubusercontent.com/MichaIng/DietPi/dev/.build/images/U-Boot/boot.cmd'
+		# Pre-v9.14: Download new boot.cmd for multi-overlay-prefix and raw initrd support, and legacy uInitrd generation script
+		if [[ $G_GITBRANCH != 'dev' ]]
+		then
+			G_EXEC curl -sSfo "$dir/.build/images/U-Boot/boot.cmd" 'https://raw.githubusercontent.com/MichaIng/DietPi/raw-initrd/.build/images/U-Boot/boot.cmd'
+			G_EXEC curl -sSfo "$dir/.build/images/OdroidXU4/boot.ini" 'https://raw.githubusercontent.com/MichaIng/DietPi/raw-initrd/.build/images/OdroidXU4/boot.ini'
+			G_EXEC curl -sSfo "$dir/.build/images/U-Boot/99-dietpi-uboot" 'https://raw.githubusercontent.com/MichaIng/DietPi/raw-initrd/.build/images/U-Boot/99-dietpi-uboot'
+			G_EXEC curl -sSfo "$dir/.build/images/U-Boot/99-dietpi-uboot-legacy" 'https://raw.githubusercontent.com/MichaIng/DietPi/raw-initrd/.build/images/U-Boot/99-dietpi-uboot-legacy'
+		fi
 
 		[[ -d '/boot' ]] || G_EXEC mkdir /boot
 
@@ -656,40 +662,47 @@ _EOF_
 			# Boot in 64-bit mode if this is a 64-bit image
 			[[ $userland_arch == 'arm64' ]] && G_CONFIG_INJECT 'arm_64bit=' 'arm_64bit=1' /boot/config.txt
 
-		elif [[ $G_HW_MODEL =~ ^(10|11)$ ]]
+		# Odroid C1 (32-bit)
+		elif (( $G_HW_MODEL == 10 ))
 		then
 			armbian_packages=1
-			local model='OdroidC1'
-			(( $G_HW_MODEL == 11 )) && model='OdroidXU4'
-			G_EXEC mv "$dir/.build/images/$model/boot.ini" /boot/boot.ini
+			G_EXEC mv "$dir/.build/images/OdroidC1/boot.ini" /boot/boot.ini
 			G_EXEC sed --follow-symlinks -i "s/root=[^[:blank:]]*/root=UUID=$(findmnt -Ufnro UUID -M /)/" /boot/boot.ini
 			G_EXEC sed --follow-symlinks -i "s/rootfstype=[^[:blank:]]*/rootfstype=$(findmnt -Ufnro FSTYPE -M /)/" /boot/boot.ini
-			G_EXEC mkdir -p /etc/kernel/post{inst,rm}.d /etc/initramfs/post-update.d
+			G_EXEC mkdir -p /etc/initramfs/post-update.d /etc/kernel/post{inst,rm}.d
+			G_EXEC mv "$dir/.build/images/U-Boot/99-dietpi-uboot-legacy" /etc/initramfs/post-update.d/99-dietpi-uboot
 			G_EXEC mv "$dir/.build/images/U-Boot/dietpi-initramfs_cleanup" /etc/kernel/postinst.d/dietpi-initramfs_cleanup
 			G_EXEC ln -sf /etc/kernel/post{inst,rm}.d/dietpi-initramfs_cleanup
+
+		# Odroid XU4 (32-bit)
+		elif (( $G_HW_MODEL == 11 ))
+		then
+			armbian_packages=1
+			G_EXEC mv "$dir/.build/images/OdroidXU4/boot.ini" /boot/boot.ini
+			G_EXEC sed --follow-symlinks -i "s/root=[^[:blank:]]*/root=UUID=$(findmnt -Ufnro UUID -M /)/" /boot/boot.ini
+			G_EXEC sed --follow-symlinks -i "s/rootfstype=[^[:blank:]]*/rootfstype=$(findmnt -Ufnro FSTYPE -M /)/" /boot/boot.ini
+			G_EXEC mkdir -p /etc/initramfs/post-update.d
 			G_EXEC mv "$dir/.build/images/U-Boot/99-dietpi-uboot" /etc/initramfs/post-update.d/99-dietpi-uboot
-			G_EXEC sed --follow-symlinks -i 's/arm64/arm/' /etc/initramfs/post-update.d/99-dietpi-uboot
 
 		elif [[ $G_HW_MODEL =~ ^(12|15|16|40|42|43|44|45|46|47|48|52|54|55|56|57|58|59|60|62|63|64|65|66|67|68|72|73|74|76|77|78|79|80|82|83|85|86|87|88|89|90|91|92|93|94|95|96)$ ]]
 		then
+			# Amlogic 64-bit
 			armbian_packages=1
 			G_EXEC mv "$dir/.build/images/U-Boot/boot.cmd" /boot/boot.cmd
 			G_EXEC mv "$dir/.build/images/U-Boot/dietpiEnv.txt" /boot/dietpiEnv.txt
 			G_CONFIG_INJECT 'rootdev=' "rootdev=UUID=$(findmnt -Ufnro UUID -M /)" /boot/dietpiEnv.txt
 			G_CONFIG_INJECT 'rootfstype=' "rootfstype=$(findmnt -Ufnro FSTYPE -M /)" /boot/dietpiEnv.txt
-			G_EXEC mkdir -p /etc/kernel/post{inst,rm}.d /etc/initramfs/post-update.d
-			G_EXEC mv "$dir/.build/images/U-Boot/dietpi-initramfs_cleanup" /etc/kernel/postinst.d/dietpi-initramfs_cleanup
-			G_EXEC ln -sf /etc/kernel/post{inst,rm}.d/dietpi-initramfs_cleanup
+			G_EXEC mkdir -p /etc/initramfs/post-update.d
 			G_EXEC mv "$dir/.build/images/U-Boot/99-dietpi-uboot" /etc/initramfs/post-update.d/99-dietpi-uboot
+
 			# Odroid C2: Fix USB device detection: https://github.com/MichaIng/DietPi/issues/5963
 			if (( $G_HW_MODEL == 12 ))
 			then
 				G_EXEC sed --follow-symlinks -i 's/coherent_pool=2M/coherent_pool=2M usbcore.autosuspend=-1/' /boot/boot.cmd
 
-			# Odroid N2/HC4
+			# Odroid N2/HC4: Enable USB boot via petitboot support: https://github.com/MichaIng/DietPi/issues/5634
 			elif [[ $G_HW_MODEL =~ ^(15|16)$ ]]
 			then
-				# Enable USB boot via petitboot support: https://github.com/MichaIng/DietPi/issues/5634
 				G_EXEC sed --follow-symlinks -i '1i[main]' /boot/dietpiEnv.txt
 				# shellcheck disable=SC2016
 				(( $G_HW_MODEL == 15 )) && G_EXEC sed --follow-symlinks -i '/^setenv overlay_error/a\
@@ -771,7 +784,7 @@ setenv rootuuid "true"' /boot/boot.cmd
 			# ASUS Tinker Board (32-bit)
 			elif (( $G_HW_MODEL == 52 ))
 			then
-				G_EXEC sed --follow-symlinks -i 's/arm64/arm/' /etc/initramfs/post-update.d/99-dietpi-uboot /boot/boot.cmd
+				G_EXEC sed --follow-symlinks -i 's/arm64/arm/' /boot/boot.cmd
 				G_EXEC sed --follow-symlinks -Ei '/^setenv (kernel_addr_r|fdt_addr_r|overlay_path)/d' /boot/boot.cmd
 				G_CONFIG_INJECT 'setenv scriptaddr ' 'setenv scriptaddr "0x39000000"' /boot/boot.cmd
 				G_CONFIG_INJECT 'setenv ramdisk_addr_r ' 'setenv ramdisk_addr_r "0x21000000"' /boot/boot.cmd '^setenv scriptaddr'
@@ -818,7 +831,7 @@ setenv rootuuid "true"' /boot/boot.cmd
 			# Allwinner H3 (32-bit)
 			elif [[ $G_HW_MODEL =~ ^(48|59|60|63|64|66)$ ]]
 			then
-				G_EXEC sed --follow-symlinks -i 's/arm64/arm/' /etc/initramfs/post-update.d/99-dietpi-uboot /boot/boot.cmd
+				G_EXEC sed --follow-symlinks -i 's/arm64/arm/' /boot/boot.cmd
 				G_EXEC sed --follow-symlinks -Ei '/^setenv (kernel_addr_r|fdt_addr_r|overlay_path)/d' /boot/boot.cmd
 				G_CONFIG_INJECT 'setenv scriptaddr ' 'setenv scriptaddr "0x45000000"' /boot/boot.cmd
 				# shellcheck disable=SC2016
@@ -845,6 +858,11 @@ setenv rootuuid "true"' /boot/boot.cmd
 				G_EXEC mv "$dir/.build/images/NanoPiM3/boot.cmd" /boot/boot.cmd
 				G_EXEC sed --follow-symlinks -i '/overlay/d' /boot/dietpiEnv.txt
 				G_EXEC sed --follow-symlinks -i 's/ttyAML0/ttySAC0/' /boot/dietpiEnv.txt
+				G_EXEC mv "$dir/.build/images/U-Boot/99-dietpi-uboot-legacy" /etc/initramfs/post-update.d/99-dietpi-uboot
+				G_EXEC sed --follow-symlinks -i 's/ arm / arm64 /' /etc/initramfs/post-update.d/99-dietpi-uboot
+				G_EXEC mkdir -p /etc/kernel/post{inst,rm}.d
+				G_EXEC mv "$dir/.build/images/U-Boot/dietpi-initramfs_cleanup" /etc/kernel/postinst.d/dietpi-initramfs_cleanup
+				G_EXEC ln -sf /etc/kernel/post{inst,rm}.d/dietpi-initramfs_cleanup
 				# Device tree
 				case $HW_VARIANT in
 					2) G_CONFIG_INJECT 'fdtfile=' 'fdtfile=s5p6818-nanopi-fire3.dtb' /boot/dietpiEnv.txt;;
@@ -854,7 +872,7 @@ setenv rootuuid "true"' /boot/boot.cmd
 		fi
 
 		# shellcheck disable=SC2016
-		[[ -f '/etc/initramfs/post-update.d/99-dietpi-uboot' && $(findmnt -t vfat -M /boot) ]] && G_EXEC sed --follow-symlinks -i '/^ln -s/c\mv -v "/boot/uInitrd-$1" /boot/uInitrd' /etc/initramfs/post-update.d/99-dietpi-uboot # FAT does not support symlinks
+		[[ -f '/etc/initramfs/post-update.d/99-dietpi-uboot' && $(findmnt -t vfat -M /boot) ]] && G_EXEC sed --follow-symlinks -i 's|^ln -sfv "initrd|mv -v "/boot/initrd|' /etc/initramfs/post-update.d/99-dietpi-uboot # FAT does not support symlinks
 
 		G_EXEC mv "$dir/dietpi.txt" /boot/
 		G_EXEC mv "$dir/README.md" /boot/dietpi-README.md
@@ -1245,6 +1263,7 @@ _EOF_
 
 			# Cleanup
 			[[ $G_HW_MODEL != 10 && -f '/boot/uImage' ]] && G_EXEC rm /boot/uImage
+			(( $G_HW_MODEL != 10 && $G_HW_MODEL != 62 )) && G_EXEC rm -f /boot/uInitrd*
 			[[ -f '/boot/.next' ]] && G_EXEC rm /boot/.next
 			[[ -f '/boot/armbianEnv.txt' ]] && G_EXEC rm /boot/armbianEnv.txt
 			[[ -f '/boot/orangepiEnv.txt' ]] && G_EXEC rm /boot/orangepiEnv.txt
@@ -1475,15 +1494,15 @@ _EOF_
 				done < <(dpkg-query -Wf '${Package}\n' | mawk -v pat="^$i" '$0~pat')
 			done
 
-			# Add initramfs-tools and u-boot-tools, required to convert initramfs images into u-boot format
+			# Add initramfs-tools and u-boot-tools, required to convert initramfs images into legacy U-Boot format
 			aPACKAGES_REQUIRED_INSTALL+=('initramfs-tools' 'u-boot-tools')
 
-			# Generate and cleanup uInitrd
+			# Generate and cleanup legacy uInitrd, still needed by Armbian boot.scr, which we do not touch here
 			local arch='arm'
 			(( $G_HW_ARCH == 3 )) && arch='arm64'
 			G_EXEC mkdir -p /etc/kernel/post{inst,rm}.d /etc/initramfs/post-update.d
 			cat << _EOF_ > /etc/initramfs/post-update.d/99-dietpi-uboot
-#!/bin/dash
+#!/bin/dash -e
 echo 'update-initramfs: Converting to U-Boot format'
 mkimage -A $arch -O linux -T ramdisk -C gzip -n uInitrd -d "\$2" "/boot/uInitrd-\$1"
 ln -sfv "uInitrd-\$1" /boot/uInitrd || mv -v "/boot/uInitrd-\$1" /boot/uInitrd
@@ -1491,7 +1510,7 @@ exit 0
 _EOF_
 			G_EXEC chmod +x /etc/initramfs/post-update.d/99-dietpi-uboot
 			cat << '_EOF_' > /etc/kernel/postinst.d/dietpi-initramfs_cleanup
-#!/bin/dash
+#!/bin/dash -e
 echo 'Removing obsolete initramfs images'
 find /boot -maxdepth 1 -name 'initrd.img-*' -o -name 'uInitrd-*' | while read -r f
 do


### PR DESCRIPTION
Since a decade or so, U-Boot supports loading raw `initrd` images directly and does not require its own `uInitrd` format anymore. Only requirement is that the file size is passed along with the initramfs memory address. This can be easily achieved by loading the initramfs last, so that we can use the `${filesize}` variable, generated by U-Boot on every `load` call.

Likely due to some boards with old U-Boot, Armbian never migrated, and keeps generating the legacy initramfs image, along with the needed cleanup script etc.

Among the SBCs we support, and which use this U-Boot setup, only the Odroid C1 and NanoPi M3/T3/Fire3 do not support raw initramfs images, and we will drop support for NanoPi M3/T3/Fire3 by the end of the year (as the kernel is too old to support Debian Bookworm properly). Hence generate new images for all other devices without `uInitrd` generation, and keep a set of legacy scripts for the two SBCs which do not support it. Do not touch existing systems, as this requires too many adjustments to critical parts of the system. Maybe we can do this later, once we know for a bit longer that really none of the SBCs has any issue with it. Also generic Armbian images still need to keep it, since we do not touch their boot scripts or environment either.

As a next step, we can migrate from `Image` and `zImage` names to `vmlinuz`, which would then allow to use `linux-update-symlinks` and get rid of the custom initramfs hook entirely. There was a bug in the Armbian kernel package, generating the kernel image symlink falsely, which we however fixed in our fork.

End goal is to get rid of the initramfs entirely. This however requires to builtin all essential kernel modules. We do not aim to support network boot without an initramfs, but core controller and filesystem drivers to mount any rootfs on any type of boot media is needed, which requires careful testing with each SBC individually. Another approach is to derive the needed modules from the initramfs, which is identical on every SBC which uses the same kernel, including all block device and network drivers, from which we can drop the latter. However, due to the large number of SBCs supported by one kernel build, it is not ruled out that the (kernel) image grows too much by this, or causing other issues, which revert the benefit.

But to make possibly needed debugging easier, we do one step at a time.