### PR TITLE
Dietpi-Software: add BirdNET-Go

### DIFF
--- a/.github/workflows/dietpi-software.bash
+++ b/.github/workflows/dietpi-software.bash
@@ -227,6 +227,7 @@ Process_Software()
 			124) aSERVICES[i]='networkaudiod';; # aUDP[i]='????';;
 			125) aSERVICES[i]='synapse' aTCP[i]='8008';;
 			126) aSERVICES[i]='adguardhome' aUDP[i]='53' aTCP[i]='8083'; [[ ${aSERVICES[182]} ]] && aUDP[i]+=' 5335';; # Unbound uses port 5335 if AdGuard Home is installed
+			127) aSERVICES[i]='birdnet' aTCP[i]='8127';;
 			128) aSERVICES[i]='mpd' aTCP[i]='6600';;
 			#129) O!MPD
 			130) aCOMMANDS[i]='python3 -V';;

--- a/.github/workflows/update_urls.bash
+++ b/.github/workflows/update_urls.bash
@@ -145,6 +145,14 @@ aREGEX[$software_id]='https://hndl.urbackup.org/Server/.*/urbackup-server_.*_\$a
 # NAA Daemon: Currently has no fallback URL/version
 software_id=124
 
+# BirdNET-Go
+software_id=127
+aCHECK[$software_id]='curl -sSf '\''https://api.github.com/repos/tphakala/birdnet-go/releases'\'' | mawk -F\" '\''/^ *"tag_name": "[^"]*",$/{print $4} | head -1'
+aARCH[$software_id]='arm64 amd64'
+aARCH_CHECK[$software_id]='armhf riscv64'
+aREGEX[$software_id]='bnet_vers='\''[^'\'']*'\'
+aREPLACE[$software_id]='bnet_vers='\''$release'\'
+
 # YaCy
 software_id=133
 aCHECK[$software_id]='curl -sSf '\''https://download.yacy.net/?C=N;O=D'\'' | grep -o '\''yacy_v[0-9._a-f]*\.tar\.gz'\'' | head -1'

--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -589,6 +589,7 @@ shopt -s extglob # +(expr) syntax
 	do
 		aSOFTWARE_NAME9_19[i]=${aSOFTWARE_NAME9_18[i]}
 	done
+	aSOFTWARE_NAME9_19[127]='BirdNET-Go'
 
 	# Pre-create software counter array so that we can see also software (available in newest version) with 0 installs
 	for i in "${aSOFTWARE_NAME9_19[@]}"

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,9 @@
 v9.19
 (2025-11-15)
 
+New software:
+- BirdNET-Go | This continuous avian monitoring and identification system has been added to our software catalogue. Many thanks to @mtekman for implementing this software option: https://github.com/MichaIng/DietPi/pull/7770
+
 Bug fixes:
 - Raspberry Pi | We updated our raspberrypi-sys-mods package to be compatible with the new kernel stack and Raspberry Pi 5. This solves several issues like missing serial console access on first boot, missing device nodes or permissions to access them with gpio/i2c/spi/video system groups.
 - DietPi-Update | Resolved an issue on Debian Trixie systems with ZeroTier installed, where the update from DietPi v9.17 to v9.18 updated the ZeroTier APT repo falsely, leading to an "apt update" error. Many thanks to @randell1993 for reporting this isseue: https://dietpi.com/forum/t/cannot-update-to-v9-18-due-to-zerotier/24580

--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ Links to hardware and software manufacturers, sources and build instructions use
 - [UrBackup](https://github.com/uroni/urbackup_backend)
 - [PiJuice](https://github.com/PiSupply/PiJuice)
 - [LazyLibrarian](https://gitlab.com/LazyLibrarian/LazyLibrarian)
+- [BirdNET-Go](https://github.com/tphakala/birdnet-go)
 
 ---
 

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -221,6 +221,7 @@ _EOF_
 			'motioneye'
 			'raspimjpeg'
 			'mjpg-streamer'
+			'birdnet'
 
 			# - Printing
 			'octoprint'

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9356,99 +9356,6 @@ _EOF_
 			fi
 		fi
 
-		if To_Install 127 birdnet # BirdNET-Go: https://github.com/tphakala/birdnet-go/blob/main/install.sh
-		then
-			local bnet_vers='nightly-20251028'
-			local bnet_inst='/opt/birdnet'
-			local bnet_data='/mnt/dietpi_userdata/birdnet'
-			local bnet_conf="$bnet_data/.config/birdnet-go/config.yaml"
-			local bnet_logs='/var/log/birdnet'
-			local bnet_user='birdnet'
-			local bnet_port=8127
-
-			# Dependencies
-			aDEPS=('sox' 'patchelf')
-			# - Add yq only on first install
-			local install_yq=0
-			[[ -f $bnet_conf ]] || command -v yq > /dev/null || install_yq=0 aDEPS+=('yq')
-
-			case $G_HW_ARCH in
-				3) local arch='arm64';;
-				*) local arch='amd64';;
-			esac
-
-			# Download
-			Download_Install "https://github.com/tphakala/birdnet-go/releases/download/$bnet_vers/birdnet-go-linux-$arch.tar.gz" birdnet
-
-			# Change rpath for birdnet-go to make use of libtensorflowlite_c.so in its own dir
-			G_EXEC patchelf --set-rpath "$bnet_inst" birdnet/birdnet-go
-
-			# Install: Remove old dir on reinstall
-			[[ -d $bnet_inst ]] && G_EXEC rm -R "$bnet_inst"
-			G_EXEC mv birdnet "$bnet_inst"
-
-			# User
-			Create_User -d "$bnet_data" "$bnet_user"
-
-			# Data dir
-			G_EXEC mkdir -p "$bnet_data"
-			G_EXEC chown -R "$bnet_user:$bnet_user" "$bnet_data"
-
-			# Config
-			# - Checks hard-coded paths in this order: ~/.config/birdnet-go/config.yaml > /etc/birdnet-go/config.yaml
-			if [[ ! -f $bnet_conf ]]
-			then
-				# Initial call to generate ~/.config/birdnet-go/config.yaml
-				G_EXEC runuser -u "$bnet_user" -- "$bnet_inst/birdnet-go"
-				# Replace paths, otherwise defaults to the working directory
-				# Disable MQTT and CPU/memory/disk monitoring
-				# Enable new web UI at $bnet_port
-				G_EXEC yq -yi "
-					.output.sqlite.path = \"$bnet_data/birdnet.db\" |
-					.main.log.path = \"$bnet_logs/birdnet.log\" |
-					.realtime.log.path = \"$bnet_logs/birdnet.txt\" |
-					.realtime.audio.export.path = \"$bnet_data/clips\" |
-					.realtime.output.file.path = \"$bnet_data/output\" |
-					.realtime.mqtt.enabled = false |
-					.realtime.monitoring.enabled = false |
-					.realtime.webserver.enabled = true |
-					.realtime.dashboard.newui = true |
-					.webserver.port = $bnet_port" "$bnet_conf"
-				# Purge yq if it was installed for BirdNET-Go only
-				(( $install_yq )) && G_AGP yq
-			fi
-
-			# Service
-			cat << _EOF_ > /etc/systemd/system/birdnet.service
-[Unit]
-Description=BirdNet-Go
-Wants=network-online.target
-After=network-online.target
-StartLimitIntervalSec=60
-StartLimitBurst=3
-
-[Service]
-User=$bnet_user
-WorkingDirectory=$bnet_data
-LogsDirectory=birdnet
-ExecStart=$bnet_inst/birdnet-go realtime
-Restart=on-failure
-RestartSec=5
-
-# Hardening
-ProtectSystem=strict
-ProtectHome=1
-PrivateTmp=1
-PrivateDevices=1
-ProtectKernelTunables=1
-ProtectControlGroups=1
-ReadWritePaths=-$bnet_data -$bnet_logs -/tmp
-
-[Install]
-WantedBy=multi-user.target
-_EOF_
-		fi
-
 		if To_Install 138 virtualhere # VirtualHere
 		then
 			case $G_HW_ARCH in
@@ -12332,6 +12239,97 @@ ReadWritePaths=-/opt/lazylibrarian -/mnt -/media -/var/log/lazylibrarian -/tmp
 WantedBy=multi-user.target
 _EOF_
 		fi
+
+		if To_Install 127 birdnet # BirdNET-Go: https://github.com/tphakala/birdnet-go/blob/main/install.sh
+		then
+			local bnet_vers='nightly-20251028'
+			local bnet_inst='/opt/birdnet'
+			local bnet_data='/mnt/dietpi_userdata/birdnet'
+			local bnet_conf="$bnet_data/.config/birdnet-go/config.yaml"
+			local bnet_user='birdnet'
+			local bnet_port=8127
+
+			# Dependencies
+			aDEPS=('sox' 'patchelf')
+			# - Add yq only on first install
+			local install_yq=0
+			[[ -f $bnet_conf ]] || command -v yq > /dev/null || install_yq=0 aDEPS+=('yq')
+
+			case $G_HW_ARCH in
+				3) local arch='arm64';;
+				*) local arch='amd64';;
+			esac
+
+			# Download
+			Download_Install "https://github.com/tphakala/birdnet-go/releases/download/$bnet_vers/birdnet-go-linux-$arch.tar.gz" birdnet
+
+			# Change rpath for birdnet-go to make use of libtensorflowlite_c.so in its own dir
+			G_EXEC patchelf --set-rpath "$bnet_inst" birdnet/birdnet-go
+
+			# Install: Remove old dir on reinstall
+			[[ -d $bnet_inst ]] && G_EXEC rm -R "$bnet_inst"
+			G_EXEC mv birdnet "$bnet_inst"
+
+			# User
+			Create_User -d "$bnet_data" "$bnet_user"
+
+			# Data dir
+			G_EXEC mkdir -p "$bnet_data"
+			G_EXEC chown -R "$bnet_user:$bnet_user" "$bnet_data"
+
+			# Config
+			# - Checks hard-coded paths in this order: ~/.config/birdnet-go/config.yaml > /etc/birdnet-go/config.yaml
+			if [[ ! -f $bnet_conf ]]
+			then
+				# Initial call to generate ~/.config/birdnet-go/config.yaml
+				G_EXEC runuser -u "$bnet_user" -- "$bnet_inst/birdnet-go"
+				# Replace paths, otherwise defaults to the working directory
+				# Disable MQTT and CPU/memory/disk monitoring
+				# Enable new web UI at $bnet_port
+				G_EXEC yq -yi "
+					.output.sqlite.path = \"$bnet_data/birdnet.db\" |
+					.main.log.path = \"$bnet_data/logs/birdnet.log\" |
+					.realtime.log.path = \"$bnet_data/logs/birdnet.txt\" |
+					.realtime.audio.export.path = \"$bnet_data/clips\" |
+					.realtime.output.file.path = \"$bnet_data/output\" |
+					.realtime.mqtt.enabled = false |
+					.realtime.monitoring.enabled = false |
+					.realtime.webserver.enabled = true |
+					.realtime.dashboard.newui = true |
+					.webserver.port = $bnet_port" "$bnet_conf"
+				# Purge yq if it was installed for BirdNET-Go only
+				(( $install_yq )) && G_AGP yq
+			fi
+
+			# Service
+			cat << _EOF_ > /etc/systemd/system/birdnet.service
+[Unit]
+Description=BirdNet-Go
+Wants=network-online.target
+After=network-online.target
+StartLimitIntervalSec=60
+StartLimitBurst=3
+
+[Service]
+User=$bnet_user
+WorkingDirectory=$bnet_data
+ExecStart=$bnet_inst/birdnet-go realtime
+Restart=on-failure
+RestartSec=5
+
+# Hardening
+ProtectSystem=strict
+ProtectHome=1
+PrivateTmp=1
+PrivateDevices=1
+ProtectKernelTunables=1
+ProtectControlGroups=1
+ReadWritePaths=-$bnet_data -/tmp
+
+[Install]
+WantedBy=multi-user.target
+_EOF_
+		fi
 	}
 
 	# $1: 0=None -1=Dropbear -2=OpenSSH
@@ -12934,7 +12932,6 @@ _EOF_
 			Remove_Service birdnet 1 1
 			G_AGP sox
 			G_EXEC rm -Rf /opt/birdnet
-			G_EXEC rm -Rf /var/log/birdnet
 			G_EXEC rm -Rf /mnt/dietpi_userdata/birdnet
 		fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9384,19 +9384,19 @@ _EOF_
 			## initial call to generate config
 			LD_LIBRARY_PATH="${bnet_install}:$LD_LIBRARY_PATH" G_EXEC "${bnet_install}"/birdnet-go
 
-			local tmp_config=${HOME}/.config/birdnet-go/config.yaml
+			local config="${bnet_data}"/.config/birdnet-go/config.yaml
 			# Replace paths
 			# - Paths otherwise default to the working directory at ${bnet_install}
 			G_AGI yq
-			yq -i -y ".main.log.path = \"${bnet_log}/birdnet.log\"" "${tmp_config}" &&
-			yq -i -y ".realtime.log.path = \"${bnet_log}/birdnet.txt\"" "${tmp_config}" &&
-			yq -i -y ".realtime.audio.export.path = \"${bnet_data}/clips/\"" "${tmp_config}" &&
-			yq -i -y ".realtime.output.file.path = \"${bnet_data}/output/\"" "${tmp_config}" &&
+			yq -i -y ".main.log.path = \"${bnet_log}/birdnet.log\"" "${config}" &&
+			yq -i -y ".realtime.log.path = \"${bnet_log}/birdnet.txt\"" "${config}" &&
+			yq -i -y ".realtime.audio.export.path = \"${bnet_data}/clips/\"" "${config}" &&
+			yq -i -y ".realtime.output.file.path = \"${bnet_data}/output/\"" "${config}" &&
 			## Set services
-			yq -i -y '.realtime.mqtt.enabled = false' "${tmp_config}" &&
-			yq -i -y '.realtime.monitoring.enabled = false' "${tmp_config}" &&	# cpu/memory/disk
-			yq -i -y '.realtime.webserver.enabled = true' "${tmp_config}" &&
-			yq -i -y ".webserver.port = \"${bnet_http_port}\"" "${tmp_config}" ## replace port
+			yq -i -y '.realtime.mqtt.enabled = false' "${config}" &&
+			yq -i -y '.realtime.monitoring.enabled = false' "${config}" &&	# cpu/memory/disk
+			yq -i -y '.realtime.webserver.enabled = true' "${config}" &&
+			yq -i -y ".webserver.port = \"${bnet_http_port}\"" "${config}" ## replace port
 			G_AGP yq
 
 			G_EXEC mkdir /etc/birdnet-go

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9382,7 +9382,7 @@ _EOF_
 			# - $HOME/.config/birdnet-go/config.yaml (default)
 			# - /etc/birdnet-go/config.yaml
 			## initial call to generate config
-			LD_LIBRARY_PATH="${bnet_install}:$LD_LIBRARY_PATH" "${bnet_install}"/birdnet-go >/dev/null
+			LD_LIBRARY_PATH="${bnet_install}:$LD_LIBRARY_PATH" G_EXEC "${bnet_install}"/birdnet-go
 
 			local tmp_config=${HOME}/.config/birdnet-go/config.yaml
 			# Replace paths

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9356,9 +9356,9 @@ _EOF_
 		then
 			local bnet_release="nightly-20250904"
 			local bnet_http_port=8127
-			local bnet_install=/opt/birdnet-go
+			local bnet_install=/opt/birdnet
 			local bnet_log=/var/log/birdnet
-			local bnet_data=/mnt/dietpi_userdata/birdnet-go
+			local bnet_data=/mnt/dietpi_userdata/birdnet
 			local bnet_user=birdnet
 
 			case $G_HW_ARCH in
@@ -9408,7 +9408,7 @@ _EOF_
 			G_EXEC chown -R birdnet:dietpi "${bnet_install}"
 
 			## Generate systemd file
-			cat <<EOF > /etc/systemd/system/birdnet-go.service
+			cat <<EOF > /etc/systemd/system/birdnet.service
 [Unit]
 Description=BirdNet-Go Realtime Bird Sound Analyzer
 After=network.target
@@ -9420,7 +9420,7 @@ RestartSec=5
 User=${bnet_user}
 WorkingDirectory=${bnet_install}
 Environment="LD_LIBRARY_PATH=${bnet_install}:\$LD_LIBRARY_PATH"
-SyslogIdentifier=birdnet-go
+SyslogIdentifier=birdnet
 
 [Install]
 WantedBy=multi-user.target
@@ -12911,13 +12911,13 @@ _EOF_
 
 		if To_Uninstall 127 # BirdNET-Go
 		then
-			Remove_Service birdnet-go
+			Remove_Service birdnet
 			G_AGP sox
-			[[ -d '/opt/birdnet-go' ]] && G_EXEC rm -R '/opt/birdnet-go'
+			[[ -d '/opt/birdnet' ]] && G_EXEC rm -R '/opt/birdnet'
 			[[ -f '/var/log/birdnet.txt' ]] && G_EXEC rm '/var/log/birdnet.txt'
 			[[ -f '/var/log/birdnet.log' ]] && G_EXEC rm '/var/log/birdnet.log'
 			[[ -d '/etc/birdnet-go' ]] && G_EXEC rm -R '/etc/birdnet-go'
-			[[ -d '/mnt/dietpi_userdata/birdnet-go' ]] && G_EXEC rm -R '/mnt/dietpi_userdata/birdnet-go'
+			[[ -d '/mnt/dietpi_userdata/birdnet' ]] && G_EXEC rm -R '/mnt/dietpi_userdata/birdnet'
 		fi
 
 		if To_Uninstall 138 # VirtualHere

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9399,11 +9399,12 @@ _EOF_
 			if [[ ! -f $config ]]
 			then
 				# Initial call to generate ~/.config/birdnet-go/config.yaml
-				G_EXEC_OUTPUT=1 G_EXEC runuser -u "$bnet_user" -- "$bnet_inst/birdnet-go"
-				# Replace paths, otherwise default to the working directory at $bnet_inst
+				G_EXEC runuser -u "$bnet_user" -- "$bnet_inst/birdnet-go"
+				# Replace paths, otherwise defaults to the working directory
 				# Disable MQTT and CPU/memory/disk monitoring
 				# Enable new web UI at $bnet_port
-				G_EXEC yq -i -y "
+				G_EXEC yq -yi "
+					.output.sqlite.path = \"$bnet_data/birdnet.db\" |
 					.main.log.path = \"$bnet_logs/birdnet.log\" |
 					.realtime.log.path = \"$bnet_logs/birdnet.txt\" |
 					.realtime.audio.export.path = \"$bnet_data/clips\" |
@@ -12930,7 +12931,7 @@ _EOF_
 
 		if To_Uninstall 127 # BirdNET-Go
 		then
-			Remove_Service birdnet
+			Remove_Service birdnet 1 1
 			G_AGP sox
 			G_EXEC rm -Rf /opt/birdnet
 			G_EXEC rm -Rf /var/log/birdnet

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12253,7 +12253,7 @@ _EOF_
 			aDEPS=('sox' 'patchelf')
 			# - Add yq only on first install
 			local install_yq=0
-			[[ -f $bnet_conf ]] || command -v yq > /dev/null || install_yq=0 aDEPS+=('yq')
+			[[ -f $bnet_conf ]] || command -v yq > /dev/null || install_yq=1 aDEPS+=('yq')
 
 			case $G_HW_ARCH in
 				3) local arch='arm64';;

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1093,7 +1093,7 @@ Available commands:
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/camera/#mjpg-streamer'
 		#------------------
 		software_id=127
-		aSOFTWARE_NAME[$software_id]='birdnet-go'
+		aSOFTWARE_NAME[$software_id]='BirdNET-Go'
 		aSOFTWARE_DESC[$software_id]='Continuous avian monitoring and identification'
 		aSOFTWARE_CATX[$software_id]=7
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/camera/#birdnet-go'
@@ -9399,6 +9399,7 @@ _EOF_
 			yq -i -y '.realtime.mqtt.enabled = false' "${config}" &&
 			yq -i -y '.realtime.monitoring.enabled = false' "${config}" &&	# cpu/memory/disk
 			yq -i -y '.realtime.webserver.enabled = true' "${config}" &&
+            yq -i -y '.realtime.dashboard.newui = true' "${config}" &&
 			yq -i -y ".webserver.port = \"${bnet_http_port}\"" "${config}" ## replace port
 			G_AGP yq
 
@@ -9423,7 +9424,6 @@ SyslogIdentifier=birdnet
 WantedBy=multi-user.target
 
 EOF
-			G_EXEC systemctl start birdnet-go
 		fi
 
 		if To_Install 138 virtualhere # VirtualHere

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1097,7 +1097,9 @@ Available commands:
 		aSOFTWARE_DESC[$software_id]='Continuous avian monitoring and identification'
 		aSOFTWARE_CATX[$software_id]=7
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/camera/#birdnet-go'
-		aSOFTWARE_DEPS[$software_id]='7 87' ## ffmpeg sqlite3
+		aSOFTWARE_DEPS[$software_id]='7 87'
+		# - ARMv6/7/RISC-V: https://github.com/tphakala/birdnet-go/releases
+		(( $G_HW_ARCH == 3 || $G_HW_ARCH == 10 )) || aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,$G_HW_ARCH]=0
 
 		# System Stats & Management
 		#--------------------------------------------------------------------------------
@@ -9352,78 +9354,91 @@ _EOF_
 			fi
 		fi
 
-		if To_Install 127 birdnet-go # BirdNET-Go
+		if To_Install 127 birdnet # BirdNET-Go: https://github.com/tphakala/birdnet-go/blob/main/install.sh
 		then
-			local bnet_release="nightly-20251012"
-			local bnet_http_port=8127
-			local bnet_install=/opt/birdnet
-			local bnet_log=/var/log/birdnet
-			local bnet_data=/mnt/dietpi_userdata/birdnet
-			local bnet_user=birdnet
+			local bnet_vers='nightly-20251028'
+			local bnet_inst='/opt/birdnet'
+			local bnet_data='/mnt/dietpi_userdata/birdnet'
+			local bnet_conf="$bnet_data/.config/birdnet-go/config.yaml"
+			local bnet_logs='/var/log/birdnet'
+			local bnet_user='birdnet'
+			local bnet_port=8127
+
+			# Dependencies
+			aDEPS=('sox' 'patchelf' 'yq')
 
 			case $G_HW_ARCH in
 				3) local arch='arm64';;
 				*) local arch='amd64';;
 			esac
-			aDEPS=("sox")
 
-			# Download binary and library
-			Download_Install "https://github.com/tphakala/birdnet-go/releases/download/${bnet_release}/birdnet-go-linux-${arch}.tar.gz"	 birdnet
+			# Download
+			Download_Install "https://github.com/tphakala/birdnet-go/releases/download/$bnet_vers/birdnet-go-linux-$arch.tar.gz" birdnet
+
+			# Change rpath for birdnet-go to make use of libtensorflowlite_c.so in its own dir
+			G_EXEC patchelf --set-rpath "$bnet_inst" birdnet/birdnet-go
+
+			# Install: Remove old dir on reinstall
+			[[ -d $bnet_inst ]] && G_EXEC rm -R "$bnet_inst"
+			G_EXEC mv birdnet "$bnet_inst"
 
 			# User
-			G_EXEC mkdir "${bnet_data}"
-			## Move binaries to final destination
-			G_EXEC mkdir "${bnet_install}"
-			G_EXEC mv birdnet/birdnet-go "${bnet_install}"/birdnet-go
-			G_EXEC mv birdnet/libtensorflowlite_c.so "${bnet_install}"/libtensorflowlite_c.so
-			G_EXEC rmdir birdnet # cleanup
+			Create_User -d "$bnet_data" "$bnet_user"
 
-			Create_User -g "${bnet_user}" -d "${bnet_data}" "${bnet_user}"
-			G_EXEC chown -R "${bnet_user}":"${bnet_user}" "${bnet_data}"
+			# Data dir
+			G_EXEC mkdir -p "$bnet_data"
+			G_EXEC chown -R "$bnet_user:$bnet_user" "$bnet_data"
 
-			# Initialise config: hard-coded to check only
-			# - $HOME/.config/birdnet-go/config.yaml (default)
-			# - /etc/birdnet-go/config.yaml
-			## initial call to generate config
-			LD_LIBRARY_PATH="${bnet_install}:$LD_LIBRARY_PATH" G_EXEC sudo -u "${bnet_user}" "${bnet_install}"/birdnet-go
+			# Config
+			# - Checks hard-coded paths in this order: ~/.config/birdnet-go/config.yaml > /etc/birdnet-go/config.yaml
+			if [[ ! -f $config ]]
+			then
+				# - Initial call to generate ~/.config/birdnet-go/config.yaml
+				G_EXEC_OUTPUT=1 G_EXEC runuser -u "$bnet_user" -- "$bnet_inst/birdnet-go"
+				# - Replace paths, otherwise default to the working directory at $bnet_inst
+				# - Disable MQTT and CPU/memory/disk monitoring
+				# - Enable new web UI at $bnet_port
+				G_EXEC yq -i -y "
+					.main.log.path = \"$bnet_logs/birdnet.log\" |
+					.realtime.log.path = \"$bnet_logs/birdnet.txt\" |
+					.realtime.audio.export.path = \"$bnet_data/clips\" |
+					.realtime.output.file.path = \"$bnet_data/output\" |
+					.realtime.mqtt.enabled = false |
+					.realtime.monitoring.enabled = false |
+					.realtime.webserver.enabled = true |
+					.realtime.dashboard.newui = true |
+					.webserver.port = $bnet_port" "$bnet_conf"
+			fi
 
-			local config="${bnet_data}"/.config/birdnet-go/config.yaml
-			# Replace paths
-			# - Paths otherwise default to the working directory at ${bnet_install}
-			G_AGI yq
-			yq -i -y ".main.log.path = \"${bnet_log}/birdnet.log\"" "${config}" &&
-			yq -i -y ".realtime.log.path = \"${bnet_log}/birdnet.txt\"" "${config}" &&
-			yq -i -y ".realtime.audio.export.path = \"${bnet_data}/clips/\"" "${config}" &&
-			yq -i -y ".realtime.output.file.path = \"${bnet_data}/output/\"" "${config}" &&
-			## Set services
-			yq -i -y '.realtime.mqtt.enabled = false' "${config}" &&
-			yq -i -y '.realtime.monitoring.enabled = false' "${config}" &&	# cpu/memory/disk
-			yq -i -y '.realtime.webserver.enabled = true' "${config}" &&
-            yq -i -y '.realtime.dashboard.newui = true' "${config}" &&
-			yq -i -y ".webserver.port = \"${bnet_http_port}\"" "${config}" ## replace port
-			G_AGP yq
-
-			G_EXEC chown -R "${bnet_user}":"${bnet_user}" "${bnet_install}"
-
-			## Generate systemd file
-			cat <<EOF > /etc/systemd/system/birdnet.service
+			# Service
+			cat << _EOF_ > /etc/systemd/system/birdnet.service
 [Unit]
-Description=BirdNet-Go Realtime Bird Sound Analyzer
-After=network.target
+Description=BirdNet-Go
+Wants=network-online.target
+After=network-online.target
+StartLimitIntervalSec=60
+StartLimitBurst=3
 
 [Service]
-ExecStart=${bnet_install}/birdnet-go realtime
+User=$bnet_user
+WorkingDirectory=$bnet_data
+LogsDirectory=birdnet
+ExecStart=$bnet_inst/birdnet-go realtime
 Restart=on-failure
 RestartSec=5
-User=${bnet_user}
-WorkingDirectory=${bnet_install}
-Environment="LD_LIBRARY_PATH=${bnet_install}:\$LD_LIBRARY_PATH"
-SyslogIdentifier=birdnet
+
+# Hardening
+ProtectSystem=strict
+ProtectHome=1
+PrivateTmp=1
+PrivateDevices=1
+ProtectKernelTunables=1
+ProtectControlGroups=1
+ReadWritePaths=-$bnet_inst -$bnet_data -$bnet_logs
 
 [Install]
 WantedBy=multi-user.target
-
-EOF
+_EOF_
 		fi
 
 		if To_Install 138 virtualhere # VirtualHere
@@ -12910,10 +12925,9 @@ _EOF_
 		then
 			Remove_Service birdnet
 			G_AGP sox
-			[[ -d '/opt/birdnet' ]] && G_EXEC rm -R '/opt/birdnet'
-			[[ -f '/var/log/birdnet.txt' ]] && G_EXEC rm '/var/log/birdnet.txt'
-			[[ -f '/var/log/birdnet.log' ]] && G_EXEC rm '/var/log/birdnet.log'
-			[[ -d '/mnt/dietpi_userdata/birdnet' ]] && G_EXEC rm -R '/mnt/dietpi_userdata/birdnet'
+			G_EXEC rm -Rf /opt/birdnet
+			G_EXEC rm -Rf /var/log/birdnet
+			G_EXEC rm -Rf /mnt/dietpi_userdata/birdnet
 		fi
 
 		if To_Uninstall 138 # VirtualHere

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9354,7 +9354,7 @@ _EOF_
 
 		if To_Install 127 birdnet-go # BirdNET-Go
 		then
-			local bnet_release="nightly-20250904"
+			local bnet_release="nightly-20251012"
 			local bnet_http_port=8127
 			local bnet_install=/opt/birdnet
 			local bnet_log=/var/log/birdnet
@@ -9385,7 +9385,7 @@ _EOF_
 			# - $HOME/.config/birdnet-go/config.yaml (default)
 			# - /etc/birdnet-go/config.yaml
 			## initial call to generate config
-			LD_LIBRARY_PATH="${bnet_install}:$LD_LIBRARY_PATH" G_EXEC "${bnet_install}"/birdnet-go
+			LD_LIBRARY_PATH="${bnet_install}:$LD_LIBRARY_PATH" G_EXEC sudo -u "${bnet_user}" "${bnet_install}"/birdnet-go
 
 			local config="${bnet_data}"/.config/birdnet-go/config.yaml
 			# Replace paths
@@ -9402,7 +9402,7 @@ _EOF_
 			yq -i -y ".webserver.port = \"${bnet_http_port}\"" "${config}" ## replace port
 			G_AGP yq
 
-			G_EXEC chown -R birdnet:dietpi "${bnet_install}"
+			G_EXEC chown -R "${bnet_user}":"${bnet_user}" "${bnet_install}"
 
 			## Generate systemd file
 			cat <<EOF > /etc/systemd/system/birdnet.service

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9371,41 +9371,41 @@ _EOF_
 			Download_Install "https://github.com/tphakala/birdnet-go/releases/download/${bnet_release}/birdnet-go-linux-${arch}.tar.gz"	 birdnet
 
 			# User
-			G_EXEC mkdir ${bnet_data}
+			G_EXEC mkdir "${bnet_data}"
 			## Move binaries to final destination
-			G_EXEC mkdir ${bnet_install}
-			G_EXEC mv birdnet/birdnet-go ${bnet_install}/birdnet-go
-			G_EXEC mv birdnet/libtensorflowlite_c.so ${bnet_install}/libtensorflowlite_c.so
+			G_EXEC mkdir "${bnet_install}"
+			G_EXEC mv birdnet/birdnet-go "${bnet_install}"/birdnet-go
+			G_EXEC mv birdnet/libtensorflowlite_c.so "${bnet_install}"/libtensorflowlite_c.so
 			G_EXEC rmdir birdnet # cleanup
 
 			# Initialise config: hard-coded to check only
 			# - $HOME/.config/birdnet-go/config.yaml (default)
 			# - /etc/birdnet-go/config.yaml
 			## initial call to generate config
-			LD_LIBRARY_PATH="${bnet_install}:$LD_LIBRARY_PATH" ${bnet_install}/birdnet-go >/dev/null
+			LD_LIBRARY_PATH="${bnet_install}:$LD_LIBRARY_PATH" "${bnet_install}"/birdnet-go >/dev/null
 
 			local tmp_config=${HOME}/.config/birdnet-go/config.yaml
 			# Replace paths
 			# - Paths otherwise default to the working directory at ${bnet_install}
 			G_AGI yq
-			yq -i -y ".main.log.path = \"${bnet_log}/birdnet.log\"" ${tmp_config} &&
-			yq -i -y ".realtime.log.path = \"${bnet_log}/birdnet.txt\"" ${tmp_config} &&
-			yq -i -y ".realtime.audio.export.path = \"${bnet_data}/clips/\"" ${tmp_config} &&
-			yq -i -y ".realtime.output.file.path = \"${bnet_data}/output/\"" ${tmp_config} &&
+			yq -i -y ".main.log.path = \"${bnet_log}/birdnet.log\"" "${tmp_config}" &&
+			yq -i -y ".realtime.log.path = \"${bnet_log}/birdnet.txt\"" "${tmp_config}" &&
+			yq -i -y ".realtime.audio.export.path = \"${bnet_data}/clips/\"" "${tmp_config}" &&
+			yq -i -y ".realtime.output.file.path = \"${bnet_data}/output/\"" "${tmp_config}" &&
 			## Set services
-			yq -i -y '.realtime.mqtt.enabled = false' ${tmp_config} &&
-			yq -i -y '.realtime.monitoring.enabled = false' ${tmp_config} &&	# cpu/memory/disk
-			yq -i -y '.realtime.webserver.enabled = true' ${tmp_config} &&
-			yq -i -y ".webserver.port = \"${bnet_http_port}\"" ${tmp_config} ## replace port
+			yq -i -y '.realtime.mqtt.enabled = false' "${tmp_config}" &&
+			yq -i -y '.realtime.monitoring.enabled = false' "${tmp_config}" &&	# cpu/memory/disk
+			yq -i -y '.realtime.webserver.enabled = true' "${tmp_config}" &&
+			yq -i -y ".webserver.port = \"${bnet_http_port}\"" "${tmp_config}" ## replace port
 			G_AGP yq
 
 			G_EXEC mkdir /etc/birdnet-go
-			G_EXEC mv ${tmp_config} /etc/birdnet-go/config.yaml	   # move config to hardcoded /etc path
+			G_EXEC mv "${tmp_config}" /etc/birdnet-go/config.yaml	   # move config to hardcoded /etc path
 
-			Create_User -g dietpi -d ${bnet_data} birdnet
+			Create_User -g dietpi -d "${bnet_data}" birdnet
 			G_EXEC chown -R birdnet:dietpi /etc/birdnet-go
-			G_EXEC chown -R birdnet:dietpi ${bnet_data}
-			G_EXEC chown -R birdnet:dietpi ${bnet_install}
+			G_EXEC chown -R birdnet:dietpi "${bnet_data}"
+			G_EXEC chown -R birdnet:dietpi "${bnet_install}"
 
 			## Generate systemd file
 			cat <<EOF > /etc/systemd/system/birdnet-go.service

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9442,7 +9442,7 @@ PrivateTmp=1
 PrivateDevices=1
 ProtectKernelTunables=1
 ProtectControlGroups=1
-ReadWritePaths=-$bnet_inst -$bnet_data -$bnet_logs
+ReadWritePaths=-$bnet_data -$bnet_logs -/tmp
 
 [Install]
 WantedBy=multi-user.target

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9357,7 +9357,7 @@ _EOF_
 			local bnet_release="nightly-20250904"
 			local bnet_http_port=8127
 			local bnet_install=/opt/birdnet-go
-			local bnet_log=/var/log
+			local bnet_log=/var/log/birdnet
 			local bnet_data=/mnt/dietpi_userdata/birdnet-go
 			local bnet_user=birdnet
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9370,7 +9370,7 @@ _EOF_
 			aDEPS=('sox' 'patchelf')
 			# - Add yq only on first install
 			local install_yq=0
-			[[ -f $config ]] || command -v yq > /dev/null || install_yq=0 aDEPS+=('yq')
+			[[ -f $bnet_conf ]] || command -v yq > /dev/null || install_yq=0 aDEPS+=('yq')
 
 			case $G_HW_ARCH in
 				3) local arch='arm64';;
@@ -9396,7 +9396,7 @@ _EOF_
 
 			# Config
 			# - Checks hard-coded paths in this order: ~/.config/birdnet-go/config.yaml > /etc/birdnet-go/config.yaml
-			if [[ ! -f $config ]]
+			if [[ ! -f $bnet_conf ]]
 			then
 				# Initial call to generate ~/.config/birdnet-go/config.yaml
 				G_EXEC runuser -u "$bnet_user" -- "$bnet_inst/birdnet-go"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9378,6 +9378,9 @@ _EOF_
 			G_EXEC mv birdnet/libtensorflowlite_c.so "${bnet_install}"/libtensorflowlite_c.so
 			G_EXEC rmdir birdnet # cleanup
 
+			Create_User -g "${bnet_user}" -d "${bnet_data}" "${bnet_user}"
+			G_EXEC chown -R "${bnet_user}":"${bnet_user}" "${bnet_data}"
+
 			# Initialise config: hard-coded to check only
 			# - $HOME/.config/birdnet-go/config.yaml (default)
 			# - /etc/birdnet-go/config.yaml
@@ -9399,9 +9402,6 @@ _EOF_
 			yq -i -y ".webserver.port = \"${bnet_http_port}\"" "${config}" ## replace port
 			G_AGP yq
 
-
-			Create_User -g dietpi -d "${bnet_data}" birdnet
-			G_EXEC chown -R birdnet:dietpi "${bnet_data}"
 			G_EXEC chown -R birdnet:dietpi "${bnet_install}"
 
 			## Generate systemd file

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1091,6 +1091,13 @@ Available commands:
 		aSOFTWARE_DESC[$software_id]='Simple camera streaming tool with HTML plugin'
 		aSOFTWARE_CATX[$software_id]=7
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/camera/#mjpg-streamer'
+		#------------------
+		software_id=127
+		aSOFTWARE_NAME[$software_id]='birdnet-go'
+		aSOFTWARE_DESC[$software_id]='Continuous avian monitoring and identification'
+		aSOFTWARE_CATX[$software_id]=7
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/camera/#birdnet-go'
+		aSOFTWARE_DEPS[$software_id]='7 87' ## ffmpeg sqlite3
 
 		# System Stats & Management
 		#--------------------------------------------------------------------------------
@@ -9345,6 +9352,83 @@ _EOF_
 			fi
 		fi
 
+		if To_Install 127 birdnet-go # BirdNET-Go
+		then
+			local bnet_release="nightly-20250904"
+			local bnet_http_port=8127
+			local bnet_install=/opt/birdnet-go
+			local bnet_log=/var/log
+			local bnet_data=/mnt/dietpi_userdata/birdnet-go
+			local bnet_user=birdnet
+
+			case $G_HW_ARCH in
+				3) local arch='arm64';;
+				*) local arch='amd64';;
+			esac
+			aDEPS=("sox")
+
+			# Download binary and library
+			Download_Install "https://github.com/tphakala/birdnet-go/releases/download/${bnet_release}/birdnet-go-linux-${arch}.tar.gz"	 birdnet
+
+			# User
+			G_EXEC mkdir ${bnet_data}
+			## Move binaries to final destination
+			G_EXEC mkdir ${bnet_install}
+			G_EXEC mv birdnet/birdnet-go ${bnet_install}/birdnet-go
+			G_EXEC mv birdnet/libtensorflowlite_c.so ${bnet_install}/libtensorflowlite_c.so
+			G_EXEC rmdir birdnet # cleanup
+
+			# Initialise config: hard-coded to check only
+			# - $HOME/.config/birdnet-go/config.yaml (default)
+			# - /etc/birdnet-go/config.yaml
+			## initial call to generate config
+			LD_LIBRARY_PATH="${bnet_install}:$LD_LIBRARY_PATH" ${bnet_install}/birdnet-go >/dev/null
+
+			local tmp_config=${HOME}/.config/birdnet-go/config.yaml
+			# Replace paths
+			# - Paths otherwise default to the working directory at ${bnet_install}
+			G_AGI yq
+			yq -i -y ".main.log.path = \"${bnet_log}/birdnet.log\"" ${tmp_config} &&
+			yq -i -y ".realtime.log.path = \"${bnet_log}/birdnet.txt\"" ${tmp_config} &&
+			yq -i -y ".realtime.audio.export.path = \"${bnet_data}/clips/\"" ${tmp_config} &&
+			yq -i -y ".realtime.output.file.path = \"${bnet_data}/output/\"" ${tmp_config} &&
+			## Set services
+			yq -i -y '.realtime.mqtt.enabled = false' ${tmp_config} &&
+			yq -i -y '.realtime.monitoring.enabled = false' ${tmp_config} &&	# cpu/memory/disk
+			yq -i -y '.realtime.webserver.enabled = true' ${tmp_config} &&
+			yq -i -y ".webserver.port = \"${bnet_http_port}\"" ${tmp_config} ## replace port
+			G_AGP yq
+
+			G_EXEC mkdir /etc/birdnet-go
+			G_EXEC mv ${tmp_config} /etc/birdnet-go/config.yaml	   # move config to hardcoded /etc path
+
+			Create_User -g dietpi -d ${bnet_data} birdnet
+			G_EXEC chown -R birdnet:dietpi /etc/birdnet-go
+			G_EXEC chown -R birdnet:dietpi ${bnet_data}
+			G_EXEC chown -R birdnet:dietpi ${bnet_install}
+
+			## Generate systemd file
+			cat <<EOF > /etc/systemd/system/birdnet-go.service
+[Unit]
+Description=BirdNet-Go Realtime Bird Sound Analyzer
+After=network.target
+
+[Service]
+ExecStart=${bnet_install}/birdnet-go realtime
+Restart=on-failure
+RestartSec=5
+User=${bnet_user}
+WorkingDirectory=${bnet_install}
+Environment="LD_LIBRARY_PATH=${bnet_install}:\$LD_LIBRARY_PATH"
+SyslogIdentifier=birdnet-go
+
+[Install]
+WantedBy=multi-user.target
+
+EOF
+			G_EXEC systemctl start birdnet-go
+		fi
+
 		if To_Install 138 virtualhere # VirtualHere
 		then
 			case $G_HW_ARCH in
@@ -12823,6 +12907,17 @@ _EOF_
 		then
 			Remove_Service mjpg-streamer 1
 			[[ -d '/opt/mjpg-streamer' ]] && G_EXEC rm -R /opt/mjpg-streamer
+		fi
+
+		if To_Uninstall 127 # BirdNET-Go
+		then
+			Remove_Service birdnet-go
+			G_AGP sox
+			[[ -d '/opt/birdnet-go' ]] && G_EXEC rm -R '/opt/birdnet-go'
+			[[ -f '/var/log/birdnet.txt' ]] && G_EXEC rm '/var/log/birdnet.txt'
+			[[ -f '/var/log/birdnet.log' ]] && G_EXEC rm '/var/log/birdnet.log'
+			[[ -d '/etc/birdnet-go' ]] && G_EXEC rm -R '/etc/birdnet-go'
+			[[ -d '/mnt/dietpi_userdata/birdnet-go' ]] && G_EXEC rm -R '/mnt/dietpi_userdata/birdnet-go'
 		fi
 
 		if To_Uninstall 138 # VirtualHere

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1100,6 +1100,8 @@ Available commands:
 		aSOFTWARE_DEPS[$software_id]='7 87'
 		# - ARMv6/7/RISC-V: https://github.com/tphakala/birdnet-go/releases
 		(( $G_HW_ARCH == 3 || $G_HW_ARCH == 10 )) || aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,$G_HW_ARCH]=0
+		# - Bullseye: Too old libc6/libstdc++6 and missing yq
+		aSOFTWARE_AVAIL_G_DISTRO[$software_id,6]=0
 
 		# System Stats & Management
 		#--------------------------------------------------------------------------------
@@ -9365,7 +9367,10 @@ _EOF_
 			local bnet_port=8127
 
 			# Dependencies
-			aDEPS=('sox' 'patchelf' 'yq')
+			aDEPS=('sox' 'patchelf')
+			# - Add yq only on first install
+			local install_yq=0
+			[[ -f $config ]] || command -v yq > /dev/null || install_yq=0 aDEPS+=('yq')
 
 			case $G_HW_ARCH in
 				3) local arch='arm64';;
@@ -9393,11 +9398,11 @@ _EOF_
 			# - Checks hard-coded paths in this order: ~/.config/birdnet-go/config.yaml > /etc/birdnet-go/config.yaml
 			if [[ ! -f $config ]]
 			then
-				# - Initial call to generate ~/.config/birdnet-go/config.yaml
+				# Initial call to generate ~/.config/birdnet-go/config.yaml
 				G_EXEC_OUTPUT=1 G_EXEC runuser -u "$bnet_user" -- "$bnet_inst/birdnet-go"
-				# - Replace paths, otherwise default to the working directory at $bnet_inst
-				# - Disable MQTT and CPU/memory/disk monitoring
-				# - Enable new web UI at $bnet_port
+				# Replace paths, otherwise default to the working directory at $bnet_inst
+				# Disable MQTT and CPU/memory/disk monitoring
+				# Enable new web UI at $bnet_port
 				G_EXEC yq -i -y "
 					.main.log.path = \"$bnet_logs/birdnet.log\" |
 					.realtime.log.path = \"$bnet_logs/birdnet.txt\" |
@@ -9408,6 +9413,8 @@ _EOF_
 					.realtime.webserver.enabled = true |
 					.realtime.dashboard.newui = true |
 					.webserver.port = $bnet_port" "$bnet_conf"
+				# Purge yq if it was installed for BirdNET-Go only
+				(( $install_yq )) && G_AGP yq
 			fi
 
 			# Service

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9399,11 +9399,8 @@ _EOF_
 			yq -i -y ".webserver.port = \"${bnet_http_port}\"" "${config}" ## replace port
 			G_AGP yq
 
-			G_EXEC mkdir /etc/birdnet-go
-			G_EXEC mv "${tmp_config}" /etc/birdnet-go/config.yaml	   # move config to hardcoded /etc path
 
 			Create_User -g dietpi -d "${bnet_data}" birdnet
-			G_EXEC chown -R birdnet:dietpi /etc/birdnet-go
 			G_EXEC chown -R birdnet:dietpi "${bnet_data}"
 			G_EXEC chown -R birdnet:dietpi "${bnet_install}"
 
@@ -12916,7 +12913,6 @@ _EOF_
 			[[ -d '/opt/birdnet' ]] && G_EXEC rm -R '/opt/birdnet'
 			[[ -f '/var/log/birdnet.txt' ]] && G_EXEC rm '/var/log/birdnet.txt'
 			[[ -f '/var/log/birdnet.log' ]] && G_EXEC rm '/var/log/birdnet.log'
-			[[ -d '/etc/birdnet-go' ]] && G_EXEC rm -R '/etc/birdnet-go'
 			[[ -d '/mnt/dietpi_userdata/birdnet' ]] && G_EXEC rm -R '/mnt/dietpi_userdata/birdnet'
 		fi
 


### PR DESCRIPTION
Add BirdNET-Go, a realtime bird call monitoring webserver using embedded AI models

https://github.com/tphakala/birdnet-go

Inspired by this blog post: https://hannahilea.com/blog/birdnet-intro/

Notes:
* It's relatively low footprint on my RPi5 (0.7% passive CPU usage)
* Dependencies list sqlite3, but it could easily be mariadb, it just needs a config switch.
* The install consists solely of binaries, from FOSS software, but still it's pure binaries.
* Supported arches: amd64 and arm64
* It's listed under "Cameras" despite being an audio monitoring tool

Once installed you need to navigate to ~http://localhost:8127/ui (there's an [ongoing bug](https://github.com/tphakala/birdnet-go/issues/1045) with the root URL)~ http://localhost:8127