### PR TITLE
dietpi-software: Navidrome: enable riscv64 support

### DIFF
--- a/.github/workflows/dietpi-software.bash
+++ b/.github/workflows/dietpi-software.bash
@@ -502,6 +502,8 @@ then
 		G_EXEC eval 'echo -e '\''[Service]\nProtectHome=0\nProtectSystem=0\nPrivateTmp=0\nReadWritePaths=\nPrivateDevices=0'\'' > rootfs/etc/systemd/system/vaultwarden.service.d/dietpi-container.conf'
 		G_EXEC eval 'echo -e '\''[Service]\nPrivateTmp=0'\'' > rootfs/etc/systemd/system/blynkserver.service.d/dietpi-container.conf'
 		G_EXEC eval 'echo -e '\''[Service]\nProtectSystem=0\nPrivateTmp=0\nPrivateDevices=0\nReadWritePaths='\'' > rootfs/etc/systemd/system/gogs.service.d/dietpi-container.conf'
+		G_EXEC eval 'echo -e '\''[Service]\nProtectSystem=0\nPrivateTmp=0\nPrivateUsers=0\nProtectKernelModules=0\nProtectControlGroups=0\nProtectKernelTunables=0\nReadWritePaths='\'' > rootfs/etc/systemd/system/navidrome.service.d/dietpi-container.conf'
+
 		# /dev/console == /dev/pts/0 seen as "Inappropriate ioctl for device" leading to failing console-getty.service and StandardOutput=tty
 		G_EXEC eval 'echo -e '\''#!/bin/dash\nexec /boot/dietpi/dietpi-login > /dev/console 2>&1'\'' > rootfs/var/lib/dietpi/postboot.d/dietpi-login'
 		G_EXEC sed --follow-symlinks -i '/^StandardOutput=/c\StandardOutput=journal+console' rootfs/etc/systemd/system/dietpi-{first,post}boot.service

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ v10.1
 
 Enhancements:
 - DietPi-Tools | DietPi-Banner: New option to output the Linux kernel version
+- DietPi-Software | Navidrome: Support for RISC-V has been unlocked, as official builds have been added with the v0.60.0 release on GitHub.
 
 Bug fixes:
 - DietPi-Software | BirdNET-Go: Resolved an issue where the install failed since the initial call tries to create the logs directory in the working directory as unprivileged user, rather than in its home directory. Many thanks to @shagr4th for implementing a fix: https://github.com/MichaIng/DietPi/pull/7929

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -589,8 +589,6 @@ Available commands:
 		aSOFTWARE_CATX[$software_id]=2
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/media/#navidrome'
 		aSOFTWARE_DEPS[$software_id]='5 7'
-		# - RISC-V: https://github.com/navidrome/navidrome/releases/
-		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,11]=0
 		#------------------
 		software_id=212
 		aSOFTWARE_NAME[$software_id]='Kavita'
@@ -6126,6 +6124,7 @@ _EOF_
 				1) local arch='armv6';;
 				2) local arch='armv7';;
 				3) local arch='arm64';;
+				11) local arch='riscv64';;
 				*) local arch='amd64';;
 			esac
 


### PR DESCRIPTION
For now with own Navidrome fork which implements `riscv64` builds, for testing.

Test installs: https://github.com/MichaIng/DietPi/actions/runs/21454349203