### PR TITLE
images: add initial support for NanoPi R3S (LTS)/R76S/M5

### DIFF
--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -174,6 +174,10 @@ case $HW_MODEL in
 	97) iname='OrangePiRV' HW_ARCH=11 partition_start=4 root_size=1000;;
 	98) iname='OrangePiRV2' HW_ARCH=11 partition_start=4 root_size=1000;;
 	99) iname='OrangePi3' HW_ARCH=3 partition_start=4 root_size=1000;;
+	100) iname='NanoPiR3S' HW_ARCH=3 partition_start=16 root_size=1200;;
+	101) iname='NanoPiR3SLTS' HW_ARCH=3 partition_start=16 root_size=1200;;
+	102) iname='NanoPiR76S' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size=1200;;
+	103) iname='NanoPiM5' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size=1200;;
 	*) Error_Exit "Invalid hardware model \"$HW_MODEL\" passed";;
 esac
 

--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -428,12 +428,16 @@ _EOF_
 						'67' ': NanoPi K1 Plus'
 						'54' ': NanoPi K2'
 						'55' ': NanoPi R2S'
+						'100' ': NanoPi R3S'
+						'101' ': NanoPi R3S LTS'
 						'47' ': NanoPi R4S'
 						'76.1' ': NanoPi R5S'
 						'76.2' ': NanoPi R5C'
 						'79.1' ': NanoPi R6S'
 						'79.2' ': NanoPi R6C'
+						'102' ': NanoPi R76S'
 						'79.3' ': NanoPC T6'
+						'103' ': NanoPi M5'
 						'92' ': NanoPi M6'
 						'72.1' ': ROCK 4 (all other variants)'
 						'72.2' ': ROCK 4 SE'
@@ -686,7 +690,8 @@ _EOF_
 			G_EXEC mv "$dir/.build/images/U-Boot/dietpi-initramfs_cleanup" /etc/kernel/postinst.d/dietpi-initramfs_cleanup
 			G_EXEC ln -sf /etc/kernel/post{inst,rm}.d/dietpi-initramfs_cleanup
 
-		elif [[ $G_HW_MODEL =~ ^(12|15|16|17|40|42|43|44|45|46|47|48|52|54|55|56|57|58|59|60|62|63|64|65|66|67|68|72|73|74|76|77|78|79|80|82|83|85|86|87|88|89|90|91|92|93|94|95|96|99)$ ]]
+		# SBCs using Armbian build system for kernel/bootloader packages and boot.scr
+		elif [[ $G_HW_MODEL =~ ^(12|15|16|17|40|42|43|44|45|46|47|48|52|54|55|56|57|58|59|60|62|63|64|65|66|67|68|72|73|74|76|77|78|79|80|82|83|85|86|87|88|89|90|91|92|93|94|95|96|99|100|101|102|103)$ ]]
 		then
 			# Amlogic 64-bit
 			armbian_packages=1
@@ -728,10 +733,14 @@ setenv rootuuid "true"' /boot/boot.cmd
 				(( $G_HW_MODEL == 15 )) && G_EXEC eval 'echo '\''meson_rng'\'' > /etc/modules-load.d/dietpi-hwrng.conf'
 
 			# Rockchip 64-bit
-			elif [[ $G_HW_MODEL =~ ^(42|43|46|47|55|56|58|68|72|73|76|77|78|79|80|82|85|86|87|90|91|92|93|94|95)$ ]]
+			elif [[ $G_HW_MODEL =~ ^(42|43|46|47|55|56|58|68|72|73|76|77|78|79|80|82|85|86|87|90|91|92|93|94|95|100|101|102|103)$ ]]
 			then
+				# Load addresses
 				G_EXEC sed --follow-symlinks -Ei '/^setenv (kernel|fdt)_addr_r/d' /boot/boot.cmd
-				G_CONFIG_INJECT 'setenv scriptaddr ' 'setenv scriptaddr "0x9000000"' /boot/boot.cmd
+				case $G_HW_MODEL in
+					102|103) G_CONFIG_INJECT 'setenv scriptaddr ' 'setenv scriptaddr "0x48000000"' /boot/boot.cmd;; # RK3576
+					*) G_CONFIG_INJECT 'setenv scriptaddr ' 'setenv scriptaddr "0x9000000"' /boot/boot.cmd;;
+				esac
 				G_CONFIG_INJECT 'overlay_path=' 'overlay_path=rockchip' /boot/dietpiEnv.txt
 				# Device tree
 				case $G_HW_MODEL in
@@ -761,16 +770,19 @@ setenv rootuuid "true"' /boot/boot.cmd
 				# Overlay prefix
 				case $G_HW_MODEL in
 					73) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rk3308' /boot/dietpiEnv.txt;;
-					78) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rock-5b rock-5 rockchip-rk3588 rk3588' /boot/dietpiEnv.txt;;
-					80) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=orangepi-5 rockchip-rk3588 rk3588' /boot/dietpiEnv.txt;;
-					82) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=orangepi-5-plus rockchip-rk3588 rk3588' /boot/dietpiEnv.txt;;
-					85) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rock-5a rock-5 rockchip-rk3588 rk3588' /boot/dietpiEnv.txt;;
-					90) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=radxa-zero3 rk3568 rockchip' /boot/dietpiEnv.txt;;
-					92) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=nanopi-m6 rockchip-rk3588 rk3588' /boot/dietpiEnv.txt;;
-					93) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=orangepi-5-pro rockchip-rk3588 rk3588' /boot/dietpiEnv.txt;;
-					94) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=orangepi-5-ultra rockchip-rk3588 rk3588' /boot/dietpiEnv.txt;;
-					95) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=orangepi-cm5 rockchip-rk3588 rk3588' /boot/dietpiEnv.txt;;
-					79|91) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rockchip-rk3588 rk3588' /boot/dietpiEnv.txt;;
+					78) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rock-5b rock-5 rockchip-rk3588 rk3588 rockchip' /boot/dietpiEnv.txt;;
+					80) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=orangepi-5 rockchip-rk3588 rk3588 rockchip' /boot/dietpiEnv.txt;;
+					82) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=orangepi-5-plus rockchip-rk3588 rk3588 rockchip' /boot/dietpiEnv.txt;;
+					85) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rock-5a rock-5 rockchip-rk3588 rk3588 rockchip' /boot/dietpiEnv.txt;;
+					90) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=radxa-zero3 rk3568 rockchip-rk3566 rockchip-rk3568 rockchip' /boot/dietpiEnv.txt;;
+					92) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=nanopi-m6 rockchip-rk3588-nanopi-m6 rockchip-rk3588 rk3588 rockchip' /boot/dietpiEnv.txt;;
+					93) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=orangepi-5-pro rockchip-rk3588 rk3588 rockchip' /boot/dietpiEnv.txt;;
+					94) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=orangepi-5-ultra rockchip-rk3588 rk3588 rockchip' /boot/dietpiEnv.txt;;
+					95) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=orangepi-cm5 rockchip-rk3588 rk3588 rockchip' /boot/dietpiEnv.txt;;
+					79|91) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rockchip-rk3588 rk3588 rockchip' /boot/dietpiEnv.txt;; # RK3588 vendor + mainline
+					87|100|101) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rockchip-rk3566 rockchip-rk3568 rockchip' /boot/dietpiEnv.txt;; # RK3566 mainline
+					76|77) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rockchip-rk3568 rockchip' /boot/dietpiEnv.txt;; # RK3568 mainline
+					102|103) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rk3576 rockchip' /boot/dietpiEnv.txt;; # RK3576 vendor + mainline
 					*) G_CONFIG_INJECT 'overlay_prefix=' 'overlay_prefix=rockchip' /boot/dietpiEnv.txt;;
 				esac
 				# Overlays
@@ -782,8 +794,8 @@ setenv rootuuid "true"' /boot/boot.cmd
 				# shellcheck disable=SC2015
 				case $G_HW_MODEL in
 					73) G_CONFIG_INJECT 'consoleargs=' 'consoleargs=console=ttyS0,1500000' /boot/dietpiEnv.txt;; # headless
-					47|55|56) G_CONFIG_INJECT 'consoleargs=' 'consoleargs=console=ttyS2,1500000' /boot/dietpiEnv.txt;; # headless
-					78|79|80|82|85|90|91|92|93|94|95) [[ $RK35XX_MAINLINE == 1 ]] && G_EXEC sed --follow-symlinks -i 's/ttyAML0,115200/ttyS2,1500000/' /boot/dietpiEnv.txt || G_EXEC sed --follow-symlinks -i 's/ttyAML0,115200/ttyFIQ0,1500000/' /boot/dietpiEnv.txt;; # mainline or vendor
+					47|55|56|100) G_CONFIG_INJECT 'consoleargs=' 'consoleargs=console=ttyS2,1500000' /boot/dietpiEnv.txt;; # headless
+					78|79|80|82|85|90|91|92|93|94|95|102|103) [[ $RK35XX_MAINLINE == 1 ]] && G_EXEC sed --follow-symlinks -i 's/ttyAML0,115200/ttyS2,1500000/' /boot/dietpiEnv.txt || G_EXEC sed --follow-symlinks -i 's/ttyAML0,115200/ttyFIQ0,1500000/' /boot/dietpiEnv.txt;; # mainline or vendor
 					*) G_EXEC sed --follow-symlinks -i 's/ttyAML0,115200/ttyS2,1500000/' /boot/dietpiEnv.txt;; # mainline
 				esac
 
@@ -1236,6 +1248,10 @@ _EOF_
 				95) model='orangepicm5' kernel='rk35xx' branch='vendor';;
 				96) model='orangepi4a' kernel='sun55iw3' branch='legacy';;
 				99) model='orangepi3' kernel='sunxi64';;
+				100) model='nanopi-r3s' kernel='rockchip64';;
+				101) model='nanopi-r3s-lts' kernel='rockchip64';;
+				102) model='nanopi-r76s' kernel='rk35xx' branch='vendor';;
+				103) model='nanopi-m5' kernel='rk35xx' branch='vendor';;
 				*) :;;
 			esac
 

--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -105,6 +105,10 @@ shopt -s extglob # +(expr) syntax
 		[97]='Orange Pi RV'
 		[98]='Orange Pi RV2'
 		[99]='Orange Pi 3'
+		[100]='NanoPi R3S'
+		[101]='NanoPi R3S LTS'
+		[102]='NanoPi R76S'
+		[103]='NanoPi M5'
 	)
 
 	## Benchmark data arrays: aBENCH_XX[$HW_MODEL,${aBENCH_XX_INDEX[$HW_MODEL]}]

--- a/dietpi/func/dietpi-obtain_hw_model
+++ b/dietpi/func/dietpi-obtain_hw_model
@@ -12,6 +12,10 @@
 	# - Generates /boot/dietpi/.hw_model
 	# - Called from /boot/dietpi/preboot, called by /etc/systemd/system/dietpi-preboot.service
 	#
+	# G_HW_MODEL 103 NanoPi M5
+	# G_HW_MODEL 102 NanoPi R76S
+	# G_HW_MODEL 101 NanoPi R3S LTS
+	# G_HW_MODEL 100 NanoPi R3S
 	# G_HW_MODEL 99 Orange Pi 3
 	# G_HW_MODEL 98 Orange Pi RV2
 	# G_HW_MODEL 97 Orange Pi RV
@@ -109,10 +113,14 @@
 	# G_HW_CPUID 9 Rockchip RK3566
 	# G_HW_CPUID 10 Rockchip RK3568
 	# G_HW_CPUID 11 Rockchip RK3588
+	# G_HW_CPUID 12 Rockchip RK3576
 	# ----------------
+	# G_DISTRO 4 Stretch
+	# G_DISTRO 5 Buster
 	# G_DISTRO 6 Bullseye
 	# G_DISTRO 7 Bookworm
 	# G_DISTRO 8 Trixie
+	# G_DISTRO 9 Forky
 	#////////////////////////////////////
 
 	#/////////////////////////////////////////////////////////////////////////////////////
@@ -352,7 +360,27 @@
 		then
 			read -r G_HW_MODEL < /etc/.dietpi_hw_model_identifier
 
-			if (( $G_HW_MODEL == 99 ))
+			if (( $G_HW_MODEL == 103 ))
+			then
+				G_HW_MODEL_NAME='NanoPi M5'
+				G_HW_CPUID=12
+
+			elif (( $G_HW_MODEL == 102 ))
+			then
+				G_HW_MODEL_NAME='NanoPi R76S'
+				G_HW_CPUID=12
+
+			elif (( $G_HW_MODEL == 101 ))
+			then
+				G_HW_MODEL_NAME='NanoPi R3S LTS'
+				G_HW_CPUID=9
+
+			elif (( $G_HW_MODEL == 100 ))
+			then
+				G_HW_MODEL_NAME='NanoPi R3S'
+				G_HW_CPUID=9
+
+			elif (( $G_HW_MODEL == 99 ))
 			then
 				G_HW_MODEL_NAME='Orange Pi 3'
 

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -1533,7 +1533,7 @@ _EOF_
 				elif (( $DIETPIENV || $G_HW_MODEL == 49 || $G_HW_MODEL == 76 || $G_HW_MODEL == 79 ))
 				then
 					local baudrate='115200'
-					if [[ $G_HW_MODEL =~ ^(42|43|46|47|49|55|56|58|68|72|76|77|78|79|80|82|85|87|90|91|92|93|94|95)$ && $INPUT_ADDITIONAL =~ ^('ttyS2'|'ttyFIQ0')$ ]] || [[ $G_HW_MODEL == 73 && $INPUT_ADDITIONAL == 'ttyS'[012] ]]
+					if [[ $G_HW_MODEL =~ ^(42|43|46|47|49|55|56|58|68|72|76|77|78|79|80|82|85|87|90|91|92|93|94|95|100|101|102|103)$ && $INPUT_ADDITIONAL =~ ^('ttyS2'|'ttyFIQ0')$ ]] || [[ $G_HW_MODEL == 73 && $INPUT_ADDITIONAL == 'ttyS'[012] ]]
 					then
 						baudrate='1500000'
 						[[ -d /etc/systemd/system/serial-getty@$INPUT_ADDITIONAL.service.d ]] || G_EXEC mkdir "/etc/systemd/system/serial-getty@$INPUT_ADDITIONAL.service.d"

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -307,6 +307,10 @@ $FP_SCRIPT	rpi_kernel_choice		<empty> Supported on Debian Bookworm or newer on R
 			97) all_components='orangepirv';;
 			98) all_components='orangepirv2';;
 			99) all_components='orangepi3';;
+			100) all_components='nanopir3s';;
+			101) all_components='nanopir3slts';;
+			102) all_components='nanopir76s';;
+			103) all_components='nanopim5';;
 			*) :;;
 		esac
 		G_EXEC eval "echo 'deb https://dietpi.com/apt $G_DISTRO_NAME $components' > /etc/apt/sources.list.d/dietpi.list"


### PR DESCRIPTION
Additionally extend device tree overlay prefixes for Rockchip SoC SBCs with vendor kernel to support mainline kernel overlays and the generic `rockchip-fixup.scr` fixup boot script.

Test builds:
- NanoPi R3S: https://github.com/MichaIng/DietPi/actions/runs/18570785277
- NanoPi R3S LTS: https://github.com/MichaIng/DietPi/actions/runs/18570790051
- NanoPi R76S: https://github.com/MichaIng/DietPi/actions/runs/18570793380
- NanoPi M5: https://github.com/MichaIng/DietPi/actions/runs/18570797424