### PR TITLE
dietpi-software: UrBackup: switch to DEB822

### DIFF
--- a/.update/pre-patches
+++ b/.update/pre-patches
@@ -573,6 +573,30 @@ then
 		G_EXEC rm mosquitto-repo.gpg
 		G_EXEC eval "echo 'deb https://repo.mosquitto.org/debian $G_DISTRO_NAME main' > /etc/apt/sources.list.d/dietpi-mosquitto.list"
 	fi
+	if [[ -f '/boot/dietpi/.installed' ]] && grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[111\]=2' /boot/dietpi/.installed
+	then
+		G_DIETPI-NOTIFY 2 'Adding UrBackup APT repository'
+		# APT distro
+		distro='Debian_'
+		(( $G_HW_ARCH == 1 )) && distro='Raspbian_'
+		case $G_DISTRO in
+			6) distro+='11';;
+			7) distro+='12';;
+			*) (( $G_HW_ARCH == 1 )) && distro+='12' || distro+='13';;
+		esac
+		# APT key
+		G_EXEC mkdir -p /etc/apt/keyrings
+		G_EXEC curl -sSfLo /etc/apt/keyrings/dietpi-urbackup.asc "https://download.opensuse.org/repositories/home:/uroni/$distro/Release.key"
+		# APT source
+		G_EXEC eval "cat << '_EOF_' > /etc/apt/sources.list.d/dietpi-urbackup.sources
+Types: deb
+URIs: https://download.opensuse.org/repositories/home:/uroni/$distro
+Suites: /
+Signed-By: /etc/apt/keyrings/dietpi-urbackup.asc
+_EOF_"
+		# Beta cleanup
+		[[ -f '/etc/apt/sources.list.d/dietpi-urbackup.list' ]] && G_EXEC rm /etc/apt/sources.list.d/dietpi-urbackup.list
+	fi
 fi
 
 exit 0

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5493,8 +5493,13 @@ _EOF_
 			G_EXEC mkdir -p /etc/apt/keyrings
 			G_EXEC curl -sSfLo /etc/apt/keyrings/dietpi-urbackup.asc "https://download.opensuse.org/repositories/home:/uroni/$distro/Release.key"
 
-			# APT list
-			G_EXEC eval "echo 'deb [signed-by=/etc/apt/keyrings/dietpi-urbackup.asc] https://download.opensuse.org/repositories/home:/uroni/$distro /' > /etc/apt/sources.list.d/dietpi-urbackup.list"
+			# APT source
+			G_EXEC eval "cat << '_EOF_' > /etc/apt/sources.list.d/dietpi-urbackup.sources
+Types: deb
+URIs: https://download.opensuse.org/repositories/home:/uroni/$distro
+Suites: /
+Signed-By: /etc/apt/keyrings/dietpi-urbackup.asc
+_EOF_"
 			G_AGUP
 
 			# APT package


### PR DESCRIPTION
I thought it would not support path suites, but it does. Also install the repo on DietPi update

Test installs: https://github.com/MichaIng/DietPi/actions/runs/19396204736