### PR TITLE
dietpi-software: SABnzbd: harden config generation

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ Bug fixes:
 - DietPi-Software | Jellyfin: Resolved an issue where the service start failed due to new strict space requirements for logging (512 MiB) and temporary directories (2 GiB). To support low RAM devices, we use /mnt/dietpi_userdata/jellyfin/log for log files, and a subdirectory in /mnt/dietpi_userdata/jellyfin/cache for temporary files, restoring behaviour from Jellyfin before v10.10. This can be adjusted in /etc/default/jellyfin.
 - DietPi-Software | Node.js: Resolved an issue where usage could have failed, including Node-RED, Blynk Server, and MineOS installation, since it requires libatomic now for all architectures. Many thanks to @devifast for reporting this issue: https://dietpi.com/forum/t/24574
 - DietPi-Software | Lidarr/Prowlarr: Resolved an issue on Bullseye systems where the service fails due to an incompatible embedded SQLite library: https://wiki.servarr.com/lidarr/faq#lidarr-wont-start-on-debian-11-or-older-systems-due-to-sqlite-version, https://wiki.servarr.com/prowlarr/faq#prowlarr-wont-start-on-debian-11-or-older-systems-due-to-sqlite-version
+- DietPi-Software | SABnzbd: Resolved an issue where the installation could have finished with an incomplete config file. Many thanks to @DealsBeam for resolving this issue: https://github.com/MichaIng/DietPi/pull/7797
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9444,10 +9444,8 @@ _EOF_
 			# - Touch only if it does not yet exist, assume reinstall otherwise and preserve custom changes
 			# - API keys and initial config are only generated during 1st run
 			# - We need to launch program, then apply our config tweaks, else, wizard setup in web interface simply loops without API keys.
-			if [[ ! -f '/etc/sabnzbd/sabnzbd.ini' ]] && Create_Config /etc/sabnzbd/sabnzbd.ini sabnzbd
+			if [[ ! -f '/etc/sabnzbd/sabnzbd.ini' ]] && CREATE_CONFIG_CONTENT='[misc]' Create_Config /etc/sabnzbd/sabnzbd.ini sabnzbd
 			then
-				G_SLEEP 1 # Additional wait, config being overwritten after below changes: https://dietpi.com/forum/t/bug-sabnzbd/1224
-
 				G_CONFIG_INJECT 'log_level[[:blank:]]+=' 'log_level = 0' /etc/sabnzbd/sabnzbd.ini # Warnings and errors only
 				G_CONFIG_INJECT 'auto_browser[[:blank:]]+=' 'auto_browser = 0' /etc/sabnzbd/sabnzbd.ini
 				G_CONFIG_INJECT 'host[[:blank:]]+=' 'host = 0.0.0.0' /etc/sabnzbd/sabnzbd.ini


### PR DESCRIPTION
The script was modifying the sabnzbd.ini file immediately after starting the service, often before the service had finished writing the initial configuration. This resulted in the script's changes being overwritten.

This fix replaces the unreliable 'G_SLEEP 1' with a call to 'Create_Config' that includes 'CREATE_CONFIG_CONTENT=[misc]'. This ensures that the script waits until the '[misc]' section is present in sabnzbd.ini before attempting to modify it, thus resolving the race condition.