### PR TITLE
Add rustdesk server to dietpi-software

### DIFF
--- a/.github/workflows/dietpi-software.bash
+++ b/.github/workflows/dietpi-software.bash
@@ -116,7 +116,7 @@ Process_Software()
 			9) aCOMMANDS[i]='node -v';;
 			10) aCOMMANDS[i]='amiberry-lite -h | grep '\''^\$VER: Amiberry-Lite '\';;
 			11) aCOMMANDS[i]='gzdoom -norun | grep '\''^GZDoom version '\';;
-			12) aSERVICES[i]='rustdesksignal rustdeskrelay' aTCP[i]='21116 21117';;
+			12) aSERVICES[i]='rustdesksignal rustdeskrelay' aTCP[i]='21115 21116 21117 21118 21119' aUDP[i]='21116';;
 			#16) aSERVICES[i]='microblog-pub' aTCP[i]='8007';; Service enters a CPU-intense internal error loop until it has been configured interactively via "microblog-pub configure", hence it is not enabled and started anymore after install but instead as part of "microblog-pub configure"
 			17) aCOMMANDS[i]='git --version';; # from Bookworm on, the shorthand "-v" is supported
 			#22) QuiteRSS: has no CLI

--- a/.github/workflows/dietpi-software.bash
+++ b/.github/workflows/dietpi-software.bash
@@ -116,6 +116,7 @@ Process_Software()
 			9) aCOMMANDS[i]='node -v';;
 			10) aCOMMANDS[i]='amiberry-lite -h | grep '\''^\$VER: Amiberry-Lite '\';;
 			11) aCOMMANDS[i]='gzdoom -norun | grep '\''^GZDoom version '\';;
+			12) aSERVICES[i]='rustdesksignal rustdeskrelay' aTCP[i]='21116 21117';;
 			#16) aSERVICES[i]='microblog-pub' aTCP[i]='8007';; Service enters a CPU-intense internal error loop until it has been configured interactively via "microblog-pub configure", hence it is not enabled and started anymore after install but instead as part of "microblog-pub configure"
 			17) aCOMMANDS[i]='git --version';; # from Bookworm on, the shorthand "-v" is supported
 			#22) QuiteRSS: has no CLI

--- a/.github/workflows/update_urls.bash
+++ b/.github/workflows/update_urls.bash
@@ -12,6 +12,13 @@ Exit_Error()
 
 ### Software definitions ###
 
+# RustDesk Server
+software_id=12
+aCHECK[$software_id]='curl -sSfL '\''https://api.github.com/repos/rustdesk/rustdesk-server/releases/latest'\'' | mawk -F\" "/^ *\"browser_download_url\": \".*\/rustdesk-server-linux-$arch\.zip\"$/{print \$4}"'
+aARCH[$software_id]='armv7 arm64v8 amd64'
+aARCH_CHECK[$software_id]='riscv64'
+aREGEX[$software_id]='https://github.com/rustdesk/rustdesk-server/releases/download/.*/rustdesk-server-linux-\$arch\.zip'
+
 # microblog.pub: Update Python version
 software_id=16
 aCHECK[$software_id]='curl -sSf '\''https://api.github.com/repos/pyenv/pyenv/contents/plugins/python-build/share/python-build?ref=master'\'' | mawk -F\" '\''/^ *"name": "3\.11\.[0-9]*",$/{print $4}'\'' | sort -Vr | head -1'

--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -596,6 +596,7 @@ shopt -s extglob # +(expr) syntax
 	do
 		aSOFTWARE_NAME9_20[i]=${aSOFTWARE_NAME9_19[i]}
 	done
+	aSOFTWARE_NAME9_20[12]='RustDesk'
 
 	# Pre-create software counter array so that we can see also software (available in newest version) with 0 installs
 	for i in "${aSOFTWARE_NAME9_20[@]}"

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,9 @@
 v9.20
 (2025-12-13)
 
+New software:
+- RustDesk Server | The signalling and relay server component for the RustDesk remote desktop system has been added to our software catalogue. Many thanks to @JappeHallunken for implementing this software option: https://github.com/MichaIng/DietPi/pull/7842
+
 Enhancement:
 - Orange Pi 5/Max/Ultra | Our images ship now with all USB-A ports and, depending on model, one USB-C port enabled in host mode, making them functional for USB devices. This is done with a device tree overlay "dwc3-host". Removing it from /boot/dietpiEnv.txt reverts the affected port(s), which share one controller, to their default OTG mode, in which case attached USB devices are not detected or even powered. For existing instances, add "dwc3-host" to the "overlays=" line in /boot/dietpiEnv.txt to apply this change. Many thanks to @DiegoBM and @pavel-kamaev for reporting this issue: https://github.com/MichaIng/DietPi/issues/7738
 - Radxa ZERO 3 | New images will ship with Linux 6.12 mainline LTS kernel now, and the DietPi update migrates systems with legacy and vendor kernel to mainline LTS as well.

--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ Links to hardware and software manufacturers, sources and build instructions use
 - [PiJuice](https://github.com/PiSupply/PiJuice)
 - [LazyLibrarian](https://gitlab.com/LazyLibrarian/LazyLibrarian)
 - [BirdNET-Go](https://github.com/tphakala/birdnet-go)
+- [RustDesk](https://github.com/rustdesk/rustdesk-server)
 
 ---
 

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -295,6 +295,8 @@ _EOF_
 				'vncserver'
 				'xrdp'
 				'nxserver'		# NoMachine
+        'rustdeskrelay'
+        'rustdesksignal'
 
 				# VPN: Servers as well as client shall not be DietPi-controlled. VPN servers may be used for remote maintenance sessions, VPN clients may be wanted/needed for anonymised Internet requests.
 				#'wg-quick@wg0'		# Currently instantiated services are not supported

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -295,8 +295,8 @@ _EOF_
 				'vncserver'
 				'xrdp'
 				'nxserver'		# NoMachine
-        'rustdeskrelay'
-        'rustdesksignal'
+				'rustdesksignal'
+				'rustdeskrelay'
 
 				# VPN: Servers as well as client shall not be DietPi-controlled. VPN servers may be used for remote maintenance sessions, VPN clients may be wanted/needed for anonymised Internet requests.
 				#'wg-quick@wg0'		# Currently instantiated services are not supported

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12435,19 +12435,19 @@ _EOF_
 # NB: "info" logs client IPs, hence we suggest to switch to "warn" for production.
 #RUST_LOG=info
 
-# Speed limit in MiB/s (default: 32)
-#LIMIT_SPEED=32
-
-# Max bandwidth for a single connection in MiB/s (default: 128)
-#SINGLE_BANDWIDTH=128
-
-# Max total bandwidth in MiB/s (default: 1024)
+# Total bandwidth limit in MiB/s (default: 1024)
 #TOTAL_BANDWIDTH=1024
 
-# Delay before downgrade check in seconds (default: 1800)
+# Single connection bandwidth limit in MiB/s (default: 128)
+#SINGLE_BANDWIDTH=128
+
+# Bandwidth limit for clients listed in $rd_data/blacklist.txt in MiB/s (default: 32)
+#LIMIT_SPEED=32
+
+# Delay before limiting bandwidth in seconds (default: 1800)
 #DOWNGRADE_START_CHECK=1800
 
-# Threshold of downgrade check in bit/ms (default: 0.66)
+# Threshold before limiting bandwidth in bit/ms (default: 0.66)
 #DOWNGRADE_THRESHOLD=0.66
 _EOF_
 			G_EXEC chmod 0700 "$rd_data"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12384,10 +12384,10 @@ _EOF_
       local rd_data="/mnt/dietpi_userdata/rustdesk"
       local rd_latest=$(curl -s https://api.github.com/repos/rustdesk/rustdesk-server/releases/latest | grep tag_name | cut -d '"' -f 4)
 
-			case $G_HW_ARCH in
+			case "$G_HW_ARCH" in
 				2) local rd_arch='armv7';;
 				3) local rd_arch='arm64v8';;
-				10) local rd_arch='amd64';;
+				*) local rd_arch='amd64';;
 			esac
 
       # User
@@ -12397,19 +12397,18 @@ _EOF_
       Download_Install "https://github.com/rustdesk/rustdesk-server/releases/download/$rd_latest/rustdesk-server-linux-$rd_arch.zip" rustdesk
 
       # Working Dir
-      G_EXEC mkdir -p $rd_work
-      G_EXEC mv rustdesk/$rd_arch/* $rd_work
-      G_EXEC chown -R rustdesk $rd_work
-      G_EXEC chmod +x $rd_work/*
+      G_EXEC mkdir -p "$rd_work"
+      G_EXEC mv "rustdesk/$rd_arch"/* "$rd_work"
+      G_EXEC chown -R rustdesk "$rd_work"
+      G_EXEC chmod +x "$rd_work"/*
 
       # Data Dir and config file
-      G_EXEC mkdir -p $rd_data
-      G_EXEC touch $rd_data/hbbs.env $rd_data/hbbr.env
-      G_EXEC chown -R dietpi:dietpi $rd_data
-      G_EXEC chmod 700 $rd_data
-      G_EXEC chmod 600 $rd_data/*
+      G_EXEC mkdir -p "$rd_data"
+      G_EXEC touch "$rd_data/hbbs.env" "$rd_data/hbbr.env"
+      G_EXEC chown -R dietpi:dietpi "$rd_data"
+      G_EXEC chmod 700 "$rd_data"
+      G_EXEC chmod 600 "$rd_data"/*
 
-      # Permissions
       # Clean
       G_EXEC rm -r rustdesk
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12380,8 +12380,8 @@ _EOF_
 		if To_Install 12 # rustdesk
 
 		then
-      local rd_user='rustdesk'
-			local rd_work="/opt/$rd_user"
+			local rd_work="/opt/rustdesk"
+      local rd_data="/mnt/dietpi_userdata/rustdesk"
       local rd_latest=$(curl -s https://api.github.com/repos/rustdesk/rustdesk-server/releases/latest | grep tag_name | cut -d '"' -f 4)
 
 			case $G_HW_ARCH in
@@ -12391,18 +12391,27 @@ _EOF_
 			esac
 
       # User
-			Create_User $rd_user
+			Create_User rustdesk
 
 			# Download
-      Download_Install "https://github.com/rustdesk/rustdesk-server/releases/download/$rd_latest/rustdesk-server-linux-$rd_arch.zip" $rd_user
+      Download_Install "https://github.com/rustdesk/rustdesk-server/releases/download/$rd_latest/rustdesk-server-linux-$rd_arch.zip" rustdesk
 
+      # Working Dir
       G_EXEC mkdir -p $rd_work
       G_EXEC mv rustdesk/$rd_arch/* $rd_work
-      # Permissions
-      G_EXEC chown -R $rd_user $rd_work
+      G_EXEC chown -R rustdesk $rd_work
       G_EXEC chmod +x $rd_work/*
+
+      # Data Dir and config file
+      G_EXEC mkdir -p $rd_data
+      G_EXEC touch $rd_data/hbbs.env $rd_data/hbbr.env
+      G_EXEC chown -R dietpi:dietpi $rd_data
+      G_EXEC chmod 700 $rd_data
+      G_EXEC chmod 600 $rd_data/*
+
+      # Permissions
       # Clean
-      G_EXEC rm -r $rd_user
+      G_EXEC rm -r rustdesk
 
 			# Service hbbs
       cat << _EOF_ > /etc/systemd/system/rustdesksignal.service
@@ -12412,8 +12421,9 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-User=$rd_user
+User=rustdesk
 WorkingDirectory=$rd_work
+EnvironmentFile=$rd_data/hbbs.env
 ExecStart=$rd_work/hbbs
 Restart=on-failure
 RestartSec=5
@@ -12421,7 +12431,7 @@ RestartSec=5
 [Install]
 WantedBy=multi-user.target
 _EOF_
-      # Service hbbs
+      # Service hbbr
       cat << _EOF_ > /etc/systemd/system/rustdeskrelay.service
 [Unit]
 Description=Rustdesk Relay Server
@@ -12429,8 +12439,9 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-User=$rd_user
+User=rustdesk
 WorkingDirectory=$rd_work
+EnvironmentFile=$rd_data/hbbr.env
 ExecStart=$rd_work/hbbr
 Restart=on-failure
 RestartSec=5
@@ -14594,6 +14605,7 @@ _EOF_
       Remove_Service rustdeskrelay
       Remove_Service rustdesksignal rustdesk
       G_EXEC rm -Rf /opt/rustdesk
+      G_EXEC rm -Rf /mnt/dietpi_userdata/rustdesk
     fi
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Finalising uninstall'

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12420,7 +12420,7 @@ _EOF_
 #PORT=                  # listening port. default: 21116
 #RUST_LOG=              # set debug level (error|warn|info|debug|trace). default is info
 #SINGLE_BANDWIDTH=      # max bandwidth for a single connection (in Mb/s)
-#TOTAL_BANDWIDTH=       # max total bandwidth (in Mb/s). 
+#TOTAL_BANDWIDTH=       # max total bandwidth (in Mb/s).
 _EOF_
 
 			G_EXEC chmod 0700 "$rd_data"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -310,7 +310,6 @@ Available commands:
 		aSOFTWARE_DESC[$software_id]='open-source remote desktop server, written in Rust'
 		aSOFTWARE_CATX[$software_id]=1
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/remote_desktop/#TBD'
-		aSOFTWARE_DEPS[$software_id]='desktop'
     # RISC-V & ARMv6: https://github.com/rustdesk/rustdesk-server/releases
     aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
     aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,11]=0
@@ -12381,8 +12380,8 @@ _EOF_
 		if To_Install 12 # rustdesk
 
 		then
-			local rd_inst='/opt/rustdesk'
-			local rd_user='rustdesk'
+      local rd_user='rustdesk'
+			local rd_work="/opt/$rd_user"
       local rd_latest=$(curl -s https://api.github.com/repos/rustdesk/rustdesk-server/releases/latest | grep tag_name | cut -d '"' -f 4)
 
 			case $G_HW_ARCH in
@@ -12391,68 +12390,60 @@ _EOF_
 				10) local rd_arch='amd64';;
 			esac
 
+      # User
+			Create_User $rd_user
+
 			# Download
-      Download_Install "https://github.com/rustdesk/rustdesk-server/releases/download/${rd_latest}/rustdesk-server-linux-${rd_arch}.zip" 
+      Download_Install "https://github.com/rustdesk/rustdesk-server/releases/download/$rd_latest/rustdesk-server-linux-$rd_arch.zip" $rd_user
 
-			# User
-			Create_User -G audio -d "$bnet_data" "$bnet_user"
+      G_EXEC mkdir -p $rd_work
+      G_EXEC mv rustdesk/$rd_arch/* $rd_work
+      # Permissions
+      G_EXEC chown -R $rd_user $rd_work
+      G_EXEC chmod +x $rd_work/*
+      # Clean
+      G_EXEC rm -r $rd_user
 
-			# Data dir
-			G_EXEC mkdir -p "$bnet_data"
-			G_EXEC chown -R "$bnet_user:$bnet_user" "$bnet_data"
-
-			# Config
-			# - Checks hard-coded paths in this order: ~/.config/birdnet-go/config.yaml > /etc/birdnet-go/config.yaml
-			if [[ ! -f $bnet_conf ]]
-			then
-				# Initial call to generate ~/.config/birdnet-go/config.yaml
-				G_EXEC runuser -u "$bnet_user" -- "$bnet_inst/birdnet-go"
-				# Replace paths, otherwise defaults to the working directory
-				# Disable MQTT and CPU/memory/disk monitoring
-				# Enable new web UI at $bnet_port
-				G_EXEC yq -yi "
-					.output.sqlite.path = \"$bnet_data/birdnet.db\" |
-					.main.log.path = \"$bnet_data/logs/birdnet.log\" |
-					.realtime.log.path = \"$bnet_data/logs/birdnet.txt\" |
-					.realtime.audio.export.path = \"$bnet_data/clips\" |
-					.realtime.output.file.path = \"$bnet_data/output\" |
-					.realtime.mqtt.enabled = false |
-					.realtime.monitoring.enabled = false |
-					.realtime.webserver.enabled = true |
-					.realtime.dashboard.newui = true |
-					.webserver.port = $bnet_port" "$bnet_conf"
-				# Purge yq if it was installed for BirdNET-Go only
-				(( $install_yq )) && G_AGP yq
-			fi
-
-			# Service
-			cat << _EOF_ > /etc/systemd/system/birdnet.service || exit 1
+			# Service hbbs
+      cat << _EOF_ > /etc/systemd/system/rustdesksignal.service
 [Unit]
-Description=BirdNet-Go
+Description=Rustdesk Signal Server
 Wants=network-online.target
 After=network-online.target
-StartLimitIntervalSec=60
-StartLimitBurst=3
 
 [Service]
-User=$bnet_user
-WorkingDirectory=$bnet_data
-ExecStart=$bnet_inst/birdnet-go realtime
+User=$rd_user
+WorkingDirectory=$rd_work
+ExecStart=$rd_work/hbbs
 Restart=on-failure
 RestartSec=5
-
-# Hardening
-ProtectSystem=strict
-ProtectHome=1
-PrivateTmp=1
-ProtectKernelTunables=1
-ProtectControlGroups=1
-ReadWritePaths=-$bnet_data -/tmp
 
 [Install]
 WantedBy=multi-user.target
 _EOF_
-		fi
+      # Service hbbs
+      cat << _EOF_ > /etc/systemd/system/rustdeskrelay.service
+[Unit]
+Description=Rustdesk Relay Server
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=$rd_user
+WorkingDirectory=$rd_work
+ExecStart=$rd_work/hbbr
+Restart=on-failure
+RestartSec=5
+LimitNOFILE=4096
+
+[Install]
+WantedBy=multi-user.target
+_EOF_
+
+    aSTART_SERVICES+=('rustdeskrelay')
+    aSTART_SERVICES+=('rustdesksignal')
+    fi
+
 	}
 
 	# $1: 0=None -1=Dropbear -2=OpenSSH
@@ -14597,6 +14588,13 @@ _EOF_
 			G_EXEC rm -Rf /var/log/lazylibrarian
 			G_EXEC rm -Rf /mnt/dietpi_userdata/lazylibrarian
 		fi
+
+    if To_Uninstall 12 # rustdesk
+    then
+      Remove_Service rustdeskrelay
+      Remove_Service rustdesksignal rustdesk
+      G_EXEC rm -Rf /opt/rustdesk
+    fi
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Finalising uninstall'
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12381,8 +12381,8 @@ _EOF_
 
 		then
 			local rd_work="/opt/rustdesk"
-      local rd_data="/mnt/dietpi_userdata/rustdesk"
-      local rd_latest=$(curl -s https://api.github.com/repos/rustdesk/rustdesk-server/releases/latest | grep tag_name | cut -d '"' -f 4)
+			local rd_data="/mnt/dietpi_userdata/rustdesk"
+			local rd_latest=$(curl -s https://api.github.com/repos/rustdesk/rustdesk-server/releases/latest | grep tag_name | cut -d '"' -f 4)
 
 			case "$G_HW_ARCH" in
 				2) local rd_arch='armv7';;
@@ -12390,30 +12390,30 @@ _EOF_
 				*) local rd_arch='amd64';;
 			esac
 
-      # User
+			# User
 			Create_User rustdesk
 
 			# Download
-      Download_Install "https://github.com/rustdesk/rustdesk-server/releases/download/$rd_latest/rustdesk-server-linux-$rd_arch.zip" rustdesk
+			Download_Install "https://github.com/rustdesk/rustdesk-server/releases/download/$rd_latest/rustdesk-server-linux-$rd_arch.zip" rustdesk
 
-      # Working Dir
-      G_EXEC mkdir -p "$rd_work"
-      G_EXEC mv "rustdesk/$rd_arch"/* "$rd_work"
-      G_EXEC chown -R rustdesk "$rd_work"
-      G_EXEC chmod +x "$rd_work"/*
+			# Working Dir
+			G_EXEC mkdir -p "$rd_work"
+			G_EXEC mv "rustdesk/$rd_arch"/* "$rd_work"
+			G_EXEC chown -R rustdesk "$rd_work"
+			G_EXEC chmod +x "$rd_work"/*
 
-      # Data Dir and config file
-      G_EXEC mkdir -p "$rd_data"
-      G_EXEC touch "$rd_data/hbbs.env" "$rd_data/hbbr.env"
-      G_EXEC chown -R dietpi:dietpi "$rd_data"
-      G_EXEC chmod 700 "$rd_data"
-      G_EXEC chmod 600 "$rd_data"/*
+			# Data Dir and config file
+			G_EXEC mkdir -p "$rd_data"
+			G_EXEC touch "$rd_data/hbbs.env" "$rd_data/hbbr.env"
+			G_EXEC chown -R dietpi:dietpi "$rd_data"
+			G_EXEC chmod 700 "$rd_data"
+			G_EXEC chmod 600 "$rd_data"/*
 
-      # Clean
-      G_EXEC rm -r rustdesk
+			# Clean
+			G_EXEC rm -r rustdesk
 
 			# Service hbbs
-      cat << _EOF_ > /etc/systemd/system/rustdesksignal.service
+			cat << _EOF_ > /etc/systemd/system/rustdesksignal.service
 [Unit]
 Description=Rustdesk Signal Server
 Wants=network-online.target
@@ -12430,8 +12430,8 @@ RestartSec=5
 [Install]
 WantedBy=multi-user.target
 _EOF_
-      # Service hbbr
-      cat << _EOF_ > /etc/systemd/system/rustdeskrelay.service
+			# Service hbbr
+			cat << _EOF_ > /etc/systemd/system/rustdeskrelay.service
 [Unit]
 Description=Rustdesk Relay Server
 Wants=network-online.target
@@ -12450,8 +12450,8 @@ LimitNOFILE=4096
 WantedBy=multi-user.target
 _EOF_
 
-    aSTART_SERVICES+=('rustdeskrelay')
-    aSTART_SERVICES+=('rustdesksignal')
+			aSTART_SERVICES+=('rustdeskrelay')
+			aSTART_SERVICES+=('rustdesksignal')
     fi
 
 	}
@@ -14599,13 +14599,13 @@ _EOF_
 			G_EXEC rm -Rf /mnt/dietpi_userdata/lazylibrarian
 		fi
 
-    if To_Uninstall 12 # rustdesk
-    then
-      Remove_Service rustdeskrelay
-      Remove_Service rustdesksignal rustdesk
-      G_EXEC rm -Rf /opt/rustdesk
-      G_EXEC rm -Rf /mnt/dietpi_userdata/rustdesk
-    fi
+		if To_Uninstall 12 # rustdesk
+		then
+			Remove_Service rustdeskrelay
+			Remove_Service rustdesksignal rustdesk
+			G_EXEC rm -Rf /opt/rustdesk
+			G_EXEC rm -Rf /mnt/dietpi_userdata/rustdesk
+		fi
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Finalising uninstall'
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12399,30 +12399,57 @@ _EOF_
 			# User
 			Create_User -d "$rd_data" rustdesk
 
-			# Data dir and config files: https://github.com/rustdesk/rustdesk-server/blob/c6502179/README.md
-			# more config variables: https://github.com/rustdesk/rustdesk-server/discussions/371#discussioncomment-13971105
+			# Data dir and config files:
+			# - https://github.com/rustdesk/rustdesk-server/blob/c6502179/README.md
+			# - https://github.com/rustdesk/rustdesk-server/discussions/371#discussioncomment-13971105
 			G_EXEC mkdir -p "$rd_data"
-			cat << _EOF_ > "$rd_data/signaling_conf.env"
-# RustDesk Signaling Server Configs
-#ALWAYS_USE_RELAY=  # if set to "Y" disallows direct peer connection.
-#DB_URL=            # path for database file, default is working directory /opt/rustdesk/db_v2.sqlite3
-#KEY=               # if set force the use of a specific key, if set to "_" force the use of any key
-#PORT=              # listening port. default: 21116
-#RELAY=             # IP address/DNS name of the machines running relay server (separated by comma)
-#RUST_LOG=          # set debug level (error|warn|info|debug|trace). default: info
-_EOF_
-			cat << _EOF_ > "$rd_data/relay_conf.env"
-# RustDesk Relay Server Config
-#DOWNGRADE_START_CHECK= # delay (in seconds) before downgrade check
-#DOWNGRADE_THRESHOLD=   # threshold of downgrade check (bit/ms)
-#KEY=                   # if set force the use of a specific key, if set to "_" force the use of any key
-#LIMIT_SPEED=           # speed limit (in Mb/s)
-#PORT=                  # listening port. default: 21116
-#RUST_LOG=              # set debug level (error|warn|info|debug|trace). default is info
-#SINGLE_BANDWIDTH=      # max bandwidth for a single connection (in Mb/s)
-#TOTAL_BANDWIDTH=       # max total bandwidth (in Mb/s).
-_EOF_
+			[[ -f $rd_data/signal.env ]] || cat << _EOF_ > "$rd_data/signal.env" || exit 1
+# RustDesk Signal Server settings: "$rd_data/signal.env
 
+# TCP/UDP listening port (default: 21116)
+#PORT=21116
+
+# Client authentication key, else the auto-generated $rd_data/id_ed25519.pub is used
+#KEY=
+
+# Log level error|warn|info|debug|trace (default: info)
+# NB: "info" logs client IPs, hence we suggest to switch to "warn" for production.
+#RUST_LOG=info
+
+# Database path relative to $rd_data (default: db_v2.sqlite3)
+#DB_URL=db_v2.sqlite3
+
+# Set to "Y" to disallows direct P2P connections (default: N)
+#ALWAYS_USE_RELAY=N
+_EOF_
+			[[ -f $rd_data/relay.env ]] || cat << _EOF_ > "$rd_data/relay.env" || exit 1
+# RustDesk Relay Server settings: $rd_data/relay.env
+
+# TCP listening port (default: 21117)
+#PORT=21117
+
+# Client authentication key, else the auto-generated $rd_data/id_ed25519.pub is used
+#KEY=
+
+# Log level error|warn|info|debug|trace (default: info)
+# NB: "info" logs client IPs, hence we suggest to switch to "warn" for production.
+#RUST_LOG=info
+
+# Speed limit in MiB/s (default: 32)
+#LIMIT_SPEED=32
+
+# Max bandwidth for a single connection in MiB/s (default: 128)
+#SINGLE_BANDWIDTH=128
+
+# Max total bandwidth in MiB/s (default: 1024)
+#TOTAL_BANDWIDTH=1024
+
+# Delay before downgrade check in seconds (default: 1800)
+#DOWNGRADE_START_CHECK=1800
+
+# Threshold of downgrade check in bit/ms (default: 0.66)
+#DOWNGRADE_THRESHOLD=0.66
+_EOF_
 			G_EXEC chmod 0700 "$rd_data"
 			G_EXEC chmod 0600 "$rd_data"/*
 			G_EXEC chown -R rustdesk:0 "$rd_data"
@@ -12437,10 +12464,10 @@ StartLimitIntervalSec=60
 StartLimitBurst=3
 
 [Service]
-SyslogIdentifier=Rustdesk Signaling Server
+SyslogIdentifier=RustDesk Signal Server
 User=rustdesk
 WorkingDirectory=$rd_data
-EnvironmentFile=$rd_data/signaling_conf.env
+EnvironmentFile=$rd_data/signal.env
 ExecStart=$rd_inst/hbbs
 Restart=on-failure
 RestartSec=5
@@ -12471,10 +12498,10 @@ StartLimitIntervalSec=60
 StartLimitBurst=3
 
 [Service]
-SyslogIdentifier=Rustdesk Relay Server
+SyslogIdentifier=RustDesk Relay Server
 User=rustdesk
 WorkingDirectory=$rd_data
-EnvironmentFile=$rd_data/relay_conf.env
+EnvironmentFile=$rd_data/relay.env
 ExecStart=$rd_inst/hbbr
 Restart=on-failure
 RestartSec=5

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12397,7 +12397,7 @@ _EOF_
 			G_EXEC rm -R rustdesk
 
 			# User
-			Create_User rustdesk
+			Create_User -d "$rd_data" rustdesk
 
 			# Data dir and config files: https://github.com/rustdesk/rustdesk-server/blob/c6502179/README.md
 			G_EXEC mkdir -p "$rd_data"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12382,18 +12382,18 @@ _EOF_
 			local rd_inst='/opt/rustdesk'
 			local rd_data='/mnt/dietpi_userdata/rustdesk'
 			case "$G_HW_ARCH" in
-				2) local rd_arch='armv7';;
-				3) local rd_arch='arm64v8';;
-				*) local rd_arch='amd64';;
+				2) local arch='armv7';;
+				3) local arch='arm64v8';;
+				*) local arch='amd64';;
 			esac
 
 			# Download
-			local fallback_url="https://github.com/rustdesk/rustdesk-server/releases/download/1.1.14/rustdesk-server-linux-$rd_arch.zip"
-			Download_Install "$(curl -sSfL 'https://api.github.com/repos/rustdesk/rustdesk-server/releases/latest' | mawk -F\" "/^ *\"browser_download_url\": \".*\/rustdesk-server-linux-$rd_arch\.zip\"$/{print \$4}")" rustdesk
+			local fallback_url="https://github.com/rustdesk/rustdesk-server/releases/download/1.1.14/rustdesk-server-linux-$arch.zip"
+			Download_Install "$(curl -sSfL 'https://api.github.com/repos/rustdesk/rustdesk-server/releases/latest' | mawk -F\" "/^ *\"browser_download_url\": \".*\/rustdesk-server-linux-$arch\.zip\"$/{print \$4}")" rustdesk
 
 			# Install: remove old install dir
 			[[ -d $rd_inst ]] && G_EXEC rm -R "$rd_inst"
-			G_EXEC mv "rustdesk/$rd_arch" "$rd_inst"
+			G_EXEC mv "rustdesk/$arch" "$rd_inst"
 			G_EXEC rm -R rustdesk
 
 			# User

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -304,15 +304,15 @@ Available commands:
 		aSOFTWARE_CONFLICTS[$software_id]='28'
 		# RPi only (archive.raspberrypi.com repo, libraspberrypi0 dependency, license)
 		(( $G_HW_MODEL > 9 )) && aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,$G_HW_MODEL]=0
-    #------------------
-    software_id=12
-		aSOFTWARE_NAME[$software_id]='Rustdesk Server'
+		#------------------
+		software_id=12
+		aSOFTWARE_NAME[$software_id]='RustDesk Server'
 		aSOFTWARE_DESC[$software_id]='open-source remote desktop server, written in Rust'
 		aSOFTWARE_CATX[$software_id]=1
-		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/remote_desktop/#TBD'
-    # RISC-V & ARMv6: https://github.com/rustdesk/rustdesk-server/releases
-    aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
-    aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,11]=0
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/remote_desktop/#rustdesk-server'
+		# - RISC-V & ARMv6: https://github.com/rustdesk/rustdesk-server/releases
+		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
+		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,11]=0
 
 		# Media Systems
 		#--------------------------------------------------------------------------------
@@ -12377,83 +12377,105 @@ WantedBy=multi-user.target
 _EOF_
 		fi
 
-		if To_Install 12 # rustdesk
-
+		if To_Install 12 # RustDesk
 		then
-			local rd_work="/opt/rustdesk"
-			local rd_data="/mnt/dietpi_userdata/rustdesk"
-			local rd_latest=$(curl -s https://api.github.com/repos/rustdesk/rustdesk-server/releases/latest | grep tag_name | cut -d '"' -f 4)
-
+			local rd_inst='/opt/rustdesk'
+			local rd_data='/mnt/dietpi_userdata/rustdesk'
 			case "$G_HW_ARCH" in
 				2) local rd_arch='armv7';;
 				3) local rd_arch='arm64v8';;
 				*) local rd_arch='amd64';;
 			esac
 
+			# Download
+			local fallback_url="https://github.com/rustdesk/rustdesk-server/releases/download/1.1.14/rustdesk-server-linux-$rd_arch.zip"
+			Download_Install "$(curl -sSfL 'https://api.github.com/repos/rustdesk/rustdesk-server/releases/latest' | mawk -F\" "/^ *\"browser_download_url\": \".*\/rustdesk-server-linux-$rd_arch\.zip\"$/{print \$4}")" rustdesk
+
+			# Install: remove old install dir
+			[[ -d $rd_inst ]] && G_EXEC rm -R "$rd_inst"
+			G_EXEC mv "rustdesk/$rd_arch" "$rd_inst"
+			G_EXEC rm -R rustdesk
+
 			# User
 			Create_User rustdesk
 
-			# Download
-			Download_Install "https://github.com/rustdesk/rustdesk-server/releases/download/$rd_latest/rustdesk-server-linux-$rd_arch.zip" rustdesk
-
-			# Working Dir
-			G_EXEC mkdir -p "$rd_work"
-			G_EXEC mv "rustdesk/$rd_arch"/* "$rd_work"
-			G_EXEC chown -R rustdesk "$rd_work"
-			G_EXEC chmod +x "$rd_work"/*
-
-			# Data Dir and config file
+			# Data dir and config files: https://github.com/rustdesk/rustdesk-server/blob/c6502179/README.md
 			G_EXEC mkdir -p "$rd_data"
 			G_EXEC touch "$rd_data/hbbs.env" "$rd_data/hbbr.env"
-			G_EXEC chown -R dietpi:dietpi "$rd_data"
-			G_EXEC chmod 700 "$rd_data"
-			G_EXEC chmod 600 "$rd_data"/*
+			G_EXEC chmod 0700 "$rd_data"
+			G_EXEC chmod 0600 "$rd_data"/*
+			G_EXEC chown -R rustdesk:0 "$rd_data"
 
-			# Clean
-			G_EXEC rm -r rustdesk
-
-			# Service hbbs
+			# Service hbbs: https://github.com/rustdesk/rustdesk-server/blob/master/systemd/rustdesk-hbbs.service
 			cat << _EOF_ > /etc/systemd/system/rustdesksignal.service
 [Unit]
-Description=Rustdesk Signal Server
+Description=RustDesk Signal Server
 Wants=network-online.target
 After=network-online.target
+StartLimitIntervalSec=60
+StartLimitBurst=3
 
 [Service]
 User=rustdesk
-WorkingDirectory=$rd_work
+WorkingDirectory=$rd_data
 EnvironmentFile=$rd_data/hbbs.env
-ExecStart=$rd_work/hbbs
+ExecStart=$rd_inst/hbbs
 Restart=on-failure
 RestartSec=5
+
+# Hardening
+ProtectSystem=strict
+ProtectHome=1
+PrivateUsers=1
+PrivateTmp=1
+PrivateDevices=1
+ProtectKernelTunables=1
+ProtectControlGroups=1
+ProtectKernelModules=1
+ProtectKernelLogs=1
+ProtectClock=1
+ReadWritePaths=-$rd_data -/tmp
 
 [Install]
 WantedBy=multi-user.target
 _EOF_
-			# Service hbbr
+			# Service hbbr: https://github.com/rustdesk/rustdesk-server/blob/master/systemd/rustdesk-hbbr.service
 			cat << _EOF_ > /etc/systemd/system/rustdeskrelay.service
 [Unit]
-Description=Rustdesk Relay Server
+Description=RustDesk Relay Server
 Wants=network-online.target
 After=network-online.target
+StartLimitIntervalSec=60
+StartLimitBurst=3
 
 [Service]
 User=rustdesk
-WorkingDirectory=$rd_work
+WorkingDirectory=$rd_data
 EnvironmentFile=$rd_data/hbbr.env
-ExecStart=$rd_work/hbbr
+ExecStart=$rd_inst/hbbr
 Restart=on-failure
 RestartSec=5
 LimitNOFILE=4096
 
+# Hardening
+ProtectSystem=strict
+ProtectHome=1
+PrivateUsers=1
+PrivateTmp=1
+PrivateDevices=1
+ProtectKernelTunables=1
+ProtectControlGroups=1
+ProtectKernelModules=1
+ProtectKernelLogs=1
+ProtectClock=1
+ReadWritePaths=-$rd_data -/tmp
+
 [Install]
 WantedBy=multi-user.target
 _EOF_
-
-			aSTART_SERVICES+=('rustdeskrelay')
-			aSTART_SERVICES+=('rustdesksignal')
-    fi
-
+			aSTART_SERVICES+=('rustdesksignal' 'rustdeskrelay')
+			unset -v rd_inst rd_data
+		fi
 	}
 
 	# $1: 0=None -1=Dropbear -2=OpenSSH
@@ -14599,10 +14621,10 @@ _EOF_
 			G_EXEC rm -Rf /mnt/dietpi_userdata/lazylibrarian
 		fi
 
-		if To_Uninstall 12 # rustdesk
+		if To_Uninstall 12 # RustDesk
 		then
 			Remove_Service rustdeskrelay
-			Remove_Service rustdesksignal rustdesk
+			Remove_Service rustdesksignal rustdesk rustdesk
 			G_EXEC rm -Rf /opt/rustdesk
 			G_EXEC rm -Rf /mnt/dietpi_userdata/rustdesk
 		fi

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12400,8 +12400,29 @@ _EOF_
 			Create_User -d "$rd_data" rustdesk
 
 			# Data dir and config files: https://github.com/rustdesk/rustdesk-server/blob/c6502179/README.md
+      # more config variables: https://github.com/rustdesk/rustdesk-server/discussions/371#discussioncomment-13971105
 			G_EXEC mkdir -p "$rd_data"
-			G_EXEC touch "$rd_data/hbbs.env" "$rd_data/hbbr.env"
+			cat << _EOF_ > "$rd_data/signaling_conf.env"
+# RustDesk Signaling Server Configs
+#ALWAYS_USE_RELAY=  # if set to "Y" disallows direct peer connection.
+#DB_URL=            # path for database file, default is working directory /opt/rustdesk/db_v2.sqlite3
+#KEY=               # if set force the use of a specific key, if set to "_" force the use of any key
+#PORT=              # listening port. default: 21116
+#RELAY=             # IP address/DNS name of the machines running relay server (separated by comma)
+#RUST_LOG=          # set debug level (error|warn|info|debug|trace). default: info
+_EOF_
+			cat << _EOF_ > "$rd_data/relay_conf.env"
+# RustDesk Relay Server Config
+#DOWNGRADE_START_CHECK= # delay (in seconds) before downgrade check
+#DOWNGRADE_THRESHOLD=   # threshold of downgrade check (bit/ms)
+#KEY=                   # if set force the use of a specific key, if set to "_" force the use of any key
+#LIMIT_SPEED=           # speed limit (in Mb/s)
+#PORT=                  # listening port. default: 21116
+#RUST_LOG=              # set debug level (error|warn|info|debug|trace). default is info
+#SINGLE_BANDWIDTH=      # max bandwidth for a single connection (in Mb/s)
+#TOTAL_BANDWIDTH=       # max total bandwidth (in Mb/s). 
+_EOF_
+
 			G_EXEC chmod 0700 "$rd_data"
 			G_EXEC chmod 0600 "$rd_data"/*
 			G_EXEC chown -R rustdesk:0 "$rd_data"
@@ -12416,9 +12437,10 @@ StartLimitIntervalSec=60
 StartLimitBurst=3
 
 [Service]
+SyslogIdentifier=Rustdesk Signaling Server
 User=rustdesk
 WorkingDirectory=$rd_data
-EnvironmentFile=$rd_data/hbbs.env
+EnvironmentFile=$rd_data/signaling_conf.env
 ExecStart=$rd_inst/hbbs
 Restart=on-failure
 RestartSec=5
@@ -12449,9 +12471,10 @@ StartLimitIntervalSec=60
 StartLimitBurst=3
 
 [Service]
+SyslogIdentifier=Rustdesk Relay Server
 User=rustdesk
 WorkingDirectory=$rd_data
-EnvironmentFile=$rd_data/hbbr.env
+EnvironmentFile=$rd_data/relay_conf.env
 ExecStart=$rd_inst/hbbr
 Restart=on-failure
 RestartSec=5

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -304,6 +304,16 @@ Available commands:
 		aSOFTWARE_CONFLICTS[$software_id]='28'
 		# RPi only (archive.raspberrypi.com repo, libraspberrypi0 dependency, license)
 		(( $G_HW_MODEL > 9 )) && aSOFTWARE_AVAIL_G_HW_MODEL[$software_id,$G_HW_MODEL]=0
+    #------------------
+    software_id=12
+		aSOFTWARE_NAME[$software_id]='Rustdesk Server'
+		aSOFTWARE_DESC[$software_id]='open-source remote desktop server, written in Rust'
+		aSOFTWARE_CATX[$software_id]=1
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/remote_desktop/#TBD'
+		aSOFTWARE_DEPS[$software_id]='desktop'
+    # RISC-V & ARMv6: https://github.com/rustdesk/rustdesk-server/releases
+    aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,1]=0
+    aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,11]=0
 
 		# Media Systems
 		#--------------------------------------------------------------------------------
@@ -12307,6 +12317,82 @@ _EOF_
 			# Install: Remove old dir on reinstall
 			[[ -d $bnet_inst ]] && G_EXEC rm -R "$bnet_inst"
 			G_EXEC mv birdnet "$bnet_inst"
+
+			# User
+			Create_User -G audio -d "$bnet_data" "$bnet_user"
+
+			# Data dir
+			G_EXEC mkdir -p "$bnet_data"
+			G_EXEC chown -R "$bnet_user:$bnet_user" "$bnet_data"
+
+			# Config
+			# - Checks hard-coded paths in this order: ~/.config/birdnet-go/config.yaml > /etc/birdnet-go/config.yaml
+			if [[ ! -f $bnet_conf ]]
+			then
+				# Initial call to generate ~/.config/birdnet-go/config.yaml
+				G_EXEC runuser -u "$bnet_user" -- "$bnet_inst/birdnet-go"
+				# Replace paths, otherwise defaults to the working directory
+				# Disable MQTT and CPU/memory/disk monitoring
+				# Enable new web UI at $bnet_port
+				G_EXEC yq -yi "
+					.output.sqlite.path = \"$bnet_data/birdnet.db\" |
+					.main.log.path = \"$bnet_data/logs/birdnet.log\" |
+					.realtime.log.path = \"$bnet_data/logs/birdnet.txt\" |
+					.realtime.audio.export.path = \"$bnet_data/clips\" |
+					.realtime.output.file.path = \"$bnet_data/output\" |
+					.realtime.mqtt.enabled = false |
+					.realtime.monitoring.enabled = false |
+					.realtime.webserver.enabled = true |
+					.realtime.dashboard.newui = true |
+					.webserver.port = $bnet_port" "$bnet_conf"
+				# Purge yq if it was installed for BirdNET-Go only
+				(( $install_yq )) && G_AGP yq
+			fi
+
+			# Service
+			cat << _EOF_ > /etc/systemd/system/birdnet.service || exit 1
+[Unit]
+Description=BirdNet-Go
+Wants=network-online.target
+After=network-online.target
+StartLimitIntervalSec=60
+StartLimitBurst=3
+
+[Service]
+User=$bnet_user
+WorkingDirectory=$bnet_data
+ExecStart=$bnet_inst/birdnet-go realtime
+Restart=on-failure
+RestartSec=5
+
+# Hardening
+ProtectSystem=strict
+ProtectHome=1
+PrivateTmp=1
+ProtectKernelTunables=1
+ProtectControlGroups=1
+ReadWritePaths=-$bnet_data -/tmp
+
+[Install]
+WantedBy=multi-user.target
+_EOF_
+		fi
+
+		if To_Install 12 # rustdesk
+
+		then
+			local rd_inst='/opt/rustdesk'
+			local rd_user='rustdesk'
+      local rd_latest=$(curl -s https://api.github.com/repos/rustdesk/rustdesk-server/releases/latest | grep tag_name | cut -d '"' -f 4)
+
+			case $G_HW_ARCH in
+				2) local rd_arch='armv7';;
+				3) local rd_arch='arm64v8';;
+				10) local rd_arch='amd64';;
+			esac
+
+			# Download
+      Download_Install "https://github.com/rustdesk/rustdesk-server/releases/download/${rd_latest}/rustdesk-server-linux-${rd_arch}.zip" 
 
 			# User
 			Create_User -G audio -d "$bnet_data" "$bnet_user"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12377,7 +12377,7 @@ WantedBy=multi-user.target
 _EOF_
 		fi
 
-		if To_Install 12 # RustDesk
+		if To_Install 12 # RustDesk Server
 		then
 			local rd_inst='/opt/rustdesk'
 			local rd_data='/mnt/dietpi_userdata/rustdesk'
@@ -14671,7 +14671,7 @@ _EOF_
 			G_EXEC rm -Rf /mnt/dietpi_userdata/lazylibrarian
 		fi
 
-		if To_Uninstall 12 # RustDesk
+		if To_Uninstall 12 # RustDesk Server
 		then
 			Remove_Service rustdeskrelay
 			Remove_Service rustdesksignal rustdesk rustdesk

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12400,7 +12400,7 @@ _EOF_
 			Create_User -d "$rd_data" rustdesk
 
 			# Data dir and config files: https://github.com/rustdesk/rustdesk-server/blob/c6502179/README.md
-      # more config variables: https://github.com/rustdesk/rustdesk-server/discussions/371#discussioncomment-13971105
+			# more config variables: https://github.com/rustdesk/rustdesk-server/discussions/371#discussioncomment-13971105
 			G_EXEC mkdir -p "$rd_data"
 			cat << _EOF_ > "$rd_data/signaling_conf.env"
 # RustDesk Signaling Server Configs


### PR DESCRIPTION
I added rustdesk server OSS version ([https://github.com/rustdesk/rustdesk-server](https://github.com/rustdesk/rustdesk-server)) which is somewhat [requested from users](https://github.com/MichaIng/DietPi/discussions/5656)

It creates 2 systemd services, one for the relay server and one for the signaling server.
Both services can be configured via env files, the available options are listed here: [https://github.com/rustdes~k/rustdesk-server/blob/c6502179/README.md#env-variables](https://github.com/rustdesk/rustdesk-server/blob/c6502179/README.md#env-variables) and it need's to be in `ini` format, like `PORT=22222`. Sections can be ommited.
The env files are located in `/mnt/dietpi_userdata/rustdesk`, working directory is `/opt/rustdesk`.

On the first start, right after the installation, it will generate a private and public key, both located in the working directory. The public key is needed for the clients for connection to the signal and/or relay server.
It also comes with `rustdesk-utils`, it can generate new key pairs, validate them and can do a basic "health check". (It checks if the API is running, which the OSS version does not need. It can also check if the configured ports are reachable.)

I tested it on a RPi3B to connect a Windows PC to my Fedora Laptop. It works in both directions, but controlling the Laptop from the Windows machine is not really possible, wayland support is still experimental. But the installation is working tho.

Reinstallation does not overwrite the .env files, so configs are preserved. :heavy_check_mark:

To test that the environment files actually work, I changed the listening ports for both services.  :heavy_check_mark:

Tomorrow I will config rustdesk to force-use the relay server, because I just tested inside my LAN and then it will use a P2P connection between the clients, no relay needed. So let's see how capabale a RPi3B is for this task. But I guess no problem with only 2 clients.
