### PR TITLE
Raspberry Pi: remove obsolete FFmpeg workaround for Trixie

### DIFF
--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -948,12 +948,6 @@ setenv rootuuid "true"' /boot/boot.cmd
 				G_EXEC rm keyring.deb
 				aPACKAGES_REQUIRED_INSTALL+=('raspberrypi-archive-keyring')
 			fi
-
-			if (( $DISTRO_TARGET > 7 ))
-			then
-				G_DIETPI-NOTIFY 2 'Enforcing Debian Trixie FFmpeg packages over RPi repo ones'
-				G_EXEC eval 'echo -e '\''Package: src:ffmpeg\nPin: origin archive.raspberrypi.com\nPin-Priority: -1'\'' > /etc/apt/preferences.d/dietpi-ffmpeg'
-			fi
 		fi
 
 		G_AGUP

--- a/.github/workflows/dietpi-software.bash
+++ b/.github/workflows/dietpi-software.bash
@@ -329,8 +329,6 @@ then
 	G_EXEC curl -sSfo keyring.deb 'https://archive.raspberrypi.com/debian/pool/main/r/raspberrypi-archive-keyring/raspberrypi-archive-keyring_2021.1.1+rpt1_all.deb'
 	G_EXEC dpkg --root=rootfs -i keyring.deb
 	G_EXEC rm keyring.deb
-	# Enforce Debian Trixie FFmpeg packages over RPi repo ones
-	[[ $DISTRO == 'trixie' ]] && G_EXEC eval 'echo -e '\''Package: src:ffmpeg\nPin: origin archive.raspberrypi.com\nPin-Priority: -1'\'' > /etc/apt/preferences.d/dietpi-ffmpeg'
 	# sysctl cannot succeed in containers. It is skipped with G_HW_MODEL=75, but here we changed that ID. Run the command, so we see it in logs, but do not abort as it fails.
 	G_EXEC sed --follow-symlinks -i '/# Start DietPi-Software/a\sed -i '\''/^[[:blank:]]*G_EXEC sysctl /s/G_EXEC sysctl /G_EXEC_NOHALT=1 G_EXEC sysctl /'\'' /boot/dietpi/dietpi-software' rootfs/boot/dietpi/dietpi-login
 fi

--- a/.update/pre-patches
+++ b/.update/pre-patches
@@ -275,11 +275,6 @@ then
 		G_DIETPI-NOTIFY 2 'Migrating myMPD APT repository from testing suite to Bookworm suite'
 		G_EXEC sed --follow-symlinks -i 's/Debian_Testing/Debian_12/' /etc/apt/sources.list.d/dietpi-mympd.list
 	fi
-	if [[ $G_DISTRO == 7 && -f '/etc/apt/sources.list.d/raspi.list' && -f '/etc/apt/preferences.d/dietpi-ffmpeg' ]]
-	then
-		G_DIETPI-NOTIFY 2 'Removing obsolete FFmpeg workaround from RPi Bookworm systems'
-		G_EXEC rm /etc/apt/preferences.d/dietpi-ffmpeg
-	fi
 	if [[ -f '/etc/apt/sources.list.d/dietpi-openhab.list' ]]
 	then
 		G_DIETPI-NOTIFY 2 'Migrating openHAB APT repository from testing suite to stable suite'
@@ -324,17 +319,6 @@ then
 	G_EXEC mkdir -p "../DietPi-Update/DietPi-$GITBRANCH_TARGET/dietpi"
 	# shellcheck disable=SC2261
 	grep -q 'DietPi v6' /boot/dietpi/dietpi-update && > "../DietPi-Update/DietPi-$GITBRANCH_TARGET/dietpi/server_version-6" > "../DietPi-Update/DietPi-$GITBRANCH_TARGET/dietpi/pre-patch_file" > /boot/dietpi/patch_file
-fi
-
-# v9.1
-if (( $G_DIETPI_VERSION_CORE < 9 || ( $G_DIETPI_VERSION_CORE == 9 && $G_DIETPI_VERSION_SUB < 1 ) ))
-then
-	# RPi/ARMv6 container Trixie
-	if [[ $G_DISTRO -ge 8 && -f '/etc/apt/sources.list.d/raspi.list' ]]
-	then
-		G_DIETPI-NOTIFY 2 'Adding FFmpeg workaround for RPi Trixie systems'
-		G_EXEC eval 'echo -e '\''Package: src:ffmpeg\nPin: origin archive.raspberrypi.com\nPin-Priority: -1'\'' > /etc/apt/preferences.d/dietpi-ffmpeg'
-	fi
 fi
 
 # v9.3
@@ -477,6 +461,16 @@ then
 		G_EXEC curl -sSfLo /etc/apt/trusted.gpg.d/dietpi-webmin.asc 'https://webmin.com/developers-key.asc'
 		G_EXEC eval 'echo '\''deb https://download.webmin.com/download/newkey/repository stable contrib'\'' > /etc/apt/sources.list.d/dietpi-webmin.list'
 		G_EXEC rm -f /etc/apt/sources.list.d/webmin.list /etc/apt/trusted.gpg.d/dietpi-webmin.gpg
+	fi
+fi
+
+# v9.15
+if (( $G_DIETPI_VERSION_CORE < 9 || ( $G_DIETPI_VERSION_CORE == 9 && $G_DIETPI_VERSION_SUB < 15 ) ))
+then
+	if [[ -f '/etc/apt/sources.list.d/raspi.list' && -f '/etc/apt/preferences.d/dietpi-ffmpeg' ]]
+	then
+		G_DIETPI-NOTIFY 2 'Removing obsolete FFmpeg workaround from RPi systems'
+		G_EXEC rm /etc/apt/preferences.d/dietpi-ffmpeg
 	fi
 fi
 


### PR DESCRIPTION
The RPi Trixie repo suite does not contain FFmpeg packages, so this is not required anymore. It might even solve regular dependency issues on Raspbian Trixie/testing, leading to certain CI software build and test failures on ARMv6 at the moment.
