### PR TITLE
dietpi-software: MinIO: add console client

### DIFF
--- a/.github/workflows/dietpi-software.bash
+++ b/.github/workflows/dietpi-software.bash
@@ -256,7 +256,7 @@ Process_Software()
 			155) aSERVICES[i]='htpc-manager' aTCP[i]='8085'; (( $emulation )) && aDELAY[i]=30;;
 			#156) Steam
 			157) aSERVICES[i]='home-assistant' aTCP[i]='8123'; (( $emulation )) && aDELAY[i]=900 || aDELAY[i]=60;;
-			158) aSERVICES[i]='minio' aTCP[i]='9001 9004';;
+			158) aSERVICES[i]='minio' aTCP[i]='9001 9004' aCOMMANDS[i]='bash -ic '\''mc mb local/test'\';;
 			#159) Allo GUI full
 			#160) Allo GUI without dependencies
 			161) aSERVICES[i]='bdd' aTCP[i]='80 443';;

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ New images:
 Enhancements:
 - DietPi-Tools | DietPi-Banner: New option to output the Linux kernel version
 - DietPi-Software | Navidrome: Support for RISC-V has been unlocked, as official builds have been added with the v0.60.0 release on GitHub.
+- DietPi-Software | MinIO: The console client "mc" is now installed along with the server, to make up with the lost administration functionalities of the community server web UI. A shell alias is generated to invoke it as "minio-user" user, using a pre-generated config file /mnt/dietpi_userdata/minio-data/.mc/config.json. It adds the local MinIO server instance as "local" alias. Additionally, the default credentials have been changed to username (access key) "dietpi" and the default software password as secret key. Since MinIO requires the password to be at least 8 characters long, the default software password is concatenated until 8 characters are reached. E.g. if "test" was used, it will be "testtest" for MinIO. However, don't try it and use a secure default software password of 12 characters or more on production systems ;). Change it afterwards for the MinIO server in /etc/default/minio, and for the console client "mc" accordingly in /mnt/dietpi_userdata/minio-data/.mc/config.json.
 
 Bug fixes:
 - DietPi-Software | BirdNET-Go: Resolved an issue where the install failed since the initial call tries to create the logs directory in the working directory as unprivileged user, rather than in its home directory. Many thanks to @shagr4th for implementing a fix: https://github.com/MichaIng/DietPi/pull/7929

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10246,14 +10246,10 @@ _EOF_
 			G_EXEC mkdir -p /mnt/dietpi_userdata/minio-data
 			G_EXEC chown -R minio-user:minio-user /mnt/dietpi_userdata/minio-data
 
-			# Console client alias
-			G_EXEC eval "echo 'alias mc='\''sudo -u minio-user /usr/local/bin/mc --dp'\' > /etc/bashrc.d/dietpi-minio.sh"
-			G_EXEC_NOFAIL=1 G_EXEC runuser -u minio-user -- /usr/local/bin/mc --dp
-			G_EXEC sed --follow-symlinks -i 's|"http://localhost:9000"|"http://127.0.0.1:9004"|' /mnt/dietpi_userdata/minio-data/.mc/config.json
-
 			# Config
 			if [[ ! -f '/etc/default/minio' ]]
 			then
+				G_DIETPI-NOTIFY 2 'Generating MinIO server config'
 				G_EXEC install -g minio-user -m 0640 /dev/null /etc/default/minio
 				cat << _EOF_ > /etc/default/minio || exit 1
 # Docs: https://minio.community/community/minio-object-store/reference/minio-server/settings.html
@@ -10271,6 +10267,31 @@ MINIO_ROOT_USER='dietpi'
 MINIO_ROOT_PASSWORD='$GLOBAL_PW'
 _EOF_
 			fi
+
+			# Console client config and alias
+			if [[ ! -f '/mnt/dietpi_userdata/minio-data/.mc/config.json' ]]
+			then
+				G_DIETPI-NOTIFY 2 'Generating MinIO console client "mc" config'
+				G_EXEC mkdir -p /mnt/dietpi_userdata/minio-data/.mc
+				G_EXEC install -o minio-user -g minio-user -m 0640 /dev/null /mnt/dietpi_userdata/minio-data/.mc/config.json
+				# shellcheck disable=SC1091
+				. /etc/default/minio
+				cat << _EOF_ > /mnt/dietpi_userdata/minio-data/.mc/config.json || exit 1
+{
+        "aliases": {
+                "local": {
+                        "url": "http://127.0.0.1:9004",
+                        "accessKey": "${MINIO_ROOT_USER:-${MINIO_ACCESS_KEY:-dietpi}}",
+                        "secretKey": "${MINIO_ROOT_PASSWORD:-${MINIO_SECRET_KEY:-$GLOBAL_PW}}",
+                        "api": "S3v4",
+                        "path": "auto"
+                }
+        }
+}
+_EOF_
+				unset -v MINIO_ROOT_PASSWORD MINIO_SECRET_KEY
+			fi
+			G_EXEC eval "echo 'alias mc='\''sudo -u minio-user /usr/local/bin/mc --dp'\' > /etc/bashrc.d/dietpi-minio.sh"
 		fi
 
 		if To_Install 162 docker # Docker

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10250,6 +10250,9 @@ _EOF_
 			if [[ ! -f '/etc/default/minio' ]]
 			then
 				G_DIETPI-NOTIFY 2 'Generating MinIO server config'
+				# Password needs to be >=8 characters long
+				local minio_pw=$GLOBAL_PW
+				until (( ${#minio_pw} >= 8 )); do minio_pw+=$GLOBAL_PW; done
 				G_EXEC install -g minio-user -m 0640 /dev/null /etc/default/minio
 				cat << _EOF_ > /etc/default/minio || exit 1
 # Docs: https://minio.community/community/minio-object-store/reference/minio-server/settings.html
@@ -10264,8 +10267,9 @@ MINIO_OPTS='--address :9004 --console-address :9001'
 MINIO_ROOT_USER='dietpi'
 
 # Admin password
-MINIO_ROOT_PASSWORD='$GLOBAL_PW'
+MINIO_ROOT_PASSWORD='$minio_pw'
 _EOF_
+				unset -v minio_pw
 			fi
 
 			# Console client config and alias

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10220,7 +10220,7 @@ _EOF_
 			Create_Desktop_Shortcut steam
 		fi
 
-		if To_Install 158 minio # MinIO
+		if To_Install 158 minio # MinIO: https://minio.community/community/minio-object-store/index.html
 		then
 			case $G_HW_ARCH in
 				3) local arch='arm64';;
@@ -10228,11 +10228,16 @@ _EOF_
 				*) local arch='arm';;
 			esac
 
+			# Server
 			G_EXEC curl -sSfLo /usr/local/bin/minio "https://dl.minio.io/server/minio/release/linux-$arch/minio"
 			G_EXEC chmod +x /usr/local/bin/minio
 
+			# Console client
+			G_EXEC curl -sSfLo /usr/local/bin/mc "https://dl.min.io/client/mc/release/linux-$arch/mc"
+			G_EXEC chmod +x /usr/local/bin/mc
+
 			# Service
-			G_EXEC curl -sSfLo /etc/systemd/system/minio.service 'https://github.com/minio/minio-service/raw/master/linux-systemd/minio.service'
+			G_EXEC curl -sSfLo /etc/systemd/system/minio.service 'https://raw.githubusercontent.com/minio/minio-service/master/linux-systemd/minio.service'
 
 			# User
 			Create_User -d /mnt/dietpi_userdata/minio-data minio-user
@@ -10241,17 +10246,31 @@ _EOF_
 			G_EXEC mkdir -p /mnt/dietpi_userdata/minio-data
 			G_EXEC chown -R minio-user:minio-user /mnt/dietpi_userdata/minio-data
 
+			# Console client alias
+			G_EXEC eval "echo 'alias mc='\''sudo -u minio-user /usr/local/bin/mc --dp'\' > /etc/bashrc.d/dietpi-minio.sh"
+			G_EXEC_NOFAIL=1 G_EXEC runuser -u minio-user -- /usr/local/bin/mc --dp
+			G_EXEC sed --follow-symlinks -i 's|"http://localhost:9000"|"http://127.0.0.1:9004"|' /mnt/dietpi_userdata/minio-data/.mc/config.json
+
 			# Config
-			[[ -f '/etc/default/minio' ]] || cat << '_EOF_' > /etc/default/minio
-# Default file path
-MINIO_VOLUMES="/mnt/dietpi_userdata/minio-data"
-# Use if you want to run MinIO on a custom port.
-MINIO_OPTS="--address :9004 --console-address :9001"
-# Access key of the server.
-#MINIO_ACCESS_KEY=Server-Access-Key
-# Secret key of the server.
-#MINIO_SECRET_KEY=Server-Secret-Key
+			if [[ ! -f '/etc/default/minio' ]]
+			then
+				G_EXEC install -g minio-user -m 0640 /dev/null /etc/default/minio
+				cat << _EOF_ > /etc/default/minio || exit 1
+# Docs: https://minio.community/community/minio-object-store/reference/minio-server/settings.html
+
+# Path(s) to storage volume(s)
+MINIO_VOLUMES='/mnt/dietpi_userdata/minio-data'
+
+# CLI options
+MINIO_OPTS='--address :9004 --console-address :9001'
+
+# Admin username
+MINIO_ROOT_USER='dietpi'
+
+# Admin password
+MINIO_ROOT_PASSWORD='$GLOBAL_PW'
 _EOF_
+			fi
 		fi
 
 		if To_Install 162 docker # Docker
@@ -13741,11 +13760,14 @@ _EOF_
 			Remove_Service minio minio-user minio-user
 
 			# Files
-			[[ -f '/usr/local/bin/minio' ]] && G_EXEC rm /usr/local/bin/minio
-			[[ -f '/etc/default/minio' ]] && G_EXEC rm /etc/default/minio
+			G_EXEC rm -f /etc/bashrc.d/dietpi-minio.sh
+			G_EXEC rm -f /usr/local/bin/mc
+			G_EXEC rm -Rf /{root,home/*}/.mc
+			G_EXEC rm -f /usr/local/bin/minio
+			G_EXEC rm -f /etc/default/minio
 
 			# Certbot hook
-			[[ -f '/etc/letsencrypt/renewal-hooks/deploy/dietpi-minio.sh' ]] && G_EXEC rm /etc/letsencrypt/renewal-hooks/deploy/dietpi-minio.sh
+			G_EXEC rm -f /etc/letsencrypt/renewal-hooks/deploy/dietpi-minio.sh
 			# - Pre-v8.0
 			[[ -f '/etc/systemd/system/certbot.service.d/dietpi-minio.conf' ]] && G_EXEC rm /etc/systemd/system/certbot.service.d/dietpi-minio.conf
 			[[ -d '/etc/systemd/system/certbot.service.d' ]] && G_EXEC rmdir --ignore-fail-on-non-empty /etc/systemd/system/certbot.service.d

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -10243,7 +10243,7 @@ _EOF_
 			Create_User -d /mnt/dietpi_userdata/minio-data minio-user
 
 			# Data dir
-			G_EXEC mkdir -p /mnt/dietpi_userdata/minio-data
+			G_EXEC mkdir -p /mnt/dietpi_userdata/minio-data/.mc
 			G_EXEC chown -R minio-user:minio-user /mnt/dietpi_userdata/minio-data
 
 			# Config
@@ -10276,7 +10276,6 @@ _EOF_
 			if [[ ! -f '/mnt/dietpi_userdata/minio-data/.mc/config.json' ]]
 			then
 				G_DIETPI-NOTIFY 2 'Generating MinIO console client "mc" config'
-				G_EXEC mkdir -p /mnt/dietpi_userdata/minio-data/.mc
 				G_EXEC install -o minio-user -g minio-user -m 0640 /dev/null /mnt/dietpi_userdata/minio-data/.mc/config.json
 				# shellcheck disable=SC1091
 				. /etc/default/minio


### PR DESCRIPTION
and update environment file.

Since admin functionality has been removed from the web UI of the community edition, without the console client "mc", one cannot really do anything. It is hence now installed as well, along with a shell alias to call it as minio user, using a config where the "local" instance alias points to the correct port, and omitting this annoying pager invoked by default. See also #7940 regarding 3rd party web UIs/forks as alternative.

Additionally, default admin credentials have been adjusted, using the global default software password.

Test installs: https://github.com/MichaIng/DietPi/actions/runs/21842920240

I also thought about enabling HTTPS by default, using a self-signed certificate. However, S3 clients require any cert to validate by default, and there is no way to enable HTTPS for the web UI only, and not for the S3 listener. So this is something admins should better setup with a proper public CA cert, which we can mention in our docs, linking the respective MinIO docs section: https://minio.community/community/minio-object-store/operations/network-encryption.html#minio-tls-on-baremetal