### PR TITLE
dietpi-banner: merge dashcolon and colon word-wrap options

### DIFF
--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -63,7 +63,7 @@
 		'Let'\''s Encrypt cert status'
 		'RAM usage'
 		'Load average'
-		'Word-wrap on small screens'
+		'Word-wrap lines on small screens'
 	)
 
 	# Set defaults: Disable CPU temp by default in VMs
@@ -83,10 +83,9 @@
 		'\e[91m'	# Red		| Update notifications
 	)
 
-	# Folding type, minimum indent, minimum characters after indent
-	BW_INDENT_TYPE='dashcolon'
-	BW_INDENT_MIN=3
-	BW_MIN_USEABLE_SPACE=8
+	# Folding type (colon, dash, fixed), and fixed indent
+	BW_INDENT_TYPE='colon'
+	BW_INDENT_FIXED=3
 
 	# Load settings here, to have chosen ${aCOLOUR[0]} applied to below strings
 	# shellcheck disable=SC1090
@@ -151,8 +150,7 @@
 		done
 
 		echo "BW_INDENT_TYPE='$BW_INDENT_TYPE'"
-		echo "BW_INDENT_MIN=$BW_INDENT_MIN"
-		echo "BW_MIN_USEABLE_SPACE=$BW_MIN_USEABLE_SPACE"
+		echo "BW_INDENT_FIXED=$BW_INDENT_FIXED"
 	}
 
 	Print_Header()
@@ -323,7 +321,7 @@ $GREEN_LINE"
 		# Pipe to awk script for word-wrap if enabled
 		if (( ${aENABLED[19]} ))
 		then
-			Print_Banner_raw | mawk -v "MAXCOL=$(tput cols)" -v "INDENT_TYPE=$BW_INDENT_TYPE" -v "INDENT_MIN=$BW_INDENT_MIN" -v "MIN_USEABLE_SPACE=$BW_MIN_USEABLE_SPACE" -f "$FP_BANNERWRAP_AWK"
+			Print_Banner_raw | mawk -v "MAXCOL=$(tput cols)" -v "INDENT_TYPE=$BW_INDENT_TYPE" -v "INDENT_FIXED=$BW_INDENT_FIXED" -f "$FP_BANNERWRAP_AWK"
 		else
 			Print_Banner_raw
 		fi
@@ -366,18 +364,19 @@ NB: It is executed as bash script, so it needs to be in bash compatible syntax.
 
 			elif (( $i == 19 ))
 			then
-				# Banner word wrap options
+				# Banner word-wrap options
 				G_WHIP_MENU_ARRAY=(
-					'min' 'Indent to a fixed minimum offset'
+					'colon' 'Indent to the green colon if present, else to the green dash'
 					'dash' 'Indent to the green dash character'
-					'colon' 'Indent to the green colon character'
-					'dashcolon' 'Indent first to Colon then Dash'
+					'fixed' 'Indent to a fixed offset'
 				)
 				G_WHIP_DEFAULT_ITEM=$BW_INDENT_TYPE
-				G_WHIP_MENU 'Choose the type of word-wrapping' && BW_INDENT_TYPE=$G_WHIP_RETURNED_VALUE
-				## Indent min
-				G_WHIP_DEFAULT_ITEM=$BW_INDENT_MIN
-				G_WHIP_INPUTBOX 'Please set the minimum offset' && BW_INDENT_MIN=$G_WHIP_RETURNED_VALUE
+				G_WHIP_MENU 'Choose how word-wrapped lines shall be indented:' || continue
+				BW_INDENT_TYPE=$G_WHIP_RETURNED_VALUE
+				[[ $BW_INDENT_TYPE == 'fixed' ]] || continue
+				G_WHIP_DEFAULT_ITEM=$BW_INDENT_FIXED
+				G_WHIP_INPUTBOX_REGEX='^[1-9][0-9]*$' G_WHIP_INPUTBOX_REGEX_TEXT='be a number'
+				G_WHIP_INPUTBOX 'Please set the fixed offset column to indent word-wrapped lines to:' && BW_INDENT_FIXED=$G_WHIP_RETURNED_VALUE
 			fi
 		done
 

--- a/dietpi/func/dietpi-banner-wrap.awk
+++ b/dietpi/func/dietpi-banner-wrap.awk
@@ -1,50 +1,52 @@
-function make_whitespace_offset(clean_line){
+function make_whitespace_offset(clean_line) {
     ## Generate leading spaces based on global INDENT_TYPE
-    if (INDENT_TYPE == "min"){
-        return sprintf("%*s", INDENT_MIN, "")
+    if (INDENT_TYPE == "fixed") {
+        return sprintf("%*s", INDENT_FIXED, "")
     }
-    lead_spaces = ""
-    if ((INDENT_TYPE == "dash" || INDENT_TYPE == "dashcolon") && match(clean_line, green_dash)){
-        lead_spaces = sprintf("%*s", RSTART + RLENGTH - 1, "")
+    lead_spaces = INDENT_MIN
+    if (match(clean_line, green_dash)) {
+        lead_spaces = RSTART + RLENGTH - 1
     }
-    if ((INDENT_TYPE == "colon" || INDENT_TYPE == "dashcolon") && match(clean_line, green_colon)){
-        lead_spaces = sprintf("%*s", RSTART + RLENGTH - 1, "")
+    if ((INDENT_TYPE == "colon") && match(clean_line, green_colon)) {
+        lead_spaces = RSTART + RLENGTH - 1
     }
     # Useable space check
     # - "Let's Encrypt cert status" would be squashed otherwise
-    if ( (MAXCOL - length(lead_spaces)) < MIN_USEABLE_SPACE){
-        lead_spaces = sprintf("%*s", INDENT_MIN, "")
+    if ((MAXCOL - lead_spaces) < MIN_USEABLE_SPACE) {
+        lead_spaces = INDENT_MIN
     }
-    return lead_spaces
+    return sprintf("%*s", lead_spaces, "")
 }
 
 BEGIN {
-    green_dash = "^[[:space:]]+-[[:space:]]"  # green "bullets"
-    green_colon = "[[:space:]]:[[:space:]]"  # green colon in middle
-    color_regex = "[[:cntrl:]][[0-9;?]*[A-Za-z]"  # all color codes
+    green_dash = "^[[:space:]]+-[[:space:]]"             # green "bullets"
+    green_colon = "[[:space:]]:[[:space:]]"              # green colon in middle
+    color_regex = "[[:cntrl:]][[0-9;?]*[A-Za-z]"         # all color codes
     ## Init from CLI, or use defaults here
-    if (MIN_USEABLE_SPACE == ""){MIN_USEABLE_SPACE = 8} ## min space on the right to keep
-    if (MAXCOL == ""){MAXCOL = 30}                      ## Wrap to column number
-    if (INDENT_MIN == ""){INDENT_MIN = 1}               ## min offset seen in dietpi banner
-    if (INDENT_TYPE == ""){INDENT_TYPE = "dashcolon"}   ## Indent modes:
-    ## min - use minimum
+    if (MIN_USEABLE_SPACE == "") {MIN_USEABLE_SPACE = 8} ## min space on the right to keep
+    if (MAXCOL == "") {MAXCOL = 55}                      ## Wrap to column number
+    if (INDENT_MIN == "") {INDENT_MIN = 3}               ## min offset, matching dash-alignment
+    if (INDENT_FIXED == "") {INDENT_FIXED = 3}           ## fixed offset if INDENT_TYPE == "fixed"
+    if (INDENT_TYPE == "") {INDENT_TYPE = "colon"}       ## Indent modes:
+    ## fixed - use fixed offset
     ## dash - green_dash only
-    ## colon - green_colon only
-    ## dashcolon - match dash first then colon (colon overrides)
+    ## colon - green_dash first then green_colon (colon overrides)
 }
 
 {
     ## ASCII ART: Skip or Hide
-    if (match($0, /^[^a-zA-Z0-9─]+$/)){
-        if (MAXCOL > (RSTART+RLENGTH)){print $0;}
-        next;
+    if (match($0, /^[^a-zA-Z0-9─]+$/)) {
+        if (MAXCOL > (RSTART + RLENGTH)) {print $0}
+        next
     }
-    ## Green Lines: Truncate to MAXCOL
-    if (match($0, /────/)){
-        new_grn_line = sprintf("%*s", MAXCOL - 2, "") ## new line: of spaces
-        gsub(/ /, "─", new_grn_line)                  ## new line: change spaces to line char
-        sub(/[─]+/, new_grn_line, $0)                 ## old line: replace line with new line
-        print; next;
+    ## Green Lines: Truncate to MAXCOL or 55
+    if (match($0, /────/)) {
+        if (MAXCOL < 55) {line_len = MAXCOL - 2}    ## line len: max column - leading space - count starts at 1
+	else {line_len = 53}                        ## line len: 53 is the line length if word-wrap is disabled
+        new_grn_line = sprintf("%*s", line_len, "") ## new line: of spaces
+        gsub(/ /, "─", new_grn_line)                ## new line: change spaces to line char
+        sub(/[─]+/, new_grn_line, $0)               ## old line: replace line with new line
+        print; next
     }
     ## Begin word-wrapping
     ## - Wrap based on stripped colour position
@@ -60,8 +62,8 @@ BEGIN {
     wn = split($0, words, /[[:space:]]+/)
     sn = split(clean_line, stripped_words, /[[:space:]]+/)
 
-    if (sn > 0 && wn != sn){
-        print "[WARN] Color word order does not match stripped word order"
+    if (sn > 0 && wn != sn) {
+        print "[WARN] Banner word-wrap: Word count changed after stripping color codes"
         next
     }
 


### PR DESCRIPTION
For lines without a colon, probably no one would want to not have them indented at all. Hence squash the two options.

Rename "min" to "fixed", and only ask for the fixed indent column if that option was chosen. Assure that only numbers are accepted by the inputbox, it otherwise repeats with an error internally.

Remove the BW_MIN_USEABLE_SPACE variable handling, as it is currently unused.

Limit length of green lines to 53, matching the banner if word-wrap is disabled.

If word-wrapped lines are still too long, indent to fixed `INDENT_MIN = 1` independent of `INDENT_FIXED`.

Enhance `make_whitespace_offset` function: avoid printing leading spaces to variable, which can happen multiple times, but store only the number of spaces and return the actual spaces only once at the end.

@mtekman as discussed. I also removed `BW_MIN_USEABLE_SPACE` which was not editable in banner options anyway. As far as I understand, the 8 needs to be hardcoded for the Let's Encrypt cert line to not break? What is the issue with that one actually? Probably we can change that line instead of enforcing 8 trailing spaces?