### PR TITLE
live patch 0: fix DietPi-Dashboard nightly installation

### DIFF
--- a/.update/version
+++ b/.update/version
@@ -14,6 +14,6 @@ G_MIN_DEBIAN=6
 # Alternative Git branch to automatically migrate to when Debian version is too low
 G_OLD_DEBIAN_BRANCH='8'
 # Live patches
-G_LIVE_PATCH_DESC=()
-G_LIVE_PATCH_COND=()
-G_LIVE_PATCH=()
+G_LIVE_PATCH_DESC=('Fix DietPi-Dashboard nightly installation')
+G_LIVE_PATCH_COND=('! sed -n '\''/^\t\tif To_Install 200 /,/Download_Install .*nightly\.link/p'\'' /boot/dietpi/dietpi-software | grep -q '\''G_AGI unzip'\')
+G_LIVE_PATCH=('sed -i '\''/Download_Install .*nightly\.link/i\command -v unzip > /dev/null || G_AGI unzip; aDEPS=()'\'' /boot/dietpi/dietpi-software')


### PR DESCRIPTION
If `unzip` is not installed, or the `aDEPS` array is not empty, possible after X11 installation within same run, a HEAD request is done to check the nightly download URL, which always returns 404, even if the download via GET would succeed.

The patch assures that `unzip` is installed and the `aDEPS` array is empty before the download is attempted.
