### PR TITLE
dietpi-builld: use smaller image sizes

### DIFF
--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -93,7 +93,7 @@ done
 partition_start=1
 efi_size=0
 boot_size=0
-root_size=1200
+root_size=
 boot_fstype='fat32'
 case $HW_MODEL in
 	0) iname='RPi' HW_ARCH=${HW_ARCH:-1} boot_size=128 root_size=895;;
@@ -101,81 +101,93 @@ case $HW_MODEL in
 	2) iname='RPi2' HW_ARCH=2 boot_size=128 root_size=895;;
 	4) iname='RPi234' HW_ARCH=3 boot_size=128 root_size=1000;;
 	5) iname='RPi5' HW_ARCH=3 boot_size=128 root_size=1000;;
-	10) iname='OdroidC1' HW_ARCH=2 partition_start=4 boot_size=128 root_size=900 boot_fstype='fat16';;
-	11) iname='OdroidXU4' HW_ARCH=2 partition_start=4 root_size=900;;
-	12) iname='OdroidC2' HW_ARCH=3 partition_start=4 root_size=1200;;
-	15) iname='OdroidN2' HW_ARCH=3 partition_start=4 root_size=1200;;
-	16) iname='OdroidC4' HW_ARCH=3 partition_start=4 root_size=1200;;
-	17) iname='OdroidHC4' HW_ARCH=3 partition_start=4 root_size=1200;;
+	10) iname='OdroidC1' HW_ARCH=2 partition_start=4 boot_size=128 root_size='meson' boot_fstype='fat16';;
+	11) iname='OdroidXU4' HW_ARCH=2 partition_start=4 root_size='meson';;
+	12) iname='OdroidC2' HW_ARCH=3 partition_start=4 root_size='meson64';;
+	15) iname='OdroidN2' HW_ARCH=3 partition_start=4 root_size='meson64';;
+	16) iname='OdroidC4' HW_ARCH=3 partition_start=4 root_size='meson64';;
+	17) iname='OdroidHC4' HW_ARCH=3 partition_start=4 root_size='meson64';;
 	20) iname='VM' HW_ARCH=${HW_ARCH:-10} root_size=1200;;
-	21) iname='NativePC' HW_ARCH=10 root_size=1663;;
-	40) iname='PINEA64' HW_ARCH=3 partition_start=4 root_size=1100;;
-	42) iname='ROCKPro64' HW_ARCH=3 partition_start=16 root_size=1300;;
-	43) iname='ROCK64' HW_ARCH=3 partition_start=16 root_size=1300;;
-	44) iname='Pinebook' HW_ARCH=3 partition_start=4 root_size=1100;;
-	45) iname='PINEH64' HW_ARCH=3 partition_start=4 root_size=1100;;
-	46) iname='PinebookPro' HW_ARCH=3 partition_start=16 root_size=1300;;
-	47) iname='NanoPiR4S' HW_ARCH=3 partition_start=16 root_size=1300;;
-	48) iname='NanoPiR1' HW_ARCH=2 partition_start=4 root_size=1000;;
-	'49.1') iname='Quartz64A' HW_ARCH=3 partition_start=16 root_size=1000;;
-	'49.2') iname='Quartz64B' HW_ARCH=3 partition_start=16 root_size=1000;;
-	'49.3') iname='SOQuartz' HW_ARCH=3 partition_start=16 root_size=1000;;
-	52) iname='ASUSTB' HW_ARCH=2 partition_start=4 root_size=900;;
-	54) iname='NanoPiK2' HW_ARCH=3 partition_start=4 root_size=1200;;
-	55) iname='NanoPiR2S' HW_ARCH=3 partition_start=16 root_size=1300;;
-	56) iname='NanoPiNEO3' HW_ARCH=3 partition_start=16 root_size=1300;;
-	57) iname='NanoPiNEOPlus2' HW_ARCH=3 partition_start=4 root_size=1100;;
-	58) iname='NanoPiM4V2' HW_ARCH=3 partition_start=16 root_size=1300;;
-	59) iname='ZeroPi' HW_ARCH=2 partition_start=4 root_size=1000;;
-	60) iname='NanoPiNEO' HW_ARCH=2 partition_start=4 root_size=1000;;
-	63) iname='NanoPiM1' HW_ARCH=2 partition_start=4 root_size=1000;;
-	64) iname='NanoPiNEOAir' HW_ARCH=2 partition_start=4 root_size=1000;;
-	'65.1') iname='NanoPiNEO2' HW_ARCH=3 partition_start=4 root_size=1100;;
-	'65.2') iname='NanoPiNEO2Black' HW_ARCH=3 partition_start=4 root_size=1100;;
-	66) iname='NanoPiM1Plus' HW_ARCH=2 partition_start=4 root_size=1000;;
-	67) iname='NanoPiK1Plus' HW_ARCH=3 partition_start=4 root_size=1100;;
-	'68.1') iname='NanoPiM4' HW_ARCH=3 partition_start=16 root_size=1300;;
-	'68.2') iname='NanoPCT4' HW_ARCH=3 partition_start=16 root_size=1300;;
-	'68.3') iname='NanoPiNEO4' HW_ARCH=3 partition_start=16 root_size=1300;;
-	'72.1') iname='ROCKPi4' HW_ARCH=3 partition_start=16 root_size=1300;;
-	'72.2') iname='ROCK4SE' HW_ARCH=3 partition_start=16 root_size=1300;;
-	'72.3') iname='ROCK4CPlus' HW_ARCH=3 partition_start=16 root_size=1300;;
-	73) iname='ROCKPiS' HW_ARCH=3 partition_start=16 root_size=1300;;
-	74) iname='RadxaZero' HW_ARCH=3 partition_start=4 root_size=1200;;
+	21) iname='NativePC' HW_ARCH=10 root_size=1600;;
+	40) iname='PINEA64' HW_ARCH=3 partition_start=4 root_size='sunxi64';;
+	42) iname='ROCKPro64' HW_ARCH=3 partition_start=16 root_size='rockchip64';;
+	43) iname='ROCK64' HW_ARCH=3 partition_start=16 root_size='rockchip64';;
+	44) iname='Pinebook' HW_ARCH=3 partition_start=4 root_size='sunxi64';;
+	45) iname='PINEH64' HW_ARCH=3 partition_start=4 root_size='sunxi64';;
+	46) iname='PinebookPro' HW_ARCH=3 partition_start=16 root_size='rockchip64';;
+	47) iname='NanoPiR4S' HW_ARCH=3 partition_start=16 root_size='rockchip64';;
+	48) iname='NanoPiR1' HW_ARCH=2 partition_start=4 root_size='sunxi';;
+	'49.1') iname='Quartz64A' HW_ARCH=3 partition_start=16 root_size='quartz64';;
+	'49.2') iname='Quartz64B' HW_ARCH=3 partition_start=16 root_size='quartz64';;
+	'49.3') iname='SOQuartz' HW_ARCH=3 partition_start=16 root_size='quartz64';;
+	52) iname='ASUSTB' HW_ARCH=2 partition_start=4 root_size='rockchip';;
+	54) iname='NanoPiK2' HW_ARCH=3 partition_start=4 root_size='meson64';;
+	55) iname='NanoPiR2S' HW_ARCH=3 partition_start=16 root_size='rockchip64';;
+	56) iname='NanoPiNEO3' HW_ARCH=3 partition_start=16 root_size='rockchip64';;
+	57) iname='NanoPiNEOPlus2' HW_ARCH=3 partition_start=4 root_size='sunxi64';;
+	58) iname='NanoPiM4V2' HW_ARCH=3 partition_start=16 root_size='rockchip64';;
+	59) iname='ZeroPi' HW_ARCH=2 partition_start=4 root_size='sunxi';;
+	60) iname='NanoPiNEO' HW_ARCH=2 partition_start=4 root_size='sunxi';;
+	63) iname='NanoPiM1' HW_ARCH=2 partition_start=4 root_size='sunxi';;
+	64) iname='NanoPiNEOAir' HW_ARCH=2 partition_start=4 root_size='sunxi';;
+	'65.1') iname='NanoPiNEO2' HW_ARCH=3 partition_start=4 root_size='sunxi64';;
+	'65.2') iname='NanoPiNEO2Black' HW_ARCH=3 partition_start=4 root_size='sunxi64';;
+	66) iname='NanoPiM1Plus' HW_ARCH=2 partition_start=4 root_size='sunxi';;
+	67) iname='NanoPiK1Plus' HW_ARCH=3 partition_start=4 root_size='sunxi64';;
+	'68.1') iname='NanoPiM4' HW_ARCH=3 partition_start=16 root_size='rockchip64';;
+	'68.2') iname='NanoPCT4' HW_ARCH=3 partition_start=16 root_size='rockchip64';;
+	'68.3') iname='NanoPiNEO4' HW_ARCH=3 partition_start=16 root_size='rockchip64';;
+	'72.1') iname='ROCKPi4' HW_ARCH=3 partition_start=16 root_size='rockchip64';;
+	'72.2') iname='ROCK4SE' HW_ARCH=3 partition_start=16 root_size='rockchip64';;
+	'72.3') iname='ROCK4CPlus' HW_ARCH=3 partition_start=16 root_size='rockchip64';;
+	73) iname='ROCKPiS' HW_ARCH=3 partition_start=16 root_size='rockchip64';;
+	74) iname='RadxaZero' HW_ARCH=3 partition_start=4 root_size='meson64';;
 	75) iname='Container' HW_ARCH=${HW_ARCH:-10} root_size=700;;
-	'76.1') iname='NanoPiR5S' HW_ARCH=3 partition_start=16 root_size=1300;;
-	'76.2') iname='NanoPiR5C' HW_ARCH=3 partition_start=16 root_size=1300;;
-	77) iname='ROCK3A' HW_ARCH=3 partition_start=16 root_size=1300;;
-	78) iname='ROCK5B' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size=1300;;
-	'79.1') iname='NanoPiR6S' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size=1300;;
-	'79.2') iname='NanoPiR6C' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size=1300;;
-	'79.3') iname='NanoPCT6' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size=1300;;
-	80) iname='OrangePi5' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size=1300;;
-	81) iname='VisionFive2' HW_ARCH=11 root_size=800;;
-	82) iname='OrangePi5Plus' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size=1300;;
-	83) iname='OrangePiZero3' HW_ARCH=3 partition_start=4 root_size=1100;;
-	84) iname='Star64' HW_ARCH=11 root_size=800;;
-	85) iname='ROCK5A' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size=1300;;
-	86) iname='ASUSTB2' HW_ARCH=3 partition_start=16 root_size=1300;;
-	87) iname='OrangePi3B' HW_ARCH=3 partition_start=16 root_size=1300;;
-	88) iname='OrangePiZero2W' HW_ARCH=3 partition_start=4 root_size=1100;;
-	89) iname='OrangePi3LTS' HW_ARCH=3 partition_start=4 root_size=1100;;
-	90) iname='RadxaZERO3' HW_ARCH=3 partition_start=16 root_size=1300;;
-	91) iname='OrangePi5Max' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size=1300;;
-	92) iname='NanoPiM6' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size=1300;;
-	93) iname='OrangePi5Pro' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size=1300;;
-	94) iname='OrangePi5Ultra' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size=1300;;
-	95) iname='OrangePiCM5' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size=1300;;
+	'76.1') iname='NanoPiR5S' HW_ARCH=3 partition_start=16 root_size='rockchip64';;
+	'76.2') iname='NanoPiR5C' HW_ARCH=3 partition_start=16 root_size='rockchip64';;
+	77) iname='ROCK3A' HW_ARCH=3 partition_start=16 root_size='rockchip64';;
+	78) iname='ROCK5B' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size='rk35xx';;
+	'79.1') iname='NanoPiR6S' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size='rk35xx';;
+	'79.2') iname='NanoPiR6C' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size='rk35xx';;
+	'79.3') iname='NanoPCT6' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size='rk35xx';;
+	80) iname='OrangePi5' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size='rk35xx';;
+	81) iname='VisionFive2' HW_ARCH=11 root_size='riscv';;
+	82) iname='OrangePi5Plus' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size='rk35xx';;
+	83) iname='OrangePiZero3' HW_ARCH=3 partition_start=4 root_size='sunxi64';;
+	84) iname='Star64' HW_ARCH=11 root_size='riscv';;
+	85) iname='ROCK5A' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size='rk35xx';;
+	86) iname='ASUSTB2' HW_ARCH=3 partition_start=16 root_size='rockchip64';;
+	87) iname='OrangePi3B' HW_ARCH=3 partition_start=16 root_size='rockchip64';;
+	88) iname='OrangePiZero2W' HW_ARCH=3 partition_start=4 root_size='sunxi64';;
+	89) iname='OrangePi3LTS' HW_ARCH=3 partition_start=4 root_size='sunxi64';;
+	90) iname='RadxaZERO3' HW_ARCH=3 partition_start=16 root_size='rockchip64';;
+	91) iname='OrangePi5Max' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size='rk35xx';;
+	92) iname='NanoPiM6' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size='rk35xx';;
+	93) iname='OrangePi5Pro' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size='rk35xx';;
+	94) iname='OrangePi5Ultra' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size='rk35xx';;
+	95) iname='OrangePiCM5' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size='rk35xx';;
 	96) iname='OrangePi4A' HW_ARCH=3 partition_start=4 root_size=1000;;
 	97) iname='OrangePiRV' HW_ARCH=11 partition_start=4 root_size=1000;;
 	98) iname='OrangePiRV2' HW_ARCH=11 partition_start=4 root_size=1000;;
-	99) iname='OrangePi3' HW_ARCH=3 partition_start=4 root_size=1100;;
-	100) iname='NanoPiR3S' HW_ARCH=3 partition_start=16 root_size=1300;;
-	101) iname='NanoPiR3SLTS' HW_ARCH=3 partition_start=16 root_size=1300;;
-	102) iname='NanoPiR76S' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size=1300;;
-	103) iname='NanoPiM5' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size=1300;;
-	104) iname='NanoPiZero2' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size=1300;;
+	99) iname='OrangePi3' HW_ARCH=3 partition_start=4 root_size='sunxi64';;
+	100) iname='NanoPiR3S' HW_ARCH=3 partition_start=16 root_size='rockchip64';;
+	101) iname='NanoPiR3SLTS' HW_ARCH=3 partition_start=16 root_size='rockchip64';;
+	102) iname='NanoPiR76S' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size='rk35xx';;
+	103) iname='NanoPiM5' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size='rk35xx';;
+	104) iname='NanoPiZero2' HW_ARCH=3 PTTYPE='gpt' partition_start=16 root_size='rk35xx';;
 	*) Error_Exit "Invalid hardware model \"$HW_MODEL\" passed";;
+esac
+case $root_size in
+	'riscv') root_size=650; (( $DISTRO > 8 )) && ((root_size+=50));;
+	'meson') root_size=650; (( $DISTRO > 7 && ! $boot_size )) && ((root_size+=50));;
+	'rockchip') root_size=700;;
+	'quartz64') root_size=700; (( $DISTRO > 8 )) && ((root_size+=50));;
+	'sunxi') root_size=700; (( $DISTRO > 7 )) && ((root_size+=50));;
+	'sunxi64') root_size=800;;
+	'meson64') root_size=850;;
+	'rockchip64') root_size=900;;
+	'rk35xx') root_size=1000;;
+	*) (( $root_size )) || Error_Exit "Invalid root_size=$root_size";;
 esac
 
 [[ $VARIANT =~ ^(|iso|vbox|vmx|esxi|hyperv|utm|proxmox|all)$ ]] || Error_Exit "Invalid variant \"$VARIANT\" passed"
@@ -1274,9 +1286,6 @@ then
 	[[ $SIGN_PASS ]] && { G_DIETPI-NOTIFY 2 'Signing archive ...'; gpg --batch --pinentry-mode loopback --passphrase "$SIGN_PASS" -b --armor "$image_name.qcow2.xz" || exit 1; signature=("$image_name.qcow2.xz.asc"); }
 	[[ -x 'upload.sh' ]] && G_EXEC_OUTPUT=1 G_EXEC ./upload.sh "$image_name.qcow2.xz"{,.sha256} "${signature[@]}" && G_EXEC rm "$image_name.qcow2.xz"{,.sha256} "${signature[@]}"
 fi
-
-# Cleanup
-G_EXEC rm "$OUTPUT_IMG_NAME.img"
 
 exit 0
 }

--- a/.github/workflows/dietpi-build.yml
+++ b/.github/workflows/dietpi-build.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - id: buildargs
       run: |
-        if [ "${{ github.event.inputs.buildargs }}" = 'all' ]
+        if [ "${{ github.event.inputs.buildargs }}" = 'sbcs' ]
         then
           echo buildargs=[\
         '"-m 10 -d 7", "-m 10 -d 8", "-m 10 -d 9",'\
@@ -34,10 +34,6 @@ jobs:
         '"-m 15 -d 7", "-m 15 -d 8", "-m 15 -d 9",'\
         '"-m 16 -d 7", "-m 16 -d 8", "-m 16 -d 9",'\
         '"-m 17 -d 7", "-m 17 -d 8", "-m 17 -d 9",'\
-        '"-m 20 -d 7 -v all", "-m 20 -d 8 -v all", "-m 20 -d 9 -v all",'\
-        '"-m 20 -d 7 -v all -p gpt", "-m 20 -d 8 -v all -p gpt", "-m 20 -d 9 -v all -p gpt",'\
-        '"-m 21 -d 7 -v all", "-m 21 -d 8 -v all", "-m 21 -d 9 -v all",'\
-        '"-m 21 -d 7 -v all -p gpt", "-m 21 -d 8 -v all -p gpt", "-m 21 -d 9 -v all -p gpt",'\
         '"-m 40 -d 7", "-m 40 -d 8", "-m 40 -d 9",'\
         '"-m 42 -d 7", "-m 42 -d 8", "-m 42 -d 9",'\
         '"-m 43 -d 7", "-m 43 -d 8", "-m 43 -d 9",'\
@@ -71,9 +67,6 @@ jobs:
         '"-m 72.3 -d 7", "-m 72.3 -d 8", "-m 72.3 -d 9",'\
         '"-m 73 -d 7", "-m 73 -d 8", "-m 73 -d 9",'\
         '"-m 74 -d 7", "-m 74 -d 8", "-m 74 -d 9",'\
-        '"-m 75 -a 1 -d 7", "-m 75 -a 2 -d 7", "-m 75 -a 3 -d 7", "-m 75 -a 10 -d 7",'\
-        '"-m 75 -a 1 -d 8", "-m 75 -a 2 -d 8", "-m 75 -a 3 -d 8", "-m 75 -a 10 -d 8", "-m 75 -a 11 -d 8",'\
-        '"-m 75 -a 1 -d 9", "-m 75 -a 2 -d 9", "-m 75 -a 3 -d 9", "-m 75 -a 10 -d 9", "-m 75 -a 11 -d 9",'\
         '"-m 76.1 -d 7", "-m 76.1 -d 8", "-m 76.1 -d 9",'\
         '"-m 76.2 -d 7", "-m 76.2 -d 8", "-m 76.2 -d 9",'\
         '"-m 77 -d 7", "-m 77 -d 8", "-m 77 -d 9",'\
@@ -127,9 +120,11 @@ jobs:
         '"-m 75 -a 1 -d 7", "-m 75 -a 2 -d 7", "-m 75 -a 3 -d 7", "-m 75 -a 10 -d 7",'\
         '"-m 75 -a 1 -d 8", "-m 75 -a 2 -d 8", "-m 75 -a 3 -d 8", "-m 75 -a 10 -d 8", "-m 75 -a 11 -d 8",'\
         '"-m 75 -a 1 -d 9", "-m 75 -a 2 -d 9", "-m 75 -a 3 -d 9", "-m 75 -a 10 -d 9", "-m 75 -a 11 -d 9"]' >> "$GITHUB_OUTPUT"
-        elif [ "${{ github.event.inputs.buildargs }}" = 'pc' ]
+        elif [ "${{ github.event.inputs.buildargs }}" = 'x86' ]
         then
           echo buildargs=[\
+        '"-m 20 -d 7 -v all", "-m 20 -d 8 -v all", "-m 20 -d 9 -v all",'\
+        '"-m 20 -d 7 -v all -p gpt", "-m 20 -d 8 -v all -p gpt", "-m 20 -d 9 -v all -p gpt",'\
         '"-m 21 -d 7 -v all", "-m 21 -d 8 -v all", "-m 21 -d 9 -v all",'\
         '"-m 21 -d 7 -v all -p gpt", "-m 21 -d 8 -v all -p gpt", "-m 21 -d 9 -v all -p gpt"]' >> "$GITHUB_OUTPUT"
         else


### PR DESCRIPTION
Two changes were done to make this possible:
- 180 MiB of firmware for a single Snapdragon handheld device we do not support has been removed from our `armbian-firmware` package. A recent x4 duplication of already large ~40 MiB of firmware blobs lead to failing builds without raising the sizes, which caught my attention.
- Kernel module compression is again enabled for all kernel builds. Some change in Linux 6.12 lead to this being again disabled by default, requiring new flags. This reduces the size of the kernel modules by ~70%, saving 100 - 150 MiB disk space with Armbian kernel, though much less for our own custom mainline kernel builds. Thinking about it now, it probably was never widely enabled across Armbian kernel builds, but just for `x86_64` (Debian builds), RPi, and our Quartz64 an RISC-V kernel builds. Anyway, I tested all Armbian builds with compression enforced, and it works well. Only issue happened when enabling in-kernel decompression support on Rockchip vendor kernel: It fails to load modules with error 6/ENXIO. Not that I am much surprised as the vendor kernel has a lot of bad code and half-baked feature backports. Disabling in-kernel decompression, so that userland tools do this before passing the module to the kernel, solved it. This matches how we did earlier with Quartz64 and RISC-V, as I was not aware of in-kernel decompression.

Test builds: https://github.com/MichaIng/DietPi/actions/runs/22287991626

=> 200 MiB - 400 MiB smaller (uncompressed) image sizes with those 2 changes 🤩.

On our server it saved only a little more than half a GiB. Makes sense, since it is overall more efficient to compress an image with uncompressed kernel modules, than compressing an image with compressed kernel modules. Double-compressed files usually take even more disk space. And the firmware size was due to 4 sets of duplicate files + some more single duplicates, which can be compressed at least by the duplication, I guess. However, it overall still made the downloads a little smaller, and the extracted images, hence flashing time and I/O anyway.