### PR TITLE
dietpi-globals: G_AGUP: skip if last run was <1h ago

### DIFF
--- a/.update/patches
+++ b/.update/patches
@@ -691,7 +691,6 @@ Patch_8_7()
 		# Remove repo if present and remove package to avoid downgrade error
 		G_EXEC rm /etc/apt/sources.list.d/raspotify.list
 		[[ -f '/etc/apt/trusted.gpg.d/dietpi-raspotify.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-raspotify.gpg
-		G_AGUP
 		if dpkg-query -s raspotify &> /dev/null
 		then
 			G_EXEC dpkg -r raspotify

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ v9.16
 (2025-08-23)
 
 Enhancements:
+- General | The number of APT update calls within our script has been reduced: it is skipped in case the less than an hour ago, sources lists and architectures were not changed in between. This should speed up certain update and install processes, and reduce disk writes. The 1 hour however is taken somewhat arbitrary. If you ever face the issue that a package install of upgrade fails with 404, while it works after a fresh "apt update", please let us know.
 - Raspberry Pi | The primary UART adapter is now enabled on first boot. It was unintentionally disabled on our Raspberry Pi images.
 - DietPi-Software | Domoticz: This software option has been enabled for all Debian versions and architectures. We build and distribute own packages via our own APT server for this purpose. All files in /mnt/dietpi_userdata/domoticz are treated as "conffiles", hence manual changes will never be overwritten by package upgrades. For fresh installs, however, the plain HTTP listener at port 8124 has been disabled, hence by default, access is possible via HTTPS on port 8424 only. A sudoers config has been added to make the system shutdown and restart options from the web UI work.
 - DietPi-Software | Kodi: On Raspberry Pi Bookworm systems, Kodi 21 is now installed, provided as separate package from the RPi APT repository. If you want to upgrade your previously installed instance: sudo dietpi-software reinstall 31

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9526,8 +9526,6 @@ _EOF_
 
 				# APT list: Buster is the latest available suite: https://apt.sonarr.tv/debian/dists/
 				G_EXEC eval 'echo '\''deb https://apt.sonarr.tv/debian buster main'\'' > /etc/apt/sources.list.d/sonarr.list'
-
-				# Update package lists
 				G_AGUP
 
 				# Pre-configure DEB package

--- a/dietpi/func/dietpi-globals
+++ b/dietpi/func/dietpi-globals
@@ -281,13 +281,13 @@ $(ps f -eo pid,user,tty,cmd | grep -i 'dietpi')" && continue
 				Print 1
 
 				# If redirect to existent PID file fails due to noclobber, don't start processing animation.
-				# - This method prevents a tiny condition race from checking file existence until creating it, when doing: [[ ! -e file ]] && > file
+				# - This method prevents a tiny race condition from checking file existence until creating it, when doing: [[ ! -e file ]] && > file
 				set -C
 				if { > /tmp/dietpi-process.pid; } &> /dev/null
 				then
 					set +C
-					Start_Process_Animation(){
-
+					Start_Process_Animation()
+					{
 						local bright_dot='\e[1;33m.' dimmed_dot='\e[0;33m.'
 						# Alternative: \u23F9
 						local aprocess_string=(
@@ -308,10 +308,9 @@ $(ps f -eo pid,user,tty,cmd | grep -i 'dietpi')" && continue
 						for (( i=0; i<=${#aprocess_string[@]}; i++ ))
 						do
 							(( i == ${#aprocess_string[@]} )) && i=0
-							[[ -w '/tmp/dietpi-process.pid' ]] && echo -ne "\e[2G${aprocess_string[$i]}$reset\e[C" || return
+							[[ -w '/tmp/dietpi-process.pid' ]] && echo -ne "\e[2G${aprocess_string[$i]}$reset\e[C" || return 0
 							G_SLEEP 0.15
 						done
-
 					}
 					{ Start_Process_Animation & echo $! > /tmp/dietpi-process.pid; disown; } 2> /dev/null
 					unset -f Start_Process_Animation
@@ -900,8 +899,8 @@ $grey─────────────────────────
 
 			# Execute command, store output to $fp_log file and store exit code to $exit_code variable
 			# - Print full command output if $G_EXEC_OUTPUT=1 is given
-			if [[ $G_EXEC_OUTPUT == 1 ]]; then
-
+			if [[ $G_EXEC_OUTPUT == 1 ]]
+			then
 				# Print $G_EXEC_DESC if given, else raw input command string and show current non-interactive attempt count if $G_EXEC_RETRIES is given
 				G_DIETPI-NOTIFY 2 "${G_EXEC_DESC:-$ecommand}, please wait...${G_EXEC_RETRIES:+ ($attempt/$((G_EXEC_RETRIES+1)))}"
 				[[ $G_EXEC_OUTPUT_COL ]] && echo -ne "$G_EXEC_OUTPUT_COL"
@@ -911,11 +910,9 @@ $grey─────────────────────────
 
 			# - Else print animated processing message only
 			else
-
 				G_DIETPI-NOTIFY -2 "${G_EXEC_DESC:-$ecommand}${G_EXEC_RETRIES:+ ($attempt/$((G_EXEC_RETRIES+1)))}"
 				"${acommand[@]}" &> "$fp_log"
 				exit_code=$?
-
 			fi
 
 			declare -F G_EXEC_POST_FUNC &> /dev/null && G_EXEC_POST_FUNC
@@ -1609,9 +1606,21 @@ Press any key to continue...'
 	#	$2 = Optional file path to store number of available APT upgrades to
 	# - $1 = -v: Store number of available APT upgrades to variable, which defaults to: G_AGUP_COUNT
 	#	$2 = Optional variable name to store number of available APT upgrades to
+	# - $1 = -F: Force update even if last one was done less than an hour ago, sources lists and architectures were not changed in between, and the available update count is not updated with "-f"/"-v" options. This should never be needed unless one wants to sync a known upstream repo update from within the last hour, or if installs/upgrades run into 404 errors, of course.
 	# shellcheck disable=SC2120
 	G_AGUP()
 	{
+		# If not enforced, skip if last APT update was less than an our ago
+		if [[ ! $1 ]]
+		then
+			# Obtain path of downloaded lists
+			local dir files=()
+			eval "$(apt-config shell dir 'Dir::State::lists/d')"
+			mapfile -t files < <(find /etc/apt/sources.list{,.d} /var/lib/dpkg/arch 2> /dev/null)
+			# shellcheck disable=SC2068
+			[[ -d $dir/partial && $(find "$dir/partial" -mmin -60 ${files[@]/#/-newer } -print -quit) ]] && { G_DIETPI-NOTIFY 2 'Skipping APT update, as last call was less than an hour ago and neither sources lists nor architectures changed since.'; return 0; }
+		fi
+
 		G_CHECK_ROOT_USER 1
 
 		# Clean cache before every update, which can corrupt and gets fully rewritten anyway

--- a/rootfs/etc/bashrc.d/dietpi.bash
+++ b/rootfs/etc/bashrc.d/dietpi.bash
@@ -61,7 +61,7 @@
 	# - 1337 moments ;)
 	alias 1337='echo "Indeed, you are =)"'
 
-	# "G_DIETPI-NOFITY -2 message" starts a process animation. If scripts fail to kill the animation, e.g. SIGKILL, terminal bash prompt has to do it as last resort.
+	# "G_DIETPI-NOFITY -2 message" starts a process animation. If scripts fail to kill the animation, e.g. cancelled by user, terminal bash prompt has to do it as last resort.
 	[[ $PROMPT_COMMAND == *'dietpi-process.pid'* ]] || PROMPT_COMMAND="[[ -w '/tmp/dietpi-process.pid' ]] && rm -f /tmp/dietpi-process.pid &> /dev/null && echo -ne '\r\e[J'; $PROMPT_COMMAND"
 
 	# Workaround if SSH client overrides locale with "POSIX" fallback: https://github.com/MichaIng/DietPi/issues/1540#issuecomment-367066178


### PR DESCRIPTION
and if neither /etc/apt/sources.list nor any list in /etc/apt/sources.list.d, nor architectures changed after the last update.

Sadly there is no way to directly check whether anything within a directory changed. `nano dir/file` updates the mtime of the directory, but e.g. `echo foo >> dir/file` does not. Hence we need to check this for every *.list file within the directory, and to be failsafe for the directory itself as well, which matches file removals as well.

Architectures are stored in `/var/lib/dpkg/arch`, which is missing on a fresh Debian instance if never changed.

The last APT update execution can be obtained from the `partial/` sub directory of the directory where repository lists are downloaded to, usually `/var/lib/apt/lists`, or `/tmp/apt/lists` if moved to RAM via `dietpi-config`. This directory is used even if no repo lists are downloaded, its modification timestamp is always updated. `dietpi-set_software apt clean` remoes the directory, in which case APT update is not skipped.

Add an `-F` CLI flag to enforce the update in any case. Since using the other options `-f` and `-v` to get/update the available package updates counter require an actual update to work, they act as enforcement as well.

An alternative regarding the available updates counter, would be to do this just on every `G_AGUP` call. The little added execution time does not matter much with the fewer calls. This could be even done via `apt.conf.d` => `APT::Update::Post-Invoke-Success:: "foo"` for `apt update` as well.