### PR TITLE
Add Uptime Kuma - A fancy self-hosted monitoring tool 

### DIFF
--- a/.github/workflows/dietpi-software.bash
+++ b/.github/workflows/dietpi-software.bash
@@ -275,6 +275,7 @@ Process_Software()
 			#173 LXQt: all executables strictly require a Qt session, no help or version output possible
 			174) aCOMMANDS[i]='gimp -v';;
 			175) aCOMMANDS[i]='xfce4-power-manager -V';;
+			176) aSERVICES[i]='uptime-kuma' aTCP[i]='3002';;
 			177) aSERVICES[i]='forgejo' aTCP[i]='3000';;
 			178) aSERVICES[i]='jellyfin' aTCP[i]='8097';;
 			179) aSERVICES[i]='komga' aTCP[i]='2037'; (( $emulation )) && aDELAY[i]=300 || aDELAY[i]=30;;

--- a/.github/workflows/update_urls.bash
+++ b/.github/workflows/update_urls.bash
@@ -66,7 +66,7 @@ aREGEX[$software_id]='https://github.com/MediaBrowser/Emby.Releases/releases/dow
 
 # ownCloud Infinite Scale
 software_id=47
-aCHECK[$software_id]='curl -sSfL '\''https://api.github.com/repos/owncloud/ocis/releases/latest'\'' | mawk -F\" "/^ *\"browser_download_url\": \".*\/ocis-[^\"\/]*-linux-$arch\"$/{print \$4}"'
+aCHECK[$software_id]='curl -sSf '\''https://api.github.com/repos/owncloud/ocis/releases/latest'\'' | mawk -F\" "/^ *\"browser_download_url\": \".*\/ocis-[^\"\/]*-linux-$arch\"$/{print \$4}"'
 aARCH[$software_id]='arm arm64 amd64'
 aARCH_CHECK[$software_id]='riscv64'
 aREGEX[$software_id]='https://github.com/owncloud/ocis/releases/download/.*/ocis-.*-linux-\$arch'
@@ -214,6 +214,12 @@ software_id=171
 aCHECK[$software_id]='curl -sSf '\''https://api.github.com/repos/fatedier/frp/releases/latest'\'' | mawk -F\" "/^ *\"browser_download_url\": \".*\/frp_[0-9.]*_linux_$arch\.tar\.gz\"$/{print \$4}"'
 aARCH[$software_id]='arm arm_hf arm64 amd64 riscv64'
 aREGEX[$software_id]='https://github.com/fatedier/frp/releases/download/.*/frp_.*_linux_\$arch.tar.gz'
+
+# Uptime Kuma
+software_id=176
+aCHECK[$software_id]='curl -sSf '\''https://api.github.com/repos/louislam/uptime-kuma/releases/latest'\'' | mawk -F\" '\''/^ *"tag_name": "[^"]*",$/{print $4}'\'
+aREGEX[$software_id]='version='\''[^'\'']*'\''; '
+aREPLACE[$software_id]='version='\''$release'\''; '
 
 # Forgejo
 software_id=177

--- a/.meta/dietpi-survey_report
+++ b/.meta/dietpi-survey_report
@@ -588,6 +588,7 @@ shopt -s extglob # +(expr) syntax
 		aSOFTWARE_NAME10_0[i]=${aSOFTWARE_NAME9_20[i]}
 	done
 	unset -v 'aSOFTWARE_NAME10_0[59]' # RPi Cam Web Interface
+	aSOFTWARE_NAME10_0[176]='Uptime Kuma'
 
 	# Pre-create software counter array so that we can see also software (available in newest version) with 0 installs
 	for i in "${aSOFTWARE_NAME10_0[@]}"

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ Breaking:
 
 New software:
 - ownCloud Infinite Scale | This successor of the classic ownCloud file sync and share platform has been added to our software catalogue.
+- Uptime Kuma | This self-hosted monitoring tool has been added to our software catalogue. Many thanks to @JappeHallunken for implementing this software option: https://github.com/MichaIng/DietPi/pull/7888
 
 Removed SBC support:
 - The removed of support for Debian 11 Bullseye implies the removal of support for the Sparky SBC, NanoPi M2/T2/Fire2, and NanoPi M3/T3/Fire3 families. Images for those SBCs ship with very old vendor Linux versions, which cannot run Debian 13 Trixie. They already had issues which Debian 12 Bookworm, which is the reason we provided only Bullseye images for them. If anyone finds functional mainline-based Linux and U-Boot sources, or is able to rebase the needed drivers and device trees, we are happy to re-implement support.

--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ Links to hardware and software manufacturers, sources and build instructions use
 - [LazyLibrarian](https://gitlab.com/LazyLibrarian/LazyLibrarian)
 - [BirdNET-Go](https://github.com/tphakala/birdnet-go)
 - [RustDesk](https://github.com/rustdesk/rustdesk-server)
+- [Uptime Kuma](https://github.com/louislam/uptime-kuma)
 
 ---
 

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -260,7 +260,7 @@ _EOF_
 			'htpc-manager'
 			'node_exporter'
 			'raspberrypi_exporter'
-      'uptime-kuma'
+            'uptime-kuma'
 
 			# - Misc
 			'docker'

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -260,7 +260,7 @@ _EOF_
 			'htpc-manager'
 			'node_exporter'
 			'raspberrypi_exporter'
-            'uptime-kuma'
+			'uptime-kuma'
 
 			# - Misc
 			'docker'

--- a/dietpi/dietpi-services
+++ b/dietpi/dietpi-services
@@ -260,6 +260,7 @@ _EOF_
 			'htpc-manager'
 			'node_exporter'
 			'raspberrypi_exporter'
+      'uptime-kuma'
 
 			# - Misc
 			'docker'

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1184,6 +1184,13 @@ Available commands:
 		aSOFTWARE_CATX[$software_id]=8
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/system_stats/#homer'
 		aSOFTWARE_DEPS[$software_id]='webserver'
+    #------------------
+		software_id=176
+		aSOFTWARE_NAME[$software_id]='Uptime Kuma'
+		aSOFTWARE_DESC[$software_id]='A fancy self-hosted monitoring tool'
+		aSOFTWARE_CATX[$software_id]=8
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/system_stats/#uptime_kuma'
+		aSOFTWARE_DEPS[$software_id]='17 24' # Git, Node.js
 
 		# Remote Access
 		#--------------------------------------------------------------------------------

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1184,7 +1184,7 @@ Available commands:
 		aSOFTWARE_CATX[$software_id]=8
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/system_stats/#homer'
 		aSOFTWARE_DEPS[$software_id]='webserver'
-    #------------------
+        #------------------
 		software_id=176
 		aSOFTWARE_NAME[$software_id]='Uptime Kuma'
 		aSOFTWARE_DESC[$software_id]='A fancy self-hosted monitoring tool'

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12162,27 +12162,27 @@ _EOF_
 			unset -v rd_inst rd_data
 		fi
 
-    if To_Install 176 # Uptime Kuma
-    then
-      local opt='/opt/uptime-kuma'
-      local mnt='/mnt/dietpi_userdata/uptime-kuma'
+        if To_Install 176 # Uptime Kuma
+        then
+          local opt='/opt/uptime-kuma'
+          local mnt='/mnt/dietpi_userdata/uptime-kuma'
 
-      # Reinstall
-      [[ -d $opt ]] && G_EXEC rm -R "$opt"
+          # Reinstall
+          [[ -d $opt ]] && G_EXEC rm -R "$opt"
 
-      # User and directories
-      Create_User -d "$mnt" uptime-kuma
-      
-      # Clone & install https://github.com/louislam/uptime-kuma/wiki/%F0%9F%94%A7-How-to-Install#-non-docker
-      G_EXEC git clone https://github.com/louislam/uptime-kuma.git "$opt"
-      G_EXEC cd "$opt" && /usr/local/bin/npm run setup
+          # User and directories
+          Create_User -d "$mnt" uptime-kuma
+          
+          # Clone & install https://github.com/louislam/uptime-kuma/wiki/%F0%9F%94%A7-How-to-Install#-non-docker
+          G_EXEC git clone https://github.com/louislam/uptime-kuma.git "$opt"
+          G_EXEC cd "$opt" && /usr/local/bin/npm run setup
 
-      # Create data dir and link it
-      G_EXEC mkdir -p "$mnt"
-      G_EXEC ln -s "$mnt" "$opt/data"
+          # Create data dir and link it
+          G_EXEC mkdir -p "$mnt"
+          G_EXEC ln -s "$mnt" "$opt/data"
 
-      # Create db-config to pre-select usage of sqlite3 (without this you can choose between mariaDB and sqlite on first run)
-      [[ -f "$mnt/db-config.json" ]] || cat << _EOF_ > "$mnt/db-config.json" || exit 1
+          # Create db-config to pre-select usage of sqlite3 (without this you can choose between mariaDB and sqlite on first run)
+          [[ -f "$mnt/db-config.json" ]] || cat << _EOF_ > "$mnt/db-config.json" || exit 1
 {
     "type": "sqlite",
     "port": 3306,
@@ -12192,11 +12192,11 @@ _EOF_
     "dbName": "kuma"
 }
 _EOF_
-     G_EXEC chown -R uptime-kuma:uptime-kuma "$mnt"
-     G_EXEC chmod -R 755 "$mnt"
+         G_EXEC chown -R uptime-kuma:uptime-kuma "$mnt"
+         G_EXEC chmod -R 755 "$mnt"
 
-     # Create systemd service, we do not use pm2 to run it
-     cat << _EOF_ > /etc/systemd/system/uptime-kuma.service
+         # Create systemd service, we do not use pm2 to run it
+         cat << _EOF_ > /etc/systemd/system/uptime-kuma.service
 # /etc/systemd/system/uptime-kuma.service
 [Unit]
 Description=Uptime Kuma
@@ -12215,9 +12215,9 @@ Environment=NODE_ENV=production
 [Install]
 WantedBy=multi-user.target
 _EOF_
-      aSTART_SERVICES+=('uptime-kuma')
-      unset -v mnt opt
-    fi
+          aSTART_SERVICES+=('uptime-kuma')
+          unset -v mnt opt
+        fi
 	}
 
 	# $1: 0=None -1=Dropbear -2=OpenSSH

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12175,6 +12175,8 @@ _EOF_
 
 			# Install
 			G_EXEC cd "uptime-kuma-$version"
+			# - Temporary workaround for false v2.0.1 string in 2.0.2 code
+			[[ $version == '2.0.2' ]] && G_EXEC sed --follow-symlinks -i '1,/"version": "2.0.1"/s/"version": "2.0.1"/"version": "2.0.2"/' package.json
 			G_EXEC_OUTPUT=1 G_EXEC npm ci --omit dev --no-audit
 			G_EXEC_OUTPUT=1 G_EXEC npm run download-dist
 			G_EXEC cd "$G_WORKING_DIR"
@@ -12182,8 +12184,7 @@ _EOF_
 			G_EXEC mv "uptime-kuma-$version" "$opt"
 
 			# Data dir
-			G_EXEC mkdir -p "$opt" "$mnt"
-			G_EXEC ln -s "$mnt" "$opt/data"
+			G_EXEC mkdir -p "$mnt"
 
 			# Create db-config to pre-select usage of SQLite. Else, first access gives a choice between MariaDB and SQLite.
 			[[ -f "$mnt/db-config.json" ]] || G_EXEC eval "echo '{\"type\":\"sqlite\"}' > '$mnt/db-config.json'"
@@ -12203,10 +12204,10 @@ StartLimitIntervalSec=60
 StartLimitBurst=3
 
 [Service]
+SyslogIdentifier=Uptime Kuma
 User=uptime-kuma
 WorkingDirectory=$opt
-Environment=NODE_ENV=production
-ExecStart=/usr/local/bin/node server/server.js
+ExecStart=/usr/local/bin/node server/server.js --data-dir=$mnt --port=3002
 Restart=on-failure
 RestartSec=10
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1190,7 +1190,7 @@ Available commands:
 		aSOFTWARE_DESC[$software_id]='A fancy self-hosted monitoring tool'
 		aSOFTWARE_CATX[$software_id]=8
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/system_stats/#uptime_kuma'
-		aSOFTWARE_DEPS[$software_id]='17 24' # Git, Node.js
+		aSOFTWARE_DEPS[$software_id]='17 9' # Git, Node.js
 
 		# Remote Access
 		#--------------------------------------------------------------------------------
@@ -12161,6 +12161,55 @@ _EOF_
 			aSTART_SERVICES+=('rustdesksignal' 'rustdeskrelay')
 			unset -v rd_inst rd_data
 		fi
+
+    if To_Install 176 # Uptime Kuma
+    then
+      # User and directories
+      Create_User -d /mnt/dietpi_userdata/uptime-kuma uptime-kuma
+      
+      # Clone and install
+      G_EXEC git clone https://github.com/louislam/uptime-kuma.git /opt/uptime-kuma
+      G_EXEC cd /opt/uptime-kuma && /usr/local/bin/npm run setup
+
+      # Create data dir and link it
+      G_EXEC mkdir -p /mnt/dietpi_userdata/uptime-kuma
+      G_EXEC ln -s /mnt/dietpi_userdata/uptime-kuma /opt/uptime-kuma/data
+
+      # Create db-config to pre-select usage of sqlite3 (without this you can choose between mariaDB and sqlite on first run)
+      [[ -f /mnt/dietpi_userdata/uptime-kuma/db-config.json ]] || cat << _EOF_ > /mnt/dietpi_userdata/uptime-kuma/db-config.json || exit 1
+{
+    "type": "sqlite",
+    "port": 3306,
+    "hostname": "",
+    "username": "",
+    "password": "",
+    "dbName": "kuma"
+}
+_EOF_
+     G_EXEC chown -R uptime-kuma:uptime-kuma /mnt/dietpi_userdata/uptime-kuma
+     G_EXEC chmod -R 755 /mnt/dietpi_userdata/uptime-kuma
+
+     cat << _EOF_ > /etc/systemd/system/uptime-kuma.service
+# /etc/systemd/system/uptime-kuma.service
+[Unit]
+Description=Uptime Kuma
+After=network.target
+
+[Service]
+Type=simple
+User=uptime-kuma
+Group=uptime-kuma
+WorkingDirectory=/opt/uptime-kuma
+ExecStart=/usr/local/bin/node server/server.js
+Restart=on-failure
+RestartSec=10
+Environment=NODE_ENV=production
+
+[Install]
+WantedBy=multi-user.target
+_EOF_
+      aSTART_SERVICES+=('uptime-kuma')
+    fi
 	}
 
 	# $1: 0=None -1=Dropbear -2=OpenSSH
@@ -14259,6 +14308,13 @@ _EOF_
 			G_EXEC rm -Rf /opt/rustdesk
 			G_EXEC rm -Rf /mnt/dietpi_userdata/rustdesk
 		fi
+
+    if To_Uninstall 176 # Uptime kuma
+    then
+      Remove_Service uptime-kuma uptime-kuma uptime-kuma
+      G_EXEC rm -Rf /opt/uptime-kuma
+      G_EXEC rm -Rf /mnt/dietpi_userdata/uptime-kuma
+    fi
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Finalising uninstall'
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1184,12 +1184,12 @@ Available commands:
 		aSOFTWARE_CATX[$software_id]=8
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/system_stats/#homer'
 		aSOFTWARE_DEPS[$software_id]='webserver'
-        #------------------
+		#------------------
 		software_id=176
 		aSOFTWARE_NAME[$software_id]='Uptime Kuma'
 		aSOFTWARE_DESC[$software_id]='A fancy self-hosted monitoring tool'
 		aSOFTWARE_CATX[$software_id]=8
-		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/system_stats/#uptime_kuma'
+		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/system_stats/#uptime-kuma'
 		aSOFTWARE_DEPS[$software_id]='9' # Node.js
 
 		# Remote Access
@@ -12162,53 +12162,51 @@ _EOF_
 			unset -v rd_inst rd_data
 		fi
 
-        if To_Install 176 uptime-kuma # Uptime Kuma
-        then
-          local opt='/opt/uptime-kuma'
-          local mnt='/mnt/dietpi_userdata/uptime-kuma'
-          local LATEST_TAG=$(curl -s https://api.github.com/repos/louislam/uptime-kuma/tags | grep -Po '"name": "\K.*?(?=")' | head -n1)
+		if To_Install 176 uptime-kuma # Uptime Kuma: https://github.com/louislam/uptime-kuma/wiki/🔧-How-to-Install#-non-docker
+		then
+			local opt='/opt/uptime-kuma' mnt='/mnt/dietpi_userdata/uptime-kuma'
 
-          # Reinstall
-          [[ -d $opt ]] && G_EXEC rm -R "$opt"
+			# Download
+			local version=$(curl -sSfL 'https://api.github.com/repos/louislam/uptime-kuma/releases/latest' | mawk -F\" '/^ *"tag_name": "[^"]*",$/{print $4}')
+			[[ $version ]] || { version='2.0.2'; G_DIETPI-NOTIFY 1 "Automatic latest ${aSOFTWARE_NAME[$software_id]} version detection failed. Version \"$version\" will be installed as fallback, but a newer version might be available. Please report this at: https://github.com/MichaIng/DietPi/issues"; }
+			Download_Install "https://github.com/louislam/uptime-kuma/archive/$version.tar.gz"
 
-          # User and directories
-          Create_User -d "$mnt" uptime-kuma
+			# Install
+			G_EXEC cd "uptime-kuma-$version"
+			G_EXEC_OUTPUT=1 G_EXEC npm ci --omit dev --no-audit
+			G_EXEC_OUTPUT=1 G_EXEC npm run download-dist
+			G_EXEC cd "$G_WORKING_DIR"
+			[[ -d $opt ]] && G_EXEC rm -R "$opt"
+			G_EXEC mv "uptime-kuma-$version" "$opt"
 
-          G_EXEC mkdir -p "$opt" "$mnt"
+			# Data dir
+			G_EXEC mkdir -p "$opt" "$mnt"
+			G_EXEC ln -s "$mnt" "$opt/data"
 
-          # Clone & install https://github.com/louislam/uptime-kuma/wiki/%F0%9F%94%A7-How-to-Install#-non-docker
-          Download_Install "https://github.com/louislam/uptime-kuma/archive/refs/tags/${LATEST_TAG}.tar.gz" /opt
+			# Create db-config to pre-select usage of SQLite. Else, first access gives a choice between MariaDB and SQLite.
+			[[ -f "$mnt/db-config.json" ]] || G_EXEC eval "echo '{\"type\":\"sqlite\"}' > '$mnt/db-config.json'"
 
-          G_EXEC rsync -a "/opt/uptime-kuma-$LATEST_TAG/" "$opt/"
-          G_EXEC rm -R "/opt/uptime-kuma-$LATEST_TAG"
-          G_EXEC ln -s "$mnt" "$opt/data"
+			# User
+			Create_User -d "$mnt" uptime-kuma
+			G_EXEC chown -R uptime-kuma:uptime-kuma "$mnt"
 
-          G_EXEC cd "$opt"
-          G_EXEC_OUTPUT=1 G_EXEC npm ci --omit dev --no-audit
-          G_EXEC_OUTPUT=1 G_EXEC npm run download-dist
-
-          # Create db-config to pre-select usage of sqlite3 (without this you can choose between mariaDB and sqlite on first run)
-          [[ -f "$mnt/db-config.json" ]] || G_EXEC eval "echo '{\"type\":\"sqlite\"}' > '$mnt/db-config.json'"
-
-          G_EXEC chown -R uptime-kuma:uptime-kuma "$mnt"
-          G_EXEC chmod -R 755 "$mnt"
-
-          # Create systemd service, we do not use pm2 to run it
-          cat << _EOF_ > /etc/systemd/system/uptime-kuma.service
+			# Service (instead of PM2 as suggested by their wiki)
+			cat << _EOF_ > /etc/systemd/system/uptime-kuma.service
 # /etc/systemd/system/uptime-kuma.service
 [Unit]
 Description=Uptime Kuma
-After=network.target
+Wants=network-online.target
+After=network-online.target
+StartLimitIntervalSec=60
+StartLimitBurst=3
 
 [Service]
-Type=simple
 User=uptime-kuma
-Group=uptime-kuma
 WorkingDirectory=$opt
+Environment=NODE_ENV=production
 ExecStart=/usr/local/bin/node server/server.js
 Restart=on-failure
 RestartSec=10
-Environment=NODE_ENV=production
 
 # Hardening
 ProtectSystem=strict
@@ -12226,8 +12224,8 @@ ReadWritePaths=-$mnt
 [Install]
 WantedBy=multi-user.target
 _EOF_
-          unset -v mnt opt LATEST_TAG
-        fi
+			unset -v mnt opt
+		fi
 	}
 
 	# $1: 0=None -1=Dropbear -2=OpenSSH
@@ -14327,11 +14325,12 @@ _EOF_
 			G_EXEC rm -Rf /mnt/dietpi_userdata/rustdesk
 		fi
 
-        if To_Uninstall 176 # Uptime kuma
-        then
-          Remove_Service uptime-kuma 1 1
-          G_EXEC rm -Rf /opt/uptime-kuma
-        fi
+		if To_Uninstall 176 # Uptime Kuma
+		then
+			Remove_Service uptime-kuma 1 1
+			G_EXEC rm -Rf /opt/uptime-kuma
+			G_WHIP_BUTTON_CANCEL_TEXT='Skip' G_WHIP_YESNO "Shall all ${aSOFTWARE_NAME[$software_id]} data at /mnt/dietpi_userdata/uptime-kuma be removed as well?" && G_EXEC rm -Rf /mnt/dietpi_userdata/uptime-kuma
+		fi
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Finalising uninstall'
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -14317,12 +14317,12 @@ _EOF_
 			G_EXEC rm -Rf /mnt/dietpi_userdata/rustdesk
 		fi
 
-    if To_Uninstall 176 # Uptime kuma
-    then
-      Remove_Service uptime-kuma uptime-kuma uptime-kuma
-      G_EXEC rm -Rf /opt/uptime-kuma
-      G_EXEC rm -Rf /mnt/dietpi_userdata/uptime-kuma
-    fi
+        if To_Uninstall 176 # Uptime kuma
+        then
+          Remove_Service uptime-kuma uptime-kuma uptime-kuma
+          G_EXEC rm -Rf /opt/uptime-kuma
+          G_EXEC rm -Rf /mnt/dietpi_userdata/uptime-kuma
+        fi
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Finalising uninstall'
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12164,19 +12164,25 @@ _EOF_
 
     if To_Install 176 # Uptime Kuma
     then
+      local opt='/opt/uptime-kuma'
+      local mnt='/mnt/dietpi_userdata/uptime-kuma'
+      # Reinstall
+      [[ -d $opt ]] && G_EXEC rm -R "$opt"
+
+
       # User and directories
-      Create_User -d /mnt/dietpi_userdata/uptime-kuma uptime-kuma
+      Create_User -d "$mnt" uptime-kuma
       
-      # Clone and install
-      G_EXEC git clone https://github.com/louislam/uptime-kuma.git /opt/uptime-kuma
-      G_EXEC cd /opt/uptime-kuma && /usr/local/bin/npm run setup
+      # Clone and install or update, if already present
+      G_EXEC git clone https://github.com/louislam/uptime-kuma.git "$opt"
+      G_EXEC cd "$opt" && /usr/local/bin/npm run setup
 
       # Create data dir and link it
-      G_EXEC mkdir -p /mnt/dietpi_userdata/uptime-kuma
-      G_EXEC ln -s /mnt/dietpi_userdata/uptime-kuma /opt/uptime-kuma/data
+      G_EXEC mkdir -p "$mnt"
+      G_EXEC ln -s "$mnt" "$opt/data"
 
       # Create db-config to pre-select usage of sqlite3 (without this you can choose between mariaDB and sqlite on first run)
-      [[ -f /mnt/dietpi_userdata/uptime-kuma/db-config.json ]] || cat << _EOF_ > /mnt/dietpi_userdata/uptime-kuma/db-config.json || exit 1
+      [[ -f "$mnt/db-config.json" ]] || cat << _EOF_ > "$mnt/db-config.json" || exit 1
 {
     "type": "sqlite",
     "port": 3306,
@@ -12186,8 +12192,8 @@ _EOF_
     "dbName": "kuma"
 }
 _EOF_
-     G_EXEC chown -R uptime-kuma:uptime-kuma /mnt/dietpi_userdata/uptime-kuma
-     G_EXEC chmod -R 755 /mnt/dietpi_userdata/uptime-kuma
+     G_EXEC chown -R uptime-kuma:uptime-kuma "$mnt"
+     G_EXEC chmod -R 755 "$mnt"
 
      cat << _EOF_ > /etc/systemd/system/uptime-kuma.service
 # /etc/systemd/system/uptime-kuma.service
@@ -12199,7 +12205,7 @@ After=network.target
 Type=simple
 User=uptime-kuma
 Group=uptime-kuma
-WorkingDirectory=/opt/uptime-kuma
+WorkingDirectory=$opt
 ExecStart=/usr/local/bin/node server/server.js
 Restart=on-failure
 RestartSec=10
@@ -12209,6 +12215,7 @@ Environment=NODE_ENV=production
 WantedBy=multi-user.target
 _EOF_
       aSTART_SERVICES+=('uptime-kuma')
+      unset -v mnt opt
     fi
 	}
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12172,7 +12172,7 @@ _EOF_
 
           # User and directories
           Create_User -d "$mnt" uptime-kuma
-          
+
           # Clone & install https://github.com/louislam/uptime-kuma/wiki/%F0%9F%94%A7-How-to-Install#-non-docker
           G_EXEC git clone https://github.com/louislam/uptime-kuma.git "$opt"
           G_EXEC cd "$opt" && /usr/local/bin/npm run setup

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1191,6 +1191,8 @@ Available commands:
 		aSOFTWARE_CATX[$software_id]=8
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/system_stats/#uptime-kuma'
 		aSOFTWARE_DEPS[$software_id]='9' # Node.js
+		# - RISC-V: https://github.com/louislam/node-sqlite3/releases
+		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,11]=0
 
 		# Remote Access
 		#--------------------------------------------------------------------------------

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1190,7 +1190,7 @@ Available commands:
 		aSOFTWARE_DESC[$software_id]='A fancy self-hosted monitoring tool'
 		aSOFTWARE_CATX[$software_id]=8
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/system_stats/#uptime_kuma'
-		aSOFTWARE_DEPS[$software_id]='17 9' # Git, Node.js
+		aSOFTWARE_DEPS[$software_id]='9' # Node.js
 
 		# Remote Access
 		#--------------------------------------------------------------------------------
@@ -12162,10 +12162,11 @@ _EOF_
 			unset -v rd_inst rd_data
 		fi
 
-        if To_Install 176 # Uptime Kuma
+        if To_Install 176 uptime-kuma # Uptime Kuma
         then
           local opt='/opt/uptime-kuma'
           local mnt='/mnt/dietpi_userdata/uptime-kuma'
+          local LATEST_TAG=$(curl -s https://api.github.com/repos/louislam/uptime-kuma/tags | grep -Po '"name": "\K.*?(?=")' | head -n1)
 
           # Reinstall
           [[ -d $opt ]] && G_EXEC rm -R "$opt"
@@ -12173,30 +12174,27 @@ _EOF_
           # User and directories
           Create_User -d "$mnt" uptime-kuma
 
-          # Clone & install https://github.com/louislam/uptime-kuma/wiki/%F0%9F%94%A7-How-to-Install#-non-docker
-          G_EXEC git clone https://github.com/louislam/uptime-kuma.git "$opt"
-          G_EXEC cd "$opt" && /usr/local/bin/npm run setup
+          G_EXEC mkdir -p "$opt" "$mnt"
 
-          # Create data dir and link it
-          G_EXEC mkdir -p "$mnt"
+          # Clone & install https://github.com/louislam/uptime-kuma/wiki/%F0%9F%94%A7-How-to-Install#-non-docker
+          Download_Install "https://github.com/louislam/uptime-kuma/archive/refs/tags/${LATEST_TAG}.tar.gz" /opt
+
+          G_EXEC rsync -a "/opt/uptime-kuma-$LATEST_TAG/" "$opt/"
+          G_EXEC rm -R "/opt/uptime-kuma-$LATEST_TAG"
           G_EXEC ln -s "$mnt" "$opt/data"
 
-          # Create db-config to pre-select usage of sqlite3 (without this you can choose between mariaDB and sqlite on first run)
-          [[ -f "$mnt/db-config.json" ]] || cat << _EOF_ > "$mnt/db-config.json" || exit 1
-{
-    "type": "sqlite",
-    "port": 3306,
-    "hostname": "",
-    "username": "",
-    "password": "",
-    "dbName": "kuma"
-}
-_EOF_
-         G_EXEC chown -R uptime-kuma:uptime-kuma "$mnt"
-         G_EXEC chmod -R 755 "$mnt"
+          G_EXEC cd "$opt"
+          G_EXEC_OUTPUT=1 G_EXEC npm ci --omit dev --no-audit
+          G_EXEC_OUTPUT=1 G_EXEC npm run download-dist
 
-         # Create systemd service, we do not use pm2 to run it
-         cat << _EOF_ > /etc/systemd/system/uptime-kuma.service
+          # Create db-config to pre-select usage of sqlite3 (without this you can choose between mariaDB and sqlite on first run)
+          [[ -f "$mnt/db-config.json" ]] || G_EXEC eval "echo '{\"type\":\"sqlite\"}' > '$mnt/db-config.json'"
+
+          G_EXEC chown -R uptime-kuma:uptime-kuma "$mnt"
+          G_EXEC chmod -R 755 "$mnt"
+
+          # Create systemd service, we do not use pm2 to run it
+          cat << _EOF_ > /etc/systemd/system/uptime-kuma.service
 # /etc/systemd/system/uptime-kuma.service
 [Unit]
 Description=Uptime Kuma
@@ -12212,11 +12210,23 @@ Restart=on-failure
 RestartSec=10
 Environment=NODE_ENV=production
 
+# Hardening
+ProtectSystem=strict
+ProtectHome=1
+PrivateUsers=1
+PrivateTmp=1
+PrivateDevices=1
+ProtectKernelTunables=1
+ProtectControlGroups=1
+ProtectKernelModules=1
+ProtectKernelLogs=1
+ProtectClock=1
+ReadWritePaths=-$mnt
+
 [Install]
 WantedBy=multi-user.target
 _EOF_
-          aSTART_SERVICES+=('uptime-kuma')
-          unset -v mnt opt
+          unset -v mnt opt LATEST_TAG
         fi
 	}
 
@@ -14321,7 +14331,6 @@ _EOF_
         then
           Remove_Service uptime-kuma uptime-kuma uptime-kuma
           G_EXEC rm -Rf /opt/uptime-kuma
-          G_EXEC rm -Rf /mnt/dietpi_userdata/uptime-kuma
         fi
 
 		G_DIETPI-NOTIFY 3 "$G_PROGRAM_NAME" 'Finalising uninstall'

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -14329,7 +14329,7 @@ _EOF_
 
         if To_Uninstall 176 # Uptime kuma
         then
-          Remove_Service uptime-kuma uptime-kuma uptime-kuma
+          Remove_Service uptime-kuma 1 1
           G_EXEC rm -Rf /opt/uptime-kuma
         fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12166,14 +12166,14 @@ _EOF_
     then
       local opt='/opt/uptime-kuma'
       local mnt='/mnt/dietpi_userdata/uptime-kuma'
+
       # Reinstall
       [[ -d $opt ]] && G_EXEC rm -R "$opt"
-
 
       # User and directories
       Create_User -d "$mnt" uptime-kuma
       
-      # Clone and install or update, if already present
+      # Clone & install https://github.com/louislam/uptime-kuma/wiki/%F0%9F%94%A7-How-to-Install#-non-docker
       G_EXEC git clone https://github.com/louislam/uptime-kuma.git "$opt"
       G_EXEC cd "$opt" && /usr/local/bin/npm run setup
 
@@ -12195,6 +12195,7 @@ _EOF_
      G_EXEC chown -R uptime-kuma:uptime-kuma "$mnt"
      G_EXEC chmod -R 755 "$mnt"
 
+     # Create systemd service, we do not use pm2 to run it
      cat << _EOF_ > /etc/systemd/system/uptime-kuma.service
 # /etc/systemd/system/uptime-kuma.service
 [Unit]


### PR DESCRIPTION
https://github.com/louislam/uptime-kuma

@StephanStS mailed me about this a few days ago and it looks pretty nice. It's a web dashboard  where you can add your self-hosted services (or you could also monitor external services, basically everything that's accessible via the internet).

In the current form it just runs on it's own port, I did not add any webserver integrations / reversy proxy configs.
It's also a bit of a hassle to run it from a subpath, officially it's not supported, see: [https://github.com/louislam/uptime-kuma/issues/147](https://github.com/louislam/uptime-kuma/issues/147)
I think most DietPi users will run not their own domain, most likely they run it locally or they have a DynDNS domain, so for running it on a subdomain another DynDNS domain would be necessary.

We could simply add proxy configuration notes to the software documentation or link to the Uptime Kuma docs, and avoid providing integration via dietpi-software, since it can run standalone and does not require a web server or reverse proxy for its core functionality.