### PR TITLE
dietpi-softwaer: Bazarr: fix Sonarr/Radarr configuration

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@ Bug fixes:
 - DietPi-Software | Node.js: Resolved an issue where usage could have failed, including Node-RED, Blynk Server, and MineOS installation, since it requires libatomic now for all architectures. Many thanks to @devifast for reporting this issue: https://dietpi.com/forum/t/24574
 - DietPi-Software | Lidarr/Prowlarr: Resolved an issue on Bullseye systems where the service fails due to an incompatible embedded SQLite library: https://wiki.servarr.com/lidarr/faq#lidarr-wont-start-on-debian-11-or-older-systems-due-to-sqlite-version, https://wiki.servarr.com/prowlarr/faq#prowlarr-wont-start-on-debian-11-or-older-systems-due-to-sqlite-version
 - DietPi-Software | SABnzbd: Resolved an issue where the installation could have finished with an incomplete config file. Many thanks to @DealsBeam for resolving this issue: https://github.com/MichaIng/DietPi/pull/7797
+- DietPi-Software | Bazarr: Resolved an issue where configuring Sonarr and Radarr usage automatically if installed did not work, because Bazarr switched from bazarr.ini to bazarr.yaml as its config file. Many thanks to @Joulinar for reporting this issue: https://github.com/MichaIng/DietPi/issues/7185
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/7806
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9988,6 +9988,7 @@ LogsDirectory=bazarr
 WorkingDirectory=/mnt/dietpi_userdata/bazarr
 ExecStart=/usr/bin/python3 /opt/bazarr/bazarr.py -c /mnt/dietpi_userdata/bazarr
 KillSignal=SIGINT
+TimeoutStopSec=20
 
 # Hardening
 ProtectSystem=strict
@@ -10002,29 +10003,29 @@ ReadWritePaths=-/opt/bazarr -/mnt -/media -/var/log/bazarr -/tmp
 WantedBy=multi-user.target
 _EOF_
 			# On fresh install, pre-configure for Sonarr and Radarr when found
-			if (( ${aSOFTWARE_INSTALL_STATE[144]} + ${aSOFTWARE_INSTALL_STATE[145]} > 0 )) && Create_Config /mnt/dietpi_userdata/bazarr/config/config.ini bazarr
+			if (( ${aSOFTWARE_INSTALL_STATE[144]} + ${aSOFTWARE_INSTALL_STATE[145]} > 0 )) && CREATE_CONFIG_CONTENT='^sonarr:' Create_Config /mnt/dietpi_userdata/bazarr/config/config.yaml bazarr
 			then
 				# Sonarr
 				if (( ${aSOFTWARE_INSTALL_STATE[144]} > 0 )) && CREATE_CONFIG_CONTENT='ApiKey' Create_Config /mnt/dietpi_userdata/sonarr/config.xml sonarr
 				then
 					local port=$(sed -nE '/<Port>[0-9]+<\/Port>/{s/^.*<Port>([0-9]+)<\/Port>.*$/\1/p;q}' /mnt/dietpi_userdata/sonarr/config.xml)
 					local apikey=$(sed -nE '/<ApiKey>.+<\/ApiKey>/{s/^.*<ApiKey>(.+)<\/ApiKey>.*$/\1/p;q}' /mnt/dietpi_userdata/sonarr/config.xml)
-					G_EXEC sed --follow-symlinks -i '/\[sonarr\]/,/^$/s/^ip = .*$/ip = 127.0.0.1/' /mnt/dietpi_userdata/bazarr/config/config.ini
-					G_EXEC sed --follow-symlinks -i "/\[sonarr\]/,/^$/s/^port = .*$/port = $port/" /mnt/dietpi_userdata/bazarr/config/config.ini
-					G_EXEC sed --follow-symlinks -i '/\[sonarr\]/,/^$/s/^base_url = .*$/base_url = \//' /mnt/dietpi_userdata/bazarr/config/config.ini
-					G_EXEC sed --follow-symlinks -i "/\[sonarr\]/,/^$/s/^apikey = .*$/apikey = $apikey/" /mnt/dietpi_userdata/bazarr/config/config.ini
-					G_CONFIG_INJECT 'use_sonarr[[:blank:]]*=' 'use_sonarr = True' /mnt/dietpi_userdata/bazarr/config/config.ini '\[general\]'
+					G_EXEC sed --follow-symlinks -i '/^sonarr:/,/^[^[:blank:]]/s/ ip: .*$/ ip: 127.0.0.1/' /mnt/dietpi_userdata/bazarr/config/config.yaml
+					G_EXEC sed --follow-symlinks -i "/^sonarr:/,/^[^[:blank:]]/s/ port = .*$/ port: $port/" /mnt/dietpi_userdata/bazarr/config/config.yaml
+					G_EXEC sed --follow-symlinks -i '/^sonarr:/,/^[^[:blank:]]/s/ base_url: .*$/ base_url: \//' /mnt/dietpi_userdata/bazarr/config/config.yaml
+					G_EXEC sed --follow-symlinks -i "/^sonarr:/,/^[^[:blank:]]/s/ apikey: .*$/ apikey: $apikey/" /mnt/dietpi_userdata/bazarr/config/config.yaml
+					G_CONFIG_INJECT 'use_sonarr:' '  use_sonarr: true' /mnt/dietpi_userdata/bazarr/config/config.yaml '^general:'
 				fi
 				# Radarr
 				if (( ${aSOFTWARE_INSTALL_STATE[145]} > 0 )) && CREATE_CONFIG_CONTENT='ApiKey' Create_Config /mnt/dietpi_userdata/radarr/config.xml radarr
 				then
 					local port=$(sed -nE '/<Port>[0-9]+<\/Port>/{s/^.*<Port>([0-9]+)<\/Port>.*$/\1/p;q}' /mnt/dietpi_userdata/radarr/config.xml)
 					local apikey=$(sed -nE '/<ApiKey>.+<\/ApiKey>/{s/^.*<ApiKey>(.+)<\/ApiKey>.*$/\1/p;q}' /mnt/dietpi_userdata/radarr/config.xml)
-					G_EXEC sed --follow-symlinks -i '/\[radarr\]/,/^$/s/^ip = .*$/ip = 127.0.0.1/' /mnt/dietpi_userdata/bazarr/config/config.ini
-					G_EXEC sed --follow-symlinks -i "/\[radarr\]/,/^$/s/^port = .*$/port = $port/" /mnt/dietpi_userdata/bazarr/config/config.ini
-					G_EXEC sed --follow-symlinks -i '/\[radarr\]/,/^$/s/^base_url = .*$/base_url = \//' /mnt/dietpi_userdata/bazarr/config/config.ini
-					G_EXEC sed --follow-symlinks -i "/\[radarr\]/,/^$/s/^apikey = .*$/apikey = $apikey/" /mnt/dietpi_userdata/bazarr/config/config.ini
-					G_CONFIG_INJECT 'use_radarr[[:blank:]]*=' 'use_radarr = True' /mnt/dietpi_userdata/bazarr/config/config.ini '\[general\]'
+					G_EXEC sed --follow-symlinks -i '/^radarr:/,/^[^[:blank:]]/s/ ip: .*$/ ip: 127.0.0.1/' /mnt/dietpi_userdata/bazarr/config/config.yaml
+					G_EXEC sed --follow-symlinks -i "/^radarr:/,/^[^[:blank:]]/s/ port: .*$/ port: $port/" /mnt/dietpi_userdata/bazarr/config/config.yaml
+					G_EXEC sed --follow-symlinks -i '/^radarr:/,/^[^[:blank:]]/s/ base_url: .*$/ base_url: \//' /mnt/dietpi_userdata/bazarr/config/config.yaml
+					G_EXEC sed --follow-symlinks -i "/^radarr:/,/^[^[:blank:]]/s/ apikey: .*$/ apikey: $apikey/" /mnt/dietpi_userdata/bazarr/config/config.yaml
+					G_CONFIG_INJECT 'use_radarr:' '  use_radarr: true' /mnt/dietpi_userdata/bazarr/config/config.yaml '^general:'
 				fi
 			fi
 		fi


### PR DESCRIPTION
Additionally, reduce timeout for graceful shutdown from 90 seconds (default) to 20 seconds. This follows the example unit from [Bazarr docs](https://wiki.bazarr.media/Getting-Started/Autostart/Linux/linux/#systemd-service-file-for-debian-ubuntu), and makes sense given that Bazarr hangs forever and does not react to any graceful signal in case of e.g. config validation errors.

Standalone install tests: https://github.com/MichaIng/DietPi/actions/runs/19238502377
Install tests with Sonarr and Radarr: https://github.com/MichaIng/DietPi/actions/runs/19238616179