### PR TITLE
dietpi-drive_manager: use mount source as drive index

### DIFF
--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -40,14 +40,14 @@
 	APT_CHECK=0
 
 	# Drive menu
-	MENU_DRIVE_INDEX=
+	MENU_DRIVE_SELECTED=
 
 	# Format menu
-	FORMAT_GPT=1 # default GPT: https://github.com/MichaIng/DietPi/issues/531. 0=MBR
-	FORMAT_FILESYSTEM_TYPE=0 # 0=ext4 1=ntfs 2=fat32 3=hfs+ 4=btrfs 5=f2fs 6=exfat 7=xfs
-	FORMAT_COMPLETED=0
+	FORMAT_GPT=1 # 0=MBR, default GPT: https://github.com/MichaIng/DietPi/issues/531
+	FORMAT_FS_TYPE=0 # 0=ext4 1=ntfs 2=fat32 3=hfs+ 4=btrfs 5=f2fs 6=exfat 7=xfs
 	FORMAT_MODE=1 # 0=drive 1=partition
 	MOVE_ROOTFS=0 # Whether the formatted drive is used as rootfs
+	FORMAT_COMPLETED=0
 
 	# Drive data
 	FP_USERDATA_CURRENT=
@@ -55,33 +55,22 @@
 
 	Init_New_Device()
 	{
-		aDRIVE_UUID[$source]=
-		aDRIVE_PART_UUID[$source]=
-		aDRIVE_MOUNT_TARGET[$source]=
-		aDRIVE_SOURCE_DEVICE[$source]=
-		aDRIVE_FSTYPE[$source]=
-		aDRIVE_SIZE_TOTAL[$source]=
-		aDRIVE_SIZE_USED[$source]=
-		aDRIVE_SIZE_PERCENTUSED[$source]=
-		aDRIVE_ISFILESYSTEM[$source]=0
-		aDRIVE_ISMOUNTED[$source]=0
-		aDRIVE_ISREADONLY_CURRENTLY[$source]=0
-		aDRIVE_ISNETWORKED[$source]=0
-		aDRIVE_ISROM[$source]=0
-		aDRIVE_ISPARTITIONTABLE[$source]=0
-		aDRIVE_ISACCESS[$source]=1
+		aDRIVE_MOUNT_TARGET[$source]= aDRIVE_SOURCE_DEVICE[$source]=
+		aDRIVE_FSTYPE[$source]= aDRIVE_UUID[$source]= aDRIVE_PART_UUID[$source]=
+		aDRIVE_SIZE_TOTAL[$source]= aDRIVE_SIZE_USED[$source]= aDRIVE_SIZE_USED_PCT[$source]=
+		aDRIVE_ISFILESYSTEM[$source]=0 aDRIVE_ISMOUNTED[$source]=0
+		aDRIVE_ISREADONLY[$source]=0 aDRIVE_ISACCESS[$source]=1 aDRIVE_ISPARTITION[$source]=0
+		aDRIVE_ISNETWORKED[$source]=0 aDRIVE_ISROM[$source]=0
 	}
 
-	Destroy()
+	Init_Arrays()
 	{
-		declare -Ag aDRIVE_UUID=() aDRIVE_PART_UUID=()
-		declare -Ag aDRIVE_MOUNT_TARGET=()
-		declare -Ag aDRIVE_SOURCE_DEVICE=() aDRIVE_FSTYPE=()
-		declare -Ag aDRIVE_SIZE_TOTAL=() aDRIVE_SIZE_USED=()
-		declare -Ag aDRIVE_SIZE_PERCENTUSED=()
+		declare -Ag aDRIVE_MOUNT_TARGET=() aDRIVE_SOURCE_DEVICE=()
+		declare -Ag aDRIVE_FSTYPE=() aDRIVE_UUID=() aDRIVE_PART_UUID=()
+		declare -Ag aDRIVE_SIZE_TOTAL=() aDRIVE_SIZE_USED=() aDRIVE_SIZE_USED_PCT=()
 		declare -Ag aDRIVE_ISFILESYSTEM=() aDRIVE_ISMOUNTED=()
-		declare -Ag aDRIVE_ISREADONLY_CURRENTLY=() aDRIVE_ISNETWORKED=()
-		declare -Ag aDRIVE_ISROM=() aDRIVE_ISPARTITIONTABLE=() aDRIVE_ISACCESS=()
+		declare -Ag aDRIVE_ISREADONLY=() aDRIVE_ISACCESS=() aDRIVE_ISPARTITION=()
+		declare -Ag aDRIVE_ISNETWORKED=() aDRIVE_ISROM=() 
 	}
 
 	Init_Drives_and_Refresh()
@@ -90,7 +79,7 @@
 		ls -d /mnt/*/. &> /dev/null
 
 		# Recreate drive arrays from scratch
-		Destroy
+		Init_Arrays
 
 		# Obtain actual user data location on disk (follow symlinks)
 		FP_USERDATA_CURRENT=$(readlink -f /mnt/dietpi_userdata)
@@ -165,7 +154,7 @@ $swap_mounts
 			aDRIVE_MOUNT_TARGET[$source]=$(findmnt -Ufnro TARGET -S "$source") # Use only first result since bind mounts lead to multiple matches
 			aDRIVE_SIZE_TOTAL[$source]=$(findmnt -Ufnro SIZE -M "${aDRIVE_MOUNT_TARGET[$source]}")
 			aDRIVE_SIZE_USED[$source]=$(findmnt -Ufnro USED -M "${aDRIVE_MOUNT_TARGET[$source]}")
-			aDRIVE_SIZE_PERCENTUSED[$source]=$(findmnt -Ufnro USE% -M "${aDRIVE_MOUNT_TARGET[$source]}")
+			aDRIVE_SIZE_USED_PCT[$source]=$(findmnt -Ufnro USE% -M "${aDRIVE_MOUNT_TARGET[$source]}")
 
 			# Physical
 			if [[ $source == '/dev/'* ]]
@@ -173,10 +162,10 @@ $swap_mounts
 				G_DIETPI-NOTIFY 2 " - Detected mounted physical drive: $source > ${aDRIVE_MOUNT_TARGET[$source]}"
 
 				aDRIVE_SOURCE_DEVICE[$source]=$(Return_Drive_Without_Partitions "$source")
-				[[ $source == /dev/${aDRIVE_SOURCE_DEVICE[$source]} ]] || aDRIVE_ISPARTITIONTABLE[$source]=1
+				[[ $source == /dev/${aDRIVE_SOURCE_DEVICE[$source]} ]] || aDRIVE_ISPARTITION[$source]=1
 				[[ -b $source ]] || aDRIVE_ISACCESS[$source]=0 # continue
 				aDRIVE_UUID[$source]=$(findmnt -Ufnro UUID -M "${aDRIVE_MOUNT_TARGET[$source]}")
-				(( ${aDRIVE_ISPARTITIONTABLE[$source]} )) && aDRIVE_PART_UUID[$source]=$(findmnt -Ufnro PARTUUID -M "${aDRIVE_MOUNT_TARGET[$source]}")
+				(( ${aDRIVE_ISPARTITION[$source]} )) && aDRIVE_PART_UUID[$source]=$(findmnt -Ufnro PARTUUID -M "${aDRIVE_MOUNT_TARGET[$source]}")
 				# blkid is required here, as findmnt will show "fuseblk" for NTFS filesytems, which is a correct result but cannot be used in fstab or for mounting the drive.
 				aDRIVE_FSTYPE[$source]=$(blkid -s TYPE -o value "$source")
 
@@ -196,7 +185,7 @@ $swap_mounts
 			#	/dev/mmcblk0p2 / ext4 ro,noatime,discard,data=ordered 0 0
 			if grep -q "[[:blank:]]${aDRIVE_MOUNT_TARGET[$source]}[[:blank:]].*[[:blank:]]ro," /proc/mounts
 			then
-				aDRIVE_ISREADONLY_CURRENTLY[$source]=1
+				aDRIVE_ISREADONLY[$source]=1
 
 				# RootFS R/W check
 				if [[ ${aDRIVE_MOUNT_TARGET[$source]} == '/' ]]
@@ -204,7 +193,7 @@ $swap_mounts
 					if G_WHIP_YESNO "RootFS is currently set to \"Read Only (R/O)\". $G_PROGRAM_NAME requires \"Read Write (R/W)\" access to function.\n\nWould you like to re-enable R/W access on RootFS?"
 					then
 						G_EXEC mount -v -o remount,rw "${aDRIVE_MOUNT_TARGET[$source]}"
-						aDRIVE_ISREADONLY_CURRENTLY[$source]=0
+						aDRIVE_ISREADONLY[$source]=0
 						G_DIETPI-NOTIFY 0 'Remounted RootFS with R/W access'
 					else
 						G_DIETPI-NOTIFY 1 "RootFS is currently set to R/O. $G_PROGRAM_NAME requires R/W access to function. Aborting..."
@@ -226,7 +215,7 @@ $swap_mounts
 				# R/W or R/O?
 				# - Add rw flag to mount options. This should be default but seems to be not in rare cases: https://github.com/MichaIng/DietPi/issues/3268
 				local options=',rw'
-				(( ${aDRIVE_ISREADONLY_CURRENTLY[$source]} )) && options=',ro'
+				(( ${aDRIVE_ISREADONLY[$source]} )) && options=',ro'
 
 				# Additional FS-specific options
 				# - NTFS: Enable POSIX permissions and prevent splitting write buffers into 4k chunks: https://manpages.debian.org/ntfs-3g#OPTIONS
@@ -283,10 +272,11 @@ $swap_mounts
 			aDRIVE_UUID[$source]=$uuid
 			aDRIVE_MOUNT_TARGET[$source]="/mnt/${aDRIVE_UUID[$source]}"
 			aDRIVE_SOURCE_DEVICE[$source]=$(Return_Drive_Without_Partitions "$source")
-			[[ $source == /dev/${aDRIVE_SOURCE_DEVICE[$source]} ]] || aDRIVE_ISPARTITIONTABLE[$source]=1
-			(( ${aDRIVE_ISPARTITIONTABLE[$source]} )) && aDRIVE_PART_UUID[$source]=$(blkid -s PARTUUID -o value "$source")
+			[[ $source == /dev/${aDRIVE_SOURCE_DEVICE[$source]} ]] || aDRIVE_ISPARTITION[$source]=1
+			(( ${aDRIVE_ISPARTITION[$source]} )) && aDRIVE_PART_UUID[$source]=$(blkid -s PARTUUID -o value "$source")
 			aDRIVE_FSTYPE[$source]=$(blkid -s TYPE -o value "$source")
 			[[ ${aDRIVE_FSTYPE[$source]} ]] && aDRIVE_ISFILESYSTEM[$source]=1
+			aDRIVE_SIZE_TOTAL[$source]=$(lsblk -nro SIZE "$source")
 
 		done < <(blkid -o device)
 
@@ -309,6 +299,7 @@ $swap_mounts
 			aDRIVE_MOUNT_TARGET[$source]="/mnt/${source#/dev/}"
 			aDRIVE_SOURCE_DEVICE[$source]=${source#/dev/}
 			[[ -b $source ]] || aDRIVE_ISACCESS[$source]=0
+			aDRIVE_SIZE_TOTAL[$source]=$(lsblk -ndro SIZE "$source")
 
 		done < <(lsblk -npro NAME | sed '/^mtdblock[0-9]/d')
 
@@ -454,35 +445,35 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 
 	Resize_FS()
 	{
-		if [[ ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} == '/' ]]
+		if [[ ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]} == '/' ]]
 		then
 			G_EXEC systemctl enable dietpi-fs_partition_resize
 			G_WHIP_YESNO 'RootFS resize will occur on next reboot.\n\nWould you like to reboot the system now?' && { reboot; exit 0; } || return
 
-		elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == ext[2-4] ]]
+		elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_SELECTED]} == ext[2-4] ]]
 		then
-			if (( ! ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} ))
+			if (( ! ${aDRIVE_ISMOUNTED[$MENU_DRIVE_SELECTED]} ))
 			then
 				G_DIETPI-NOTIFY 2 'Running full interactive fsck, required for unmounted ext filesystems to be resized...'
-				e2fsck -f "$MENU_DRIVE_INDEX"
+				e2fsck -f "$MENU_DRIVE_SELECTED"
 			fi
-			G_EXEC_NOEXIT=1 G_EXEC resize2fs "$MENU_DRIVE_INDEX"
+			G_EXEC_NOEXIT=1 G_EXEC resize2fs "$MENU_DRIVE_SELECTED"
 
-		elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'f2fs' ]]
+		elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_SELECTED]} == 'f2fs' ]]
 		then
-			(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} )) && G_EXEC_NOEXIT=1 G_EXEC umount "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}" || return 1
-			G_EXEC_NOEXIT=1 G_EXEC resize.f2fs "$MENU_DRIVE_INDEX"
-			(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} )) && G_EXEC_NOEXIT=1 G_EXEC mount "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
+			(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_SELECTED]} )) && G_EXEC_NOEXIT=1 G_EXEC umount "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}" || return 1
+			G_EXEC_NOEXIT=1 G_EXEC resize.f2fs "$MENU_DRIVE_SELECTED"
+			(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_SELECTED]} )) && G_EXEC_NOEXIT=1 G_EXEC mount "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}"
 
-		elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'btrfs' ]]
+		elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_SELECTED]} == 'btrfs' ]]
 		then
-			if (( ! ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} ))
+			if (( ! ${aDRIVE_ISMOUNTED[$MENU_DRIVE_SELECTED]} ))
 			then
 				G_EXEC_NOEXIT=1 G_EXEC mkdir -p /tmp/temporary_f2fs_mountpoint || return 1
-				G_EXEC_NOEXIT=1 G_EXEC mount "$MENU_DRIVE_INDEX" /tmp/temporary_f2fs_mountpoint || return 1
+				G_EXEC_NOEXIT=1 G_EXEC mount "$MENU_DRIVE_SELECTED" /tmp/temporary_f2fs_mountpoint || return 1
 			fi
-			G_EXEC_NOEXIT=1 G_EXEC btrfs filesystem resize max "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
-			if (( ! ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} ))
+			G_EXEC_NOEXIT=1 G_EXEC btrfs filesystem resize max "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}"
+			if (( ! ${aDRIVE_ISMOUNTED[$MENU_DRIVE_SELECTED]} ))
 			then
 				G_EXEC_NOEXIT=1 G_EXEC umount /tmp/temporary_f2fs_mountpoint
 				G_EXEC_NOEXIT=1 G_EXEC rmdir /tmp/temporary_f2fs_mountpoint
@@ -494,14 +485,14 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 	Run_Format()
 	{
 		# Failsafe: No partition table, force drive wipe - actually done in parent menu already
-		(( ${aDRIVE_ISPARTITIONTABLE[$MENU_DRIVE_INDEX]} )) || FORMAT_MODE=0
+		(( ${aDRIVE_ISPARTITION[$MENU_DRIVE_SELECTED]} )) || FORMAT_MODE=0
 
 		if (( $FORMAT_MODE ))
 		then
-			local device=$MENU_DRIVE_INDEX
-			local text_menu="UUID: ${aDRIVE_UUID[$MENU_DRIVE_INDEX]}\nALL DATA on this PARTITION will be DELETED.\nDo you wish to continue?"
+			local device=$MENU_DRIVE_SELECTED
+			local text_menu="UUID: ${aDRIVE_UUID[$MENU_DRIVE_SELECTED]}\nALL DATA on this PARTITION will be DELETED.\nDo you wish to continue?"
 		else
-			local device="/dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}"
+			local device="/dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_SELECTED]}"
 			local text_menu="Partition table: $partition_table_text\nALL DATA and PARTITIONS on this drive will be DELETED.\nDo you wish to continue?"
 		fi
 
@@ -511,7 +502,7 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 		if (( $FORMAT_MODE ))
 		then
 			# Unmount
-			(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} )) && { Unmount_Drive "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}" || return 1; }
+			(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_SELECTED]} )) && { Unmount_Drive "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}" || return 1; }
 
 			# Clear partition from device
 			G_DIETPI-NOTIFY 2 "Erasing partition: $device"
@@ -533,10 +524,10 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 			done
 
 			# Unmount whole drive in case of fs on drive without partition table
-			(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} )) && { Unmount_Drive "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}" || return 1; }
+			(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_SELECTED]} )) && { Unmount_Drive "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}" || return 1; }
 
 			# Clear partition table from device
-			G_DIETPI-NOTIFY 2 "Erasing partition table: /dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}"
+			G_DIETPI-NOTIFY 2 "Erasing partition table: /dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_SELECTED]}"
 			G_EXEC dd if=/dev/zero of="$device" bs=4K count=1337 # Block device wipe
 
 			# Create partition table type
@@ -550,7 +541,7 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 
 			# Append new partition to device path
 			# - hda1/sda1/vda1/xvda1
-			if [[ ${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]} =~ ^(sd|hd|vd|xvd)[a-z]$ ]]
+			if [[ ${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_SELECTED]} =~ ^(sd|hd|vd|xvd)[a-z]$ ]]
 			then
 				device+='1'
 
@@ -560,51 +551,18 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 			fi
 		fi
 
-		# Format ext4
-		if (( $FORMAT_FILESYSTEM_TYPE == 0 ))
-		then
-			# -F: force | -m: reserved blocks | -e error behaviour
-			G_EXEC mkfs.ext4 -F -m 0 -e 'remount-ro' "$device"
-
-		# Format NTFS
-		elif (( $FORMAT_FILESYSTEM_TYPE == 1 ))
-		then
-			# -f: fast format | -I: no indexing | -F: force
-			G_EXEC mkfs.ntfs -f -I -F "$device"
-
-		# Format FAT32
-		elif (( $FORMAT_FILESYSTEM_TYPE == 2 ))
-		then
-			# -I: Use 1 partition on whole device | -F 32: FAT32
-			G_EXEC mkfs.fat -I -F 32 "$device"
-
-		# Format HFS+
-		elif (( $FORMAT_FILESYSTEM_TYPE == 3 ))
-		then
-			G_EXEC mkfs.hfsplus "$device"
-
-		# Format Btrfs
-		elif (( $FORMAT_FILESYSTEM_TYPE == 4 ))
-		then
-			# -f: force
-			G_EXEC mkfs.btrfs -f "$device"
-
-		# Format f2fs
-		elif (( $FORMAT_FILESYSTEM_TYPE == 5 ))
-		then
-			G_EXEC mkfs.f2fs "$device"
-
-		# Format exFAT
-		elif (( $FORMAT_FILESYSTEM_TYPE == 6 ))
-		then
-			G_EXEC mkfs.exfat "$device"
-
-		# Format XFS
-		elif (( $FORMAT_FILESYSTEM_TYPE == 7 ))
-		then
-			# -f: force
-			G_EXEC mkfs.xfs -f "$device"
-		fi
+		# Format partition with filesystem
+		case $FORMAT_FS_TYPE in
+			0) G_EXEC mkfs.ext4 -F -m 0 -e 'remount-ro' "$device";; # ext4 | -F: force | -m: reserved blocks | -e error behaviour
+			1) G_EXEC mkfs.ntfs -f -I -F "$device";; # NTFS | -f: fast format | -I: no indexing | -F: force
+			2) G_EXEC mkfs.fat -I -F 32 "$device";; # FAT32 | -I: Use 1 partition on whole device | -F 32: FAT32
+			3) G_EXEC mkfs.hfsplus "$device";; # HFS+
+			4) G_EXEC mkfs.btrfs -f "$device";; # Btrfs | -f: force
+			5) G_EXEC mkfs.f2fs "$device";; # F2FS
+			6) G_EXEC mkfs.exfat "$device";; # exFAT
+			7) G_EXEC mkfs.xfs -f "$device";; # XFS | -f: force
+			*) G_DIETPI-NOTIFY 1 "Invalid filesystem type ID \"$FORMAT_FS_TYPE\""; exit 1;;
+		esac
 
 		G_EXEC sync # Sync to disk, as well to add a slight delay since XFS formatted filesystems do not return a UUID (below) immediately
 
@@ -612,21 +570,21 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 		FORMAT_COMPLETED=1
 
 		# Remove old mount point
-		[[ -e ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} ]] && G_EXEC_NOEXIT=1 G_EXEC rm -R "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
+		[[ -e ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]} ]] && G_EXEC_NOEXIT=1 G_EXEC rm -R "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}"
 
 		# Automatically mount it
 		local new_uuid=$(blkid -s UUID -o value "$device")
-		Mount_Drive "$device" "/mnt/${new_uuid:-${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}}"
+		Mount_Drive "$device" "/mnt/${new_uuid:-${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_SELECTED]}}"
 		Init_Drives_and_Refresh
-		MENU_DRIVE_INDEX=$device
+		MENU_DRIVE_SELECTED=$device
 		TARGETMENUID=1 # Drive menu
 
 		G_WHIP_MSG "[  OK  ] Format completed\n
  - Format Mode      : $format_mode_text
  - Filesystem Type  : $text_fs_type
  - Mount Source     : $device
- - Mount Target     : ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}
- - UUID             : ${aDRIVE_UUID[$MENU_DRIVE_INDEX]}"
+ - Mount Target     : ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}
+ - UUID             : ${aDRIVE_UUID[$MENU_DRIVE_SELECTED]}"
 	}
 
 	RootFS_Move()
@@ -643,7 +601,7 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 		G_EXEC mount "$G_ROOTFS_DEV" /tmp/tmp_rootfs
 
 		# Start rsync
-		if ! G_EXEC_NOEXIT=1 G_EXEC rsync -aHv --delete /tmp/tmp_rootfs/ "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}/"
+		if ! G_EXEC_NOEXIT=1 G_EXEC rsync -aHv --delete /tmp/tmp_rootfs/ "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}/"
 		then
 			G_DIETPI-NOTIFY 1 'Rsync has failed, RootFS transfer has been aborted.'
 			umount /tmp/tmp_rootfs
@@ -652,16 +610,16 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 		fi
 
 		# Remove volatile systemd service PrivateTmp dirs in /var/tmp and target drive mount point dir
-		rm -Rf "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"/var/tmp/systemd-private-*
-		rmdir "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
+		rm -Rf "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}"/var/tmp/systemd-private-*
+		rmdir "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}"
 
 		# Update fstab
 		# - Remove automatic entry for target drive
-		G_EXEC sed --follow-symlinks -i "\@[[:blank:]]${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}[[:blank:]]@d" "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}/etc/fstab"
+		G_EXEC sed --follow-symlinks -i "\@[[:blank:]]${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}[[:blank:]]@d" "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}/etc/fstab"
 		# - Replace old with new rootfs entry
-		local dev_entry="UUID=${aDRIVE_UUID[$MENU_DRIVE_INDEX]}"
-		(( $G_HW_MODEL < 10 )) && dev_entry="PARTUUID=${aDRIVE_PART_UUID[$MENU_DRIVE_INDEX]}"
-		G_EXEC sed --follow-symlinks -i "\@[[:blank:]]/[[:blank:]]@c$dev_entry / ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} noatime,lazytime,rw 0 1" "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}/etc/fstab"
+		local dev_entry="UUID=${aDRIVE_UUID[$MENU_DRIVE_SELECTED]}"
+		(( $G_HW_MODEL < 10 )) && dev_entry="PARTUUID=${aDRIVE_PART_UUID[$MENU_DRIVE_SELECTED]}"
+		G_EXEC sed --follow-symlinks -i "\@[[:blank:]]/[[:blank:]]@c$dev_entry / ${aDRIVE_FSTYPE[$MENU_DRIVE_SELECTED]} noatime,lazytime,rw 0 1" "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}/etc/fstab"
 
 		# Find and replace current root and rootfstype kernel command line entries
 		# - RPi: /boot/cmdline.txt
@@ -671,7 +629,7 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 			G_EXEC sed --follow-symlinks -i "s#$rootfs_current#root=$dev_entry#g" /boot/cmdline.txt
 
 			local rootfstype_current=$(mawk '{for(i=1;i<=NF;i++) if($i~/^rootfstype=/) {print $i;exit}}' /boot/cmdline.txt)
-			[[ $rootfstype_current ]] && G_EXEC sed --follow-symlinks -i "s#$rootfstype_current#rootfstype=${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]}#g" /boot/cmdline.txt
+			[[ $rootfstype_current ]] && G_EXEC sed --follow-symlinks -i "s#$rootfstype_current#rootfstype=${aDRIVE_FSTYPE[$MENU_DRIVE_SELECTED]}#g" /boot/cmdline.txt
 
 		# - Odroids: /boot/boot.ini
 		else
@@ -679,7 +637,7 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 			G_EXEC sed --follow-symlinks -i "s#$rootfs_current#root=$dev_entry#g" /boot/boot.ini
 
 			local rootfstype_current=$(mawk '-F[" ]' '{for(i=1;i<=NF;i++) if($i~/^rootfstype=/) {print $i;exit}}' /boot/boot.ini)
-			[[ $rootfstype_current ]] && G_EXEC sed --follow-symlinks -i "s#$rootfstype_current#rootfstype=${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]}#g" /boot/boot.ini
+			[[ $rootfstype_current ]] && G_EXEC sed --follow-symlinks -i "s#$rootfstype_current#rootfstype=${aDRIVE_FSTYPE[$MENU_DRIVE_SELECTED]}#g" /boot/boot.ini
 		fi
 
 		G_EXEC systemctl daemon-reload
@@ -695,20 +653,20 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 		local exit_status=0
 		local message_result=0
 
-		if (( ${aDRIVE_ISREADONLY_CURRENTLY[$MENU_DRIVE_INDEX]} ))
+		if (( ${aDRIVE_ISREADONLY[$MENU_DRIVE_SELECTED]} ))
 		then
-			message_result=$(mount -v -o remount,rw "$MENU_DRIVE_INDEX" 2>&1)
+			message_result=$(mount -v -o remount,rw "$MENU_DRIVE_SELECTED" 2>&1)
 			exit_status=$?
 		else
 			(( $SERVICES_STOPPED )) || { /boot/dietpi/dietpi-services stop; SERVICES_STOPPED=1; }
 
 			# RootFS, set fstab now, else, will not be applied to /etc/fstab during Init as already RO: https://github.com/MichaIng/DietPi/issues/2604
-			if [[ ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} == '/' ]]
+			if [[ ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]} == '/' ]]
 			then
-				local line_number=$(grep -n "[[:blank:]]${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}[[:blank:]].*,rw" /etc/fstab | cut -d : -f 1)
+				local line_number=$(grep -n "[[:blank:]]${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}[[:blank:]].*,rw" /etc/fstab | cut -d : -f 1)
 				sed --follow-symlinks -i "${line_number}s/,rw/,ro/" /etc/fstab
 			fi
-			message_result=$(mount -v -o remount,ro "$MENU_DRIVE_INDEX" 2>&1)
+			message_result=$(mount -v -o remount,ro "$MENU_DRIVE_SELECTED" 2>&1)
 			exit_status=$?
 		fi
 
@@ -752,21 +710,21 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 					# Drive is fully mounted
 					if (( ${aDRIVE_ISMOUNTED[$j]} ))
 					then
-						G_WHIP_MENU_ARRAY+=("$j" ": ${aDRIVE_MOUNT_TARGET[$j]} | ${aDRIVE_FSTYPE[$j]} | Capacity: ${aDRIVE_SIZE_TOTAL[$j]} | Used: ${aDRIVE_SIZE_USED[$j]} (${aDRIVE_SIZE_PERCENTUSED[$j]})")
+						G_WHIP_MENU_ARRAY+=("$j" ": ${aDRIVE_MOUNT_TARGET[$j]} | ${aDRIVE_FSTYPE[$j]} | Capacity: ${aDRIVE_SIZE_TOTAL[$j]} | Used: ${aDRIVE_SIZE_USED[$j]} (${aDRIVE_SIZE_USED_PCT[$j]})")
 
 					# Drive has filesystem
 					elif (( ${aDRIVE_ISFILESYSTEM[$j]} ))
 					then
-						G_WHIP_MENU_ARRAY+=("$j" ": ${aDRIVE_MOUNT_TARGET[$j]} | ${aDRIVE_FSTYPE[$j]} | Not mounted")
+						G_WHIP_MENU_ARRAY+=("$j" ": Not mounted | ${aDRIVE_FSTYPE[$j]} | Capacity: ${aDRIVE_SIZE_TOTAL[$j]}")
 
 					# Drive is not formatted
 					else
 						# ROM device with no ROM attached
 						if (( ${aDRIVE_ISROM[$j]} ))
 						then
-							G_WHIP_MENU_ARRAY+=("$j" ": ${aDRIVE_MOUNT_TARGET[$j]} | Please insert media into the ROM device")
+							G_WHIP_MENU_ARRAY+=("$j" ': Please insert media into the ROM device')
 						else
-							G_WHIP_MENU_ARRAY+=("$j" ": ${aDRIVE_MOUNT_TARGET[$j]} | No filesystem / format required")
+							G_WHIP_MENU_ARRAY+=("$j" ": No filesystem / format required | Capacity: ${aDRIVE_SIZE_TOTAL[$j]}")
 						fi
 					fi
 				fi
@@ -846,7 +804,7 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 		elif [[ $G_WHIP_RETURNED_VALUE ]]
 		then
 			TARGETMENUID=1 # Drive menu
-			MENU_DRIVE_INDEX=$G_WHIP_RETURNED_VALUE
+			MENU_DRIVE_SELECTED=$G_WHIP_RETURNED_VALUE
 		fi
 	}
 
@@ -860,7 +818,6 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 		then
 			G_WHIP_MSG "[FAILED]\n\nThe DietPi swap file is currently located on this drive:\n - $FP_SWAPFILE_CURRENT\n\nThe requested option for this drive is not currently possible.\n\nPlease move the swap file elsewhere, before trying again."
 		fi
-
 	}
 
 	Install_exFAT_Tools()
@@ -884,13 +841,13 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 		G_WHIP_MENU_ARRAY=()
 		local partition_contains_userdata=0
 		local partition_contains_swapfile=0
-		local whiptail_desc="Mount target: ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
-		whiptail_desc+="\nMount source: $MENU_DRIVE_INDEX"
+		local whiptail_desc="Mount target: ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}"
+		whiptail_desc+="\nMount source: $MENU_DRIVE_SELECTED"
 
 		# No filesystem
-		if (( ! ${aDRIVE_ISFILESYSTEM[$MENU_DRIVE_INDEX]} ))
+		if (( ! ${aDRIVE_ISFILESYSTEM[$MENU_DRIVE_SELECTED]} ))
 		then
-			if (( ${aDRIVE_ISROM[$MENU_DRIVE_INDEX]} ))
+			if (( ${aDRIVE_ISROM[$MENU_DRIVE_SELECTED]} ))
 			then
 				whiptail_desc+='\nStatus:       No media found, please insert media into the ROM device'
 				G_WHIP_MENU_ARRAY+=('Refresh' ': No media found, please insert media into the ROM device')
@@ -902,18 +859,18 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 
 		# Filesystem
 		else
-			whiptail_desc+="\nFilesystem:   ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]}"
-			[[ ${aDRIVE_UUID[$MENU_DRIVE_INDEX]} ]] && whiptail_desc+="\nUUID:         ${aDRIVE_UUID[$MENU_DRIVE_INDEX]}"
+			whiptail_desc+="\nFilesystem:   ${aDRIVE_FSTYPE[$MENU_DRIVE_SELECTED]}"
+			[[ ${aDRIVE_UUID[$MENU_DRIVE_SELECTED]} ]] && whiptail_desc+="\nUUID:         ${aDRIVE_UUID[$MENU_DRIVE_SELECTED]}"
 
-			if (( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} ))
+			if (( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_SELECTED]} ))
 			then
-				whiptail_desc+="\nAllocation:   Capacity: ${aDRIVE_SIZE_TOTAL[$MENU_DRIVE_INDEX]}iB | Used: ${aDRIVE_SIZE_USED[$MENU_DRIVE_INDEX]}iB (${aDRIVE_SIZE_PERCENTUSED[$MENU_DRIVE_INDEX]})\nStatus:       Drive is online and ready for use"
+				whiptail_desc+="\nAllocation:   Capacity: ${aDRIVE_SIZE_TOTAL[$MENU_DRIVE_SELECTED]}iB | Used: ${aDRIVE_SIZE_USED[$MENU_DRIVE_SELECTED]}iB (${aDRIVE_SIZE_USED_PCT[$MENU_DRIVE_SELECTED]})\nStatus:       Drive is online and ready for use"
 
 				# Unmount: Disable for root and boot mounts
-				if [[ ! ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} =~ ^/(boot(/efi|/firmware)?)?$ ]]
+				if [[ ! ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]} =~ ^/(boot(/efi|/firmware)?)?$ ]]
 				then
 					G_WHIP_MENU_ARRAY+=('' '●─ Mount Control ')
-					if (( ${aDRIVE_ISNETWORKED[$MENU_DRIVE_INDEX]} ))
+					if (( ${aDRIVE_ISNETWORKED[$MENU_DRIVE_SELECTED]} ))
 					then
 						G_WHIP_MENU_ARRAY+=('Remove' ': Unmount networked drive and remove it from database')
 					else
@@ -921,20 +878,20 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 					fi
 				fi
 
-				if (( ! ${aDRIVE_ISROM[$MENU_DRIVE_INDEX]} ))
+				if (( ! ${aDRIVE_ISROM[$MENU_DRIVE_SELECTED]} ))
 				then
-					if (( ! ${aDRIVE_ISREADONLY_CURRENTLY[$MENU_DRIVE_INDEX]} ))
+					if (( ! ${aDRIVE_ISREADONLY[$MENU_DRIVE_SELECTED]} ))
 					then
 						G_WHIP_MENU_ARRAY+=('' '●─ Benchmark Options ')
 						G_WHIP_MENU_ARRAY+=('Benchmark' ': Test read and write speeds')
 
 						# User data and swap file location
-						if (( ! ${aDRIVE_ISNETWORKED[$MENU_DRIVE_INDEX]} ))
+						if (( ! ${aDRIVE_ISNETWORKED[$MENU_DRIVE_SELECTED]} ))
 						then
 							G_WHIP_MENU_ARRAY+=('' '●─ Userdata & Swap options ')
 
 							# User data
-							if [[ ( ( $FP_USERDATA_CURRENT == "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}" || $FP_USERDATA_CURRENT == "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}/"* ) && ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} != '/' ) || ( $FP_USERDATA_CURRENT == '/mnt/dietpi_userdata' && ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} == '/' ) ]]
+							if [[ ( ( $FP_USERDATA_CURRENT == "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}" || $FP_USERDATA_CURRENT == "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}/"* ) && ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]} != '/' ) || ( $FP_USERDATA_CURRENT == '/mnt/dietpi_userdata' && ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]} == '/' ) ]]
 							then
 								partition_contains_userdata=1
 								G_WHIP_MENU_ARRAY+=('User data' ": [X] | DietPi user data is currently located on this drive")
@@ -946,7 +903,7 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 							if (( $G_HW_MODEL != 75 ))
 							then
 								local swapfile_size=$(sed -n '/^[[:blank:]]*AUTO_SETUP_SWAPFILE_SIZE=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-								if (( $swapfile_size > 0 )) && [[ ( $FP_SWAPFILE_CURRENT == ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}* && ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} != '/' ) || ( $FP_SWAPFILE_CURRENT == '/var/swap' && ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} == '/' ) ]]
+								if (( $swapfile_size > 0 )) && [[ ( $FP_SWAPFILE_CURRENT == ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}* && ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]} != '/' ) || ( $FP_SWAPFILE_CURRENT == '/var/swap' && ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]} == '/' ) ]]
 								then
 									partition_contains_swapfile=1
 									G_WHIP_MENU_ARRAY+=('Swap file' ": [X] | ${swapfile_size} MiB used on this drive, select to change size")
@@ -957,13 +914,13 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 						fi
 					fi
 
-					if (( ! ${aDRIVE_ISNETWORKED[$MENU_DRIVE_INDEX]} ))
+					if (( ! ${aDRIVE_ISNETWORKED[$MENU_DRIVE_SELECTED]} ))
 					then
 						G_WHIP_MENU_ARRAY+=('' '●─ Advanced options ')
 
 						# Read only?
 						local read_only_state='[ ]' read_only_state_text='Disabled'
-						(( ${aDRIVE_ISREADONLY_CURRENTLY[$MENU_DRIVE_INDEX]} )) && read_only_state='[X]' read_only_state_text='Enabled'
+						(( ${aDRIVE_ISREADONLY[$MENU_DRIVE_SELECTED]} )) && read_only_state='[X]' read_only_state_text='Enabled'
 						G_WHIP_MENU_ARRAY+=('Read Only' ": $read_only_state | Select to toggle RW/RO modes")
 						whiptail_desc+="\nRead only:    $read_only_state_text"
 					fi
@@ -971,18 +928,18 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 			else
 				whiptail_desc+='\nStatus:       Drive is not mounted and can be unplugged'
 				G_WHIP_MENU_ARRAY+=('' '●─ Mount Control ')
-				G_WHIP_MENU_ARRAY+=('Mount' ": Mount the drive to ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}")
+				G_WHIP_MENU_ARRAY+=('Mount' ": Mount the drive to ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}")
 				G_WHIP_MENU_ARRAY+=('' '●─ Advanced Options ')
 			fi
 			G_WHIP_DEFAULT_ITEM_NEXT_SUB1=${G_WHIP_DEFAULT_ITEM_NEXT_SUB1:-${G_WHIP_MENU_ARRAY[2]}}
 
-			if (( ${aDRIVE_ISACCESS[$MENU_DRIVE_INDEX]} && ! ${aDRIVE_ISROM[$MENU_DRIVE_INDEX]} && ! ${aDRIVE_ISNETWORKED[$MENU_DRIVE_INDEX]} ))
+			if (( ${aDRIVE_ISACCESS[$MENU_DRIVE_SELECTED]} && ! ${aDRIVE_ISROM[$MENU_DRIVE_SELECTED]} && ! ${aDRIVE_ISNETWORKED[$MENU_DRIVE_SELECTED]} ))
 			then
 				# Reserved blocks percentage on ext4 filesystems
-				if [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'ext4' ]]
+				if [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_SELECTED]} == 'ext4' ]]
 				then
 					local blocks reserved_blocks block_size
-					read -r blocks reserved_blocks block_size < <(dumpe2fs -h "$MENU_DRIVE_INDEX" 2> /dev/null | mawk '$0~/^(Block count|Reserved block count|Block size):/{print $NF}' ORS=' ')
+					read -r blocks reserved_blocks block_size < <(dumpe2fs -h "$MENU_DRIVE_SELECTED" 2> /dev/null | mawk '$0~/^(Block count|Reserved block count|Block size):/{print $NF}' ORS=' ')
 					local reserved_blocks_size=$(( $reserved_blocks * $block_size / 1024**2 )) # MiB
 					G_WHIP_MENU_ARRAY+=('Reserved blocks' ": [$reserved_blocks_size MiB] | Space reserved for root user")
 				fi
@@ -991,24 +948,24 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 				G_WHIP_MENU_ARRAY+=('Check & Repair' ': Check and optionally repair filesystem')
 
 				# Resize
-				[[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} =~ ^(ext[2-4]|f2fs|btrfs)$ ]] && G_WHIP_MENU_ARRAY+=('Resize' ': Maximize the available filesystem size')
+				[[ ${aDRIVE_FSTYPE[$MENU_DRIVE_SELECTED]} =~ ^(ext[2-4]|f2fs|btrfs)$ ]] && G_WHIP_MENU_ARRAY+=('Resize' ': Maximize the available filesystem size')
 
 				# Format: Disable for root and boot mounts
-				[[ ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} =~ ^/(boot(/efi|/firmware)?)?$ ]] || G_WHIP_MENU_ARRAY+=('Format' ': Select to see formatting options')
+				[[ ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]} =~ ^/(boot(/efi|/firmware)?)?$ ]] || G_WHIP_MENU_ARRAY+=('Format' ': Select to see formatting options')
 			fi
 		fi
 
-		if (( ${aDRIVE_ISACCESS[$MENU_DRIVE_INDEX]} && ! ${aDRIVE_ISROM[$MENU_DRIVE_INDEX]} && ! ${aDRIVE_ISNETWORKED[$MENU_DRIVE_INDEX]} ))
+		if (( ${aDRIVE_ISACCESS[$MENU_DRIVE_SELECTED]} && ! ${aDRIVE_ISROM[$MENU_DRIVE_SELECTED]} && ! ${aDRIVE_ISNETWORKED[$MENU_DRIVE_SELECTED]} ))
 		then
 			# Transfer RootFS: Supported on RPi and Odroids C2/XU4/N2/C4 if there is a dedicated boot mount
-			if [[ $MENU_DRIVE_INDEX != "$G_ROOTFS_DEV" ]] && { (( $G_HW_MODEL < 10 )) || { (( $G_HW_MODEL < 20 )) && findmnt -M /boot > /dev/null; }; }
+			if [[ $MENU_DRIVE_SELECTED != "$G_ROOTFS_DEV" ]] && { (( $G_HW_MODEL < 10 )) || { (( $G_HW_MODEL < 20 )) && findmnt -M /boot > /dev/null; }; }
 			then
 				G_WHIP_MENU_ARRAY+=('Transfer RootFS' ': Transfer RootFS to this drive')
 			fi
 		fi
 
 		# I/O scheduler
-		local io_schedulers="/sys/block/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}/queue/scheduler"
+		local io_schedulers="/sys/block/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_SELECTED]}/queue/scheduler"
 		if [[ -e $io_schedulers ]]
 		then
 			local aio_schedulers=() bfq=0
@@ -1036,7 +993,7 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 
 		if [[ $G_WHIP_RETURNED_VALUE == 'Mount' ]]
 		then
-			Mount_Drive "$MENU_DRIVE_INDEX" "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
+			Mount_Drive "$MENU_DRIVE_SELECTED" "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}"
 			Init_Drives_and_Refresh
 
 		elif [[ $G_WHIP_RETURNED_VALUE == 'Unmount' || $G_WHIP_RETURNED_VALUE == 'Remove' ]]
@@ -1053,21 +1010,21 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 			elif [[ $G_WHIP_RETURNED_VALUE == 'Remove' ]]
 			then
 				if G_WHIP_YESNO "Do you wish to unmount and remove the following networked drive from this system?
- - $MENU_DRIVE_INDEX > ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}
+ - $MENU_DRIVE_SELECTED > ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}
 \nNB: You can add additional network shares at a later date through the 'dietpi-drive_manager' main menu."
 				then
 					# Remove credentials file
-					local cred="/var/lib/dietpi/dietpi-drive_manager${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]//\//-}.cred"
+					local cred="/var/lib/dietpi/dietpi-drive_manager${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]//\//-}.cred"
 					cred=${cred/drive_manager-mnt-/drive_manager\/mnt-}
 					[[ -f $cred ]] && G_EXEC rm "$cred"
 					[[ -d '/var/lib/dietpi/dietpi-drive_manager' ]] && G_EXEC rmdir --ignore-fail-on-non-empty /var/lib/dietpi/dietpi-drive_manager
 
-					Unmount_Drive "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
+					Unmount_Drive "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}"
 					Init_Drives_and_Refresh
 					TARGETMENUID=0 # Main menu
 				fi
 			else
-				Unmount_Drive "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
+				Unmount_Drive "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}"
 				Init_Drives_and_Refresh
 			fi
 
@@ -1076,8 +1033,8 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 			local min=0
 			local current=0
 			[[ $partition_contains_swapfile && -f $FP_SWAPFILE_CURRENT ]] && current=$(( $(stat -c '%s' "$FP_SWAPFILE_CURRENT") / 1024**2 ))
-			local max=$(( $(G_CHECK_FREESPACE "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}") + ${current:=0} ))
-			if [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'btrfs' ]]
+			local max=$(( $(G_CHECK_FREESPACE "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}") + ${current:=0} ))
+			if [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_SELECTED]} == 'btrfs' ]]
 			then
 				G_WHIP_MSG '[FAILED] The filesystem Btrfs does not support swap files.\n
 Please choose another drive or format this one with another filesystem, e.g. ext4.'
@@ -1090,8 +1047,8 @@ Please choose another drive or format this one with another filesystem, e.g. ext
 				then
 					if G_CHECK_VALIDINT "$G_WHIP_RETURNED_VALUE" "$min" "$max"
 					then
-						local fp_target_swapfile="${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}/.swapfile"
-						[[ ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} == '/' ]] && fp_target_swapfile='/var/swap'
+						local fp_target_swapfile="${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}/.swapfile"
+						[[ ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]} == '/' ]] && fp_target_swapfile='/var/swap'
 
 						(( $SERVICES_STOPPED )) || { /boot/dietpi/dietpi-services stop; SERVICES_STOPPED=1; }
 						/boot/dietpi/func/dietpi-set_swapfile "$G_WHIP_RETURNED_VALUE" "$fp_target_swapfile" || read -rp " - Press any key to return to $G_PROGRAM_NAME..."
@@ -1113,7 +1070,7 @@ Please choose another drive or format this one with another filesystem, e.g. ext
 
 				if disable_error=1 G_CHECK_VALIDINT "$G_WHIP_RETURNED_VALUE" 0 "$reserved_blocks_max"
 				then
-					G_EXEC tune2fs -r $(( $G_WHIP_RETURNED_VALUE * 1024**2 / $block_size )) "$MENU_DRIVE_INDEX"
+					G_EXEC tune2fs -r $(( $G_WHIP_RETURNED_VALUE * 1024**2 / $block_size )) "$MENU_DRIVE_SELECTED"
 					break
 				else
 					error_text="[FAILED] The entered value must be between 0 and $reserved_blocks_max.\n\n"
@@ -1122,10 +1079,10 @@ Please choose another drive or format this one with another filesystem, e.g. ext
 
 		elif [[ $G_WHIP_RETURNED_VALUE == 'User data' ]]
 		then
-			local fp_target_userdata_dir=${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}
+			local fp_target_userdata_dir=${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}
 
 			# Store below /mnt when moved to rootfs
-			[[ ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} == '/' ]] && fp_target_userdata_dir='/mnt'
+			[[ ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]} == '/' ]] && fp_target_userdata_dir='/mnt'
 
 			# Always move to dedicated dietpi_userdata subdir
 			fp_target_userdata_dir+='/dietpi_userdata'
@@ -1134,10 +1091,10 @@ Please choose another drive or format this one with another filesystem, e.g. ext
 			[[ $fp_target_userdata_dir == "$FP_USERDATA_CURRENT" ]] && return 0
 
 			# Check for supported filesystem type
-			if [[ ! ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} =~ ^(ext[2-4]|(f2|btr|x|z)fs)$ ]]
+			if [[ ! ${aDRIVE_FSTYPE[$MENU_DRIVE_SELECTED]} =~ ^(ext[2-4]|(f2|btr|x|z)fs)$ ]]
 			then
-				G_DIETPI-NOTIFY 1 "Filesystem type ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} is not supported for transferring DietPi user data"
-				G_WHIP_MSG "Filesystem type not supported:\n\n${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} has a filesystem type of ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]}, which is not supported.\n\nThe filesystem type must be ext2/3/4, F2FS, Btrfs, XFS or ZFS for native symlink and UNIX permissions compatibilities.\n\nYou may format the partition with a supported filesystem type and retry."
+				G_DIETPI-NOTIFY 1 "Filesystem type ${aDRIVE_FSTYPE[$MENU_DRIVE_SELECTED]} is not supported for transferring DietPi user data"
+				G_WHIP_MSG "Filesystem type not supported:\n\n${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]} has a filesystem type of ${aDRIVE_FSTYPE[$MENU_DRIVE_SELECTED]}, which is not supported.\n\nThe filesystem type must be ext2/3/4, F2FS, Btrfs, XFS or ZFS for native symlink and UNIX permissions compatibilities.\n\nYou may format the partition with a supported filesystem type and retry."
 				return 1
 			fi
 
@@ -1226,75 +1183,75 @@ Please choose another drive or format this one with another filesystem, e.g. ext
 		elif [[ $G_WHIP_RETURNED_VALUE == 'Benchmark' ]]
 		then
 			(( $SERVICES_STOPPED )) || { /boot/dietpi/dietpi-services stop; SERVICES_STOPPED=1; }
-			FP_BENCHFILE=${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} /boot/dietpi/func/dietpi-benchmark 1
+			FP_BENCHFILE=${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]} /boot/dietpi/func/dietpi-benchmark 1
 
 		elif [[ $G_WHIP_RETURNED_VALUE == 'Check & Repair' ]]
 		then
-			if [[ ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} == '/' ]]
+			if [[ ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]} == '/' ]]
 			then
 				if G_WHIP_YESNO 'The root filesystem can only be checked on reboot.
 \nDo you want to force a filesystem check of root partition on next reboot?
-\nNB: Logs can be found after reboot either via "journalctl -t systemd-fsck" or "cat /run/initramfs/fsck.log"'
+\nNB: Logs can be found after reboot either via "cat /run/initramfs/fsck.log" or "journalctl -t systemd-fsck"'
 				then
 					> /forcefsck
 					G_WHIP_YESNO 'Do you want to reboot now?' && { reboot; exit 0; }
 				fi
-				return
+				return 0
 			fi
 
-			if [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == ext[2-4] ]]
+			if [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_SELECTED]} == ext[2-4] ]]
 			then
 				G_AG_CHECK_INSTALL_PREREQ e2fsprogs
 				local fsck_dry='e2fsck -n -f'
 				local fsck_fix='e2fsck -y -f'
 
-			elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'exfat' ]]
+			elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_SELECTED]} == 'exfat' ]]
 			then
 				Install_exFAT_Tools
 				local fsck_dry='fsck.exfat -n'
 				local fsck_fix='fsck.exfat -p'
 
-			elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} =~ 'fat' ]]
+			elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_SELECTED]} =~ 'fat' ]]
 			then
 				G_AG_CHECK_INSTALL_PREREQ dosfstools
 				local fsck_dry='fsck.fat -n'
 				local fsck_fix='fsck.fat -y'
 
-			elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'ntfs' ]]
+			elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_SELECTED]} == 'ntfs' ]]
 			then
 				G_AG_CHECK_INSTALL_PREREQ ntfs-3g
 				local fsck_dry='ntfsfix -n'
 				local fsck_fix='ntfsfix'
 
-			elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} =~ 'hfs' ]]
+			elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_SELECTED]} =~ 'hfs' ]]
 			then
 				G_AG_CHECK_INSTALL_PREREQ hfsplus hfsprogs hfsutils
 				local fsck_dry='fsck.hfsplus -n -f'
 				local fsck_fix='fsck.hfsplus -y -f'
 
-			elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'f2fs' ]]
+			elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_SELECTED]} == 'f2fs' ]]
 			then
 				G_AG_CHECK_INSTALL_PREREQ f2fs-tools
 				local fsck_dry='fsck.f2fs'
 				local fsck_fix='fsck.f2fs -f'
 
-			elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'btrfs' ]]
+			elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_SELECTED]} == 'btrfs' ]]
 			then
 				G_AG_CHECK_INSTALL_PREREQ btrfs-progs
 				local fsck_dry='btrfs check --readonly'
 				local fsck_fix='btrfs check --repair'
 
-			elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'xfs' ]]
+			elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_SELECTED]} == 'xfs' ]]
 			then
 				G_AG_CHECK_INSTALL_PREREQ xfsprogs
 				local fsck_dry='xfs_repair -n'
 				local fsck_fix='xfs_repair'
 			else
-				G_WHIP_MSG "Filesystem checks are currently not supported for '${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]}'. Aborting..."
+				G_WHIP_MSG "Filesystem checks are currently not supported for '${aDRIVE_FSTYPE[$MENU_DRIVE_SELECTED]}'. Aborting..."
 				return 1
 			fi
 
-			if (( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} ))
+			if (( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_SELECTED]} ))
 			then
 				G_WHIP_YESNO 'For safe check and repair, the drive needs to be unmounted.
 \nDo you want to continue with the drive being unmounted automatically?' || return 1
@@ -1305,36 +1262,36 @@ Please choose another drive or format this one with another filesystem, e.g. ext
 				(( $partition_contains_swapfile )) && G_EXEC swapoff -a
 
 				# Unmount drive
-				G_EXEC umount "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
+				G_EXEC umount "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}"
 			fi
 
 			# Do a dry-run first
-			G_WHIP_MSG "The following drive will now be checked for errors:\n$MENU_DRIVE_INDEX\n\nNo repair will be completed during this process. An option to repair the drive, will be provided after the check."
-			$fsck_dry "$MENU_DRIVE_INDEX" &> .fsck_out_tmp
+			G_WHIP_MSG "The following drive will now be checked for errors:\n$MENU_DRIVE_SELECTED\n\nNo repair will be completed during this process. An option to repair the drive, will be provided after the check."
+			$fsck_dry "$MENU_DRIVE_SELECTED" &> .fsck_out_tmp
 			log=1 G_WHIP_VIEWFILE .fsck_out_tmp
 			rm .fsck_out_tmp
 
-			if [[ $fsck_fix ]] && G_WHIP_YESNO "Would you like to run an automated repair on the following drive now?\n$MENU_DRIVE_INDEX
+			if [[ $fsck_fix ]] && G_WHIP_YESNO "Would you like to run an automated repair on the following drive now?\n$MENU_DRIVE_SELECTED
 \nNB:
 - Automated repair steps potentially lead to data loss, which would have been able to recover by professional drive recovery services.
 - If the data is extremely important and you don't have any backup, you might want to hand the drive to a recovery service as is.
 - These services are usually very expensive, but might be able to recover more data than (after) this automated repair steps!"
 			then
-				$fsck_fix "$MENU_DRIVE_INDEX" &> .fsck_out_tmp
+				$fsck_fix "$MENU_DRIVE_SELECTED" &> .fsck_out_tmp
 				log=1 G_WHIP_VIEWFILE .fsck_out_tmp
 				rm .fsck_out_tmp
 
 			elif [[ ! $fsck_fix ]]
 			then
-				G_WHIP_MSG "The fsck tool for ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} filesystems does not support repairing yet on Debian ${G_DISTRO_NAME^}.
+				G_WHIP_MSG "The fsck tool for ${aDRIVE_FSTYPE[$MENU_DRIVE_SELECTED]} filesystems does not support repairing yet on Debian ${G_DISTRO_NAME^}.
 \nWe recommend to migrate to a new Debian release which supports this feature, either by installing a new DietPi image or following our HowTo to upgrade your system:
 => https://dietpi.com/docs/usage/#how-to-upgrade-to-buster"
 			fi
 
-			if (( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} ))
+			if (( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_SELECTED]} ))
 			then
 				# Remount drive
-				G_EXEC mount "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
+				G_EXEC mount "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}"
 
 				# Re-enable swap
 				(( $partition_contains_swapfile )) && G_EXEC swapon -a
@@ -1343,22 +1300,22 @@ Please choose another drive or format this one with another filesystem, e.g. ext
 		elif [[ $G_WHIP_RETURNED_VALUE == 'I/O Scheduler' ]]
 		then
 			local udev_rules='/etc/udev/rules.d/99-dietpi-io_schedulers.rules'
-			[[ -f $udev_rules ]] && grep -q "KERNEL==\"${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}\"" "$udev_rules" && G_WHIP_MENU_ARRAY=('Reset' ': Reset to system defaults') || G_WHIP_MENU_ARRAY=()
+			[[ -f $udev_rules ]] && grep -q "KERNEL==\"${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_SELECTED]}\"" "$udev_rules" && G_WHIP_MENU_ARRAY=('Reset' ': Reset to system defaults') || G_WHIP_MENU_ARRAY=()
 			for i in "${aio_schedulers[@]}"; do G_WHIP_MENU_ARRAY+=("$i"); done
 			G_WHIP_DEFAULT_ITEM=$io_scheduler_current
 			G_WHIP_MENU "Please select an I/O scheduler.\n
-NB: This will apply to the whole drive: /dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}
+NB: This will apply to the whole drive: /dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_SELECTED]}
     It always applies to the drive with this dev name, as well if naming changes due to new attached drives.\n
 Read more about I/O scheduling: https://wiki.archlinux.org/index.php/Improving_performance#Input/output_schedulers" || return 0
 
 			if [[ $G_WHIP_RETURNED_VALUE == 'Reset' ]]
 			then
-				sed --follow-symlinks -i "/KERNEL==\"${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}\"/d" "$udev_rules"
+				sed --follow-symlinks -i "/KERNEL==\"${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_SELECTED]}\"/d" "$udev_rules"
 				grep -q '^ACTION' "$udev_rules" || rm "$udev_rules"
 				G_WHIP_YESNO '[ INFO ] A reboot is required to reset the I/O scheduler to default.\n\nDo you wish to reboot now?' && { reboot; exit 0; }
 			else
 				[[ -f $udev_rules ]] || echo '# Please run "dietpi-drive_manager" to adjust I/O schedulers' > "$udev_rules"
-				G_CONFIG_INJECT "ACTION==\"add\|change\", KERNEL==\"${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}\"" "ACTION==\"add|change\", KERNEL==\"${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}\", ATTR{queue/scheduler}=\"$G_WHIP_RETURNED_VALUE\"" "$udev_rules"
+				G_CONFIG_INJECT "ACTION==\"add\|change\", KERNEL==\"${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_SELECTED]}\"" "ACTION==\"add|change\", KERNEL==\"${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_SELECTED]}\", ATTR{queue/scheduler}=\"$G_WHIP_RETURNED_VALUE\"" "$udev_rules"
 				echo "$G_WHIP_RETURNED_VALUE" > "$io_schedulers"
 			fi
 		fi
@@ -1377,39 +1334,22 @@ Read more about I/O scheduling: https://wiki.archlinux.org/index.php/Improving_p
 		(( $FORMAT_MODE )) && format_mode_text='Partition'
 
 		local text_fs_type='ext4'
-		if (( $FORMAT_FILESYSTEM_TYPE == 1 ))
-		then
-			text_fs_type='NTFS'
-
-		elif (( $FORMAT_FILESYSTEM_TYPE == 2 ))
-		then
-			text_fs_type='FAT32'
-
-		elif (( $FORMAT_FILESYSTEM_TYPE == 3 ))
-		then
-			text_fs_type='HFS+'
-
-		elif (( $FORMAT_FILESYSTEM_TYPE == 4 ))
-		then
-			text_fs_type='Btrfs'
-
-		elif (( $FORMAT_FILESYSTEM_TYPE == 5 ))
-		then
-			text_fs_type='F2FS'
-
-		elif (( $FORMAT_FILESYSTEM_TYPE == 6 ))
-		then
-			text_fs_type='exFAT'
-
-		elif (( $FORMAT_FILESYSTEM_TYPE == 7 ))
-		then
-			text_fs_type='XFS'
-		fi
+		case $FORMAT_FS_TYPE in
+			0) text_fs_type='ext4';;
+			1) text_fs_type='NTFS';;
+			2) text_fs_type='FAT32';;
+			3) text_fs_type='HFS+';;
+			4) text_fs_type='Btrfs';;
+			5) text_fs_type='F2FS';;
+			6) text_fs_type='exFAT';;
+			7) text_fs_type='XFS';;
+			*) G_DIETPI-NOTIFY 1 "Invalid filesystem type ID \"$FORMAT_FS_TYPE\""; exit 1;;
+		esac
 
 		G_WHIP_MENU_ARRAY=()
 
 		# Has partition table, offer to format current partition or whole drive
-		if (( ${aDRIVE_ISPARTITIONTABLE[$MENU_DRIVE_INDEX]} ))
+		if (( ${aDRIVE_ISPARTITION[$MENU_DRIVE_SELECTED]} ))
 		then
 			G_WHIP_MENU_ARRAY+=('Format Mode' ": [$format_mode_text] Format the whole drive or current partition only")
 
@@ -1437,8 +1377,8 @@ Read more about I/O scheduling: https://wiki.archlinux.org/index.php/Improving_p
 		then
 			G_WHIP_MENU_ARRAY=(
 
-				'Partition' ": $MENU_DRIVE_INDEX | UUID=${aDRIVE_UUID[$MENU_DRIVE_INDEX]}"
-				'Drive' ": /dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}"
+				'Partition' ": $MENU_DRIVE_SELECTED | UUID=${aDRIVE_UUID[$MENU_DRIVE_SELECTED]}"
+				'Drive' ": /dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_SELECTED]}"
 			)
 
 			if G_WHIP_MENU 'Please select a formatting mode:\n\n - Formatting the drive will DELETE all data on the DRIVE and create a new partition table.\n - Formatting the partition, will DELETE all data on the current PARTITION only.\n
@@ -1470,55 +1410,26 @@ NB: If you are planning to dedicate the drive to this system, it is recommended 
 				)
 			fi
 
-			G_WHIP_DEFAULT_ITEM=$FORMAT_FILESYSTEM_TYPE
+			G_WHIP_DEFAULT_ITEM=$FORMAT_FS_TYPE
 			G_WHIP_MENU 'Please select a filesystem type for this format:
 \next4:\nHighly recommended if you plan to use this drive solely on this system (dedicated drive).
 \nNTFS:\nRecommended if you plan to use this drive on a Windows system. High CPU usage during transfers.
 \nFull list of different filesystem types:\nhttps://dietpi.com/docs/dietpi_tools/#dietpi-drive-manager' || return 0
 
-			FORMAT_FILESYSTEM_TYPE=$G_WHIP_RETURNED_VALUE
+			FORMAT_FS_TYPE=$G_WHIP_RETURNED_VALUE
 
 			# Install FS pre-reqs
-			# - ext
-			if (( $FORMAT_FILESYSTEM_TYPE == 0 ))
-			then
-				G_AG_CHECK_INSTALL_PREREQ e2fsprogs
-
-			# - NTFS
-			elif (( $FORMAT_FILESYSTEM_TYPE == 1 ))
-			then
-				G_AG_CHECK_INSTALL_PREREQ ntfs-3g
-
-			# - FAT32
-			elif (( $FORMAT_FILESYSTEM_TYPE == 2 ))
-			then
-				G_AG_CHECK_INSTALL_PREREQ dosfstools
-
-			# - HFS+
-			elif (( $FORMAT_FILESYSTEM_TYPE == 3 ))
-			then
-				G_AG_CHECK_INSTALL_PREREQ hfsplus hfsprogs hfsutils
-
-			# - Btrfs
-			elif (( $FORMAT_FILESYSTEM_TYPE == 4 ))
-			then
-				G_AG_CHECK_INSTALL_PREREQ btrfs-progs
-
-			# - F2FS
-			elif (( $FORMAT_FILESYSTEM_TYPE == 5 ))
-			then
-				G_AG_CHECK_INSTALL_PREREQ f2fs-tools
-
-			# - exFAT
-			elif (( $FORMAT_FILESYSTEM_TYPE == 6 ))
-			then
-				Install_exFAT_Tools
-
-			# - XFS
-			elif (( $FORMAT_FILESYSTEM_TYPE == 7 ))
-			then
-				G_AG_CHECK_INSTALL_PREREQ xfsprogs
-			fi
+			case $FORMAT_FS_TYPE in
+				0) G_AG_CHECK_INSTALL_PREREQ e2fsprogs;; # ext4
+				1) G_AG_CHECK_INSTALL_PREREQ ntfs-3g;; # NTFS
+				2) G_AG_CHECK_INSTALL_PREREQ dosfstools;; # FAT32
+				3) G_AG_CHECK_INSTALL_PREREQ hfsplus hfsprogs hfsutils;; # HFS+
+				4) G_AG_CHECK_INSTALL_PREREQ btrfs-progs;; # Btrfs
+				5) G_AG_CHECK_INSTALL_PREREQ f2fs-tools;; # F2FS
+				6) Install_exFAT_Tools;; # exFAT
+				7) G_AG_CHECK_INSTALL_PREREQ xfsprogs;; # XFS
+				*) G_DIETPI-NOTIFY 1 "Invalid filesystem type ID \"$FORMAT_FS_TYPE\""; exit 1;;
+			esac
 
 		elif [[ $G_WHIP_RETURNED_VALUE == 'Format' ]]
 		then
@@ -1606,7 +1517,7 @@ _EOF_
 				echo "$source $samba_fp_mount_target cifs cred=$cred,iocharset=utf8,gid=dietpi,file_mode=0770,dir_mode=0770,vers=$i,noauto,x-systemd.automount" >> /etc/fstab
 
 				Init_Drives_and_Refresh
-				MENU_DRIVE_INDEX=$source
+				MENU_DRIVE_SELECTED=$source
 				TARGETMENUID=1 # Drive menu
 
 				G_WHIP_MSG "Mount completed. The new mount can be accessed at:\n - $samba_fp_mount_target\n - CIFS vers=$i"
@@ -1719,7 +1630,7 @@ _EOF_
 			echo "$source $nfs_fp_mount_target nfs noauto,x-systemd.automount" >> /etc/fstab
 
 			Init_Drives_and_Refresh
-			MENU_DRIVE_INDEX=$source
+			MENU_DRIVE_SELECTED=$source
 			TARGETMENUID=1 # Drive menu
 
 			G_WHIP_MSG "Mount completed. The new mount can be accessed at:\n - $nfs_fp_mount_target"
@@ -1792,22 +1703,12 @@ _EOF_
 	# Else  : Run menus
 	[[ $INPUT == [34] ]] || until (( $TARGETMENUID < 0 ))
 	do
-		G_TERM_CLEAR
-
-		if (( $TARGETMENUID == 1 ))
-		then
-			Menu_Drive
-
-		elif (( $TARGETMENUID == 2 ))
-		then
-			Menu_Format
-
-		elif (( $TARGETMENUID == 3 ))
-		then
-			Menu_Add_Network_Drive
-		else
-			Menu_Main
-		fi
+		case $TARGETMENUID in
+			1) Menu_Drive;;
+			2) Menu_Format;;
+			3) Menu_Add_Network_Drive;;
+			*) Menu_Main;;
+		esac
 	done
 	#-----------------------------------------------------------------------------------
 	exit "$EXIT_CODE"

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -40,8 +40,7 @@
 	APT_CHECK=0
 
 	# Drive menu
-	MENU_DRIVE_INDEX=0
-	MENU_DRIVE_TARGET=
+	MENU_DRIVE_INDEX=
 
 	# Format menu
 	FORMAT_GPT=1 # default GPT: https://github.com/MichaIng/DietPi/issues/531. 0=MBR
@@ -54,47 +53,43 @@
 	FP_USERDATA_CURRENT=
 	FP_SWAPFILE_CURRENT=
 
-	Init_New_Device(){
-
-		((index++))
-
-		aDRIVE_UUID[$index]=
-		aDRIVE_PART_UUID[$index]=
-		aDRIVE_MOUNT_SOURCE[$index]=
-		aDRIVE_MOUNT_TARGET[$index]=
-		aDRIVE_SOURCE_DEVICE[$index]=
-		aDRIVE_FSTYPE[$index]=
-		aDRIVE_SIZE_TOTAL[$index]=
-		aDRIVE_SIZE_USED[$index]=
-		aDRIVE_SIZE_PERCENTUSED[$index]=
-		aDRIVE_ISFILESYSTEM[$index]=0
-		aDRIVE_ISMOUNTED[$index]=0
-		aDRIVE_ISREADONLY_CURRENTLY[$index]=0
-		aDRIVE_ISNETWORKED[$index]=0
-		aDRIVE_ISROM[$index]=0
-		aDRIVE_ISPARTITIONTABLE[$index]=0
-		aDRIVE_ISACCESS[$index]=1
+	Init_New_Device()
+	{
+		aDRIVE_UUID[$source]=
+		aDRIVE_PART_UUID[$source]=
+		aDRIVE_MOUNT_TARGET[$source]=
+		aDRIVE_SOURCE_DEVICE[$source]=
+		aDRIVE_FSTYPE[$source]=
+		aDRIVE_SIZE_TOTAL[$source]=
+		aDRIVE_SIZE_USED[$source]=
+		aDRIVE_SIZE_PERCENTUSED[$source]=
+		aDRIVE_ISFILESYSTEM[$source]=0
+		aDRIVE_ISMOUNTED[$source]=0
+		aDRIVE_ISREADONLY_CURRENTLY[$source]=0
+		aDRIVE_ISNETWORKED[$source]=0
+		aDRIVE_ISROM[$source]=0
+		aDRIVE_ISPARTITIONTABLE[$source]=0
+		aDRIVE_ISACCESS[$source]=1
 	}
 
-	Destroy(){
-
-		unset -v aDRIVE_UUID aDRIVE_PART_UUID
-		unset -v aDRIVE_MOUNT_SOURCE aDRIVE_MOUNT_TARGET
-		unset -v aDRIVE_SOURCE_DEVICE aDRIVE_FSTYPE
-		unset -v aDRIVE_SIZE_TOTAL aDRIVE_SIZE_USED
-		unset -v aDRIVE_SIZE_PERCENTUSED
-		unset -v aDRIVE_ISFILESYSTEM aDRIVE_ISMOUNTED
-		unset -v aDRIVE_ISREADONLY_CURRENTLY aDRIVE_ISNETWORKED
-		unset -v aDRIVE_ISROM aDRIVE_ISPARTITIONTABLE aDRIVE_ISACCESS
+	Destroy()
+	{
+		declare -Ag aDRIVE_UUID=() aDRIVE_PART_UUID=()
+		declare -Ag aDRIVE_MOUNT_TARGET=()
+		declare -Ag aDRIVE_SOURCE_DEVICE=() aDRIVE_FSTYPE=()
+		declare -Ag aDRIVE_SIZE_TOTAL=() aDRIVE_SIZE_USED=()
+		declare -Ag aDRIVE_SIZE_PERCENTUSED=()
+		declare -Ag aDRIVE_ISFILESYSTEM=() aDRIVE_ISMOUNTED=()
+		declare -Ag aDRIVE_ISREADONLY_CURRENTLY=() aDRIVE_ISNETWORKED=()
+		declare -Ag aDRIVE_ISROM=() aDRIVE_ISPARTITIONTABLE=() aDRIVE_ISACCESS=()
 	}
 
-	Init_Drives_and_Refresh(){
-
+	Init_Drives_and_Refresh()
+	{
 		# Trigger automounts to assure those are detected as mounted
 		ls -d /mnt/*/. &> /dev/null
 
-		# Reset current index and delete arrays
-		local i index=-1
+		# Recreate drive arrays from scratch
 		Destroy
 
 		# Obtain actual user data location on disk (follow symlinks)
@@ -111,22 +106,20 @@
 		local swap_mounts tmpfs_mounts misc_mounts net_mounts
 
 		# Mode 4: Force reset/clean fstab (DietPi-Installer)
-		if (( $INPUT == 4 )); then
-
+		if (( $INPUT == 4 ))
+		then
 			local var_log_size=$(sed -n '/^[[:blank:]]*AUTO_SETUP_RAMLOG_MAXSIZE=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 			tmpfs_mounts="tmpfs /tmp tmpfs noatime,lazytime,nodev,nosuid,mode=1777
 tmpfs /var/log tmpfs size=${var_log_size:-50}M,noatime,lazytime,nodev,nosuid"
 
 		# Else: Grab current mounts
 		else
-
 			swap_mounts=$(grep '^[[:blank:]]*[^#].*[[:blank:]]swap[[:blank:]]' "$fp_fstab_tmp")
 			tmpfs_mounts=$(grep '^[[:blank:]]*tmpfs[[:blank:]]' "$fp_fstab_tmp")
 			# ecryptfs, vboxsf, glusterfs, mergerfs, bind, Btrfs subvolume mounts
 			misc_mounts=$(grep -E '^[[:blank:]]*[^#].*([[:blank:]](ecryptfs|vboxsf|glusterfs|(fuse\.)?mergerfs)[[:blank:]]|[[:blank:],]bind[[:blank:],]|[[:blank:]]btrfs[[:blank:]]+(.+,)?subvol=)' "$fp_fstab_tmp")
 			# CurlFtpFS, CIFS/SMB/Samba, NFS, SSHFS
 			net_mounts=$(grep -E '^[[:blank:]]*(curlftpfs|sshfs#|[^#].*[[:blank:]](cifs|nfs4?|fuse.sshfs)[[:blank:]])' "$fp_fstab_tmp")
-
 		fi
 
 		echo "# You can use \"dietpi-drive_manager\" to setup mounts.
@@ -158,44 +151,42 @@ $swap_mounts
 		G_DIETPI-NOTIFY 2 'Detecting drives, please wait...'
 
 		# Detect mounted drives via df
-		# - Exclude special treated fs types: tmpfs, ecryptfs, vboxsf, glusterfs
+		# - Exclude special treated fs types: tmpfs, ecryptfs, vboxsf, glusterfs, mergerfs
 		# - Workaround for /dev/root on RPi: Replace with actual device path $G_ROOTFS_DEV
 		# - Only detect mounts with "/" in source path, which excludes other special/pseudo fs types
 		# - Remove duplicates, e.g. from bind mounts and due to /dev/root conversion: https://github.com/MichaIng/DietPi/issues/2013#issuecomment-417413867
-		while read -r line
+		local source
+		while read -r source
 		do
 			Init_New_Device
 
-			aDRIVE_ISMOUNTED[$index]=1
-			aDRIVE_ISFILESYSTEM[$index]=1
-			aDRIVE_MOUNT_SOURCE[$index]=$line
-			aDRIVE_MOUNT_TARGET[$index]=$(findmnt -Ufnro TARGET -S "${aDRIVE_MOUNT_SOURCE[$index]}") # Use only first result since bind mounts lead to multiple matches
-			aDRIVE_SIZE_TOTAL[$index]=$(findmnt -Ufnro SIZE -M "${aDRIVE_MOUNT_TARGET[$index]}")
-			aDRIVE_SIZE_USED[$index]=$(findmnt -Ufnro USED -M "${aDRIVE_MOUNT_TARGET[$index]}")
-			aDRIVE_SIZE_PERCENTUSED[$index]=$(findmnt -Ufnro USE% -M "${aDRIVE_MOUNT_TARGET[$index]}")
+			aDRIVE_ISMOUNTED[$source]=1
+			aDRIVE_ISFILESYSTEM[$source]=1
+			aDRIVE_MOUNT_TARGET[$source]=$(findmnt -Ufnro TARGET -S "$source") # Use only first result since bind mounts lead to multiple matches
+			aDRIVE_SIZE_TOTAL[$source]=$(findmnt -Ufnro SIZE -M "${aDRIVE_MOUNT_TARGET[$source]}")
+			aDRIVE_SIZE_USED[$source]=$(findmnt -Ufnro USED -M "${aDRIVE_MOUNT_TARGET[$source]}")
+			aDRIVE_SIZE_PERCENTUSED[$source]=$(findmnt -Ufnro USE% -M "${aDRIVE_MOUNT_TARGET[$source]}")
 
 			# Physical
-			if [[ ${aDRIVE_MOUNT_SOURCE[$index]} == '/dev/'* ]]; then
+			if [[ $source == '/dev/'* ]]
+			then
+				G_DIETPI-NOTIFY 2 " - Detected mounted physical drive: $source > ${aDRIVE_MOUNT_TARGET[$source]}"
 
-				G_DIETPI-NOTIFY 2 " - Detected mounted physical drive: ${aDRIVE_MOUNT_SOURCE[$index]} > ${aDRIVE_MOUNT_TARGET[$index]}"
-
-				aDRIVE_SOURCE_DEVICE[$index]=$(Return_Drive_Without_Partitions "${aDRIVE_MOUNT_SOURCE[$index]}")
-				[[ ${aDRIVE_MOUNT_SOURCE[$index]} == /dev/${aDRIVE_SOURCE_DEVICE[$index]} ]] || aDRIVE_ISPARTITIONTABLE[$index]=1
-				[[ -b ${aDRIVE_MOUNT_SOURCE[$index]} ]] || aDRIVE_ISACCESS[$index]=0 # continue
-				aDRIVE_UUID[$index]=$(findmnt -Ufnro UUID -M "${aDRIVE_MOUNT_TARGET[$index]}")
-				(( ${aDRIVE_ISPARTITIONTABLE[$index]} )) && aDRIVE_PART_UUID[$index]=$(findmnt -Ufnro PARTUUID -M "${aDRIVE_MOUNT_TARGET[$index]}")
+				aDRIVE_SOURCE_DEVICE[$source]=$(Return_Drive_Without_Partitions "$source")
+				[[ $source == /dev/${aDRIVE_SOURCE_DEVICE[$source]} ]] || aDRIVE_ISPARTITIONTABLE[$source]=1
+				[[ -b $source ]] || aDRIVE_ISACCESS[$source]=0 # continue
+				aDRIVE_UUID[$source]=$(findmnt -Ufnro UUID -M "${aDRIVE_MOUNT_TARGET[$source]}")
+				(( ${aDRIVE_ISPARTITIONTABLE[$source]} )) && aDRIVE_PART_UUID[$source]=$(findmnt -Ufnro PARTUUID -M "${aDRIVE_MOUNT_TARGET[$source]}")
 				# blkid is required here, as findmnt will show "fuseblk" for NTFS filesytems, which is a correct result but cannot be used in fstab or for mounting the drive.
-				aDRIVE_FSTYPE[$index]=$(blkid -s TYPE -o value "${aDRIVE_MOUNT_SOURCE[$index]}")
+				aDRIVE_FSTYPE[$source]=$(blkid -s TYPE -o value "$source")
 
 			# Network
 			else
+				G_DIETPI-NOTIFY 2 " - Detected mounted network drive: $source > ${aDRIVE_MOUNT_TARGET[$source]}"
 
-				G_DIETPI-NOTIFY 2 " - Detected mounted network drive: ${aDRIVE_MOUNT_SOURCE[$index]} > ${aDRIVE_MOUNT_TARGET[$index]}"
-
-				aDRIVE_ISNETWORKED[$index]=1
+				aDRIVE_ISNETWORKED[$source]=1
 				# findmnt is required here, as blkid works only for physical block devices
-				aDRIVE_FSTYPE[$index]=$(findmnt -Ufnro FSTYPE -M "${aDRIVE_MOUNT_TARGET[$index]}")
-
+				aDRIVE_FSTYPE[$source]=$(findmnt -Ufnro FSTYPE -M "${aDRIVE_MOUNT_TARGET[$source]}")
 			fi
 
 			# R/O mounted?
@@ -203,53 +194,48 @@ $swap_mounts
 			#	root@DietPi:~# cat /proc/mounts | grep ' / '
 			#	rootfs / rootfs rw 0 0
 			#	/dev/mmcblk0p2 / ext4 ro,noatime,discard,data=ordered 0 0
-			if grep -q "[[:blank:]]${aDRIVE_MOUNT_TARGET[$index]}[[:blank:]].*[[:blank:]]ro," /proc/mounts; then
-
-				aDRIVE_ISREADONLY_CURRENTLY[$index]=1
+			if grep -q "[[:blank:]]${aDRIVE_MOUNT_TARGET[$source]}[[:blank:]].*[[:blank:]]ro," /proc/mounts
+			then
+				aDRIVE_ISREADONLY_CURRENTLY[$source]=1
 
 				# RootFS R/W check
-				if [[ ${aDRIVE_MOUNT_TARGET[$index]} == '/' ]]; then
-
-					if G_WHIP_YESNO "RootFS is currently set to \"Read Only (R/O)\". $G_PROGRAM_NAME requires \"Read Write (R/W)\" access to function.\n\nWould you like to re-enable R/W access on RootFS?"; then
-
-						G_EXEC mount -v -o remount,rw "${aDRIVE_MOUNT_TARGET[$index]}"
-						aDRIVE_ISREADONLY_CURRENTLY[$index]=0
+				if [[ ${aDRIVE_MOUNT_TARGET[$source]} == '/' ]]
+				then
+					if G_WHIP_YESNO "RootFS is currently set to \"Read Only (R/O)\". $G_PROGRAM_NAME requires \"Read Write (R/W)\" access to function.\n\nWould you like to re-enable R/W access on RootFS?"
+					then
+						G_EXEC mount -v -o remount,rw "${aDRIVE_MOUNT_TARGET[$source]}"
+						aDRIVE_ISREADONLY_CURRENTLY[$source]=0
 						G_DIETPI-NOTIFY 0 'Remounted RootFS with R/W access'
-
 					else
-
 						G_DIETPI-NOTIFY 1 "RootFS is currently set to R/O. $G_PROGRAM_NAME requires R/W access to function. Aborting..."
 						G_DIETPI-NOTIFY 2 'Rerun "dietpi-drive_manager" to enable RootFS R/W access.'
 						exit 1
-
 					fi
-
 				fi
-
 			fi
 
 			# Add only physical drives to fstab, network drives are handled outside of this loop
-			if [[ ${aDRIVE_ISNETWORKED[$index]} == 0 ]]; then
-
+			if [[ ${aDRIVE_ISNETWORKED[$source]} == 0 ]]
+			then
 				# Skip if block device path does not exist, e.g. rootfs within a container
-				(( ${aDRIVE_ISACCESS[$index]} )) || { G_DIETPI-NOTIFY 2 " - Skipping /etc/fstab entry as system as no access to ${aDRIVE_MOUNT_SOURCE[$index]}"; continue; }
+				(( ${aDRIVE_ISACCESS[$source]} )) || { G_DIETPI-NOTIFY 2 " - Skipping /etc/fstab entry as system as no access to $source"; continue; }
 
 				# Print error when physical drive has not UUID, as we cannot add it to fstab then
-				[[ ${aDRIVE_UUID[$index]} ]] || { G_DIETPI-NOTIFY 1 " - Skipping /etc/fstab entry as ${aDRIVE_MOUNT_SOURCE[$index]} has not UUID"; continue; }
+				[[ ${aDRIVE_UUID[$source]} ]] || { G_DIETPI-NOTIFY 1 " - Skipping /etc/fstab entry as $source has not UUID"; continue; }
 
 				# R/W or R/O?
 				# - Add rw flag to mount options. This should be default but seems to be not in rare cases: https://github.com/MichaIng/DietPi/issues/3268
 				local options=',rw'
-				(( ${aDRIVE_ISREADONLY_CURRENTLY[$index]} )) && options=',ro'
+				(( ${aDRIVE_ISREADONLY_CURRENTLY[$source]} )) && options=',ro'
 
 				# Additional FS-specific options
 				# - NTFS: Enable POSIX permissions and prevent splitting write buffers into 4k chunks: https://manpages.debian.org/ntfs-3g#OPTIONS
-				if [[ ${aDRIVE_FSTYPE[$index]} == 'ntfs' ]]
+				if [[ ${aDRIVE_FSTYPE[$source]} == 'ntfs' ]]
 				then
 					options+=',permissions,big_writes'
 
 				# - exFAT: Grant (only) "dietpi" group R/W access: https://github.com/MichaIng/DietPi/issues/4680
-				elif [[ ${aDRIVE_FSTYPE[$index]} == 'exfat' ]]
+				elif [[ ${aDRIVE_FSTYPE[$source]} == 'exfat' ]]
 				then
 					getent group dietpi > /dev/null && options+=',gid=dietpi,fmask=0002,dmask=0002'
 				fi
@@ -259,100 +245,95 @@ $swap_mounts
 				# - nofail: Allow boot to continue, if mount fails, not wanted for Root/BootFS
 				# - x-systemd.automount: The rootfs is logically mounted anyway and we want the bootfs to be available ASAP as well
 				# Source device entry
-				local dev_entry="UUID=${aDRIVE_UUID[$index]}"
-				if [[ ${aDRIVE_MOUNT_TARGET[$index]} =~ ^/(boot(/efi|/firmware)?)?$ ]]; then
-
+				local dev_entry="UUID=${aDRIVE_UUID[$source]}"
+				if [[ ${aDRIVE_MOUNT_TARGET[$source]} =~ ^/(boot(/efi|/firmware)?)?$ ]]
+				then
 					# On RPi we need to use PARTUUID for Root/BootFS
-					(( $G_HW_MODEL > 9 )) || dev_entry="PARTUUID=${aDRIVE_PART_UUID[$index]}"
-					[[ ${aDRIVE_MOUNT_TARGET[$index]} == '/' ]] && options+=' 0 1' || options+=' 0 2' # dump + fsck flag
-
+					(( $G_HW_MODEL > 9 )) || dev_entry="PARTUUID=${aDRIVE_PART_UUID[$source]}"
+					[[ ${aDRIVE_MOUNT_TARGET[$source]} == '/' ]] && options+=' 0 1' || options+=' 0 2' # dump + fsck flag
 				else
-
 					options+=',noauto,x-systemd.automount'
-
 				fi
 
-				echo "$dev_entry ${aDRIVE_MOUNT_TARGET[$index]} ${aDRIVE_FSTYPE[$index]:-auto} noatime,lazytime$options" >> "$fp_fstab_tmp"
-
+				echo "$dev_entry ${aDRIVE_MOUNT_TARGET[$source]} ${aDRIVE_FSTYPE[$source]:-auto} noatime,lazytime$options" >> "$fp_fstab_tmp"
 			fi
 
-		done < <(df -a --output=source --exclude-type=tmpfs --exclude-type=ecryptfs --exclude-type=vboxsf --exclude-type=glusterfs | sed "\|^/dev/root$|c$G_ROOTFS_DEV" | mawk '/\// && !x[$0]++')
+		done < <(df -a --output=source --exclude-type=tmpfs --exclude-type=ecryptfs --exclude-type=vboxsf --exclude-type=glusterfs --exclude-type=mergerfs --exclude-type=fuse.mergerfs | sed "\|^/dev/root$|c$G_ROOTFS_DEV" | mawk '/\// && !x[$0]++')
 
 		# Check blkid for unmounted filesystems
-		while read -r line
+		local i
+		while read -r source
 		do
-			[[ $line ]] || continue
+			[[ $source ]] || continue
 
 			# Exclude drives already found (mounted)
-			for i in "${aDRIVE_MOUNT_SOURCE[@]}"
+			for i in "${!aDRIVE_MOUNT_TARGET[@]}"
 			do
-				[[ $i == "$line"* ]] && continue 2
+				[[ $i == "$source"* ]] && continue 2
 			done
 
 			# Failsafe: Must have a valid UUID! But blkid should print only drives with filesystems.
-			local uuid=$(blkid -s UUID -o value "$line")
+			local uuid=$(blkid -s UUID -o value "$source")
 			[[ $uuid ]] || continue
 
-			G_DIETPI-NOTIFY 2 " - Detected unmounted drive: $line"
+			G_DIETPI-NOTIFY 2 " - Detected unmounted drive: $source"
 
 			Init_New_Device
 
-			aDRIVE_UUID[$index]=$uuid
-			aDRIVE_MOUNT_SOURCE[$index]=$line
-			aDRIVE_MOUNT_TARGET[$index]="/mnt/${aDRIVE_UUID[$index]}"
-			aDRIVE_SOURCE_DEVICE[$index]=$(Return_Drive_Without_Partitions "${aDRIVE_MOUNT_SOURCE[$index]}")
-			[[ ${aDRIVE_MOUNT_SOURCE[$index]} == /dev/${aDRIVE_SOURCE_DEVICE[$index]} ]] || aDRIVE_ISPARTITIONTABLE[$index]=1
-			(( ${aDRIVE_ISPARTITIONTABLE[$index]} )) && aDRIVE_PART_UUID[$index]=$(blkid -s PARTUUID -o value "${aDRIVE_MOUNT_SOURCE[$index]}")
-			aDRIVE_FSTYPE[$index]=$(blkid -s TYPE -o value "${aDRIVE_MOUNT_SOURCE[$index]}")
-			[[ ${aDRIVE_FSTYPE[$index]} ]] && aDRIVE_ISFILESYSTEM[$index]=1
+			aDRIVE_UUID[$source]=$uuid
+			aDRIVE_MOUNT_TARGET[$source]="/mnt/${aDRIVE_UUID[$source]}"
+			aDRIVE_SOURCE_DEVICE[$source]=$(Return_Drive_Without_Partitions "$source")
+			[[ $source == /dev/${aDRIVE_SOURCE_DEVICE[$source]} ]] || aDRIVE_ISPARTITIONTABLE[$source]=1
+			(( ${aDRIVE_ISPARTITIONTABLE[$source]} )) && aDRIVE_PART_UUID[$source]=$(blkid -s PARTUUID -o value "$source")
+			aDRIVE_FSTYPE[$source]=$(blkid -s TYPE -o value "$source")
+			[[ ${aDRIVE_FSTYPE[$source]} ]] && aDRIVE_ISFILESYSTEM[$source]=1
 
-		done < <(blkid -o device -c /dev/null)
+		done < <(blkid -o device)
 
 		# Find unformatted drives
 		# - Exclude mtdblock devices: https://github.com/MichaIng/DietPi/issues/2067#issuecomment-422400520
-		while read -r line
+		while read -r source
 		do
-			[[ $line ]] || continue
+			[[ $source ]] || continue
 
 			# Exclude drives already found (formatted)
 			for i in "${aDRIVE_SOURCE_DEVICE[@]}"
 			do
-				[[ $line == $i* ]] && continue 2
+				[[ ${source#/dev/} == $i* ]] && continue 2
 			done
 
-			G_DIETPI-NOTIFY 2 " - Detected unformatted drive: /dev/$line"
+			G_DIETPI-NOTIFY 2 " - Detected unformatted drive: $source"
 
 			Init_New_Device
 
-			aDRIVE_MOUNT_SOURCE[$index]="/dev/$line"
-			aDRIVE_MOUNT_TARGET[$index]="/tmp/$line"
-			aDRIVE_SOURCE_DEVICE[$index]=$line
-			[[ -b ${aDRIVE_MOUNT_SOURCE[$index]} ]] || aDRIVE_ISACCESS[$index]=0
+			aDRIVE_MOUNT_TARGET[$source]="/mnt/${source#/dev/}"
+			aDRIVE_SOURCE_DEVICE[$source]=${source#/dev/}
+			[[ -b $source ]] || aDRIVE_ISACCESS[$source]=0
 
-		done < <(lsblk -nro NAME | sed '/^mtdblock[0-9]/d')
+		done < <(lsblk -npro NAME | sed '/^mtdblock[0-9]/d')
 
 		# Set required global flags and deps for all drives found
 		local deps=()
-		for i in "${!aDRIVE_MOUNT_SOURCE[@]}"
+		for i in "${!aDRIVE_MOUNT_TARGET[@]}"
 		do
 			# Detect and set ROM drives
-			[[ ${aDRIVE_MOUNT_SOURCE[$i]} == '/dev/sr'* ]] && aDRIVE_ISROM[$i]=1
+			[[ $i == '/dev/sr'* ]] && aDRIVE_ISROM[$i]=1
 
 			# Collect required APT packages for FS R/W access
-			if [[ ${aDRIVE_FSTYPE[$i]} == 'ext'[2-4] ]]; then
-
+			if [[ ${aDRIVE_FSTYPE[$i]} == 'ext'[2-4] ]]
+			then
 				deps+=('e2fsprogs')
 
-			elif [[ ${aDRIVE_FSTYPE[$i]} == 'ntfs' ]]; then
-
+			elif [[ ${aDRIVE_FSTYPE[$i]} == 'ntfs' ]]
+			then
 				deps+=('ntfs-3g')
 
-			elif [[ ${aDRIVE_FSTYPE[$i]} =~ 'hfs' ]]; then
-
+			elif [[ ${aDRIVE_FSTYPE[$i]} =~ 'hfs' ]]
+			then
 				deps+=('hfsplus')
 
-			elif [[ ${aDRIVE_FSTYPE[$i]} == 'exfat' ]]; then
-
+			elif [[ ${aDRIVE_FSTYPE[$i]} == 'exfat' ]]
+			then
 				# Install exFAT FUSE driver if the kernel does not support it natively yet, else purge it
 				# - Container: Assume host supports it
 				if (( $G_HW_MODEL == 75 )) || modprobe -nq exfat
@@ -362,7 +343,6 @@ $swap_mounts
 				else
 					deps+=('exfat-fuse')
 				fi
-
 			fi
 		done
 
@@ -374,8 +354,6 @@ $swap_mounts
 			G_DIETPI-NOTIFY 2 'autofs4 module not available in kernel, x-systemd.automount has been disabled, all drives will be mounted at boot instead'
 		fi
 
-		Update_Menu_Drive_Index
-
 		# Move new fstab in place and reload systemd generators
 		G_EXEC mv "$fp_fstab_tmp" /etc/fstab
 		G_EXEC systemctl daemon-reload
@@ -384,21 +362,6 @@ $swap_mounts
 		[[ $APT_CHECK == 0 && ${deps[0]} ]] && G_AG_CHECK_INSTALL_PREREQ "${deps[@]}" && APT_CHECK=1
 		# Workaround for exfat-fuse: https://github.com/MichaIng/DietPi/issues/5166
 		[[ -e '/sbin/mount.exfat-fuse' && ! -e '/sbin/mount.exfat' ]] && G_EXEC ln -sf mount.exfat-fuse /sbin/mount.exfat
-
-		G_EXEC sync
-
-	}
-
-	Update_Menu_Drive_Index(){
-
-		local i
-		[[ $MENU_DRIVE_TARGET ]] && for i in "${!aDRIVE_MOUNT_TARGET[@]}"
-		do
-			[[ $MENU_DRIVE_TARGET == "${aDRIVE_MOUNT_TARGET[$i]}" ]] || continue
-			MENU_DRIVE_INDEX=$i
-			break
-		done
-
 	}
 
 	# $1=source
@@ -423,8 +386,8 @@ $swap_mounts
 	}
 
 	# $1=source $2=target
-	Mount_Drive(){
-
+	Mount_Drive()
+	{
 		local source=$1
 		local target=$2
 
@@ -473,14 +436,11 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 
 		G_EXEC_NOEXIT=1 G_EXEC mkdir -p "$target" || return 1
 		G_EXEC_NOEXIT=1 G_EXEC mount -o "$options" "$source" "$target" || return 1
-		MENU_DRIVE_TARGET=$target
-		Init_Drives_and_Refresh
-
 	}
 
 	# $1=target
-	Unmount_Drive(){
-
+	Unmount_Drive()
+	{
 		local target=$1
 
 		G_EXEC_NOEXIT=1 G_EXEC umount "$target" || return 1
@@ -490,38 +450,36 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 		[[ $automount ]] && { automount=${automount//-/\\x2d}; automount=${automount//\//-}; }
 		[[ -f /run/systemd/generator/$automount.automount ]] && G_EXEC systemctl stop "$automount.automount"
 		G_EXEC_NOEXIT=1 G_EXEC rmdir "$target"
-		Init_Drives_and_Refresh
-
 	}
 
-	Resize_FS(){
-
-		if [[ ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} == '/' ]]; then
-
+	Resize_FS()
+	{
+		if [[ ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} == '/' ]]
+		then
 			G_EXEC systemctl enable dietpi-fs_partition_resize
-			G_WHIP_YESNO 'RootFS resize will occur on next reboot.\n\nWould you like to reboot the system now?' && reboot || return
+			G_WHIP_YESNO 'RootFS resize will occur on next reboot.\n\nWould you like to reboot the system now?' && { reboot; exit 0; } || return
 
-		elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == ext[2-4] ]]; then
-
+		elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == ext[2-4] ]]
+		then
 			if (( ! ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} ))
 			then
 				G_DIETPI-NOTIFY 2 'Running full interactive fsck, required for unmounted ext filesystems to be resized...'
-				e2fsck -f "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
+				e2fsck -f "$MENU_DRIVE_INDEX"
 			fi
-			G_EXEC_NOEXIT=1 G_EXEC resize2fs "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
+			G_EXEC_NOEXIT=1 G_EXEC resize2fs "$MENU_DRIVE_INDEX"
 
-		elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'f2fs' ]]; then
-
+		elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'f2fs' ]]
+		then
 			(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} )) && G_EXEC_NOEXIT=1 G_EXEC umount "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}" || return 1
-			G_EXEC_NOEXIT=1 G_EXEC resize.f2fs "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
+			G_EXEC_NOEXIT=1 G_EXEC resize.f2fs "$MENU_DRIVE_INDEX"
 			(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} )) && G_EXEC_NOEXIT=1 G_EXEC mount "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
 
-		elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'btrfs' ]]; then
-
+		elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'btrfs' ]]
+		then
 			if (( ! ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} ))
 			then
 				G_EXEC_NOEXIT=1 G_EXEC mkdir -p /tmp/temporary_f2fs_mountpoint || return 1
-				G_EXEC_NOEXIT=1 G_EXEC mount "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}" /tmp/temporary_f2fs_mountpoint || return 1
+				G_EXEC_NOEXIT=1 G_EXEC mount "$MENU_DRIVE_INDEX" /tmp/temporary_f2fs_mountpoint || return 1
 			fi
 			G_EXEC_NOEXIT=1 G_EXEC btrfs filesystem resize max "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
 			if (( ! ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} ))
@@ -531,170 +489,148 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 			fi
 		fi
 		Init_Drives_and_Refresh
-
 	}
 
-	Run_Format(){
-
-		local i text_desc info_format_fs_type
-		local info_format_type_output='Drive format' # Used in complete message
-
+	Run_Format()
+	{
 		# Failsafe: No partition table, force drive wipe - actually done in parent menu already
 		(( ${aDRIVE_ISPARTITIONTABLE[$MENU_DRIVE_INDEX]} )) || FORMAT_MODE=0
 
-		if (( $FORMAT_MODE )); then
-
-			text_desc=" - ${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}\n - UUID=${aDRIVE_UUID[$MENU_DRIVE_INDEX]}\n - Filesystem type: $format_type_text\n\nALL DATA on this PARTITION will be DELETED.\nDo you wish to continue?"
-
+		if (( $FORMAT_MODE ))
+		then
+			local device=$MENU_DRIVE_INDEX
+			local text_menu="UUID: ${aDRIVE_UUID[$MENU_DRIVE_INDEX]}\nALL DATA on this PARTITION will be DELETED.\nDo you wish to continue?"
 		else
-
-			text_desc=" - /dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}\n - UUID=${aDRIVE_UUID[$MENU_DRIVE_INDEX]}\n - Partition table: $partition_table_text\n - Filesystem type: $format_type_text\n\nALL DATA and PARTITIONS on this drive will be DELETED.\nDo you wish to continue?"
-
+			local device="/dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}"
+			local text_menu="Partition table: $partition_table_text\nALL DATA and PARTITIONS on this drive will be DELETED.\nDo you wish to continue?"
 		fi
 
-		if G_WHIP_YESNO "Ready to format:\n$text_desc"; then
+		G_WHIP_YESNO "Ready to format:\n - $device\n - Filesystem type: $text_fs_type\n - $text_menu" || return 0
 
-			# Partition format
-			if (( $FORMAT_MODE ))
+		# Partition format
+		if (( $FORMAT_MODE ))
+		then
+			# Unmount
+			(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} )) && { Unmount_Drive "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}" || return 1; }
+
+			# Clear partition from device
+			G_DIETPI-NOTIFY 2 "Erasing partition: $device"
+			G_EXEC dd if=/dev/zero of="$device" bs=4K count=1337
+
+		# Drive format: Create a new partition table
+		else
+			# Unmount and zero all partitions on device
+			# - Partition wipe must be done 1st, else UUIDs are still reported.
+			local i
+			for i in "$device"?*
+			do
+				[[ $i == '/dev/mmcblk'[0-9]'boot'[0-9] ]] && continue # Skip /dev/mmcblk0boot0 special boot sector eMMC partitions on e.g. Odroid N2
+				[[ -b $i ]] || continue
+				local target=$(findmnt -Ufnro TARGET -S "$i")
+				[[ $target ]] && { Unmount_Drive "$target" || return 1; }
+				G_DIETPI-NOTIFY 2 "Writing zeros to partition: $i"
+				G_EXEC dd if=/dev/zero of="$i" bs=4K count=10
+			done
+
+			# Unmount whole drive in case of fs on drive without partition table
+			(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} )) && { Unmount_Drive "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}" || return 1; }
+
+			# Clear partition table from device
+			G_DIETPI-NOTIFY 2 "Erasing partition table: /dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}"
+			G_EXEC dd if=/dev/zero of="$device" bs=4K count=1337 # Block device wipe
+
+			# Create partition table type
+			local partition_table_type='gpt'
+			(( $FORMAT_GPT )) || partition_table_type='msdos'
+
+			G_DIETPI-NOTIFY 2 "Creating new $partition_table_type partition table"
+			G_EXEC parted -s "$device" mklabel "$partition_table_type"
+			G_EXEC parted -s "$device" mkpart primary 0% 100%
+			G_EXEC partx -u "$device"
+
+			# Append new partition to device path
+			# - hda1/sda1/vda1/xvda1
+			if [[ ${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]} =~ ^(sd|hd|vd|xvd)[a-z]$ ]]
 			then
-				info_format_type_output='Single partition format'
+				device+='1'
 
-				# Unmount
-				(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} )) && { Unmount_Drive "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}" || return 1; }
-
-				# Clear partition from device
-				G_DIETPI-NOTIFY 2 "Erasing partition: ${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
-				G_EXEC dd if=/dev/zero of="${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}" bs=4K count=1337
-
-			# Drive format: Create a new partition table
+			# - mmcblk0p1/nvme0n0p1/loop0p1
 			else
-				# Unmount and zero all partitions on device
-				# - Partition wipe must be done 1st, else UUIDs are still reported.
-				for i in "/dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}"?*
-				do
-					[[ $i == '/dev/mmcblk'[0-9]'boot'[0-9] ]] && continue # Skip /dev/mmcblk0boot0 special boot sector eMMC partitions on e.g. Odroid N2
-					[[ -b $i ]] || continue
-					local target=$(findmnt -Ufnro TARGET -S "$i")
-					[[ $target ]] && { Unmount_Drive "$target"  || return 1; }
-					G_DIETPI-NOTIFY 2 "Writing zeros to partition: $i"
-					G_EXEC dd if=/dev/zero of="$i" bs=4K count=10
-				done
-
-				# Unmount whole drive in case of fs on drive without partition table
-				(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} )) && { Unmount_Drive "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}" || return 1; }
-
-				# Clear partition table from device
-				G_DIETPI-NOTIFY 2 "Erasing partition table: /dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}"
-				G_EXEC dd if=/dev/zero of="/dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}" bs=4K count=1337 # Block device wipe
-
-				# Create partition table type
-				local partition_table_type='gpt'
-				(( $FORMAT_GPT )) || partition_table_type='msdos'
-
-				G_DIETPI-NOTIFY 2 "Creating new $partition_table_type partition table"
-				G_EXEC parted -s "/dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}" mklabel "$partition_table_type"
-				G_EXEC parted -s "/dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}" mkpart primary 0% 100%
-				G_EXEC partprobe "/dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}"
-				G_EXEC partx -u "/dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}"
-
-				# Generate new aDRIVE_MOUNT_SOURCE location to use
-				# - hda1/sda1/vda1
-				if [[ ${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]} == [shv]d[a-z] ]]
-				then
-					aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]="/dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}1"
-
-				# - mmcblk0p1/nvme0n0p1/loop0p1
-				else
-					aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]="/dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}p1"
-				fi
+				device+='p1'
 			fi
-
-			# Format ext4
-			if (( $FORMAT_FILESYSTEM_TYPE == 0 )); then
-
-				# force
-				info_format_fs_type='ext4'
-				G_EXEC mkfs.ext4 -F -m 0 "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
-				G_EXEC resize2fs "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
-
-			# Format NTFS
-			elif (( $FORMAT_FILESYSTEM_TYPE == 1 )); then
-
-				# -f: fast format | -I: no indexing | -F: force
-				info_format_fs_type='NTFS'
-				G_EXEC mkfs.ntfs -f -I -F "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
-
-			# Format FAT32
-			elif (( $FORMAT_FILESYSTEM_TYPE == 2 )); then
-
-				# -I: Use 1 partition on whole device
-				info_format_fs_type='FAT'
-				G_EXEC mkfs.fat -I "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
-
-			# Format HFS+
-			elif (( $FORMAT_FILESYSTEM_TYPE == 3 )); then
-
-				info_format_fs_type='HFS+'
-				G_EXEC mkfs.hfsplus "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
-
-			# Format Btrfs
-			elif (( $FORMAT_FILESYSTEM_TYPE == 4 )); then
-
-				# -f: force
-				info_format_fs_type='Btrfs'
-				G_EXEC mkfs.btrfs -f "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
-
-			# Format f2fs
-			elif (( $FORMAT_FILESYSTEM_TYPE == 5 )); then
-
-				info_format_fs_type='F2FS'
-				G_EXEC mkfs.f2fs "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
-
-			# Format exFAT
-			elif (( $FORMAT_FILESYSTEM_TYPE == 6 )); then
-
-				info_format_fs_type='exFAT'
-				G_EXEC mkfs.exfat "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
-
-			# Format XFS
-			elif (( $FORMAT_FILESYSTEM_TYPE == 7 )); then
-
-				# -f: force
-				info_format_fs_type='XFS'
-				G_EXEC mkfs.xfs -f "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
-
-			fi
-
-			G_EXEC sync # Sync to disk, as well to add a slight delay since XFS formatted filesystems do not return a UUID (below) immediately
-
-			G_DIETPI-NOTIFY 0 "Created $info_format_fs_type filesystem: ${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
-			FORMAT_COMPLETED=1
-
-			# Remove old mount point
-			[[ -e ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} ]] && G_EXEC_NOEXIT=1 G_EXEC rm -R "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
-
-			# Automatically mount it
-			local new_uuid=$(blkid -s UUID -o value "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}")
-			if ! Mount_Drive "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}" "/mnt/$new_uuid"; then
-
-				MENU_DRIVE_TARGET="/mnt/$new_uuid"
-				Init_Drives_and_Refresh
-
-			fi
-
-			G_WHIP_MSG "[  OK  ] Format completed\n
- - Format Type      : $info_format_type_output
- - Filesystem Type  : $info_format_fs_type
- - Mount Source     : ${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}
- - Mount Target     : $MENU_DRIVE_TARGET
- - UUID             : $new_uuid"
-
 		fi
 
+		# Format ext4
+		if (( $FORMAT_FILESYSTEM_TYPE == 0 ))
+		then
+			# -F: force | -m: reserved blocks | -e error behaviour
+			G_EXEC mkfs.ext4 -F -m 0 -e 'remount-ro' "$device"
+
+		# Format NTFS
+		elif (( $FORMAT_FILESYSTEM_TYPE == 1 ))
+		then
+			# -f: fast format | -I: no indexing | -F: force
+			G_EXEC mkfs.ntfs -f -I -F "$device"
+
+		# Format FAT32
+		elif (( $FORMAT_FILESYSTEM_TYPE == 2 ))
+		then
+			# -I: Use 1 partition on whole device | -F 32: FAT32
+			G_EXEC mkfs.fat -I -F 32 "$device"
+
+		# Format HFS+
+		elif (( $FORMAT_FILESYSTEM_TYPE == 3 ))
+		then
+			G_EXEC mkfs.hfsplus "$device"
+
+		# Format Btrfs
+		elif (( $FORMAT_FILESYSTEM_TYPE == 4 ))
+		then
+			# -f: force
+			G_EXEC mkfs.btrfs -f "$device"
+
+		# Format f2fs
+		elif (( $FORMAT_FILESYSTEM_TYPE == 5 ))
+		then
+			G_EXEC mkfs.f2fs "$device"
+
+		# Format exFAT
+		elif (( $FORMAT_FILESYSTEM_TYPE == 6 ))
+		then
+			G_EXEC mkfs.exfat "$device"
+
+		# Format XFS
+		elif (( $FORMAT_FILESYSTEM_TYPE == 7 ))
+		then
+			# -f: force
+			G_EXEC mkfs.xfs -f "$device"
+		fi
+
+		G_EXEC sync # Sync to disk, as well to add a slight delay since XFS formatted filesystems do not return a UUID (below) immediately
+
+		G_DIETPI-NOTIFY 0 "Created $text_fs_type filesystem: $device"
+		FORMAT_COMPLETED=1
+
+		# Remove old mount point
+		[[ -e ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} ]] && G_EXEC_NOEXIT=1 G_EXEC rm -R "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
+
+		# Automatically mount it
+		local new_uuid=$(blkid -s UUID -o value "$device")
+		Mount_Drive "$device" "/mnt/${new_uuid:-${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}}"
+		Init_Drives_and_Refresh
+		MENU_DRIVE_INDEX=$device
+		TARGETMENUID=1 # Drive menu
+
+		G_WHIP_MSG "[  OK  ] Format completed\n
+ - Format Mode      : $format_mode_text
+ - Filesystem Type  : $text_fs_type
+ - Mount Source     : $device
+ - Mount Target     : ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}
+ - UUID             : ${aDRIVE_UUID[$MENU_DRIVE_INDEX]}"
 	}
 
-	RootFS_Move(){
-
+	RootFS_Move()
+	{
 		(( $SERVICES_STOPPED )) || { /boot/dietpi/dietpi-services stop; SERVICES_STOPPED=1; }
 
 		# Install rsync
@@ -707,13 +643,12 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 		G_EXEC mount "$G_ROOTFS_DEV" /tmp/tmp_rootfs
 
 		# Start rsync
-		if ! G_EXEC_NOEXIT=1 G_EXEC rsync -aHv --delete /tmp/tmp_rootfs/ "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}/"; then
-
+		if ! G_EXEC_NOEXIT=1 G_EXEC rsync -aHv --delete /tmp/tmp_rootfs/ "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}/"
+		then
 			G_DIETPI-NOTIFY 1 'Rsync has failed, RootFS transfer has been aborted.'
 			umount /tmp/tmp_rootfs
 			rmdir --ignore-fail-on-non-empty /tmp/tmp_rootfs
 			return 1
-
 		fi
 
 		# Remove volatile systemd service PrivateTmp dirs in /var/tmp and target drive mount point dir
@@ -752,66 +687,55 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 
 		G_WHIP_MSG 'RootFS transfer has successfully completed.\n\nA reboot is required, please press <return> to reboot now.'
 		reboot
-
+		exit 0
 	}
 
-	Toggle_WriteMode(){
-
+	Toggle_WriteMode()
+	{
 		local exit_status=0
 		local message_result=0
 
-		if (( ${aDRIVE_ISREADONLY_CURRENTLY[$MENU_DRIVE_INDEX]} )); then
-
-			message_result=$(mount -v -o remount,rw "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}" 2>&1)
+		if (( ${aDRIVE_ISREADONLY_CURRENTLY[$MENU_DRIVE_INDEX]} ))
+		then
+			message_result=$(mount -v -o remount,rw "$MENU_DRIVE_INDEX" 2>&1)
 			exit_status=$?
-
 		else
-
 			(( $SERVICES_STOPPED )) || { /boot/dietpi/dietpi-services stop; SERVICES_STOPPED=1; }
 
 			# RootFS, set fstab now, else, will not be applied to /etc/fstab during Init as already RO: https://github.com/MichaIng/DietPi/issues/2604
-			if [[ ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} == '/' ]]; then
-
+			if [[ ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} == '/' ]]
+			then
 				local line_number=$(grep -n "[[:blank:]]${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}[[:blank:]].*,rw" /etc/fstab | cut -d : -f 1)
 				sed --follow-symlinks -i "${line_number}s/,rw/,ro/" /etc/fstab
-
 			fi
-			message_result=$(mount -v -o remount,ro "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}" 2>&1)
+			message_result=$(mount -v -o remount,ro "$MENU_DRIVE_INDEX" 2>&1)
 			exit_status=$?
-
 		fi
 
 		(( $exit_status )) && G_WHIP_MSG "[FAILED] Could not apply\n\nError log:\n - $message_result"
 		Init_Drives_and_Refresh
-
 	}
 
 	TARGETMENUID=0
 	G_WHIP_DEFAULT_ITEM_NEXT=
-	Menu_Main(){
-
+	Menu_Main()
+	{
 		# Generate menu
 		G_WHIP_MENU_ARRAY=()
 
-		# - Create a nice category list, to match items to their block device (eg: mmcblk0)
+		# Create a nice category list, to match items to their block device (eg: mmcblk0)
 		local acategory_list=()
 		local i j
-		for i in "${!aDRIVE_MOUNT_SOURCE[@]}"
+		for i in "${aDRIVE_SOURCE_DEVICE[@]}"
 		do
-			local new_cat=1
-
+			# Skip if category exists already
 			for j in "${!acategory_list[@]}"
 			do
-				if [[ ${aDRIVE_SOURCE_DEVICE[$i]} == "${acategory_list[$j]}" ]]; then
-
-					new_cat=0
-					break
-
-				fi
+				[[ $i == "${acategory_list[$j]}" ]] && continue 2
 			done
 
 			# Add
-			(( $new_cat )) && acategory_list+=("${aDRIVE_SOURCE_DEVICE[$i]}")
+			acategory_list+=("$i")
 		done
 
 		# List all available drives, if no drive found, list info for user.
@@ -821,54 +745,44 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 			drive_available=1
 			G_WHIP_MENU_ARRAY+=('' "●─ ${acategory_list[$i]} ")
 
-			for j in "${!aDRIVE_MOUNT_SOURCE[@]}"
+			for j in "${!aDRIVE_MOUNT_TARGET[@]}"
 			do
-				if [[ ${aDRIVE_SOURCE_DEVICE[$j]} == "${acategory_list[$i]}" ]]; then
-
+				if [[ ${aDRIVE_SOURCE_DEVICE[$j]} == "${acategory_list[$i]}" ]]
+				then
 					# Drive is fully mounted
-					if (( ${aDRIVE_ISMOUNTED[$j]} )); then
-
-						G_WHIP_MENU_ARRAY+=("${aDRIVE_MOUNT_TARGET[$j]}" ": ${aDRIVE_MOUNT_SOURCE[$j]} | ${aDRIVE_FSTYPE[$j]} | Capacity: ${aDRIVE_SIZE_TOTAL[$j]} | Used: ${aDRIVE_SIZE_USED[$j]} (${aDRIVE_SIZE_PERCENTUSED[$j]})")
+					if (( ${aDRIVE_ISMOUNTED[$j]} ))
+					then
+						G_WHIP_MENU_ARRAY+=("$j" ": ${aDRIVE_MOUNT_TARGET[$j]} | ${aDRIVE_FSTYPE[$j]} | Capacity: ${aDRIVE_SIZE_TOTAL[$j]} | Used: ${aDRIVE_SIZE_USED[$j]} (${aDRIVE_SIZE_PERCENTUSED[$j]})")
 
 					# Drive has filesystem
-					elif (( ${aDRIVE_ISFILESYSTEM[$j]} )); then
-
-						G_WHIP_MENU_ARRAY+=("${aDRIVE_MOUNT_TARGET[$j]}" ": ${aDRIVE_MOUNT_SOURCE[$j]} | ${aDRIVE_FSTYPE[$j]} | Not mounted")
+					elif (( ${aDRIVE_ISFILESYSTEM[$j]} ))
+					then
+						G_WHIP_MENU_ARRAY+=("$j" ": ${aDRIVE_MOUNT_TARGET[$j]} | ${aDRIVE_FSTYPE[$j]} | Not mounted")
 
 					# Drive is not formatted
 					else
-
 						# ROM device with no ROM attached
-						if (( ${aDRIVE_ISROM[$j]} )); then
-
-							G_WHIP_MENU_ARRAY+=("${aDRIVE_MOUNT_TARGET[$j]}" ": ${aDRIVE_MOUNT_SOURCE[$j]} | Please insert media into the ROM device")
-
+						if (( ${aDRIVE_ISROM[$j]} ))
+						then
+							G_WHIP_MENU_ARRAY+=("$j" ": ${aDRIVE_MOUNT_TARGET[$j]} | Please insert media into the ROM device")
 						else
-
-							G_WHIP_MENU_ARRAY+=("${aDRIVE_MOUNT_TARGET[$j]}" ": ${aDRIVE_MOUNT_SOURCE[$j]} | No filesystem / format required")
-
+							G_WHIP_MENU_ARRAY+=("$j" ": ${aDRIVE_MOUNT_TARGET[$j]} | No filesystem / format required")
 						fi
-
 					fi
-
 				fi
 			done
 		done
-
-		unset acategory_list
+		unset -v acategory_list
 
 		G_WHIP_MENU_ARRAY+=('' '●─ Global Options ')
 		G_WHIP_MENU_ARRAY+=('Idle Spindown' ': Set a global idle duration, before drives power down')
 		G_WHIP_MENU_ARRAY+=('' '●─ Add / Refresh Drives ')
 		G_WHIP_MENU_ARRAY+=('Add network drive' ': Select to mount networked drives')
-		if (( $drive_available )); then
-
+		if (( $drive_available ))
+		then
 			G_WHIP_MENU_ARRAY+=('Refresh' ': Scan for recently added/removed drives')
-
 		else
-
 			G_WHIP_MENU_ARRAY+=('Refresh' ': No drives found. Insert a drive and select this option')
-
 		fi
 
 		# User data
@@ -877,84 +791,74 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 
 		G_WHIP_DEFAULT_ITEM=${G_WHIP_DEFAULT_ITEM_NEXT:-${G_WHIP_MENU_ARRAY[2]}}
 		G_WHIP_BUTTON_CANCEL_TEXT='Exit'
-		if G_WHIP_MENU "Please select a drive to see available options.\n - User data location: $userdata_location_text"; then
+		G_WHIP_MENU "Please select a drive to see available options.\n - User data location: $userdata_location_text" || { TARGETMENUID=-1; return 0; } # Exit
 
-			G_WHIP_DEFAULT_ITEM_NEXT=$G_WHIP_RETURNED_VALUE
+		G_WHIP_DEFAULT_ITEM_NEXT=$G_WHIP_RETURNED_VALUE
 
-			# Refresh
-			if [[ $G_WHIP_RETURNED_VALUE == 'Refresh' ]]; then
+		# Refresh
+		if [[ $G_WHIP_RETURNED_VALUE == 'Refresh' ]]
+		then
+			APT_CHECK=0 # Recheck for required APT packages, in case a new drive got attached
+			Init_Drives_and_Refresh
 
-				APT_CHECK=0 # Recheck for required APT packages, in case a new drive got attached
-				Init_Drives_and_Refresh
+		elif [[ $G_WHIP_RETURNED_VALUE == 'Add network drive' ]]
+		then
+			TARGETMENUID=3 # Add network drive menu
 
-			elif [[ $G_WHIP_RETURNED_VALUE == 'Add network drive' ]]; then
+		elif [[ $G_WHIP_RETURNED_VALUE == 'Idle Spindown' ]]
+		then
+			local current_spindown=
+			[[ -f '/etc/hdparm.conf' ]] && current_spindown=$(sed -n '/^[[:blank:]]*force_spindown_time[[:blank:]=]/{s/^[^=]*=[[:blank:]]*//p;q}' /etc/hdparm.conf)
+			disable_error=1 G_CHECK_VALIDINT "$current_spindown" 0 251 && G_WHIP_DEFAULT_ITEM=$current_spindown || G_WHIP_DEFAULT_ITEM=241
 
-				TARGETMENUID=3 # Add network drive menu
+			G_WHIP_MENU_ARRAY=('0' ': Disabled')
 
-			elif [[ $G_WHIP_RETURNED_VALUE == 'Idle Spindown' ]]
-			then
-				local current_spindown=
-				[[ -f '/etc/hdparm.conf' ]] && current_spindown=$(sed -n '/^[[:blank:]]*force_spindown_time[[:blank:]=]/{s/^[^=]*=[[:blank:]]*//p;q}' /etc/hdparm.conf)
-				disable_error=1 G_CHECK_VALIDINT "$current_spindown" 0 251 && G_WHIP_DEFAULT_ITEM=$current_spindown || G_WHIP_DEFAULT_ITEM=241
+			local minutes seconds text
+			for i in {12..251}
+			do
+				if (( $i < 241 ))
+				then
+					minutes=$(( $i * 5 / 60 ))
+					seconds=$(( $i * 5 % 60 ))
+					text="$minutes Minute"
+					(( $minutes > 1 )) && text+='s'
+					(( $seconds )) && text+=", $seconds Seconds"
+				else
+					text=" $(( ( $i - 240 ) * 30 )) Minutes"
+				fi
 
-				G_WHIP_MENU_ARRAY=('0' ': Disabled')
+				G_WHIP_MENU_ARRAY+=("$i" ": $text")
+			done
 
-				local minutes seconds text
-				for i in {12..251}
-				do
-					if (( $i < 241 ))
-					then
-						minutes=$(( $i * 5 / 60 ))
-						seconds=$(( $i * 5 % 60 ))
-						text="$minutes Minute"
-						(( $minutes > 1 )) && text+='s'
-						(( $seconds )) && text+=", $seconds Seconds"
-					else
-						text=" $(( ( $i - 240 ) * 30 )) Minutes"
-					fi
-
-					G_WHIP_MENU_ARRAY+=("$i" ": $text")
-				done
-
-				if G_WHIP_MENU 'Please select an idle duration of time, before drives are powered down:
+			if G_WHIP_MENU 'Please select an idle duration of time, before drives are powered down:
  - This will be applied to all drives on the system.
  - Not all drives support the features of "hdparm". End results may vary.
  - You can check status with "hdparm -C /dev/[sh]d[a-z]"'
-				then
-					G_DIETPI-NOTIFY 2 'Applying spindown timeout to all drives now ...'
-					G_EXEC_NOHALT=1 G_EXEC hdparm -S "$G_WHIP_RETURNED_VALUE" /dev/[sh]d[a-z]
+			then
+				G_DIETPI-NOTIFY 2 'Applying spindown timeout to all drives now ...'
+				G_EXEC_NOHALT=1 G_EXEC hdparm -S "$G_WHIP_RETURNED_VALUE" /dev/[sh]d[a-z]
 
-					G_DIETPI-NOTIFY 2 'Applying spindown timeout to /etc/hdparm.conf as default from next boot on ...'
-					G_CONFIG_INJECT 'force_spindown_time[[:blank:]=]' "force_spindown_time = $G_WHIP_RETURNED_VALUE" /etc/hdparm.conf
-				fi
-
-			# Edit drive
-			elif [[ $G_WHIP_RETURNED_VALUE ]]; then
-
-				TARGETMENUID=1 # Drive menu
-				MENU_DRIVE_TARGET=$G_WHIP_RETURNED_VALUE
-				Update_Menu_Drive_Index
-
+				G_DIETPI-NOTIFY 2 'Applying spindown timeout to /etc/hdparm.conf as default from next boot on ...'
+				G_CONFIG_INJECT 'force_spindown_time[[:blank:]=]' "force_spindown_time = $G_WHIP_RETURNED_VALUE" /etc/hdparm.conf
 			fi
 
-		else
-
-			TARGETMENUID=-1 # Exit
-
+		# Edit drive
+		elif [[ $G_WHIP_RETURNED_VALUE ]]
+		then
+			TARGETMENUID=1 # Drive menu
+			MENU_DRIVE_INDEX=$G_WHIP_RETURNED_VALUE
 		fi
-
 	}
 
-	Notification(){
-
-		if (( $1 == 0 )); then
-
+	Notification()
+	{
+		if (( $1 == 0 ))
+		then
 			G_WHIP_MSG "[FAILED]\n\nYour DietPi userdata is currently located on this drive:\n - $FP_USERDATA_CURRENT\n\nThe requested option for this drive is not currently possible.\n\nPlease move your userdata elsewhere, before trying again:\nhttps://dietpi.com/docs/dietpi_tools/#quick-selections"
 
-		elif (( $1 == 1 )); then
-
+		elif (( $1 == 1 ))
+		then
 			G_WHIP_MSG "[FAILED]\n\nThe DietPi swap file is currently located on this drive:\n - $FP_SWAPFILE_CURRENT\n\nThe requested option for this drive is not currently possible.\n\nPlease move the swap file elsewhere, before trying again."
-
 		fi
 
 	}
@@ -975,66 +879,58 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 
 	# TARGETMENUID=1
 	G_WHIP_DEFAULT_ITEM_NEXT_SUB1=
-	Menu_Drive(){
-
+	Menu_Drive()
+	{
 		G_WHIP_MENU_ARRAY=()
 		local partition_contains_userdata=0
 		local partition_contains_swapfile=0
 		local whiptail_desc="Mount target: ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
-		whiptail_desc+="\nMount source: ${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
+		whiptail_desc+="\nMount source: $MENU_DRIVE_INDEX"
 
 		# No filesystem
-		if (( ! ${aDRIVE_ISFILESYSTEM[$MENU_DRIVE_INDEX]} )); then
-
-			if (( ${aDRIVE_ISROM[$MENU_DRIVE_INDEX]} )); then
-
+		if (( ! ${aDRIVE_ISFILESYSTEM[$MENU_DRIVE_INDEX]} ))
+		then
+			if (( ${aDRIVE_ISROM[$MENU_DRIVE_INDEX]} ))
+			then
 				whiptail_desc+='\nStatus:       No media found, please insert media into the ROM device'
 				G_WHIP_MENU_ARRAY+=('Refresh' ': No media found, please insert media into the ROM device')
-
 			else
-
 				whiptail_desc+='\nStatus:       Drive has no known filesystem and must be formatted'
 				G_WHIP_MENU_ARRAY+=('Format' ': Create a filesystem for this drive/partition')
-
 			fi
 			G_WHIP_DEFAULT_ITEM_NEXT_SUB1=${G_WHIP_DEFAULT_ITEM_NEXT_SUB1:-${G_WHIP_MENU_ARRAY[0]}}
 
 		# Filesystem
 		else
-
 			whiptail_desc+="\nFilesystem:   ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]}"
 			[[ ${aDRIVE_UUID[$MENU_DRIVE_INDEX]} ]] && whiptail_desc+="\nUUID:         ${aDRIVE_UUID[$MENU_DRIVE_INDEX]}"
 
-			if (( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} )); then
-
+			if (( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} ))
+			then
 				whiptail_desc+="\nAllocation:   Capacity: ${aDRIVE_SIZE_TOTAL[$MENU_DRIVE_INDEX]}iB | Used: ${aDRIVE_SIZE_USED[$MENU_DRIVE_INDEX]}iB (${aDRIVE_SIZE_PERCENTUSED[$MENU_DRIVE_INDEX]})\nStatus:       Drive is online and ready for use"
 
 				# Unmount: Disable for root and boot mounts
-				if [[ ! ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} =~ ^/(boot(/efi|/firmware)?)?$ ]]; then
-
+				if [[ ! ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} =~ ^/(boot(/efi|/firmware)?)?$ ]]
+				then
 					G_WHIP_MENU_ARRAY+=('' '●─ Mount Control ')
-					if (( ${aDRIVE_ISNETWORKED[$MENU_DRIVE_INDEX]} )); then
-
+					if (( ${aDRIVE_ISNETWORKED[$MENU_DRIVE_INDEX]} ))
+					then
 						G_WHIP_MENU_ARRAY+=('Remove' ': Unmount networked drive and remove it from database')
-
 					else
-
 						G_WHIP_MENU_ARRAY+=('Unmount' ': Allows you to physically remove the drive')
-
 					fi
-
 				fi
 
-				if (( ! ${aDRIVE_ISROM[$MENU_DRIVE_INDEX]} )); then
-
-					if (( ! ${aDRIVE_ISREADONLY_CURRENTLY[$MENU_DRIVE_INDEX]} )); then
-
+				if (( ! ${aDRIVE_ISROM[$MENU_DRIVE_INDEX]} ))
+				then
+					if (( ! ${aDRIVE_ISREADONLY_CURRENTLY[$MENU_DRIVE_INDEX]} ))
+					then
 						G_WHIP_MENU_ARRAY+=('' '●─ Benchmark Options ')
 						G_WHIP_MENU_ARRAY+=('Benchmark' ': Test read and write speeds')
 
 						# User data and swap file location
-						if (( ! ${aDRIVE_ISNETWORKED[$MENU_DRIVE_INDEX]} )); then
-
+						if (( ! ${aDRIVE_ISNETWORKED[$MENU_DRIVE_INDEX]} ))
+						then
 							G_WHIP_MENU_ARRAY+=('' '●─ Userdata & Swap options ')
 
 							# User data
@@ -1058,13 +954,11 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 									G_WHIP_MENU_ARRAY+=('Swap file' ': [ ] | Select to transfer swap file to this drive')
 								fi
 							fi
-
 						fi
-
 					fi
 
-					if (( ! ${aDRIVE_ISNETWORKED[$MENU_DRIVE_INDEX]} )); then
-
+					if (( ! ${aDRIVE_ISNETWORKED[$MENU_DRIVE_INDEX]} ))
+					then
 						G_WHIP_MENU_ARRAY+=('' '●─ Advanced options ')
 
 						# Read only?
@@ -1072,28 +966,23 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 						(( ${aDRIVE_ISREADONLY_CURRENTLY[$MENU_DRIVE_INDEX]} )) && read_only_state='[X]' read_only_state_text='Enabled'
 						G_WHIP_MENU_ARRAY+=('Read Only' ": $read_only_state | Select to toggle RW/RO modes")
 						whiptail_desc+="\nRead only:    $read_only_state_text"
-
 					fi
-
 				fi
-
 			else
-
 				whiptail_desc+='\nStatus:       Drive is not mounted and can be unplugged'
 				G_WHIP_MENU_ARRAY+=('' '●─ Mount Control ')
 				G_WHIP_MENU_ARRAY+=('Mount' ": Mount the drive to ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}")
 				G_WHIP_MENU_ARRAY+=('' '●─ Advanced Options ')
-
 			fi
 			G_WHIP_DEFAULT_ITEM_NEXT_SUB1=${G_WHIP_DEFAULT_ITEM_NEXT_SUB1:-${G_WHIP_MENU_ARRAY[2]}}
 
-			if (( ${aDRIVE_ISACCESS[$MENU_DRIVE_INDEX]} && ! ${aDRIVE_ISROM[$MENU_DRIVE_INDEX]} && ! ${aDRIVE_ISNETWORKED[$MENU_DRIVE_INDEX]} )); then
-
+			if (( ${aDRIVE_ISACCESS[$MENU_DRIVE_INDEX]} && ! ${aDRIVE_ISROM[$MENU_DRIVE_INDEX]} && ! ${aDRIVE_ISNETWORKED[$MENU_DRIVE_INDEX]} ))
+			then
 				# Reserved blocks percentage on ext4 filesystems
 				if [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'ext4' ]]
 				then
 					local blocks reserved_blocks block_size
-					read -r blocks reserved_blocks block_size < <(dumpe2fs -h "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}" 2> /dev/null | mawk '$0~/^(Block count|Reserved block count|Block size):/{print $NF}' ORS=' ')
+					read -r blocks reserved_blocks block_size < <(dumpe2fs -h "$MENU_DRIVE_INDEX" 2> /dev/null | mawk '$0~/^(Block count|Reserved block count|Block size):/{print $NF}' ORS=' ')
 					local reserved_blocks_size=$(( $reserved_blocks * $block_size / 1024**2 )) # MiB
 					G_WHIP_MENU_ARRAY+=('Reserved blocks' ": [$reserved_blocks_size MiB] | Space reserved for root user")
 				fi
@@ -1106,18 +995,15 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 
 				# Format: Disable for root and boot mounts
 				[[ ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} =~ ^/(boot(/efi|/firmware)?)?$ ]] || G_WHIP_MENU_ARRAY+=('Format' ': Select to see formatting options')
-
 			fi
-
 		fi
 
 		if (( ${aDRIVE_ISACCESS[$MENU_DRIVE_INDEX]} && ! ${aDRIVE_ISROM[$MENU_DRIVE_INDEX]} && ! ${aDRIVE_ISNETWORKED[$MENU_DRIVE_INDEX]} ))
 		then
 			# Transfer RootFS: Supported on RPi and Odroids C2/XU4/N2/C4 if there is a dedicated boot mount
-			if [[ ${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]} != "$G_ROOTFS_DEV" ]] && { (( $G_HW_MODEL < 10 )) || { (( $G_HW_MODEL < 20 )) && findmnt -M /boot > /dev/null; }; } then
-
+			if [[ $MENU_DRIVE_INDEX != "$G_ROOTFS_DEV" ]] && { (( $G_HW_MODEL < 10 )) || { (( $G_HW_MODEL < 20 )) && findmnt -M /boot > /dev/null; }; }
+			then
 				G_WHIP_MENU_ARRAY+=('Transfer RootFS' ': Transfer RootFS to this drive')
-
 			fi
 		fi
 
@@ -1144,370 +1030,344 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 
 		G_WHIP_BUTTON_CANCEL_TEXT='Back'
 		G_WHIP_DEFAULT_ITEM=$G_WHIP_DEFAULT_ITEM_NEXT_SUB1
-		if G_WHIP_MENU "$whiptail_desc"; then
+		G_WHIP_MENU "$whiptail_desc" || { TARGETMENUID=0; return 0; } # Main menu
 
-			G_WHIP_DEFAULT_ITEM_NEXT_SUB1=$G_WHIP_RETURNED_VALUE
+		G_WHIP_DEFAULT_ITEM_NEXT_SUB1=$G_WHIP_RETURNED_VALUE
 
-			if [[ $G_WHIP_RETURNED_VALUE == 'Mount' ]]; then
+		if [[ $G_WHIP_RETURNED_VALUE == 'Mount' ]]
+		then
+			Mount_Drive "$MENU_DRIVE_INDEX" "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
+			Init_Drives_and_Refresh
 
-				Mount_Drive "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}" "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
+		elif [[ $G_WHIP_RETURNED_VALUE == 'Unmount' || $G_WHIP_RETURNED_VALUE == 'Remove' ]]
+		then
+			# Disallow if userdata is located on this drive!
+			if (( $partition_contains_userdata ))
+			then
+				Notification 0
 
-			elif [[ $G_WHIP_RETURNED_VALUE == 'Unmount' || $G_WHIP_RETURNED_VALUE == 'Remove' ]]; then
+			elif (( $partition_contains_swapfile ))
+			then
+				Notification 1
 
-				# Disallow if userdata is located on this drive!
-				if (( $partition_contains_userdata )); then
-
-					Notification 0
-
-				elif (( $partition_contains_swapfile )); then
-
-					Notification 1
-
-				elif [[ $G_WHIP_RETURNED_VALUE == 'Remove' ]]; then
-
-					if G_WHIP_YESNO "Do you wish to unmount and remove the following networked drive from this system?
- - ${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]} > ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}
-\nNB: You can add additional network shares at a later date through the 'dietpi-drive_manager' main menu."; then
-
-						# Remove credentials file
-						local cred="/var/lib/dietpi/dietpi-drive_manager${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]//\//-}.cred"
-						cred=${cred/drive_manager-mnt-/drive_manager\/mnt-}
-						[[ -f $cred ]] && G_EXEC rm "$cred"
-						[[ -d '/var/lib/dietpi/dietpi-drive_manager' ]] && G_EXEC rmdir --ignore-fail-on-non-empty /var/lib/dietpi/dietpi-drive_manager
-
-						Unmount_Drive "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
-						TARGETMENUID=0 # Main menu
-
-					fi
-
-				else
+			elif [[ $G_WHIP_RETURNED_VALUE == 'Remove' ]]
+			then
+				if G_WHIP_YESNO "Do you wish to unmount and remove the following networked drive from this system?
+ - $MENU_DRIVE_INDEX > ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}
+\nNB: You can add additional network shares at a later date through the 'dietpi-drive_manager' main menu."
+				then
+					# Remove credentials file
+					local cred="/var/lib/dietpi/dietpi-drive_manager${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]//\//-}.cred"
+					cred=${cred/drive_manager-mnt-/drive_manager\/mnt-}
+					[[ -f $cred ]] && G_EXEC rm "$cred"
+					[[ -d '/var/lib/dietpi/dietpi-drive_manager' ]] && G_EXEC rmdir --ignore-fail-on-non-empty /var/lib/dietpi/dietpi-drive_manager
 
 					Unmount_Drive "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
-
+					Init_Drives_and_Refresh
+					TARGETMENUID=0 # Main menu
 				fi
+			else
+				Unmount_Drive "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
+				Init_Drives_and_Refresh
+			fi
 
-			elif [[ $G_WHIP_RETURNED_VALUE == 'Swap file' ]]; then
-
-				local min=0
-				local current=0
-				[[ $partition_contains_swapfile && -f $FP_SWAPFILE_CURRENT ]] && current=$(( $(stat -c '%s' "$FP_SWAPFILE_CURRENT") / 1024**2 ))
-				local max=$(( $(G_CHECK_FREESPACE "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}") + ${current:=0} ))
-				if [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'btrfs' ]]
-				then
-					G_WHIP_MSG '[FAILED] The filesystem Btrfs does not support swap files.\n
+		elif [[ $G_WHIP_RETURNED_VALUE == 'Swap file' ]]
+		then
+			local min=0
+			local current=0
+			[[ $partition_contains_swapfile && -f $FP_SWAPFILE_CURRENT ]] && current=$(( $(stat -c '%s' "$FP_SWAPFILE_CURRENT") / 1024**2 ))
+			local max=$(( $(G_CHECK_FREESPACE "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}") + ${current:=0} ))
+			if [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'btrfs' ]]
+			then
+				G_WHIP_MSG '[FAILED] The filesystem Btrfs does not support swap files.\n
 Please choose another drive or format this one with another filesystem, e.g. ext4.'
-				else
-					G_WHIP_DEFAULT_ITEM=${current:-$swapfile_size}
-					if G_WHIP_INPUTBOX "Please enter a new size in MiB for the swap file on this drive:
+			else
+				G_WHIP_DEFAULT_ITEM=${current:-$swapfile_size}
+				if G_WHIP_INPUTBOX "Please enter a new size in MiB for the swap file on this drive:
 \nSwap space on DietPi has a swappiness setting of 1 and is hence used to prevent out of memory errors only.
 \n - 0 = Disable swap file\n - 1 = Auto size: 2 GiB minus physical RAM size, recommend!\n - 2 and above = Manual size
 \nEnter a value between $min and $max, based on available space.\n - Current: $current"
+				then
+					if G_CHECK_VALIDINT "$G_WHIP_RETURNED_VALUE" "$min" "$max"
 					then
-						if G_CHECK_VALIDINT "$G_WHIP_RETURNED_VALUE" "$min" "$max"
-						then
-							local fp_target_swapfile="${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}/.swapfile"
-							[[ ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} == '/' ]] && fp_target_swapfile='/var/swap'
+						local fp_target_swapfile="${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}/.swapfile"
+						[[ ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} == '/' ]] && fp_target_swapfile='/var/swap'
 
-							(( $SERVICES_STOPPED )) || { /boot/dietpi/dietpi-services stop; SERVICES_STOPPED=1; }
-							/boot/dietpi/func/dietpi-set_swapfile "$G_WHIP_RETURNED_VALUE" "$fp_target_swapfile" || read -rp " - Press any key to return to $G_PROGRAM_NAME..."
-							FP_SWAPFILE_CURRENT=$fp_target_swapfile
-							Init_Drives_and_Refresh
-						fi
+						(( $SERVICES_STOPPED )) || { /boot/dietpi/dietpi-services stop; SERVICES_STOPPED=1; }
+						/boot/dietpi/func/dietpi-set_swapfile "$G_WHIP_RETURNED_VALUE" "$fp_target_swapfile" || read -rp " - Press any key to return to $G_PROGRAM_NAME..."
+						FP_SWAPFILE_CURRENT=$fp_target_swapfile
+						Init_Drives_and_Refresh
 					fi
 				fi
+			fi
 
-			elif [[ $G_WHIP_RETURNED_VALUE == 'Reserved blocks' ]]; then
-
-				local error_text='' reserved_blocks_max=$(( $blocks * $block_size / 1024**2 / 2 )) # MiB
-				while :
-				do
-					G_WHIP_DEFAULT_ITEM=$reserved_blocks_size
-					G_WHIP_INPUTBOX "${error_text}Ext4 formatted filesystems allow the reservation of space for the root user to maintain system functionality if filled by other users or services, and to avoid fragmentation of large files.
+		elif [[ $G_WHIP_RETURNED_VALUE == 'Reserved blocks' ]]
+		then
+			local error_text='' reserved_blocks_max=$(( $blocks * $block_size / 1024**2 / 2 )) # MiB
+			while :
+			do
+				G_WHIP_DEFAULT_ITEM=$reserved_blocks_size
+				G_WHIP_INPUTBOX "${error_text}Ext4 formatted filesystems allow the reservation of space for the root user to maintain system functionality if filled by other users or services, and to avoid fragmentation of large files.
 \nHowever, on modern drives, the default of 5% reserved blocks is often by orders of magnitude larger than necessary. You may want to reduce it to an absolute reserved space of about 500 MiB, which should be sufficient to enable the root user starting and maintaining the system when space got otherwise filled. Additionally, on non system drives reserved blocks are usually not necessary at all.
 \nPlease enter the desired reserved space in MiB. It can be anything between 0 and $reserved_blocks_max (up to half of the overall filesystem size)." || break
 
-					if disable_error=1 G_CHECK_VALIDINT "$G_WHIP_RETURNED_VALUE" 0 "$reserved_blocks_max"
-					then
-						G_EXEC tune2fs -r $(( $G_WHIP_RETURNED_VALUE * 1024**2 / $block_size )) "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}"
-						break
-					else
-						error_text="[FAILED] The entered value must be between 0 and $reserved_blocks_max.\n\n"
-					fi
-				done
-
-			elif [[ $G_WHIP_RETURNED_VALUE == 'User data' ]]; then
-
-				local fp_target_userdata_dir=${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}
-
-				# Store below /mnt when moved to rootfs
-				[[ ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} == '/' ]] && fp_target_userdata_dir='/mnt'
-
-				# Always move to dedicated dietpi_userdata subdir
-				fp_target_userdata_dir+='/dietpi_userdata'
-
-				# Do nothing when user data are located here already
-				[[ $fp_target_userdata_dir == "$FP_USERDATA_CURRENT" ]] && return 0
-
-				# Check for supported filesystem type
-				if [[ ! ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} =~ ^(ext[2-4]|(f2|btr|x|z)fs)$ ]]
+				if disable_error=1 G_CHECK_VALIDINT "$G_WHIP_RETURNED_VALUE" 0 "$reserved_blocks_max"
 				then
-					G_DIETPI-NOTIFY 1 "Filesystem type ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} is not supported for transferring DietPi user data"
-					G_WHIP_MSG "Filesystem type not supported:\n\n${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} has a filesystem type of ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]}, which is not supported.\n\nThe filesystem type must be ext2/3/4, F2FS, Btrfs, XFS or ZFS for native symlink and UNIX permissions compatibilities.\n\nYou may format the partition with a supported filesystem type and retry."
-					return 1
-				fi
-
-				# Ask for confirmation
-				G_WHIP_YESNO "Your user data will be moved:\n - From: $FP_USERDATA_CURRENT\n - To: $fp_target_userdata_dir\n\nDo you wish to continue?" || return 0
-
-				(( $SERVICES_STOPPED )) || { /boot/dietpi/dietpi-services stop; SERVICES_STOPPED=1; }
-				export G_DIETPI_SERVICES_DISABLE=1
-				# shellcheck disable=SC2015
-				/boot/dietpi/func/dietpi-set_userdata "$FP_USERDATA_CURRENT" "$fp_target_userdata_dir" && FP_USERDATA_CURRENT=$fp_target_userdata_dir || read -rp " - Press any key to return to $G_PROGRAM_NAME..."
-				unset -v G_DIETPI_SERVICES_DISABLE
-				G_SLEEP 1
-				Init_Drives_and_Refresh
-
-			elif [[ $G_WHIP_RETURNED_VALUE == 'Format' ]]; then
-
-				# Disallow if user data is located on this drive!
-				if (( $partition_contains_userdata )); then
-
-					Notification 0
-
-				elif (( $partition_contains_swapfile )); then
-
-					Notification 1
-
+					G_EXEC tune2fs -r $(( $G_WHIP_RETURNED_VALUE * 1024**2 / $block_size )) "$MENU_DRIVE_INDEX"
+					break
 				else
-
-					TARGETMENUID=2 # Format menu
-
+					error_text="[FAILED] The entered value must be between 0 and $reserved_blocks_max.\n\n"
 				fi
+			done
 
-			# Resize
-			elif [[ $G_WHIP_RETURNED_VALUE == 'Resize' ]]; then
+		elif [[ $G_WHIP_RETURNED_VALUE == 'User data' ]]
+		then
+			local fp_target_userdata_dir=${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}
 
-				Resize_FS
+			# Store below /mnt when moved to rootfs
+			[[ ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} == '/' ]] && fp_target_userdata_dir='/mnt'
 
-			# Transfer RootFS
-			elif [[ $G_WHIP_RETURNED_VALUE == 'Transfer RootFS' ]]; then
+			# Always move to dedicated dietpi_userdata subdir
+			fp_target_userdata_dir+='/dietpi_userdata'
 
-				# Check whether required kernel command line config file is present
-				if [[ $G_HW_MODEL -le 9 && ! -f '/boot/cmdline.txt' ]]
-				then
-					G_WHIP_MSG '[ INFO ] /boot/cmdline.txt not found
+			# Do nothing when user data are located here already
+			[[ $fp_target_userdata_dir == "$FP_USERDATA_CURRENT" ]] && return 0
+
+			# Check for supported filesystem type
+			if [[ ! ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} =~ ^(ext[2-4]|(f2|btr|x|z)fs)$ ]]
+			then
+				G_DIETPI-NOTIFY 1 "Filesystem type ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} is not supported for transferring DietPi user data"
+				G_WHIP_MSG "Filesystem type not supported:\n\n${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} has a filesystem type of ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]}, which is not supported.\n\nThe filesystem type must be ext2/3/4, F2FS, Btrfs, XFS or ZFS for native symlink and UNIX permissions compatibilities.\n\nYou may format the partition with a supported filesystem type and retry."
+				return 1
+			fi
+
+			# Ask for confirmation
+			G_WHIP_YESNO "Your user data will be moved:\n - From: $FP_USERDATA_CURRENT\n - To: $fp_target_userdata_dir\n\nDo you wish to continue?" || return 0
+
+			(( $SERVICES_STOPPED )) || { /boot/dietpi/dietpi-services stop; SERVICES_STOPPED=1; }
+			export G_DIETPI_SERVICES_DISABLE=1
+			# shellcheck disable=SC2015
+			/boot/dietpi/func/dietpi-set_userdata "$FP_USERDATA_CURRENT" "$fp_target_userdata_dir" && FP_USERDATA_CURRENT=$fp_target_userdata_dir || read -rp " - Press any key to return to $G_PROGRAM_NAME..."
+			unset -v G_DIETPI_SERVICES_DISABLE
+			G_SLEEP 1
+			Init_Drives_and_Refresh
+
+		elif [[ $G_WHIP_RETURNED_VALUE == 'Format' ]]
+		then
+			# Disallow if user data is located on this drive!
+			if (( $partition_contains_userdata ))
+			then
+				Notification 0
+
+			elif (( $partition_contains_swapfile ))
+			then
+				Notification 1
+			else
+				TARGETMENUID=2 # Format menu
+			fi
+
+		# Resize
+		elif [[ $G_WHIP_RETURNED_VALUE == 'Resize' ]]
+		then
+			Resize_FS
+
+		# Transfer RootFS
+		elif [[ $G_WHIP_RETURNED_VALUE == 'Transfer RootFS' ]]
+		then
+			# Check whether required kernel command line config file is present
+			if [[ $G_HW_MODEL -le 9 && ! -f '/boot/cmdline.txt' ]]
+			then
+				G_WHIP_MSG '[ INFO ] /boot/cmdline.txt not found
 \nThe required /boot/cmdline.txt file to adjust the root filesystem entry for the kernel has not been found.
 \nTransferring the root filesystem is not supported on your device. Aborting...'
-					return 1
+				return 1
 
-				elif [[ $G_HW_MODEL -gt 9 && ! -f '/boot/boot.ini' ]]
-				then
-					G_WHIP_MSG '[ INFO ] /boot/boot.ini not found
+			elif [[ $G_HW_MODEL -gt 9 && ! -f '/boot/boot.ini' ]]
+			then
+				G_WHIP_MSG '[ INFO ] /boot/boot.ini not found
 \nThe required /boot/boot.ini file to adjust the root filesystem entry for the kernel has not been found.
 \nTransferring the root filesystem is not supported on your device. Aborting...'
-					return 1
-				fi
+				return 1
+			fi
 
-				(( $partition_contains_userdata )) && { Notification 0; return 1; }
+			(( $partition_contains_userdata )) && { Notification 0; return 1; }
 
-				G_WHIP_YESNO 'This process will move the root filesystem data to another location. This may increase R/W performance when using a USB drive over SDcard, however, there are some limitations:
+			G_WHIP_YESNO 'This process will move the root filesystem data to another location. This may increase R/W performance when using a USB drive over SDcard, however, there are some limitations:
 \n - The SD/eMMC card, which holds kernel and bootloader, is still required for the boot process. On RPi 3 and RPi 4 models, which support full USB boot, instead it is recommended to flash the whole DietPi image to a USB drive and boot the system without SDcard.
 \n - Custom software installs might use info of the old root mount/filesystem, hence we recommend to move the root filesystem on fresh DietPi systems only.
 \n - An immediate reboot is done after the transfer has successfully finished to assure that fstab and cmdline cannot be reverted.
 \nDo you wish to continue?' || return 0
 
-				G_WHIP_MSG 'On the next screen, you will be asked to format the target partition.
+			G_WHIP_MSG 'On the next screen, you will be asked to format the target partition.
 \nPlease see the following limitations for the RootFS target filesystem type:
 \n - Odroid: ONLY ext4 is supported\n\n - Raspberry Pi: ext4 and F2FS are supported'
 
-				# NB: We don't enter main loop in this func
-				TARGETMENUID=2 # Format menu
-				MOVE_ROOTFS=1
-				while (( $TARGETMENUID == 2 ))
-				do
-					Menu_Format
-				done
-				MOVE_ROOTFS=0
+			# NB: We don't enter main loop in this func
+			TARGETMENUID=2 # Format menu
+			MOVE_ROOTFS=1
+			while (( $TARGETMENUID == 2 ))
+			do
+				Menu_Format
+			done
+			MOVE_ROOTFS=0
 
-				(( $FORMAT_COMPLETED )) && RootFS_Move
+			(( $FORMAT_COMPLETED )) && RootFS_Move
 
-			elif [[ $G_WHIP_RETURNED_VALUE == 'Read Only' ]]; then
+		elif [[ $G_WHIP_RETURNED_VALUE == 'Read Only' ]]
+		then
+			# Disallow if userdata is located on this drive!
+			if (( $partition_contains_swapfile ))
+			then
+				Notification 1
+			else
+				Toggle_WriteMode
+			fi
 
-				# Disallow if userdata is located on this drive!
-				if (( $partition_contains_swapfile )); then
+		elif [[ $G_WHIP_RETURNED_VALUE == 'Benchmark' ]]
+		then
+			(( $SERVICES_STOPPED )) || { /boot/dietpi/dietpi-services stop; SERVICES_STOPPED=1; }
+			FP_BENCHFILE=${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} /boot/dietpi/func/dietpi-benchmark 1
 
-					Notification 1
-
-				else
-
-					Toggle_WriteMode
-
-				fi
-
-			elif [[ $G_WHIP_RETURNED_VALUE == 'Benchmark' ]]; then
-
-				(( $SERVICES_STOPPED )) || { /boot/dietpi/dietpi-services stop; SERVICES_STOPPED=1; }
-				FP_BENCHFILE=${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} /boot/dietpi/func/dietpi-benchmark 1
-
-			elif [[ $G_WHIP_RETURNED_VALUE == 'Check & Repair' ]]; then
-
-				if [[ ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} == '/' ]]; then
-
-					if G_WHIP_YESNO 'The root filesystem can only be checked on reboot.
+		elif [[ $G_WHIP_RETURNED_VALUE == 'Check & Repair' ]]
+		then
+			if [[ ${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]} == '/' ]]
+			then
+				if G_WHIP_YESNO 'The root filesystem can only be checked on reboot.
 \nDo you want to force a filesystem check of root partition on next reboot?
-\nNB: Logs can be found after reboot either via "journalctl -t systemd-fsck" or "cat /run/initramfs/fsck.log"'; then
-
-						> /forcefsck
-						G_WHIP_YESNO 'Do you want to reboot now?' && reboot
-
-					fi
-					return
-
-				fi
-
-				if [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == ext[2-4] ]]; then
-
-					G_AG_CHECK_INSTALL_PREREQ e2fsprogs
-					local fsck_dry='e2fsck -n -f'
-					local fsck_fix='e2fsck -y -f'
-
-				elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'exfat' ]]; then
-
-					Install_exFAT_Tools
-					local fsck_dry='fsck.exfat -n'
-					local fsck_fix='fsck.exfat -p'
-
-				elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} =~ 'fat' ]]; then
-
-					G_AG_CHECK_INSTALL_PREREQ dosfstools
-					local fsck_dry='fsck.fat -n'
-					local fsck_fix='fsck.fat -y'
-
-				elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'ntfs' ]]; then
-
-					G_AG_CHECK_INSTALL_PREREQ ntfs-3g
-					local fsck_dry='ntfsfix -n'
-					local fsck_fix='ntfsfix'
-
-				elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} =~ 'hfs' ]]; then
-
-					G_AG_CHECK_INSTALL_PREREQ hfsplus hfsprogs hfsutils
-					local fsck_dry='fsck.hfsplus -n -f'
-					local fsck_fix='fsck.hfsplus -y -f'
-
-				elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'f2fs' ]]; then
-
-					G_AG_CHECK_INSTALL_PREREQ f2fs-tools
-					local fsck_dry='fsck.f2fs'
-					local fsck_fix='fsck.f2fs -f'
-
-				elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'btrfs' ]]; then
-
-					G_AG_CHECK_INSTALL_PREREQ btrfs-progs
-					local fsck_dry='btrfs check --readonly'
-					local fsck_fix='btrfs check --repair'
-
-				elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'xfs' ]]; then
-
-					G_AG_CHECK_INSTALL_PREREQ xfsprogs
-					local fsck_dry='xfs_repair -n'
-					local fsck_fix='xfs_repair'
-
-				else
-
-					G_WHIP_MSG "Filesystem checks are currently not supported for '${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]}'. Aborting..."
-					return 1
-
-				fi
-
-				if (( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} ))
+\nNB: Logs can be found after reboot either via "journalctl -t systemd-fsck" or "cat /run/initramfs/fsck.log"'
 				then
-					G_WHIP_YESNO 'For safe check and repair, the drive needs to be unmounted.
+					> /forcefsck
+					G_WHIP_YESNO 'Do you want to reboot now?' && { reboot; exit 0; }
+				fi
+				return
+			fi
+
+			if [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == ext[2-4] ]]
+			then
+				G_AG_CHECK_INSTALL_PREREQ e2fsprogs
+				local fsck_dry='e2fsck -n -f'
+				local fsck_fix='e2fsck -y -f'
+
+			elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'exfat' ]]
+			then
+				Install_exFAT_Tools
+				local fsck_dry='fsck.exfat -n'
+				local fsck_fix='fsck.exfat -p'
+
+			elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} =~ 'fat' ]]
+			then
+				G_AG_CHECK_INSTALL_PREREQ dosfstools
+				local fsck_dry='fsck.fat -n'
+				local fsck_fix='fsck.fat -y'
+
+			elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'ntfs' ]]
+			then
+				G_AG_CHECK_INSTALL_PREREQ ntfs-3g
+				local fsck_dry='ntfsfix -n'
+				local fsck_fix='ntfsfix'
+
+			elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} =~ 'hfs' ]]
+			then
+				G_AG_CHECK_INSTALL_PREREQ hfsplus hfsprogs hfsutils
+				local fsck_dry='fsck.hfsplus -n -f'
+				local fsck_fix='fsck.hfsplus -y -f'
+
+			elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'f2fs' ]]
+			then
+				G_AG_CHECK_INSTALL_PREREQ f2fs-tools
+				local fsck_dry='fsck.f2fs'
+				local fsck_fix='fsck.f2fs -f'
+
+			elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'btrfs' ]]
+			then
+				G_AG_CHECK_INSTALL_PREREQ btrfs-progs
+				local fsck_dry='btrfs check --readonly'
+				local fsck_fix='btrfs check --repair'
+
+			elif [[ ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} == 'xfs' ]]
+			then
+				G_AG_CHECK_INSTALL_PREREQ xfsprogs
+				local fsck_dry='xfs_repair -n'
+				local fsck_fix='xfs_repair'
+			else
+				G_WHIP_MSG "Filesystem checks are currently not supported for '${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]}'. Aborting..."
+				return 1
+			fi
+
+			if (( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} ))
+			then
+				G_WHIP_YESNO 'For safe check and repair, the drive needs to be unmounted.
 \nDo you want to continue with the drive being unmounted automatically?' || return 1
 
-					(( $SERVICES_STOPPED )) || { /boot/dietpi/dietpi-services stop; SERVICES_STOPPED=1; }
+				(( $SERVICES_STOPPED )) || { /boot/dietpi/dietpi-services stop; SERVICES_STOPPED=1; }
 
-					# Disable swap
-					(( $partition_contains_swapfile )) && G_EXEC swapoff -a
+				# Disable swap
+				(( $partition_contains_swapfile )) && G_EXEC swapoff -a
 
-					# Unmount drive
-					G_EXEC umount "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
-				fi
+				# Unmount drive
+				G_EXEC umount "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
+			fi
 
-				# Do a dry-run first
-				G_WHIP_MSG "The following drive will now be checked for errors:\n${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}\n\nNo repair will be completed during this process. An option to repair the drive, will be provided after the check."
-				$fsck_dry "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}" &> .fsck_out_tmp
-				log=1 G_WHIP_VIEWFILE .fsck_out_tmp
-				rm .fsck_out_tmp
+			# Do a dry-run first
+			G_WHIP_MSG "The following drive will now be checked for errors:\n$MENU_DRIVE_INDEX\n\nNo repair will be completed during this process. An option to repair the drive, will be provided after the check."
+			$fsck_dry "$MENU_DRIVE_INDEX" &> .fsck_out_tmp
+			log=1 G_WHIP_VIEWFILE .fsck_out_tmp
+			rm .fsck_out_tmp
 
-				if [[ $fsck_fix ]] && G_WHIP_YESNO "Would you like to run an automated repair on the following drive now?\n${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}
+			if [[ $fsck_fix ]] && G_WHIP_YESNO "Would you like to run an automated repair on the following drive now?\n$MENU_DRIVE_INDEX
 \nNB:
 - Automated repair steps potentially lead to data loss, which would have been able to recover by professional drive recovery services.
 - If the data is extremely important and you don't have any backup, you might want to hand the drive to a recovery service as is.
-- These services are usually very expensive, but might be able to recover more data than (after) this automated repair steps!"; then
+- These services are usually very expensive, but might be able to recover more data than (after) this automated repair steps!"
+			then
+				$fsck_fix "$MENU_DRIVE_INDEX" &> .fsck_out_tmp
+				log=1 G_WHIP_VIEWFILE .fsck_out_tmp
+				rm .fsck_out_tmp
 
-					$fsck_fix "${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]}" &> .fsck_out_tmp
-					log=1 G_WHIP_VIEWFILE .fsck_out_tmp
-					rm .fsck_out_tmp
-
-				elif [[ ! $fsck_fix ]]; then
-
-					G_WHIP_MSG "The fsck tool for ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} filesystems does not support repairing yet on Debian ${G_DISTRO_NAME^}.
+			elif [[ ! $fsck_fix ]]
+			then
+				G_WHIP_MSG "The fsck tool for ${aDRIVE_FSTYPE[$MENU_DRIVE_INDEX]} filesystems does not support repairing yet on Debian ${G_DISTRO_NAME^}.
 \nWe recommend to migrate to a new Debian release which supports this feature, either by installing a new DietPi image or following our HowTo to upgrade your system:
 => https://dietpi.com/docs/usage/#how-to-upgrade-to-buster"
-
-				fi
-
-				if (( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} ))
-				then
-					# Remount drive
-					G_EXEC mount "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
-
-					# Re-enable swap
-					(( $partition_contains_swapfile )) && G_EXEC swapon -a
-				fi
-
-			elif [[ $G_WHIP_RETURNED_VALUE == 'I/O Scheduler' ]]; then
-
-				local udev_rules='/etc/udev/rules.d/99-dietpi-io_schedulers.rules'
-				[[ -f $udev_rules ]] && grep -q "KERNEL==\"${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}\"" "$udev_rules" && G_WHIP_MENU_ARRAY=('Reset' ': Reset to system defaults') || G_WHIP_MENU_ARRAY=()
-				for i in "${aio_schedulers[@]}"; do G_WHIP_MENU_ARRAY+=("$i"); done
-				G_WHIP_DEFAULT_ITEM=$io_scheduler_current
-				if G_WHIP_MENU "Please select an I/O scheduler.\n
-NB: This will apply to the whole drive: /dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}
-    It always applies to the drive with this dev name, as well if naming changes due to new attached drives.\n
-Read more about I/O scheduling: https://wiki.archlinux.org/index.php/Improving_performance#Input/output_schedulers"; then
-
-					if [[ $G_WHIP_RETURNED_VALUE == 'Reset' ]]; then
-
-						sed --follow-symlinks -i "/KERNEL==\"${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}\"/d" "$udev_rules"
-						grep -q '^ACTION' "$udev_rules" || rm "$udev_rules"
-						G_WHIP_YESNO '[ INFO ] A reboot is required to reset the I/O scheduler to default.\n\nDo you wish to reboot now?' && reboot
-
-					else
-
-						[[ -f $udev_rules ]] || echo '# Please run "dietpi-drive_manager" to adjust I/O schedulers' > "$udev_rules"
-						G_CONFIG_INJECT "ACTION==\"add\|change\", KERNEL==\"${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}\"" "ACTION==\"add|change\", KERNEL==\"${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}\", ATTR{queue/scheduler}=\"$G_WHIP_RETURNED_VALUE\"" "$udev_rules"
-						echo "$G_WHIP_RETURNED_VALUE" > "$io_schedulers"
-
-					fi
-
-				fi
-
 			fi
 
-		else
+			if (( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_INDEX]} ))
+			then
+				# Remount drive
+				G_EXEC mount "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_INDEX]}"
 
-			TARGETMENUID=0 # Main menu
+				# Re-enable swap
+				(( $partition_contains_swapfile )) && G_EXEC swapon -a
+			fi
 
+		elif [[ $G_WHIP_RETURNED_VALUE == 'I/O Scheduler' ]]
+		then
+			local udev_rules='/etc/udev/rules.d/99-dietpi-io_schedulers.rules'
+			[[ -f $udev_rules ]] && grep -q "KERNEL==\"${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}\"" "$udev_rules" && G_WHIP_MENU_ARRAY=('Reset' ': Reset to system defaults') || G_WHIP_MENU_ARRAY=()
+			for i in "${aio_schedulers[@]}"; do G_WHIP_MENU_ARRAY+=("$i"); done
+			G_WHIP_DEFAULT_ITEM=$io_scheduler_current
+			G_WHIP_MENU "Please select an I/O scheduler.\n
+NB: This will apply to the whole drive: /dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}
+    It always applies to the drive with this dev name, as well if naming changes due to new attached drives.\n
+Read more about I/O scheduling: https://wiki.archlinux.org/index.php/Improving_performance#Input/output_schedulers" || return 0
+
+			if [[ $G_WHIP_RETURNED_VALUE == 'Reset' ]]
+			then
+				sed --follow-symlinks -i "/KERNEL==\"${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}\"/d" "$udev_rules"
+				grep -q '^ACTION' "$udev_rules" || rm "$udev_rules"
+				G_WHIP_YESNO '[ INFO ] A reboot is required to reset the I/O scheduler to default.\n\nDo you wish to reboot now?' && { reboot; exit 0; }
+			else
+				[[ -f $udev_rules ]] || echo '# Please run "dietpi-drive_manager" to adjust I/O schedulers' > "$udev_rules"
+				G_CONFIG_INJECT "ACTION==\"add\|change\", KERNEL==\"${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}\"" "ACTION==\"add|change\", KERNEL==\"${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}\", ATTR{queue/scheduler}=\"$G_WHIP_RETURNED_VALUE\"" "$udev_rules"
+				echo "$G_WHIP_RETURNED_VALUE" > "$io_schedulers"
+			fi
 		fi
-
 	}
 
 	# TARGETMENUID=2
 	G_WHIP_DEFAULT_ITEM_NEXT_SUB2=
-	Menu_Format(){
-
+	Menu_Format()
+	{
 		FORMAT_COMPLETED=0
 
 		local partition_table_text='GPT'
@@ -1516,177 +1376,159 @@ Read more about I/O scheduling: https://wiki.archlinux.org/index.php/Improving_p
 		local format_mode_text='Drive'
 		(( $FORMAT_MODE )) && format_mode_text='Partition'
 
-		local format_type_text='ext4'
-		if (( $FORMAT_FILESYSTEM_TYPE == 1 )); then
+		local text_fs_type='ext4'
+		if (( $FORMAT_FILESYSTEM_TYPE == 1 ))
+		then
+			text_fs_type='NTFS'
 
-			format_type_text='NTFS'
+		elif (( $FORMAT_FILESYSTEM_TYPE == 2 ))
+		then
+			text_fs_type='FAT32'
 
-		elif (( $FORMAT_FILESYSTEM_TYPE == 2 )); then
+		elif (( $FORMAT_FILESYSTEM_TYPE == 3 ))
+		then
+			text_fs_type='HFS+'
 
-			format_type_text='FAT32'
+		elif (( $FORMAT_FILESYSTEM_TYPE == 4 ))
+		then
+			text_fs_type='Btrfs'
 
-		elif (( $FORMAT_FILESYSTEM_TYPE == 3 )); then
+		elif (( $FORMAT_FILESYSTEM_TYPE == 5 ))
+		then
+			text_fs_type='F2FS'
 
-			format_type_text='HFS+'
+		elif (( $FORMAT_FILESYSTEM_TYPE == 6 ))
+		then
+			text_fs_type='exFAT'
 
-		elif (( $FORMAT_FILESYSTEM_TYPE == 4 )); then
-
-			format_type_text='Btrfs'
-
-		elif (( $FORMAT_FILESYSTEM_TYPE == 5 )); then
-
-			format_type_text='F2FS'
-
-		elif (( $FORMAT_FILESYSTEM_TYPE == 6 )); then
-
-			format_type_text='exFAT'
-
-		elif (( $FORMAT_FILESYSTEM_TYPE == 7 )); then
-
-			format_type_text='XFS'
-
+		elif (( $FORMAT_FILESYSTEM_TYPE == 7 ))
+		then
+			text_fs_type='XFS'
 		fi
 
 		G_WHIP_MENU_ARRAY=()
 
 		# Has partition table, offer to format current partition or whole drive
-		if (( ${aDRIVE_ISPARTITIONTABLE[$MENU_DRIVE_INDEX]} )); then
-
+		if (( ${aDRIVE_ISPARTITIONTABLE[$MENU_DRIVE_INDEX]} ))
+		then
 			G_WHIP_MENU_ARRAY+=('Format Mode' ": [$format_mode_text] Format the whole drive or current partition only")
 
 		# No partition table, force drive wipe
 		else
-
 			FORMAT_MODE=0
-
 		fi
 
 		(( $FORMAT_MODE )) || G_WHIP_MENU_ARRAY+=('Partition Table' ": [$partition_table_text] Format with MBR or GPT partition table")
-		G_WHIP_MENU_ARRAY+=('Filesystem Type' ": [$format_type_text] Select the new filesystem type")
+		G_WHIP_MENU_ARRAY+=('Filesystem Type' ": [$text_fs_type] Select the new filesystem type")
 		G_WHIP_MENU_ARRAY+=('Format' ': Start the format process with selected options')
 
 		G_WHIP_DEFAULT_ITEM=${G_WHIP_DEFAULT_ITEM_NEXT_SUB2:-${G_WHIP_MENU_ARRAY[0]}}
 		G_WHIP_BUTTON_CANCEL_TEXT='Back'
-		if G_WHIP_MENU 'Please select formatting options:'; then
+		G_WHIP_MENU 'Please select formatting options:' || { TARGETMENUID=1; return 0; } # Drive menu
 
-			G_WHIP_DEFAULT_ITEM_NEXT_SUB2=$G_WHIP_RETURNED_VALUE
+		G_WHIP_DEFAULT_ITEM_NEXT_SUB2=$G_WHIP_RETURNED_VALUE
 
-			if [[ $G_WHIP_RETURNED_VALUE == 'Partition Table' ]]; then
+		if [[ $G_WHIP_RETURNED_VALUE == 'Partition Table' ]]
+		then
+			G_WHIP_BUTTON_OK_TEXT='MBR' G_WHIP_BUTTON_CANCEL_TEXT='GPT'
+			G_WHIP_YESNO 'Would you like to use GPT or MBR parition table?\n - GPT is required for 2TB+ drives\n - MBR does NOT support 2TB+ drives\n\nIf unsure, select GPT (default)' && FORMAT_GPT=0 || FORMAT_GPT=1
 
-				G_WHIP_BUTTON_OK_TEXT='MBR' G_WHIP_BUTTON_CANCEL_TEXT='GPT'
-				G_WHIP_YESNO 'Would you like to use GPT or MBR parition table?\n - GPT is required for 2TB+ drives\n - MBR does NOT support 2TB+ drives\n\nIf unsure, select GPT (default)' && FORMAT_GPT=0 || FORMAT_GPT=1
+		elif [[ $G_WHIP_RETURNED_VALUE == 'Format Mode' ]]
+		then
+			G_WHIP_MENU_ARRAY=(
 
-			elif [[ $G_WHIP_RETURNED_VALUE == 'Format Mode' ]]; then
+				'Partition' ": $MENU_DRIVE_INDEX | UUID=${aDRIVE_UUID[$MENU_DRIVE_INDEX]}"
+				'Drive' ": /dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}"
+			)
 
-				G_WHIP_MENU_ARRAY=(
-
-					'Partition' ": ${aDRIVE_MOUNT_SOURCE[$MENU_DRIVE_INDEX]} | UUID=${aDRIVE_UUID[$MENU_DRIVE_INDEX]}"
-					'Drive' ": /dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_INDEX]}"
-
-				)
-
-				if G_WHIP_MENU 'Please select a formatting mode:\n\n - Formatting the drive will DELETE all data on the DRIVE and create a new partition table.\n - Formatting the partition, will DELETE all data on the current PARTITION only.\n
-NB: If you are planning to dedicate the drive to this system, it is recommended to format the whole drive where possible, this will ensure full drive capacity is available for use.'; then
-
-					[[ $G_WHIP_RETURNED_VALUE == 'Partition' ]] && FORMAT_MODE=1 || FORMAT_MODE=0
-
-				fi
-
-			elif [[ $G_WHIP_RETURNED_VALUE == 'Filesystem Type' ]]; then
-
-				# Limit available filesystem types when this is used to move the root filesystem to
-				if (( $MOVE_ROOTFS ))
-				then
-					# Odroids only support ext4
-					G_WHIP_MENU_ARRAY=('0' ': ext4   | Default (Recommended)')
-					# RPis additionally support F2FS
-					(( $G_HW_MODEL > 9 )) || G_WHIP_MENU_ARRAY+=('5' ': F2FS   | Linux (Flash filesystem)')
-				else
-					G_WHIP_MENU_ARRAY=(
-
-						'0' ': ext4   | Default (Recommended)'
-						'1' ': NTFS   | Windows (High CPU usage)'
-						'2' ': FAT32  | All OS (4GB filesize limit)'
-						'3' ': HFS+   | macOS (Apple default filesystem)'
-						'4' ': Btrfs  | Linux (Modern filesystem)'
-						'5' ': F2FS   | Linux (Flash filesystem)'
-						'6' ': exFAT  | Windows (Flash filesystem)'
-						'7' ': XFS    | Linux (Modern filesystem)'
-
-					)
-				fi
-
-				G_WHIP_DEFAULT_ITEM=$FORMAT_FILESYSTEM_TYPE
-				if G_WHIP_MENU 'Please select a filesystem type for this format:
-\next4:\nHighly recommended if you plan to use this drive solely on this system (dedicated drive).
-\nNTFS:\nRecommended if you plan to use this drive on a Windows system. High CPU usage during transfers.
-\nFull list of different filesystem types:\nhttps://dietpi.com/docs/dietpi_tools/#dietpi-drive-manager'; then
-
-					# Install FS pre-reqs
-					# - ext
-					if (( $G_WHIP_RETURNED_VALUE == 0 )); then
-
-						G_AG_CHECK_INSTALL_PREREQ e2fsprogs
-
-					# - NTFS
-					elif (( $G_WHIP_RETURNED_VALUE == 1 )); then
-
-						G_AG_CHECK_INSTALL_PREREQ ntfs-3g
-
-					# - FAT32
-					elif (( $G_WHIP_RETURNED_VALUE == 2 )); then
-
-						G_AG_CHECK_INSTALL_PREREQ dosfstools
-
-					# - HFS+
-					elif (( $G_WHIP_RETURNED_VALUE == 3 )); then
-
-						G_AG_CHECK_INSTALL_PREREQ hfsplus hfsprogs hfsutils
-
-					# - Btrfs
-					elif (( $G_WHIP_RETURNED_VALUE == 4 )); then
-
-						G_AG_CHECK_INSTALL_PREREQ btrfs-progs
-
- 					# - F2FS
-					elif (( $G_WHIP_RETURNED_VALUE == 5 )); then
-
-						G_AG_CHECK_INSTALL_PREREQ f2fs-tools
-
-					# - exFAT
-					elif (( $G_WHIP_RETURNED_VALUE == 6 )); then
-
-						Install_exFAT_Tools
-
-					# - XFS
-					elif (( $G_WHIP_RETURNED_VALUE == 7 )); then
-
-						G_AG_CHECK_INSTALL_PREREQ xfsprogs
-
-					fi
-
-					FORMAT_FILESYSTEM_TYPE=$G_WHIP_RETURNED_VALUE
-
-				fi
-
-			elif [[ $G_WHIP_RETURNED_VALUE == 'Format' ]]; then
-
-				Run_Format
-				TARGETMENUID=1 # Drive menu
-
+			if G_WHIP_MENU 'Please select a formatting mode:\n\n - Formatting the drive will DELETE all data on the DRIVE and create a new partition table.\n - Formatting the partition, will DELETE all data on the current PARTITION only.\n
+NB: If you are planning to dedicate the drive to this system, it is recommended to format the whole drive where possible, this will ensure full drive capacity is available for use.'
+			then
+				[[ $G_WHIP_RETURNED_VALUE == 'Partition' ]] && FORMAT_MODE=1 || FORMAT_MODE=0
 			fi
 
-		else
+		elif [[ $G_WHIP_RETURNED_VALUE == 'Filesystem Type' ]]
+		then
+			# Limit available filesystem types when this is used to move the root filesystem to
+			if (( $MOVE_ROOTFS ))
+			then
+				# Odroids only support ext4
+				G_WHIP_MENU_ARRAY=('0' ': ext4   | Default (Recommended)')
+				# RPis additionally support F2FS
+				(( $G_HW_MODEL > 9 )) || G_WHIP_MENU_ARRAY+=('5' ': F2FS   | Linux (Flash filesystem)')
+			else
+				G_WHIP_MENU_ARRAY=(
 
-			TARGETMENUID=1 # Drive menu
+					'0' ': ext4   | Default (Recommended)'
+					'1' ': NTFS   | Windows (High CPU usage)'
+					'2' ': FAT32  | All OS (4GB filesize limit)'
+					'3' ': HFS+   | macOS (Apple default filesystem)'
+					'4' ': Btrfs  | Linux (Modern filesystem)'
+					'5' ': F2FS   | Linux (Flash filesystem)'
+					'6' ': exFAT  | Windows (Flash filesystem)'
+					'7' ': XFS    | Linux (Modern filesystem)'
+				)
+			fi
 
+			G_WHIP_DEFAULT_ITEM=$FORMAT_FILESYSTEM_TYPE
+			G_WHIP_MENU 'Please select a filesystem type for this format:
+\next4:\nHighly recommended if you plan to use this drive solely on this system (dedicated drive).
+\nNTFS:\nRecommended if you plan to use this drive on a Windows system. High CPU usage during transfers.
+\nFull list of different filesystem types:\nhttps://dietpi.com/docs/dietpi_tools/#dietpi-drive-manager' || return 0
+
+			FORMAT_FILESYSTEM_TYPE=$G_WHIP_RETURNED_VALUE
+
+			# Install FS pre-reqs
+			# - ext
+			if (( $FORMAT_FILESYSTEM_TYPE == 0 ))
+			then
+				G_AG_CHECK_INSTALL_PREREQ e2fsprogs
+
+			# - NTFS
+			elif (( $FORMAT_FILESYSTEM_TYPE == 1 ))
+			then
+				G_AG_CHECK_INSTALL_PREREQ ntfs-3g
+
+			# - FAT32
+			elif (( $FORMAT_FILESYSTEM_TYPE == 2 ))
+			then
+				G_AG_CHECK_INSTALL_PREREQ dosfstools
+
+			# - HFS+
+			elif (( $FORMAT_FILESYSTEM_TYPE == 3 ))
+			then
+				G_AG_CHECK_INSTALL_PREREQ hfsplus hfsprogs hfsutils
+
+			# - Btrfs
+			elif (( $FORMAT_FILESYSTEM_TYPE == 4 ))
+			then
+				G_AG_CHECK_INSTALL_PREREQ btrfs-progs
+
+			# - F2FS
+			elif (( $FORMAT_FILESYSTEM_TYPE == 5 ))
+			then
+				G_AG_CHECK_INSTALL_PREREQ f2fs-tools
+
+			# - exFAT
+			elif (( $FORMAT_FILESYSTEM_TYPE == 6 ))
+			then
+				Install_exFAT_Tools
+
+			# - XFS
+			elif (( $FORMAT_FILESYSTEM_TYPE == 7 ))
+			then
+				G_AG_CHECK_INSTALL_PREREQ xfsprogs
+			fi
+
+		elif [[ $G_WHIP_RETURNED_VALUE == 'Format' ]]
+		then
+			Run_Format
 		fi
-
 	}
 
 	# shellcheck disable=SC2329
-	Mount_Samba(){
-
+	Mount_Samba()
+	{
 		local fp_tmp='.samba_mount_out'
 		local samba_clientname='192.168.'
 		local samba_clientshare samba_clientuser samba_clientpassword
@@ -1744,8 +1586,8 @@ NB: If you are planning to dedicate the drive to this system, it is recommended 
 		for i in '3.1.1' '3.0.2' '3.0' '2.1' '2.0' '1.0'
 		do
 			G_DIETPI-NOTIFY 2 "Attempting to mount with CIFS version: $i"
-			if mount -t cifs -o "username=$samba_clientuser,password=$samba_clientpassword,iocharset=utf8,gid=dietpi,file_mode=0770,dir_mode=0770,vers=$i" "//$samba_clientname/$samba_clientshare" "$samba_fp_mount_target" &>> "$fp_tmp"; then
-
+			if mount -t cifs -o "username=$samba_clientuser,password=$samba_clientpassword,iocharset=utf8,gid=dietpi,file_mode=0770,dir_mode=0770,vers=$i" "//$samba_clientname/$samba_clientshare" "$samba_fp_mount_target" &>> "$fp_tmp"
+			then
 				# Create credentials file
 				G_EXEC mkdir -p /var/lib/dietpi/dietpi-drive_manager
 				local cred="/var/lib/dietpi/dietpi-drive_manager${samba_fp_mount_target//\//-}.cred"
@@ -1760,16 +1602,16 @@ _EOF_
 				# Apply to fstab
 				sed --follow-symlinks -i "\#[[:blank:]]${samba_fp_mount_target}[[:blank:]]#d" /etc/fstab
 				# - NB: Convert spaces to '\040': https://github.com/MichaIng/DietPi/issues/1201#issuecomment-339720271
-				echo "//$samba_clientname/${samba_clientshare//[[:blank:]]/\\040} $samba_fp_mount_target cifs cred=$cred,iocharset=utf8,gid=dietpi,file_mode=0770,dir_mode=0770,vers=$i,noauto,x-systemd.automount" >> /etc/fstab
+				local source="//$samba_clientname/${samba_clientshare//[[:blank:]]/\\040}"
+				echo "$source $samba_fp_mount_target cifs cred=$cred,iocharset=utf8,gid=dietpi,file_mode=0770,dir_mode=0770,vers=$i,noauto,x-systemd.automount" >> /etc/fstab
 
-				MENU_DRIVE_TARGET=$samba_fp_mount_target
 				Init_Drives_and_Refresh
+				MENU_DRIVE_INDEX=$source
 				TARGETMENUID=1 # Drive menu
 
 				G_WHIP_MSG "Mount completed. The new mount can be accessed at:\n - $samba_fp_mount_target\n - CIFS vers=$i"
 				rm "$fp_tmp"
 				return 0
-
 			fi
 		done
 
@@ -1778,12 +1620,11 @@ _EOF_
 		G_WHIP_VIEWFILE "$fp_tmp"
 		rm "$fp_tmp"
 		rmdir --ignore-fail-on-non-empty "$samba_fp_mount_target"
-
 	}
 
 	# shellcheck disable=SC2329
-	Mount_NFS(){
-
+	Mount_NFS()
+	{
 		local fp_tmp='.nfs_mount_out'
 		local nfs_server_ip='192.168.'
 		local nfs_exports nfs_export
@@ -1874,10 +1715,11 @@ _EOF_
 		then
 			# Apply to fstab
 			sed --follow-symlinks -i "\#[[:blank:]]${nfs_fp_mount_target}[[:blank:]]#d" /etc/fstab
-			echo "$nfs_server_ip:$nfs_fp_server_share $nfs_fp_mount_target nfs noauto,x-systemd.automount" >> /etc/fstab
+			local source="$nfs_server_ip:$nfs_fp_server_share"
+			echo "$source $nfs_fp_mount_target nfs noauto,x-systemd.automount" >> /etc/fstab
 
-			MENU_DRIVE_TARGET=$nfs_fp_mount_target
 			Init_Drives_and_Refresh
+			MENU_DRIVE_INDEX=$source
 			TARGETMENUID=1 # Drive menu
 
 			G_WHIP_MSG "Mount completed. The new mount can be accessed at:\n - $nfs_fp_mount_target"
@@ -1890,25 +1732,22 @@ _EOF_
 		G_WHIP_VIEWFILE "$fp_tmp"
 		rm "$fp_tmp"
 		rmdir --ignore-fail-on-non-empty "$nfs_fp_mount_target"
-
 	}
 
 	# TARGETMENUID=3
-	Menu_Add_Network_Drive(){
-
+	Menu_Add_Network_Drive()
+	{
 		G_WHIP_MENU_ARRAY=(
 
 			'Samba' ': Setup a connection for a Samba/SMB/CIFS/Windows compatible file share'
 			'NFS' ': Setup a connection for a NFS compatible file share'
-
 		)
 
 		G_WHIP_MENU 'Please select the network mount protocol:' && "Mount_$G_WHIP_RETURNED_VALUE" || TARGETMENUID=0 # Main menu
-
 	}
 
-	Menu_Select_Mount_Location(){
-
+	Menu_Select_Mount_Location()
+	{
 		local fp_mount_selection='/tmp/dietpi-drive_manager_selmnt'
 
 		# Remove last selection
@@ -1928,7 +1767,6 @@ _EOF_
 		G_DIETPI-NOTIFY 0 "Drive mount selected: $G_WHIP_RETURNED_VALUE"
 		echo "$G_WHIP_RETURNED_VALUE" > "$fp_mount_selection"
 		exit 0
-
 	}
 
 	#/////////////////////////////////////////////////////////////////////////////////////
@@ -1943,7 +1781,7 @@ _EOF_
 		G_WHIP_BUTTON_CANCEL_TEXT='Skip' G_WHIP_YESNO "[ INFO ] A reboot is recommended
 \nKernel modules for the loaded kernel at /lib/modules/$(uname -r) are missing. This is most likely the case as of a recently applied kernel upgrade where a reboot is required to load the new kernel.
 \nWe recommend to perform a reboot now for the system to be able to load kernel modules, like filesystem drivers, ondemand. If your kernel does not use dedicated modules, please create the mentioned directory manually to mute this info in the future.
-\nDo you want to reboot now?" && reboot
+\nDo you want to reboot now?" && { reboot; exit 0; }
 	fi
 	#-----------------------------------------------------------------------------------
 	# Init drives, generate /etc/fstab based on current drive mounts

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -55,9 +55,9 @@
 
 	Init_New_Device()
 	{
-		aDRIVE_MOUNT_TARGET[$source]= aDRIVE_SOURCE_DEVICE[$source]=
-		aDRIVE_FSTYPE[$source]= aDRIVE_UUID[$source]= aDRIVE_PART_UUID[$source]=
-		aDRIVE_SIZE_TOTAL[$source]= aDRIVE_SIZE_USED[$source]= aDRIVE_SIZE_USED_PCT[$source]=
+		aDRIVE_MOUNT_TARGET[$source]='' aDRIVE_SOURCE_DEVICE[$source]=''
+		aDRIVE_FSTYPE[$source]='' aDRIVE_UUID[$source]='' aDRIVE_PART_UUID[$source]=''
+		aDRIVE_SIZE_TOTAL[$source]='' aDRIVE_SIZE_USED[$source]='' aDRIVE_SIZE_USED_PCT[$source]=''
 		aDRIVE_ISFILESYSTEM[$source]=0 aDRIVE_ISMOUNTED[$source]=0
 		aDRIVE_ISREADONLY[$source]=0 aDRIVE_ISACCESS[$source]=1 aDRIVE_ISPARTITION[$source]=0
 		aDRIVE_ISNETWORKED[$source]=0 aDRIVE_ISROM[$source]=0
@@ -70,7 +70,7 @@
 		declare -Ag aDRIVE_SIZE_TOTAL=() aDRIVE_SIZE_USED=() aDRIVE_SIZE_USED_PCT=()
 		declare -Ag aDRIVE_ISFILESYSTEM=() aDRIVE_ISMOUNTED=()
 		declare -Ag aDRIVE_ISREADONLY=() aDRIVE_ISACCESS=() aDRIVE_ISPARTITION=()
-		declare -Ag aDRIVE_ISNETWORKED=() aDRIVE_ISROM=() 
+		declare -Ag aDRIVE_ISNETWORKED=() aDRIVE_ISROM=()
 	}
 
 	Init_Drives_and_Refresh()
@@ -490,13 +490,13 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 		if (( $FORMAT_MODE ))
 		then
 			local device=$MENU_DRIVE_SELECTED
-			local text_menu="UUID: ${aDRIVE_UUID[$MENU_DRIVE_SELECTED]}\nALL DATA on this PARTITION will be DELETED.\nDo you wish to continue?"
+			local text_menu="Current UUID: ${aDRIVE_UUID[$MENU_DRIVE_SELECTED]}\n\nALL DATA on this PARTITION will be DELETED!"
 		else
 			local device="/dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_SELECTED]}"
-			local text_menu="Partition table: $partition_table_text\nALL DATA and PARTITIONS on this drive will be DELETED.\nDo you wish to continue?"
+			local text_menu="Target partition table: $partition_table_text\n\nALL DATA and PARTITIONS on this drive will be DELETED!"
 		fi
 
-		G_WHIP_YESNO "Ready to format:\n - $device\n - Filesystem type: $text_fs_type\n - $text_menu" || return 0
+		G_WHIP_YESNO "Ready to format:\n - $format_mode_text: $device\n - Target filesystem type: $text_fs_type\n - $text_menu\nDo you wish to continue?" || return 0
 
 		# Partition format
 		if (( $FORMAT_MODE ))
@@ -524,7 +524,7 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 			done
 
 			# Unmount whole drive in case of fs on drive without partition table
-			(( ${aDRIVE_ISMOUNTED[$MENU_DRIVE_SELECTED]} )) && { Unmount_Drive "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}" || return 1; }
+			(( ! ${aDRIVE_ISPARTITION[$MENU_DRIVE_SELECTED]} && ${aDRIVE_ISMOUNTED[$MENU_DRIVE_SELECTED]} )) && { Unmount_Drive "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}" || return 1; }
 
 			# Clear partition table from device
 			G_DIETPI-NOTIFY 2 "Erasing partition table: /dev/${aDRIVE_SOURCE_DEVICE[$MENU_DRIVE_SELECTED]}"
@@ -803,8 +803,9 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 		# Edit drive
 		elif [[ $G_WHIP_RETURNED_VALUE ]]
 		then
-			TARGETMENUID=1 # Drive menu
 			MENU_DRIVE_SELECTED=$G_WHIP_RETURNED_VALUE
+			G_WHIP_DEFAULT_ITEM_NEXT_SUB1=
+			TARGETMENUID=1 # Drive menu
 		fi
 	}
 


### PR DESCRIPTION
A numerical index is fragile, as it can change when drives are rescanned, as the whole array is rebuilt from scratch. A function was in place to align the numerical index with the mount target of the selected drive with a dedicated global variable, but it was not made use of in the `Unmount_Drive` function. This could cause false partitions or false whole drives to be formatted unintentionally, if a filesystem from that drive was mounted, and hence unmounted by the script.

To harden the situation, the following changes have been done:
* The mount source device node is used as index, using associative arrays, which is assured to never change and never require any manual alignment unless a drive is formatted differently.
* The `Mount_Drive` and `Umount_Drive` functions themselves do not trigger a drive rescan anymore, instead this is done from the parent functions where needed. Notable during drive formatting, rescans could have happened multiple times if multiple filesystems from the formatted drive were mounted, unnecessary until the whole process finished, and the reason for the swapped drive index and false format target which triggered me to do this rework.
* The format run function now uses a dedicated local variable to hold the device path to be formatted, to not rely on any external index.

Unrelated changes:
* Show drive/partition capacity for unmounted/unformatted drives, which can obtained via `lsblk`, and surely helps to identify certain drives or filesystems better than based on the device name only. Hide the UUID/device name based placeholder mount point for those, instead show unmounted/unformatted info where mouonted drives show the mount point.
* Fix an error when selecting a mounted drive with a partition and select full drive format mode: It was attempted to additionally unmount the partition after it has been unmounted and formatted in a previous "all partitions" loop. Do a dedicated unmount attempt only if there is no partition table, but the filesystem was written on the bare drive without partition table. This is what it was meant for.
* mergerfs mounts are now excluded from the mounted drive loop, since they are special-handled like tmpfs/ecryptfs/vboxsf/glusterfs mounts: their `/etc/fstab` entries are extracted and preserved untouched.
* Do not skip the `blkid` cache when searching for unmounted filesystems. When executed as root, it is assured to check the current state, and despite that it performs faster when not using `/dev/null` as cache path. This has been change for the other calls already, but forgotten for this case.
* Skip the sync call at the end of the drive detection loop, there is no real reason to do that
* When doing a reboot, always exit the script immediately, since the reboot is done asynchronously and hence the script can continue unnecessarily before being killed by systemd
* Some more variables used in info output and menu texts are shared between the format menu and the final format run function.
* Shell code enhancements and format alignments