### PR TITLE
dietpi-software: PHP: skip JIT for ARMv8

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,7 +6,7 @@ New images:
 - Orange Pi CM5 | Support for the latest compute module from Xunlong/Orange Pi has been added to DietPi. It features an RK3588S SoC 2-16 GiB DDR4 RAM, 32-256 MiB onboard eMMC storage, other features depending on the used base board. It has been tested on the Tablet Base Board. If you have the other Base Board, please check the following discussion to check or report which features have been tested successfully: https://github.com/MichaIng/DietPi/discussions/7574
 
 New software:
-- GZDoom | This modder-friendly OpenGL and Vulkan source port based on the DOOM engine has been added to our software catalogue.
+- GZDoom | This modder-friendly OpenGL and Vulkan source port based on the DOOM engine has been added to our software catalogue. Many thanks to @Captain-Beefheart for suggestion and supporting the implementation of this software option: https://github.com/MichaIng/DietPi/discussions/7497
 
 Enhancements:
 - Container | sysctl cannot change values from within containers, but it needs to be done on the host instead. When dietpi-software would apply sysctl settings for certain software options, on container systems, it instead shows a dialogue with additional information, and how to apply the suggested change on the host.

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3736,7 +3736,9 @@ sudo sysctl -p /etc/sysctl.d/98-dietpi-redis.conf'
 			G_CONFIG_INJECT 'opcache.memory_consumption[[:blank:]=]' "opcache.memory_consumption=$cache_size" "$target_php_ini"
 			G_CONFIG_INJECT 'opcache.revalidate_freq[[:blank:]=]' 'opcache.revalidate_freq=60' "$target_php_ini" # 1 minute
 			# - JIT is available since PHP 8.0 for x86_64 and since PHP 8.2 for ARMv8. Enable it with 2 MiB size, since we never saw usage far above 1 MiB for whatever reason.
-			if (( $G_DISTRO > 6 && ( $G_HW_ARCH == 10 || $G_HW_ARCH == 3 ) ))
+			# - Skip on ARMv8 for now, since tracing JIT produces segmentation faults there, and function JIT requires a lot more memory: https://github.com/php/php-src/issues/7817
+			# - On dietpi.com x86_64 server, we suffered from segmentation faults as well for a while, but there it seems to have been solved.
+			if (( $G_DISTRO > 6 && $G_HW_ARCH == 10 ))
 			then
 				G_CONFIG_INJECT 'opcache.jit[[:blank:]=]' 'opcache.jit=1' "$target_php_ini" # 1/on = "tracing", follow default for now: https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.jit
 				G_CONFIG_INJECT 'opcache.jit_buffer_size[[:blank:]=]' 'opcache.jit_buffer_size=2M' "$target_php_ini"


### PR DESCRIPTION
Better be safe than sorry. Not sure how wirely this problem applies, but on my home server, I get segmentation faults as well with tracing JIT. Function JIT works well (compiling all functions on script load without any tracing), but for one Nextcloud instance, memory size raised from prior 2 MiB to 128 MiB for JIT. It would require some more consideration whether/from which RAM size on this is reasonable.

<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
