### PR TITLE
Add version check for BirdNET-Go installation

### DIFF
--- a/.github/workflows/update_urls.bash
+++ b/.github/workflows/update_urls.bash
@@ -148,9 +148,10 @@ software_id=124
 
 # BirdNET-Go
 software_id=127
-aCHECK[$software_id]='curl -sSf '\''https://api.github.com/repos/tphakala/birdnet-go/releases'\'' | mawk -F\" '\''/^ *"tag_name": "[^"]*",$/{print $4}'\'' | head -1'
-aREGEX[$software_id]='bnet_vers='\''[^'\'']*'\'
-aREPLACE[$software_id]='bnet_vers='\''$release'\'
+aCHECK[$software_id]='curl -sSf '\''https://api.github.com/repos/tphakala/birdnet-go/releases'\'' | mawk -F\" "/^ *\"browser_download_url\": \"[^\"]*-linux-$arch\.tar\.gz\"$/{print \$4}" | head -1'
+aARCH[$software_id]='arm64 amd64'
+aARCH_CHECK[$software_id]='riscv64'
+aREGEX[$software_id]='https://github.com/tphakala/birdnet-go/releases/download/.*-linux-\$arch\.tar\.gz'
 
 # YaCy
 software_id=133

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -25,6 +25,7 @@ Bug fixes:
 - Orange Pi 3/3 LTS | Resolved an issue where WiFi and Bluetooth did not work without manually loading the related kernel modules "sprdwl_ng" and "sprdbt_tty" respectively. This is now done when toggling WiFi and Bluetooth via dietpi-config or dietpi.txt. Many thanks to @iMagz for reporting this issue: https://github.com/MichaIng/DietPi/issues/7878
 - DietPi-Software | Home Assistant: Resolved an issue where the installation could have failed on RISC-V and ARMv6/7 Bookworm systems due to missing dependencies.
 - DietPi-Software | Home Assistant: Worked around an issue where the installation and service start failed due to a missing upper dependency declaration. The issue has been solved at Home Assistant for their upcoming release, which will make our workaround obsolete.
+- DietPi-Software | BirdNET-Go: The latest (pre-)release will now be detected and installed instead of a hardcoded version, which solves an upstream bug where reviewing bird detections did not work. Many thanks to @Sonnenfleck and @oturn for reporting the issue and testing newer versions, as well as @JappeHallunken for implementing the dynamic release download: https://github.com/MichaIng/DietPi/issues/7861, https://github.com/MichaIng/DietPi/issues/7861
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/ADDME
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11926,7 +11926,7 @@ _EOF_
 
 		if To_Install 127 birdnet # BirdNET-Go: https://github.com/tphakala/birdnet-go/blob/main/install.sh
 		then
-			local bnet_vers='nightly-20251028'
+			local bnet_vers=$(curl -s https://api.github.com/repos/tphakala/birdnet-go/releases | grep -oP '"tag_name":\s*"\Knightly-[0-9]+' | sort -r | head -n1)
 			local bnet_inst='/opt/birdnet'
 			local bnet_data='/mnt/dietpi_userdata/birdnet'
 			local bnet_conf="$bnet_data/.config/birdnet-go/config.yaml"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11926,7 +11926,7 @@ _EOF_
 
 		if To_Install 127 birdnet # BirdNET-Go: https://github.com/tphakala/birdnet-go/blob/main/install.sh
 		then
-			local bnet_vers=$(curl -s https://api.github.com/repos/tphakala/birdnet-go/releases | grep -oP '"tag_name":\s*"\Knightly-[0-9]+' | sort -r | head -n1)
+			local bnet_vers=$(curl -s https://api.github.com/repos/tphakala/birdnet-go/releases | grep -oP '"tag_name":\s*"\K[^"]+' | head -n1)
 			local bnet_inst='/opt/birdnet'
 			local bnet_data='/mnt/dietpi_userdata/birdnet'
 			local bnet_conf="$bnet_data/.config/birdnet-go/config.yaml"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11926,7 +11926,6 @@ _EOF_
 
 		if To_Install 127 birdnet # BirdNET-Go: https://github.com/tphakala/birdnet-go/blob/main/install.sh
 		then
-			local bnet_vers=$(curl -s https://api.github.com/repos/tphakala/birdnet-go/releases | grep -oP '"tag_name":\s*"\K[^"]+' | head -n1)
 			local bnet_inst='/opt/birdnet'
 			local bnet_data='/mnt/dietpi_userdata/birdnet'
 			local bnet_conf="$bnet_data/.config/birdnet-go/config.yaml"
@@ -11945,7 +11944,8 @@ _EOF_
 			esac
 
 			# Download
-			Download_Install "https://github.com/tphakala/birdnet-go/releases/download/$bnet_vers/birdnet-go-linux-$arch.tar.gz" birdnet
+			local fallback_url="https://github.com/tphakala/birdnet-go/releases/download/nightly-20251223/birdnet-go-linux-$arch.tar.gz"
+			Download_Install "$(curl -sSfL 'https://api.github.com/repos/tphakala/birdnet-go/releases' | mawk -F\" "/^ *\"browser_download_url\": \"[^\"]*-linux-$arch\.tar\.gz\"$/{print \$4}" | head -1)" birdnet
 
 			# Change rpath for birdnet-go to make use of libtensorflowlite_c.so in its own dir
 			G_EXEC patchelf --set-rpath "$bnet_inst" birdnet/birdnet-go


### PR DESCRIPTION
Removed the hardcoded nightly version and replaced it with a check via github API.