### PR TITLE
Raspberry Pi: remove obsolete rpi[2-5] APT component

### DIFF
--- a/.update/patches
+++ b/.update/patches
@@ -2258,6 +2258,9 @@ Patch_9_16()
 			G_DIETPI-NOTIFY 2 'Disabling serial console on /dev/serial0 device node'
 			/boot/dietpi/func/dietpi-set_hardware serialconsole disable serial0
 		fi
+
+		# Remove obsolete rpi[2-5] component
+		[[ -f '/etc/apt/sources.list.d/dietpi.list' ]] && grep -q ' rpi[2-5]$' /etc/apt/sources.list.d/dietpi.list && G_EXEC sed --follow-symlinks -i '1s/ rpi[2-5]$//' /etc/apt/sources.list.d/dietpi.list
 	fi
 
 	# Remove obsolete configs from pre-patches

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -120,8 +120,7 @@ $FP_SCRIPT	rpi_kernel_choice		<empty> Supported on Debian Bookworm or newer on R
 		# - ARMv6: Since Debian cannot distinguish between ARMv6hf and ARMv7, both armhf, we use a dedicated main component for those.
 		local components='main' all_components=''
 		(( $G_HW_ARCH == 1 )) && components='main-armv6'
-		# - Additional components for SBC-specific packages and builds, some per distro version, some for all distro versions
-		[[ $G_HW_MODEL == [2-5] ]] && components+=" rpi$G_HW_MODEL"
+		# - Additional components for SBC-specific distro-agnostic packages
 		case $G_HW_MODEL in
 			[0-9]) all_components='rpi';;
 			10) all_components='odroidc1';;


### PR DESCRIPTION
<!--
Before submitting a pull request:
- Please ensure the target branch is "dev" (active development): https://github.com/MichaIng/DietPi/tree/dev
- Please ensure changes have been tested and verified functional.
-->
