### PR TITLE
Fix birdnet installation

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ v10.1
 Enhancements:
 
 Bug fixes:
+- DietPi-Software | BirdNET-Go: Resolved an issue where the install failed since the initial call tries to create the logs directory in the working directory as unprivileged user, rather than in its home directory. Many thanks to @shagr4th for implementing a fix: https://github.com/MichaIng/DietPi/pull/7929
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11914,8 +11914,11 @@ _EOF_
 			# - Checks hard-coded paths in this order: ~/.config/birdnet-go/config.yaml > /etc/birdnet-go/config.yaml
 			if [[ ! -f $bnet_conf ]]
 			then
-				# Initial call to generate ~/.config/birdnet-go/config.yaml (move to the user's directory beforehand to avoid permission issues)
-				G_EXEC runuser -u "$bnet_user" -- sh -c "cd && $bnet_inst/birdnet-go"
+				# Initial call to generate ~/.config/birdnet-go/config.yaml
+				# - Needs to be done in $bnet_data to prevent logs dir generation failure in working dir.
+				G_EXEC cd "$bnet_data"
+				G_EXEC runuser -u "$bnet_user" -- "$bnet_inst/birdnet-go"
+				G_EXEC cd "$G_WORKING_DIR"
 				# Replace paths, otherwise defaults to the working directory
 				# Disable MQTT and CPU/memory/disk monitoring
 				# Enable new web UI at $bnet_port

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11914,8 +11914,8 @@ _EOF_
 			# - Checks hard-coded paths in this order: ~/.config/birdnet-go/config.yaml > /etc/birdnet-go/config.yaml
 			if [[ ! -f $bnet_conf ]]
 			then
-				# Initial call to generate ~/.config/birdnet-go/config.yaml
-				G_EXEC runuser -u "$bnet_user" -- "$bnet_inst/birdnet-go"
+				# Initial call to generate ~/.config/birdnet-go/config.yaml (move to the user's directory beforehand to avoid permission issues)
+				G_EXEC runuser -u "$bnet_user" -- sh -c "cd && $bnet_inst/birdnet-go"
 				# Replace paths, otherwise defaults to the working directory
 				# Disable MQTT and CPU/memory/disk monitoring
 				# Enable new web UI at $bnet_port


### PR DESCRIPTION
Hi, small fix for an issue I encountered while installing Birdnet-go. If the dietpi-software install command is launched from a protected directory (/root, or whatever), the app installation will fail with the following error:

```
ERROR [main] Failed to initialize logger error="failed to create base handler: failed to create log directory:
failed to create directory logs: mkdir logs: permission denied"
```

Likely cause : first `birdnet-go` execution as the `birdnet` user create a default config file at the right place, but then try to mkdir a `logs` directory under the current directory, leading to this permission issue. PR ensures that the `birdnet-go` first launch is done in the proper user home's directory