### PR TITLE
Added Kernel version output option to dietpi-banner

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ v10.1
 (2026-02-21)
 
 Enhancements:
+- DietPi-Tools | DietPi-Banner: New option to output the Linux kernel version
 
 Bug fixes:
 - DietPi-Software | BirdNET-Go: Resolved an issue where the install failed since the initial call tries to create the logs directory in the working directory as unprivileged user, rather than in its home directory. Many thanks to @shagr4th for implementing a fix: https://github.com/MichaIng/DietPi/pull/7929

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -64,14 +64,15 @@
 		'RAM usage'
 		'Load average'
 		'Word-wrap lines on small screens'
+        'Kernel'
 	)
 
 	# Set defaults: Disable CPU temp by default in VMs
 	if (( $G_HW_MODEL == 20 ))
 	then
-		aENABLED=(1 0 0 0 0 1 0 1 0 0 0 1 1 0 0 1 0 0 0 0)
+		aENABLED=(1 0 0 0 0 1 0 1 0 0 0 1 1 0 0 1 0 0 0 0 0)
 	else
-		aENABLED=(1 0 1 0 0 1 0 0 0 0 0 1 1 0 0 1 0 0 0 0)
+		aENABLED=(1 0 1 0 0 1 0 0 0 0 0 1 1 0 0 1 0 0 0 0 0)
 	fi
 
 	COLOUR_RESET='\e[0m'
@@ -262,6 +263,8 @@ $GREEN_LINE"
 		(( ${aENABLED[0]} )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[0]} $GREEN_SEPARATOR $G_HW_MODEL_NAME"
 		# Uptime
 		(( ${aENABLED[1]} )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[1]} $GREEN_SEPARATOR $(uptime -p 2>&1)"
+        # Linux kernel version
+        (( ${aENABLED[20]} )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[20]} $GREEN_SEPARATOR $(uname -r 2>&1)"
 		# CPU temp
 		(( ${aENABLED[2]} )) && echo -e "$GREEN_BULLET ${aCOLOUR[1]}${aDESCRIPTION[2]} $GREEN_SEPARATOR $(print_full_info=1 G_OBTAIN_CPU_TEMP 2>&1)"
 		# RAM usage


### PR DESCRIPTION
Example output with Kernel version (see line "Kernel"):

<img width="441" height="206" alt="grafik" src="https://github.com/user-attachments/assets/4d865b98-99cf-4c08-aa5b-f54dc7d372d4" />
