### PR TITLE
updated influxdb repo key. current key is not valid anymore

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7509,7 +7509,7 @@ _EOF_
 		if To_Install 74 influxdb # InfluxDB
 		then
 			# APT key
-			local url='https://repos.influxdata.com/influxdata-archive_compat.key'
+			local url='https://repos.influxdata.com/influxdata-archive_compat-exp2029.key'
 			G_CHECK_URL "$url"
 			G_EXEC eval "curl -sSfL '$url' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-influxdb.gpg --yes"
 


### PR DESCRIPTION
[A user reported problems while installing influxDB](https://dietpi.com/forum/t/error-installing-influxdb/24892/2).
Turns out they have a new key for the repo, the old one is not valid anymore.
The new URL for the key is [https://repos.influxdata.com/influxdata-archive_compat-exp2029.key](https://repos.influxdata.com/influxdata-archive_compat-exp2029.key)

Ref.: [https://repos.influxdata.com/](https://repos.influxdata.com/)

