### PR TITLE
dietpi-software: add function to select Python APT dependencies

### DIFF
--- a/.github/workflows/dietpi-software.bash
+++ b/.github/workflows/dietpi-software.bash
@@ -216,7 +216,7 @@ Process_Software()
 			177) aSERVICES[i]='forgejo' aTCP[i]='3000';;
 			178) aSERVICES[i]='jellyfin' aTCP[i]='8097';;
 			179) aSERVICES[i]='komga' aTCP[i]='2037'; (( $emulation )) && aDELAY[i]=300 || aDELAY[i]=30;;
-			180) aSERVICES[i]='bazarr' aTCP[i]='6767'; (( $emulation )) && aDELAY[i]=60 || aDELAY[i]=30;;
+			180) aSERVICES[i]='bazarr' aTCP[i]='6767'; (( $emulation )) && aDELAY[i]=120 || aDELAY[i]=30;;
 			181) aSERVICES[i]='papermc' aTCP[i]='25565 25575'; (( $emulation )) && aDELAY[i]=600 || aDELAY[i]=60;;
 			182) aSERVICES[i]='unbound' aUDP[i]='53'; [[ ${aSERVICES[126]} ]] && aUDP[i]+=' 5335';; # Uses port 5335 if Pi-hole or AdGuard Home is installed, but those do listen on port 53 instead
 			183) aSERVICES[i]='vaultwarden' aTCP[i]='8001';;

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2605,6 +2605,109 @@ sudo sysctl -p /etc/sysctl.d/dietpi-$1.conf"
 			fi
 		}
 
+		# Store APT dependencies for Python modules in aDEPS array, or optionally install them directly
+		# Arguments:
+		#   --install, -i   Install APT packages directly
+		#   --user, -u      User to install Rust with
+		#   pyenv           Add APT dependencies needed to compile Python for pyenv
+		#   <module>        Add APT dependencies needed to compile and in case run the named module
+		# Environment variables:
+		#   PYTHON_VERSION  Python version in case e.g. pyenv is used
+		Python_Deps()
+		{
+			local install=0 user rust=0 piwheels=0
+
+			# Can piwheels be used?
+			if (( $G_HW_MODEL < 3 ))
+			then
+				if [[ $PYTHON_VERSION ]]
+				then
+					dpkg --compare-version "$PYTHON_VERSION" lt '3.12' && piwheels=1
+				else
+					(( $G_DISTRO < 8 )) && piwheels=1
+				fi
+			fi
+			unset -v PYTHON_VERSION
+
+			# Process arguments
+			while (( $# ))
+			do
+				case $1 in
+					'--install'|'-i') install=1;;
+					'--user'|'-u') shift; user=$1;;
+					'av') (( $G_HW_ARCH < 3 || $G_HW_ARCH == 11 )) && aDEPS+=('libavdevice-dev');;
+					'bcrypt') (( $G_HW_ARCH == 11 )) && rust=1;;
+					'brotli'|'sabctools'|'ujson') (( $G_HW_ARCH == 11 || ( $G_HW_ARCH < 3 && ! $piwheels ) )) && aDEPS+=('g++');;
+					'cffi') (( $G_HW_ARCH == 11 || ( $G_HW_ARCH < 3 && ! $piwheels ) )) && aDEPS+=('gcc' 'libffi-dev');;
+					'cryptography')
+						if (( $G_HW_ARCH == 1 || $G_HW_ARCH == 11 ))
+						then
+							aDEPS+=('pkg-config' 'libssl-dev')
+							rust=1
+						fi
+						set -- "$@" cffi
+					;;
+					'libsass') (( $G_HW_ARCH == 10 || $piwheels )) || aDEPS+=('g++');;
+					'lxml') (( $G_HW_ARCH == 1 || $G_HW_ARCH == 11 )) && aDEPS+=('libxslt1-dev');;
+					'netifaces') (( $piwheels || ( $G_HW_ARCH == 10 && $G_DISTRO == 6 ) )) || aDEPS+=('gcc');;
+					'numpy')
+						(( $G_HW_ARCH < 3 || $G_HW_ARCH == 11 )) && aDEPS+=('g++' 'pkg-config' 'libopenblas-dev')
+						# cmake + make + automake > patchelf > meson-python > numpy
+						# cmake > ninja > meson-python > numpy
+						(( $G_HW_ARCH == 1 || $G_HW_ARCH == 11 )) && aDEPS+=('cmake' 'make' 'automake')
+					;;
+					'pillow') (( $G_HW_ARCH < 3 || $G_HW_ARCH == 11 )) && aDEPS+=('gcc' 'libjpeg62-turbo-dev');;
+					'poetry')
+						# cryptography > SecretStorage > keyring > poetry
+						set -- "$@" cryptography
+					;;
+					'psutil') (( $G_HW_ARCH < 3 || $G_HW_ARCH == 11 )) && aDEPS+=('gcc');;
+					'psycopg2') (( $G_HW_ARCH < 2 && $piwheels )) || aDEPS+=('gcc' 'libpq-dev');;
+					'pycurl') (( $G_HW_ARCH == 11 || ( $G_HW_ARCH < 3 && ! $piwheels ) )) && aDEPS+=('gcc' 'libcurl4-openssl-dev' 'libssl-dev');;
+					'pydantic')
+						# pydantic_core > pydantic
+						(( $G_HW_ARCH == 1 || $G_HW_ARCH == 11 )) && rust=1
+					;;
+					'pyenv')
+						# Required: gcc libc6-dev make libssl-dev zlib1g-dev
+						# Optional to suppress warnings: libbz2-dev libreadline-dev libsqlite3-dev liblzma-dev
+						# libffi-dev for the optional _ctypes module, needed at least for Home Assistant => include it in all pyenv builds to avoid surprises
+						aDEPS+=('gcc' 'libc6-dev' 'make' 'libssl-dev' 'zlib1g-dev' 'libbz2-dev' 'libreadline-dev' 'libsqlite3-dev' 'liblzma-dev' 'libffi-dev')
+					;;
+					'pynacl')
+						(( $G_HW_ARCH == 11 || ( $G_HW_ARCH < 3 && ! $piwheels ) )) && aDEPS+=('make')
+						set -- "$@" cffi
+					;;
+					*) G_DIETPI-NOTIFY 1 "Unknown argument \"$1\" for Python_Deps(). This should never happen unless you are developing a software implementation. Otherwise, please report this at https://github.com/MichaIng/DietPi/issues. Aborting ..."; exit 1;;
+				esac
+				shift
+			done
+
+			# Install Rust if needed
+			if (( $rust ))
+			then
+				G_EXEC curl -sSfo rustup-init.sh 'https://sh.rustup.rs'
+				G_EXEC chmod +x rustup-init.sh
+				# ARMv6 Bullseye: rustup-init depends on libatomic1, not assured to be pre-installed on Bullseye
+				(( $G_HW_ARCH == 1 && $G_DISTRO == 6 )) && G_AGI libatomic1 "${aDEPS[@]}" && aDEPS=() install=0
+				G_EXEC_OUTPUT=1 G_EXEC ${user:+runuser -u "$user" --} ./rustup-init.sh -y --profile minimal
+				G_EXEC rm rustup-init.sh
+				[[ $user ]] || export PATH="/root/.cargo/bin:$PATH"
+			fi
+
+			[[ ${aDEPS[*]} ]] || return 0
+
+			# Deduplicate
+			declare -A dedupe
+			for i in "${aDEPS[@]}"; do dedupe["$i"]=; done
+			aDEPS=("${!dedupe[@]}")
+
+			# Return or install packages
+			(( $install )) || return 0
+			G_AGI "${aDEPS[@]}"
+			aDEPS=()
+		}
+
 		To_Install()
 		{
 			(( ${aSOFTWARE_INSTALL_STATE[$1]} == 1 )) || return 1
@@ -3842,24 +3945,8 @@ sudo sysctl -p /etc/sysctl.d/98-dietpi-redis.conf'
 
 		if To_Install 125 synapse # Synapse: https://element-hq.github.io/synapse/latest/setup/installation.html#installing-as-a-python-module-from-pypi
 		then
-			# APT deps for Synapse with PostgreSQL
-			case $G_HW_ARCH in
-				1|2)
-					local libtiff='libtiff6'
-					(( $G_DISTRO < 7 )) && libtiff='libtiff5'
-					G_AGI "$libtiff" libopenjp2-7 libxcb1 # ARMv6/7: Runtime libs for Pillow from piwheels (libtiff pulls libjpeg62-turbo)
-				;;
-				11)
-					# gcc and libffi-dev for cffi, Rust for cryptography and matrix-synapse, libpq-dev for psycopg2, make for PyNaCl, libjpeg62-turbo-dev for Pillow, libssl-dev and pkg-config for cryptography
-					G_AGI gcc libffi-dev libpq-dev make libjpeg62-turbo-dev libssl-dev pkg-config
-					G_EXEC curl -sSf 'https://sh.rustup.rs/' -o rustup-init.sh
-					G_EXEC chmod +x rustup-init.sh
-					G_EXEC_OUTPUT=1 G_EXEC ./rustup-init.sh -y --profile minimal
-					G_EXEC rm rustup-init.sh
-					export PATH="/root/.cargo/bin:$PATH"
-				;;
-				*) G_AGI gcc libpq-dev;; # ARMv8/x86_64: psycopg2 needs to be compiled
-			esac
+			# Dependencies
+			Python_Deps -i bcrypt cryptography pillow psycopg2
 
 			# Install
 			G_EXEC_OUTPUT=1 G_EXEC pip3 install -U matrix-synapse psycopg2
@@ -4202,24 +4289,7 @@ sudo sysctl -p /etc/sysctl.d/dietpi-ipfs.conf
 			G_EXEC chown -R "$micro_name:$micro_name" "$micro_data_dir"
 
 			# Dependencies
-			# - gcc, libc6-dev, make, libssl-dev, zlib1g-dev for Python build. libbz2-dev; libreadline-dev, libsqlite3-dev, liblzma-dev to suppress warnings; libffi-dev for ModuleNotFoundError: No module named '_ctypes'; g++ for libsass on all but x86_64 and for poetry brotli install on all architectures
-			aDEPS=('g++' 'libc6-dev' 'make' 'libssl-dev' 'zlib1g-dev' 'libbz2-dev' 'libreadline-dev' 'libsqlite3-dev' 'liblzma-dev' 'libffi-dev')
-			# - ARMv6/7/RISC-V
-			if [[ $G_HW_ARCH =~ ^(1|2|11)$ ]]
-			then
-				# pkg-config for cryptography, libjpeg62-turbo-dev for Pillow
-				aDEPS+=('pkg-config' 'libjpeg62-turbo-dev')
-				# Rust for cryptography
-				G_EXEC curl -sSf 'https://sh.rustup.rs/' -o rustup-init.sh
-				G_EXEC chmod +x rustup-init.sh
-				# - ARMv6 Bullseye: rustup-init depends on libatomic1, not assured to be pre-installed on Bullseye
-				(( $G_HW_ARCH == 1 && $G_DISTRO == 6 )) && G_AGI libatomic1
-				# - RPi with 64-bit kernel on 32-bit image: Enforce 32-bit toolchain: https://github.com/MichaIng/DietPi/issues/6306
-				G_EXEC_OUTPUT=1 G_EXEC runuser -u "$micro_name" -- ./rustup-init.sh -y --profile minimal ${RPI_64KERNEL_32OS:+'--default-host' 'armv7-unknown-linux-gnueabihf'}
-				G_EXEC rm rustup-init.sh
-				# ARMv6/RISC-V: libxslt1-dev for lxml
-				(( $G_HW_ARCH == 1 || $G_HW_ARCH == 11 )) && aDEPS+=('libxslt1-dev')
-			fi
+			PYTHON_VERSION=$micro_python_version Python_Deps -u "$micro_name" pyenv poetry bcrypt brotli libsass lxml pillow
 
 			# Create a Python environment via pyenv
 			# - https://python-poetry.org/docs/managing-environments/
@@ -9007,26 +9077,20 @@ _EOF_
 
 		if To_Install 136 motioneye # motionEye
 		then
-			# APT deps
-			# - RISC-V/ARMv6/7 Trixie: libcurl4-openssl-dev, gcc and libssl-dev for pycurl, libjpeg62-turbo-dev for Pillow
-			if (( ( $G_HW_ARCH < 3 || $G_HW_ARCH == 11 ) && $G_DISTRO > 7 ))
-			then
-				G_AGI libcurl4-openssl-dev gcc libssl-dev libjpeg62-turbo-dev
-
-			# - ARMv6/7: gcc and libjpeg62-turbo-dev for Pillow, until piwheels provides the latest version: https://piwheels.org/project/pillow/
-			elif (( $G_HW_ARCH < 3 ))
-			then
-				G_AGI gcc libjpeg62-turbo-dev
-			fi
+			# Dependencies
+			Python_Deps -i pillow pycurl
 
 			# RPi: Enable camera module
-			(( $G_HW_MODEL > 9 )) || /boot/dietpi/func/dietpi-set_hardware rpi-camera enable
+			(( $G_HW_MODEL > 9 )) || /boot/dietpi/func/dietpi-set_hardware rpi-camera 1
 
 			# motionEye
 			G_EXEC_OUTPUT=1 G_EXEC pip3 install -U --pre motioneye
 			G_EXEC_OUTPUT=1 G_EXEC motioneye_init --skip-apt-update
 			G_EXEC systemctl stop motioneye
-			G_EXEC systemctl --no-reload disable --now motion # motionEye starts motion directly.
+
+			# Prevent the conflicting motion daemon from starting
+			G_EXEC systemctl --no-reload disable --now motion
+			G_EXEC systemctl --no-reload mask motion
 
 			# Data directory
 			G_EXEC mkdir -p /mnt/dietpi_userdata/motioneye
@@ -9148,16 +9212,7 @@ _EOF_
 			# APT deps
 			aDEPS=('par2')
 			(( $G_DISTRO > 7 )) && aDEPS+=('7zip') || aDEPS+=('p7zip-full')
-			# - RISC-V: gcc and libffi-dev for cffi; pkg-config, libssl-dev and Rust for cryptography, g++ for sabctools and ujson
-			if (( $G_HW_ARCH == 11 ))
-			then
-				aDEPS+=('g++' 'libffi-dev' 'libssl-dev' 'pkg-config')
-				G_EXEC curl -sSf 'https://sh.rustup.rs/' -o rustup-init.sh
-				G_EXEC chmod +x rustup-init.sh
-				G_EXEC_OUTPUT=1 G_EXEC ./rustup-init.sh -y --profile minimal
-				G_EXEC rm rustup-init.sh
-				export PATH="/root/.cargo/bin:$PATH"
-			fi
+			Python_Deps cffi cryptography sabctools ujson
 
 			Download_Install 'https://github.com/sabnzbd/sabnzbd/archive/master.tar.gz'
 
@@ -9683,16 +9738,7 @@ _EOF_
 			(( $G_DISTRO > 7 )) && aDEPS+=('7zip') || aDEPS+=('p7zip')
 			# - ARMv6 does not support unrar-nonfree and Bazarr does not support unrar-free, so we need to use "unar": https://github.com/morpheus65535/bazarr/issues/2172
 			(( $G_HW_ARCH == 1 )) && aDEPS+=('unar')
-			# - ARMv6/7 with piwheels: libopenblas0-pthread for numpy from piwheels: https://piwheels.org/project/numpy/
-			(( $G_DISTRO < 8 && $G_HW_ARCH < 3 )) && aDEPS+=('libopenblas0-pthread')
-			# - ARMv6/7/RISC-V without piwheels:
-			# -- numpy: g++ pkg-config libopenblas-dev
-			# -- Pillow: gcc libjpeg62-turbo-dev
-			(( $G_DISTRO > 7 && ( $G_HW_ARCH < 3 || $G_HW_ARCH == 11 ) )) && aDEPS+=('g++' 'pkg-config' 'libopenblas-dev' 'libjpeg62-turbo-dev')
-			# - ARMv6/RISC-V without piwheels: libxslt1-dev for lxml
-			(( $G_DISTRO > 7 && ( $G_HW_ARCH == 1 || $G_HW_ARCH == 11 ) )) && aDEPS+=('libxslt1-dev')
-			# - RISC-V: cmake for ninja; make and automake for patchelf
-			(( $G_HW_ARCH == 11 )) && aDEPS+=('cmake' 'make' 'automake')
+			Python_Deps lxml numpy pillow
 
 			# Download
 			Download_Install 'https://github.com/morpheus65535/bazarr/releases/latest/download/bazarr.zip' bazarr
@@ -10084,28 +10130,11 @@ _EOF_
 
 		if To_Install 155 htpc-manager # HTPC Manager
 		then
-			local url='https://github.com/HTPC-Manager/HTPC-Manager.git'
+			local url='https://github.com/HTPC-Manager/HTPC-Manager'
 			G_CHECK_URL "$url"
 
 			# APT deps
-			case $G_HW_ARCH in
-				1|2)
-					local libtiff='libtiff6'
-					(( $G_DISTRO < 7 )) && libtiff='libtiff5'
-					G_AGI "$libtiff" libopenjp2-7 libxcb1 # ARMv6/7: Runtime libs for Pillow from piwheels (libtiff pulls libjpeg62-turbo)
-				;;
-				3) G_AGI gcc;; # gcc for psutil
-				11)
-					# gcc and libffi-dev for cffi, libssl-dev and Rust for cryptography and bcrypt, make for PyNaCl, libjpeg62-turbo-dev for Pillow, pkg-config for cryptography
-					G_AGI gcc libffi-dev libssl-dev make libjpeg62-turbo-dev pkg-config
-					G_EXEC curl -sSf 'https://sh.rustup.rs/' -o rustup-init.sh
-					G_EXEC chmod +x rustup-init.sh
-					G_EXEC_OUTPUT=1 G_EXEC ./rustup-init.sh -y --profile minimal
-					G_EXEC rm rustup-init.sh
-					export PATH="/root/.cargo/bin:$PATH"
-				;;
-				*) :;;
-			esac
+			Python_Deps -i cryptography pillow psutil
 
 			if [[ -d '/mnt/dietpi_userdata/htpc-manager/.git' ]]
 			then
@@ -10151,28 +10180,14 @@ _EOF_
 			G_EXEC chown -R octoprint:octoprint /mnt/dietpi_userdata/octoprint
 
 			# Deps
-			# - RISC-V: gcc and libffi-dev for cffi, Rust for maturin
-			local aPATH=()
-			if (( $G_HW_ARCH == 11 ))
-			then
-				aDEPS=('gcc' 'libffi-dev')
-				G_EXEC curl -sSf 'https://sh.rustup.rs/' -o rustup-init.sh
-				G_EXEC chmod +x rustup-init.sh
-				G_EXEC_OUTPUT=1 G_EXEC runuser -u octoprint -- ./rustup-init.sh -y --profile minimal
-				G_EXEC rm rustup-init.sh
-				aPATH=("PATH='/mnt/dietpi_userdata/octoprint/.cargo/bin:$PATH'")
-
-			# - ARMv8: gcc for psutil
-			elif (( $G_HW_ARCH == 3 ))
-			then
-				G_AGI gcc
-			fi
+			Python_Deps -i -u octoprint cffi netifaces psutil pydantic
 
 			# Clear pip cache in case it got somehow created
 			[[ -d '/mnt/dietpi_userdata/octoprint/.cache' ]] && G_EXEC rm -R /mnt/dietpi_userdata/octoprint/.cache
 
 			# Install OctoPrint
-			G_EXEC_OUTPUT=1 G_EXEC runuser -u octoprint -- "${aPATH[@]}" pip3 install -U --user --no-warn-script-location octoprint
+			# shellcheck disable=SC2016
+			G_EXEC_OUTPUT=1 G_EXEC runuser -u octoprint -- dash -c 'PATH="$HOME/.cargo/bin:$PATH" pip3 install -U --user --no-warn-script-location octoprint'
 
 			# Service: https://github.com/OctoPrint/OctoPrint/blob/master/scripts/octoprint.service
 			cat << '_EOF_' > /etc/systemd/system/octoprint.service
@@ -11195,30 +11210,11 @@ _EOF_
 
 			# User
 			Create_User -G dialout,gpio,i2c -d "$ha_home" "$ha_user"
-
-			# Dependencies
-			# - All: gcc, libc6-dev, make, libssl-dev, zlib1g-dev for Python build and libbz2-dev, libreadline-dev, libsqlite3-dev, liblzma-dev to suppress warnings
-			# - All: libffi-dev to solve "ModuleNotFoundError: No module named '_ctypes'" and cffi build on ARMv6/7/RISC-V, g++ for pymicro-vad
-			aDEPS=('g++' 'make' 'libssl-dev' 'zlib1g-dev' 'libbz2-dev' 'libreadline-dev' 'libsqlite3-dev' 'liblzma-dev' 'libffi-dev')
-			# - ARMv6/7/RISC-V
 			G_EXEC mkdir -p "$ha_home"
 			G_EXEC chown "$ha_user:$ha_user" "$ha_home"
-			if [[ $G_HW_ARCH =~ ^(1|2|11)$ ]]
-			then
-				# libjpeg62-turbo-dev for Pillow, libopenblas-dev and pkg-config for numpy, pkg-config for cryptography and av, g++ for numpy, automake for patchelf > meson-python > numpy, libavdevice-dev for av
-				# - While av is (tried to be) installed dynamically on HA start and not really needed for core functionality, we could ignore it. But the install and hence download is attempted on each HA start, also throwing a large error in service logs. Hence mute that one.
-				aDEPS+=('libjpeg62-turbo-dev' 'libopenblas-dev' 'pkg-config' 'automake' 'libavdevice-dev')
-				# Rust for cryptography and bcrypt
-				G_EXEC curl -sSf 'https://sh.rustup.rs/' -o rustup-init.sh
-				G_EXEC chmod +x rustup-init.sh
-				# - ARMv6 Bullseye: rustup-init depends on libatomic1, not assured to be pre-installed on Bullseye
-				(( $G_HW_ARCH == 1 && $G_DISTRO == 6 )) && G_AGI libatomic1
-				# - RPi with 64-bit kernel on 32-bit image: Enforce 32-bit toolchain: https://github.com/MichaIng/DietPi/issues/6306
-				G_EXEC_OUTPUT=1 G_EXEC runuser -u "$ha_user" -- ./rustup-init.sh -y --profile minimal ${RPI_64KERNEL_32OS:+'--default-host' 'armv7-unknown-linux-gnueabihf'}
-				G_EXEC rm rustup-init.sh
-				# ARMv6/RISC-V: cmake for ninja > numpy
-				(( $G_HW_ARCH == 1 || $G_HW_ARCH == 11 )) && aDEPS+=('cmake')
-			fi
+
+			# Dependencies
+			PYTHON_VERSION=$ha_python_version Python_Deps -u "$ha_user" av bcrypt cryptography numpy pyenv pillow
 			# - Custom dependencies, e.g. MariaDB support: G_AGI libmariadb-dev; pip3 install mysqlclient|PyMySQL
 			local custom_apt_deps=$(sed -n '/^[[:blank:]]*SOFTWARE_HOMEASSISTANT_APT_DEPS=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			mapfile -t -d' ' -O "${#aDEPS[@]}" aDEPS < <(echo -n "$custom_apt_deps")


### PR DESCRIPTION
APT packages needed to compile certain Python modules depend on architecture, OS/Python version, and whether piwheels provides latest/needed pre-compiled wheels for ARMv6/7 or not. Currently, we maintain and regularly update these dependencies for each software title individually, even that it is basically the same in all cases, with some Python modules which needs to be compiled for multiple software titles: Pillow, NumPy, cryptography, ...

This function allows to merge the logic for all of them, with a single place to update dependencies if needed, and document the dependency trees more in detail without adding many lines on multiple places.