### PR TITLE
dietpi-letsencrypt: update HTTP/2 syntax and add HTTP/3/QUIC

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,7 @@ Removed software:
 - The removal of support for Debian 11 Bullseye implies the removal of the classic ownCloud software option. It does not support PHP 8.x, and development stalled. Instead we integrated support for the actively developed ownCloud Infinite Scale (see above), and a migration to Nextcloud is alternatively possible.
 
 Enhancement:
+- DietPi-LetsEncrypt | For Nginx from Debian Trixie on, the HTTP/2 syntax has been updated and HTTP/3 with QUIC is enabled. The change can be applied retrospectively by re-runnin dietpi-letsencrypt. Many thanks to @JappeHallunken for implementing this enhancement: https://github.com/MichaIng/DietPi/pull/7860
 
 Bug fixes:
 - Radxa ZERO 3 | Resolved an issue where onboard WiFi on the 3W did not work with the new kernel. Many thanks to @lsx285 and others for reporting this issue and testing fixed kernel builds: https://github.com/MichaIng/DietPi/issues/7867. The kernel has been updated on our AP repository, hence the issue won't appear anymore when updating DietPi or the package.

--- a/dietpi/dietpi-letsencrypt
+++ b/dietpi/dietpi-letsencrypt
@@ -225,7 +225,7 @@ _EOF_
 			fi
 
 			# Enable HTTP/2: https://github.com/certbot/certbot/issues/3646
-			grep -q 'http2' /etc/nginx/sites-available/default || G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*listen /s/443 ssl/443 ssl http2/' /etc/nginx/sites-available/default
+			grep -q 'http2 on;' /etc/nginx/sites-available/default || G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*listen 443 ssl;/a \    http2 on;' /etc/nginx/sites-available/default
 
 			Apply_To_Web_Applications
 

--- a/dietpi/dietpi-letsencrypt
+++ b/dietpi/dietpi-letsencrypt
@@ -228,7 +228,6 @@ _EOF_
 			# Update syntax for HTTP/2 and add also QUIC / HTTP/3
 			grep -q 'http2 on;' /etc/nginx/sites-available/default || G_EXEC sed --follow-symlinks -i 's|listen \[::\]:443 ssl http2 ipv6only=on; # managed by Certbot\nlisten 443 ssl http2; # managed by Certbot|listen 443 quic reuseport;\n    listen [::]:443 quic reuseport;\n\n    # HTTP/1.1 and HTTP/2 fallback (TCP)\n    listen 443 ssl;\n    listen [::]:443 ssl;\n    http2 on;\n\n    # QUIC settings (http3 is on by default)\n    quic_retry on; # Address validation (DDoS protection)\n    quic_gso on; # Generic Segmentation Offload (performance)\n    # Advertise HTTP/3 availability to clients\n    add_header Alt-Svc '\''h3=\"\:443\"; ma=86400'\'' always;|g' /etc/nginx/sites-available/default
 
-
 			Apply_To_Web_Applications
 
 			# Add HSTS header to software location blocks where required: https://dietpi.com/forum/t/warnings-in-the-configuration-nextcloud/15002/13

--- a/dietpi/dietpi-letsencrypt
+++ b/dietpi/dietpi-letsencrypt
@@ -225,7 +225,9 @@ _EOF_
 			fi
 
 			# Enable HTTP/2: https://github.com/certbot/certbot/issues/3646
-			grep -q 'http2 on;' /etc/nginx/sites-available/default || G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*listen 443 ssl;/a \    http2 on;' /etc/nginx/sites-available/default
+			# Update syntax for HTTP/2 and add also QUIC / HTTP/3
+			grep -q 'http2 on;' /etc/nginx/sites-available/default || G_EXEC sed --follow-symlinks -i 's|listen \[::\]:443 ssl http2 ipv6only=on; # managed by Certbot\nlisten 443 ssl http2; # managed by Certbot|listen 443 quic reuseport;\n    listen [::]:443 quic reuseport;\n\n    # HTTP/1.1 and HTTP/2 fallback (TCP)\n    listen 443 ssl;\n    listen [::]:443 ssl;\n    http2 on;\n\n    # QUIC settings (http3 is on by default)\n    quic_retry on; # Address validation (DDoS protection)\n    quic_gso on; # Generic Segmentation Offload (performance)\n    # Advertise HTTP/3 availability to clients\n    add_header Alt-Svc '\''h3=\"\:443\"; ma=86400'\'' always;|g' /etc/nginx/sites-available/default
+
 
 			Apply_To_Web_Applications
 

--- a/dietpi/dietpi-letsencrypt
+++ b/dietpi/dietpi-letsencrypt
@@ -224,9 +224,19 @@ _EOF_
 
 			fi
 
-			# Enable HTTP/2: https://github.com/certbot/certbot/issues/3646
-			# Update syntax for HTTP/2 and add also QUIC / HTTP/3
-			grep -q 'http2 on;' /etc/nginx/sites-available/default || G_EXEC sed --follow-symlinks -i 's|listen \[::\]:443 ssl http2 ipv6only=on; # managed by Certbot\nlisten 443 ssl http2; # managed by Certbot|listen 443 quic reuseport;\n    listen [::]:443 quic reuseport;\n\n    # HTTP/1.1 and HTTP/2 fallback (TCP)\n    listen 443 ssl;\n    listen [::]:443 ssl;\n    http2 on;\n\n    # QUIC settings (http3 is on by default)\n    quic_retry on; # Address validation (DDoS protection)\n    quic_gso on; # Generic Segmentation Offload (performance)\n    # Advertise HTTP/3 availability to clients\n    add_header Alt-Svc '\''h3=\"\:443\"; ma=86400'\'' always;|g' /etc/nginx/sites-available/default
+			# Bookworm: Enable HTTP/2: https://github.com/certbot/certbot/issues/3646
+			(( $G_DISTRO > 7 )) || grep -q 'http2' /etc/nginx/sites-available/default || G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*listen[[:blank:]]/s/443 ssl/443 ssl http2/' /etc/nginx/sites-available/default
+			# Trixie: Update syntax for HTTP/2 and add enable QUIC / HTTP/3
+			if (( $G_DISTRO > 7 )) && ! grep -q '^[[:blank:]]*http2 on;' /etc/nginx/sites-available/default
+			then
+				G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*listen[[:blank:]]/s/443 ssl http2/443 ssl/' /etc/nginx/sites-available/default
+				GCI_PRESERVE=1 G_CONFIG_INJECT 'https[[:blank:]]' '	http2 on;' /etc/nginx/sites-available/default 'listen[[:blank:]]+\[::\]:443[[:blank:]]'
+				grep -Eq '^[[:blank:]]*listen[[:blank:]]+443[[:blank:]].*quic' /etc/nginx/sites-available/default || G_EXEC sed --follow-symlinks -Ei '/^[[:blank:]]*listen[[:blank:]]+443/i\	listen 443 quic reuseport;' /etc/nginx/sites-available/default
+				GCI_PRESERVE=1 G_CONFIG_INJECT 'listen[[:blank:]]+\[::\]:443[[:blank:]].*quic' '	listen [::]:443 quic reuseport;' /etc/nginx/sites-available/default 'listen[[:blank:]]+443[[:blank:]].*quic'
+				GCI_PRESERVE=1 G_CONFIG_INJECT 'quic_retry[[:blank:]]' '	quic_retry on; # Address validation (DDoS protection)' /etc/nginx/sites-available/default 'listen[[:blank:]]+\[::\]:443[[:blank:]].*quic'
+				GCI_PRESERVE=1 G_CONFIG_INJECT 'quic_gso[[:blank:]]' '	quic_gso on; # Generic Segmentation Offload (performance)' /etc/nginx/sites-available/default 'quic_retry[[:blank:]]'
+				GCI_PRESERVE=1 G_CONFIG_INJECT 'add_header[[:blank:]]+Alt-Svc[[:blank:]]' '	add_header Alt-Svc '\''h3=":443"; ma=86400'\'' always; # Advertise HTTP/3 availability to clients' /etc/nginx/sites-available/default 'quic_gso[[:blank:]]'
+			fi
 
 			Apply_To_Web_Applications
 


### PR DESCRIPTION
Nginx throws a warning at startup, because

> "listen ... http2" directive is deprecated, use the "http2" directive instead

Changed from
```
listen [::]:443 ssl http2 ipv6only=on; # managed by Certbot
listen 443 ssl http2; # managed by Certbot
```
to
```
listen [::]:443 ssl ipv6only=on; # managed by Certbot
listen 443 ssl; # managed by Certbot
http2 on;
```