### PR TITLE
 Quartz64: disable UEFI boot manager

### DIFF
--- a/.github/workflows/quartz64.yml
+++ b/.github/workflows/quartz64.yml
@@ -43,8 +43,6 @@ jobs:
         export ROCKCHIP_TPL='ddr.bin'
         export BL31='bl31.elf'
         cd "u-boot-$uboot_version"
-        # Patch kernel_comp_addr_r being too narrow for our kernel image
-        sed --follow-symlinks -i 's/kernel_comp_addr_r=0x08000000/kernel_comp_addr_r=0x10000000/' include/configs/rk3568_common.h
         # Disable UEFI boot manager, which causes issues in some circumstances: https://github.com/MichaIng/DietPi/issues/7709
         echo 'CONFIG_BOOTMETH_EFI_BOOTMGR=n' >> configs/quartz64-a-rk3566_defconfig
         make quartz64-a-rk3566_defconfig

--- a/.github/workflows/quartz64.yml
+++ b/.github/workflows/quartz64.yml
@@ -45,14 +45,18 @@ jobs:
         cd "u-boot-$uboot_version"
         # Patch kernel_comp_addr_r being too narrow for our kernel image
         sed --follow-symlinks -i 's/kernel_comp_addr_r=0x08000000/kernel_comp_addr_r=0x10000000/' include/configs/rk3568_common.h
+        # Disable UEFI boot manager, which causes issues in some circumstances: https://github.com/MichaIng/DietPi/issues/7709
+        echo 'CONFIG_BOOTMETH_EFI_BOOTMGR=n' >> configs/quartz64-a-rk3566_defconfig
         make quartz64-a-rk3566_defconfig
         make -j$(nproc)
         mv u-boot-rockchip.bin ../firmware-quartz64a/boot/u-boot.bin
+        echo 'CONFIG_BOOTMETH_EFI_BOOTMGR=n' >> configs/quartz64-b-rk3566_defconfig
         make quartz64-b-rk3566_defconfig
         make -j$(nproc)
         mv u-boot-rockchip.bin ../firmware-quartz64b/boot/u-boot.bin
         # Use CM4 config but add poweroff command. Currently, the 3 available (base board) configs differ in default (kernel) device tree only, and the model A base board config additionally has CONFIG_CMD_POWEROFF=y, since it has a power button, so poweroff can be used without the need for a power cycle.
         echo 'CONFIG_CMD_POWEROFF=y' >> configs/soquartz-cm4-rk3566_defconfig
+        echo 'CONFIG_BOOTMETH_EFI_BOOTMGR=n' >> configs/soquartz-cm4-rk3566_defconfig
         make soquartz-cm4-rk3566_defconfig
         make -j$(nproc)
         mv u-boot-rockchip.bin ../firmware-soquartz/boot/u-boot.bin


### PR DESCRIPTION
Additional commit: Quartz64: remove obsolete patch
The issue has been solved upstream: https://github.com/u-boot/u-boot/commit/69b7387