### PR TITLE
dietpi-software: Medusa: unlock for Trixie

### DIFF
--- a/.meta/dietpi-trixie-upgrade
+++ b/.meta/dietpi-trixie-upgrade
@@ -18,7 +18,6 @@ do
 		22) alist+=('QuiteRSS');;
 		65) alist+=('Netdata');;
 		111) (( $G_HW_ARCH == 1 )) && alist+=('UrBackup');;
-		116) alist+=('Medusa');;
 		148) (( $G_HW_ARCH == 1 )) && alist+=('myMPD');;
 		178) (( $G_HW_ARCH < 3 )) && alist+=('Jellyfin');;
 		194) (( $G_HW_ARCH < 3 )) && alist+=('PostgreSQL');;

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Enhancement:
 - DietPi-Software | UrBackup: Packages are now installed via official APT repository: https://download.opensuse.org/repositories/home:/uroni/. Aside of the benefit of updates via "apt upgrade", this allowed us to unlock support for Debian Trixie and above. Also support for ARMv6 has been added, but only until Debian Bookworm for now. A Raspbian Trixie suite does not exist yet
 - DietPi-Software | NAA Daemon: Support for Debian Trixie and above on ARMv6/7 systems has been unlocked.
 - DietPi-Software | Moonlight (GUI): Support for Debian Trixie and above on ARMv7 systems has been unlocked.
+- DietPi-Software | Medusa: Support for Debian Trixie has been unlocked thanks to Python 3.13 support with v1.0.25: https://github.com/pymedusa/Medusa/releases/tag/v1.0.25
 
 Bug fixes:
 - Raspberry Pi | We updated our raspberrypi-sys-mods package to be compatible with the new kernel stack and Raspberry Pi 5. This solves several issues like missing serial console access on first boot, missing device nodes or permissions to access them with gpio/i2c/spi/video system groups.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,7 @@ Bug fixes:
 - DietPi-Software | Lidarr/Prowlarr: Resolved an issue on Bullseye systems where the service fails due to an incompatible embedded SQLite library: https://wiki.servarr.com/lidarr/faq#lidarr-wont-start-on-debian-11-or-older-systems-due-to-sqlite-version, https://wiki.servarr.com/prowlarr/faq#prowlarr-wont-start-on-debian-11-or-older-systems-due-to-sqlite-version
 - DietPi-Software | SABnzbd: Resolved an issue where the installation could have finished with an incomplete config file. Many thanks to @DealsBeam for resolving this issue: https://github.com/MichaIng/DietPi/pull/7797
 - DietPi-Software | Bazarr: Resolved an issue where configuring Sonarr and Radarr usage automatically if installed did not work, because Bazarr switched from bazarr.ini to bazarr.yaml as its config file. Many thanks to @Joulinar for reporting this issue: https://github.com/MichaIng/DietPi/issues/7185
+- DietPi-Software | Medusa: Resolved an issue where the service failed to start because it tries to lift sandboxing for a directory that does not exist. We create our own systemd service from now on, instead of using and altering the template, which implies tailored sandboxing, better startup ordering, and a meaningful system log identifier.
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/7806
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -9093,17 +9093,37 @@ _EOF_
 			Create_User -g dietpi -d /mnt/dietpi_userdata/medusa medusa
 
 			# Service: https://github.com/pymedusa/Medusa/blob/master/runscripts/init.systemd
-			G_EXEC cp /mnt/dietpi_userdata/medusa/runscripts/init.systemd /etc/systemd/system/medusa.service
-			# - Prevent unlimited restarts on failure: Permit up to three restarts in 10 minutes
-			G_CONFIG_INJECT 'StartLimitIntervalSec=' 'StartLimitIntervalSec=600' /etc/systemd/system/medusa.service '\[Unit\]'
-			G_CONFIG_INJECT 'StartLimitBurst=' 'StartLimitBurst=3' /etc/systemd/system/medusa.service 'StartLimitIntervalSec='
-			# - Remove "Group=medusa" which does not exist, instead fallback to primary group "dietpi"
-			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*Group=/d' /etc/systemd/system/medusa.service
-			# - Launch from our install and data directory
-			G_CONFIG_INJECT 'ExecStart=' 'ExecStart=/usr/bin/python3 /mnt/dietpi_userdata/medusa/start.py -q --nolaunch --datadir=/mnt/dietpi_userdata/medusa' /etc/systemd/system/medusa.service
+			cat << '_EOF_' > /etc/systemd/system/medusa.service || exit 1
+[Unit]
+Description=Medusa (DietPi)
+Wants=network-online.target
+After=network-online.target
+StartLimitIntervalSec=60
+StartLimitBurst=3
 
+[Service]
+SyslogIdentifier=Medusa
+User=medusa
+UMask=002
+ExecStart=/usr/bin/python3 /mnt/dietpi_userdata/medusa/start.py -q --nolaunch --datadir=/mnt/dietpi_userdata/medusa
+TimeoutStopSec=25
+KillMode=process
+Restart=on-failure
+
+# Hardening
+ProtectSystem=strict
+ProtectHome=1
+PrivateTmp=1
+PrivateDevices=1
+ProtectKernelTunables=1
+ProtectControlGroups=1
+ReadWritePaths=-/mnt /media -/tmp
+
+[Install]
+WantedBy=multi-user.target
+_EOF_
 			# Permissions
-			G_EXEC chown -R medusa:dietpi /mnt/dietpi_userdata/medusa
+			G_EXEC chown -R medusa:0 /mnt/dietpi_userdata/medusa
 		fi
 
 		if To_Install 50 syncthing # Syncthing

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -627,8 +627,6 @@ Available commands:
 		aSOFTWARE_CATX[$software_id]=3
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/bittorrent/#medusa'
 		aSOFTWARE_DEPS[$software_id]='170'
-		# - Trixie: Outstanding Python 3.13 support: https://github.com/pymedusa/Medusa/pull/11967
-		aSOFTWARE_AVAIL_G_DISTRO[$software_id,8]=0
 		#------------------
 		software_id=132
 		aSOFTWARE_NAME[$software_id]='Aria2'


### PR DESCRIPTION
Test installs: https://github.com/MichaIng/DietPi/actions/runs/19306130062

Additionally generate own systemd unit instead of starting with the template: It is quite bloated, has execute bit which triggers a systemd warning, comes with zero hardening/sandboxing, recently added an unnecessary  `ReadWritePaths` (unnecessary without `ProtectSystem` or other sandboxing) to a path which does not exist on DietPi, and needed a bunch of adjustments already. Creating an own one makes it easier to keep it in sync with our other systemd units, applying our common sandboxing, restart loop limits, logging identifier, startup ordering etc.