### PR TITLE
dietpi-trixie-upgrade: add script for Debian Trixie upgrade

### DIFF
--- a/.conf/dps_85/nginx.conf
+++ b/.conf/dps_85/nginx.conf
@@ -28,7 +28,7 @@ http {
 
 	# Upstream to abstract back-end connection(s) for PHP
 	upstream php {
-		server unix:/run/php/php7.3-fpm.sock;
+		server unix:/run/php/php-fpm.sock;
 	}
 
 	# Set the mime-types via the mime.types external file

--- a/.meta/dietpi-bookworm-upgrade
+++ b/.meta/dietpi-bookworm-upgrade
@@ -22,8 +22,10 @@ while read -r id
 do
 	case $id in
 		47) alist+=('ownCloud');;
+		48) alist+=('Pydio');;
 		59) alist+=('RPi Cam Web Interface');;
 		140) alist+=('Domoticz');;
+		167) (( $G_HW_ARCH == 1 )) && alist+=('Raspotify');;
 		*) :;;
 	esac
 done < <(sed -nE 's/^aSOFTWARE_INSTALL_STATE\[([0-9]+)\]=2$/\1/p' /boot/dietpi/.installed)
@@ -54,7 +56,7 @@ unset -v apackages
 
 G_DIETPI-NOTIFY 2 'Migrating package lists to Bookworm suite'
 G_EXEC sed --follow-symlinks -i 's/bullseye/bookworm/g' /etc/apt/sources.list
-(( $G_RASPBIAN )) || G_EXEC sed --follow-symlinks -i 's/ non-free$/ non-free non-free-firmware/' /etc/apt/sources.list
+(( $G_RASPBIAN )) || G_EXEC sed --follow-symlinks -i -e 's/ non-free$/ non-free non-free-firmware/' -e 's/archive.debian.org/deb.debian.org/' /etc/apt/sources.list
 # Remove obsolete WSDD repo
 [[ -f '/etc/apt/sources.list.d/dietpi-wsdd.list' ]] && G_EXEC rm /etc/apt/sources.list.d/dietpi-wsdd.list
 [[ -f '/etc/apt/trusted.gpg.d/dietpi-wsdd.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-wsdd.gpg
@@ -73,6 +75,12 @@ G_DIETPI-NOTIFY 2 'Reverting some package lists to Bullseye which have no Bookwo
 G_DIETPI-NOTIFY 2 'Removing obsolete APT pinnings'
 G_EXEC rm -f /etc/apt/preferences.d/dietpi-{php,openssl,xrdp,wireguard,kodi,openhab}
 
+if dpkg-query -s 'postgresql' &> /dev/null
+then
+	G_DIETPI-NOTIFY 2 'Preventing automatic v15 main cluster generation'
+	G_CONFIG_INJECT 'create_main_cluster[[:blank:]]' 'create_main_cluster = false' /etc/postgresql-common/createcluster.conf
+fi
+
 G_DIETPI-NOTIFY 2 'Applying the actual upgrade to Debian Bookworm'
 /boot/dietpi/dietpi-services stop
 G_AGUP
@@ -89,10 +97,13 @@ read -rp 'Next, some migrations are done for all software to run nicely on Bookw
 
 G_DIETPI-NOTIFY 2 'Running post upgrade migrations'
 /boot/dietpi/dietpi-services stop
+
 # Switch from RSA to shorter and modern Ed25519 ssh.dietpi.com host key
 G_CONFIG_INJECT '\[?ssh.dietpi.com(]:29248)?[[:blank:]]' '[ssh.dietpi.com]:29248 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJdEPlagpQ+RVHNOX3jkG1Bya7Oza1dAke8h8NszVW84' /root/.ssh/known_hosts
+
 # We do not want G_AGP to purge the old kernel package on x86_64!
 eval "$(declare -f G_AGP | sed 's/autopurge/purge/')"
+
 # Migrate from CRDA to builtin kernel WiFi country code feature. CRDA is not available and does not work on Bookworm anymore. For non-Debian kernels, it is required to switch to the upstream regulatory database.
 if dpkg-query -s wireless-regdb &> /dev/null
 then
@@ -100,35 +111,66 @@ then
 	G_EXEC apt-mark manual wireless-regdb
 	G_AGP crda
 fi
+
 # Migrate OpenSSH server setting: https://manpages.debian.org/bookworm/sshd_config#KbdInteractiveAuthentication~2
 [[ -f '/etc/ssh/sshd_config' ]] && grep -q '^[[:blank:]]*ChallengeResponseAuthentication[[:blank:]]' /etc/ssh/sshd_config && ! grep -q '^[[:blank:]]*KbdInteractiveAuthentication[[:blank:]]' /etc/ssh/sshd_config && G_EXEC sed --follow-symlinks -Ei 's/^([[:blank:]]*)ChallengeResponseAuthentication([[:blank:]])/\1KbdInteractiveAuthentication\2/' /etc/ssh/sshd_config
+
 # Remove deprecated OpenVPN setting: https://manpages.debian.org/bullseye/openvpn#keysize
 for i in /etc/openvpn/*.{conf,ovpn}
 do
 	[[ -f $i ]] && grep -q '^[[:blank:]]*keysize[[:blank:]]' && G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*keysize[[:blank:]]/d' "$i"
 done
+
 # Purge obsolete GCC versions
 G_AGP gcc-{8,9,10,11}-base
+
 # Purge PHP 7.4 packages, obsolete after PHP 8.2 install
 G_AGP '*php7.4*'
+
 # Remove obsolete PHP 7.4 configs and Python 3.9 modules, obsolete after Python 3.11 install
 G_EXEC rm -Rf /etc/php/7.4 /usr/local/lib/python3.9 /usr/local/bin/pip3*
+
 # Install (mark as manually installed) root trust anchors for Unbound, which was degraded from dependency to recommendation: https://github.com/MichaIng/DietPi/issues/5612
 dpkg-query -s unbound &> /dev/null && G_AGI dns-root-data
+
 # Allow IPv6 port binding failure explicitly, not implicit anymore since Bookworm: https://github.com/MichaIng/DietPi/pull/6103#issuecomment-1407749720
 [[ -f '/etc/redis/redis.conf' ]] && G_EXEC sed --follow-symlinks -i '/^bind 127.0.0.1 ::1$/c\bind 127.0.0.1 -::1' /etc/redis/redis.conf
-# Reinstall all PHP applications which require non-standard PHP modules, webservers which did access a versioned PHP-FPM socket, Python applications installed via pip, ...
-G_PROMPT_BACKUP_DISABLED=1 /boot/dietpi/dietpi-software reinstall 38 40 47 48 83 84 85 89 93 114 118 125 130 134 136 139 143 153 155 157 180
 
-# PostgreSQL upgrade
-if grep -q '^aSOFTWARE_INSTALL_STATE\[194\]=2$' /boot/dietpi/.installed
+if apt-mark showmanual | grep -q 'libicu67'
 then
-	G_DIETPI-NOTIFY 2 'Migrating PostgreSQL databases from v13 to v15'
-	G_EXEC systemctl stop postgresql
-	G_EXEC pg_dropcluster 15 main
-	G_EXEC pg_upgradecluster 13 main
-	G_EXEC pg_dropcluster 13 main
+	G_DIETPI-NOTIFY 2 'Migrating from libicu67 to libicu72'
+	G_AGI libicu72
+	G_EXEC apt-mark auto libicu67
 fi
+
+# PostgreSQL migration
+if dpkg-query -s 'postgresql' &> /dev/null
+then
+	G_DIETPI-NOTIFY 2 'Migrating PostgreSQL 13 clusters to v15'
+	mapfile -t clusters < <(pg_lsclusters | mawk '$1 == "13" {print $2}')
+	skipped=0
+	G_EXEC systemctl start postgresql
+	for cluster in "${clusters[@]}"
+	do
+		[[ -d /var/lib/postgresql/15/$cluster ]] && { G_DIETPI-NOTIFY 2 "PostgreSQL 15 cluster \"$cluster\" exists already, skipping migration"; skipped=1; continue; }
+		G_DIETPI-NOTIFY 2 "Found PostgreSQL 13 cluster \"$cluster\", starting migration ...";
+		G_EXEC pg_upgradecluster 13 "$cluster"
+		G_EXEC pg_dropcluster 13 "$cluster"
+	done
+	if (( $skipped ))
+	then
+		G_WHIP_MSG '[ INFO ] PostgreSQL 13 to v15 migration incomplete
+\nFor some PostgreSQL 13 cluster(s), the respective v15 cluster existed already, and the migration has hence been skipped.
+\nPlease review those left clusters and in case remove or migrate them to v15 manually. PostgreSQL 13 is kept installed for that. Once all needed clusters have been migrated, purge PostgreSQL 13 with the following commands:
+\nsudo rm /etc/apt/apt.conf.d/02autoremove-postgresql
+sudo apt autopurge'
+	else
+		G_EXEC rm /etc/apt/apt.conf.d/02autoremove-postgresql
+	fi
+fi
+
+# Reinstall all PHP applications which require non-standard PHP modules, Python applications installed via pip, Home Assistant to get latest version, ...
+G_PROMPT_BACKUP_DISABLED=1 /boot/dietpi/dietpi-software reinstall 38 40 89 114 118 125 130 136 139 141 143 153 155 157 180 210
 
 cat << '_EOF_' > /etc/bashrc.d/zz-dietpi-autopurge.bash
 {

--- a/.meta/dietpi-trixie-upgrade
+++ b/.meta/dietpi-trixie-upgrade
@@ -1,0 +1,174 @@
+#!/bin/bash
+{
+# Import DietPi-Globals ---------------------------------------------------------------
+. /boot/dietpi/func/dietpi-globals
+readonly G_PROGRAM_NAME='dietpi-trixie-upgrade'
+[[ $G_DISTRO == [78] ]] || { G_DIETPI-NOTIFY 1 'You must run a Debian Bookworm system to run this script!'; exit 1; }
+(( $G_HW_ARCH < 3 )) && dpkg --compare-versions "$(uname -r)" lt-nl 5.6 && { G_DIETPI-NOTIFY 1 '32-bit systems with Linux older than 5.6 cannot run Debian Trixie, due to missing time64 syscall support. Please upgrade your kernel to run this scritp!'; exit 1; }
+G_CHECK_ROOT_USER
+G_CHECK_ROOTFS_RW
+G_INIT
+# Import DietPi-Globals ---------------------------------------------------------------
+
+# Warn about incompatible installed software titles
+alist=()
+while read -r id
+do
+	case $id in
+		148) (( $G_HW_ARCH == 1 )) && alist+=('myMPD');;
+		207) (( $G_HW_ARCH < 3 )) && alist+=('Moonlight (CLI)');;
+		208) (( $G_HW_ARCH < 3 )) && alist+=('Moonlight (GUI)');;
+		*) :;;
+	esac
+done < <(sed -nE 's/^aSOFTWARE_INSTALL_STATE\[([0-9]+)\]=2$/\1/p' /boot/dietpi/.installed)
+(( ! ${#alist[@]} )) || G_WHIP_BUTTON_OK_TEXT='Continue' G_WHIP_BUTTON_CANCEL_TEXT='Exit' G_WHIP_YESNO "[WARNING] Incompatible software titles found
+\nThe following installed software titles are not yet compatible with Debian Trixie on your system:
+${alist[*]}
+\nDo you want to continue regardless?\n" || exit 0
+
+# Offer a backup before doing any changes to the system
+G_PROMPT_BACKUP
+
+G_DIETPI-NOTIFY 2 'Upgrading APT packages to latest versions provided by Debian Bookworm'
+/boot/dietpi/dietpi-services stop
+G_AGUP
+G_AGDUG
+G_AGA
+
+G_CHECK_KERNEL || { G_WHIP_YESNO '[ INFO ] Reboot required
+\nYour system needs to be rebootet to apply a recent kernel upgrade. Please do this first and then rerun this script to proceed with the Trixie upgrade.
+\nShall we reboot your system now?' && reboot; exit 0; }
+
+G_DIETPI-NOTIFY 2 'Updating DietPi to latest version'
+/boot/dietpi/dietpi-update 1
+
+mapfile -t apackages < <(apt-mark showhold)
+[[ ${apackages[0]} ]] && G_EXEC_DESC='Unholding all packages' G_EXEC apt-mark unhold "${apackages[@]}"
+unset -v apackages
+
+G_DIETPI-NOTIFY 2 'Migrating package lists to Trixie suite'
+G_EXEC sed --follow-symlinks -i 's/bookworm/trixie/g' /etc/apt/sources.list
+# Remove obsolete lists, including those obsoleted with Bookworm
+G_EXEC rm -f /etc/apt/sources.list.d/dietpi-{mono,mosquitto,wsdd}.list /etc/apt/trusted.gpg.d/dietpi-{mono,mosquitto,wsdd}.gpg
+for i in /etc/apt/sources.list.d/*.list
+do
+	[[ $i == '/etc/apt/sources.list.d/*.list' ]] && break
+	G_EXEC sed --follow-symlinks -i 's/bookworm/trixie/g' "$i"
+	G_EXEC sed --follow-symlinks -i '/download\.opensuse\.org/s/Debian_12/Debian_Testing/' "$i"
+	G_EXEC sed --follow-symlinks -i '/download\.opensuse\.org/s/Raspbian_12/Raspbian_Testing/' "$i"
+done
+
+G_DIETPI-NOTIFY 2 'Reverting some package lists to Bookworm which have no Trixie suite (yet)'
+[[ -f '/etc/apt/sources.list.d/dietpi-mympd.list' ]] && G_EXEC sed --follow-symlinks -i 's/Raspbian_Testing/Raspbian_12/g' /etc/apt/sources.list.d/dietpi-mympd.list
+[[ -f '/etc/apt/sources.list.d/dietpi-mopidy.list' ]] && G_EXEC sed --follow-symlinks -i 's/trixie/bookworm/g' /etc/apt/sources.list.d/dietpi-mopidy.list
+[[ -f '/etc/apt/sources.list.d/dietpi-influxdb.list' ]] && G_EXEC sed --follow-symlinks -i 's/trixie/bookworm/g' /etc/apt/sources.list.d/dietpi-influxdb.list
+[[ -f '/etc/apt/sources.list.d/dietpi-zerotier.list' ]] && G_EXEC sed --follow-symlinks -i 's/trixie/bookworm/g' /etc/apt/sources.list.d/dietpi-zerotier.list
+[[ $G_RASPBIAN == 1 && -f '/etc/apt/sources.list.d/dietpi-docker.list' ]] && G_EXEC sed --follow-symlinks -i 's/trixie/bookworm/g' /etc/apt/sources.list.d/dietpi-docker.list
+[[ -f '/etc/apt/sources.list.d/dietpi-moonlight.list' ]] && G_EXEC sed --follow-symlinks -i 's/trixie/bookworm/g' /etc/apt/sources.list.d/dietpi-moonlight.list
+[[ -f '/etc/apt/sources.list.d/dietpi-moonlight-qt.list' ]] && G_EXEC sed --follow-symlinks -i 's/trixie/bookworm/g' /etc/apt/sources.list.d/dietpi-moonlight-qt.list
+
+G_DIETPI-NOTIFY 2 'Removing obsolete APT pinnings' # including those obsoleted with Bullseye and Bookworm
+G_EXEC rm -f /etc/apt/preferences.d/dietpi-{php,openssl,xrdp,wireguard,kodi,openhab}
+
+G_DIETPI-NOTIFY 2 'Applying the actual upgrade to Debian Trixie'
+/boot/dietpi/dietpi-services stop
+G_AGUP
+G_AGUG
+G_AGDUG
+
+/boot/dietpi/func/dietpi-obtain_hw_model
+. /boot/dietpi/.hw_model
+
+G_DIETPI-NOTIFY 0 'Congratulations, you are now on Trixie:'
+head -4 /etc/os-release
+echo
+read -rp 'Next, some migrations are done for all software to run nicely on Trixie. This can include dietpi-software reinstalls. Press ENTER to continue or CTRL+C to abort ...'
+
+G_DIETPI-NOTIFY 2 'Running post upgrade migrations'
+/boot/dietpi/dietpi-services stop
+
+# We do not want G_AGP to purge the old kernel package yet!
+eval "$(declare -f G_AGP | sed 's/autopurge/purge/')"
+
+if dpkg-query -s 'p7zip' &> /dev/null || dpkg-query -s 'p7zip-full' &> /dev/null
+then
+	G_DIETPI-NOTIFY 2 'Migrating from obsolete p7zip to modern 7zip'
+	G_AGI 7zip
+	G_AGP p7zip p7zip-full
+fi
+
+if apt-mark showmanual | grep -q 'libicu72'
+then
+	G_DIETPI-NOTIFY 2 'Migrating from libicu72 to libicu76'
+	G_AGI libicu76
+	G_EXEC apt-mark auto libicu72
+fi
+
+# Java migration: openHAB does not support Java 25 yet
+version=25
+dpkg-query -s 'openhab' &> /dev/null && version=21
+if dpkg-query -s 'openjdk-17-jdk-headless' &> /dev/null
+then
+	G_DIETPI-NOTIFY 2 "Migrating from Java JDK from 17 to $version"
+	G_AGI "openjdk-$version-jdk-headless"
+	G_AGP openjdk-17-jdk-headless
+fi
+if dpkg-query -s 'openjdk-17-jre-headless' &> /dev/null
+then
+	G_DIETPI-NOTIFY 2 "Migrating from Java JRE from 17 to $version"
+	G_AGI "openjdk-$version-jre-headless"
+	G_AGP openjdk-17-jre-headless
+fi
+
+# Purge PHP 8.2 packages, obsolete after PHP 8.2 install
+G_AGP '*php8.2*'
+
+# Remove obsolete PHP 8.2 configs and Python 3.11 modules, obsolete after Python 3.13 install
+G_EXEC rm -Rf /etc/php/8.2 /usr/local/lib/python3.11 /usr/local/bin/pip3*
+
+# PostgreSQL migration
+if dpkg-query -s 'postgresql' &> /dev/null
+then
+	G_DIETPI-NOTIFY 2 'Migrating PostgreSQL 15 clusters to v17'
+	mapfile -t clusters < <(pg_lsclusters | mawk '$1 == "15" {print $2}')
+	skipped=0
+	G_EXEC systemctl start postgresql
+	for cluster in "${clusters[@]}"
+	do
+		[[ -d /var/lib/postgresql/17/$cluster ]] && { G_DIETPI-NOTIFY 2 "PostgreSQL 17 cluster \"$cluster\" exists already, skipping migration"; skipped=1; continue; }
+		G_DIETPI-NOTIFY 2 "Found PostgreSQL 15 cluster \"$cluster\", starting migration ...";
+		G_EXEC pg_upgradecluster 15 "$cluster"
+		G_EXEC pg_dropcluster 15 "$cluster"
+	done
+	if (( $skipped ))
+	then
+		G_WHIP_MSG '[ INFO ] PostgreSQL 15 to v17 migration incomplete
+\nFor some PostgreSQL 15 cluster(s), the respective v17 cluster existed already, and the migration has hence been skipped.
+\nPlease review those left clusters and in case remove or migrate them to v17 manually. PostgreSQL 15 is kept installed for that. Once all needed clusters have been migrated, purge PostgreSQL 15 with the following commands:
+\nsudo rm /etc/apt/apt.conf.d/02autoremove-postgresql
+sudo apt autopurge'
+	else
+		G_EXEC rm /etc/apt/apt.conf.d/02autoremove-postgresql
+	fi
+fi
+
+# Reinstalls:
+# - PHP and all PHP applications which require additional PHP modules: 38 40 89 114 143 210
+# - Python and all Python applications which require pip installs: 118 125 130 136 139 141 153 155 180
+# - UnRAR on non-ARMv6 Raspbian systems, for which we host the respective Debian packages on our server
+extra=()
+(( $G_HW_MODEL != 1 )) && (( $G_RASPBIAN )) && extra+=(170)
+# - PaperMC for latest version: 181
+G_PROMPT_BACKUP_DISABLED=1 /boot/dietpi/dietpi-software reinstall 38 40 89 114 118 125 130 136 139 141 143 153 155 180 181 210 "${extra[@]}"
+
+cat << '_EOF_' > /etc/bashrc.d/zz-dietpi-autopurge.bash
+{
+(( $UID )) && return 0
+G_DIETPI-NOTIFY 2 'Autoremoving leftover packages from Trixie upgrade...'
+G_EXEC_NOHALT=1 G_EXEC rm /etc/bashrc.d/zz-dietpi-autopurge.bash
+G_AGA
+}
+_EOF_
+
+G_WHIP_YESNO 'All finished!\n\nWe highly recommend to reboot, shall we reboot now?\n\nNB: To have obsolete leftover packages autoremoved, login as root user once after reboot, or run "sudo apt autopurge".' && reboot
+}

--- a/.update/patches
+++ b/.update/patches
@@ -2459,9 +2459,6 @@ _EOF_
 			# Change web UI port to 8089 and 8489 (HTTPS) to avoid conflict with webservers and other web applications
 			G_EXEC pihole-FTL --config webserver.port 8089,8489s
 
-			# Migrate QUERY_LOGGING=false: https://github.com/pi-hole/FTL/pull/2264
-			grep -q '^QUERY_LOGGING=false$' /etc/pihole/migration_backup_v6/setupVars.conf && G_EXEC pihole-FTL --config dns.queryLogging 'false'
-
 			# Inform user about differences to stock Pi-hole installation
 			G_WHIP_MSG "[ INFO ] Pi-hole network ports changed to 8089 and 8489
 \nTo align migrated Pi-hole v6 instances with fresh installs, and avoid possible conflicts with dedicated webservers, the network ports have been changed to 8089 and 8489 (HTTPS). Your Pi-hole instance will hence be available at:
@@ -2470,7 +2467,7 @@ _EOF_
 \nThis can be changed via web UI or following console command, e.g. for ports 80 and 443 (HTTPS):
 - pihole-FTL --config webserver.port 80,443s"
 
-			# Offer to uninstall websever and PHP if no dependant is installed
+			# Offer to uninstall webserver and PHP if no dependant is installed
 			# - If only PHP or only a webserver is installed, one has been uninstalled already, and the other is assumed to be still needed for something else.
 			if grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[89\]=2' /boot/dietpi/.installed && grep -Eq '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[(83|84|85)\]=2' /boot/dietpi/.installed
 			then
@@ -2497,7 +2494,7 @@ _EOF_
 		fi
 
 		# Nextcloud
-		[[ -f '/etc/apache2/sites-available/dietpi-nextcloud.conf' ]] && G_EXEC mv "../DietPi-Update/DietPi-${G_GITBRANCH//\//-}/.conf/dps_114/apache.nexcloud.conf" /etc/apache2/sites-available/dietpi-nextcloud.conf
+		[[ -f '/etc/apache2/sites-available/dietpi-nextcloud.conf' ]] && G_EXEC mv "../DietPi-Update/DietPi-${G_GITBRANCH//\//-}/.conf/dps_114/apache.nextcloud.conf" /etc/apache2/sites-available/dietpi-nextcloud.conf
 
 		# Unbound
 		if [[ -f '/etc/unbound/unbound.conf.d/dietpi.conf' ]]
@@ -2513,6 +2510,55 @@ _EOF_
 			fi
 		fi
 		[[ -f '/etc/cron.monthly/dietpi-unbound' ]] && G_EXEC rm /etc/cron.monthly/dietpi-unbound
+
+		# Lighttpd: Buster => Bullseye migrations
+		if [[ -f '/etc/lighttpd/lighttpd.conf' ]]
+		then
+			# mod_compress has been superseded by mod_deflate
+			if grep -q '^[[:blank:]]*"mod_compress",$' /etc/lighttpd/lighttpd.conf
+			then
+				G_DIETPI-NOTIFY 2 'Bullseye upgrade detected: Migrating from mod_compress to mod_deflate'
+				G_EXEC sed --follow-symlinks -Ei '/^compress\..*=[[:blank:]]*["(].*[")]$/d' /etc/lighttpd/lighttpd.conf
+				G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*"mod_compress",$/d' /etc/lighttpd/lighttpd.conf
+				G_AGI lighttpd-mod-deflate
+			fi
+
+			# Install OpenSSL module if DietPi-LetsEncrypt was used
+			if [[ -f '/etc/lighttpd/conf-available/50-dietpi-https.conf' ]] && ! dpkg-query -s 'lighttpd-mod-openssl' &> /dev/null
+			then
+				G_DIETPI-NOTIFY 2 'Bullseye upgrade detected: Installing dedicatged Lighttpd OpenSSL module'
+				G_AGI lighttpd-mod-openssl
+				grep -q '"mod_openssl"' /etc/lighttpd/conf-available/50-dietpi-https.conf || G_EXEC sed --follow-symlinks -i '1iserver.modules += ( "mod_openssl" )' /etc/lighttpd/conf-available/50-dietpi-https.conf
+			fi
+
+			# Remove obsolete socket version string from FPM module
+			if [[ -f '/etc/lighttpd/conf-available/15-fastcgi-php-fpm.conf' ]] && grep -q 'php.\..-fpm\.sock' /etc/lighttpd/conf-available/15-fastcgi-php-fpm.conf
+			then
+				G_DIETPI-NOTIFY 2 'Removing obsolete PHP FPM socket version string from Lighttpd config'
+				G_EXEC sed --follow-symlinks -i 's/php.\..-fpm\.sock/php-fpm.sock/' /etc/lighttpd/conf-available/15-fastcgi-php-fpm.conf
+			fi
+		fi
+
+		# Nginx
+		if [[ -f '/etc/nginx/nginx.conf' ]] && grep -q 'php.\..-fpm\.sock' /etc/nginx/nginx.conf
+		then
+			G_DIETPI-NOTIFY 2 'Removing obsolete PHP FPM socket version string from Nginx config'
+			G_EXEC sed --follow-symlinks -i 's/php.\..-fpm\.sock/php-fpm.sock/' /etc/nginx/nginx.conf
+		fi
+
+		# Docker Compose
+		if grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[134\]=2' /boot/dietpi/.installed
+		then
+			if command -v docker-compose > /dev/null && ! dpkg-query -s 'docker-compose-plugin' &> /dev/null
+			then
+				G_WHIP_MSG '[ INFO ] Migrating from obsolete "docker-compose" to "docker compose" plugin
+\nThe dedicated "docker-compose" application and executable is deprecated, in favor of Docker'\''s native compose plugin. We are migrating you instance to the new plugin now.
+\nNote that the command to call Docker Compose in turn changed from "docker-compose" to "docker compose", hence without the dash, but as an argument of the "docker" command.'
+				G_AGI docker-compose-plugin
+				command -v docker-compose > /dev/null && command -v pip3 > /dev/null && G_EXEC_OUTPUT=1 G_EXEC pip3 uninstall -y docker-compose # Pre-v8.2
+				[[ -f '/usr/local/bin/docker-compose' ]] && G_EXEC rm /usr/local/bin/docker-compose # Pre-v8.14
+			fi
+		fi
 	fi
 }
 

--- a/.update/pre-patches
+++ b/.update/pre-patches
@@ -475,7 +475,7 @@ then
 	if (( $G_DISTRO < 7 )) && grep -q '^deb .* bullseye-backports ' /etc/apt/sources.list
 	then
 		G_DIETPI-NOTIFY 2 'Pulling bullseye-backports APT suite from archive.debian.org, since it has been removed from main repo'
-		G_EXEC sed --follow-symlinks -i 's/^deb .* bullseye-backports /deb https://archive.debian.org/debian bullseye-backports /' /etc/apt/sources.list
+		G_EXEC sed --follow-symlinks -i 's|^[[:blank:]]*deb[[:blank:]].*[[:blank:]]bullseye-backports[[:blank:]]|deb https://archive.debian.org/debian bullseye-backports |' /etc/apt/sources.list
 	fi
 fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3002,10 +3002,12 @@ unix_socket_directories = '/run/postgresql'" > "$i/00dietpi.conf"
 
 		if To_Install 196 # Java JRE
 		then
-			# Trixie without openHAB
-			if (( $G_DISTRO > 7 && ${aSOFTWARE_INSTALL_STATE[206]} < 1 ))
+			# Trixie
+			if (( $G_DISTRO > 7 ))
 			then
 				local version=25
+				# openHAB does not support Java 25 yet
+				(( ${aSOFTWARE_INSTALL_STATE[206]} < 1 )) && version=21
 
 			# Bullseye/Bookworm
 			else
@@ -3018,10 +3020,12 @@ unix_socket_directories = '/run/postgresql'" > "$i/00dietpi.conf"
 
 		if To_Install 8 # Java JDK
 		then
-			# Trixie without openHAB
-			if (( $G_DISTRO > 7 && ${aSOFTWARE_INSTALL_STATE[206]} < 1 ))
+			# Trixie
+			if (( $G_DISTRO > 7 ))
 			then
 				local version=25
+				# openHAB does not support Java 25 yet
+				(( ${aSOFTWARE_INSTALL_STATE[206]} < 1 )) && version=21
 
 			# Bullseye/Bookworm
 			else
@@ -3612,8 +3616,6 @@ _EOF_
 
 			G_BACKUP_FP /etc/nginx/nginx.conf
 			dps_index=$software_id Download_Install 'nginx.conf' /etc/nginx/nginx.conf
-			# Adjust socket name to PHP version
-			G_EXEC sed --follow-symlinks -i "s#/run/php/php.*-fpm.sock#/run/php/php$PHP_VERSION-fpm.sock#g" /etc/nginx/nginx.conf
 
 			# CPU core count
 			G_EXEC sed --follow-symlinks -i "/worker_processes/c\worker_processes $G_HW_CPU_CORES;" /etc/nginx/nginx.conf
@@ -3632,43 +3634,11 @@ _EOF_
 
 		if To_Install 84 lighttpd # Lighttpd
 		then
-			# Migrate existing configs in case of distro upgrades
-			local deflate=() openssl=()
-			if [[ -f '/etc/lighttpd/lighttpd.conf' ]]
-			then
-				# mod_compress has been superseded by mod_deflate
-				if grep -q '^[[:blank:]]*"mod_compress",$' /etc/lighttpd/lighttpd.conf
-				then
-					G_DIETPI-NOTIFY 2 'Bullseye upgrade detected: Migrating from mod_compress to mod_deflate'
-					G_EXEC sed --follow-symlinks -Ei '/^compress\..*=[[:blank:]]*["(].*[")]$/d' /etc/lighttpd/lighttpd.conf
-					G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*"mod_compress",$/d' /etc/lighttpd/lighttpd.conf
-					deflate=('lighttpd-mod-deflate')
-				fi
-
-				# Install OpenSSL module if DietPi-LetsEncrypt was used
-				if [[ -f '/boot/dietpi/.dietpi-letsencrypt' ]]
-				then
-					G_DIETPI-NOTIFY 2 'DietPi-LetsEncrypt usage detected: Installing OpenSSL module'
-					openssl=('lighttpd-mod-openssl')
-					[[ -f '/etc/lighttpd/conf-available/50-dietpi-https.conf' ]] && ! grep -q '"mod_openssl"' /etc/lighttpd/conf-available/50-dietpi-https.conf && G_EXEC sed --follow-symlinks -i '1iserver.modules += ( "mod_openssl" )' /etc/lighttpd/conf-available/50-dietpi-https.conf
-				fi
-
-				# Remove obsolete socket version string from FPM module
-				if [[ -f '/etc/lighttpd/conf-available/15-fastcgi-php-fpm.conf' ]] && grep -q 'php.\..-fpm\.sock' /etc/lighttpd/conf-available/15-fastcgi-php-fpm.conf
-				then
-					G_DIETPI-NOTIFY 2 'Bullseye upgrade detected: Removing obsolete socket version string from FPM module'
-					G_EXEC sed --follow-symlinks -i 's/php.\..-fpm\.sock/php-fpm.sock/' /etc/lighttpd/conf-available/15-fastcgi-php-fpm.conf
-				fi
-			fi
-
 			# perl is required for lighty-enable-mod, but is a recommendation only
-			G_AGI lighttpd perl "${deflate[@]}" "${openssl[@]}"
+			G_AGI lighttpd perl
 			G_EXEC systemctl stop lighttpd
 
 			Remove_SysV lighttpd
-
-			# Enable mod_deflate if flagged
-			[[ ${deflate[0]} && ! -f '/etc/lighttpd/conf-enabled/20-deflate.conf' ]] && G_EXEC lighty-enable-mod deflate
 
 			# Change webroot from /var/www/html to /var/www
 			G_CONFIG_INJECT 'server.document-root' 'server.document-root = "/var/www"' /etc/lighttpd/lighttpd.conf
@@ -3858,12 +3828,6 @@ sudo sysctl -p /etc/sysctl.d/98-dietpi-redis.conf'
 			# - APCu
 			G_CONFIG_INJECT 'apc.shm_size[[:blank:]=]' "apc.shm_size=$(( $cache_size / 2 ))M" "$target_php_ini"
 			G_CONFIG_INJECT 'apc.ttl[[:blank:]=]' 'apc.ttl=259200' "$target_php_ini" # 3 days
-
-			# Enable all available PHP modules
-			local amodules=()
-			mapfile -t amodules < <(find "/etc/php/$PHP_VERSION/mods-available" -type f -name '*.ini' -printf '%f\n')
-			G_EXEC phpenmod "${amodules[@]%.ini}"
-			unset -v amodules
 
 			# Apache: Enable PHP-FPM
 			command -v a2enconf > /dev/null && { G_EXEC a2enmod proxy_fcgi setenvif; G_EXEC a2enconf "php$PHP_VERSION-fpm"; }
@@ -6238,7 +6202,8 @@ _EOF_
 			# .NET dependency: https://github.com/dotnet/docs/blob/main/docs/core/install/linux-debian.md#dependencies
 			case $G_DISTRO in
 				6) aDEPS=('libicu67');;
-				*) aDEPS=('libicu72');;
+				7) aDEPS=('libicu72');;
+				*) aDEPS=('libicu76');;
 			esac
 
 			case $G_HW_ARCH in
@@ -7285,9 +7250,9 @@ _EOF_
 			# Fix Dropbear filter for STDOUT logging since Bookworm: https://github.com/fail2ban/fail2ban/pull/3597
 			[[ -f '/etc/fail2ban/filter.d/dropbear.local' ]] || G_EXEC curl -sSf 'https://raw.githubusercontent.com/fail2ban/fail2ban/master/config/filter.d/dropbear.conf' -o /etc/fail2ban/filter.d/dropbear.local
 
-			# Trixie: Temporarily install python3-setuptools explicitly, until post-v1.1.0 release removes the need: https://packages.debian.org/trixie/fail2ban. python3-systemd on the other hand has become hard package dependency since Trixie.
+			# Trixie: python3-systemd has become hard package dependency
 			local deps=()
-			(( $G_DISTRO > 7 )) && deps=('python3-setuptools') || deps=('python3-systemd')
+			(( $G_DISTRO > 7 )) || deps=('python3-systemd')
 			G_AGI "${deps[@]}" fail2ban
 			Remove_SysV fail2ban 1
 
@@ -9482,7 +9447,8 @@ _EOF_
 				# - .NET: https://github.com/dotnet/docs/blob/main/docs/core/install/linux-debian.md#dependencies
 				case $G_DISTRO in
 					6) aDEPS+=('libicu67');;
-					*) aDEPS+=('libicu72');;
+					7) aDEPS+=('libicu72');;
+					*) aDEPS+=('libicu76');;
 				esac
 
 				# Download
@@ -9568,7 +9534,8 @@ _EOF_
 			then
 				case $G_DISTRO in
 					6) aDEPS+=('libicu67');;
-					*) aDEPS+=('libicu72');;
+					7) aDEPS+=('libicu72');;
+					*) aDEPS+=('libicu76');;
 				esac
 			fi
 
@@ -9655,7 +9622,8 @@ _EOF_
 			then
 				case $G_DISTRO in
 					6) aDEPS+=('libicu67');;
-					*) aDEPS+=('libicu72');;
+					7) aDEPS+=('libicu72');;
+					*) aDEPS+=('libicu76');;
 				esac
 			fi
 
@@ -9868,7 +9836,8 @@ _EOF_
 			then
 				case $G_DISTRO in
 					6) aDEPS=('libicu67');;
-					*) aDEPS=('libicu72');;
+					7) aDEPS=('libicu72');;
+					*) aDEPS=('libicu76');;
 				esac
 			fi
 
@@ -9998,7 +9967,8 @@ _EOF_
 			# .NET dependency: https://github.com/dotnet/docs/blob/main/docs/core/install/linux-debian.md#dependencies
 			case $G_DISTRO in
 				6) aDEPS=('libicu67');;
-				*) aDEPS=('libicu72');;
+				7) aDEPS=('libicu72');;
+				*) aDEPS=('libicu76');;
 			esac
 
 			# Download
@@ -10066,7 +10036,8 @@ _EOF_
 			# .NET dependency: https://github.com/dotnet/docs/blob/main/docs/core/install/linux-debian.md#dependencies
 			case $G_DISTRO in
 				6) aDEPS=('libicu67');;
-				*) aDEPS=('libicu72');;
+				7) aDEPS=('libicu72');;
+				*) aDEPS=('libicu76');;
 			esac
 
 			# Download
@@ -10246,7 +10217,8 @@ _EOF_
 			# .NET dependency: https://github.com/dotnet/docs/blob/main/docs/core/install/linux-debian.md#dependencies
 			case $G_DISTRO in
 				6) aDEPS=('libicu67');;
-				*) aDEPS=('libicu72');;
+				7) aDEPS=('libicu72');;
+				*) aDEPS=('libicu76');;
 			esac
 
 			# Reinstall: Skip download and install, advice to use internal updater
@@ -10315,7 +10287,7 @@ _EOF_
 
 				G_AGI steam
 
-				#Reapply GPU drivers to install required i386 items
+				# Reapply GPU drivers to install required i386 items
 				local gpu_current=$(sed -n '/^[[:blank:]]*CONFIG_GPU_DRIVER=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 				/boot/dietpi/func/dietpi-set_hardware gpudriver "$gpu_current"
 
@@ -10441,8 +10413,6 @@ _EOF_
 
 		if To_Install 134 # Docker Compose
 		then
-			[[ -f '/usr/local/bin/docker-compose' ]] && G_EXEC rm /usr/local/bin/docker-compose # Pre-v8.14
-			command -v docker-compose > /dev/null && command -v pip3 > /dev/null && G_EXEC_OUTPUT=1 G_EXEC pip3 uninstall -y docker-compose # Pre-v8.2
 			G_AGI docker-compose-plugin
 		fi
 

--- a/dietpi/dietpi-update
+++ b/dietpi/dietpi-update
@@ -292,8 +292,8 @@
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Installing new DietPi code'
 		G_EXEC_DESC='Downloading update archive' G_EXEC curl -sSfLO "https://github.com/$GITOWNER_TARGET/DietPi/archive/$GITBRANCH_TARGET.tar.gz"
 		G_EXEC_DESC='Unpacking update archive' G_EXEC tar xf "${GITBRANCH_TARGET##*/}.tar.gz" # Support for Git branch names with forward slashes
+		G_EXEC_DESC='Removing update archive' G_EXEC rm "${GITBRANCH_TARGET##*/}.tar.gz"
 		local dir="DietPi-${GITBRANCH_TARGET//\//-}" # GitHub translates forward slashes into dashes
-		G_EXEC_DESC='Removing unused files' G_EXEC rm "${GITBRANCH_TARGET##*/}.tar.gz"
 		G_EXEC_DESC='Hardening update archive mode' G_EXEC chmod -R g-w "$dir"
 		G_EXEC_DESC='Installing new DietPi scripts' G_EXEC cp -a "$dir/dietpi" /boot/
 		G_EXEC_DESC='Installing new DietPi system files' G_EXEC cp -a "$dir/rootfs/." /


### PR DESCRIPTION
Add `dietpi-trixie-upgrade` to work the same way for seamless Debian upgrade like `dietpi-bookworm-upgrade` does.

### Some additional changes were done to simplify and enhence the work of those scripts:
- Our Nginx config does not use the versioned PHP-FPM socket anymore, but the generic symlink. The change is applied as well on DietPi update, so that the migration does not need to be carried in `dietpi-software`, and the upgrade script does not need to reinstall Nginx for the change.
- The 3 Buster => Bullseye migration steps for Lighttpd are now done on DietPi update, so that the code does not need to be carried in `dietpi-software`, and the upgrade script does not need to reinstall Lighttpd.
- For completeness, the versioned Apache PHP-FPM module is enabled on PHP (re)install, which is needed in any case.
- The Docker Compose migration from `docker-compose` to native Docker plugin is now done on DietPi update. This allows us to properly inform users, while previously the missing `docker-compose` command (in favour of `docker compose`) could cause confusion. That we we do not need to handle this in `dietpi-software` and the migration scripts hence do not need to reinstall Docker Compose, since it cannot be a Python module anymore.

### Further updates have been done to the Bookworm upgrade script:
- Added missing Pydio and Raspotify for ARMv6 to incompatible software list
- Migrate backports from archive back to main repo
- Add MediaWiki to reinstalls, which depends on additional PHP modules
- The libicu version is migrated if manually installed for e.g. .NET
- The PostgreSQL migration is been complemented and hardened: Instead of only the main cluster, all clusters are migrated, but only if the respective cluster for the new version does not exist yet. On Bookworm, it is auto-generated, which can however be prevented, and is hereby done. On Trixie, this is not needed anymore, since the main cluster auto-generation is skipped if any cluster of any PostgreSQL version exists. The migration requires both PostgreSQL versions to be installed. The old version is prevent from autoremoval via APT config. If all clusters could be migrated, this config is removed, else it is kept, and the user informed.

### Unrelated changes:
- Fix typo in Nextcloud config update
- Fix syntax in Bullseye backports pre-patch
- Fix Java install on Trixie if openHAB is installed as well: Trixie does not provide Java 17 anymoe, but Java 21, which is as well the recommended version for openHAB (which does not support Java 25 yet)
- Fix libicu install on Trixie for .NET, where a new package libicu76 is provided now
- PHP (re)installs do tno enable all PHP modules anymore. Defaults are fine, other PHP applications enable all needed modules explicitly, and it breaks possible tailored setups, like my personal ones.