### PR TITLE
ci: dietpi-software test: complement list of test IDs

### DIFF
--- a/.github/workflows/dietpi-software.bash
+++ b/.github/workflows/dietpi-software.bash
@@ -100,6 +100,10 @@ Process_Software()
 			0) aCOMMANDS[i]='ssh -V';;
 			1) aCOMMANDS[i]='smbclient -V';;
 			2) aSERVICES[i]='fahclient' aTCP[i]='7396';;
+			3) aCOMMANDS[i]='mc -V';;
+			4) aCOMMANDS[i]='fish -v';;
+			5) aCOMMANDS[i]='aplay -l';;
+			6) aCOMMANDS[i]='X -version';;
 			7) aCOMMANDS[i]='ffmpeg -version';;
 			8) aCOMMANDS[i]='javac -version';;
 			9) aCOMMANDS[i]='node -v';;
@@ -107,52 +111,81 @@ Process_Software()
 			11) aCOMMANDS[i]='gzdoom -norun | grep '\''^GZDoom version '\';;
 			#16) aSERVICES[i]='microblog-pub' aTCP[i]='8007';; Service enters a CPU-intense internal error loop until it has been configured interactively via "microblog-pub configure", hence it is not enabled and started anymore after install but instead as part of "microblog-pub configure"
 			17) aCOMMANDS[i]='git --version';; # from Bookworm on, the shorthand "-v" is supported
+			#22) QuiteRSS: has no CLI
+			23) aCOMMANDS[i]='lxsession -h';;
+			24) aCOMMANDS[i]='mate-session -h';;
+			25) aCOMMANDS[i]='xfce4-session -h';;
+			26) aCOMMANDS[i]='gnustep-tests';;
+			#27) TasmoAdmin
 			28) aSERVICES[i]='vncserver' aTCP[i]='5901';;
 			29) aSERVICES[i]='xrdp' aTCP[i]='3389';;
 			30) aSERVICES[i]='nxserver' aTCP[i]='4000';;
+			31) [[ $arch == 1 && $DISTRO == 'bookworm' ]] || aCOMMANDS[i]='kodi -v';; # Bookworm RPi repo "kodi" calls fgconsole and chvt which both fails in non-interactive container: "Couldn't get a file descriptor referring to the console."
 			32) aSERVICES[i]='ympd' aTCP[i]='1337';;
 			33) (( $emulation )) || aSERVICES[i]='airsonic' aTCP[i]='8080' aDELAY[i]=60;; # Fails in QEMU-emulated containers, probably due to missing device access
+			34) aCOMMANDS[i]='COMPOSER_ALLOW_SUPERUSER=1 composer -n -V';;
 			35) [[ $DISTRO != 'trixie' ]] || (( $arch > 2 )) && aSERVICES[i]='lyrionmusicserver' aTCP[i]='9000';; # disable check on 32-bit ARM Trixie for now: https://github.com/LMS-Community/slimserver/tree/public/9.1/CPAN/arch/5.40
 			36) aCOMMANDS[i]='squeezelite -t';; # Service listens on random high UDP port and exits if no audio device has been found, which does not exist on GitHub Actions runners, respectively within the containers
 			37) aSERVICES[i]='shairport-sync' aTCP[i]='5000';; # AirPlay 2 would be TCP port 7000
+			38) aCOMMANDS[i]='/opt/FreshRSS/cli/user-info.php';;
 			39) aSERVICES[i]='minidlna' aTCP[i]='8200';;
+			#40) Ampache
 			41) aSERVICES[i]='emby-server' aTCP[i]='8096';;
 			42) aSERVICES[i]='plexmediaserver' aTCP[i]='32400';;
 			43) aSERVICES[i]='mumble-server' aTCP[i]='64738';;
 			44) aSERVICES[i]='transmission-daemon' aTCP[i]='9091 51413' aUDP[i]='51413';;
 			45) aSERVICES[i]='deluged deluge-web' aTCP[i]='8112 58846 6882';;
 			46) aSERVICES[i]='qbittorrent' aTCP[i]='1340 6881';;
+			47) aCOMMANDS[i]='sudo -u www-data php /var/www/owncloud/occ status';;
+			#48) Pydio
 			49) aSERVICES[i]='gogs' aTCP[i]='3000';;
 			50) aSERVICES[i]='syncthing' aTCP[i]='8384';;
 			51) aCOMMANDS[i]='/usr/games/opentyrian/opentyrian -h';;
 			52) aSERVICES[i]='cuberite' aTCP[i]='1339' aDELAY[i]=60;;
 			53) aSERVICES[i]='mineos' aTCP[i]='8443';;
+			#54) phpBB
+			#55) WordPress
+			#56) Single File PHP Gallery
+			#57) Baïkal
 			58) aCOMMANDS[i]='tailscale version';; # aSERVICES[i]='tailscaled' aUDP[i]='41641' GitHub Actions runners do not support the TUN module
 			59) aSERVICES[i]='raspimjpeg';;
 			60) aCOMMANDS[i]='iptables -V' aSERVICES[i]='isc-dhcp-server' aUDP[i]='67';; # aSERVICES[i]='hostapd' fails without actual WiFi interface
 			61) aSERVICES[i]='tor' aTCP[i]='9040' aUDP[i]='53';;
 			62) aCOMMANDS[i]='box86 -v';;
+			#63 LinuxDash
+			#64 phpSysInfo
 			65) aSERVICES[i]='netdata' aTCP[i]='19999';;
 			66) aSERVICES[i]='rpimonitor' aTCP[i]='8888';;
 			67) aCOMMANDS[i]='firefox-esr -v';;
 			68) aSERVICES[i]='schannel' aUDP[i]='5980';; # remoteit@.service service listens on random high UDP port
+			#69) RPi.GPIO
 			70) aCOMMANDS[i]='gpio -v | grep '\''gpio version'\';;
 			71) aSERVICES[i]='webiopi' aTCP[i]='8002';;
+			#72) I2C
 			73) aSERVICES[i]='fail2ban';;
 			74) aSERVICES[i]='influxdb' aTCP[i]='8086 8088';;
+			#75) LASP
+			#76) LAMP
 			77) aSERVICES[i]='grafana-server' aTCP[i]='3001' aDELAY[i]=30;;
+			#78) LESP
+			#79) LEMP
 			80) aSERVICES[i]='ubooquity' aTCP[i]='2038 2039'; (( $emulation )) && aDELAY[i]=30;;
+			#81) LLSP
+			#82) LLMP
 			83) aSERVICES[i]='apache2' aTCP[i]='80';;
 			84) aSERVICES[i]='lighttpd' aTCP[i]='80';;
 			85) aSERVICES[i]='nginx' aTCP[i]='80';;
 			86) aSERVICES[i]='roon-extension-manager' SYSCALLS+=' add_key keyctl bpf';;
+			87) aCOMMANDS[i]='sqlite3 -version';;
 			88) aSERVICES[i]='mariadb' aTCP[i]='3306';;
 			89) case $DISTRO in
 				'bullseye') aSERVICES[i]='php7.4-fpm';;
 				'bookworm') aSERVICES[i]='php8.2-fpm';;
 				*) aSERVICES[i]='php8.4-fpm';;
 			esac;;
+			#90 phpMyAdmin
 			91) aSERVICES[i]='redis-server' aTCP[i]='6379';;
+			92) aCOMMANDS[i]='certbot --version';;
 			93) aSERVICES[i]='pihole-FTL' aUDP[i]='53';;
 			94) aSERVICES[i]='proftpd' aTCP[i]='21';;
 			95) aSERVICES[i]='vsftpd' aTCP[i]='21';;
@@ -160,9 +193,10 @@ Process_Software()
 			97) aCOMMANDS[i]='openvpn --version';; # aSERVICES[i]='openvpn' aUDP[i]='1194' GitHub Actions runners do not support the TUN module
 			98) aSERVICES[i]='haproxy' aTCP[i]='80 1338';;
 			99) aSERVICES[i]='node_exporter' aTCP[i]='9100';;
-			#100) (( $arch < 3 )) && aCOMMANDS[i]='/usr/bin/pijuice_cli32 -V' || aCOMMANDS[i]='/usr/bin/pijuice_cli64 -V' aSERVICES[i]='pijuice' aTCP[i]='????' Service does not start without I2C device, not present in container and CLI command always puts you in interactive console
+			#100) (( $arch < 3 )) && aCOMMANDS[i]='/usr/bin/pijuice_cli32 -V' || aCOMMANDS[i]='/usr/bin/pijuice_cli64 -V'; aSERVICES[i]='pijuice' aTCP[i]='????';; Service does not start without I2C device, not present in container and CLI command always puts you in interactive console
 			101) aCOMMANDS[i]='logrotate -v /etc/logrotate.conf';;
 			102) aSERVICES[i]='rsyslog';;
+			103) aSERVICES[i]='dietpi-ramlog' aCOMMANDS[i]='/boot/dietpi/func/dietpi-ramlog 1 && /boot/dietpi/func/dietpi-ramlog 0 && findmnt -t tmpfs /var/log';;
 			104) aSERVICES[i]='dropbear' aTCP[i]='22';;
 			105) aSERVICES[i]='ssh' aTCP[i]='22';;
 			106) aSERVICES[i]='lidarr' aTCP[i]='8686';;
@@ -171,10 +205,15 @@ Process_Software()
 			109) aSERVICES[i]='nfs-kernel-server' aTCP[i]='2049';;
 			110) aCOMMANDS[i]='mount.nfs -V';;
 			111) aSERVICES[i]='urbackupsrv' aTCP[i]='55414';;
+			112) aCOMMANDS[i]='/mnt/dietpi_userdata/dxx-rebirth/d1x-rebirth_rpigl -h';;
+			113) aCOMMANDS[i]='chromium --version'; [[ $DISTRO == 'bullseye' && $RPI == 'true' ]] && (( $arch < 10 )) && aCOMMANDS[i]='chromium-browser --version';;
+			114) aCOMMANDS[i]='sudo -u www-data php /var/www/nextcloud/occ status';;
 			115) aSERVICES[i]='webmin' aTCP[i]='10000';;
 			116) aSERVICES[i]='medusa' aTCP[i]='8081'; (( $emulation )) && aDELAY[i]=30;;
 			#117) :;; # ToDo: Implement automated install via /boot/unattended_pivpn.conf
 			118) aSERVICES[i]='mopidy' aTCP[i]='6680';;
+			119) aCOMMANDS[i]='cava -v';;
+			#120) RealVNC
 			121) aSERVICES[i]='roonbridge' aUDP[i]='9003';;
 			122) aSERVICES[i]='node-red' aTCP[i]='1880'; (( $emulation )) && aDELAY[i]=30;;
 			123) aSERVICES[i]='mosquitto' aTCP[i]='1883';;
@@ -182,6 +221,8 @@ Process_Software()
 			125) aSERVICES[i]='synapse' aTCP[i]='8008';;
 			126) aSERVICES[i]='adguardhome' aUDP[i]='53' aTCP[i]='8083'; [[ ${aSERVICES[182]} ]] && aUDP[i]+=' 5335';; # Unbound uses port 5335 if AdGuard Home is installed
 			128) aSERVICES[i]='mpd' aTCP[i]='6600';;
+			#129) O!MPD
+			130) aCOMMANDS[i]='python3 -V';;
 			131) (( $arch < 3 || $arch == 11 )) || aSERVICES[i]='blynkserver' aTCP[i]='9443'; (( $arch == 10 || $arch == 2 || $arch == 11 )) || aDELAY[i]=60;;
 			132) aSERVICES[i]='aria2' aTCP[i]='6800';; # aTCP[i]+=' 6881-6999';; # Listens on random port
 			133) (( $arch < 3 || $arch == 11 )) || aSERVICES[i]='yacy' aTCP[i]='8090'; (( $arch == 10 )) && aDELAY[i]=30; (( $arch == 10 || $arch == 2 || $arch == 11)) || aDELAY[i]=90;;
@@ -192,6 +233,7 @@ Process_Software()
 			138) aSERVICES[i]='virtualhere' aTCP[i]='7575';;
 			139) aSERVICES[i]='sabnzbd' aTCP[i]='8080'; (( $arch == 10 )) || aDELAY[i]=30;; # ToDo: Solve conflict with Airsonic
 			140) aSERVICES[i]='domoticz' aTCP[i]='8424';;
+			141) aSERVICES[i]='adsb-setup' aTCP[i]='1099' SYSCALLS+=' add_key keyctl bpf'; (( $emulation )) || aSERVICES[i]+=' adsb-docker';; # Container cannot start in QEMU-emulated container. Else, depending on container startup race condition, the Dozzle port can be 9999 (default) or 1094 (changed by internal setup step). I remains 1094 on subsequent restarts, and other ports join depending on manual init setup selections.
 			# MicroK8s: /run/udev and on Bullseye /sys/devices required for snapd update to succeed on first attempt doing a udev trigger; ~@mount + loop devices for snapd snaps=squashfs mounts; /dev/kmsg mount + CAP_SYSLOG: "Error: failed to run Kubelet: failed to create kubelet: open /dev/kmsg: no such file or directory"
 			142) aCOMMANDS[i]='/snap/bin/microk8s status' aSERVICES[i]='snapd snap.microk8s.daemon-containerd' aDELAY[i]=30 CAPABILITIES+=',CAP_NET_ADMIN,CAP_MAC_ADMIN,CAP_SYSLOG' SYSCALLS+=' add_key keyctl bpf ~@mount' aOPTIONS+=('--bind-ro=/run/udev' '--bind=/dev/loop-control' '--bind=/dev/loop'{1,2,3,4,5,6,7} '--bind=/dev/kmsg'); [[ $DISTRO == 'bullseye' ]] && aOPTIONS+=('--bind=/sys/devices') ;;
 			143) aSERVICES[i]='koel' aTCP[i]='8003'; (( $emulation )) && aDELAY[i]=30;;
@@ -207,8 +249,11 @@ Process_Software()
 			153) aSERVICES[i]='octoprint' aTCP[i]='5001'; (( $emulation )) && aDELAY[i]=60;;
 			154) aSERVICES[i]='roonserver';; # Listens on a variety of different port ranges
 			155) aSERVICES[i]='htpc-manager' aTCP[i]='8085'; (( $emulation )) && aDELAY[i]=30;;
+			#156) Steam
 			157) aSERVICES[i]='home-assistant' aTCP[i]='8123'; (( $emulation )) && aDELAY[i]=900 || aDELAY[i]=60;;
 			158) aSERVICES[i]='minio' aTCP[i]='9001 9004';;
+			#159) Allo GUI full
+			#160) Allo GUI without dependencies
 			161) aSERVICES[i]='bdd' aTCP[i]='80 443';;
 			162) aCOMMANDS[i]='docker -v' aSERVICES[i]='containerd' CAPABILITIES+=',CAP_NET_ADMIN'; (( $emulation )) || aSERVICES[i]+=' docker';; # QEMU: Docker daemon fails with "iptables: Failed to initialize nft: Protocol not supported" and similar error with iptables-legacy
 			163) aSERVICES[i]='gmediarender';; # DLNA => UPnP high range of ports
@@ -220,7 +265,9 @@ Process_Software()
 			170) aCOMMANDS[i]='unrar -V';;
 			171) aSERVICES[i]='frps frpc' aTCP[i]='7000 7400 7500';;
 			172) aCOMMANDS[i]='wg' aSERVICES[i]='wg-quick@wg0' aUDP[i]='51820' CAPABILITIES+=',CAP_NET_ADMIN';;
+			#173 LXQt: all executables strictly require a Qt session, no help or version output possible
 			174) aCOMMANDS[i]='gimp -v';;
+			175) aCOMMANDS[i]='xfce4-power-manager -V';;
 			177) aSERVICES[i]='forgejo' aTCP[i]='3000';;
 			178) aSERVICES[i]='jellyfin' aTCP[i]='8097';;
 			179) aSERVICES[i]='komga' aTCP[i]='2037'; (( $emulation )) && aDELAY[i]=300 || aDELAY[i]=30;;
@@ -249,10 +296,12 @@ Process_Software()
 			202) aCOMMANDS[i]='rclone version';;
 			203) aSERVICES[i]='readarr' aTCP[i]='8787';;
 			204) aSERVICES[i]='navidrome' aTCP[i]='4533';;
+			#205 Homer
 			206) aSERVICES[i]='openhab' aTCP[i]='8444'; (( $emulation )) && aDELAY[i]=600;;
 			#207) Moonlight (CLI), "moonlight" command
 			#208) Moonlight (GUI), "moonlight-qt" command
 			209) aCOMMANDS[i]='restic version';;
+			#210) MediaWiki
 			211) aCOMMANDS[i]='hb-service status' aSERVICES[i]='homebridge' aTCP[i]='8581';;
 			212) aSERVICES[i]='kavita' aTCP[i]='2036' aDELAY[i]=30;;
 			213) aSERVICES[i]='soju' aTCP[i]='6667';;
@@ -276,10 +325,13 @@ do
 		61) Process_Software 60;;
 		125) Process_Software 194;;
 		86|134|185) Process_Software 162;;
+		141) Process_Software 17 130 134 162;;
 		166) Process_Software 70;;
 		180) (( $arch == 10 || $arch == 3 )) || Process_Software 170;;
-		188) Process_Software 17;; # 93 (Pi-hole) cannot be installed non-interactively
+		188) Process_Software 17;;
 		213) Process_Software 17 188;;
+		106|144|145|151|183|203) Process_Software 87;;
+		31|37|128|138|163|167|187) Process_Software 152;;
 		75) Process_Software 83 87 89;;
 		76) Process_Software 83 88 89;;
 		78) Process_Software 85 87 89;;
@@ -488,8 +540,8 @@ fi
 # shellcheck disable=SC2016
 (( ${aINSTALL[192]} )) && G_EXEC sed --follow-symlinks -i '/# Start DietPi-Software/i\sed -i '\''s/-p \$snapcast_server_port/-p \$snapcast_server_port --player file/'\'' /boot/dietpi/dietpi-software' rootfs/boot/dietpi/dietpi-login
 
-# Portainer/K3s
-if (( ${aINSTALL[185]} )) || (( ${aINSTALL[193]} ))
+# ADS-B Feeder/Portainer/K3s
+if (( ${aINSTALL[141]} )) || (( ${aINSTALL[185]} )) || (( ${aINSTALL[193]} ))
 then
 	# Unmount R/O /proc/sys created by systemd-nspawn: "failed to disable IPv6 on container's interface eth0" resp. "open /proc/sys/foo/bar: read-only file system"
 	# - systemd-journald restart fixes missing "journalctl -e/-u" outputs

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -27,6 +27,7 @@ Bug fixes:
 - DietPi-Software | openHAB: Resolved an issue where the latest package could not run anymore on Debian Bullseye and Bookworm systems, since the minimum Java version requirement raised to Java 21 with openHAB 5. This is now possible on 64-bit systems, as we moved to Adoptium Temurin Java packages. On 32-bit Bullseye and Bookworm systems, the latest openHAB 4 will be installed instead, and the DietPi update performs a downgrade if needed. Many thanks to @MDAR for reporting this issue: https://github.com/MichaIng/DietPi/issues/7657
 - DietPi-Software | Nukkit: Resolved an issue where a reinstall/update overwrote the config file. It is now never overwritten if present.
 - DietPi-Software | Node.js: Resolved an issue where the installed Node.js on ARMv6 Bullseye systems was not functional, since it required a newer C++ ABI version than provided by Raspbian Bullseye.
+- DietPi-Software | ADS-B Feeder: Resolved an issue on non-usr-merged Bullseye systems where the service startup failed due to explicit /usr/bin/bash usage.
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/7678
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -900,6 +900,8 @@ Available commands:
 		aSOFTWARE_DEPS[$software_id]='5'
 		# RPi only
 		(( $G_HW_MODEL > 9 )) && aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,$G_HW_MODEL]=0
+		# - ARMv8
+		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,3]=0
 		#------------------
 		software_id=52
 		aSOFTWARE_NAME[$software_id]='Cuberite'
@@ -1225,7 +1227,7 @@ Available commands:
 		aSOFTWARE_CATX[$software_id]=10
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/hardware_projects/#wiringpi'
 		# RPi, Odroids and Orange Pi only
-		(( $G_HW_MODEL > 19 )) && [[ ! $G_HW_MODEL =~ ^(80|82|83|87|88|89|91|93|94|95|96)$ ]] && aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,$G_HW_MODEL]=0
+		(( $G_HW_MODEL > 19 )) && [[ ! $G_HW_MODEL =~ ^(80|82|83|87|88|89|91|93|94|95|96|97|98)$ ]] && aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,$G_HW_MODEL]=0
 		#------------------
 		software_id=71
 		aSOFTWARE_NAME[$software_id]='WebIOPi'
@@ -5297,7 +5299,7 @@ _EOF_
 
 		if To_Install 112 # DXX-Rebirth
 		then
-			aDEPS=('libsdl-mixer1.2' 'libsdl1.2debian' 'libphysfs1')
+			aDEPS=('libsdl-mixer1.2' 'libsdl1.2debian' 'libphysfs1' 'libgl1' 'libglu1-mesa')
 			Download_Install 'https://dietpi.com/downloads/binaries/rpi/dxx-rebirth.7z' /mnt/dietpi_userdata
 
 			# Symlink savegames to root
@@ -11787,13 +11789,15 @@ _EOF_
 		if To_Install 141 adsb-setup adsb-docker # ADS-B Feeder
 		then
 			# clone the adsb-feeder repo into /tmp
-			G_EXEC_OUTPUT=1 G_EXEC git clone -b dietpi 'https://github.com/dirkhh/adsb-feeder-image.git' /tmp/adsb-feeder
+			G_EXEC_OUTPUT=1 G_EXEC git clone -b dietpi 'https://github.com/dirkhh/adsb-feeder-image' /tmp/adsb-feeder
 
 			# remove the service that isn't needed for an app install on DietPi and install the rest
 			G_EXEC cd /tmp/adsb-feeder/src/modules/adsb-feeder/filesystem/root
 			G_EXEC rm ./usr/lib/systemd/system/adsb-bootstrap.service
 			G_EXEC rm ./usr/lib/systemd/system/adsb-update.service
 			G_EXEC rm ./usr/lib/systemd/system/adsb-update.timer
+			# Fix bash path on potentially non-usr-merged systems
+			[[ -f '/usr/bin/bash' ]] || G_EXEC sed --follow-symlinks -i 's|/usr/bin/bash|/bin/bash|' ./usr/lib/systemd/system/adsb-*.service
 			G_EXEC mv ./usr/lib/systemd/system/* /etc/systemd/system/
 
 			# determine the version
@@ -13543,6 +13547,8 @@ _EOF_
 			[[ -f '/root/.d2x-rebirth' ]] && G_EXEC rm /root/.d2x-rebirth
 			G_EXEC rm -f /{root,home/*}/Desktop/dxx-rebirth.desktop
 			[[ -f '/usr/share/applications/dxx-rebirth.desktop' ]] && G_EXEC rm /usr/share/applications/dxx-rebirth.desktop
+			# shellcheck disable=SC2046
+			apt-mark auto $(dpkg --get-selections 'libsdl-mixer1.2' 'libsdl1.2debian' 'libphysfs1' 'libgl1' 'libglu1-mesa' 2> /dev/null | mawk '{print $1}') 2> /dev/null
 		fi
 
 		if To_Uninstall 113 # Chromium


### PR DESCRIPTION
Test CLI commands where possible, add placeholders for remaining software IDs, especially PHP web applications where we need to think about whether to test some web UI HTTP response or header via `curl`, to assure the UI is ready at the expected path.

Add full service and port tests for ADS-B Feeder.

Fix ADS-B Feeder install on non-usr-merged Bullseye systems.

Disable DXX-Rebirth for 64-bit, which did never work.