### PR TITLE
dietpi-software: Mosquitto: use official repo for Trixie

### DIFF
--- a/.meta/dietpi-trixie-upgrade
+++ b/.meta/dietpi-trixie-upgrade
@@ -74,7 +74,7 @@ unset -v apackages
 G_DIETPI-NOTIFY 2 'Migrating package lists to Trixie suite'
 G_EXEC sed --follow-symlinks -i 's/bookworm/trixie/g' /etc/apt/sources.list
 # Remove obsolete lists, including those obsoleted with Bookworm
-G_EXEC rm -f /etc/apt/sources.list.d/dietpi-{mono,mosquitto,wsdd}.list /etc/apt/trusted.gpg.d/dietpi-{mono,mosquitto,wsdd}.gpg
+G_EXEC rm -f /etc/apt/sources.list.d/dietpi-{mono,wsdd}.list /etc/apt/trusted.gpg.d/dietpi-{mono,wsdd}.gpg
 for i in /etc/apt/sources.list.d/*.list
 do
 	[[ $i == '/etc/apt/sources.list.d/*.list' ]] && break

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -6886,7 +6886,7 @@ _EOF_
 		then
 			# Use official APT repository where available: https://repo.mosquitto.org/debian/pool/main/m/mosquitto/
 			# - Current builds are not ARMv6 compatible: https://github.com/MichaIng/DietPi/issues/5140
-			if (( $G_DISTRO < 8 )) && [[ $G_HW_ARCH == 2 || $G_HW_ARCH == 10 || ( $G_HW_ARCH == 3 && $G_DISTRO == 7 ) ]]
+			if (( $G_DISTRO < 9 )) && (( $G_HW_ARCH == 2 || $G_HW_ARCH == 10 || ( $G_HW_ARCH == 3 && $G_DISTRO > 6 ) ))
 			then
 				# APT key
 				local url='https://repo.mosquitto.org/debian/mosquitto-repo.gpg'


### PR DESCRIPTION
Trixie packages are now available, which should work on Forky as well.

Test installs: https://github.com/MichaIng/DietPi/actions/runs/19273303216