### PR TITLE
raspberrypi: use /boot/firmware path throughout our scripts

### DIFF
--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -569,7 +569,7 @@ then
 	# Enable Amiberry fast boot autostart option
 	G_CONFIG_INJECT 'AUTO_SETUP_AUTOSTART_TARGET_INDEX=' 'AUTO_SETUP_AUTOSTART_TARGET_INDEX=6' rootfs/boot/dietpi.txt
 	# RPi: Enable onboard audio so that it can be detected and configured on first boot
-	[[ -f 'rootfs/boot/config.txt' ]] && G_CONFIG_INJECT 'dtparam=audio=' 'dtparam=audio=on' rootfs/boot/config.txt
+	[[ -f 'rootfs/boot/firmware/config.txt' ]] && G_CONFIG_INJECT 'dtparam=audio=' 'dtparam=audio=on' rootfs/boot/firmware/config.txt
 
 	G_EXEC umount -R rootfs
 	G_EXEC rmdir rootfs
@@ -671,8 +671,8 @@ then
 	/boot/dietpi/func/dietpi-set_hardware serialconsole 0 ttyS0
 	systemctl mask serial-getty@ttyS0
 	/boot/dietpi/func/dietpi-set_hardware serialconsole 1 serial0
-	G_CONFIG_INJECT 'temp_limit=' 'temp_limit=75' /boot/config.txt # since most RPis are now RPi 4 and Allo ships the CM3 with USBridge Sig and Allo GUI image
-	G_EXEC sed --follow-symlinks -Ei 's/^(arm_freq|over_voltage)=/#\1=/' /boot/config.txt
+	G_CONFIG_INJECT 'temp_limit=' 'temp_limit=75' /boot/firmware/config.txt # since most RPis are now RPi 4 and Allo ships the CM3 with USBridge Sig and Allo GUI image
+	G_EXEC sed --follow-symlinks -Ei 's/^(arm_freq|over_voltage)=/#\1=/' /boot/firmware/config.txt
 fi
 
 # FirstBoot

--- a/.build/images/dietpi-installer
+++ b/.build/images/dietpi-installer
@@ -630,12 +630,10 @@ _EOF_
 		local armbian_packages=0
 		if (( $G_HW_MODEL < 10 ))
 		then
-			G_EXEC ln -sf firmware/cmdline.txt /boot/cmdline.txt
-			G_EXEC ln -sf firmware/config.txt /boot/config.txt
 			G_EXEC mv "$dir/.build/images/RPi/config.txt" /boot/firmware/
-			G_EXEC eval "echo 'root=PARTUUID=$(findmnt -Ufnro PARTUUID -M /) rootfstype=$(findmnt -Ufnro FSTYPE -M /) rootwait fsck.repair=yes net.ifnames=0 logo.nologo console=serial0,115200 console=tty1' > /boot/cmdline.txt"
+			G_EXEC eval "echo 'root=PARTUUID=$(findmnt -Ufnro PARTUUID -M /) rootfstype=$(findmnt -Ufnro FSTYPE -M /) rootwait fsck.repair=yes net.ifnames=0 logo.nologo console=serial0,115200 console=tty1' > /boot/firmware/cmdline.txt"
 			# Boot in 64-bit mode if this is a 64-bit image
-			[[ $userland_arch == 'arm64' ]] && G_CONFIG_INJECT 'arm_64bit=' 'arm_64bit=1' /boot/config.txt
+			[[ $userland_arch == 'arm64' ]] && G_CONFIG_INJECT 'arm_64bit=' 'arm_64bit=1' /boot/firmware/config.txt
 
 		# Odroid C1/XU4 (32-bit)
 		elif [[ $G_HW_MODEL =~ ^(10|11)$ ]]
@@ -2002,7 +2000,7 @@ _EOF_'
 		# On RPi the primary serial console depends on model, use "serial0" which links to the primary console, converts to correct device on first boot
 		if (( $G_HW_MODEL < 10 ))
 		then
-			G_CONFIG_INJECT 'enable_uart=' 'enable_uart=1' /boot/config.txt
+			G_CONFIG_INJECT 'enable_uart=' 'enable_uart=1' /boot/firmware/config.txt
 			/boot/dietpi/func/dietpi-set_hardware serialconsole enable serial0
 			# Disable and mask the others explicitly to be independent of currently available serial devices
 			/boot/dietpi/func/dietpi-set_hardware serialconsole disable ttyAMA0

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>
   - `/var/tmp/dietpi/`
   - `/boot/dietpi/`
 - `/boot/dietpi.txt`
-- `/boot/config.txt` (RPi)
+- `/boot/firmware/config.txt` (RPi)
 - `/boot/boot.ini` (Odroid)
 - All files prefixed with: `dietpi-`
 

--- a/dietpi/dietpi-autostart
+++ b/dietpi/dietpi-autostart
@@ -96,7 +96,7 @@ _EOF_
 			command -v X > /dev/null || { G_WHIP_MSG '[FAILED] No X server has been found\n\nLightDM requires an X server. Please install a desktop or other X application first.'; return 1; }
 			G_AG_CHECK_INSTALL_PREREQ lightdm
 			# Raspberry Pi Trixie: Requires KMS/DRM: https://github.com/MichaIng/DietPi/issues/7644#issuecomment-3229785538
-			(( $G_DISTRO < 8 || $G_HW_MODEL > 9 )) || grep -Eq '^[[:blank:]]*dtoverlay=vc4-f?kms-v3d' /boot/config.txt || /boot/dietpi/func/dietpi-set_hardware rpi-opengl vc4-kms-v3d
+			(( $G_DISTRO < 8 || $G_HW_MODEL > 9 )) || grep -Eq '^[[:blank:]]*dtoverlay=vc4-f?kms-v3d' /boot/firmware/config.txt || /boot/dietpi/func/dietpi-set_hardware rpi-opengl vc4-kms-v3d
 			# graphical.target Wants=display-manager.service
 			G_EXEC ln -sf /lib/systemd/system/lightdm.service /etc/systemd/system/display-manager.service
 
@@ -147,7 +147,7 @@ _EOF_
 				command -v X > /dev/null || { G_WHIP_MSG '[FAILED] No X server has been found\n\nDesktop autologin requires an X server. Please install a desktop or other X application first.'; return 1; }
 				G_AG_CHECK_INSTALL_PREREQ lightdm
 				# Raspberry Pi Trixie: Requires KMS/DRM: https://github.com/MichaIng/DietPi/issues/7644#issuecomment-3229785538
-				(( $G_DISTRO < 8 || $G_HW_MODEL > 9 )) || grep -Eq '^[[:blank:]]*dtoverlay=vc4-f?kms-v3d' /boot/config.txt || /boot/dietpi/func/dietpi-set_hardware rpi-opengl vc4-kms-v3d
+				(( $G_DISTRO < 8 || $G_HW_MODEL > 9 )) || grep -Eq '^[[:blank:]]*dtoverlay=vc4-f?kms-v3d' /boot/firmware/config.txt || /boot/dietpi/func/dietpi-set_hardware rpi-opengl vc4-kms-v3d
 				# graphical.target Wants=display-manager.service
 				G_EXEC ln -sf /lib/systemd/system/lightdm.service /etc/systemd/system/display-manager.service
 

--- a/dietpi/dietpi-backup
+++ b/dietpi/dietpi-backup
@@ -257,7 +257,7 @@ However, this check is a rough estimation in reasonable time, thus it could be m
 			UPDATE_GRUB=1
 
 		# - RPi
-		elif [[ $G_HW_MODEL -le 9 && -f $FP_TARGET/$DATA/boot/cmdline.txt ]]
+		elif [[ $G_HW_MODEL -le 9 && -f $FP_TARGET/$DATA/boot/firmware/cmdline.txt ]]
 		then
 			UPDATE_RPI=1
 
@@ -325,7 +325,7 @@ However, this check is a rough estimation in reasonable time, thus it could be m
 		# - RPi
 		elif (( $UPDATE_RPI == 1 ))
 		then
-			G_EXEC sed --follow-symlinks -Ei "s/(^|[[:blank:]])root=[^[:blank:]]*/\1root=PARTUUID=$PARTUUID_ROOT/" /boot/cmdline.txt
+			G_EXEC sed --follow-symlinks -Ei "s/(^|[[:blank:]])root=[^[:blank:]]*/\1root=PARTUUID=$PARTUUID_ROOT/" /boot/firmware/cmdline.txt
 
 		# - DietPi modern U-Boot
 		elif (( $UPDATE_DIETPI == 1 ))

--- a/dietpi/dietpi-bugreport
+++ b/dietpi/dietpi-bugreport
@@ -80,8 +80,8 @@ Available commands:
 		'/var/log'
 
 		# Boot/kernel configs
-		'/boot/config.txt' # RPi
-		'/boot/cmdline.txt' # RPi
+		'/boot/firmware/config.txt' # RPi
+		'/boot/firmware/cmdline.txt' # RPi
 		'/boot/boot.ini' # Odroid C1/XU4
 		'/boot/boot.scr'
 		'/boot/dietpiEnv.txt'

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -93,22 +93,22 @@
 	# $1: 0=landscape 1=portrait
 	Display_Rotation_Calc_XY_Invert()
 	{
-		local framebuffer_x=$(grep -m1 '^[[:blank:]]*framebuffer_width=' /boot/config.txt || vcgencmd get_config framebuffer_width)
+		local framebuffer_x=$(grep -m1 '^[[:blank:]]*framebuffer_width=' /boot/firmware/config.txt || vcgencmd get_config framebuffer_width)
 		framebuffer_x=${framebuffer_x#*=}; framebuffer_x=${framebuffer_x:-0}
-		local framebuffer_y=$(grep -m1 '^[[:blank:]]*framebuffer_height=' /boot/config.txt || vcgencmd get_config framebuffer_height)
+		local framebuffer_y=$(grep -m1 '^[[:blank:]]*framebuffer_height=' /boot/firmware/config.txt || vcgencmd get_config framebuffer_height)
 		framebuffer_y=${framebuffer_y#*=}; framebuffer_y=${framebuffer_y:-0}
 
 		# 0/180 landscape
 		if (( $1 == 0 && $framebuffer_x < $framebuffer_y ))
 		then
-			G_CONFIG_INJECT 'framebuffer_width=' "framebuffer_width=$framebuffer_y" /boot/config.txt
-			G_CONFIG_INJECT 'framebuffer_height=' "framebuffer_height=$framebuffer_x" /boot/config.txt
+			G_CONFIG_INJECT 'framebuffer_width=' "framebuffer_width=$framebuffer_y" /boot/firmware/config.txt
+			G_CONFIG_INJECT 'framebuffer_height=' "framebuffer_height=$framebuffer_x" /boot/firmware/config.txt
 
 		# 90/270 portrait
 		elif (( $1 == 1 && $framebuffer_x > $framebuffer_y ))
 		then
-			G_CONFIG_INJECT 'framebuffer_width=' "framebuffer_width=$framebuffer_y" /boot/config.txt
-			G_CONFIG_INJECT 'framebuffer_height=' "framebuffer_height=$framebuffer_x" /boot/config.txt
+			G_CONFIG_INJECT 'framebuffer_width=' "framebuffer_width=$framebuffer_y" /boot/firmware/config.txt
+			G_CONFIG_INJECT 'framebuffer_height=' "framebuffer_height=$framebuffer_x" /boot/firmware/config.txt
 		fi
 	}
 
@@ -148,15 +148,15 @@
 			G_WHIP_MENU_ARRAY+=('2' ': GPU/RAM memory split')
 
 			# HDMI rotation
-			local rotation_hdmi_current=$(sed -n '/^[[:blank:]]*display_hdmi_rotate=/{s/^[^=]*=//p;q}' /boot/config.txt)
+			local rotation_hdmi_current=$(sed -n '/^[[:blank:]]*display_hdmi_rotate=/{s/^[^=]*=//p;q}' /boot/firmware/config.txt)
 			G_WHIP_MENU_ARRAY+=('4' ": Rotation (HDMI)     : [${rotation_hdmi_current:=0}]")
 
 			# LCD rotation
-			local rotation_lcd_current=$(sed -n '/^[[:blank:]]*lcd_rotate=/{s/^[^=]*=//p;q}' /boot/config.txt)
+			local rotation_lcd_current=$(sed -n '/^[[:blank:]]*lcd_rotate=/{s/^[^=]*=//p;q}' /boot/firmware/config.txt)
 			G_WHIP_MENU_ARRAY+=('5' ": Rotation (LCD)      : [${rotation_lcd_current:=0}]")
 
 			# Display overscan
-			local overscan_disabled=$(grep -cm1 '^[[:blank:]]*disable_overscan=1' /boot/config.txt)
+			local overscan_disabled=$(grep -cm1 '^[[:blank:]]*disable_overscan=1' /boot/firmware/config.txt)
 			local overscan_text='On'
 			(( $overscan_disabled )) && overscan_text='Off'
 			G_WHIP_MENU_ARRAY+=('6' ": Overscan            : [$overscan_text]")
@@ -164,17 +164,17 @@
 			if (( ! $overscan_disabled ))
 			then
 				local overscan_options=('overscan_left' 'overscan_right' 'overscan_top' 'overscan_bottom')
-				local overscan_left=$(grep -m1 '^[[:blank:]]*overscan_left=' /boot/config.txt || vcgencmd get_config overscan_left); overscan_left=${overscan_left#*=}
-				local overscan_right=$(grep -m1 '^[[:blank:]]*overscan_right=' /boot/config.txt || vcgencmd get_config overscan_right); overscan_right=${overscan_right#*=}
-				local overscan_top=$(grep -m1 '^[[:blank:]]*overscan_top=' /boot/config.txt || vcgencmd get_config overscan_top); overscan_top=${overscan_top#*=}
-				local overscan_bottom=$(grep -m1 '^[[:blank:]]*overscan_bottom=' /boot/config.txt || vcgencmd get_config overscan_bottom); overscan_bottom=${overscan_bottom#*=}
+				local overscan_left=$(grep -m1 '^[[:blank:]]*overscan_left=' /boot/firmware/config.txt || vcgencmd get_config overscan_left); overscan_left=${overscan_left#*=}
+				local overscan_right=$(grep -m1 '^[[:blank:]]*overscan_right=' /boot/firmware/config.txt || vcgencmd get_config overscan_right); overscan_right=${overscan_right#*=}
+				local overscan_top=$(grep -m1 '^[[:blank:]]*overscan_top=' /boot/firmware/config.txt || vcgencmd get_config overscan_top); overscan_top=${overscan_top#*=}
+				local overscan_bottom=$(grep -m1 '^[[:blank:]]*overscan_bottom=' /boot/firmware/config.txt || vcgencmd get_config overscan_bottom); overscan_bottom=${overscan_bottom#*=}
 				G_WHIP_MENU_ARRAY+=('15' ": Overscan Compensation [L:${overscan_left:-N/A}] [R:${overscan_right:-N/A}] [T:${overscan_top:-N/A}] [B:${overscan_bottom:-N/A}]")
 			fi
 
 			# HDMI signal boost, RPi up to 3 only
 			if (( $G_HW_MODEL < 4 ))
 			then
-				local hdmi_boost_current=$(grep -m1 '^[[:blank:]]*config_hdmi_boost=' /boot/config.txt || vcgencmd get_config config_hdmi_boost); hdmi_boost_current=${hdmi_boost_current#*=}
+				local hdmi_boost_current=$(grep -m1 '^[[:blank:]]*config_hdmi_boost=' /boot/firmware/config.txt || vcgencmd get_config config_hdmi_boost); hdmi_boost_current=${hdmi_boost_current#*=}
 				G_WHIP_MENU_ARRAY+=('7'	": HDMI Boost          : [${hdmi_boost_current:-N/A}]")
 			fi
 
@@ -184,13 +184,13 @@
 			G_WHIP_MENU_ARRAY+=('18' ": RPi Codecs          : [$rpi_codecs_text] V4L2 hardware video codecs")
 
 			# RPi camera module
-			local rpi_camera_module_enabled=$(grep -cm1 '^[[:blank:]]*start_x=1' /boot/config.txt)
+			local rpi_camera_module_enabled=$(grep -cm1 '^[[:blank:]]*start_x=1' /boot/firmware/config.txt)
 			local rpi_camera_module_text='Off'
 			(( $rpi_camera_module_enabled )) && rpi_camera_module_text='On'
 			G_WHIP_MENU_ARRAY+=('8' ": RPi Camera          : [$rpi_camera_module_text]")
 
 			# RPi camera LED
-			local rpi_camera_led_disabled=$(grep -cm1 '^[[:blank:]]*disable_camera_led=1' /boot/config.txt)
+			local rpi_camera_led_disabled=$(grep -cm1 '^[[:blank:]]*disable_camera_led=1' /boot/firmware/config.txt)
 			local rpi_camera_led_text='On'
 			(( $rpi_camera_led_disabled )) && rpi_camera_led_text='Off'
 			G_WHIP_MENU_ARRAY+=('9' ": RPi Camera LED      : [$rpi_camera_led_text]")
@@ -201,11 +201,11 @@
 			G_WHIP_MENU_ARRAY+=('11' ": JustBoom IR remote  : [$justboom_ir_remote_text]")
 
 			# VC1 key
-			local vc1_key_current=$(sed -n '/^[[:blank:]]*decode_WVC1=/{s/^[^=]*=//p;q}' /boot/config.txt)
+			local vc1_key_current=$(sed -n '/^[[:blank:]]*decode_WVC1=/{s/^[^=]*=//p;q}' /boot/firmware/config.txt)
 			G_WHIP_MENU_ARRAY+=('12' ": VC1 Key             : [${vc1_key_current:-none}]")
 
 			# MPEG2 key
-			local mpeg2_key_current=$(sed -n '/^[[:blank:]]*decode_MPG2=/{s/^[^=]*=//p;q}' /boot/config.txt)
+			local mpeg2_key_current=$(sed -n '/^[[:blank:]]*decode_MPG2=/{s/^[^=]*=//p;q}' /boot/firmware/config.txt)
 			G_WHIP_MENU_ARRAY+=('13' ": MPEG2 Key           : [${mpeg2_key_current:-none}]")
 
 		# Odroids only
@@ -237,7 +237,7 @@
 				G_WHIP_DEFAULT_ITEM=${!i}
 				G_WHIP_INPUTBOX "Please enter a value (pixel count) for $i\n - E.g.: 16" || break
 
-				G_CONFIG_INJECT "$i=" "$i=$G_WHIP_RETURNED_VALUE" /boot/config.txt
+				G_CONFIG_INJECT "$i=" "$i=$G_WHIP_RETURNED_VALUE" /boot/firmware/config.txt
 				REBOOT_REQUIRED=1
 			done
 
@@ -272,12 +272,12 @@
 		then
 			if (( $overscan_disabled ))
 			then
-				G_CONFIG_INJECT 'disable_overscan=' 'disable_overscan=0' /boot/config.txt
+				G_CONFIG_INJECT 'disable_overscan=' 'disable_overscan=0' /boot/firmware/config.txt
 			else
-				G_CONFIG_INJECT 'disable_overscan=' 'disable_overscan=1' /boot/config.txt
+				G_CONFIG_INJECT 'disable_overscan=' 'disable_overscan=1' /boot/firmware/config.txt
 				for i in "${overscan_options[@]}"
 				do
-					sed --follow-symlinks -i "/^[[:blank:]]*$i=/c\#$i=0" /boot/config.txt
+					sed --follow-symlinks -i "/^[[:blank:]]*$i=/c\#$i=0" /boot/firmware/config.txt
 				done
 			fi
 			REBOOT_REQUIRED=1
@@ -300,7 +300,7 @@
 			G_WHIP_MENU 'Please select a HDMI boost level.\n
 A long (or insufficiently manufactured) cable may required a higher boost setting to achieve correct signal.' || return 0
 
-			G_CONFIG_INJECT 'config_hdmi_boost=' "config_hdmi_boost=$G_WHIP_RETURNED_VALUE" /boot/config.txt && REBOOT_REQUIRED=1
+			G_CONFIG_INJECT 'config_hdmi_boost=' "config_hdmi_boost=$G_WHIP_RETURNED_VALUE" /boot/firmware/config.txt && REBOOT_REQUIRED=1
 
 		elif (( $G_WHIP_RETURNED_VALUE == 18 ))
 		then
@@ -312,7 +312,7 @@ A long (or insufficiently manufactured) cable may required a higher boost settin
 
 		elif (( $G_WHIP_RETURNED_VALUE == 9 ))
 		then
-			G_CONFIG_INJECT 'disable_camera_led=' "disable_camera_led=$(( ! $rpi_camera_led_disabled ))" /boot/config.txt && REBOOT_REQUIRED=1
+			G_CONFIG_INJECT 'disable_camera_led=' "disable_camera_led=$(( ! $rpi_camera_led_disabled ))" /boot/firmware/config.txt && REBOOT_REQUIRED=1
 
 		elif (( $G_WHIP_RETURNED_VALUE == 10 ))
 		then
@@ -343,10 +343,10 @@ A long (or insufficiently manufactured) cable may required a higher boost settin
 			G_WHIP_DEFAULT_ITEM=$vc1_key_current
 			if G_WHIP_INPUTBOX 'Please enter your key for VC1:\n - EG: 0x00000000'
 			then
-				G_CONFIG_INJECT 'decode_WVC1=' "decode_WVC1=$G_WHIP_RETURNED_VALUE" /boot/config.txt
+				G_CONFIG_INJECT 'decode_WVC1=' "decode_WVC1=$G_WHIP_RETURNED_VALUE" /boot/firmware/config.txt
 
 				# https://github.com/MichaIng/DietPi/issues/1487
-				local current_gpu_mem=$(sed -n '/^[[:blank:]]*gpu_mem_1024=/{s/^[^=]*=//p;q}' /boot/config.txt)
+				local current_gpu_mem=$(sed -n '/^[[:blank:]]*gpu_mem_1024=/{s/^[^=]*=//p;q}' /boot/firmware/config.txt)
 				(( ${current_gpu_mem:=76} < 96 )) && /boot/dietpi/func/dietpi-set_hardware gpumemsplit 96
 
 				REBOOT_REQUIRED=1
@@ -357,10 +357,10 @@ A long (or insufficiently manufactured) cable may required a higher boost settin
 			G_WHIP_DEFAULT_ITEM=$mpeg2_key_current
 			if G_WHIP_INPUTBOX 'Please enter your key for MPEG2:\n - EG: 0x00000000'
 			then
-				G_CONFIG_INJECT 'decode_MPG2=' "decode_MPG2=$G_WHIP_RETURNED_VALUE" /boot/config.txt
+				G_CONFIG_INJECT 'decode_MPG2=' "decode_MPG2=$G_WHIP_RETURNED_VALUE" /boot/firmware/config.txt
 
 				# https://github.com/MichaIng/DietPi/issues/1487
-				local current_gpu_mem=$(sed -n '/^[[:blank:]]*gpu_mem_1024=/{s/^[^=]*=//p;q}' /boot/config.txt)
+				local current_gpu_mem=$(sed -n '/^[[:blank:]]*gpu_mem_1024=/{s/^[^=]*=//p;q}' /boot/firmware/config.txt)
 				(( ${current_gpu_mem:=76} < 96 )) && /boot/dietpi/func/dietpi-set_hardware gpumemsplit 96
 
 				REBOOT_REQUIRED=1
@@ -381,7 +381,7 @@ A long (or insufficiently manufactured) cable may required a higher boost settin
 			G_WHIP_MENU "Please select an option:
 \nNB: If you have the RPi touchscreen, please set this to 0 and use LCD rotation option." || return 0
 
-			G_CONFIG_INJECT 'display_hdmi_rotate=' "display_hdmi_rotate=$G_WHIP_RETURNED_VALUE" /boot/config.txt
+			G_CONFIG_INJECT 'display_hdmi_rotate=' "display_hdmi_rotate=$G_WHIP_RETURNED_VALUE" /boot/firmware/config.txt
 
 			# rotation 90/270 | invert x/y on framebuffer (Y > X)
 			if [[ $G_WHIP_RETURNED_VALUE == [13] ]]
@@ -405,7 +405,7 @@ A long (or insufficiently manufactured) cable may required a higher boost settin
 			G_WHIP_DEFAULT_ITEM=$rotation_lcd_current
 			if G_WHIP_MENU 'Please select an option:\n\nNB: This option is for RPi touchscreen.'
 			then
-				G_CONFIG_INJECT 'lcd_rotate=' "lcd_rotate=$G_WHIP_RETURNED_VALUE" /boot/config.txt && REBOOT_REQUIRED=1
+				G_CONFIG_INJECT 'lcd_rotate=' "lcd_rotate=$G_WHIP_RETURNED_VALUE" /boot/firmware/config.txt && REBOOT_REQUIRED=1
 			fi
 
 		elif (( $G_WHIP_RETURNED_VALUE == 14 ))
@@ -582,11 +582,11 @@ A long (or insufficiently manufactured) cable may required a higher boost settin
 		# RPi
 		elif (( $G_HW_MODEL < 10 ))
 		then
-			local framebuffer_x=$(grep -m1 '^[[:blank:]]*framebuffer_width=' /boot/config.txt || vcgencmd get_config framebuffer_width)
+			local framebuffer_x=$(grep -m1 '^[[:blank:]]*framebuffer_width=' /boot/firmware/config.txt || vcgencmd get_config framebuffer_width)
 			framebuffer_x=${framebuffer_x#*=}; framebuffer_x=${framebuffer_x:-0}
-			local framebuffer_y=$(grep -m1 '^[[:blank:]]*framebuffer_height=' /boot/config.txt || vcgencmd get_config framebuffer_height)
+			local framebuffer_y=$(grep -m1 '^[[:blank:]]*framebuffer_height=' /boot/firmware/config.txt || vcgencmd get_config framebuffer_height)
 			framebuffer_y=${framebuffer_y#*=}; framebuffer_y=${framebuffer_y:-0}
-			local current_value=$(sed -n '/^[[:blank:]]*dtoverlay=vc4-/{s/^[^=]*=//p;q}' /boot/config.txt) # OpenGL check 1st
+			local current_value=$(sed -n '/^[[:blank:]]*dtoverlay=vc4-/{s/^[^=]*=//p;q}' /boot/firmware/config.txt) # OpenGL check 1st
 			if [[ ! $current_value ]]
 			then
 				# Framebuffer
@@ -640,8 +640,8 @@ Re-enabling HDMI requires a reboot. If you need emergency HDMI output, edit the 
 			# Disable composite if not chosen
 			if [[ $G_WHIP_RETURNED_VALUE != 'sdtv_mode'* ]]
 			then
-				sed --follow-symlinks -i '/sdtv_mode=/c\#sdtv_mode=0' /boot/config.txt
-				sed --follow-symlinks -i '/enable_tvout=/c\#enable_tvout=0' /boot/config.txt
+				sed --follow-symlinks -i '/sdtv_mode=/c\#sdtv_mode=0' /boot/firmware/config.txt
+				sed --follow-symlinks -i '/enable_tvout=/c\#enable_tvout=0' /boot/firmware/config.txt
 			fi
 
 			# Disable OpenGL if not chosen
@@ -656,8 +656,8 @@ Re-enabling HDMI requires a reboot. If you need emergency HDMI output, edit the 
 				case "$G_WHIP_RETURNED_VALUE" in
 					'sdtv_mode'*)
 						# Enable SDTV on RPi4, apply to all RPi to allow SD card switch
-						G_CONFIG_INJECT 'enable_tvout=' 'enable_tvout=1' /boot/config.txt
-						G_CONFIG_INJECT 'sdtv_mode=' "$G_WHIP_RETURNED_VALUE" /boot/config.txt
+						G_CONFIG_INJECT 'enable_tvout=' 'enable_tvout=1' /boot/firmware/config.txt
+						G_CONFIG_INJECT 'sdtv_mode=' "$G_WHIP_RETURNED_VALUE" /boot/firmware/config.txt
 						framebuffer_x=720 framebuffer_y=576
 					;;
 					'DietPi-CloudShell') framebuffer_x=320 framebuffer_y=240;;
@@ -672,8 +672,8 @@ Re-enabling HDMI requires a reboot. If you need emergency HDMI output, edit the 
 				esac
 
 				# Apply framebuffer size and Chromium autostart resolution
-				G_CONFIG_INJECT 'framebuffer_width=' "framebuffer_width=$framebuffer_x" /boot/config.txt
-				G_CONFIG_INJECT 'framebuffer_height=' "framebuffer_height=$framebuffer_y" /boot/config.txt
+				G_CONFIG_INJECT 'framebuffer_width=' "framebuffer_width=$framebuffer_x" /boot/firmware/config.txt
+				G_CONFIG_INJECT 'framebuffer_height=' "framebuffer_height=$framebuffer_y" /boot/firmware/config.txt
 				G_CONFIG_INJECT 'SOFTWARE_CHROMIUM_RES_X=' "SOFTWARE_CHROMIUM_RES_X=$framebuffer_x" /boot/dietpi.txt
 				G_CONFIG_INJECT 'SOFTWARE_CHROMIUM_RES_Y=' "SOFTWARE_CHROMIUM_RES_Y=$framebuffer_y" /boot/dietpi.txt
 			fi
@@ -815,20 +815,20 @@ Re-enabling HDMI requires a reboot. If you need emergency HDMI output, edit the 
 				rpi_text='\n\nOn Raspberry Pi 5/500 you can additionally enable or disable the UART device on GPIO 15+16 (pins 8+10) completely (requires reboot).'
 				local rpi_uart='ttyAMA0 (full UART)'
 				local rpi_uart_state='Off'
-				grep -q '^[[:blank:]]*enable_uart=1' /boot/config.txt && rpi_uart_state='On'
+				grep -q '^[[:blank:]]*enable_uart=1' /boot/firmware/config.txt && rpi_uart_state='On'
 
 			# Onboard WiFi/BT: "enable_uart" toggles ttyS0 (mini UART), disabled by default
 			elif (( $G_HW_ONBOARD_WIFI ))
 			then
 				local rpi_uart='ttyS0 (mini UART)'
 				local rpi_uart_state='Off'
-				grep -q '^[[:blank:]]*enable_uart=1' /boot/config.txt && rpi_uart_state='On'
+				grep -q '^[[:blank:]]*enable_uart=1' /boot/firmware/config.txt && rpi_uart_state='On'
 
 			# No onboard WiFi/BT: "enable_uart" toggles ttyAMA0 (full UART), enabled by default
 			else
 				local rpi_uart='ttyAMA0 (full UART)'
 				local rpi_uart_state='On'
-				grep -q '^[[:blank:]]*enable_uart=0' /boot/config.txt && rpi_uart_state='Off'
+				grep -q '^[[:blank:]]*enable_uart=0' /boot/firmware/config.txt && rpi_uart_state='Off'
 			fi
 			G_WHIP_MENU_ARRAY+=("$rpi_uart device" ": [$rpi_uart_state]")
 
@@ -842,7 +842,7 @@ Re-enabling HDMI requires a reboot. If you need emergency HDMI output, edit the 
 
 			local toggle=1
 			[[ $rpi_uart_state == 'On' ]] && toggle=0 && /boot/dietpi/func/dietpi-set_hardware serialconsole disable "${G_WHIP_RETURNED_VALUE%% *}"
-			G_CONFIG_INJECT 'enable_uart=' "enable_uart=$toggle" /boot/config.txt && REBOOT_REQUIRED=1
+			G_CONFIG_INJECT 'enable_uart=' "enable_uart=$toggle" /boot/firmware/config.txt && REBOOT_REQUIRED=1
 
 		elif [[ $G_WHIP_RETURNED_VALUE == *'console' ]]; then
 
@@ -954,19 +954,19 @@ Re-enabling HDMI requires a reboot. If you need emergency HDMI output, edit the 
 		elif (( $G_HW_MODEL < 10 ))
 		then
 			# I2C state
-			local rpi_i2c_enabled=$(grep -cm1 '^[[:blank:]]*dtparam=i2c_arm=on' /boot/config.txt)
+			local rpi_i2c_enabled=$(grep -cm1 '^[[:blank:]]*dtparam=i2c_arm=on' /boot/firmware/config.txt)
 			local rpi_i2c_text='Off'
 			(( $rpi_i2c_enabled )) && rpi_i2c_text='On'
 			G_WHIP_MENU_ARRAY+=('I2C state' ": [$rpi_i2c_text]")
 
 			# I2C baudrate
-			local rpi_i2c_baudrate=$(sed -n '/^[[:blank:]]*dtparam=i2c_arm_baudrate=/{s/^.*=//p;q}' /boot/config.txt)
-			# - Allow commented/non-existent entry, using default value: https://github.com/raspberrypi/firmware/blob/d69aadedb7c146ba5d3b0b45a661e5669a9141c4/boot/overlays/README#L115-L116
+			local rpi_i2c_baudrate=$(sed -n '/^[[:blank:]]*dtparam=i2c_arm_baudrate=/{s/^.*=//p;q}' /boot/firmware/config.txt)
+			# - Allow commented/non-existent entry, using default value: https://github.com/raspberrypi/firmware/blob/81a3301/boot/overlays/README#L305-L306
 			rpi_i2c_baudrate=$(( ${rpi_i2c_baudrate:-100000} / 1000 ))
 			G_WHIP_MENU_ARRAY+=('I2C frequency' ": [$rpi_i2c_baudrate kHz]")
 
 			# SPI state
-			local spi_enabled=$(grep -cm1 '^[[:blank:]]*dtparam=spi=on' /boot/config.txt)
+			local spi_enabled=$(grep -cm1 '^[[:blank:]]*dtparam=spi=on' /boot/firmware/config.txt)
 			local spi_text='Off'
 			(( $spi_enabled )) && spi_text='On'
 			G_WHIP_MENU_ARRAY+=('SPI state' ": [$spi_text]")
@@ -1265,7 +1265,7 @@ Latest release notes: https://github.com/starfive-tech/VisionFive2/releases
 		# - RPi 4/5: Allow setting firmware min frequency. Disabled on other RPi models where these can cause issues: https://github.com/MichaIng/DietPi/issues/3690
 		if (( $G_HW_MODEL > 3 && $G_HW_MODEL < 10 ))
 		then
-			local arm_freq_min=$(sed -n '/^[[:blank:]]*arm_freq_min=/{s/^[^=]*=//p;q}' /boot/config.txt)
+			local arm_freq_min=$(sed -n '/^[[:blank:]]*arm_freq_min=/{s/^[^=]*=//p;q}' /boot/firmware/config.txt)
 			[[ $arm_freq_min ]] || { (( $G_HW_MODEL == 5 )) && arm_freq_min=1500 || arm_freq_min=600; } # 1500 on RPi 5, 700 on RPi1+Zero else 600
 			G_WHIP_MENU_ARRAY+=('ARM Idle Frequency' ": [$arm_freq_min MHz]")
 		else
@@ -1289,10 +1289,10 @@ Latest release notes: https://github.com/starfive-tech/VisionFive2/releases
 		# RPi extras
 		if (( $G_HW_MODEL < 10 ))
 		then
-			local temp_limit=$(sed -n '/^[[:blank:]]*temp_limit=/{s/^[^=]*=//p;q}' /boot/config.txt)
+			local temp_limit=$(sed -n '/^[[:blank:]]*temp_limit=/{s/^[^=]*=//p;q}' /boot/firmware/config.txt)
 			G_WHIP_MENU_ARRAY+=('ARM Temp Limit' ": [${temp_limit:=85} °C]")
 
-			local initial_turbo=$(sed -n '/^[[:blank:]]*initial_turbo=/{s/^[^=]*=//p;q}' /boot/config.txt)
+			local initial_turbo=$(sed -n '/^[[:blank:]]*initial_turbo=/{s/^[^=]*=//p;q}' /boot/firmware/config.txt)
 			G_WHIP_MENU_ARRAY+=('ARM Initial Turbo' ": [${initial_turbo:=0} seconds]")
 		fi
 
@@ -1481,7 +1481,7 @@ If unsure, set any value, 'Ondemand Down Factor' option on the next screen will 
 - Recommended value: 65\n - Valid range: $MIN_VALUE - $MAX_VALUE" && G_CHECK_VALIDINT "$G_WHIP_RETURNED_VALUE" "$MIN_VALUE" "$MAX_VALUE"; then
 
 					(( $G_WHIP_RETURNED_VALUE > 75 )) && G_WHIP_MSG "Higher operating temperatures will reduce the life of your ARM SoC. Heat also dissipates through the PCB into other components, decreasing the lifespan of the whole device. Use at your own risk.\n\nDietPi recommends 65'c as a safe value (75'c for RPi 3/4).\n\nMore info: https://github.com/MichaIng/DietPi/issues/356"
-					G_CONFIG_INJECT 'temp_limit=' "temp_limit=$G_WHIP_RETURNED_VALUE" /boot/config.txt && REBOOT_REQUIRED=1
+					G_CONFIG_INJECT 'temp_limit=' "temp_limit=$G_WHIP_RETURNED_VALUE" /boot/firmware/config.txt && REBOOT_REQUIRED=1
 
 				fi
 			;;
@@ -1497,11 +1497,11 @@ If unsure, set any value, 'Ondemand Down Factor' option on the next screen will 
 
 					if disable_error=1 G_CHECK_VALIDINT "$G_WHIP_RETURNED_VALUE" "$MIN_VALUE"; then
 
-						G_CONFIG_INJECT 'arm_freq_min=' "arm_freq_min=$G_WHIP_RETURNED_VALUE" /boot/config.txt
+						G_CONFIG_INJECT 'arm_freq_min=' "arm_freq_min=$G_WHIP_RETURNED_VALUE" /boot/firmware/config.txt
 
 					else
 
-						G_EXEC sed --follow-symlinks -i "/^[[:blank:]]*arm_freq_min=/c\#arm_freq_min=$DEF_VALUE" /boot/config.txt
+						G_EXEC sed --follow-symlinks -i "/^[[:blank:]]*arm_freq_min=/c\#arm_freq_min=$DEF_VALUE" /boot/firmware/config.txt
 
 					fi
 					REBOOT_REQUIRED=1
@@ -1518,11 +1518,11 @@ If unsure, set any value, 'Ondemand Down Factor' option on the next screen will 
 
 					if disable_error=1 G_CHECK_VALIDINT "$G_WHIP_RETURNED_VALUE" "$MIN_VALUE" "$MAX_VALUE"; then
 
-						G_CONFIG_INJECT 'initial_turbo=' "initial_turbo=$G_WHIP_RETURNED_VALUE" /boot/config.txt
+						G_CONFIG_INJECT 'initial_turbo=' "initial_turbo=$G_WHIP_RETURNED_VALUE" /boot/firmware/config.txt
 
 					else
 
-						sed --follow-symlinks -i '/^[[:blank:]]*initial_turbo=/c\#initial_turbo=20' /boot/config.txt
+						sed --follow-symlinks -i '/^[[:blank:]]*initial_turbo=/c\#initial_turbo=20' /boot/firmware/config.txt
 
 					fi
 					REBOOT_REQUIRED=1
@@ -1572,8 +1572,8 @@ If unsure, set any value, 'Ondemand Down Factor' option on the next screen will 
 		# - Get override setting: gpu_mem_1024 is effective for all models with >= 1 GiB RAM
 		local size=1024 default=76
 		(( $G_HW_MEMORY_SIZE < 1024 )) && size=$G_HW_MEMORY_SIZE default=64
-		local gpu_mem_current=$(sed -n "/^[[:blank:]]*gpu_mem_$size=/{s/^[^=]*=//p;q}" /boot/config.txt) # override setting
-		[[ $gpu_mem_current ]] || gpu_mem_current=$(sed -n '/^[[:blank:]]*gpu_mem=/{s/^[^=]*=//p;q}' /boot/config.txt) # base setting
+		local gpu_mem_current=$(sed -n "/^[[:blank:]]*gpu_mem_$size=/{s/^[^=]*=//p;q}" /boot/firmware/config.txt) # override setting
+		[[ $gpu_mem_current ]] || gpu_mem_current=$(sed -n '/^[[:blank:]]*gpu_mem=/{s/^[^=]*=//p;q}' /boot/firmware/config.txt) # base setting
 		[[ $gpu_mem_current ]] || gpu_mem_current=$default # default value
 		local ram_mem_current=$((G_HW_MEMORY_SIZE-gpu_mem_current))
 
@@ -2228,7 +2228,7 @@ NB: All Ethernet connections will be temporarily dropped!' && Network_ApplyChang
 		if (( $G_HW_ONBOARD_WIFI ))
 		then
 			local onboard_wifi_enabled=1
-			if grep -q '^[[:blank:]]*dtoverlay=disable-wifi' /boot/config.txt
+			if grep -q '^[[:blank:]]*dtoverlay=disable-wifi' /boot/firmware/config.txt
 			then
 				onboard_wifi_enabled=0
 				G_WHIP_MENU_ARRAY+=('Onboard WiFi' ': [Off]')
@@ -2884,8 +2884,8 @@ Additional benchmarks:
 		sed --follow-symlinks -i -e '/^[[:blank:]]*over_voltage=/c\#over_voltage=0' \
 			-e '/^[[:blank:]]*over_voltage_min=/c\#over_voltage_min=0' \
 			-e "/^[[:blank:]]*arm_freq=/c\#arm_freq=$arm_freq_default" \
-			-e "/^[[:blank:]]*core_freq=/c\#core_freq=$core_freq_default" /boot/config.txt
-		(( $G_HW_MODEL > 3 )) || sed --follow-symlinks -i "/^[[:blank:]]*sdram_freq=/c\#sdram_freq=$sdram_freq_default" /boot/config.txt
+			-e "/^[[:blank:]]*core_freq=/c\#core_freq=$core_freq_default" /boot/firmware/config.txt
+		(( $G_HW_MODEL > 3 )) || sed --follow-symlinks -i "/^[[:blank:]]*sdram_freq=/c\#sdram_freq=$sdram_freq_default" /boot/firmware/config.txt
 		REBOOT_REQUIRED=1
 	}
 
@@ -2897,18 +2897,18 @@ Additional benchmarks:
 		# Get Current Overclocking Settings
 		Get_Overclocking_Defaults
 
-		local over_voltage=$(sed -n '/^[[:blank:]]*over_voltage=/{s/^[^=]*=//p;q}' /boot/config.txt)
+		local over_voltage=$(sed -n '/^[[:blank:]]*over_voltage=/{s/^[^=]*=//p;q}' /boot/firmware/config.txt)
 		[[ $over_voltage ]] || over_voltage=0
 
-		local arm_freq=$(sed -n '/^[[:blank:]]*arm_freq=/{s/^[^=]*=//p;q}' /boot/config.txt)
+		local arm_freq=$(sed -n '/^[[:blank:]]*arm_freq=/{s/^[^=]*=//p;q}' /boot/firmware/config.txt)
 		[[ $arm_freq ]] || arm_freq=$arm_freq_default
 
-		local core_freq=$(sed -n '/^[[:blank:]]*core_freq=/{s/^[^=]*=//p;q}' /boot/config.txt)
+		local core_freq=$(sed -n '/^[[:blank:]]*core_freq=/{s/^[^=]*=//p;q}' /boot/firmware/config.txt)
 		[[ $core_freq ]] || core_freq=$core_freq_default
 
 		if (( $G_HW_MODEL != 4 ))
 		then
-			local sdram_freq=$(sed -n '/^[[:blank:]]*sdram_freq=/{s/^[^=]*=//p;q}' /boot/config.txt)
+			local sdram_freq=$(sed -n '/^[[:blank:]]*sdram_freq=/{s/^[^=]*=//p;q}' /boot/firmware/config.txt)
 			[[ $sdram_freq ]] || sdram_freq=$sdram_freq_default
 		fi
 
@@ -2928,12 +2928,12 @@ Additional benchmarks:
 			case "$G_WHIP_RETURNED_VALUE" in
 
 				'energy saving')
-					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=-2' /boot/config.txt
+					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=-2' /boot/firmware/config.txt
 				;;
 				'high')
-					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=2' /boot/config.txt
-					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1100' /boot/config.txt
-					G_CONFIG_INJECT 'core_freq=' 'core_freq=450' /boot/config.txt
+					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=2' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1100' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'core_freq=' 'core_freq=450' /boot/firmware/config.txt
 				;;
 				*) :;;
 			esac
@@ -2955,18 +2955,18 @@ Additional benchmarks:
 			case "$G_WHIP_RETURNED_VALUE" in
 
 				'safe')
-					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=2' /boot/config.txt
-					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=900' /boot/config.txt
+					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=2' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=900' /boot/firmware/config.txt
 				;;
 				'high')
-					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=4' /boot/config.txt
-					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=900' /boot/config.txt
-					G_CONFIG_INJECT 'core_freq=' 'core_freq=500' /boot/config.txt
+					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=4' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=900' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'core_freq=' 'core_freq=500' /boot/firmware/config.txt
 				;;
 				'extreme')
-					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=6' /boot/config.txt
-					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1000' /boot/config.txt
-					G_CONFIG_INJECT 'core_freq=' 'core_freq=500' /boot/config.txt
+					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=6' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1000' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'core_freq=' 'core_freq=500' /boot/firmware/config.txt
 				;;
 				*) :;;
 			esac
@@ -2989,24 +2989,24 @@ Additional benchmarks:
 			case "$G_WHIP_RETURNED_VALUE" in
 
 				'energy saving')
-					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=-2' /boot/config.txt
-					G_CONFIG_INJECT 'over_voltage_min=' 'over_voltage_min=-2' /boot/config.txt
+					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=-2' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'over_voltage_min=' 'over_voltage_min=-2' /boot/firmware/config.txt
 				;;
 				'low')
-					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=2' /boot/config.txt
-					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1000' /boot/config.txt
-					G_CONFIG_INJECT 'core_freq=' 'core_freq=450' /boot/config.txt
+					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=2' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1000' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'core_freq=' 'core_freq=450' /boot/firmware/config.txt
 				;;
 				'med')
-					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=3' /boot/config.txt
-					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1000' /boot/config.txt
-					G_CONFIG_INJECT 'core_freq=' 'core_freq=500' /boot/config.txt
+					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=3' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1000' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'core_freq=' 'core_freq=500' /boot/firmware/config.txt
 				;;
 				'extreme')
-					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=4' /boot/config.txt
-					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1000' /boot/config.txt
-					G_CONFIG_INJECT 'core_freq=' 'core_freq=500' /boot/config.txt
-					G_CONFIG_INJECT 'sdram_freq=' 'sdram_freq=500' /boot/config.txt
+					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=4' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1000' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'core_freq=' 'core_freq=500' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'sdram_freq=' 'sdram_freq=500' /boot/firmware/config.txt
 				;;
 				*) :;;
 			esac
@@ -3029,22 +3029,22 @@ Additional benchmarks:
 			case "$G_WHIP_RETURNED_VALUE" in
 
 				'energy saving')
-					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=-2' /boot/config.txt
-					G_CONFIG_INJECT 'over_voltage_min=' 'over_voltage_min=-2' /boot/config.txt
+					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=-2' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'over_voltage_min=' 'over_voltage_min=-2' /boot/firmware/config.txt
 				;;
 				'low')
-					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=2' /boot/config.txt
-					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1200' /boot/config.txt
+					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=2' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1200' /boot/firmware/config.txt
 				;;
 				'med')
-					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=3' /boot/config.txt
-					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1200' /boot/config.txt
-					G_CONFIG_INJECT 'core_freq=' 'core_freq=450' /boot/config.txt
+					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=3' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1200' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'core_freq=' 'core_freq=450' /boot/firmware/config.txt
 				;;
 				'high')
-					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=5' /boot/config.txt
-					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1300' /boot/config.txt
-					G_CONFIG_INJECT 'core_freq=' 'core_freq=500' /boot/config.txt
+					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=5' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1300' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'core_freq=' 'core_freq=500' /boot/firmware/config.txt
 				;;
 				*) :;;
 			esac
@@ -3077,23 +3077,23 @@ Additional benchmarks:
 			case "$G_WHIP_RETURNED_VALUE" in
 
 				'safe')
-					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=1' /boot/config.txt
-					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1500' /boot/config.txt
+					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=1' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1500' /boot/firmware/config.txt
 				;;
 				'low')
-					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=3' /boot/config.txt
-					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1300' /boot/config.txt
-					G_CONFIG_INJECT 'core_freq=' 'core_freq=400' /boot/config.txt
+					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=3' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1300' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'core_freq=' 'core_freq=400' /boot/firmware/config.txt
 				;;
 				'med')
-					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=4' /boot/config.txt
-					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1300' /boot/config.txt
-					G_CONFIG_INJECT 'core_freq=' 'core_freq=450' /boot/config.txt
+					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=4' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1300' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'core_freq=' 'core_freq=450' /boot/firmware/config.txt
 				;;
 				'high')
-					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=5' /boot/config.txt
-					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1300' /boot/config.txt
-					G_CONFIG_INJECT 'core_freq=' 'core_freq=500' /boot/config.txt
+					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=5' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1300' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'core_freq=' 'core_freq=500' /boot/firmware/config.txt
 				;;
 				*) :;;
 			esac
@@ -3115,18 +3115,18 @@ Additional benchmarks:
 			case "$G_WHIP_RETURNED_VALUE" in
 
 				'energy saving')
-					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=-2' /boot/config.txt
-					G_CONFIG_INJECT 'over_voltage_min=' 'over_voltage_min=-2' /boot/config.txt
+					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=-2' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'over_voltage_min=' 'over_voltage_min=-2' /boot/firmware/config.txt
 				;;
 				'high GPU')
-					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=5' /boot/config.txt
-					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1900' /boot/config.txt
-					G_CONFIG_INJECT 'core_freq=' 'core_freq=600' /boot/config.txt
+					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=5' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1900' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'core_freq=' 'core_freq=600' /boot/firmware/config.txt
 				;;
 				'high ARM')
-					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=5' /boot/config.txt
-					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=2000' /boot/config.txt
-					G_CONFIG_INJECT 'core_freq=' 'core_freq=500' /boot/config.txt
+					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=5' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=2000' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'core_freq=' 'core_freq=500' /boot/firmware/config.txt
 				;;
 				*) :;;
 			esac
@@ -3151,31 +3151,31 @@ Additional benchmarks:
 			case "$G_WHIP_RETURNED_VALUE" in
 
 				'energy saving')
-					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=-2' /boot/config.txt
-					G_CONFIG_INJECT 'over_voltage_min=' 'over_voltage_min=-2' /boot/config.txt
+					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=-2' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'over_voltage_min=' 'over_voltage_min=-2' /boot/firmware/config.txt
 				;;
 				'safe')
-					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1600' /boot/config.txt
+					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1600' /boot/firmware/config.txt
 				;;
 				'medium GPU')
-					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=2' /boot/config.txt
-					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1700' /boot/config.txt
-					G_CONFIG_INJECT 'core_freq=' 'core_freq=600' /boot/config.txt
+					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=2' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1700' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'core_freq=' 'core_freq=600' /boot/firmware/config.txt
 				;;
 				'medium ARM')
-					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=2' /boot/config.txt
-					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1800' /boot/config.txt
-					G_CONFIG_INJECT 'core_freq=' 'core_freq=500' /boot/config.txt
+					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=2' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1800' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'core_freq=' 'core_freq=500' /boot/firmware/config.txt
 				;;
 				'high GPU')
-					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=4' /boot/config.txt
-					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1800' /boot/config.txt
-					G_CONFIG_INJECT 'core_freq=' 'core_freq=700' /boot/config.txt
+					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=4' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1800' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'core_freq=' 'core_freq=700' /boot/firmware/config.txt
 				;;
 				'high ARM')
-					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=4' /boot/config.txt
-					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1900' /boot/config.txt
-					G_CONFIG_INJECT 'core_freq=' 'core_freq=600' /boot/config.txt
+					G_CONFIG_INJECT 'over_voltage=' 'over_voltage=4' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'arm_freq=' 'arm_freq=1900' /boot/firmware/config.txt
+					G_CONFIG_INJECT 'core_freq=' 'core_freq=600' /boot/firmware/config.txt
 				;;
 				*) :;;
 			esac

--- a/dietpi/dietpi-display
+++ b/dietpi/dietpi-display
@@ -27,7 +27,7 @@ Read_Settings()
 	# RPi
 	if (( $G_HW_MODEL < 10 ))
 	then
-		read -ra cmdline < /boot/cmdline.txt
+		read -ra cmdline < /boot/firmware/cmdline.txt
 
 	# U-Boot environment file
 	elif [[ $uenv ]]
@@ -171,7 +171,7 @@ Apply_Settings()
 	if (( $G_HW_MODEL < 10 ))
 	then
 		local cmdline=() i
-		read -ra cmdline < /boot/cmdline.txt
+		read -ra cmdline < /boot/firmware/cmdline.txt
 		for i in "${!cmdline[@]}"
 		do
 			[[ ${cmdline[i]} == "video=$DISPLAY:"* ]] || continue
@@ -179,7 +179,7 @@ Apply_Settings()
 			break
 		done
 		[[ ${cmdline[i]} == "video=$DISPLAY:"* ]] || cmdline+=("$arg")
-		G_EXEC eval "echo '${cmdline[*]}' > /boot/cmdline.txt"
+		G_EXEC eval "echo '${cmdline[*]}' > /boot/firmware/cmdline.txt"
 	fi
 
 	# U-Boot environment file
@@ -224,7 +224,7 @@ Apply_Settings()
 	then
 		G_WHIP_MSG '[FAILED] Boot configuration not found
 \nWe could not find a boot configuration to apply kernel command-line arguments. So far, this script supports:
-- /boot/cmdline.txt on Raspberry Pi
+- /boot/firmware/cmdline.txt on Raspberry Pi
 - /boot/dietpiEnv.txt, /boot/armbianEnv.txt, and /boot/extlinux/extlinux.conf
 - GRUB
 \nPlease open an issue at our GitHub page or forum:
@@ -241,14 +241,14 @@ Reset_Settings()
 	if (( $G_HW_MODEL < 10 ))
 	then
 		local cmdline=() i
-		read -ra cmdline < /boot/cmdline.txt
+		read -ra cmdline < /boot/firmware/cmdline.txt
 		for i in "${!cmdline[@]}"
 		do
 			[[ ${cmdline[i]} == "video=$DISPLAY:"* ]] || continue
 			unset -v 'cmdline[i]'
 			break
 		done
-		G_EXEC eval "echo '${cmdline[*]}' > /boot/cmdline.txt"
+		G_EXEC eval "echo '${cmdline[*]}' > /boot/firmware/cmdline.txt"
 	fi
 
 	# U-Boot environment file
@@ -292,7 +292,7 @@ Reset_Settings()
 	then
 		G_WHIP_MSG '[FAILED] Boot configuration not found
 \nWe could not find a boot configuration to apply kernel command-line arguments. So far, this script supports:
-- /boot/cmdline.txt on Raspberry Pi
+- /boot/firmware/cmdline.txt on Raspberry Pi
 - /boot/dietpiEnv.txt, /boot/armbianEnv.txt, and /boot/extlinux/extlinux.conf
 - GRUB
 \nPlease open an issue at our GitHub page or forum:
@@ -393,7 +393,7 @@ Main_Menu()
 		esac
 		G_WHIP_DEFAULT_ITEM_NEXT=$G_WHIP_RETURNED_VALUE
 
-	elif (( $G_HW_MODEL < 10 )) && ! grep -q '^[[:blank:]]*dtoverlay=vc4-kms-v3d' /boot/config.txt
+	elif (( $G_HW_MODEL < 10 )) && ! grep -q '^[[:blank:]]*dtoverlay=vc4-kms-v3d' /boot/firmware/config.txt
 	then
 		G_WHIP_BUTTON_OK_TEXT='Yes' G_WHIP_BUTTON_CANCEL_TEXT='Exit'
 		G_WHIP_YESNO '[ INFO ] KMS/DRM driver is not enabled

--- a/dietpi/dietpi-drive_manager
+++ b/dietpi/dietpi-drive_manager
@@ -622,14 +622,14 @@ Do you wish to ignore this warning, and, mount the drive regardless?" || return 
 		G_EXEC sed --follow-symlinks -i "\@[[:blank:]]/[[:blank:]]@c$dev_entry / ${aDRIVE_FSTYPE[$MENU_DRIVE_SELECTED]} noatime,lazytime,rw 0 1" "${aDRIVE_MOUNT_TARGET[$MENU_DRIVE_SELECTED]}/etc/fstab"
 
 		# Find and replace current root and rootfstype kernel command line entries
-		# - RPi: /boot/cmdline.txt
+		# - RPi: /boot/firmware/cmdline.txt
 		if (( $G_HW_MODEL < 10 ))
 		then
-			local rootfs_current=$(mawk '{for(i=1;i<=NF;i++) if($i~/^root=/) {print $i;exit}}' /boot/cmdline.txt)
-			G_EXEC sed --follow-symlinks -i "s#$rootfs_current#root=$dev_entry#g" /boot/cmdline.txt
+			local rootfs_current=$(mawk '{for(i=1;i<=NF;i++) if($i~/^root=/) {print $i;exit}}' /boot/firmware/cmdline.txt)
+			G_EXEC sed --follow-symlinks -i "s#$rootfs_current#root=$dev_entry#g" /boot/firmware/cmdline.txt
 
-			local rootfstype_current=$(mawk '{for(i=1;i<=NF;i++) if($i~/^rootfstype=/) {print $i;exit}}' /boot/cmdline.txt)
-			[[ $rootfstype_current ]] && G_EXEC sed --follow-symlinks -i "s#$rootfstype_current#rootfstype=${aDRIVE_FSTYPE[$MENU_DRIVE_SELECTED]}#g" /boot/cmdline.txt
+			local rootfstype_current=$(mawk '{for(i=1;i<=NF;i++) if($i~/^rootfstype=/) {print $i;exit}}' /boot/firmware/cmdline.txt)
+			[[ $rootfstype_current ]] && G_EXEC sed --follow-symlinks -i "s#$rootfstype_current#rootfstype=${aDRIVE_FSTYPE[$MENU_DRIVE_SELECTED]}#g" /boot/firmware/cmdline.txt
 
 		# - Odroids: /boot/boot.ini
 		else
@@ -1133,10 +1133,10 @@ Please choose another drive or format this one with another filesystem, e.g. ext
 		elif [[ $G_WHIP_RETURNED_VALUE == 'Transfer RootFS' ]]
 		then
 			# Check whether required kernel command line config file is present
-			if [[ $G_HW_MODEL -le 9 && ! -f '/boot/cmdline.txt' ]]
+			if [[ $G_HW_MODEL -le 9 && ! -f '/boot/firmware/cmdline.txt' ]]
 			then
-				G_WHIP_MSG '[ INFO ] /boot/cmdline.txt not found
-\nThe required /boot/cmdline.txt file to adjust the root filesystem entry for the kernel has not been found.
+				G_WHIP_MSG '[ INFO ] /boot/firmware/cmdline.txt not found
+\nThe required /boot/firmware/cmdline.txt file to adjust the root filesystem entry for the kernel has not been found.
 \nTransferring the root filesystem is not supported on your device. Aborting...'
 				return 1
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -2527,7 +2527,7 @@ _EOF_
 		{
 			if (( $G_HW_MODEL < 10 ))
 			then
-				grep -Eq '(^|[[:blank:]])cgroup_enable=memory([[:blank:]]|$)' /boot/cmdline.txt || G_EXEC sed --follow-symlinks -i '/root=/s/[[:blank:]]*$/ cgroup_enable=memory/' /boot/cmdline.txt
+				grep -Eq '(^|[[:blank:]])cgroup_enable=memory([[:blank:]]|$)' /boot/firmware/cmdline.txt || G_EXEC sed --follow-symlinks -i '/root=/s/[[:blank:]]*$/ cgroup_enable=memory/' /boot/firmware/cmdline.txt
 
 			elif [[ -f '/boot/boot.scr' ]] && grep -q 'docker_optimizations' /boot/boot.scr
 			then
@@ -8922,7 +8922,7 @@ sudo sysctl -p /etc/sysctl.d/dietpi-syncthing.confs
 			if (( $G_HW_MODEL < 10 ))
 			then
 				# Enable KMS
-				grep -Eq '^[[:blank:]]*dtoverlay=vc4-f?kms-v3d' /boot/config.txt || /boot/dietpi/func/dietpi-set_hardware rpi-opengl vc4-kms-v3d
+				grep -Eq '^[[:blank:]]*dtoverlay=vc4-f?kms-v3d' /boot/firmware/config.txt || /boot/dietpi/func/dietpi-set_hardware rpi-opengl vc4-kms-v3d
 
 				# Enable hardware codecs
 				/boot/dietpi/func/dietpi-set_hardware rpi-codec 1
@@ -10734,8 +10734,8 @@ _EOF_
 			#G_EXEC systemctl unmask systemd-logind
 			#G_EXEC systemctl start systemd-logind
 
-			#G_CONFIG_INJECT 'dtoverlay=gpio-shutdown' 'dtoverlay=gpio-shutdown,gpio_pin=17,active_low=0,gpio_pull=down' /boot/config.txt
-			#G_CONFIG_INJECT 'dtoverlay=gpio-poweroff' 'dtoverlay=gpio-poweroff,gpiopin=22,active_low' /boot/config.txt
+			#G_CONFIG_INJECT 'dtoverlay=gpio-shutdown' 'dtoverlay=gpio-shutdown,gpio_pin=17,active_low=0,gpio_pull=down' /boot/firmware/config.txt
+			#G_CONFIG_INJECT 'dtoverlay=gpio-poweroff' 'dtoverlay=gpio-poweroff,gpiopin=22,active_low' /boot/firmware/config.txt
 		fi
 
 		if To_Install 167 raspotify # Raspotify: https://github.com/dtcooper/raspotify/blob/master/install.sh
@@ -12312,7 +12312,7 @@ _EOF_
 		# Raise memory split to default
 		local default_gpu_mem=76
 		(( $G_HW_MEMORY_SIZE < 1024 )) && default_gpu_mem=64
-		local current_gpu_mem=$(sed -n '/^[[:blank:]]*gpu_mem_1024=/{s/^[^=]*=//p;q}' /boot/config.txt)
+		local current_gpu_mem=$(sed -n '/^[[:blank:]]*gpu_mem_1024=/{s/^[^=]*=//p;q}' /boot/firmware/config.txt)
 		[[ $current_gpu_mem ]] || current_gpu_mem=$default_gpu_mem
 		(( $current_gpu_mem < $default_gpu_mem )) && /boot/dietpi/func/dietpi-set_hardware gpumemsplit "$default_gpu_mem"
 	}
@@ -13748,7 +13748,7 @@ _EOF_
 			Remove_Service pi-spc
 			[[ -d '/var/lib/dietpi/dietpi-software/installed/pi-spc' ]] && G_EXEC rm -R /var/lib/dietpi/dietpi-software/installed/pi-spc
 
-			G_EXEC sed --follow-symlinks -Ei '/^[[:blank:]]*dtoverlay=gpio-(shutdown|poweroff)/d' /boot/config.txt
+			G_EXEC sed --follow-symlinks -Ei '/^[[:blank:]]*dtoverlay=gpio-(shutdown|poweroff)/d' /boot/firmware/config.txt
 		fi
 
 		if To_Uninstall 167 # Raspotify
@@ -14628,13 +14628,13 @@ _EOF_
 				local tty=$(realpath /dev/serial0); tty=${tty#/dev/}
 
 				G_DIETPI-NOTIFY 2 "Converting serial console from symlink /dev/serial0 to native /dev/$tty"
-				if [[ $(</boot/cmdline.txt) == *'console=serial0'* ]]
+				if [[ $(</boot/firmware/cmdline.txt) == *'console=serial0'* ]]
 				then
-					if [[ $(</boot/cmdline.txt) == *"console=$tty"* ]]
+					if [[ $(</boot/firmware/cmdline.txt) == *"console=$tty"* ]]
 					then
-						G_EXEC sed --follow-symlinks -Ei 's/[[:blank:]]*console=serial0[^[:blank:]]*([[:blank:]]*$)?//' /boot/cmdline.txt
+						G_EXEC sed --follow-symlinks -Ei 's/[[:blank:]]*console=serial0[^[:blank:]]*([[:blank:]]*$)?//' /boot/firmware/cmdline.txt
 					else
-						G_EXEC sed --follow-symlinks -i "s/console=serial0/console=$tty/" /boot/cmdline.txt
+						G_EXEC sed --follow-symlinks -i "s/console=serial0/console=$tty/" /boot/firmware/cmdline.txt
 					fi
 				fi
 				if systemctl -q is-enabled serial-getty@serial0

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -115,10 +115,10 @@ $FP_SCRIPT	keyboard		[<layout>|autosetup] Apply input layout, dietpi.txt setting
 			[[ -f '/etc/modprobe.d/dietpi-disable_rpi_camera.conf' ]] && G_EXEC rm /etc/modprobe.d/dietpi-disable_rpi_camera.conf
 
 			# Enable video devices via extended start
-			G_CONFIG_INJECT 'start_x=' 'start_x=1' /boot/config.txt
+			G_CONFIG_INJECT 'start_x=' 'start_x=1' /boot/firmware/config.txt
 
 			# Requires 96 MiB memory split at least
-			local gpu_mem=$(sed -n '/^[[:blank:]]*gpu_mem_1024=/{s/^[^=]*=//p;q}' /boot/config.txt)
+			local gpu_mem=$(sed -n '/^[[:blank:]]*gpu_mem_1024=/{s/^[^=]*=//p;q}' /boot/firmware/config.txt)
 			(( ${gpu_mem:-76} < 96 )) && INPUT_DEVICE_VALUE=96 Gpu_Memory_Split_Main
 
 			# Enable H264/HEVC codecs as well
@@ -127,7 +127,7 @@ $FP_SCRIPT	keyboard		[<layout>|autosetup] Apply input layout, dietpi.txt setting
 		elif [[ $INPUT_DEVICE_VALUE == 'disable' ]]
 		then
 			# Comment extended start setting
-			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*start_x=/c\#start_x=1' /boot/config.txt
+			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*start_x=/c\#start_x=1' /boot/firmware/config.txt
 
 			# Blacklist related modules which are otherwise loaded by default
 			G_EXEC eval 'echo -e '\''blacklist bcm2835_v4l2\nblacklist bcm2835_isp\nblacklist pisp_be'\'' > /etc/modprobe.d/dietpi-disable_rpi_camera.conf'
@@ -149,7 +149,7 @@ $FP_SCRIPT	keyboard		[<layout>|autosetup] Apply input layout, dietpi.txt setting
 			[[ -f '/etc/modprobe.d/dietpi-disable_rpi_codec.conf' ]] && G_EXEC rm /etc/modprobe.d/dietpi-disable_rpi_codec.conf
 
 			# Requires 64 MiB memory split at least
-			local gpu_mem=$(sed -n '/^[[:blank:]]*gpu_mem_1024=/{s/^[^=]*=//p;q}' /boot/config.txt)
+			local gpu_mem=$(sed -n '/^[[:blank:]]*gpu_mem_1024=/{s/^[^=]*=//p;q}' /boot/firmware/config.txt)
 			(( ${gpu_mem:-76} < 64 )) && INPUT_DEVICE_VALUE=64 Gpu_Memory_Split_Main
 
 		elif [[ $INPUT_DEVICE_VALUE == 'disable' ]]
@@ -170,7 +170,7 @@ $FP_SCRIPT	keyboard		[<layout>|autosetup] Apply input layout, dietpi.txt setting
 
 		if [[ $INPUT_DEVICE_VALUE == 'enable' ]]; then
 
-			G_CONFIG_INJECT 'program_usb_boot_mode=' 'program_usb_boot_mode=1' /boot/config.txt
+			G_CONFIG_INJECT 'program_usb_boot_mode=' 'program_usb_boot_mode=1' /boot/firmware/config.txt
 
 			cat << '_EOF_' > /etc/systemd/system/dietpi-rm_program_usb_boot_mode.service
 [Unit]
@@ -179,7 +179,7 @@ Description=DietPi-rm_program_usb_boot_mode.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStartPre=/bin/sed --follow-symlinks -i '/^[[:blank:]]*program_usb_boot_mode=/d' /boot/config.txt
+ExecStartPre=/bin/sed --follow-symlinks -i '/^[[:blank:]]*program_usb_boot_mode=/d' /boot/firmware/config.txt
 ExecStartPre=/bin/systemctl disable dietpi-rm_program_usb_boot_mode
 ExecStart=/bin/rm /etc/systemd/system/dietpi-rm_program_usb_boot_mode.service
 
@@ -191,7 +191,7 @@ _EOF_
 
 		elif [[ $INPUT_DEVICE_VALUE == 'disable' ]]; then
 
-			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*program_usb_boot_mode=/d' /boot/config.txt
+			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*program_usb_boot_mode=/d' /boot/firmware/config.txt
 
 			if [[ -f '/etc/systemd/system/dietpi-rm_program_usb_boot_mode.service' ]]; then
 
@@ -269,14 +269,14 @@ _EOF_
 		if disable_error=1 G_CHECK_VALIDINT "$INPUT_DEVICE_VALUE" 16 944
 		then
 			# Remove overridden "gpu_mem" setting
-			grep -q '^[[:blank:]]*gpu_mem=' /boot/config.txt && G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*gpu_mem=/d' /boot/config.txt
+			grep -q '^[[:blank:]]*gpu_mem=' /boot/firmware/config.txt && G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*gpu_mem=/d' /boot/firmware/config.txt
 
 			local gpu_mem=$INPUT_DEVICE_VALUE
-			G_CONFIG_INJECT 'gpu_mem_1024=' "gpu_mem_1024=$gpu_mem" /boot/config.txt
+			G_CONFIG_INJECT 'gpu_mem_1024=' "gpu_mem_1024=$gpu_mem" /boot/firmware/config.txt
 			(( $gpu_mem > 448 )) && gpu_mem=448
-			G_CONFIG_INJECT 'gpu_mem_512=' "gpu_mem_512=$gpu_mem" /boot/config.txt
+			G_CONFIG_INJECT 'gpu_mem_512=' "gpu_mem_512=$gpu_mem" /boot/firmware/config.txt
 			(( $gpu_mem > 192 )) && gpu_mem=192
-			G_CONFIG_INJECT 'gpu_mem_256=' "gpu_mem_256=$gpu_mem" /boot/config.txt
+			G_CONFIG_INJECT 'gpu_mem_256=' "gpu_mem_256=$gpu_mem" /boot/firmware/config.txt
 
 			# Disable VideoCore CMA Shared Memory Driver if less than 32 MiB are applied, as it is doomed to fail with cut-down firmware loaded.
 			if (( $gpu_mem < 32 ))
@@ -302,25 +302,25 @@ _EOF_
 		if [[ $INPUT_DEVICE_VALUE == 'enable' ]]
 		then
 			# Prevent any framebuffer from being allocated
-			G_CONFIG_INJECT 'max_framebuffers=' 'max_framebuffers=0' /boot/config.txt
+			G_CONFIG_INJECT 'max_framebuffers=' 'max_framebuffers=0' /boot/firmware/config.txt
 			# Splash cannot be seen anyway without video output
-			G_CONFIG_INJECT 'disable_splash=' 'disable_splash=1' /boot/config.txt
+			G_CONFIG_INJECT 'disable_splash=' 'disable_splash=1' /boot/firmware/config.txt
 			# hdmi_blanking should not play a role, however mode 1 should be generally preferred, which on idle disables HDMI output completely instead of just blanking the screen
-			G_CONFIG_INJECT 'hdmi_blanking=' 'hdmi_blanking=1' /boot/config.txt
+			G_CONFIG_INJECT 'hdmi_blanking=' 'hdmi_blanking=1' /boot/firmware/config.txt
 			# Disable HDMI hotplug detection, which requires it to be generally responsive/active
-			G_CONFIG_INJECT 'hdmi_ignore_hotplug=' 'hdmi_ignore_hotplug=1' /boot/config.txt
+			G_CONFIG_INJECT 'hdmi_ignore_hotplug=' 'hdmi_ignore_hotplug=1' /boot/firmware/config.txt
 			# Disable SDTV on RPi 4 (default)
-			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*enable_tvout=/c\#enable_tvout=0' /boot/config.txt
+			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*enable_tvout=/c\#enable_tvout=0' /boot/firmware/config.txt
 			# dietpi.txt flag
 			G_CONFIG_INJECT 'AUTO_SETUP_HEADLESS=' 'AUTO_SETUP_HEADLESS=1' /boot/dietpi.txt
 
 		elif [[ $INPUT_DEVICE_VALUE == 'disable' ]]
 		then
-			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*max_framebuffers=/c\#max_framebuffers=2' /boot/config.txt
-			#G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*disable_splash=/c\#disable_splash=0' /boot/config.txt
-			#G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*hdmi_blanking=/c\#hdmi_blanking=0' /boot/config.txt
-			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*hdmi_ignore_hotplug=/c\#hdmi_ignore_hotplug=0' /boot/config.txt
-			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*enable_tvout=/c\#enable_tvout=0' /boot/config.txt
+			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*max_framebuffers=/c\#max_framebuffers=2' /boot/firmware/config.txt
+			#G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*disable_splash=/c\#disable_splash=0' /boot/firmware/config.txt
+			#G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*hdmi_blanking=/c\#hdmi_blanking=0' /boot/firmware/config.txt
+			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*hdmi_ignore_hotplug=/c\#hdmi_ignore_hotplug=0' /boot/firmware/config.txt
+			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*enable_tvout=/c\#enable_tvout=0' /boot/firmware/config.txt
 			G_CONFIG_INJECT 'AUTO_SETUP_HEADLESS=' 'AUTO_SETUP_HEADLESS=0' /boot/dietpi.txt
 		else
 			Unknown_Input_Mode
@@ -341,7 +341,7 @@ _EOF_
 				G_EXEC rm /etc/systemd/system/justboom-ir-mpd.service
 			fi
 			[[ -d '/etc/systemd/system/justboom-ir-mpd.service.d' ]] && G_EXEC rm -R /etc/systemd/system/justboom-ir-mpd.service.d
-			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*dtoverlay=gpio-ir/d' /boot/config.txt
+			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*dtoverlay=gpio-ir/d' /boot/firmware/config.txt
 
 		# Disable Odroids
 		elif (( $G_HW_MODEL < 20 ))
@@ -425,7 +425,7 @@ _EOF_
 			G_AG_CHECK_INSTALL_PREREQ lirc mpc
 
 			# Device tree overlay
-			G_CONFIG_INJECT 'dtoverlay=gpio-ir' 'dtoverlay=gpio-ir,gpio_pin=25' /boot/config.txt
+			G_CONFIG_INJECT 'dtoverlay=gpio-ir' 'dtoverlay=gpio-ir,gpio_pin=25' /boot/firmware/config.txt
 
 			# Config
 			cat << '_EOF_' > /etc/lirc/hardware.conf
@@ -591,10 +591,10 @@ _EOF_
 		(( $G_HW_MODEL > 9 )) && { Unsupported_Input_Name; return 1; } # Exit path for non-RPi
 
 		# Get overlay params
-		local params=$(sed -En '/^[[:blank:]]*dtoverlay=vc4-f?kms-v3d(-pi4)?,/{s/^[^,]*//p;q}' /boot/config.txt)
+		local params=$(sed -En '/^[[:blank:]]*dtoverlay=vc4-f?kms-v3d(-pi4)?,/{s/^[^,]*//p;q}' /boot/firmware/config.txt)
 
 		# Always remove previous VC4 overlay entry
-		G_EXEC sed --follow-symlinks -Ei '/^[[:blank:]]*dtoverlay=vc4-f?kms-v3d/d' /boot/config.txt
+		G_EXEC sed --follow-symlinks -Ei '/^[[:blank:]]*dtoverlay=vc4-f?kms-v3d/d' /boot/firmware/config.txt
 
 		if [[ $INPUT_DEVICE_VALUE == 'vc4-kms-v3d' || $INPUT_DEVICE_VALUE == 'vc4-fkms-v3d' ]]
 		then
@@ -604,7 +604,7 @@ _EOF_
 				[[ $params ]] && params=$(mawk -F, '{for(i=1; i<=NF; i++) {if($i~/^cma-*/){print $i;exit}}}' <<< "$params")
 			else
 				# Disable VC4 HDMI audio if onboard HDMI is disabled
-				[[ $params != *',noaudio'* ]] && { ! grep -q '^[[:blank:]]*dtparam=audio=on' /boot/config.txt || grep -Eq '(^|[[:blank:]])snd_bcm2835.enable_hdmi=0([[:blank:]]|$)' /boot/cmdline.txt; } && params+=',noaudio'
+				[[ $params != *',noaudio'* ]] && { ! grep -q '^[[:blank:]]*dtparam=audio=on' /boot/firmware/config.txt || grep -Eq '(^|[[:blank:]])snd_bcm2835.enable_hdmi=0([[:blank:]]|$)' /boot/firmware/cmdline.txt; } && params+=',noaudio'
 			fi
 
 			# Use additional argument for CMA size
@@ -618,7 +618,7 @@ _EOF_
 				fi
 			fi
 
-			G_CONFIG_INJECT "dtoverlay=$INPUT_DEVICE_VALUE" "dtoverlay=$INPUT_DEVICE_VALUE$params" /boot/config.txt
+			G_CONFIG_INJECT "dtoverlay=$INPUT_DEVICE_VALUE" "dtoverlay=$INPUT_DEVICE_VALUE$params" /boot/firmware/config.txt
 
 		elif [[ $INPUT_DEVICE_VALUE != 'disable' ]]
 		then
@@ -660,15 +660,15 @@ _EOF_
 
 		(( $G_HW_MODEL > 9 )) && { Unsupported_Input_Mode; return 1; } # Exit path for non-RPi
 
-		G_CONFIG_INJECT 'framebuffer_width=' 'framebuffer_width=1024' /boot/config.txt
-		G_CONFIG_INJECT 'framebuffer_height=' 'framebuffer_height=600' /boot/config.txt
+		G_CONFIG_INJECT 'framebuffer_width=' 'framebuffer_width=1024' /boot/firmware/config.txt
+		G_CONFIG_INJECT 'framebuffer_height=' 'framebuffer_height=600' /boot/firmware/config.txt
 		G_CONFIG_INJECT 'SOFTWARE_CHROMIUM_RES_X=' "SOFTWARE_CHROMIUM_RES_X=1024" /boot/dietpi.txt
 		G_CONFIG_INJECT 'SOFTWARE_CHROMIUM_RES_Y=' "SOFTWARE_CHROMIUM_RES_Y=600" /boot/dietpi.txt
-		G_CONFIG_INJECT 'hdmi_force_hotplug=' 'hdmi_force_hotplug=1' /boot/config.txt
-		G_CONFIG_INJECT 'hdmi_group=' 'hdmi_group=2' /boot/config.txt
-		G_CONFIG_INJECT 'hdmi_mode=' 'hdmi_mode=87' /boot/config.txt
-		G_CONFIG_INJECT 'hdmi_cvt=' 'hdmi_cvt=1024 600 60 6 0 0 0' /boot/config.txt
-		G_CONFIG_INJECT 'hdmi_drive=' 'hdmi_drive=1' /boot/config.txt
+		G_CONFIG_INJECT 'hdmi_force_hotplug=' 'hdmi_force_hotplug=1' /boot/firmware/config.txt
+		G_CONFIG_INJECT 'hdmi_group=' 'hdmi_group=2' /boot/firmware/config.txt
+		G_CONFIG_INJECT 'hdmi_mode=' 'hdmi_mode=87' /boot/firmware/config.txt
+		G_CONFIG_INJECT 'hdmi_cvt=' 'hdmi_cvt=1024 600 60 6 0 0 0' /boot/firmware/config.txt
+		G_CONFIG_INJECT 'hdmi_drive=' 'hdmi_drive=1' /boot/firmware/config.txt
 
 	}
 
@@ -676,11 +676,11 @@ _EOF_
 
 		(( $G_HW_MODEL > 9 )) && return 0 # Skip on non-RPi
 
-		G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*hdmi_force_hotplug=/c\#hdmi_force_hotplug=1' /boot/config.txt
-		G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*hdmi_group=/c\#hdmi_group=2' /boot/config.txt
-		G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*hdmi_mode=/c\#hdmi_mode=87' /boot/config.txt
-		G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*hdmi_cvt=/c\#hdmi_cvt=1024 600 60 6 0 0 0' /boot/config.txt
-		G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*hdmi_drive=/c\#hdmi_drive=1' /boot/config.txt
+		G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*hdmi_force_hotplug=/c\#hdmi_force_hotplug=1' /boot/firmware/config.txt
+		G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*hdmi_group=/c\#hdmi_group=2' /boot/firmware/config.txt
+		G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*hdmi_mode=/c\#hdmi_mode=87' /boot/firmware/config.txt
+		G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*hdmi_cvt=/c\#hdmi_cvt=1024 600 60 6 0 0 0' /boot/firmware/config.txt
+		G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*hdmi_drive=/c\#hdmi_drive=1' /boot/firmware/config.txt
 
 	}
 
@@ -723,18 +723,18 @@ _EOF_
 			G_EXEC curl -sSfL 'https://raw.githubusercontent.com/waveshare/LCD-show/master/waveshare32b-overlay.dtb' -o /boot/firmware/overlays/waveshare32b.dtbo
 
 			#consoleblank=0 no effect
-			G_EXEC sed --follow-symlinks -i 's/rootwait/rootwait fbcon=map:10 fbcon=font:ProFont6x11 logo.nologo/' /boot/cmdline.txt
+			G_EXEC sed --follow-symlinks -i 's/rootwait/rootwait fbcon=map:10 fbcon=font:ProFont6x11 logo.nologo/' /boot/firmware/cmdline.txt
 
-			G_CONFIG_INJECT 'dtparam=i2c_arm=' 'dtparam=i2c_arm=on' /boot/config.txt
-			G_CONFIG_INJECT 'dtparam=spi=' 'dtparam=spi=on' /boot/config.txt
+			G_CONFIG_INJECT 'dtparam=i2c_arm=' 'dtparam=i2c_arm=on' /boot/firmware/config.txt
+			G_CONFIG_INJECT 'dtparam=spi=' 'dtparam=spi=on' /boot/firmware/config.txt
 
 			# Set FB to match res
-			G_CONFIG_INJECT 'framebuffer_width=' 'framebuffer_width=320' /boot/config.txt
-			G_CONFIG_INJECT 'framebuffer_height=' 'framebuffer_height=240' /boot/config.txt
+			G_CONFIG_INJECT 'framebuffer_width=' 'framebuffer_width=320' /boot/firmware/config.txt
+			G_CONFIG_INJECT 'framebuffer_height=' 'framebuffer_height=240' /boot/firmware/config.txt
 			G_CONFIG_INJECT 'SOFTWARE_CHROMIUM_RES_X=' "SOFTWARE_CHROMIUM_RES_X=320" /boot/dietpi.txt
 			G_CONFIG_INJECT 'SOFTWARE_CHROMIUM_RES_Y=' "SOFTWARE_CHROMIUM_RES_Y=240" /boot/dietpi.txt
 
-			G_CONFIG_INJECT 'dtoverlay=waveshare32b' 'dtoverlay=waveshare32b:rotate=270' /boot/config.txt
+			G_CONFIG_INJECT 'dtoverlay=waveshare32b' 'dtoverlay=waveshare32b:rotate=270' /boot/firmware/config.txt
 
 			# Move fb0 xorg.conf out the way: https://github.com/MichaIng/DietPi/issues/767
 			[[ -f '/usr/share/X11/xorg.conf.d/99-fbturbo.conf' ]] && G_EXEC mv /usr/share/X11/xorg.conf.d/99-fbturbo.conf /usr/share/X11/99-fbturbo.conf
@@ -795,17 +795,16 @@ _EOF_
 		# RPi
 		if (( $G_HW_MODEL < 10 )); then
 
-			[[ -f '/boot/overlays/waveshare32b.dtbo' ]] && G_EXEC rm /boot/overlays/waveshare32b.dtbo
 			[[ -f '/boot/firmware/overlays/waveshare32b.dtbo' ]] && G_EXEC rm /boot/firmware/overlays/waveshare32b.dtbo
-			G_EXEC sed --follow-symlinks -i 's/ fbcon=map:10 fbcon=font:ProFont6x11 logo.nologo//' /boot/cmdline.txt
+			G_EXEC sed --follow-symlinks -i 's/ fbcon=map:10 fbcon=font:ProFont6x11 logo.nologo//' /boot/firmware/cmdline.txt
 
-			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*dtoverlay=waveshare32b/d' /boot/config.txt
-			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*dtoverlay=ads7846,cs=1,penirq=17/d' /boot/config.txt
-			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*dtoverlay=w1-gpio-pullup,gpiopin=4,extpullup=1/d' /boot/config.txt
+			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*dtoverlay=waveshare32b/d' /boot/firmware/config.txt
+			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*dtoverlay=ads7846,cs=1,penirq=17/d' /boot/firmware/config.txt
+			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*dtoverlay=w1-gpio-pullup,gpiopin=4,extpullup=1/d' /boot/firmware/config.txt
 
 			# Leave these enabled, just in case the user has other hardware that may use them.
-			#G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*dtparam=i2c_arm=/c\dtparam=i2c_arm=on' /boot/config.txt
-			#G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*dtparam=spi=/c\dtparam=spi=on' /boot/config.txt
+			#G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*dtparam=i2c_arm=/c\dtparam=i2c_arm=on' /boot/firmware/config.txt
+			#G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*dtparam=spi=/c\dtparam=spi=on' /boot/firmware/config.txt
 
 			# Move fb0 xorg.conf back: https://github.com/MichaIng/DietPi/issues/767
 			[[ -f '/usr/share/X11/99-fbturbo.conf' && ! -f '/usr/share/X11/xorg.conf.d/99-fbturbo.conf' ]] && G_EXEC mv /usr/share/X11/99-fbturbo.conf /usr/share/X11/xorg.conf.d/99-fbturbo.conf
@@ -1064,7 +1063,7 @@ _EOF_
 			G_CONFIG_INJECT 'i2c-dev' 'i2c-dev' /etc/modules
 
 			# config.txt
-			G_CONFIG_INJECT 'dtparam=i2c_arm=' 'dtparam=i2c_arm=on' /boot/config.txt
+			G_CONFIG_INJECT 'dtparam=i2c_arm=' 'dtparam=i2c_arm=on' /boot/firmware/config.txt
 
 			# DietPi-Software, set installed
 			[[ -f '/boot/dietpi/.installed' ]] && G_EXEC sed --follow-symlinks -i '/^aSOFTWARE_INSTALL_STATE\[72\]=/c\aSOFTWARE_INSTALL_STATE\[72\]=2' /boot/dietpi/.installed
@@ -1076,12 +1075,12 @@ _EOF_
 			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*i2c-dev/d' /etc/modules
 
 			# config.txt
-			G_EXEC sed --follow-symlinks -Ei 's/^[[:blank:]]*(dtparam=i2c.*)$/#\1/' /boot/config.txt
+			G_EXEC sed --follow-symlinks -Ei 's/^[[:blank:]]*(dtparam=i2c.*)$/#\1/' /boot/firmware/config.txt
 
 		# Set baudrate (kHz) | valid int
 		elif disable_error=1 G_CHECK_VALIDINT "$INPUT_DEVICE_VALUE" 2 10000000; then
 
-			G_CONFIG_INJECT 'dtparam=i2c_arm_baudrate=' "dtparam=i2c_arm_baudrate=$(( $INPUT_DEVICE_VALUE * 1000 ))" /boot/config.txt
+			G_CONFIG_INJECT 'dtparam=i2c_arm_baudrate=' "dtparam=i2c_arm_baudrate=$(( $INPUT_DEVICE_VALUE * 1000 ))" /boot/firmware/config.txt
 
 			# Inform user
 			INPUT_DEVICE_VALUE+=' kHz'
@@ -1105,7 +1104,7 @@ _EOF_
 			if [[ $INPUT_DEVICE_VALUE == 'enable' ]]
 			then
 				# config.txt
-				G_CONFIG_INJECT 'dtparam=spi=' 'dtparam=spi=on' /boot/config.txt
+				G_CONFIG_INJECT 'dtparam=spi=' 'dtparam=spi=on' /boot/firmware/config.txt
 
 				# Enable in runtime seems to be possible?
 				#dtparam spi=on
@@ -1113,8 +1112,8 @@ _EOF_
 			elif [[ $INPUT_DEVICE_VALUE == 'disable' ]]
 			then
 				# config.txt
-				G_CONFIG_INJECT 'dtparam=spi=' 'dtparam=spi=off' /boot/config.txt
-				G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*dtoverlay=spi[0-9]-[0-9]cs/d' /boot/config.txt # Alternative SPI interfaces and chip select lines
+				G_CONFIG_INJECT 'dtparam=spi=' 'dtparam=spi=off' /boot/firmware/config.txt
+				G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*dtoverlay=spi[0-9]-[0-9]cs/d' /boot/firmware/config.txt # Alternative SPI interfaces and chip select lines
 
 				# Disable in runtime seems to be possible?
 				#dtparam spi=off
@@ -1171,7 +1170,7 @@ _EOF_
 				# Do not stop the service, otherwise it cannot be started anymore until reboot. Also for this reason the service is not stopped on pi-bluetooth package removal, hence disabling it on "is-active" via "disable --now" fails due to missing service file: https://github.com/RPi-Distro/pi-bluetooth/issues/34, https://github.com/MichaIng/DietPi/issues/5435
 				systemctl -q is-enabled hciuart 2> /dev/null && G_EXEC systemctl disable hciuart
 				# Disable onboard Bluetooth via device tree overlay
-				G_CONFIG_INJECT 'dtoverlay=disable-bt' 'dtoverlay=disable-bt' /boot/config.txt
+				G_CONFIG_INJECT 'dtoverlay=disable-bt' 'dtoverlay=disable-bt' /boot/firmware/config.txt
 
 			# Broadcom-based models that need brcm_patchram_plus
 			elif [[ $G_HW_MODEL == 6[12] ]] && systemctl list-unit-files 'brcm_patchram_plus.service' > /dev/null
@@ -1215,7 +1214,7 @@ _EOF_
 				fi
 
 				# Remove dtoverlay
-				G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*dtoverlay=disable-bt/d' /boot/config.txt
+				G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*dtoverlay=disable-bt/d' /boot/firmware/config.txt
 
 				G_AG_CHECK_INSTALL_PREREQ pi-bluetooth
 			else
@@ -1408,14 +1407,14 @@ _EOF_
 			(( $G_HW_ONBOARD_WIFI )) || { Unsupported_Input_Mode; return 1; }
 
 			# Remove dtoverlay
-			sed --follow-symlinks -i '/^[[:blank:]]*dtoverlay=disable-wifi/d' /boot/config.txt
+			sed --follow-symlinks -i '/^[[:blank:]]*dtoverlay=disable-wifi/d' /boot/firmware/config.txt
 
 		elif [[ $INPUT_DEVICE_VALUE == 'onboard_disable' ]]; then
 
 			(( $G_HW_ONBOARD_WIFI )) || { Unsupported_Input_Mode; return 1; }
 
 			# Disable onboard WiFi via dtoverlay
-			G_CONFIG_INJECT 'dtoverlay=disable-wifi' 'dtoverlay=disable-wifi' /boot/config.txt
+			G_CONFIG_INJECT 'dtoverlay=disable-wifi' 'dtoverlay=disable-wifi' /boot/firmware/config.txt
 
 		else
 
@@ -1478,7 +1477,7 @@ _EOF_
 				# - RPi
 				elif (( $G_HW_MODEL < 10 ))
 				then
-					grep -q "console=$INPUT_ADDITIONAL" /boot/cmdline.txt || sed --follow-symlinks -i "/root=/s/$/ console=$INPUT_ADDITIONAL,115200/" /boot/cmdline.txt
+					grep -q "console=$INPUT_ADDITIONAL" /boot/firmware/cmdline.txt || sed --follow-symlinks -i "/root=/s/$/ console=$INPUT_ADDITIONAL,115200/" /boot/firmware/cmdline.txt
 
 				# - Odroid C1/C2 legacy
 				elif [[ $G_HW_MODEL == 1[02] && -f '/boot/boot.ini' ]]
@@ -1542,7 +1541,7 @@ _EOF_
 				done
 
 				# On RPi enable primary UART device
-				(( $G_HW_MODEL > 9 )) || G_CONFIG_INJECT 'enable_uart=' 'enable_uart=1' /boot/config.txt
+				(( $G_HW_MODEL > 9 )) || G_CONFIG_INJECT 'enable_uart=' 'enable_uart=1' /boot/firmware/config.txt
 
 				# Update dietpi.txt global var
 				G_CONFIG_INJECT 'CONFIG_SERIAL_CONSOLE_ENABLE=' 'CONFIG_SERIAL_CONSOLE_ENABLE=1' /boot/dietpi.txt
@@ -1570,7 +1569,7 @@ _EOF_
 				# - RPi
 				if (( $G_HW_MODEL < 10 ))
 				then
-					sed --follow-symlinks -Ei "/root=/s/[[:blank:]]*console=${INPUT_ADDITIONAL}[^[:blank:]]*([[:blank:]]*$)?//g" /boot/cmdline.txt
+					sed --follow-symlinks -Ei "/root=/s/[[:blank:]]*console=${INPUT_ADDITIONAL}[^[:blank:]]*([[:blank:]]*$)?//g" /boot/firmware/cmdline.txt
 
 				# - Odroid C1/C2/XU4 legacy
 				elif [[ $G_HW_MODEL -le 12 && -f '/boot/boot.ini' ]]
@@ -1612,7 +1611,7 @@ _EOF_
 				done
 
 				# On RPi disable primary UART device
-				(( $G_HW_MODEL > 9 )) || G_CONFIG_INJECT 'enable_uart=' 'enable_uart=0' /boot/config.txt
+				(( $G_HW_MODEL > 9 )) || G_CONFIG_INJECT 'enable_uart=' 'enable_uart=0' /boot/firmware/config.txt
 
 				# Update dietpi.txt global var
 				G_CONFIG_INJECT 'CONFIG_SERIAL_CONSOLE_ENABLE=' 'CONFIG_SERIAL_CONSOLE_ENABLE=0' /boot/dietpi.txt
@@ -1692,20 +1691,20 @@ _EOF_
 	Soundcard_Reset_RPi()
 	{
 		# Remove device tree overlays which disable HDMI audio and 3.5mm jack and those for known sound card, disable I2S and HDMI drive
-		G_EXEC sed --follow-symlinks -Ei -e '/^[[:blank:]]*(dtoverlay=(allo-|applepi-dac|dionaudio-|googlevoicehat-soundcard|hifiberry-|i-sabre-q2m|iqaudio-|justboom-|rpi-dac)|dtparam=i2s)/d' -e 's/^[[:blank:]]*(hdmi_drive(:[01])?=.*$)/#\1/' /boot/config.txt
+		G_EXEC sed --follow-symlinks -Ei -e '/^[[:blank:]]*(dtoverlay=(allo-|applepi-dac|dionaudio-|googlevoicehat-soundcard|hifiberry-|i-sabre-q2m|iqaudio-|justboom-|rpi-dac)|dtparam=i2s)/d' -e 's/^[[:blank:]]*(hdmi_drive(:[01])?=.*$)/#\1/' /boot/firmware/config.txt
 
 		# Disable onboard sound
-		G_CONFIG_INJECT 'dtparam=audio=' 'dtparam=audio=off' /boot/config.txt
+		G_CONFIG_INJECT 'dtparam=audio=' 'dtparam=audio=off' /boot/firmware/config.txt
 
 		# Blacklist onboard sound kernel module
 		G_EXEC eval 'echo '\''blacklist snd_bcm2835'\'' > /etc/modprobe.d/dietpi-disable_rpi_audio.conf'
 
 		# Remove kernel module options
-		G_EXEC sed --follow-symlinks -Ei '/root=/s/[[:blank:]]*snd_bcm2835.enable_[^[:blank:]]*([[:blank:]]*$)?//g' /boot/cmdline.txt
+		G_EXEC sed --follow-symlinks -Ei '/root=/s/[[:blank:]]*snd_bcm2835.enable_[^[:blank:]]*([[:blank:]]*$)?//g' /boot/firmware/cmdline.txt
 
 		# Disable VC4 HDMI audio
-		local kms=$(grep -Em1 '^[[:blank:]]*dtoverlay=vc4-kms-v3d(-pi4)?(,|$)' /boot/config.txt)
-		[[ $kms && ! $kms =~ ',noaudio'(,|$) ]] && G_EXEC sed --follow-symlinks -Ei '/^[[:blank:]]*dtoverlay=vc4-kms-v3d(-pi4)?(,|$)/s/$/,noaudio/' /boot/config.txt
+		local kms=$(grep -Em1 '^[[:blank:]]*dtoverlay=vc4-kms-v3d(-pi4)?(,|$)' /boot/firmware/config.txt)
+		[[ $kms && ! $kms =~ ',noaudio'(,|$) ]] && G_EXEC sed --follow-symlinks -Ei '/^[[:blank:]]*dtoverlay=vc4-kms-v3d(-pi4)?(,|$)/s/$/,noaudio/' /boot/firmware/config.txt
 
 		# On RPi 5, use "hdmi" by default, else "auto": https://dietpi.com/forum/t/19760
 		if [[ $INPUT_DEVICE_VALUE == 'default' ]]
@@ -1868,35 +1867,35 @@ _EOF_
 				(( $G_HW_MODEL == 5 )) && INPUT_DEVICE_VALUE='vc4-kms-v3d' RPi_OpenGL_Main
 
 				# Enable VC4 HDMI audio if onboard HDMI is enabled and KMS used, as the bcm2835 HDMI audio driver and KMS conflict: https://dietpi.com/forum/t/19568, https://github.com/raspberrypi/linux/issues/4651
-				if [[ $INPUT_DEVICE_VALUE != *'3.5mm' ]] && grep -Eq '^[[:blank:]]*dtoverlay=vc4-kms-v3d(-pi4)?,(noaudio|.+,noaudio)(,|$)' /boot/config.txt
+				if [[ $INPUT_DEVICE_VALUE != *'3.5mm' ]] && grep -Eq '^[[:blank:]]*dtoverlay=vc4-kms-v3d(-pi4)?,(noaudio|.+,noaudio)(,|$)' /boot/firmware/config.txt
 				then
-					G_EXEC sed --follow-symlinks -Ei '/^[[:blank:]]*dtoverlay=vc4-kms-v3d(-pi4)?,/s/,noaudio(,|$)/\1/' /boot/config.txt
+					G_EXEC sed --follow-symlinks -Ei '/^[[:blank:]]*dtoverlay=vc4-kms-v3d(-pi4)?,/s/,noaudio(,|$)/\1/' /boot/firmware/config.txt
 				fi
 
 				# Enable bcm2835 audio driver if 3.5mm is enabled or no VC4 used
-				if [[ $INPUT_DEVICE_VALUE != *'hdmi' ]] || ! grep -Eq '^[[:blank:]]*dtoverlay=vc4-kms-v3d(-pi4)?(,|$)' /boot/config.txt
+				if [[ $INPUT_DEVICE_VALUE != *'hdmi' ]] || ! grep -Eq '^[[:blank:]]*dtoverlay=vc4-kms-v3d(-pi4)?(,|$)' /boot/firmware/config.txt
 				then
 					# Remove blacklist for bcm2835 audio kernel module
 					G_EXEC rm /etc/modprobe.d/dietpi-disable_rpi_audio.conf
 
 					# Enable bcm2835 audio via device tree parameter
-					G_CONFIG_INJECT 'dtparam=audio=' 'dtparam=audio=on' /boot/config.txt
+					G_CONFIG_INJECT 'dtparam=audio=' 'dtparam=audio=on' /boot/firmware/config.txt
 
 					# Force 3.5mm output?
 					if [[ $INPUT_DEVICE_VALUE == *'3.5mm' ]]
 					then
 						# Disable HDMI audio via kernel module option
-						G_EXEC sed --follow-symlinks -i '/root=/s/$/ snd_bcm2835.enable_hdmi=0/' /boot/cmdline.txt
+						G_EXEC sed --follow-symlinks -i '/root=/s/$/ snd_bcm2835.enable_hdmi=0/' /boot/firmware/cmdline.txt
 
 					# Force HDMI output?
 					elif [[ $INPUT_DEVICE_VALUE == *'hdmi' ]]
 					then
 						# Disable headphones via kernel module option
-						G_EXEC sed --follow-symlinks -i '/root=/s/$/ snd_bcm2835.enable_headphones=0/' /boot/cmdline.txt
+						G_EXEC sed --follow-symlinks -i '/root=/s/$/ snd_bcm2835.enable_headphones=0/' /boot/firmware/cmdline.txt
 
 						# Force HDMI audio via config.txt option
-						G_CONFIG_INJECT 'hdmi_drive=' 'hdmi_drive=2' /boot/config.txt
-						(( $G_HW_MODEL > 3 )) && G_CONFIG_INJECT 'hdmi_drive:1=' 'hdmi_drive:1=2' /boot/config.txt 'hdmi_drive='
+						G_CONFIG_INJECT 'hdmi_drive=' 'hdmi_drive=2' /boot/firmware/config.txt
+						(( $G_HW_MODEL > 3 )) && G_CONFIG_INJECT 'hdmi_drive:1=' 'hdmi_drive:1=2' /boot/firmware/config.txt 'hdmi_drive='
 					fi
 
 				# If only VC4 HDMI audio is used, return here to skip /etc/asound.conf generation and remove potential root user config: https://dietpi.com/forum/t/19568
@@ -1921,7 +1920,7 @@ _EOF_
 					G_EXEC_NOHALT=1 G_EXEC rm -R piano-firmware-master
 				fi
 
-				G_CONFIG_INJECT "dtoverlay=$INPUT_DEVICE_VALUE" "dtoverlay=$INPUT_DEVICE_VALUE" /boot/config.txt
+				G_CONFIG_INJECT "dtoverlay=$INPUT_DEVICE_VALUE" "dtoverlay=$INPUT_DEVICE_VALUE" /boot/firmware/config.txt
 			;;
 
 			# dtoverlay
@@ -1939,7 +1938,7 @@ _EOF_
 			'hifiberry-'*|'justboom-'*|'allo-'*|'rpi-dac'|'i-sabre-q2m'|'applepi'*|'iqaudio-'*|'dionaudio-loco'*)
 
 				# Enable dtoverlay
-				G_CONFIG_INJECT "dtoverlay=$INPUT_DEVICE_VALUE" "dtoverlay=$INPUT_DEVICE_VALUE" /boot/config.txt
+				G_CONFIG_INJECT "dtoverlay=$INPUT_DEVICE_VALUE" "dtoverlay=$INPUT_DEVICE_VALUE" /boot/firmware/config.txt
 			;;
 
 			# --------------- Odroid ----------------

--- a/dietpi/func/dietpi-set_software
+++ b/dietpi/func/dietpi-set_software
@@ -872,15 +872,11 @@ deb $INPUT_MODE_VALUE $G_DISTRO_NAME-backports main contrib non-free non-free-fi
 		G_EXEC systemctl daemon-reload
 		findmnt -M /boot/firmware &> /dev/null || G_EXEC mount /boot/firmware
 
-		# Generate config symlinks
-		G_EXEC ln -sf firmware/cmdline.txt /boot/cmdline.txt
-		G_EXEC ln -sf firmware/config.txt /boot/config.txt
-
 		# Show kernel choice dialogue: This installs the required kernel and firmware packages and allows to select optional kernel packages for other RPi models.
 		until INPUT_MODE_VALUE='dietpi-rpi-firmware-migration' RPi_Kernel_Choice; do G_WHIP_MSG '[ INFO ] A selection is required!'; done
 
 		# Disable initramfs generation if not enabled explicitly in config.txt
-		if ! grep -q '^[[:blank:]]*auto_initramfs=' /boot/config.txt && ! grep -q '^[[:blank:]]*initramfs[[:blank:]]' /boot/config.txt
+		if ! grep -q '^[[:blank:]]*auto_initramfs=' /boot/firmware/config.txt && ! grep -q '^[[:blank:]]*initramfs[[:blank:]]' /boot/firmware/config.txt
 		then
 			G_CONFIG_INJECT 'SKIP_INITRAMFS_GEN=' 'SKIP_INITRAMFS_GEN=yes' /etc/default/raspi-firmware
 			G_EXEC rm -f /boot/initrd.img-* /boot/firmware/initramfs*
@@ -890,7 +886,7 @@ deb $INPUT_MODE_VALUE $G_DISTRO_NAME-backports main contrib non-free non-free-fi
 		G_EXEC rm -Rf /boot/firmware/{dietpi*,COPYING.linux}
 
 		# HiFiBerry DAC+ overlay split
-		if grep -q '^[[:blank:]]*dtoverlay=hifiberry-dacplus$' /boot/config.txt
+		if grep -q '^[[:blank:]]*dtoverlay=hifiberry-dacplus$' /boot/firmware/config.txt
 		then
 			G_WHIP_MSG '[ INFO ] HiFiBerry DAC+ overlay split
 \nYou are currently using the deprecated "hifiberry-dacplus" device tree overlay. The new kernel package ships two more specific overlays, one for the HiFiBerry DAC+/AMP2/AMP4 models, one for the HiFiBerry DAC+ Pro and DAC2. Please select the correct sound card (=overlay) in next menu.'
@@ -940,12 +936,12 @@ deb $INPUT_MODE_VALUE $G_DISTRO_NAME-backports main contrib non-free non-free-fi
 				['linux-image-rpi-v7']='Raspberry Pi 2/3/Zero 2'
 				['linux-image-rpi-v8']='Raspberry Pi 4/5'
 			)
-			if grep -q '^arm_64bit=1' /boot/config.txt
+			if grep -q '^arm_64bit=1' /boot/firmware/config.txt
 			then
 				models['linux-image-rpi-v7']='Raspberry Pi 2 PCB v1.1'
 				models['linux-image-rpi-v8']='Raspberry Pi 2 PCB v1.2 and Raspberry Pi 3-5'
 
-			elif grep -q '^arm_64bit=0' /boot/config.txt
+			elif grep -q '^arm_64bit=0' /boot/firmware/config.txt
 			then
 				unset -v 'models[linux-image-rpi-v8]'
 				models['linux-image-rpi-v7l']='Raspberry Pi 4/5'

--- a/rootfs/var/lib/dietpi/services/dietpi-firstboot.bash
+++ b/rootfs/var/lib/dietpi/services/dietpi-firstboot.bash
@@ -32,68 +32,68 @@
 		# RPi Zero/Zero 2 W
 		if [[ $G_HW_MODEL_NAME == *'Zero'* ]]
 		then
-			sed --follow-symlinks -i '/^#over_voltage=/c\#over_voltage=0' /boot/config.txt
-			sed --follow-symlinks -i '/^#arm_freq=/c\#arm_freq=1000' /boot/config.txt
-			sed --follow-symlinks -i '/^#core_freq=/c\#core_freq=400' /boot/config.txt
-			sed --follow-symlinks -i '/^#sdram_freq=/c\#sdram_freq=450' /boot/config.txt
+			sed --follow-symlinks -i '/^#over_voltage=/c\#over_voltage=0' /boot/firmware/config.txt
+			sed --follow-symlinks -i '/^#arm_freq=/c\#arm_freq=1000' /boot/firmware/config.txt
+			sed --follow-symlinks -i '/^#core_freq=/c\#core_freq=400' /boot/firmware/config.txt
+			sed --follow-symlinks -i '/^#sdram_freq=/c\#sdram_freq=450' /boot/firmware/config.txt
 
 		# RPi 1: Apply safe overclock mode
 		elif (( $G_HW_MODEL < 2 ))
 		then
-			GCI_PRESERVE=1 G_CONFIG_INJECT 'arm_freq=' 'arm_freq=900' /boot/config.txt
-			grep -q '^arm_freq=900$' /boot/config.txt && G_CONFIG_INJECT 'over_voltage=' 'over_voltage=2' /boot/config.txt
-			sed --follow-symlinks -i '/^#core_freq=/c\#core_freq=250' /boot/config.txt
-			sed --follow-symlinks -i '/^#sdram_freq=/c\#sdram_freq=400' /boot/config.txt
+			GCI_PRESERVE=1 G_CONFIG_INJECT 'arm_freq=' 'arm_freq=900' /boot/firmware/config.txt
+			grep -q '^arm_freq=900$' /boot/firmware/config.txt && G_CONFIG_INJECT 'over_voltage=' 'over_voltage=2' /boot/firmware/config.txt
+			sed --follow-symlinks -i '/^#core_freq=/c\#core_freq=250' /boot/firmware/config.txt
+			sed --follow-symlinks -i '/^#sdram_freq=/c\#sdram_freq=400' /boot/firmware/config.txt
 
 		# RPi 2
 		elif (( $G_HW_MODEL == 2 ))
 		then
-			sed --follow-symlinks -i '/^#over_voltage=/c\#over_voltage=0' /boot/config.txt
-			sed --follow-symlinks -i '/^#arm_freq=/c\#arm_freq=900' /boot/config.txt
-			sed --follow-symlinks -i '/^#core_freq=/c\#core_freq=250' /boot/config.txt
-			sed --follow-symlinks -i '/^#sdram_freq=/c\#sdram_freq=450' /boot/config.txt
+			sed --follow-symlinks -i '/^#over_voltage=/c\#over_voltage=0' /boot/firmware/config.txt
+			sed --follow-symlinks -i '/^#arm_freq=/c\#arm_freq=900' /boot/firmware/config.txt
+			sed --follow-symlinks -i '/^#core_freq=/c\#core_freq=250' /boot/firmware/config.txt
+			sed --follow-symlinks -i '/^#sdram_freq=/c\#sdram_freq=450' /boot/firmware/config.txt
 
 		# RPi 3
 		elif (( $G_HW_MODEL == 3 ))
 		then
-			sed --follow-symlinks -i '/^#over_voltage=/c\#over_voltage=0' /boot/config.txt
-			sed --follow-symlinks -i '/^#core_freq=/c\#core_freq=400' /boot/config.txt
-			grep -q '^temp_limit=65$' /boot/config.txt && G_CONFIG_INJECT 'temp_limit=' 'temp_limit=75' /boot/config.txt # https://github.com/MichaIng/DietPi/issues/356
+			sed --follow-symlinks -i '/^#over_voltage=/c\#over_voltage=0' /boot/firmware/config.txt
+			sed --follow-symlinks -i '/^#core_freq=/c\#core_freq=400' /boot/firmware/config.txt
+			grep -q '^temp_limit=65$' /boot/firmware/config.txt && G_CONFIG_INJECT 'temp_limit=' 'temp_limit=75' /boot/firmware/config.txt # https://github.com/MichaIng/DietPi/issues/356
 
 			# A+/B+
 			if [[ $G_HW_MODEL_NAME == *'+'* ]]
 			then
-				sed --follow-symlinks -i '/^#arm_freq=/c\#arm_freq=1400' /boot/config.txt
-				sed --follow-symlinks -i '/^#sdram_freq=/c\#sdram_freq=500' /boot/config.txt
+				sed --follow-symlinks -i '/^#arm_freq=/c\#arm_freq=1400' /boot/firmware/config.txt
+				sed --follow-symlinks -i '/^#sdram_freq=/c\#sdram_freq=500' /boot/firmware/config.txt
 			else
-				sed --follow-symlinks -i '/^#arm_freq=/c\#arm_freq=1200' /boot/config.txt
-				sed --follow-symlinks -i '/^#sdram_freq=/c\#sdram_freq=450' /boot/config.txt
+				sed --follow-symlinks -i '/^#arm_freq=/c\#arm_freq=1200' /boot/firmware/config.txt
+				sed --follow-symlinks -i '/^#sdram_freq=/c\#sdram_freq=450' /boot/firmware/config.txt
 			fi
 
 		# RPi 4
 		elif (( $G_HW_MODEL == 4 ))
 		then
-			sed --follow-symlinks -i '/^#over_voltage=/c\#over_voltage=0' /boot/config.txt
-			sed --follow-symlinks -i '/^#core_freq=/c\#core_freq=500' /boot/config.txt
-			sed --follow-symlinks -i '/^#sdram_freq=/d' /boot/config.txt # Not supported on RPi 4, defaults to 3200 MHz
-			grep -q '^temp_limit=65$' /boot/config.txt && G_CONFIG_INJECT 'temp_limit=' 'temp_limit=75' /boot/config.txt # https://github.com/MichaIng/DietPi/issues/3019
+			sed --follow-symlinks -i '/^#over_voltage=/c\#over_voltage=0' /boot/firmware/config.txt
+			sed --follow-symlinks -i '/^#core_freq=/c\#core_freq=500' /boot/firmware/config.txt
+			sed --follow-symlinks -i '/^#sdram_freq=/d' /boot/firmware/config.txt # Not supported on RPi 4, defaults to 3200 MHz
+			grep -q '^temp_limit=65$' /boot/firmware/config.txt && G_CONFIG_INJECT 'temp_limit=' 'temp_limit=75' /boot/firmware/config.txt # https://github.com/MichaIng/DietPi/issues/3019
 
 			# 400
 			if [[ $G_HW_MODEL_NAME == *'400'* ]]
 			then
-				sed --follow-symlinks -i '/^#arm_freq=/c\#arm_freq=1800' /boot/config.txt
+				sed --follow-symlinks -i '/^#arm_freq=/c\#arm_freq=1800' /boot/firmware/config.txt
 			else
-				sed --follow-symlinks -i '/^#arm_freq=/c\#arm_freq=1500' /boot/config.txt
+				sed --follow-symlinks -i '/^#arm_freq=/c\#arm_freq=1500' /boot/firmware/config.txt
 			fi
 
 		# RPi 5
 		elif (( $G_HW_MODEL == 5 ))
 		then
-			sed --follow-symlinks -i '/^#over_voltage=/c\#over_voltage=0' /boot/config.txt
-			sed --follow-symlinks -i '/^#arm_freq=/c\#arm_freq=2400' /boot/config.txt
-			sed --follow-symlinks -i '/^#core_freq=/c\#core_freq=910' /boot/config.txt
-			sed --follow-symlinks -i '/^#sdram_freq=/d' /boot/config.txt # Not supported on RPi 5, defaults to 4267 MHz
-			grep -q '^temp_limit=65$' /boot/config.txt && G_CONFIG_INJECT 'temp_limit=' 'temp_limit=75' /boot/config.txt # https://github.com/MichaIng/DietPi/issues/3019
+			sed --follow-symlinks -i '/^#over_voltage=/c\#over_voltage=0' /boot/firmware/config.txt
+			sed --follow-symlinks -i '/^#arm_freq=/c\#arm_freq=2400' /boot/firmware/config.txt
+			sed --follow-symlinks -i '/^#core_freq=/c\#core_freq=910' /boot/firmware/config.txt
+			sed --follow-symlinks -i '/^#sdram_freq=/d' /boot/firmware/config.txt # Not supported on RPi 5, defaults to 4267 MHz
+			grep -q '^temp_limit=65$' /boot/firmware/config.txt && G_CONFIG_INJECT 'temp_limit=' 'temp_limit=75' /boot/firmware/config.txt # https://github.com/MichaIng/DietPi/issues/3019
 		fi
 	}
 


### PR DESCRIPTION
Since we dropped Debian Bullseye support, including the legacy RPi kernel/firmware stack with /boot isntead of /boot/firmware FAT partition, we do not need to rely on the symlinks for backwards compatibility anymore.

Use new paths, and do not create symlinks on fresh images and kernel migration anymore. Exclude only CHANGELOG.txt and (pre-)patches: The latter run on older systems as well, and the kernel migration is enforced only at the end of DietPi v10.0 patches.