### PR TITLE
dietpi-software: Syncthing: add v2.0 compatibility

### DIFF
--- a/.update/patches
+++ b/.update/patches
@@ -2304,6 +2304,32 @@ Patch_9_16()
 			fi
 		fi
 
+		# Syncthing
+		if grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[50\]=2' /boot/dietpi/.installed
+		then
+			# Increase fs watcher limit: https://docs.syncthing.net/users/faq.html#inotify-limits
+			# - 8192 until Linux 5.11, 7x RAM size in MiB since Linux 5.11, up to 1048576
+			# Raise UDP buffer sizes: https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes
+			if (( $G_HW_MODEL == 75 ))
+			then
+				(( $(sysctl -n fs.inotify.max_user_watches) >= 204800 && $(sysctl -n net.core.rmem_max) >= 7500000 && $(sysctl -n net.core.wmem_max) >= 7500000 )) || G_WHIP_MSG '[WARNING] Filesystem watcher and UDP buffer size limits might be too low
+\nSyncthing uses filesystem (inotify) watchers to detect changes in your folders. Depending on the amount of files, the kernel version and physical RAM size of the host system, the current limit might be too low for Syncthing to start all watchers.
+\nAdditionally, for HTTP3/QUIC connections, the bandwidth can be limited by UDP buffer sizes.
+\nBoth limits can only be raised on the host of this container. E.g. add the following lines to a new sysctl config file like /etc/sysctl.d/dietpi-syncthing.conf:
+fs.inotify.max_user_watches=204800
+net.core.rmem_max=7500000
+net.core.wmem_max=7500000
+\nApply them without reboot like this:
+sudo sysctl -p /etc/sysctl.d/dietpi-syncthing.confs
+\nMore info:
+- https://docs.syncthing.net/users/faq.html#inotify-limits
+- https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Size'
+			else
+				G_EXEC eval 'echo -e '\''fs.inotify.max_user_watches=204800\nnet.core.rmem_max=7500000\nnet.core.wmem_max=7500000'\'' > /etc/sysctl.d/dietpi-syncthing.conf'
+				G_EXEC sysctl -p /etc/sysctl.d/dietpi-syncthing.conf
+			fi
+		fi
+
 		# Pi-hole v6 migration
 		# - /etc/pihole/pihole.toml indicates that Pi-hole has been upgraded to v6 already.
 		# - The /var/www/pihole symlink indicates that an instance installed via dietpi-software has not been migrated yet.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,7 @@ Bug fixes:
 - DietPi-Software | Koel: Resolved an issue where the installation failed on 32-bit systems from Debian Bookworm on, due to a pre-installed dependency which strictly requires 64-bit. The dependency is now downgraded on accepted systems via PHP Composer.
 - DietPi-Software | Kavita: Resolved an issue where the installer tried to exit a non-existing config file, so that the daemon was not listening on port 2036 as expected, but port 5000 instead.
 - DietPi-Software | Docker Compose: This software option has been enabled for the RISC-V architecture.
+- DietPi-Software | Syncthing: Resolved an issue where the installation failed due to CLI changes in the latest release v2.0.0.
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4201,7 +4201,7 @@ _EOF_
 			# Raise UDP buffer sizes: https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes
 			if (( $G_HW_MODEL == 75 ))
 			then
-				(( $(sysctl -n net.core.rmem_max) >= 7500000 || $(sysctl -n net.core.wmem_max) >= 7500000 )) || G_WHIP_MSG '[WARNING] UDP buffer size limits might be too small
+				(( $(sysctl -n net.core.rmem_max) >= 7500000 && $(sysctl -n net.core.wmem_max) >= 7500000 )) || G_WHIP_MSG '[WARNING] UDP buffer size limits might be too small
 \nFor QUIC, used by the Kubo, the bandwidth can be limited by the UDP buffer sizes. Hence it is recommended to raise their limit. This can only be done on the host of this container. E.g. add the following lines to a new sysctl config file like /etc/sysctl.d/dietpi-ipfs.conf:
 net.core.rmem_max=7500000
 net.core.wmem_max=7500000
@@ -8942,15 +8942,15 @@ _EOF_
 			# Permit self-updates
 			G_EXEC chown -R syncthing /opt/syncthing
 
-			# Pre-create and edit default config only on fresh installs
+			# Generate and edit config only on fresh installs
 			if [[ ! -f '/mnt/dietpi_userdata/syncthing/config.xml' ]]
 			then
 				# Failsafe: Assure that "syncthing" (its "dietpi" group) has permission to create the /mnt/dietpi_userdata/syncthing directory
 				G_EXEC chgrp dietpi /mnt/dietpi_userdata
 				G_EXEC chmod 'g+rwx' /mnt/dietpi_userdata
 
-				# Run Syncthing to pre-create config dir and exit
-				G_EXEC_OUTPUT=1 G_EXEC runuser -u syncthing -- /opt/syncthing/syncthing --generate=/mnt/dietpi_userdata/syncthing
+				# Generate config
+				G_EXEC_OUTPUT=1 G_EXEC runuser -u syncthing -- /opt/syncthing/syncthing generate --home=/mnt/dietpi_userdata/syncthing
 
 				# Allow remote access: https://docs.syncthing.net/users/faq.html#how-do-i-access-the-web-gui-from-another-computer
 				G_EXEC sed --follow-symlinks -i '\|:8384</address>|c\        <address>0.0.0.0:8384</address>' /mnt/dietpi_userdata/syncthing/config.xml
@@ -8959,8 +8959,13 @@ _EOF_
 				G_EXEC mkdir -p /mnt/dietpi_userdata/syncthing_data
 				G_EXEC chown -R syncthing: /mnt/dietpi_userdata/syncthing_data
 				G_EXEC chmod 0775 /mnt/dietpi_userdata/syncthing_data
-				G_EXEC sed --follow-symlinks -i '\|<folder id="default"|s|label="[^"]*"|label="Syncthing Data"|' /mnt/dietpi_userdata/syncthing/config.xml
-				G_EXEC sed --follow-symlinks -i '\|<folder id="default"|s|path="[^"]*"|path="/mnt/dietpi_userdata/syncthing_data"|' /mnt/dietpi_userdata/syncthing/config.xml
+				if grep -q '<folder id="default"' /mnt/dietpi_userdata/syncthing/config.xml
+				then
+					G_EXEC sed --follow-symlinks -i '\|<folder id="default"|s|label="[^"]*"|label="Syncthing Data"|' /mnt/dietpi_userdata/syncthing/config.xml
+					G_EXEC sed --follow-symlinks -i '\|<folder id="default"|s|path="[^"]*"|path="/mnt/dietpi_userdata/syncthing_data"|' /mnt/dietpi_userdata/syncthing/config.xml
+				else
+					G_CONFIG_INJECT '<folder id="default"' '    <folder id="default" label="Syncthing Data" path="/mnt/dietpi_userdata/syncthing_data"></folder>' /mnt/dietpi_userdata/syncthing/config.xml '^<configuration'
+				fi
 			fi
 
 			# Service: https://github.com/syncthing/syncthing/blob/main/etc/linux-systemd/system/syncthing@.service
@@ -8975,7 +8980,7 @@ StartLimitBurst=3
 [Service]
 User=syncthing
 UMask=002
-ExecStart=/opt/syncthing/syncthing --no-browser --no-restart --logflags=0 --home=/mnt/dietpi_userdata/syncthing
+ExecStart=/opt/syncthing/syncthing --no-browser --no-restart --log-level=WARN --home=/mnt/dietpi_userdata/syncthing
 Restart=on-failure
 RestartSec=1
 SuccessExitStatus=3 4
@@ -8993,14 +8998,23 @@ WantedBy=multi-user.target
 _EOF_
 			# Increase fs watcher limit: https://docs.syncthing.net/users/faq.html#inotify-limits
 			# - 8192 until Linux 5.11, 7x RAM size in MiB since Linux 5.11, up to 1048576
+			# Raise UDP buffer sizes: https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes
 			if (( $G_HW_MODEL == 75 ))
 			then
-				(( $(sysctl -n fs.inotify.max_user_watches) >= 204800 )) || G_WHIP_MSG '[WARNING] Raised filesystem watcher limit might be needed
-\nSyncthing uses filesystem/inotify watchers to detect changes among your files, if they were not done via Syncthing itself. Depending on the amount of files in the Syncthing data directory, the kernel version and physical RAM size of the host system, the current limit might be too low for Syncthing to start all watchers.
-\nLimits can be raised on the host system of this container only. Read more about it here:
-- https://docs.syncthing.net/users/faq.html#inotify-limits'
+				(( $(sysctl -n fs.inotify.max_user_watches) >= 204800 && $(sysctl -n net.core.rmem_max) >= 7500000 && $(sysctl -n net.core.wmem_max) >= 7500000 )) || G_WHIP_MSG '[WARNING] Filesystem watcher and UDP buffer size limits might be too low
+\nSyncthing uses filesystem (inotify) watchers to detect changes in your folders. Depending on the amount of files, the kernel version and physical RAM size of the host system, the current limit might be too low for Syncthing to start all watchers.
+\nAdditionally, for HTTP3/QUIC connections, the bandwidth can be limited by UDP buffer sizes.
+\nBoth limits can only be raised on the host of this container. E.g. add the following lines to a new sysctl config file like /etc/sysctl.d/dietpi-syncthing.conf:
+fs.inotify.max_user_watches=204800
+net.core.rmem_max=7500000
+net.core.wmem_max=7500000
+\nApply them without reboot like this:
+sudo sysctl -p /etc/sysctl.d/dietpi-syncthing.confs
+\nMore info:
+- https://docs.syncthing.net/users/faq.html#inotify-limits
+- https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Size'
 			else
-				G_EXEC eval 'echo '\''fs.inotify.max_user_watches=204800'\'' > /etc/sysctl.d/dietpi-syncthing.conf'
+				G_EXEC eval 'echo -e '\''fs.inotify.max_user_watches=204800\nnet.core.rmem_max=7500000\nnet.core.wmem_max=7500000'\'' > /etc/sysctl.d/dietpi-syncthing.conf'
 				G_EXEC sysctl -p /etc/sysctl.d/dietpi-syncthing.conf
 			fi
 		fi


### PR DESCRIPTION
Apart of CLI changes, a default folder does not exist anymore, hence we add it now if we can really not find it in the generated config. It can be minimal, since defaults are applied automatically.

And mute warnings about UDP buffer sizes, caused by the QUIC Go module.