### PR TITLE
dietpi-dashboard: implement reworked version

### DIFF
--- a/.github/workflows/dietpi-software.bash
+++ b/.github/workflows/dietpi-software.bash
@@ -299,7 +299,7 @@ Process_Software()
 			197) aCOMMANDS[i]='box64 -v';;
 			198) aSERVICES[i]='filebrowser' aTCP[i]='8084';;
 			199) aSERVICES[i]='spotifyd' aUDP[i]='5353';; # + random high TCP port
-			#200) aSERVICES[i]='dietpi-dashboard' aTCP[i]='5252';; "dietpi-dashboard.service: Failed to set up standard input: No such file or directory"; "dietpi-dashboard.service: Failed at step STDIN spawning /opt/dietpi-dashboard/dietpi-dashboard: No such file or directory"
+			200) aSERVICES[i]='dietpi-dashboard-frontend dietpi-dashboard-backend' aTCP[i]='5252 5353';;
 			201) aSERVICES[i]='zerotier-one' aTCP[i]='9993';;
 			202) aCOMMANDS[i]='rclone version';;
 			203) aSERVICES[i]='readarr' aTCP[i]='8787';;

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -317,8 +317,8 @@ _EOF_
 				'amiberry'		# Only support to be started on boot or manually
 				'dietpi-cloudshell'
 				'dietpi-dashboard'
-				'dietpi-dashboard-backend'
 				'dietpi-dashboard-frontend'
+				'dietpi-dashboard-backend'
 			)
 
 			# Services which must not be touched: Show only in status mode!

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -317,6 +317,8 @@ _EOF_
 				'amiberry'		# Only support to be started on boot or manually
 				'dietpi-cloudshell'
 				'dietpi-dashboard'
+				'dietpi-dashboard-backend'
+				'dietpi-dashboard-frontend'
 			)
 
 			# Services which must not be touched: Show only in status mode!

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3405,44 +3405,62 @@ Signed-By: /etc/apt/keyrings/dietpi-adoptium.asc"
 				G_WHIP_MENU 'Please choose which version of DietPi-Dashboard should be installed.' && version=$G_WHIP_RETURNED_VALUE
 			fi
 
-			# Backend only? Currently not functional!
-			local backend= #$(sed -n '/^[[:blank:]]*SOFTWARE_DIETPI_DASHBOARD_BACKEND=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-			#[[ $backend == 1 ]] && G_WHIP_DEFAULT_ITEM='Yes' || G_WHIP_DEFAULT_ITEM='No'
-			#G_WHIP_BUTTON_OK_TEXT='Yes' G_WHIP_BUTTON_CANCEL_TEXT='No'
-			#G_WHIP_YESNO 'Would you like to install the backend only, to view on another DietPi-Dashboard instance?' && backend='-backend' || backend=
+			# Determine which components to install
+			local components=('backend')
+			local backend=$(sed -n '/^[[:blank:]]*SOFTWARE_DIETPI_DASHBOARD_BACKEND=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 
-			# Download binary and set config URL
-			local config_url
+			[[ $backend == 1 ]] && G_WHIP_DEFAULT_ITEM='Backend' || G_WHIP_DEFAULT_ITEM='Frontend'
+			G_WHIP_MENU_ARRAY=(
+				'Backend' ': Install the DietPi-Dashboard backend only.'
+				'Frontend' ': Install both the DietPi-Dashboard backend and webserver.'
+			)
+			G_WHIP_MENU 'DietPi-Dashboard has two components, a frontend and a backend.
+The frontend is required to be installed on at least one node to view the webpage. The backend must be installed on all nodes.
+Which components would you like to install?'
+
+			[[ $G_WHIP_RETURNED_VALUE == 'Frontend' ]] && components+=('frontend')
+
+			# Download binary/binaries
 			if [[ $version == 'Nightly' ]]
 			then
 				command -v unzip > /dev/null || G_AGI unzip # G_CHECK_URL => HEAD request on nightly.link always returns 404, hence prevent Download_Install() from doing concurrent unzip install, which forks the download into background and runs G_CHECK_URL first.
-				Download_Install "https://nightly.link/ravenclaw900/DietPi-Dashboard/workflows/push-build/main/dietpi-dashboard-$G_HW_ARCH_NAME$backend.zip" /opt/dietpi-dashboard
-				config_url='https://raw.githubusercontent.com/ravenclaw900/DietPi-Dashboard/main/config.toml'
+
+				for component in "${components[@]}"; do
+					Download_Install "https://nightly.link/ravenclaw900/DietPi-Dashboard/workflows/push-build/rework-2/dietpi-dashboard-$G_HW_ARCH_NAME-$component.zip" "/opt/dietpi-dashboard/$component"
+				done
 			else
-				Download_Install "$(curl -sSfL 'https://api.github.com/repos/ravenclaw900/dietpi-dashboard/releases/latest' | mawk -F\" "/^ *\"browser_download_url\": \".*dietpi-dashboard-$G_HW_ARCH_NAME$backend\"$/{print \$4}")" /opt/dietpi-dashboard/dietpi-dashboard
-				config_url="https://raw.githubusercontent.com/ravenclaw900/DietPi-Dashboard/$(curl -sSfL 'https://api.github.com/repos/ravenclaw900/dietpi-dashboard/releases/latest' | mawk -F\" '/^ *"tag_name": "[^"]*",$/{print $4}')/config.toml"
+				# NB: Will not work until 0.7.0 is released
+				local manifest = "$(curl -sSfL 'https://api.github.com/repos/ravenclaw900/dietpi-dashboard/releases/latest')"
+				for component in "${components[@]}"; do
+					Download_Install "$(echo $manifest | mawk -F\" "/^ *\"browser_download_url\": \".*dietpi-dashboard-$G_HW_ARCH_NAME-$component\"$/{print \$4}")" "/opt/dietpi-dashboard/$component"
+				done
 			fi
-			G_EXEC chmod +x /opt/dietpi-dashboard/dietpi-dashboard
 
-			# Config
-			if [[ ! -f '/opt/dietpi-dashboard/config.toml' ]]
+			# Services
+			if [[ $G_WHIP_RETURNED_VALUE == 'Frontend' ]]
 			then
-				G_EXEC curl -sSfL "$config_url" -o /opt/dietpi-dashboard/config.toml
-				# Enable password protection with global software password by default
-				G_CONFIG_INJECT 'pass[[:blank:]]' 'pass = true' /opt/dietpi-dashboard/config.toml
-				G_CONFIG_INJECT 'hash[[:blank:]]' "hash = \"$(echo -n "$GLOBAL_PW" | sha512sum | mawk '{print $1}')\"" /opt/dietpi-dashboard/config.toml
-				G_CONFIG_INJECT 'secret[[:blank:]]' "secret = \"$(openssl rand -hex 32)\"" /opt/dietpi-dashboard/config.toml
-			fi
-
-			# Service
-			cat << '_EOF_' > /etc/systemd/system/dietpi-dashboard.service
+				cat << '_EOF_' > /etc/systemd/system/dietpi-dashboard-server.service
 [Unit]
-Description=Web Dashboard (DietPi)
+Description=Dashboard Web Server (DietPi)
 Wants=network-online.target
 After=network-online.target
 
 [Service]
-ExecStart=/opt/dietpi-dashboard/dietpi-dashboard
+ExecStart=/opt/dietpi-dashboard/frontend
+
+[Install]
+WantedBy=multi-user.target
+_EOF_
+			fi
+
+			cat << '_EOF_' > /etc/systemd/system/dietpi-dashboard-backend.service
+[Unit]
+Description=Dashboard Backend (DietPi)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/opt/dietpi-dashboard/backend
 # TTY input is required for web terminal input
 StandardInput=tty
 TTYPath=/dev/tty42
@@ -3451,8 +3469,22 @@ StandardOutput=journal
 [Install]
 WantedBy=multi-user.target
 _EOF_
-			# Service needs to be started manually as dietpi-services must not control it to prevent it from stopping during software installs done via dashboard itself.
-			aSTART_SERVICES+=('dietpi-dashboard')
+
+			for component in "${components[@]}"; do
+				G_EXEC chmod +x "/opt/dietpi-dashboard/$component"
+				Create_Config "/opt/dietpi-dashboard/config-$component.toml" "dietpi-dashboard-$component"
+				aSTART_SERVICES+=("dietpi-dashboard-$component")
+			done
+
+			# Config
+			# if [[ ! -f '/opt/dietpi-dashboard/config.toml' ]]
+			# then
+			# 	G_EXEC curl -sSfL "$config_url" -o /opt/dietpi-dashboard/config.toml
+			# 	# Enable password protection with global software password by default
+			# 	G_CONFIG_INJECT 'pass[[:blank:]]' 'pass = true' /opt/dietpi-dashboard/config.toml
+			# 	G_CONFIG_INJECT 'hash[[:blank:]]' "hash = \"$(echo -n "$GLOBAL_PW" | sha512sum | mawk '{print $1}')\"" /opt/dietpi-dashboard/config.toml
+			# 	G_CONFIG_INJECT 'secret[[:blank:]]' "secret = \"$(openssl rand -hex 32)\"" /opt/dietpi-dashboard/config.toml
+			# fi
 		fi
 
 		if To_Install 99 node_exporter # Prometheus Node Exporter
@@ -12836,7 +12868,8 @@ _EOF_
 
 		if To_Uninstall 200 # DietPi-Dashboard
 		then
-			Remove_Service dietpi-dashboard
+			Remove_Service dietpi-dashboard-backend
+			Remove_Service dietpi-dashboard-frontend
 			[[ -d '/opt/dietpi-dashboard' ]] && G_EXEC rm -R /opt/dietpi-dashboard
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3441,10 +3441,6 @@ After=network-online.target
 
 [Service]
 ExecStart=/opt/dietpi-dashboard/backend
-# TTY input is required for web terminal input
-StandardInput=tty
-TTYPath=/dev/tty42
-StandardOutput=journal
 
 [Install]
 WantedBy=multi-user.target

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3438,7 +3438,7 @@ Signed-By: /etc/apt/keyrings/dietpi-adoptium.asc"
 			fi
 
 			# Users
-			Create_User dietpi-dashboard-frontent
+			Create_User dietpi-dashboard-frontend
 
 			# Services
 			G_EXEC eval 'cat << '\''_EOF_'\'' > /etc/systemd/system/dietpi-dashboard-backend.service
@@ -3460,7 +3460,7 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-User=dietpi-dashboard-frontent
+User=dietpi-dashboard-frontend
 ExecStart=/opt/dietpi-dashboard/frontend
 
 # Hardening
@@ -3482,7 +3482,7 @@ _EOF_'
 			[[ -f '/opt/dietpi-dashboard/config-backend.toml' ]] || new_instance=1
 
 			# Pre-create empty frontend config with needed owner
-			[[ ${components[1]} && $new_instance == 1 ]] && G_EXEC install -m 0640 -o dietpi-dashboard-frontent /dev/null /opt/dietpi-dashboard/config-frontend.toml
+			[[ ${components[1]} && $new_instance == 1 ]] && G_EXEC install -m 0640 -o dietpi-dashboard-frontend /dev/null /opt/dietpi-dashboard/config-frontend.toml
 
 			for component in "${components[@]}"; do
 				G_EXEC chmod +x "/opt/dietpi-dashboard/$component"
@@ -3501,7 +3501,7 @@ _EOF_'
 					openssl req -reqexts SAN -subj '/CN=DietPi-Dashboard' -config <(cat /etc/ssl/openssl.cnf <(echo -ne "[SAN]\nsubjectAltName=DNS:$(</etc/hostname),IP:$(G_GET_NET ip)\nbasicConstraints=CA:TRUE,pathlen:0"))\
 						-x509 -days 7200 -sha256 -extensions SAN -out /opt/dietpi-dashboard/cert.pem\
 						-newkey ec:<(openssl ecparam -name prime256v1) -nodes -keyout /opt/dietpi-dashboard/privkey.pem || exit 1 # Replace deprecated -nodes with -noenc when dropping Bullseye support
-					G_EXEC chown dietpi-dashboard-frontent /opt/dietpi-dashboard/{cert,privkey}.pem
+					G_EXEC chown dietpi-dashboard-frontend /opt/dietpi-dashboard/{cert,privkey}.pem
 					G_CONFIG_INJECT 'cert_path[[:blank:]]' 'cert_path = "/opt/dietpi-dashboard/cert.pem"' /opt/dietpi-dashboard/config-frontend.toml
 					G_CONFIG_INJECT 'key_path[[:blank:]]' 'key_path = "/opt/dietpi-dashboard/privkey.pem"' /opt/dietpi-dashboard/config-frontend.toml
 					G_CONFIG_INJECT 'enable_tls[[:blank:]]' 'enable_tls = true' /opt/dietpi-dashboard/config-frontend.toml
@@ -3524,7 +3524,7 @@ _EOF_'
 					G_CONFIG_INJECT 'frontend_addr[[:blank:]]' "frontend_addr = \"$G_WHIP_RETURNED_VALUE\"" /opt/dietpi-dashboard/config-backend.toml
 
 					# Ask for frontend secret
-					G_WHIP_PASSWORD 'Please enter the secret of the frontent this backend shall connec to. This can be done or changed any time later in /opt/dietpi-dashboard/config-backend.toml.' &&
+					G_WHIP_PASSWORD 'Please enter the secret of the frontend this backend shall connec to. This can be done or changed any time later in /opt/dietpi-dashboard/config-backend.toml.' &&
 					GCI_PASSWORD=1 G_CONFIG_INJECT 'secret[[:blank:]]' "secret = \"${result//\"/\\\"}\"" /opt/dietpi-dashboard/config-backend.toml
 					unset -v result
 				fi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3520,11 +3520,13 @@ _EOF_'
 					G_WHIP_DEFAULT_ITEM="$(G_GET_NET gateway):5353"
 					G_WHIP_INPUTBOX_REGEX='^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9]):[1-9][0-9]+$'
 					G_WHIP_INPUTBOX_REGEX_TEXT="match the format \"<ip/hostname>:<port>\", e.g. \"$G_WHIP_DEFAULT_ITEM\""
-					G_WHIP_INPUTBOX "Please enter the IP address or hostname and network port of the frontend this backend shall connect to, in the format \"<ip/hostname>:<port>\", e.g. \"$G_WHIP_DEFAULT_ITEM\". This can be done or changed any time later in /opt/dietpi-dashboard/config-backend.toml." &&
+					G_WHIP_BUTTON_CANCEL_TEXT='Skip'
+					G_WHIP_INPUTBOX "Please enter the IP address or hostname and network port of the frontend this backend shall connect to, in the format \"<ip/hostname>:<port>\", e.g. \"$G_WHIP_DEFAULT_ITEM\". This can be changed any time later in /opt/dietpi-dashboard/config-backend.toml." &&
 					G_CONFIG_INJECT 'frontend_addr[[:blank:]]' "frontend_addr = \"$G_WHIP_RETURNED_VALUE\"" /opt/dietpi-dashboard/config-backend.toml
 
 					# Ask for frontend secret
-					G_WHIP_PASSWORD 'Please enter the secret of the frontend this backend shall connec to. This can be done or changed any time later in /opt/dietpi-dashboard/config-backend.toml.' &&
+					G_WHIP_BUTTON_CANCEL_TEXT='Skip'
+					G_WHIP_PASSWORD 'Please enter the secret of the frontend this backend shall connect to. This can be changed any time later in /opt/dietpi-dashboard/config-backend.toml.' &&
 					GCI_PASSWORD=1 G_CONFIG_INJECT 'secret[[:blank:]]' "secret = \"${result//\"/\\\"}\"" /opt/dietpi-dashboard/config-backend.toml
 					unset -v result
 				fi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1178,7 +1178,7 @@ Available commands:
 		#------------------
 		software_id=200
 		aSOFTWARE_NAME[$software_id]='DietPi-Dashboard'
-		aSOFTWARE_DESC[$software_id]='Official lightweight DietPi web interface (Rust)'
+		aSOFTWARE_DESC[$software_id]='(rework beta!) Official lightweight DietPi web interface (Rust)'
 		aSOFTWARE_CATX[$software_id]=8
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/system_stats/#dietpi-dashboard'
 		#------------------
@@ -3387,6 +3387,11 @@ Signed-By: /etc/apt/keyrings/dietpi-adoptium.asc"
 
 		if To_Install 200 # DietPi-Dashboard
 		then
+			G_WHIP_MSG '[ WARN ] Reworked DietPi-Dashboard beta version
+\nYou are about to install a reworked beta version of the DietPi-Dashboard which has not undergone much testing yet. Please assure to close its network ports (default: TCP 5252 and 5353) on your NAT/router or via firewall, to protect them from public access.
+\nIf you need to access the DietPi-Dashboard remotely, please use a VPN server on this system, like WireGuard.
+\nIf the old version is currently installed, it will remain on the system but its service is disabled. So you can switch between the versions for now, if needed. They use different config files and executables.'
+
 			# Stable release or nightly?
 			local version='Nightly' # Enforce nightly until 0.7.0 is released
 			#local version=$(sed -n '/^[[:blank:]]*SOFTWARE_DIETPI_DASHBOARD_VERSION=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
@@ -3457,21 +3462,58 @@ ExecStart=/opt/dietpi-dashboard/frontend
 [Install]
 WantedBy=multi-user.target
 _EOF_'
+			# Derive based on existing backend config (since the backend is always installed) whether this is a new instance or a reinstall, so we know whether to pre-configure it
+			local new_instance=0
+			[[ -f '/opt/dietpi-dashboard/config-backend.toml' ]] || new_instance=1
+
 			for component in "${components[@]}"; do
 				G_EXEC chmod +x "/opt/dietpi-dashboard/$component"
 				Create_Config "/opt/dietpi-dashboard/config-$component.toml" "dietpi-dashboard-$component"
 				aSTART_SERVICES+=("dietpi-dashboard-$component")
 			done
 
-			# Config
-			# if [[ ! -f '/opt/dietpi-dashboard/config.toml' ]]
-			# then
-			# 	G_EXEC curl -sSfL "$config_url" -o /opt/dietpi-dashboard/config.toml
-			# 	# Enable password protection with global software password by default
-			# 	G_CONFIG_INJECT 'pass[[:blank:]]' 'pass = true' /opt/dietpi-dashboard/config.toml
-			# 	G_CONFIG_INJECT 'hash[[:blank:]]' "hash = \"$(echo -n "$GLOBAL_PW" | sha512sum | mawk '{print $1}')\"" /opt/dietpi-dashboard/config.toml
-			# 	G_CONFIG_INJECT 'secret[[:blank:]]' "secret = \"$(openssl rand -hex 32)\"" /opt/dietpi-dashboard/config.toml
-			# fi
+			# Config: Touch for new instances only
+			if (( $new_instance ))
+			then
+				# If frontend is installed
+				if [[ ${components[1]} ]]
+				then
+					# Enable TLS OOTB with self-signed certificate
+					G_DIETPI-NOTIFY 2 'Generating a self-signed HTTPS certificate for the DietPi-Dashboard ...'
+					openssl req -reqexts SAN -subj '/CN=DietPi-Dashboard' -config <(cat /etc/ssl/openssl.cnf <(echo -ne "[SAN]\nsubjectAltName=DNS:$(</etc/hostname),IP:$(G_GET_NET ip)\nbasicConstraints=CA:TRUE,pathlen:0"))\
+						-x509 -days 7200 -sha256 -extensions SAN -out /opt/dietpi-dashboard/cert.pem\
+						-newkey ec:<(openssl ecparam -name prime256v1) -nodes -keyout /opt/dietpi-dashboard/privkey.pem || exit 1 # Replace deprecated -nodes with -noenc when dropping Bullseye support
+					G_CONFIG_INJECT 'cert_path[[:blank:]]' 'cert_path = "/opt/dietpi-dashboard/cert.pem"' /opt/dietpi-dashboard/config-frontend.toml
+					G_CONFIG_INJECT 'key_path[[:blank:]]' 'key_path = "/opt/dietpi-dashboard/privkey.pem"' /opt/dietpi-dashboard/config-frontend.toml
+					G_CONFIG_INJECT 'enable_tls[[:blank:]]' 'enable_tls = true' /opt/dietpi-dashboard/config-frontend.toml
+
+					# Enable password authentication OOTB with default software password
+					GCI_PASSWORD=1 G_CONFIG_INJECT 'hash[[:blank:]]' "hash = \"$(echo -n "$GLOBAL_PW" | sha512sum | mawk '{print $1}')\"" /opt/dietpi-dashboard/config-frontend.toml
+					G_CONFIG_INJECT 'enable_login[[:blank:]]' 'enable_login = true' /opt/dietpi-dashboard/config-frontend.toml
+
+					# Create and assign a new random secret to match frontend and backend
+					local secret=$(openssl rand -hex 32)
+					GCI_PASSWORD=1 G_CONFIG_INJECT 'secret[[:blank:]]' "secret = \"$secret\"" /opt/dietpi-dashboard/config-frontend.toml
+					GCI_PASSWORD=1 G_CONFIG_INJECT 'secret[[:blank:]]' "secret = \"$secret\"" /opt/dietpi-dashboard/config-backend.toml
+					unset -v secret
+				else
+					# Ask for frontend address to connect
+					G_WHIP_DEFAULT_ITEM="$(G_GET_NET gateway):5353"
+					G_WHIP_INPUTBOX_REGEX='^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9]):[1-9][0-9]+$'
+					G_WHIP_INPUTBOX_REGEX_TEXT="match the format \"<ip/hostname>:<port>\", e.g. \"$G_WHIP_DEFAULT_ITEM\""
+					G_WHIP_INPUTBOX "Please enter the IP address or hostname and network port of the frontend this backend shall connect to, in the format \"<ip/hostname>:<port>\", e.g. \"$G_WHIP_DEFAULT_ITEM\". This can be done or changed any time later in /opt/dietpi-dashboard/config-backend.toml." &&
+					G_CONFIG_INJECT 'frontend_addr[[:blank:]]' "frontend_addr = \"$G_WHIP_RETURNED_VALUE\"" /opt/dietpi-dashboard/config-backend.toml
+
+					# Ask for frontend secret
+					G_WHIP_PASSWORD 'Please enter the secret of the frontent this backend shall connec to. This can be done or changed any time later in /opt/dietpi-dashboard/config-backend.toml.' &&
+					GCI_PASSWORD=1 G_CONFIG_INJECT 'secret[[:blank:]]' "secret = \"${result//\"/\\\"}\"" /opt/dietpi-dashboard/config-backend.toml
+					unset -v result
+				fi
+
+				# If /mnt/dietpi_userdata points to a mount point, add that one to disks shown on system page
+				local userdata=$(findmnt -no TARGET -T "$(realpath /mnt/dietpi_userdata)")
+				[[ $userdata != '/' ]] && G_CONFIG_INJECT 'disks[[:blank:]]' "disks = [\"/\", \"$userdata\"]" /opt/dietpi-dashboard/config-backend.toml
+			fi
 
 			# Pre-v9.18: Disable old version but leave installed for now
 			[[ -f '/etc/systemd/system/dietpi-dashboard.service' ]] && G_EXEC systemctl disable dietpi-dashboard

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3437,6 +3437,9 @@ Signed-By: /etc/apt/keyrings/dietpi-adoptium.asc"
 				done
 			fi
 
+			# Users
+			Create_User dietpi-dashboard-frontent
+
 			# Services
 			G_EXEC eval 'cat << '\''_EOF_'\'' > /etc/systemd/system/dietpi-dashboard-backend.service
 [Unit]
@@ -3457,7 +3460,19 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
+User=dietpi-dashboard-frontent
 ExecStart=/opt/dietpi-dashboard/frontend
+
+# Hardening
+ProtectSystem=strict
+ProtectHome=true
+PrivateDevices=true
+PrivateTmp=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+NoNewPrivileges=true
+ReadWritePaths=-/opt/dietpi-dashboard
 
 [Install]
 WantedBy=multi-user.target
@@ -3466,9 +3481,12 @@ _EOF_'
 			local new_instance=0
 			[[ -f '/opt/dietpi-dashboard/config-backend.toml' ]] || new_instance=1
 
+			# Pre-create empty frontend config with needed owner
+			[[ ${components[1]} && $new_instance == 1 ]] && G_EXEC install -m 0640 -o dietpi-dashboard-frontent /dev/null /opt/dietpi-dashboard/config-frontend.toml
+
 			for component in "${components[@]}"; do
 				G_EXEC chmod +x "/opt/dietpi-dashboard/$component"
-				Create_Config "/opt/dietpi-dashboard/config-$component.toml" "dietpi-dashboard-$component"
+				CREATE_CONFIG_CONTENT='.' Create_Config "/opt/dietpi-dashboard/config-$component.toml" "dietpi-dashboard-$component"
 				aSTART_SERVICES+=("dietpi-dashboard-$component")
 			done
 
@@ -3483,6 +3501,7 @@ _EOF_'
 					openssl req -reqexts SAN -subj '/CN=DietPi-Dashboard' -config <(cat /etc/ssl/openssl.cnf <(echo -ne "[SAN]\nsubjectAltName=DNS:$(</etc/hostname),IP:$(G_GET_NET ip)\nbasicConstraints=CA:TRUE,pathlen:0"))\
 						-x509 -days 7200 -sha256 -extensions SAN -out /opt/dietpi-dashboard/cert.pem\
 						-newkey ec:<(openssl ecparam -name prime256v1) -nodes -keyout /opt/dietpi-dashboard/privkey.pem || exit 1 # Replace deprecated -nodes with -noenc when dropping Bullseye support
+					G_EXEC chown dietpi-dashboard-frontent /opt/dietpi-dashboard/{cert,privkey}.pem
 					G_CONFIG_INJECT 'cert_path[[:blank:]]' 'cert_path = "/opt/dietpi-dashboard/cert.pem"' /opt/dietpi-dashboard/config-frontend.toml
 					G_CONFIG_INJECT 'key_path[[:blank:]]' 'key_path = "/opt/dietpi-dashboard/privkey.pem"' /opt/dietpi-dashboard/config-frontend.toml
 					G_CONFIG_INJECT 'enable_tls[[:blank:]]' 'enable_tls = true' /opt/dietpi-dashboard/config-frontend.toml

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3388,22 +3388,17 @@ Signed-By: /etc/apt/keyrings/dietpi-adoptium.asc"
 		if To_Install 200 # DietPi-Dashboard
 		then
 			# Stable release or nightly?
-			# - RISC-V and Raspberry Pi 5: Use nightly builds, as stable does not work on these CPUs
-			if (( $G_HW_ARCH == 11 || $G_HW_MODEL == 5 ))
-			then
-				local version='Nightly'
-			else
-				local version=$(sed -n '/^[[:blank:]]*SOFTWARE_DIETPI_DASHBOARD_VERSION=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-				[[ $version == 'Nightly' ]] || version='Stable'
+			local version='Nightly' # Enforce nightly until 0.7.0 is released
+			#local version=$(sed -n '/^[[:blank:]]*SOFTWARE_DIETPI_DASHBOARD_VERSION=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+			#[[ $version == 'Nightly' ]] || version='Stable'
 
-				G_WHIP_MENU_ARRAY=(
-					'Stable' ': Use a release version of DietPi-Dashboard.'
-					'Nightly' ': Use an unstable version of DietPi-Dashboard.'
-				)
-				G_WHIP_DEFAULT_ITEM=$version
-				G_WHIP_BUTTON_CANCEL_TEXT=$version
-				G_WHIP_MENU 'Please choose which version of DietPi-Dashboard should be installed.' && version=$G_WHIP_RETURNED_VALUE
-			fi
+			#G_WHIP_MENU_ARRAY=(
+			#	'Stable' ': Use a release version of DietPi-Dashboard.'
+			#	'Nightly' ': Use an unstable version of DietPi-Dashboard.'
+			#)
+			#G_WHIP_DEFAULT_ITEM=$version
+			#G_WHIP_BUTTON_CANCEL_TEXT=$version
+			#G_WHIP_MENU 'Please choose which version of DietPi-Dashboard should be installed.' && version=$G_WHIP_RETURNED_VALUE
 
 			# Determine which components to install
 			local components=('backend')
@@ -3438,23 +3433,7 @@ Signed-By: /etc/apt/keyrings/dietpi-adoptium.asc"
 			fi
 
 			# Services
-			if [[ $G_WHIP_RETURNED_VALUE == 'Frontend' ]]
-			then
-				cat << '_EOF_' > /etc/systemd/system/dietpi-dashboard-frontend.service
-[Unit]
-Description=Dashboard Web Server (DietPi)
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-ExecStart=/opt/dietpi-dashboard/frontend
-
-[Install]
-WantedBy=multi-user.target
-_EOF_
-			fi
-
-			cat << '_EOF_' > /etc/systemd/system/dietpi-dashboard-backend.service
+			G_EXEC eval 'cat << '\''_EOF_'\'' > /etc/systemd/system/dietpi-dashboard-backend.service
 [Unit]
 Description=Dashboard Backend (DietPi)
 Wants=network-online.target
@@ -3469,8 +3448,19 @@ StandardOutput=journal
 
 [Install]
 WantedBy=multi-user.target
-_EOF_
+_EOF_'
+			[[ ${components[1]} ]] && G_EXEC eval 'cat << '\''_EOF_'\'' > /etc/systemd/system/dietpi-dashboard-frontend.service
+[Unit]
+Description=Dashboard Web Server (DietPi)
+Wants=network-online.target
+After=network-online.target dietpi-dashboard-backend.service
 
+[Service]
+ExecStart=/opt/dietpi-dashboard/frontend
+
+[Install]
+WantedBy=multi-user.target
+_EOF_'
 			for component in "${components[@]}"; do
 				G_EXEC chmod +x "/opt/dietpi-dashboard/$component"
 				Create_Config "/opt/dietpi-dashboard/config-$component.toml" "dietpi-dashboard-$component"
@@ -3486,6 +3476,9 @@ _EOF_
 			# 	G_CONFIG_INJECT 'hash[[:blank:]]' "hash = \"$(echo -n "$GLOBAL_PW" | sha512sum | mawk '{print $1}')\"" /opt/dietpi-dashboard/config.toml
 			# 	G_CONFIG_INJECT 'secret[[:blank:]]' "secret = \"$(openssl rand -hex 32)\"" /opt/dietpi-dashboard/config.toml
 			# fi
+
+			# Pre-v9.18: Disable old version but leave installed for now
+			[[ -f '/etc/systemd/system/dietpi-dashboard.service' ]] && G_EXEC systemctl disable dietpi-dashboard
 		fi
 
 		if To_Install 99 node_exporter # Prometheus Node Exporter
@@ -12869,6 +12862,7 @@ _EOF_
 
 		if To_Uninstall 200 # DietPi-Dashboard
 		then
+			Remove_Service dietpi-dashboard # Pre-v9.18
 			Remove_Service dietpi-dashboard-backend
 			Remove_Service dietpi-dashboard-frontend
 			[[ -d '/opt/dietpi-dashboard' ]] && G_EXEC rm -R /opt/dietpi-dashboard

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3453,7 +3453,7 @@ _EOF_'
 [Unit]
 Description=Dashboard Web Server (DietPi)
 Wants=network-online.target
-After=network-online.target dietpi-dashboard-backend.service
+After=network-online.target
 
 [Service]
 ExecStart=/opt/dietpi-dashboard/frontend

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3417,7 +3417,7 @@ Signed-By: /etc/apt/keyrings/dietpi-adoptium.asc"
 			G_WHIP_MENU 'DietPi-Dashboard has two components, a frontend and a backend.
 \nThe frontend is required to be installed on at least one node to view the webpage. The backend must be installed on all nodes.'
 
-			[[ $G_WHIP_RETURNED_VALUE == 'Frontend' ]] && components+=('frontend')
+			[[ $G_WHIP_RETURNED_VALUE == 'Backend' ]] || components+=('frontend')
 
 			# Download binary/binaries
 			if [[ $version == 'Nightly' ]]
@@ -3425,13 +3425,15 @@ Signed-By: /etc/apt/keyrings/dietpi-adoptium.asc"
 				command -v unzip > /dev/null || G_AGI unzip # G_CHECK_URL => HEAD request on nightly.link always returns 404, hence prevent Download_Install() from doing concurrent unzip install, which forks the download into background and runs G_CHECK_URL first.
 
 				for component in "${components[@]}"; do
-					Download_Install "https://nightly.link/ravenclaw900/DietPi-Dashboard/workflows/push-build/rework-2/dietpi-dashboard-$G_HW_ARCH_NAME-$component.zip" "/opt/dietpi-dashboard"
+					Download_Install "https://nightly.link/ravenclaw900/DietPi-Dashboard/workflows/push-build/rework-2/dietpi-dashboard-$G_HW_ARCH_NAME-$component.zip" /opt/dietpi-dashboard
 				done
 			else
 				# NB: Will not work until 0.7.0 is released
-				local manifest = "$(curl -sSfL 'https://api.github.com/repos/ravenclaw900/dietpi-dashboard/releases/latest')"
+				local manifest
+				# shellcheck disable=SC2016
+				G_EXEC eval 'manifest=$(curl -sSfL '\''https://api.github.com/repos/ravenclaw900/dietpi-dashboard/releases/latest'\'')'
 				for component in "${components[@]}"; do
-					Download_Install "$(echo $manifest | mawk -F\" "/^ *\"browser_download_url\": \".*dietpi-dashboard-$G_HW_ARCH_NAME-$component\"$/{print \$4}")" "/opt/dietpi-dashboard"
+					Download_Install "$(echo "$manifest" | mawk -F\" "/^ *\"browser_download_url\": \".*dietpi-dashboard-$G_HW_ARCH_NAME-$component\"$/{print \$4}")" /opt/dietpi-dashboard
 				done
 			fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3537,7 +3537,13 @@ _EOF_'
 			fi
 
 			# Pre-v9.18: Disable old version but leave installed for now
-			[[ -f '/etc/systemd/system/dietpi-dashboard.service' ]] && G_EXEC systemctl disable dietpi-dashboard
+			if systemctl -q is-enabled dietpi-dashboard
+			then
+				G_EXEC systemctl disable dietpi-dashboard
+				G_WHIP_MSG '[ INFO ] Reboot required for new dashboard to load
+\nThe old dashboard has been disabled, but not stopped, so this install does not kill itself in case it was triggered from the dashboard. This prevents the startup of the new service, unless network ports have been changed.
+\nHence a reboot may be required afterwards for the new dashboard to replace the old one at port 5252.'
+			fi
 		fi
 
 		if To_Install 99 node_exporter # Prometheus Node Exporter
@@ -14150,7 +14156,7 @@ _EOF_
 	systemctl --no-reload disable dietpi-ramlog
 	systemctl stop dietpi-ramlog
 	rm -R /var/tmp/dietpi/logs/dietpi-ramlog_store
-	if systemctl -q is-enabled rsyslog 2> /dev/null
+	if systemctl -q is-enabled rsyslog
 	then
 		sed --follow-symlinks -i '/^[[:blank:]]*INDEX_LOGGING=/c\INDEX_LOGGING=-3' /boot/dietpi/.installed
 	else
@@ -14420,7 +14426,7 @@ _EOF_
 		fi
 
 		# Sync DietPi-RAMlog to disk: https://github.com/MichaIng/DietPi/issues/4884
-		systemctl -q is-enabled dietpi-ramlog 2> /dev/null && /boot/dietpi/func/dietpi-ramlog 1
+		systemctl -q is-enabled dietpi-ramlog && /boot/dietpi/func/dietpi-ramlog 1
 
 		# Apply GPU Memory Splits
 		Install_Apply_GPU_Settings
@@ -14565,6 +14571,7 @@ _EOF_
 				sync # Failsafe
 				G_SLEEP 3
 				reboot
+				exit 0
 			fi
 
 		fi
@@ -15649,6 +15656,7 @@ List of installed software and their online documentation URLs:
 \nTo assure that $G_PROGRAM_NAME can run successfully, especially when performing installs, it is required that you perform a reboot so that kernel modules can be loaded ondemand.
 \nThere may be rare cases where no dedicated kernel modules are used but all require modules are builtin. If this is the case, please create the mentioned directory manually to proceed.
 \nDo you want to reboot now?" && reboot || exit 1
+		exit 0
 	fi
 	# Init software arrays
 	Software_Arrays_Init

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3415,8 +3415,7 @@ Signed-By: /etc/apt/keyrings/dietpi-adoptium.asc"
 				'Frontend' ': Install both the DietPi-Dashboard backend and webserver.'
 			)
 			G_WHIP_MENU 'DietPi-Dashboard has two components, a frontend and a backend.
-The frontend is required to be installed on at least one node to view the webpage. The backend must be installed on all nodes.
-Which components would you like to install?'
+\nThe frontend is required to be installed on at least one node to view the webpage. The backend must be installed on all nodes.'
 
 			[[ $G_WHIP_RETURNED_VALUE == 'Frontend' ]] && components+=('frontend')
 
@@ -3426,20 +3425,20 @@ Which components would you like to install?'
 				command -v unzip > /dev/null || G_AGI unzip # G_CHECK_URL => HEAD request on nightly.link always returns 404, hence prevent Download_Install() from doing concurrent unzip install, which forks the download into background and runs G_CHECK_URL first.
 
 				for component in "${components[@]}"; do
-					Download_Install "https://nightly.link/ravenclaw900/DietPi-Dashboard/workflows/push-build/rework-2/dietpi-dashboard-$G_HW_ARCH_NAME-$component.zip" "/opt/dietpi-dashboard/$component"
+					Download_Install "https://nightly.link/ravenclaw900/DietPi-Dashboard/workflows/push-build/rework-2/dietpi-dashboard-$G_HW_ARCH_NAME-$component.zip" "/opt/dietpi-dashboard"
 				done
 			else
 				# NB: Will not work until 0.7.0 is released
 				local manifest = "$(curl -sSfL 'https://api.github.com/repos/ravenclaw900/dietpi-dashboard/releases/latest')"
 				for component in "${components[@]}"; do
-					Download_Install "$(echo $manifest | mawk -F\" "/^ *\"browser_download_url\": \".*dietpi-dashboard-$G_HW_ARCH_NAME-$component\"$/{print \$4}")" "/opt/dietpi-dashboard/$component"
+					Download_Install "$(echo $manifest | mawk -F\" "/^ *\"browser_download_url\": \".*dietpi-dashboard-$G_HW_ARCH_NAME-$component\"$/{print \$4}")" "/opt/dietpi-dashboard"
 				done
 			fi
 
 			# Services
 			if [[ $G_WHIP_RETURNED_VALUE == 'Frontend' ]]
 			then
-				cat << '_EOF_' > /etc/systemd/system/dietpi-dashboard-server.service
+				cat << '_EOF_' > /etc/systemd/system/dietpi-dashboard-frontend.service
 [Unit]
 Description=Dashboard Web Server (DietPi)
 Wants=network-online.target


### PR DESCRIPTION
Sorry for the delay my end. Let's get this done for the upcoming release.

I wonder whether we shall still support the current stable version with respective old setup, or whether we shall install the Nightly automatically for now (until dashboard stable release), and just make that somewhat clear during the install process and adding some sort of beta flag to name/description.

@ravenclaw900 can you trigger a new nightly build?

EDIT: Install tests, including service status and network ports: https://github.com/MichaIng/DietPi/actions/runs/18431888612
