### PR TITLE
Fix typo and variable name

### DIFF
--- a/.meta/dietpi-trixie-upgrade
+++ b/.meta/dietpi-trixie-upgrade
@@ -4,7 +4,7 @@
 . /boot/dietpi/func/dietpi-globals
 readonly G_PROGRAM_NAME='dietpi-trixie-upgrade'
 [[ $G_DISTRO == [78] ]] || { G_DIETPI-NOTIFY 1 'You must run a Debian Bookworm system to run this script!'; exit 1; }
-(( $G_HW_ARCH < 3 )) && dpkg --compare-versions "$(uname -r)" lt-nl 5.6 && { G_DIETPI-NOTIFY 1 '32-bit systems with Linux older than 5.6 cannot run Debian Trixie, due to missing time64 syscall support. Please upgrade your kernel to run this scritp!'; exit 1; }
+(( $G_HW_ARCH < 3 )) && dpkg --compare-versions "$(uname -r)" lt-nl 5.6 && { G_DIETPI-NOTIFY 1 '32-bit systems with Linux older than 5.6 cannot run Debian Trixie, due to missing time64 syscall support. Please upgrade your kernel to run this script!'; exit 1; }
 G_CHECK_ROOT_USER "$@"
 G_CHECK_ROOTFS_RW
 G_INIT
@@ -15,7 +15,7 @@ alist=()
 while read -r id
 do
 	case $id in
-		22) alists+=('QuiteRSS');;
+		22) alist+=('QuiteRSS');;
 		65) alist+=('Netdata');;
 		111) (( $G_HW_ARCH == 3 )) || alist+=('UrBackup');;
 		116) alist+=('Medusa');;


### PR DESCRIPTION
While reviewing the `dietpi-trixie-upgrade` script, I came across these 2 typos: one in a user message and one in the `alist` variable name.