### PR TITLE
dietpi-software: Domoticz: add and use own builds

### DIFF
--- a/.build/software/dietpi-software-build.bash
+++ b/.build/software/dietpi-software-build.bash
@@ -55,7 +55,7 @@ do
 	esac
 	shift
 done
-[[ $NAME =~ ^('amiberry'|'amiberry-lite'|'gzdoom'|'gmediarender'|'gogs'|'shairport-sync'|'squeezelite'|'unbound'|'vaultwarden'|'ympd')$ ]] || Error_Exit "Invalid software title \"$NAME\" passed"
+[[ $NAME =~ ^('amiberry'|'amiberry-lite'|'domoticz'|'gzdoom'|'gmediarender'|'gogs'|'shairport-sync'|'squeezelite'|'unbound'|'vaultwarden'|'ympd')$ ]] || Error_Exit "Invalid software title \"$NAME\" passed"
 [[ $NAME == 'gogs' ]] && EXT='7z' || EXT='deb'
 [[ $DISTRO =~ ^('bullseye'|'bookworm'|'trixie')$ ]] || Error_Exit "Invalid distro \"$DISTRO\" passed"
 case $ARCH in

--- a/.build/software/domoticz/build.bash
+++ b/.build/software/domoticz/build.bash
@@ -1,0 +1,220 @@
+#!/bin/bash
+{
+. /boot/dietpi/func/dietpi-globals || exit 1
+Error_Exit(){ G_DIETPI-NOTIFY 1 "$1, aborting ..."; exit 1; }
+
+# Apply GitHub token if set
+header=()
+[[ $GH_TOKEN ]] && header=('-H' "Authorization: token $GH_TOKEN")
+
+# APT dependencies
+adeps_build=('git' 'cmake' 'make' 'g++' 'libssl-dev' 'liblua5.3-dev' 'python3-dev' 'libsqlite3-dev' 'libboost-system-dev' 'libboost-thread-dev' 'libcurl4-openssl-dev' 'libusb-dev')
+adeps=('libc6' 'libsqlite3-0' 'libusb-0.1-4')
+case $G_DISTRO in
+	6) adeps+=('libssl1.1' 'libcurl4');;
+	7) adeps+=('libssl3' 'libcurl4');;
+	8) adeps+=('libssl3t64' 'libcurl4t64');;
+	*) Error_Exit "Unsupported distro version: $G_DISTRO_NAME (ID=$G_DISTRO)";;
+esac
+
+G_AGUP
+G_AGDUG "${adeps_build[@]}"
+for i in "${adeps[@]}"
+do
+	dpkg-query -s "$i" &> /dev/null || Error_Exit "Expected dependency package was not installed: $i"
+done
+
+G_DIETPI-NOTIFY 2 'Building OpenZWave'
+G_EXEC cd /tmp
+# Full clone needed for "git describe", used in build to obtain full version string
+G_EXEC_OUTPUT=1 G_EXEC git clone 'https://github.com/domoticz/open-zwave' open-zwave-read-only
+G_EXEC cd open-zwave-read-only
+G_EXEC_OUTPUT=1 G_EXEC make
+
+# Build
+NAME='domoticz'
+ORGA='domoticz'
+PRETTY='Domoticz'
+version=$(curl -sSf "${header[@]}" "https://api.github.com/repos/$ORGA/$NAME/releases/latest" | mawk -F\" '/^  "tag_name"/{print $4}')
+[[ $version ]] || Error_Exit "No latest $PRETTY version found"
+branch='development' # Temporary
+G_DIETPI-NOTIFY 2 "Building $PRETTY version \e[33m$version"
+G_EXEC cd /tmp
+[[ -d $NAME ]] && G_EXEC rm -R "$NAME"
+G_EXEC_OUTPUT=1 G_EXEC git clone --depth=1 --recurse-submodules --shallow-submodules -b "$branch" "https://github.com/$ORGA/$NAME"
+[[ -d 'build' ]] && G_EXEC rm -R build
+G_EXEC cd "$NAME"
+DIR="/tmp/${NAME}_$G_HW_ARCH_NAME"
+export CFLAGS='-g0 -O3' CXXFLAGS='-g0 -O3'
+G_EXEC_OUTPUT=1 G_EXEC cmake -B ../build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$DIR/opt/$NAME" -DDISABLE_UPDATER=1
+G_EXEC_OUTPUT=1 G_EXEC make -C ../build "-j$(nproc)"
+[[ -d $DIR ]] && G_EXEC rm -R "$DIR"
+G_EXEC_OUTPUT=1 G_EXEC make -C ../build install
+G_EXEC strip --remove-section=.comment --remove-section=.note "$DIR/opt/$NAME/$NAME"
+
+# Cleanup
+G_EXEC rm "$DIR/opt/$NAME/scripts/"{_domoticz_main.bat,download_update.sh,install.sh,restart_domoticz,update_domoticz}
+
+# Prepare DEB package
+G_DIETPI-NOTIFY 2 "Building $PRETTY DEB package"
+G_EXEC mkdir -p "$DIR/"{DEBIAN,lib/systemd/system,"mnt/dietpi_userdata/$NAME",etc/sudoers.d}
+
+# - configs
+G_EXEC mv "$DIR/opt/$NAME/scripts/$NAME.conf" "$DIR/mnt/dietpi_userdata/$NAME/"
+G_EXEC mv "$DIR/opt/$NAME/scripts" "$DIR/mnt/dietpi_userdata/$NAME/"
+G_EXEC sed --follow-symlinks -i '/^# Disable update checking$/,/^$/d' "$DIR/mnt/dietpi_userdata/$NAME/$NAME.conf"
+grep 'updates=' "$DIR/mnt/dietpi_userdata/$NAME/$NAME.conf" && Error_Exit 'Internal updater section still present in config file'
+G_CONFIG_INJECT 'http_port=' 'http_port=0' "$DIR/mnt/dietpi_userdata/$NAME/$NAME.conf"
+G_CONFIG_INJECT 'ssl_port=' 'ssl_port=8424' "$DIR/mnt/dietpi_userdata/$NAME/$NAME.conf"
+G_CONFIG_INJECT 'ssl_cert=' "ssl_cert=/opt/$NAME/server_cert.pem" "$DIR/mnt/dietpi_userdata/$NAME/$NAME.conf"
+G_CONFIG_INJECT 'ssl_key=' "ssl_key=/opt/$NAME/server_cert.pem" "$DIR/mnt/dietpi_userdata/$NAME/$NAME.conf"
+G_CONFIG_INJECT 'ssl_dhparam=' "ssl_dhparam=/opt/$NAME/server_cert.pem" "$DIR/mnt/dietpi_userdata/$NAME/$NAME.conf"
+G_CONFIG_INJECT 'loglevel=' 'loglevel=error' "$DIR/mnt/dietpi_userdata/$NAME/$NAME.conf"
+G_CONFIG_INJECT 'syslog=' 'syslog=local7' "$DIR/mnt/dietpi_userdata/$NAME/$NAME.conf"
+G_CONFIG_INJECT 'dbase_file=' "dbase_file=/mnt/dietpi_userdata/$NAME/$NAME.db" "$DIR/mnt/dietpi_userdata/$NAME/$NAME.conf"
+G_CONFIG_INJECT 'app_path=' "app_path=/opt/$NAME" "$DIR/mnt/dietpi_userdata/$NAME/$NAME.conf"
+G_CONFIG_INJECT 'userdata_path=' "userdata_path=/mnt/dietpi_userdata/$NAME" "$DIR/mnt/dietpi_userdata/$NAME/$NAME.conf"
+
+# - sudoers: permit shutdown/restart from web UI
+G_EXEC eval "echo '$NAME ALL=NOPASSWD: $(command -v shutdown)' > '$DIR/etc/sudoers.d/$NAME'"
+
+# - conffiles
+find "$DIR/mnt/dietpi_userdata/$NAME" -type f | sed "s|^$DIR||" > "$DIR/DEBIAN/conffiles" || exit 1
+G_EXEC eval "echo '/etc/sudoers.d/$NAME' >> '$DIR/DEBIAN/conffiles'"
+
+# - service
+cat << _EOF_ > "$DIR/lib/systemd/system/$NAME.service" || exit 1
+[Unit]
+Description=$PRETTY
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=$NAME
+ExecStart=/opt/$NAME/$NAME -f /mnt/dietpi_userdata/$NAME/$NAME.conf
+
+# Hardening
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=yes
+ReadWritePaths=/mnt/dietpi_userdata/$NAME
+
+[Install]
+WantedBy=multi-user.target
+_EOF_
+
+# - postinst
+cat << _EOF_ > "$DIR/DEBIAN/postinst" || exit 1
+#!/bin/dash -e
+if [ -d '/run/systemd/system' ]
+then
+	if getent passwd $NAME > /dev/null
+	then
+		echo 'Configuring $PRETTY service user "$NAME" ...'
+		usermod -aG dialout -d /mnt/dietpi_userdata/$NAME -s /usr/sbin/nologin $NAME
+	else
+		echo 'Creating $PRETTY service user "$NAME" ...'
+		useradd -rMU -G dialout -d /mnt/dietpi_userdata/$NAME -s /usr/sbin/nologin $NAME
+	fi
+
+	echo 'Setting up $PRETTY data dir "/mnt/dietpi_userdata/$NAME" ...'
+	chown -R '$NAME:$NAME' /mnt/dietpi_userdata/$NAME
+
+	echo 'Configuring $PRETTY systemd service ...'
+	systemctl --no-reload unmask $NAME
+	systemctl enable $NAME
+	pgrep -x 'dietpi-software' || systemctl restart $NAME
+fi
+_EOF_
+
+# - prerm
+cat << _EOF_ > "$DIR/DEBIAN/prerm" || exit 1
+#!/bin/dash -e
+if [ "\$1" = 'remove' ] && [ -d '/run/systemd/system' ] && [ -f '/lib/systemd/system/$NAME.service' ]
+then
+	echo 'Deconfiguring $PRETTY systemd service ...'
+	systemctl --no-reload unmask $NAME
+	systemctl --no-reload disable --now $NAME
+fi
+_EOF_
+
+# - postrm
+cat << _EOF_ > "$DIR/DEBIAN/postrm" || exit 1
+#!/bin/dash -e
+if [ "\$1" = 'purge' ]
+then
+	if [ -d '/etc/systemd/system/$NAME.service.d' ]
+	then
+		echo 'Removing $PRETTY systemd service overrides ...'
+		rm -rv /etc/systemd/system/$NAME.service.d
+	fi
+
+	if [ -d '/mnt/dietpi_userdata/$NAME' ]
+	then
+		echo 'Removing $PRETTY data dir ...'
+		rm -rv /mnt/dietpi_userdata/$NAME
+	fi
+
+	if getent passwd $NAME > /dev/null
+	then
+		echo 'Removing $PRETTY service user "$NAME" ...'
+		userdel $NAME
+	fi
+
+	if getent group $NAME > /dev/null
+	then
+		echo 'Removing $PRETTY service group "$NAME" ...'
+		groupdel $NAME
+	fi
+fi
+_EOF_
+
+# - md5sums
+find "$DIR" ! \( -path "$DIR/DEBIAN" -prune \) -type f -exec md5sum {} + | sed "s|$DIR/||" > "$DIR/DEBIAN/md5sums"
+
+# - Obtain DEB dependency versions
+DEPS_APT_VERSIONED=
+for i in "${adeps[@]}"
+do
+	DEPS_APT_VERSIONED+=" $i (>= $(dpkg-query -Wf '${version}' "$i")),"
+done
+DEPS_APT_VERSIONED=${DEPS_APT_VERSIONED%,}
+# shellcheck disable=SC2001
+[[ $G_HW_ARCH_NAME == 'armv6l' ]] && DEPS_APT_VERSIONED=$(sed 's/+rp[it][0-9]\+[^)]*)/)/g' <<< "$DEPS_APT_VERSIONED") || DEPS_APT_VERSIONED=$(sed 's/+b[0-9]\+)/)/g' <<< "$DEPS_APT_VERSIONED")
+
+# - Obtain version suffix
+G_EXEC_NOHALT=1 G_EXEC curl -sSfo package.deb "https://dietpi.com/downloads/binaries/$G_DISTRO_NAME/${NAME}_$G_HW_ARCH_NAME.deb"
+old_version=$(dpkg-deb -f package.deb Version)
+G_EXEC_NOHALT=1 G_EXEC rm package.deb
+suffix=${old_version#*-dietpi}
+[[ $old_version == "$version-"* ]] && version+="-dietpi$((suffix+1))" || version+="-dietpi1"
+G_DIETPI-NOTIFY 2 "Old package version is:       \e[33m${old_version:-N/A}"
+G_DIETPI-NOTIFY 2 "Building new package version: \e[33m$version"
+
+# - control
+cat << _EOF_ > "$DIR/DEBIAN/control"
+Package: $NAME
+Version: $version
+Architecture: $(dpkg --print-architecture)
+Maintainer: MichaIng <micha@dietpi.com>
+Date: $(date -uR)
+Installed-Size: $(du -sk "$DIR" | mawk '{print $1}')
+Depends:$DEPS_APT_VERSIONED
+Section: misc
+Priority: optional
+Homepage: https://www.domoticz.com/
+Description: Open source home automation platform
+_EOF_
+G_CONFIG_INJECT 'Installed-Size: ' "Installed-Size: $(du -sk "$DIR" | mawk '{print $1}')" "$DIR/DEBIAN/control"
+
+# - Permissions
+G_EXEC chown -R 0:0 "$DIR"
+G_EXEC find "$DIR" -type f -exec chmod 0644 {} +
+G_EXEC find "$DIR" -type d -exec chmod 0755 {} +
+G_EXEC chmod +x "$DIR/"{"opt/$NAME/$NAME",DEBIAN/{postinst,prerm,postrm}}
+
+# Build DEB package
+G_EXEC_OUTPUT=1 G_EXEC dpkg-deb -b "$DIR"
+
+exit 0
+}

--- a/.github/workflows/dietpi-software-build.yml
+++ b/.github/workflows/dietpi-software-build.yml
@@ -5,7 +5,7 @@ on:
       name:
         description: 'Software title'
         type: choice
-        options: [amiberry, amiberry-lite, gzdoom, gmediarender, gogs, shairport-sync, squeezelite, unbound, vaultwarden, ympd, all]
+        options: [amiberry, amiberry-lite, domoticz, gzdoom, gmediarender, gogs, shairport-sync, squeezelite, unbound, vaultwarden, ympd, all]
         default: all
         required: true
       arch:
@@ -36,7 +36,7 @@ jobs:
       run: |
         if [ '${{ github.event.inputs.name }}' = 'all' ]
         then
-          echo 'name=["amiberry", "amiberry-lite", "gzdoom", "gmediarender", "gogs", "shairport-sync", "squeezelite", "unbound", "vaultwarden", "ympd"]' >> "$GITHUB_OUTPUT"
+          echo 'name=["amiberry", "amiberry-lite", "domoticz", "gzdoom", "gmediarender", "gogs", "shairport-sync", "squeezelite", "unbound", "vaultwarden", "ympd"]' >> "$GITHUB_OUTPUT"
         else
           echo 'name=["${{ github.event.inputs.name }}"]' >> "$GITHUB_OUTPUT"
         fi

--- a/.github/workflows/dietpi-software.bash
+++ b/.github/workflows/dietpi-software.bash
@@ -185,7 +185,7 @@ Process_Software()
 			137) aCOMMANDS[i]='/opt/mjpg-streamer/mjpg_streamer -v';; # aSERVICES[i]='mjpg-streamer' aTCP[i]='8082' Service does not start without an actual video device
 			138) aSERVICES[i]='virtualhere' aTCP[i]='7575';;
 			139) aSERVICES[i]='sabnzbd' aTCP[i]='8080'; (( $arch == 10 )) || aDELAY[i]=30;; # ToDo: Solve conflict with Airsonic
-			140) aSERVICES[i]='domoticz' aTCP[i]='8124 8424';;
+			140) aSERVICES[i]='domoticz' aTCP[i]='8424';;
 			#142) aSERVICES[i]='snapd';; "system does not fully support snapd: cannot mount squashfs image using "squashfs": mount: /tmp/syscheck-mountpoint-2075108377: mount failed: Operation not permitted."
 			143) aSERVICES[i]='koel' aTCP[i]='8003'; (( $emulation )) && aDELAY[i]=30;;
 			144) aSERVICES[i]='sonarr' aTCP[i]='8989';;
@@ -339,7 +339,7 @@ then
 	# shellcheck disable=SC2016
 	G_EXEC sed --follow-symlinks -i '/# Start DietPi-Software/a\G_EXEC sed --follow-symlinks -i '\''s|dietpi.com/downloads/binaries/$G_DISTRO_NAME/|dietpi.com/downloads/binaries/$G_DISTRO_NAME/testing/|'\'' /boot/dietpi/dietpi-software' rootfs/boot/dietpi/dietpi-login
 	# shellcheck disable=SC2016
-	G_EXEC sed --follow-symlinks -i '/# Start DietPi-Software/a\G_EXEC sed --follow-symlinks -Ei '\''s@G_AGI "?(amiberry|amiberry-lite|gmediarender|gzdoom|shairport-sync\\$airplay2|squeezelite|unbound|vaultwarden|ympd)"?@Download_Install "https://dietpi.com/downloads/binaries/$G_DISTRO_NAME/\\1""_$G_HW_ARCH_NAME.deb"@'\'' /boot/dietpi/dietpi-software' rootfs/boot/dietpi/dietpi-login
+	G_EXEC sed --follow-symlinks -i '/# Start DietPi-Software/a\G_EXEC sed --follow-symlinks -Ei '\''s@G_AGI "?(amiberry|amiberry-lite|domoticz|gmediarender|gzdoom|shairport-sync\\$airplay2|squeezelite|unbound|vaultwarden|ympd)"?@Download_Install "https://dietpi.com/downloads/binaries/$G_DISTRO_NAME/\\1""_$G_HW_ARCH_NAME.deb"@'\'' /boot/dietpi/dietpi-software' rootfs/boot/dietpi/dietpi-login
 	G_CONFIG_INJECT 'SOFTWARE_DIETPI_DASHBOARD_VERSION=' 'SOFTWARE_DIETPI_DASHBOARD_VERSION=Nightly' rootfs/boot/dietpi.txt
 fi
 

--- a/.update/patches
+++ b/.update/patches
@@ -2205,60 +2205,6 @@ _EOF_
 	# Software updates, migrations and patches
 	if [[ -f '/boot/dietpi/.installed' ]]
 	then
-		# Pi-hole v6 migration
-		# - /etc/pihole/pihole.toml indicates that Pi-hole has been upgraded to v6 already.
-		# - The /var/www/pihole symlink indicates that an instance installed via dietpi-software has not been migrated yet.
-		if [[ -f '/etc/pihole/pihole.toml' && -L '/var/www/pihole' ]] && grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[93\]=2' /boot/dietpi/.installed
-		then
-			# Remove DietPi specific v5 files
-			# - Symlinks
-			G_EXEC rm /var/www/pihole
-			[[ -L '/var/www/admin' ]] && G_EXEC rm /var/www/admin
-			# - Webserver configs
-			[[ -d '/etc/apache2/sites-available' ]] && G_EXEC rm -f /etc/apache2/sites-{available,enabled}/dietpi-pihole*
-			[[ -d '/etc/lighttpd/conf-available' ]] && G_EXEC rm -f /etc/lighttpd/conf-{available,enabled}/99-dietpi-pihole*
-			[[ -d '/etc/nginx/sites-dietpi' ]] && G_EXEC rm -f /etc/nginx/sites-dietpi/dietpi-pihole*
-
-			# Remove www-data user from pihole group
-			getent group pihole | grep -Eq '(:|,)www-data(,|$)' && G_EXEC gpasswd -d www-data pihole
-
-			# Change web UI port to 8089 and 8489 (HTTPS) to avoid conflict with webservers and other web applications
-			G_EXEC pihole-FTL --config webserver.port 8089,8489s
-
-			# Inform user about differences to stock Pi-hole installation
-			G_WHIP_MSG "[ INFO ] Pi-hole network ports changed to 8089 and 8489
-\nTo align migrated Pi-hole v6 instances with fresh installs, and avoid possible conflicts with dedicated webservers, the network ports have been changed to 8089 and 8489 (HTTPS). Your Pi-hole instance will hence be available at:
-- http://$(G_GET_NET ip):8089/admin/
-- https://$(G_GET_NET ip):8489/admin/
-\nThis can be changed via web UI or following console command, e.g. for ports 80 and 443 (HTTPS):
-- pihole-FTL --config webserver.port 80,443s"
-
-			# Offer to uninstall webserver and PHP if no dependant is installed
-			# - If only PHP or only a webserver is installed, one has been uninstalled already, and the other is assumed to be still needed for something else.
-			if grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[89\]=2' /boot/dietpi/.installed && grep -Eq '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[(83|84|85)\]=2' /boot/dietpi/.installed
-			then
-				G_WHIP_CHECKLIST_ARRAY=()
-				# - webserver
-				if ! /boot/dietpi/dietpi-software list | grep -q '| =2 |.*+webserver'
-				then
-					grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[83\]=2' /boot/dietpi/.installed && G_WHIP_CHECKLIST_ARRAY+=(83 'Apache webserver' off)
-					grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[84\]=2' /boot/dietpi/.installed && G_WHIP_CHECKLIST_ARRAY+=(84 'Lighttpd webserver' off)
-					grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[85\]=2' /boot/dietpi/.installed && G_WHIP_CHECKLIST_ARRAY+=(85 'Nginx webserver' off)
-				fi
-				# - PHP: Exclude webserver stacks which are meta selections only
-				/boot/dietpi/dietpi-software list | grep '| =2 |.*+PHP' | grep -vEq '^.\[32mID (75|76|78|79|81|82)' || G_WHIP_CHECKLIST_ARRAY+=(89 'PHP server' off)
-				if (( ${#G_WHIP_CHECKLIST_ARRAY[@]} ))
-				then
-					G_WHIP_BUTTON_CANCEL_TEXT='Skip'
-					# shellcheck disable=SC2086
-					G_WHIP_CHECKLIST '[ INFO ] Possibly obsolete webserver and/or PHP installation detected
-\nYou recently updated Pi-hole to v6, which now does not require any webserver or PHP anymore.
-\nWe detected a webserver and/or PHP installation on your system, but no dependant among installed dietpi-software options.
-\nIf you are sure that you do not require the webserver and/or PHP anymore, you can select them for uninstall below. Use the space bar to (de)select the ones which shall be uninstalled:' && /boot/dietpi/dietpi-software uninstall $G_WHIP_RETURNED_VALUE
-				fi
-			fi
-		fi
-
 		# Nextcloud
 		[[ -f '/etc/apache2/sites-available/dietpi-nextcloud.conf' ]] && G_EXEC mv "../DietPi-Update/DietPi-${G_GITBRANCH//\//-}/.conf/dps_114/apache.nextcloud.conf" /etc/apache2/sites-available/dietpi-nextcloud.conf
 
@@ -2323,6 +2269,77 @@ _EOF_
 				G_AGI docker-compose-plugin
 				command -v docker-compose > /dev/null && command -v pip3 > /dev/null && G_EXEC_OUTPUT=1 G_EXEC pip3 uninstall -y docker-compose # Pre-v8.2
 				[[ -f '/usr/local/bin/docker-compose' ]] && G_EXEC rm /usr/local/bin/docker-compose # Pre-v8.14
+			fi
+		fi
+	fi
+}
+
+Patch_9_16()
+{
+	# Software updates, migrations and patches
+	if [[ -f '/boot/dietpi/.installed' ]]
+	then
+		# Domoticz
+		if grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[140\]=2' /boot/dietpi/.installed
+		then
+			G_DIETPI-NOTIFY 2 'Migrating Domoticz to our new APT package'
+			[[ -f '/etc/systemd/system/domoticz.service' ]] && G_EXEC rm /etc/systemd/system/domoticz.service
+			[[ -d '/opt/domoticz' ]] && G_EXEC rm -R /opt/domoticz
+			G_AGI domoticz
+			G_EXEC apt-mark auto libusb-0.1-4 libcurl3-gnutls
+		fi
+
+		# Pi-hole v6 migration
+		# - /etc/pihole/pihole.toml indicates that Pi-hole has been upgraded to v6 already.
+		# - The /var/www/pihole symlink indicates that an instance installed via dietpi-software has not been migrated yet.
+		if [[ -f '/etc/pihole/pihole.toml' && -L '/var/www/pihole' ]] && grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[93\]=2' /boot/dietpi/.installed
+		then
+			# Remove DietPi specific v5 files
+			# - Symlinks
+			G_EXEC rm /var/www/pihole
+			[[ -L '/var/www/admin' ]] && G_EXEC rm /var/www/admin
+			# - Webserver configs
+			[[ -d '/etc/apache2/sites-available' ]] && G_EXEC rm -f /etc/apache2/sites-{available,enabled}/dietpi-pihole*
+			[[ -d '/etc/lighttpd/conf-available' ]] && G_EXEC rm -f /etc/lighttpd/conf-{available,enabled}/99-dietpi-pihole*
+			[[ -d '/etc/nginx/sites-dietpi' ]] && G_EXEC rm -f /etc/nginx/sites-dietpi/dietpi-pihole*
+
+			# Remove www-data user from pihole group
+			getent group pihole | grep -Eq '(:|,)www-data(,|$)' && G_EXEC gpasswd -d www-data pihole
+
+			# Change web UI port to 8089 and 8489 (HTTPS) to avoid conflict with webservers and other web applications
+			G_EXEC pihole-FTL --config webserver.port 8089,8489s
+
+			# Inform user about differences to stock Pi-hole installation
+			G_WHIP_MSG "[ INFO ] Pi-hole network ports changed to 8089 and 8489
+\nTo align migrated Pi-hole v6 instances with fresh installs, and avoid possible conflicts with dedicated webservers, the network ports have been changed to 8089 and 8489 (HTTPS). Your Pi-hole instance will hence be available at:
+- http://$(G_GET_NET ip):8089/admin/
+- https://$(G_GET_NET ip):8489/admin/
+\nThis can be changed via web UI or following console command, e.g. for ports 80 and 443 (HTTPS):
+- pihole-FTL --config webserver.port 80,443s"
+
+			# Offer to uninstall webserver and PHP if no dependant is installed
+			# - If only PHP or only a webserver is installed, one has been uninstalled already, and the other is assumed to be still needed for something else.
+			if grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[89\]=2' /boot/dietpi/.installed && grep -Eq '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[(83|84|85)\]=2' /boot/dietpi/.installed
+			then
+				G_WHIP_CHECKLIST_ARRAY=()
+				# - webserver
+				if ! /boot/dietpi/dietpi-software list | grep -q '| =2 |.*+webserver'
+				then
+					grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[83\]=2' /boot/dietpi/.installed && G_WHIP_CHECKLIST_ARRAY+=(83 'Apache webserver' off)
+					grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[84\]=2' /boot/dietpi/.installed && G_WHIP_CHECKLIST_ARRAY+=(84 'Lighttpd webserver' off)
+					grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[85\]=2' /boot/dietpi/.installed && G_WHIP_CHECKLIST_ARRAY+=(85 'Nginx webserver' off)
+				fi
+				# - PHP: Exclude webserver stacks which are meta selections only
+				/boot/dietpi/dietpi-software list | grep '| =2 |.*+PHP' | grep -vEq '^.\[32mID (75|76|78|79|81|82)' || G_WHIP_CHECKLIST_ARRAY+=(89 'PHP server' off)
+				if (( ${#G_WHIP_CHECKLIST_ARRAY[@]} ))
+				then
+					G_WHIP_BUTTON_CANCEL_TEXT='Skip'
+					# shellcheck disable=SC2086
+					G_WHIP_CHECKLIST '[ INFO ] Possibly obsolete webserver and/or PHP installation detected
+\nYou recently updated Pi-hole to v6, which now does not require any webserver or PHP anymore.
+\nWe detected a webserver and/or PHP installation on your system, but no dependant among installed dietpi-software options.
+\nIf you are sure that you do not require the webserver and/or PHP anymore, you can select them for uninstall below. Use the space bar to (de)select the ones which shall be uninstalled:' && /boot/dietpi/dietpi-software uninstall $G_WHIP_RETURNED_VALUE
+				fi
 			fi
 		fi
 	fi

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ v9.16
 New images:
 
 Enhancements:
+- DietPi-Software | Domoticz: This software option has been enabled for all Debian versions and architectures. We build and distribute own packages via our own APT server for this purpose. All files in /mnt/dietpi_userdata/domoticz are treated as "conffiles", hence manual changes will never be overwritten by package upgrades. For fresh installs, however, the plain HTTP listener at port 8124 has been disabled, hence by default, access is possible via HTTPS on port 8424 only. A sudoers config has been added to make the system shutdown and restart options from the web UI work.
 
 Bug fixes:
 - Debian Trixie | The install of Xfce and GNUstep desktops, as well as enabling Amiberry standard boot via dietpi-autostart failed, due the attempt to install the policykit-1 package, which is a dummy transitional on Bookworm and has been removed on Trixie. Instead, from Bookworm on, the successor polkitd package is installed, which provides the same features to elevate privileges for e.g. poweroff/reboot from desktop and systemctl execution. Many thanks to @0xB33r for reporting this issue: https://github.com/MichaIng/DietPi/issues/7650

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1532,10 +1532,6 @@ Available commands:
 		aSOFTWARE_DESC[$software_id]='Open source home automation platform'
 		aSOFTWARE_CATX[$software_id]=17
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/home_automation/#domoticz'
-		# - RISC-V: https://github.com/domoticz/domoticz/releases, https://www.domoticz.com/downloads/
-		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,11]=0
-		# - Bookworm/Trixie: https://github.com/domoticz/domoticz/issues/5233
-		(( $G_DISTRO > 6 )) && aSOFTWARE_AVAIL_G_DISTRO[$software_id,$G_DISTRO]=0
 		#------------------
 		software_id=27
 		aSOFTWARE_NAME[$software_id]='TasmoAdmin'
@@ -11387,58 +11383,7 @@ _EOF_
 
 		if To_Install 140 domoticz # Domoticz
 		then
-			# APT deps: https://install.domoticz.com/, https://github.com/MichaIng/DietPi/issues/6404
-			aDEPS=('libusb-0.1-4' 'libcurl3-gnutls')
-
-			# Download
-			Download_Install "https://releases.domoticz.com/release/domoticz_linux_${G_HW_ARCH_NAME/armv6l/armv7l}.tgz" ./domoticz
-
-			# Reinstall: Clean old install dir
-			[[ -d '/opt/domoticz' ]] && G_EXEC rm -R /opt/domoticz
-			G_EXEC mv domoticz /opt/
-
-			# Data dir
-			G_EXEC mkdir -p /mnt/dietpi_userdata/domoticz
-
-			# Config file
-			if [[ ! -f '/mnt/dietpi_userdata/domoticz/domoticz.conf' ]]
-			then
-				G_EXEC cp /opt/domoticz/scripts/domoticz.conf /mnt/dietpi_userdata/domoticz/domoticz.conf
-				G_CONFIG_INJECT 'http_port=' 'http_port=8124' /mnt/dietpi_userdata/domoticz/domoticz.conf # ToDo: Disable plain HTTP port
-				G_CONFIG_INJECT 'ssl_port=' 'ssl_port=8424' /mnt/dietpi_userdata/domoticz/domoticz.conf
-				G_CONFIG_INJECT 'ssl_cert=' 'ssl_cert=/opt/domoticz/server_cert.pem' /mnt/dietpi_userdata/domoticz/domoticz.conf
-				G_CONFIG_INJECT 'ssl_key=' 'ssl_key=/opt/domoticz/server_cert.pem' /mnt/dietpi_userdata/domoticz/domoticz.conf
-				G_CONFIG_INJECT 'ssl_dhparam=' 'ssl_dhparam=/opt/domoticz/server_cert.pem' /mnt/dietpi_userdata/domoticz/domoticz.conf
-				G_CONFIG_INJECT 'loglevel=' 'loglevel=error' /mnt/dietpi_userdata/domoticz/domoticz.conf
-				G_CONFIG_INJECT 'syslog=' 'syslog=local7' /mnt/dietpi_userdata/domoticz/domoticz.conf
-				G_CONFIG_INJECT 'dbase_file=' "dbase_file=/mnt/dietpi_userdata/domoticz/domoticz.db" /mnt/dietpi_userdata/domoticz/domoticz.conf
-				G_CONFIG_INJECT 'app_path=' 'app_path=/opt/domoticz' /mnt/dietpi_userdata/domoticz/domoticz.conf
-				G_CONFIG_INJECT 'userdata_path=' "userdata_path=/mnt/dietpi_userdata/domoticz" /mnt/dietpi_userdata/domoticz/domoticz.conf
-			fi
-
-			# User
-			Create_User -G dialout -d /mnt/dietpi_userdata/domoticz domoticz
-
-			# Permissions
-			G_EXEC chown -R domoticz:domoticz /opt/domoticz /mnt/dietpi_userdata/domoticz
-
-			# Copy scripts directory to data dir: https://dietpi.com/forum/t/domoticz-cannot-save-scripts/4945
-			G_EXEC cp -a /opt/domoticz/scripts /mnt/dietpi_userdata/domoticz/
-
-			# Service
-			cat << '_EOF_' > /etc/systemd/system/domoticz.service
-[Unit]
-Description=Domoticz (DietPi)
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-User=domoticz
-ExecStart=/opt/domoticz/domoticz -f /mnt/dietpi_userdata/domoticz/domoticz.conf
-
-[Install]
-WantedBy=multi-user.target
-_EOF_
+			G_AGI domoticz
 		fi
 
 		if To_Install 191 snapserver # Snapcast Server
@@ -13580,9 +13525,7 @@ _EOF_
 
 		if To_Uninstall 140 # Domoticz
 		then
-			Remove_Service domoticz 1 1
-			[[ -d '/opt/domoticz' ]] && G_EXEC rm -R /opt/domoticz
-			[[ -d '/mnt/dietpi_userdata/domoticz' ]] && G_EXEC rm -R /mnt/dietpi_userdata/domoticz
+			G_AGP domoticz
 		fi
 
 		if To_Uninstall 165 # Gitea


### PR DESCRIPTION
To enable support for all Debian versions and architectures. Current official builds are compatible until Debian Bullseye only, since they are compiled against `libssl1.1`, future builds will be supported only from Debian Bookworm on, and official RISC-V builds are missing.