### PR TITLE
ci: dietpi-software test: enable container tests

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1168,6 +1168,8 @@ Available commands:
 		aSOFTWARE_DESC[$software_id]='The simplest production-grade upstream K8s, light and focused'
 		aSOFTWARE_CATX[$software_id]=8
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/cloud/#microk8s'
+		# - ARMv6/7/RISC-V: https://snapcraft.io/microk8s
+		(( $G_HW_ARCH == 3 || $G_HW_ARCH == 10 )) || aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,$G_HW_ARCH]=0
 		#------------------
 		software_id=200
 		aSOFTWARE_NAME[$software_id]='DietPi-Dashboard'
@@ -9395,10 +9397,18 @@ _EOF_
 
 		if To_Install 142 # MicroK8s
 		then
-			# APT deps
+			# MicroK8s itself is a snap, hence snapd is needed
 			G_AGI snapd
 
-			# Install or upgrade
+			# Update snapd itself, needed on older Debian to install core20 snap. Both are pulled by the MicroK8s snap anyway, but while older snapd runs, installing MicroK8s fails at core20 before snapd is updated.
+			if snap list snapd &> /dev/null
+			then
+				G_EXEC_OUTPUT=1 G_EXEC snap refresh snapd
+			else
+				G_EXEC_OUTPUT=1 G_EXEC snap install snapd
+			fi
+
+			# Install or update microk8s snap
 			if snap list microk8s &> /dev/null
 			then
 				G_EXEC_OUTPUT=1 G_EXEC snap refresh microk8s
@@ -11771,7 +11781,7 @@ _EOF_
 
 			# Deploy the Portainer container
 			G_DIETPI-NOTIFY 2 'Portainer will be deployed now. This could take a while...'
-			G_EXEC_OUTPUT=1 G_EXEC docker run -d -p '9002:9000' --name=portainer --restart=always -v '/run/docker.sock:/var/run/docker.sock' -v '/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro' -v 'portainer_data:/data' 'portainer/portainer-ce'
+			G_EXEC_OUTPUT=1 G_EXEC docker run -d -p '9002:9000' -p '9442:9443' --name=portainer --restart=always -v '/run/docker.sock:/run/docker.sock' -v '/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro' -v 'portainer_data:/data' 'portainer/portainer-ce'
 		fi
 
 		if To_Install 141 adsb-setup adsb-docker # ADS-B Feeder


### PR DESCRIPTION
Further changes:
- Disables MicroK8s for ARMv6/7 and RISC-V, which was never supported anyway: https://snapcraft.io/microk8s
- Fix MicroK8s installs on Debian Bullseye and Bookworm, where previously a retry was needed. Reason was that snapd is too old at first, before it its own snap is updated. So what we do is change the order, updating snapd first, before installing the MicroK8s snap.
- Portainer: Enable HTTPS access on port 8442, HTTP is on 8002