### PR TITLE
dietpi-software: LazyLibrarian: polish

### DIFF
--- a/.github/workflows/dietpi-software.bash
+++ b/.github/workflows/dietpi-software.bash
@@ -269,6 +269,7 @@ Process_Software()
 			#166) aSERVICES[i]='pi-spc';; Service cannot reasonably start in container as WirinPi's gpio command fails reading /proc/cpuinfo
 			167) aSERVICES[i]='raspotify';;
 			168) aSERVICES[i]='coturn' aTCP[i]=3478 aUDP[i]=3478;;
+			169) aSERVICES[i]='lazylibrarian' aTCP[i]=5299; (( $emulation )) && aDELAY[i]=60;;
 			170) aCOMMANDS[i]='unrar -V';;
 			171) aSERVICES[i]='frps frpc' aTCP[i]='7000 7400 7500';;
 			172) aCOMMANDS[i]='wg' aSERVICES[i]='wg-quick@wg0' aUDP[i]='51820' CAPABILITIES+=',CAP_NET_ADMIN';;

--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -587,6 +587,7 @@ shopt -s extglob # +(expr) syntax
 	do
 		aSOFTWARE[$i]=0
 	done
+	aSOFTWARE_NAME9_18[169]='LazyLibrarian'
 
 	# $1 = File name
 	Process_File()

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,9 @@
 v9.18
 (2025-10-18)
 
+New software:
+- LazyLibrarian | This ebook and audiobook collection manager has been added to our software catalogue. It can server as a replacement for Readarr, which is not developed anymore. Many thanks to @JappeHallunken for implementing this software option: https://github.com/MichaIng/DietPi/pull/7747
+
 Enhancements:
 - DietPi-Drive_Manager/DietPi-FS_partition_resize | Support for Xen virtual block devices has been added, which follow the scheme /dev/xvd[a-z][1-9]. Many thanks to @jr551 for implementing this compatibility enhancement: https://github.com/MichaIng/DietPi/pull/7755
 

--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ Links to hardware and software manufacturers, sources and build instructions use
 - [Mumble Server](https://github.com/mumble-voip/mumble)
 - [UrBackup](https://github.com/uroni/urbackup_backend)
 - [PiJuice](https://github.com/PiSupply/PiJuice)
+- [LazyLibrarian](https://gitlab.com/LazyLibrarian/LazyLibrarian)
 
 ---
 

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -187,7 +187,6 @@ _EOF_
 			'snapclient'
 			'spotifyd'
 			'kavita'
-      'lazylibrarian'
 
 			# - Download/BitTorrent
 			'medusa'
@@ -199,6 +198,7 @@ _EOF_
 			'deluge-web'
 			'prowlarr'
 			'readarr'
+			'lazylibrarian'
 
 			# - Cloud/Backups
 			'bdd'

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -737,13 +737,13 @@ Available commands:
 		aSOFTWARE_CATX[$software_id]=3
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/bittorrent/#youtube-dl'
 		aSOFTWARE_DEPS[$software_id]='7'
-    #------------------
-    software_id=169
-    aSOFTWARE_NAME[$software_id]='LazyLibrarian'
-    aSOFTWARE_DESC[$software_id]='Ebook and audiobook collection manager'
-    aSOFTWARE_CATX[$software_id]=3
-    aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/' # TBD: add docs
-    aSOFTWARE_DEPS[$software_id]='130'
+		#------------------
+		software_id=169
+		aSOFTWARE_NAME[$software_id]='LazyLibrarian'
+		aSOFTWARE_DESC[$software_id]='Ebook and audiobook collection manager'
+		aSOFTWARE_CATX[$software_id]=3
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/bittorrent/#lazylibrarian'
+		aSOFTWARE_DEPS[$software_id]='130'
 
 		# Cloud & Backup
 		#--------------------------------------------------------------------------------
@@ -2604,13 +2604,13 @@ sudo sysctl -p /etc/sysctl.d/dietpi-$1.conf"
 			local install=0 user rust=0 piwheels=0
 
 			# Can piwheels be used?
-			if (( $G_HW_MODEL < 3 ))
+			if (( $G_HW_ARCH < 3 ))
 			then
 				if [[ $PYTHON_VERSION ]]
 				then
-					dpkg --compare-version "$PYTHON_VERSION" lt '3.12' && piwheels=1
+					dpkg --compare-version "$PYTHON_VERSION" lt '3.14' && piwheels=1
 				else
-					(( $G_DISTRO < 8 )) && piwheels=1
+					piwheels=1
 				fi
 			fi
 			unset -v PYTHON_VERSION
@@ -2625,9 +2625,9 @@ sudo sysctl -p /etc/sysctl.d/dietpi-$1.conf"
 					'av') (( $G_HW_ARCH < 3 || $G_HW_ARCH == 11 )) && aDEPS+=('libavdevice-dev');;
 					'bcrypt') (( $G_HW_ARCH == 11 )) && rust=1;;
 					'brotli'|'sabctools'|'ujson') (( $G_HW_ARCH == 11 || ( $G_HW_ARCH < 3 && ! $piwheels ) )) && aDEPS+=('g++');;
-					'cffi') (( $G_HW_ARCH == 11 || ( $G_HW_ARCH < 3 && ! $piwheels ) )) && aDEPS+=('gcc' 'libffi-dev');;
+					'cffi') (( $G_HW_ARCH == 11 || ( $G_HW_ARCH < 3 && ( ! $piwheels || $G_DISTRO > 7 ) ) )) && aDEPS+=('gcc' 'libffi-dev');; # piwheels Trixie build failed
 					'cryptography')
-						if (( $G_HW_ARCH == 1 || $G_HW_ARCH == 11 ))
+						if (( ( $G_HW_ARCH == 1 && ! $piwheels ) || $G_HW_ARCH == 11 ))
 						then
 							aDEPS+=('pkg-config' 'libssl-dev')
 							rust=1
@@ -2644,7 +2644,14 @@ sudo sysctl -p /etc/sysctl.d/dietpi-$1.conf"
 						# cmake > ninja > meson-python > numpy
 						(( $G_HW_ARCH == 1 || $G_HW_ARCH == 11 )) && aDEPS+=('cmake' 'make' 'automake')
 					;;
-					'pillow') (( $G_HW_ARCH < 3 || $G_HW_ARCH == 11 )) && aDEPS+=('gcc' 'libjpeg62-turbo-dev');;
+					'pillow')
+						(( $G_HW_ARCH == 11 || ( $G_HW_ARCH < 3 && ! $piwheels ) )) && aDEPS+=('gcc' 'libjpeg62-turbo-dev')
+						if (( $piwheels ))
+						then
+							aDEPS+=('libopenjp2-7' 'libxcb1')
+							(( $G_DISTRO > 6 )) && aDEPS+=('libtiff6') || aDEPS+=('libtiff5')
+						fi
+					;;
 					'poetry')
 						# cryptography > SecretStorage > keyring > poetry
 						set -- "$@" cryptography
@@ -2654,7 +2661,7 @@ sudo sysctl -p /etc/sysctl.d/dietpi-$1.conf"
 					'pycurl') (( $G_HW_ARCH == 11 || ( $G_HW_ARCH < 3 && ! $piwheels ) )) && aDEPS+=('gcc' 'libcurl4-openssl-dev' 'libssl-dev');;
 					'pydantic')
 						# pydantic_core > pydantic
-						(( $G_HW_ARCH == 1 || $G_HW_ARCH == 11 )) && rust=1
+						(( ( $G_HW_ARCH == 1 && ! $piwheels ) || $G_HW_ARCH == 11 )) && rust=1
 					;;
 					'pyenv')
 						# Required: gcc libc6-dev make libssl-dev zlib1g-dev
@@ -12028,48 +12035,78 @@ WantedBy=multi-user.target
 _EOF_
 		fi
 
-    if To_Install 169 lazylibrarian # LazyLibrarian
-    then
-      # Dependencies for venv
-      aDEPS=('python3-venv')
+		if To_Install 169 lazylibrarian # LazyLibrarian
+		then
+			# Dependencies
+			aDEPS=('python3-venv')
+			Python_Deps cryptography pillow
 
-      # Create user and data dir
+			# Download
+			Download_Install 'https://gitlab.com/LazyLibrarian/LazyLibrarian/-/archive/master/LazyLibrarian-master.tar.bz2'
+
+			# Add dummy unbundled.libs to prevent unnecessary attempt to remove bundled libraries which do not exist. It is falsely determined since the venv is inside the install dir.
+			> LazyLibrarian-master/unbundled.libs
+
+			# Install: Clear existing instance
+			[[ -d '/opt/lazylibrarian' ]] && G_EXEC rm -R /opt/lazylibrarian
+			G_EXEC mv LazyLibrarian-master /opt/lazylibrarian
+
+			# Python venv
+			G_EXEC python3 -m venv /opt/lazylibrarian/venv
+			G_EXEC_OUTPUT=1 G_EXEC /opt/lazylibrarian/venv/bin/pip install /opt/lazylibrarian
+
+			# User
+			Create_User -g dietpi lazylibrarian
+
+			# Data directory
 			G_EXEC mkdir -p /mnt/dietpi_userdata/lazylibrarian
-			Create_User -d /mnt/dietpi_userdata/lazylibrarian lazylibrarian
+			G_EXEC chmod 0750 /mnt/dietpi_userdata/lazylibrarian
 
-      # Download and unpack to /mnt/dietpi_userdata/lazylibrarian/LazyLibrarian-master
-			Download_Install 'https://gitlab.com/LazyLibrarian/LazyLibrarian/-/archive/master/LazyLibrarian-master.tar.gz' /mnt/dietpi_userdata/lazylibrarian
-      # Set permissions
-      G_EXEC chown -R 'lazylibrarian:lazylibrarian' -R /mnt/dietpi_userdata/lazylibrarian
-			G_EXEC chmod 0770 /mnt/dietpi_userdata/lazylibrarian
+			# Config: Preserve existing
+			[[ -f '/mnt/dietpi_userdata/lazylibrarian/config.ini' ]] || G_EXEC eval 'cat << '\''_EOF_'\'' > /mnt/dietpi_userdata/lazylibrarian/config.ini
+[GENERAL]
+ebook_dir = /mnt/dietpi_userdata/ebooks
+audio_dir = /mnt/dietpi_userdata/audiobooks
+download_dir = /mnt/dietpi_userdata/downloads
 
-      # Python venv and install
-      G_EXEC sudo -u lazylibrarian python3 -m venv /mnt/dietpi_userdata/lazylibrarian/venv
-      G_EXEC_OUTPUT=1 sudo -u lazylibrarian /mnt/dietpi_userdata/lazylibrarian/venv/bin/python3 -m pip install -e /mnt/dietpi_userdata/lazylibrarian/LazyLibrarian-master
+[LOGGING]
+logdir = /var/log/lazylibrarian
+_EOF_'
+			# Add version info to prevent unnecessary update attempt on first service start of fresh install and make update checks meaningful
+			G_EXEC mkdir -p /mnt/dietpi_userdata/lazylibrarian/cache
+			curl -sSfL 'https://gitlab.com/api/v4/projects/9317860/repository/commits?per_page=1' | mawk -F\" '{print $8}' > /mnt/dietpi_userdata/lazylibrarian/cache/version.txt
 
-      # Service
-cat << '_EOF_' > /etc/systemd/system/lazylibrarian.service
+			# Permissions
+			G_EXEC chown -R 'lazylibrarian' /mnt/dietpi_userdata/lazylibrarian
+
+			# Service: https://gitlab.com/LazyLibrarian/LazyLibrarian/-/blob/master/init
+			cat << '_EOF_' > /etc/systemd/system/lazylibrarian.service
 [Unit]
 Description=LazyLibrarian
 Documentation=https://lazylibrarian.gitlab.io
 Wants=network-online.target
-After=network-online.target
+After=network-online.target remote-fs.target transmission-daemon.service qbittorrent.service rtorrent.service nzbget.service deluged.service aria2.service sabnzbd.service
 
 [Service]
+SyslogIdentifier=LazyLibrarian
 User=lazylibrarian
-Group=lazylibrarian
-WorkingDirectory=/mnt/dietpi_userdata/lazylibrarian/LazyLibrarian-master
-ExecStart=/mnt/dietpi_userdata/lazylibrarian/venv/bin/python3 /mnt/dietpi_userdata/lazylibrarian/LazyLibrarian-master/LazyLibrarian.py
-Restart=always
+UMask=002
+LogsDirectory=lazylibrarian
+ExecStart=/opt/lazylibrarian/venv/bin/python /opt/lazylibrarian/LazyLibrarian.py --datadir=/mnt/dietpi_userdata/lazylibrarian --nolaunch
 
-StandardOutput=journal
-StandardError=journal
+# Hardening
+ProtectSystem=strict
+ProtectHome=true
+PrivateDevices=true
+PrivateTmp=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+ReadWritePaths=-/opt/lazylibrarian -/mnt -/media -/var/log/lazylibrarian -/tmp
 
 [Install]
 WantedBy=multi-user.target
 _EOF_
-
-    fi
+		fi
 	}
 
 	# $1: 0=None -1=Dropbear -2=OpenSSH
@@ -14187,11 +14224,13 @@ _EOF_
 			[[ -d '/mnt/dietpi_userdata/soju' ]] &&	G_EXEC rm -Rf /mnt/dietpi_userdata/soju
 		fi
 
-    if To_Uninstall 169 # LazyLibrarian
-    then
-      Remove_Service lazylibrarian 1 1
-      [[ -d '/mnt/dietpi_userdata/lazylibrarian' ]] && G_EXEC rm -Rf /mnt/dietpi_userdata/lazylibrarian
-    fi
+		if To_Uninstall 169 # LazyLibrarian
+		then
+			Remove_Service lazylibrarian 1 1
+			G_EXEC rm -Rf /opt/lazylibrarian
+			G_EXEC rm -Rf /var/log/lazylibrarian
+			G_EXEC rm -Rf /mnt/dietpi_userdata/lazylibrarian
+		fi
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Finalising uninstall'
 


### PR DESCRIPTION
* Add to software test script
* Add to dietpi-survey report page
* Add changelog entry
* Add credits link to readme
* Align indentations
* Download better compressed bzip2 archive instead of gzip
* Install static files and venv to `/opt/lazylibrarian`, since LazyLibrarian does not require write, and it allows simpler clean updates
* Use `/mnt/dietpi_userdata/lazylibrarian` as data directory instead
* Skip service user home directory and service working directory, since both do not seem to have any influence anyway
* Use `dietpi` as primary group to grant access to default DietPi downloads and ebooks directories, as well as downloads
* Do not permit the `dietpi` group access to the LazyLibrarian data directory
* Create a default config with download/ebooks/audiobooks directory suggestions, and logging to `/var/log/lazylibrarian`
* Start service after download servers and add permissions/sandbox hardening to align with Servarr applications
* Avoid unnecessary update attempt on first service start and bundled modules cleanup on service stop
* Add and update Python dependencies, since piwheels provides Trixie/Python 3.13 wheels now, and caught up with Bullseye and Bookworm builds as well after their long pause and internal transitions

Runs on TCP port 5299 by default, which is fine => docs and https://github.com/MichaIng/DietPi/wiki/DietPi-TCP-UDP-port-usage-list

@JappeHallunken 
Let me know if you thing something will break with those changes, will run some tests anyway. The CLI has an `--update` flag, which allows LL to update its Git repo automatically on service start, if it was cloned with Git in the first place. For this, of course it requires write access. But if such auto-update was wanted, we could instead do it easily as `ExecStartPre=` step without granting LL itself further permissions. But overall, I don't think such is commonly wanted, especially here were no stable releases exist, but just a single branch, where chances for breaking changes and bugs with each commit are higher.

Test installs: https://github.com/MichaIng/DietPi/actions/runs/18246613171