### PR TITLE
dietpi-software: GZDoom: add software option

### DIFF
--- a/.build/software/dietpi-software-build.bash
+++ b/.build/software/dietpi-software-build.bash
@@ -55,12 +55,12 @@ do
 	esac
 	shift
 done
-[[ $NAME =~ ^('amiberry'|'amiberry-lite'|'gmediarender'|'gogs'|'shairport-sync'|'squeezelite'|'vaultwarden'|'ympd')$ ]] || Error_Exit "Invalid software title \"$NAME\" passed"
+[[ $NAME =~ ^('amiberry'|'amiberry-lite'|'gzdoom'|'gmediarender'|'gogs'|'shairport-sync'|'squeezelite'|'vaultwarden'|'ympd')$ ]] || Error_Exit "Invalid software title \"$NAME\" passed"
 [[ $NAME == 'gogs' ]] && EXT='7z' || EXT='deb'
 [[ $DISTRO =~ ^('bullseye'|'bookworm'|'trixie')$ ]] || Error_Exit "Invalid distro \"$DISTRO\" passed"
 case $ARCH in
-	'armv6l') image="ARMv6-${DISTRO^}" arch=1; [[ $NAME == 'amiberry'* ]] && Error_Exit "Invalid software title \"$NAME\" for arch \"$ARCH\" passed";;
-	'armv7l') image="ARMv7-${DISTRO^}" arch=2;;
+	'armv6l') image="ARMv6-${DISTRO^}" arch=1; [[ $NAME == 'amiberry'* || $NAME == 'gzdoom' ]] && Error_Exit "Invalid software title \"$NAME\" for arch \"$ARCH\" passed";;
+	'armv7l') image="ARMv7-${DISTRO^}" arch=2; [[ $NAME == 'gzdoom' ]] && Error_Exit "Invalid software title \"$NAME\" for arch \"$ARCH\" passed";;
 	'aarch64') image="ARMv8-${DISTRO^}" arch=3;;
 	'x86_64') image="x86_64-${DISTRO^}" arch=10;;
 	'riscv64') image="RISC-V-${DISTRO^}" arch=11; [[ $DISTRO == 'trixie' ]] || Error_Exit "Invalid distro \"$DISTRO\" for arch \"$ARCH\" passed, only \"trixie\" is supported";;

--- a/.build/software/gzdoom/build.bash
+++ b/.build/software/gzdoom/build.bash
@@ -1,0 +1,154 @@
+#!/bin/bash
+{
+. /boot/dietpi/func/dietpi-globals || exit 1
+
+# APT dependencies
+# - libSDL2
+adeps_build=('make' 'gcc' 'pkg-config' 'libc6-dev' 'libdrm-dev' 'libgbm-dev' 'libasound2-dev' 'libudev-dev')
+adeps=('libc6' 'libdrm2' 'libgbm1' 'libegl1' 'libgl1-mesa-dri' 'libasound2' 'libudev1')
+(( $G_HW_ARCH == 10 )) && sdl_flags=('--disable-video-opengles2' '--enable-video-opengl') doom_flags=('-DHAVE_GLES2=OFF') adeps_build+=('libgl-dev' 'libegl1') adeps+=('libgl1') || sdl_flags=('--enable-video-opengles2' '--disable-video-opengl') doom_flags=('-DHAVE_GLES2=ON') adeps_build+=('libgles-dev') adeps+=('libgles2')
+# -- Disable Vulkan on ARMv6/7 since GZDoom does not full support 32-bit at the moment, failing with "error: cannot convert ‘std::nullptr_t’ to ‘VkSurfaceKHR’ {aka ‘long long unsigned int’} in initialization" in Vulkan-related code block.
+(( $G_HW_ARCH > 2 )) && sdl_flags+=('--enable-video-vulkan') doom_flags+=('-DHAVE_VULKAN=ON') adeps_build+=('libvulkan-dev') adeps+=('libvulkan1') || sdl_flags+=('--disable-video-vulkan') doom_flags+=('-DHAVE_VULKAN=OFF')
+# - ZMusic
+adeps_build+=('cmake' 'g++' 'libglib2.0-dev' 'libopenal1')
+adeps+=('libglib2.0-0' 'libopenal1') # OpenAL needed for MIDI synthesizer to work
+# - GZDoom
+adeps_build+=('git' 'libvpx-dev')
+case $G_DISTRO in
+	6) adeps+=('libvpx6');;
+	7) adeps+=('libvpx7');;
+	8) adeps+=('libvpx9');;
+	*) G_DIETPI-NOTIFY 1 "Unsupported distro version: $G_DISTRO_NAME (ID=$G_DISTRO)"; exit 1;;
+esac
+
+G_AGUP
+G_AGDUG "${adeps_build[@]}"
+for i in "${adeps[@]}"
+do
+	# Temporarily allow lib*t64 packages, while the 64-bit time_t transition is ongoing on Trixie: https://bugs.debian.org/1065394
+	dpkg-query -s "$i" &> /dev/null || dpkg-query -s "${i}t64" &> /dev/null && continue
+	G_DIETPI-NOTIFY 1 "Expected dependency package was not installed: $i"
+	exit 1
+done
+
+# Build libSDL2
+NAME='SDL2'
+PRETTY='libSDL2'
+version=$(curl -sSf 'https://api.github.com/repos/libsdl-org/SDL/releases' | mawk -F\" '/^ *"name": "2./{print $4}' | head -1)
+[[ $version ]] || { G_DIETPI-NOTIFY 1 "No latest $PRETTY version found, aborting ..."; exit 1; }
+G_DIETPI-NOTIFY 2 "Building $PRETTY version \e[33m$version"
+G_EXEC cd /tmp
+G_EXEC curl -sSfLO "https://github.com/libsdl-org/SDL/releases/download/release-$version/$NAME-$version.tar.gz"
+[[ -d $NAME-$version ]] && G_EXEC rm -R "$NAME-$version"
+G_EXEC tar xf "$NAME-$version.tar.gz"
+G_EXEC rm "$NAME-$version.tar.gz"
+G_EXEC cd "$NAME-$version"
+G_EXEC_OUTPUT=1 G_EXEC ./configure --prefix='/tmp/deps' --exec-prefix='/tmp/deps' CFLAGS='-g0 -O3' CXXFLAGS='-g0 -O3' --enable-{alsa,video-kmsdrm,libudev} "${sdl_flags[@]}" --disable-{video-{rpi,x11,wayland,opengles1,offscreen,dummy},pipewire,jack,diskaudio,sndio,dummyaudio,oss,dbus,ime,joystick,hidapi,hidapi-joystick,sdl2-config}
+G_EXEC_OUTPUT=1 G_EXEC make "-j$(nproc)"
+find . -type f \( -name '*.so' -o -name '*.so.*' \) -exec strip --strip-unneeded --remove-section=.comment --remove-section=.note -v {} +
+[[ -d '/tmp/deps' ]] && G_EXEC rm -R /tmp/deps
+G_EXEC_OUTPUT=1 G_EXEC make install
+
+# Build ZMusic
+NAME='ZMusic'
+PRETTY='ZMusic'
+version=$(curl -sSf 'https://api.github.com/repos/ZDoom/ZMusic/releases/latest' | mawk -F\" '/^  "tag_name"/{print $4}')
+[[ $version ]] || { G_DIETPI-NOTIFY 1 "No latest $PRETTY version found, aborting ..."; exit 1; }
+G_DIETPI-NOTIFY 2 "Building $PRETTY version \e[33m$version"
+G_EXEC cd /tmp
+G_EXEC curl -sSfLO "https://github.com/ZDoom/ZMusic/archive/$version.tar.gz"
+[[ -d $NAME-$version ]] && G_EXEC rm -R "$NAME-$version"
+G_EXEC tar xf "$version.tar.gz"
+G_EXEC rm "$version.tar.gz"
+G_EXEC cd "$NAME-$version"
+export CFLAGS='-g0 -O3' CXXFLAGS='-g0 -O3'
+# - 32-bit ARM flags
+case $G_HW_ARCH in
+	1) CFLAGS+=' -march=armv6zk+fp' CXXFLAGS+=' -march=armv6zk+fp';;
+	2) CFLAGS+=' -march=armv7-a+neon-vfpv4' CXXFLAGS+=' -march=armv7-a+neon-vfpv4';;
+	*) :;;
+esac
+G_EXEC_OUTPUT=1 G_EXEC cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX='/tmp/deps'
+G_EXEC_OUTPUT=1 G_EXEC make -C build "-j$(nproc)"
+find . -type f \( -name '*.so' -o -name '*.so.*' \) -exec strip --strip-unneeded --remove-section=.comment --remove-section=.note -v {} +
+G_EXEC_OUTPUT=1 G_EXEC make -C build install
+
+# Build GZDoom
+NAME='gzdoom'
+PRETTY='GZDoom'
+version=$(curl -sSf 'https://api.github.com/repos/ZDoom/gzdoom/releases/latest' | mawk -F\" '/^  "tag_name"/{print $4}')
+[[ $version ]] || { G_DIETPI-NOTIFY 1 "No latest $PRETTY version found, aborting ..."; exit 1; }
+version=${version#g}
+G_DIETPI-NOTIFY 2 "Building $PRETTY version \e[33m$version"
+G_EXEC cd /tmp
+[[ -d $NAME ]] && G_EXEC rm -R "$NAME"
+G_EXEC_OUTPUT=1 G_EXEC git clone -b "$version" 'https://github.com/ZDoom/gzdoom'
+G_EXEC cd "$NAME"
+export LDFLAGS='-L/tmp/deps/lib'
+G_EXEC sed --follow-symlinks -i -e '1a\include_directories(/tmp/deps/include)' -e '1a\set(CMAKE_INSTALL_RPATH "/usr/lib/gzdoom")' CMakeLists.txt
+# Prevent src/CMakeLists.txt from overwriting rpath if INSTALL_RPATH is not set, which is however expected at this point. ToDo: open PR to check for CMAKE_INSTALL_RPATH instead.
+G_EXEC sed --follow-symlinks -i '1a\set(INSTALL_RPATH "/usr/lib/gzdoom")' src/CMakeLists.txt
+# Fix ARMv6/7 builds due to bug in old lzma/7zip code: https://salsa.debian.org/debian/7zip/-/raw/debian/bullseye-backports/debian/patches/0004-Guard-ARM-v8-feature-from-old-architecture.patch
+(( $G_HW_ARCH > 2 )) || G_EXEC sed --follow-symlinks -i 's/(__GNUC__ > 4))$/(__GNUC__ > 4) \&\& (__ARM_ARCH >= 8))/' libraries/lzma/C/7zCrc.c
+DIR="/tmp/${NAME}_$G_HW_ARCH_NAME"
+G_EXEC_OUTPUT=1 G_EXEC cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH='/tmp/deps' -DCMAKE_INSTALL_PREFIX="$DIR/usr" "${doom_flags[@]}"
+G_EXEC_OUTPUT=1 G_EXEC make -C build "-j$(nproc)"
+G_EXEC strip --remove-section=.comment --remove-section=.note "build/$NAME"
+[[ -d $DIR ]] && G_EXEC rm -R "$DIR"
+G_EXEC_OUTPUT=1 G_EXEC make -C build install
+
+# Prepare DEB package
+G_DIETPI-NOTIFY 2 "Building $PRETTY DEB package"
+G_EXEC mkdir -p "$DIR/"{DEBIAN,usr/lib/gzdoom}
+
+# - Libraries
+G_EXEC cp -aL /tmp/deps/lib/{libSDL2-2.0,libzmusic}.so.[0-9] "$DIR/usr/lib/gzdoom/"
+
+# - md5sums
+find "$DIR" ! \( -path "$DIR/DEBIAN" -prune \) -type f -exec md5sum {} + | sed "s|$DIR/||" > "$DIR/DEBIAN/md5sums"
+
+# - Obtain DEB dependency versions
+DEPS_APT_VERSIONED=
+for i in "${adeps[@]}"
+do
+	# Temporarily allow lib*t64 packages, while the 64-bit time_t transition is ongoing on Trixie: https://bugs.debian.org/1065394
+	dpkg-query -s "$i" &> /dev/null || i+='t64'
+	DEPS_APT_VERSIONED+=" $i (>= $(dpkg-query -Wf '${VERSION}' "$i")),"
+done
+DEPS_APT_VERSIONED=${DEPS_APT_VERSIONED%,}
+
+# - Obtain version suffix
+G_EXEC_NOHALT=1 G_EXEC curl -sSfo package.deb "https://dietpi.com/downloads/binaries/$G_DISTRO_NAME/${NAME}_$G_HW_ARCH_NAME.deb"
+old_version=$(dpkg-deb -f package.deb Version)
+G_EXEC_NOHALT=1 G_EXEC rm package.deb
+suffix=${old_version#*-dietpi}
+[[ $old_version == "$version-"* ]] && version+="-dietpi$((suffix+1))" || version+="-dietpi1"
+
+# - control
+cat << _EOF_ > "$DIR/DEBIAN/control"
+Package: $NAME
+Version: $version
+Architecture: $(dpkg --print-architecture)
+Maintainer: MichaIng <micha@dietpi.com>
+Date: $(date -uR)
+Installed-Size: $(du -sk "$DIR" | mawk '{print $1}')
+Depends:$DEPS_APT_VERSIONED
+Section: games
+Priority: optional
+Homepage: https://zdoom.org
+Description: Modder-friendly OpenGL and Vulkan source port based on the DOOM engine
+ This package ships with an optimised libSDL2 build.
+_EOF_
+G_CONFIG_INJECT 'Installed-Size: ' "Installed-Size: $(du -sk "$DIR" | mawk '{print $1}')" "$DIR/DEBIAN/control"
+
+# - Permissions
+G_EXEC chown -R 0:0 "$DIR"
+G_EXEC find "$DIR" -type f -exec chmod 0644 {} +
+G_EXEC find "$DIR" -type d -exec chmod 0755 {} +
+G_EXEC chmod +x "$DIR/usr/bin/$NAME"
+
+# Build DEB package
+G_EXEC_OUTPUT=1 G_EXEC dpkg-deb -b "$DIR"
+
+exit 0
+}

--- a/.github/workflows/dietpi-software-build.yml
+++ b/.github/workflows/dietpi-software-build.yml
@@ -5,7 +5,7 @@ on:
       name:
         description: 'Software title'
         type: choice
-        options: [amiberry, amiberry-lite, gmediarender, gogs, shairport-sync, squeezelite, vaultwarden, ympd, all]
+        options: [amiberry, amiberry-lite, gzdoom, gmediarender, gogs, shairport-sync, squeezelite, vaultwarden, ympd, all]
         default: all
         required: true
       arch:
@@ -36,7 +36,7 @@ jobs:
       run: |
         if [ '${{ github.event.inputs.name }}' = 'all' ]
         then
-          echo 'name=["amiberry", "amiberry-lite", "gmediarender", "gogs", "shairport-sync", "squeezelite", "vaultwarden", "ympd"]' >> "$GITHUB_OUTPUT"
+          echo 'name=["amiberry", "amiberry-lite", "gzdoom", "gmediarender", "gogs", "shairport-sync", "squeezelite", "vaultwarden", "ympd"]' >> "$GITHUB_OUTPUT"
         else
           echo 'name=["${{ github.event.inputs.name }}"]' >> "$GITHUB_OUTPUT"
         fi
@@ -70,6 +70,8 @@ jobs:
         - { arch: x86_64, name: gogs }
         - { arch: armv6l, name: amiberry }
         - { arch: armv6l, name: amiberry-lite }
+        - { arch: armv6l, name: gzdoom }
+        - { arch: armv7l, name: gzdoom }
       fail-fast: false
     name: "${{ matrix.name }} - ${{ matrix.arch }} - ${{ matrix.dist }}"
     runs-on: ${{ matrix.arch == 'x86_64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}

--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -562,6 +562,7 @@ shopt -s extglob # +(expr) syntax
 	do
 		aSOFTWARE_NAME9_14[i]=${aSOFTWARE_NAME9_13[i]}
 	done
+	aSOFTWARE_NAME9_14[11]='GZDoom'
 
 	# Pre-create software counter array so that we can see also software (available in newest version) with 0 installs
 	for i in "${aSOFTWARE_NAME9_14[@]}"

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,9 @@ New images:
 - Orange Pi 5 Ultra | Support for the latest successor of the Orange Pi 5 family has been added to DietPi. Compared to the original Orange Pi 5, it features DDR5 RAM, onboard WiFi 6E, 2.5 Gbit Ethernet, an eMMC slot, an additional HDMI input port, and supports NVMe SSDs up to 2280 format. It is very similar to the Orange Pi 5 Max, but one of its HDMI port is an input port. It is disabled by default but can be enabled via device tree overlay by setting "overlays=hdmirx" in your /boot/dietpiEnv.txt.
 - Orange Pi CM5 | Support for the latest compute module from Xunlong/Orange Pi has been added to DietPi. It features an RK3588S SoC 2-16 GiB DDR4 RAM, 32-256 MiB onboard eMMC storage, other features depending on the used base board. It has been tested on the Tablet Base Board. If you have the other Base Board, please check the following discussion to check or report which features have been tested successfully: https://github.com/MichaIng/DietPi/discussions/7574
 
+New software:
+- GZDoom | This modder-friendly OpenGL and Vulkan source port based on the DOOM engine has been added to our software catalogue.
+
 Enhancements:
 - Container | sysctl cannot change values from within containers, but it needs to be done on the host instead. When dietpi-software would apply sysctl settings for certain software options, on container systems, it instead shows a dialogue with additional information, and how to apply the suggested change on the host.
 - NanoPi R4S/R5S/R5C/R6S/R6C | All onboard Ethernet adapters are now assigned a static MAC address.

--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ Links to hardware and software manufacturers, sources and build instructions use
 - [Forgejo](https://codeberg.org/forgejo/forgejo)
 - [soju](https://github.com/emersion/soju)
 - [fish](https://github.com/fish-shell/fish-shell)
+- [GZDoom](https://github.com/ZDoom/gzdoom)
 
 ---
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -990,6 +990,16 @@ Available commands:
 		(( $G_HW_MODEL > 9 )) && aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,$G_HW_MODEL]=0
 		# - ARMv6: https://github.com/moonlight-stream/moonlight-embedded/issues/832
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
+		#------------------
+		software_id=11
+		aSOFTWARE_NAME[$software_id]='GZDoom'
+		aSOFTWARE_DESC[$software_id]='Modder-friendly OpenGL and Vulkan source port based on the DOOM engine'
+		aSOFTWARE_CATX[$software_id]=5
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/gaming/#gzdoom'
+		aSOFTWARE_DEPS[$software_id]='5'
+		# - ARMv6/7: https://github.com/ZDoom/gzdoom/commit/1dedcee
+		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
+		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,2]=0
 
 		# Social & Search
 		#--------------------------------------------------------------------------------
@@ -11021,6 +11031,11 @@ _EOF_
 			/boot/dietpi/func/dietpi-set_hardware rpi-codec 1
 		fi
 
+		if To_Install 11 # GZDoom
+		then
+			G_AGI gzdoom
+		fi
+
 		if To_Install 27 # TasmoAdmin
 		then
 			# Install required PHP modules: https://github.com/TasmoAdmin/TasmoAdmin/wiki/Guide-for-Debian-Server-10-(Buster)
@@ -12901,6 +12916,11 @@ _EOF_
 			G_AGP moonlight-qt
 			[[ -f '/etc/apt/sources.list.d/dietpi-moonlight-qt.list' ]] && G_EXEC rm /etc/apt/sources.list.d/dietpi-moonlight-qt.list
 			[[ -f '/etc/apt/trusted.gpg.d/dietpi-moonlight-qt.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-moonlight-qt.gpg
+		fi
+
+		if To_Uninstall 11 # GZDoom
+		then
+			G_AGP gzdoom
 		fi
 
 		if To_Uninstall 119 # CAVA


### PR DESCRIPTION
Package build tests: https://github.com/MichaIng/DietPi/actions/runs/15665009052

The package ships with a tailored SDL2 build, with KMS/DRM graphics backend only, Vulkan and OpenGL(ES) render (ES on non-x86_64 systems), ALSA audio backend only, generally reduced to the features needed/used by GZDoom. Further tuning will be done, and features can be extended if something I did not test is not working.

No (q)ZDL yet, let's test the plain GZDoom launcher. It picks WAD files from a number of default locations like `~/.config/gzdoom/`, which can be edited in `~/.config/gzdoom/gzdoom.ini`. But ZDL has a bunch of more features, like multi-player sessions, config presets, flexible addition of WAD and other external files/mods, switching between Doom ports etc. Actually, it makes sense to add it as dedicated software option, and offer it with a dialogue to be installed along with GZDoom.

Generally, it is important to note that GZDoom is a free port of the game engine, which includes some parts of game data as well, but actual Doom games/versions need to be obtained, as WAD files. There are free implementations, like: https://freedoom.github.io/
But the original Doom and Doom II are not free and would need to be bought, e.g. from GOG or Steam. The contained WAD file(s) can then be started with GZDoom.