### PR TITLE
Add version check for node.js installation

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3130,30 +3130,30 @@ Signed-By: /etc/apt/keyrings/dietpi-adoptium.asc"
 			# Deps (verified 2025-10-22): https://github.com/MichaIng/DietPi/issues/3614, https://dietpi.com/forum/t/24574
 			(( $G_HW_ARCH == 1 )) || aDEPS=('libatomic1')
 
-      installed_ver=""
-      if command -v node &> /dev/null; then
-        installed_ver=$(node -v)
-        echo "Node.js $installed_ver is installed"
-      fi
+            installed_ver=""
+            if command -v node &> /dev/null; then
+              installed_ver=$(node -v)
+              echo "Node.js $installed_ver is installed"
+            fi
 
-      latest_ver=$(curl -sSf https://nodejs.org/dist/index.tab | awk '$3 ~ /linux-/ {print $1}' | sort -V | tail -1)
-      echo "Latest available Node.js version: $latest_ver"
+            latest_ver=$(curl -sSf https://nodejs.org/dist/index.tab | awk '$3 ~ /linux-/ {print $1}' | sort -V | tail -1)
+            echo "Latest available Node.js version: $latest_ver"
 
-      if [[ "$installed_ver" != "$latest_ver" ]]; then
-        echo "Installing Node.js $latest_ver …"
+            if [[ "$installed_ver" != "$latest_ver" ]]; then
+              echo "Installing Node.js $latest_ver …"
 
-	  		# Download installer
-	  		Download_Install 'https://raw.githubusercontent.com/MichaIng/nodejs-linux-installer/master/node-install.sh'
-	  		G_EXEC chmod +x node-install.sh
+	  		  # Download installer
+	  		  Download_Install 'https://raw.githubusercontent.com/MichaIng/nodejs-linux-installer/master/node-install.sh'
+	  		  G_EXEC chmod +x node-install.sh
 
-		  	# ARMv6/RISC-V: Use unofficial builds to get the latest version: https://github.com/MichaIng/nodejs-linux-installer/pull/2, https://github.com/MichaIng/nodejs-linux-installer/commit/cd952fe
-			  local options=()
-  			(( $G_HW_ARCH == 1 || $G_HW_ARCH == 11 )) && options=('-u')
-  			G_EXEC_OUTPUT=1 G_EXEC ./node-install.sh "${options[@]}"
-  			G_EXEC rm node-install.sh
-        else
-          echo "Node.js is up-to-date ($installed_ver) → installation skipped"
-      fi
+		  	  # ARMv6/RISC-V: Use unofficial builds to get the latest version: https://github.com/MichaIng/nodejs-linux-installer/pull/2, https://github.com/MichaIng/nodejs-linux-installer/commit/cd952fe
+              local options=()
+  			  (( $G_HW_ARCH == 1 || $G_HW_ARCH == 11 )) && options=('-u')
+  			  G_EXEC_OUTPUT=1 G_EXEC ./node-install.sh "${options[@]}"
+  			  G_EXEC rm node-install.sh
+          else
+            echo "Node.js is up-to-date ($installed_ver) → installation skipped"
+          fi
 		fi
 
 		if To_Install 130 # Python 3

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -3130,15 +3130,30 @@ Signed-By: /etc/apt/keyrings/dietpi-adoptium.asc"
 			# Deps (verified 2025-10-22): https://github.com/MichaIng/DietPi/issues/3614, https://dietpi.com/forum/t/24574
 			(( $G_HW_ARCH == 1 )) || aDEPS=('libatomic1')
 
-			# Download installer
-			Download_Install 'https://raw.githubusercontent.com/MichaIng/nodejs-linux-installer/master/node-install.sh'
-			G_EXEC chmod +x node-install.sh
+      installed_ver=""
+      if command -v node &> /dev/null; then
+        installed_ver=$(node -v)
+        echo "Node.js $installed_ver is installed"
+      fi
 
-			# ARMv6/RISC-V: Use unofficial builds to get the latest version: https://github.com/MichaIng/nodejs-linux-installer/pull/2, https://github.com/MichaIng/nodejs-linux-installer/commit/cd952fe
-			local options=()
-			(( $G_HW_ARCH == 1 || $G_HW_ARCH == 11 )) && options=('-u')
-			G_EXEC_OUTPUT=1 G_EXEC ./node-install.sh "${options[@]}"
-			G_EXEC rm node-install.sh
+      latest_ver=$(curl -sSf https://nodejs.org/dist/index.tab | awk '$3 ~ /linux-/ {print $1}' | sort -V | tail -1)
+      echo "Latest available Node.js version: $latest_ver"
+
+      if [[ "$installed_ver" != "$latest_ver" ]]; then
+        echo "Installing Node.js $latest_ver …"
+
+	  		# Download installer
+	  		Download_Install 'https://raw.githubusercontent.com/MichaIng/nodejs-linux-installer/master/node-install.sh'
+	  		G_EXEC chmod +x node-install.sh
+
+		  	# ARMv6/RISC-V: Use unofficial builds to get the latest version: https://github.com/MichaIng/nodejs-linux-installer/pull/2, https://github.com/MichaIng/nodejs-linux-installer/commit/cd952fe
+			  local options=()
+  			(( $G_HW_ARCH == 1 || $G_HW_ARCH == 11 )) && options=('-u')
+  			G_EXEC_OUTPUT=1 G_EXEC ./node-install.sh "${options[@]}"
+  			G_EXEC rm node-install.sh
+        else
+          echo "Node.js is up-to-date ($installed_ver) → installation skipped"
+      fi
 		fi
 
 		if To_Install 130 # Python 3


### PR DESCRIPTION
I'm currently implementing [https://github.com/louislam/uptime-kuma](https://github.com/louislam/uptime-kuma) (I don't know if Stephan already asked you about it, I just started doing it) which depends on node.js.
For testing I did a lot of installing and reinstalling and every time I did this node.js was pulled and installed again, despite the fact that the current version is already present. So I added just some lines to do quick check to prevent this behaviour.

**New behaviour:**
If the currently installed version matches the newest node.js version the installation process is skipped.

