### PR TITLE
dietpi-software: remove desktop dependency

### DIFF
--- a/.update/patches
+++ b/.update/patches
@@ -99,8 +99,7 @@ Patch_8_2()
 		grep -q '^8723bs$' /etc/modules && G_EXEC sed --follow-symlinks -i '/^8723bs$/d' /etc/modules
 	fi
 
-	# Remove and migrate Chromium config files
-	[[ $G_HW_MODEL -gt 9 && -f '/root/.chromium-browser.init' ]] && G_EXEC rm /root/.chromium-browser.init
+	# Migrate Chromium config file
 	[[ -f '/etc/chromium.d/custom_flags' ]] && G_EXEC mv /etc/chromium.d/{custom_flags,dietpi}
 
 	# Remove obsolete Nvidia install state
@@ -2321,6 +2320,9 @@ Patch_10_2()
 		/boot/dietpi/dietpi-servarr_to_ram enable || exit 1
 	fi
 	G_EXEC rm -f /etc/systemd/system/dietpi-arr_to_RAM.service /boot/dietpi/misc/dietpi-arr_to_RAM /boot/dietpi/misc/dietpi-servarr_to_ram /var/tmp/dietpi/logs/dietpi-arr_to_RAM.log
+
+	G_DIETPI-NOTIFY 2 'Removing obsolete files related to the "chromium-browser" package'
+	G_EXEC rm -f /{root,home/*}/{.chromium-browser.init,Desktop/chromium-browser.desktop}
 
 	# Software updates, migrations and patches
 	if [[ -f '/boot/dietpi/.installed' ]]

--- a/.update/patches
+++ b/.update/patches
@@ -136,7 +136,7 @@ Patch_8_4()
 
 	# Remove obsolete license file and setting
 	[[ -f '/var/lib/dietpi/license.txt' ]] && G_EXEC rm /var/lib/dietpi/license.txt
-	G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*AUTO_SETUP_ACCEPT_LICENSE=/d' /boot/dietpi.txt
+	G_EXEC sed --follow-symlinks -i '/^[[:blank:]#]*AUTO_SETUP_ACCEPT_LICENSE=/d' /boot/dietpi.txt
 
 	# Update DietPi initramfs cleanup script, following reasonable changes done by Armbian
 	if [[ -f '/etc/kernel/preinst.d/dietpi-initramfs_cleanup' ]]
@@ -2166,12 +2166,12 @@ Patch_9_20()
 Patch_10_0()
 {
 	# dietpi.txt migration
-	if grep -q '^[[:blank:]]*SOFTWARE_OWNCLOUD_NEXTCLOUD_USERNAME=' /boot/dietpi.txt
+	if grep -q '^[[:blank:]#]*SOFTWARE_OWNCLOUD_NEXTCLOUD_USERNAME=' /boot/dietpi.txt
 	then
-		G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*SOFTWARE_NEXTCLOUD_USERNAME=/d' /boot/dietpi.txt
+		G_EXEC sed --follow-symlinks -i '/^[[:blank:]#]*SOFTWARE_NEXTCLOUD_USERNAME=/d' /boot/dietpi.txt
 		G_EXEC sed --follow-symlinks -i 's/SOFTWARE_OWNCLOUD_NEXTCLOUD_USERNAME=/SOFTWARE_NEXTCLOUD_USERNAME=/' /boot/dietpi.txt
 	fi
-	G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*SOFTWARE_OWNCLOUD_DATADIR=/d' /boot/dietpi.txt
+	G_EXEC sed --follow-symlinks -i '/^[[:blank:]#]*SOFTWARE_OWNCLOUD_DATADIR=/d' /boot/dietpi.txt
 
 	# UNISOC/Spreadtrum WiFi driver loading: https://github.com/MichaIng/DietPi/issues/7878
 	if [[ $G_HW_MODEL =~ ^(83|87|88|89|99)$ && -f '/etc/modules-load.d/dietpi-enable_wifi.conf' ]]
@@ -2329,6 +2329,9 @@ Patch_10_2()
 	fi
 	[[ -d '/usr/lib/chromium-browser' ]] && G_EXEC rm -R /usr/lib/chromium-browser
 	G_EXEC rm -f /{root,home/*}/{.chromium-browser.init,Desktop/chromium-browser.desktop}
+
+	G_DIETPI-NOTIFY 2 'Removing obsolete dietpi.txt entry'
+	G_EXEC sed --follow-symlinks -i '/^[[:blank:]#]*AUTO_SETUP_DESKTOP_INDEX=/d' /boot/dietpi.txt
 
 	# Software updates, migrations and patches
 	if [[ -f '/boot/dietpi/.installed' ]]

--- a/.update/patches
+++ b/.update/patches
@@ -2321,7 +2321,13 @@ Patch_10_2()
 	fi
 	G_EXEC rm -f /etc/systemd/system/dietpi-arr_to_RAM.service /boot/dietpi/misc/dietpi-arr_to_RAM /boot/dietpi/misc/dietpi-servarr_to_ram /var/tmp/dietpi/logs/dietpi-arr_to_RAM.log
 
-	G_DIETPI-NOTIFY 2 'Removing obsolete files related to the "chromium-browser" package'
+	G_DIETPI-NOTIFY 2 'Purging obsolete "chromium-browser" package and leftovers'
+	if dpkg-query -s 'chromium-browser' &> /dev/null
+	then
+		dpkg-query -s 'chromium' 2> /dev/null | grep -q '^Status: install ok installed$' && G_EXEC apt-mark manual chromium
+		G_AGP chromium-browser
+	fi
+	[[ -d '/usr/lib/chromium-browser' ]] && G_EXEC rm -R /usr/lib/chromium-browser
 	G_EXEC rm -f /{root,home/*}/{.chromium-browser.init,Desktop/chromium-browser.desktop}
 
 	# Software updates, migrations and patches

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,7 +12,7 @@ New software:
 Enhancements:
 - DietPi-Benchmark | The benchmark script has been moved to /boot/dietpi/dietpi-benchmark and a shell alias has been added, so it can now be called directly from the console as "dietpi-benchmark" without having to browse through dietpi-config first.
 - DietPi-Tools | DietPi-Servarr_to_RAM: The original script dietpi-arr_to_RAM was renamed to dietpi-servarr_to_ram, got Prowlarr support, and protection against malicious symlinks when creating files and directories.
-- DietPi-Software | A desktop selection menu was added to make it clearer and easier to get started for those who require a graphical desktop environment.
+- DietPi-Software | A desktop selection menu was added to make it clearer and easier to get started for those who require a graphical desktop environment. A new dietpi.txt setting AUTO_SETUP_DESKTOP allows to pre-select a desktop for first boot. It takes textual values like "lxde" and "xfce", and serves as better accessible alternative to numerical software ID selections like AUTO_SETUP_INSTALL_SOFTWARE_ID=23.
 
 Bug fixes:
 - DietPi-Globals | G_AG_CHECK_INSTALL_PREREQ: Resolved an issue where the package installation is skipped even if the package was removed with only config files left. Many thanks to @Sympatron for reporting this issue: https://github.com/MichaIng/DietPi/issues/7772

--- a/dietpi.txt
+++ b/dietpi.txt
@@ -101,19 +101,20 @@ AUTO_SETUP_SSH_SERVER_INDEX=-1
 # - See SOFTWARE_DISABLE_SSH_PASSWORD_LOGINS below for disabling SSH password logins.
 #AUTO_SETUP_SSH_PUBKEY=ssh-ed25519 AAAAAAAA111111111111BBBBBBBBBBBB222222222222cccccccccccc333333333333 mySSHkey
 
+# Desktop choice: none, lxde, xfce, mate, lxqt, gnustep
+AUTO_SETUP_DESKTOP=none
+
 # Logging mode choice: 0=none/custom | -1=RAMlog hourly clear | -2=RAMlog hourly save to disk + clear | -3=Rsyslog + Logrotate
 AUTO_SETUP_LOGGING_INDEX=-1
 # RAMlog max tmpfs size (MiB). 50 MiB should be fine for single use. 200+ MiB for heavy webserver access log etc.
 AUTO_SETUP_RAMLOG_MAXSIZE=50
 
 # Dependency preferences
-# - DietPi-Software installs all dependencies for selected software options automatically, which can include a webserver for web applications, a desktop for GUI applications and one usually wants a web browser on desktops.
-# - Especially for non-interactive first run installs (see AUTO_SETUP_AUTOMATED below), you may want to define which webserver, desktop and/or browser you want to have installed in such case. For interactive installs you will be always asked to pick one.
-# - With below settings you can define your preference for non-interactive installs. However, it will only installed if any other selected software requires it, and an explicit webserver/desktop/browser selection overrides those settings:
+# - DietPi-Software installs all dependencies for selected software options automatically, which can include a webserver for web applications, and a web browser for desktop environments.
+# - Especially for non-interactive first run installs (see AUTO_SETUP_AUTOMATED below), you may want to define which webserver and/or browser you want to have installed in such case. For interactive installs you will be always asked to pick one.
+# - With below settings you can define your preference for non-interactive installs. However, it will only installed if any other selected software requires it, and an explicit webserver/browser selection overrides those settings:
 # - Webserver preference: 0=Apache | -1=Nginx | -2=Lighttpd
 AUTO_SETUP_WEB_SERVER_INDEX=0
-# - Desktop preference: 0=LXDE | -1=Xfce | -2=MATE | -3=LXQt | -4=GNUstep
-AUTO_SETUP_DESKTOP_INDEX=0
 # - Browser preference: 0=None | -1=Firefox | -2=Chromium
 AUTO_SETUP_BROWSER_INDEX=-1
 

--- a/dietpi/dietpi-autostart
+++ b/dietpi/dietpi-autostart
@@ -226,7 +226,7 @@ _EOF_
 			'5' ': DietPi-CloudShell'
 		)
 
-		G_WHIP_BUTTON_CANCEL_TEXT='Exit'
+		(( $HIERARCHY )) && G_WHIP_BUTTON_CANCEL_TEXT='Done' || G_WHIP_BUTTON_CANCEL_TEXT='Exit'
 		G_WHIP_DEFAULT_ITEM=$ID_AUTOSTART
 		if G_WHIP_MENU "Current AutoStart Option: $ID_AUTOSTART\n\nNB: If your choice is not \"Local Terminal\", please ensure required software is installed (or selected for install) with DietPi-Software."
 		then

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12638,27 +12638,27 @@ _EOF_
 	# $1: 0=None 23=LXDE 24=MATE 25=Xfce 26=GNUstep 173=LXQt
 	Apply_Desktop_Choices()
 	{
+		local id=0 i
+		case $1 in
+			'lxde') id=23;;
+			'mate') id=24;;
+			'xfce') id=25;;
+			'gnustep') id=26;;
+			'lqxt') id=173;;
+			*) set -- 'none';;
+		esac
 		for i in 23 24 25 26 173
 		do
-			if (( $1 == $i ))
+			if (( $i == $id ))
 			then
-				[[ ${aSOFTWARE_INSTALL_STATE[$i]} == [01] ]] && aSOFTWARE_INSTALL_STATE[$i]=1 || aSOFTWARE_INSTALL_STATE[$i]=2
+				[[ ${aSOFTWARE_INSTALL_STATE[i]} == [01] ]] && aSOFTWARE_INSTALL_STATE[i]=1 || aSOFTWARE_INSTALL_STATE[i]=2
 			else
-				[[ ${aSOFTWARE_INSTALL_STATE[$i]} == [01] ]] && aSOFTWARE_INSTALL_STATE[$i]=0 || aSOFTWARE_INSTALL_STATE[$i]=-1
+				[[ ${aSOFTWARE_INSTALL_STATE[i]} == [01] ]] && aSOFTWARE_INSTALL_STATE[i]=0 || aSOFTWARE_INSTALL_STATE[i]=-1
 			fi
 		done
 
-		# Update desktop preference index in dietpi.txt
-		local preference_index
-		case $1 in
-			23) preference_index=0;; # LXDE
-			25) preference_index=-1;; # Xfce
-			24) preference_index=-2;; # MATE
-			173) preference_index=-3;; # LXQt
-			26) preference_index=-4;; # GNUstep
-			*) return 0;;
-		esac
-		G_CONFIG_INJECT 'AUTO_SETUP_DESKTOP_INDEX=' "AUTO_SETUP_DESKTOP_INDEX=$preference_index" /boot/dietpi.txt
+		# Update desktop choice in dietpi.txt
+		G_CONFIG_INJECT 'AUTO_SETUP_DESKTOP=' "AUTO_SETUP_DESKTOP=$1" /boot/dietpi.txt
 	}
 
 	# $1: 0=None -1=Dropbear -2=OpenSSH
@@ -14963,6 +14963,7 @@ _EOF_
 		# Get settings
 		AUTOINSTALL_ENABLED=$(grep -cm1 '^[[:blank:]]*AUTO_SETUP_AUTOMATED=1' /boot/dietpi.txt)
 		AUTOINSTALL_AUTOSTARTTARGET=$(sed -n '/^[[:blank:]]*AUTO_SETUP_AUTOSTART_TARGET_INDEX=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+		local AUTOINSTALL_DESKTOP=$(sed -n '/^[[:blank:]]*AUTO_SETUP_DESKTOP=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 		local AUTOINSTALL_SSHINDEX=$(sed -n '/^[[:blank:]]*AUTO_SETUP_SSH_SERVER_INDEX=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 		local AUTOINSTALL_LOGGINGINDEX=$(sed -n '/^[[:blank:]]*AUTO_SETUP_LOGGING_INDEX=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
 		AUTOINSTALL_CUSTOMSCRIPTURL=$(sed -n '/^[[:blank:]]*AUTO_SETUP_CUSTOM_SCRIPT_EXEC=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
@@ -14972,6 +14973,7 @@ _EOF_
 
 		# Else set defaults
 		[[ $AUTOINSTALL_AUTOSTARTTARGET ]] || AUTOINSTALL_AUTOSTARTTARGET=0
+		[[ $AUTOINSTALL_DESKTOP ]] || AUTOINSTALL_DESKTOP='none'
 		[[ $AUTOINSTALL_SSHINDEX ]] || AUTOINSTALL_SSHINDEX=-1
 		[[ $AUTOINSTALL_LOGGINGINDEX ]] || AUTOINSTALL_LOGGINGINDEX=-1
 		[[ $AUTOINSTALL_CUSTOMSCRIPTURL ]] || AUTOINSTALL_CUSTOMSCRIPTURL=0
@@ -15136,7 +15138,8 @@ _EOF_
 		# Set time sync mode if no container system
 		(( $G_HW_MODEL == 75 )) || /boot/dietpi/func/dietpi-set_software ntpd-mode
 
-		# Apply choice and preference system settings
+		# Apply software choices from dietpi.txt
+		Apply_Desktop_Choices "${AUTOINSTALL_DESKTOP,,}"
 		Apply_SSHServer_Choices "$AUTOINSTALL_SSHINDEX"
 		Apply_Logging_Choices "$AUTOINSTALL_LOGGINGINDEX"
 
@@ -15865,15 +15868,7 @@ List of installed software and their online documentation URLs:
 				G_WHIP_MENU 'Please select desired desktop environment:' || return 0
 
 				# Apply selection
-				case "$G_WHIP_RETURNED_VALUE" in
-
-					"${aSOFTWARE_NAME[23]}") Apply_Desktop_Choices 23;;
-					"${aSOFTWARE_NAME[25]}") Apply_Desktop_Choices 25;;
-					"${aSOFTWARE_NAME[24]}") Apply_Desktop_Choices 24;;
-					"${aSOFTWARE_NAME[173]}") Apply_Desktop_Choices 173;;
-					"${aSOFTWARE_NAME[26]}") Apply_Desktop_Choices 26;;
-					*) Apply_Desktop_Choices 0;;
-				esac
+				Apply_Desktop_Choices "${G_WHIP_RETURNED_VALUE,,}"
 
 				# Check for changes
 				for i in 23 24 25 26 173

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12644,7 +12644,7 @@ _EOF_
 			'mate') id=24;;
 			'xfce') id=25;;
 			'gnustep') id=26;;
-			'lqxt') id=173;;
+			'lxqt') id=173;;
 			*) set -- 'none';;
 		esac
 		for i in 23 24 25 26 173

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -290,7 +290,6 @@ Available commands:
 		aSOFTWARE_DESC[$software_id]='multi-platform server and client access'
 		aSOFTWARE_CATX[$software_id]=1
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/remote_desktop/#nomachine'
-		aSOFTWARE_DEPS[$software_id]='desktop'
 		# - RISC-V: https://downloads.nomachine.com/
 		aSOFTWARE_AVAIL_G_HW_ARCH[$software_id,11]=0
 		#------------------
@@ -941,7 +940,7 @@ Available commands:
 		aSOFTWARE_DESC[$software_id]='Valve gaming platform client'
 		aSOFTWARE_CATX[$software_id]=5
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/gaming/#steam'
-		aSOFTWARE_DEPS[$software_id]='5 6 desktop'
+		aSOFTWARE_DEPS[$software_id]='5 6'
 		# Box86 required on ARM
 		(( $G_HW_ARCH == 2 )) && aSOFTWARE_DEPS[$software_id]+=' 62'
 		# x86_64 and ARMv7 only
@@ -2001,88 +2000,13 @@ Available commands:
 		done
 
 		# Software name to ID and preference index
-		if [[ $G_WHIP_RETURNED_VALUE == "${aSOFTWARE_NAME[83]}" ]]
-		then
-			SELECTED_WEBSERVER=83 preference_index=0
-
-		elif [[ $G_WHIP_RETURNED_VALUE == "${aSOFTWARE_NAME[85]}" ]]
-		then
-			SELECTED_WEBSERVER=85 preference_index=-1
-
-		elif [[ $G_WHIP_RETURNED_VALUE == "${aSOFTWARE_NAME[84]}" ]]
-		then
-			SELECTED_WEBSERVER=84 preference_index=-2
-		fi
+		case $G_WHIP_RETURNED_VALUE in
+			"${aSOFTWARE_NAME[84]}") SELECTED_WEBSERVER=84 preference_index=-2;;
+			"${aSOFTWARE_NAME[85]}") SELECTED_WEBSERVER=85 preference_index=-1;;
+			*) SELECTED_WEBSERVER=83 preference_index=0;;
+		esac
 
 		G_CONFIG_INJECT 'AUTO_SETUP_WEB_SERVER_INDEX=' "AUTO_SETUP_WEB_SERVER_INDEX=$preference_index" /boot/dietpi.txt
-		return 0
-	}
-
-	Select_Desktop_Dependency()
-	{
-		# Check for existing desktop (LXDE, MATE, Xfce, GNUstep, LXQt) installation
-		# - Do no reinstalls, as those are loose dependencies
-		(( ${aSOFTWARE_INSTALL_STATE[23]} < 1 && ${aSOFTWARE_INSTALL_STATE[24]} < 1 && ${aSOFTWARE_INSTALL_STATE[25]} < 1 && ${aSOFTWARE_INSTALL_STATE[26]} < 1 && ${aSOFTWARE_INSTALL_STATE[173]} < 1 )) || return 1
-
-		# Auto-select desktop if manually installed
-		if dpkg-query -s 'lxde' &> /dev/null
-		then
-			SELECTED_DESKTOP=23; return 0
-
-		elif dpkg-query -s 'xfce4' &> /dev/null
-		then
-			SELECTED_DESKTOP=25; return 0
-
-		elif dpkg-query -s 'mate-desktop-environment-core' &> /dev/null
-		then
-			SELECTED_DESKTOP=24; return 0
-
-		elif dpkg-query -s 'lxqt' &> /dev/null
-		then
-			SELECTED_DESKTOP=173; return 0
-
-		elif dpkg-query -s 'gnustep' &> /dev/null
-		then
-			SELECTED_DESKTOP=26; return 0
-		fi
-
-		local dependant=$1 preference_index=$(sed -n '/^[[:blank:]]*AUTO_SETUP_DESKTOP_INDEX=/{s/^[^=]*=//p;q}' /boot/dietpi.txt) software_id
-		# Preference index to software ID
-		case $preference_index in
-			-1) software_id=25;; # Xfce
-			-2) software_id=24;; # MATE
-			-3) software_id=173;; # LXQt
-			-4) software_id=26;; # GNUstep
-			*) software_id=23;; # LXDE (default)
-		esac
-
-		G_WHIP_MENU_ARRAY=(
-
-			"${aSOFTWARE_NAME[23]}" ": ${aSOFTWARE_DESC[23]}"
-			"${aSOFTWARE_NAME[25]}" ": ${aSOFTWARE_DESC[25]}"
-			"${aSOFTWARE_NAME[24]}" ": ${aSOFTWARE_DESC[24]}"
-			"${aSOFTWARE_NAME[173]}" ": ${aSOFTWARE_DESC[173]}"
-			"${aSOFTWARE_NAME[26]}" ": ${aSOFTWARE_DESC[26]}"
-		)
-
-		G_WHIP_DEFAULT_ITEM=${aSOFTWARE_NAME[$software_id]}
-		G_WHIP_BUTTON_OK_TEXT='Confirm' G_WHIP_BUTTON_CANCEL_TEXT='Exit'
-		until G_WHIP_MENU "${aSOFTWARE_NAME[$dependant]} requires a desktop. Which one shall be installed?"
-		do
-			[[ $G_WHIP_RETURNED_VALUE ]] && break
-			Menu_Exit
-		done
-
-		# Software name to ID and preference index
-		case $G_WHIP_RETURNED_VALUE in
-			"${aSOFTWARE_NAME[25]}") SELECTED_DESKTOP=25 preference_index=-1;;
-			"${aSOFTWARE_NAME[24]}") SELECTED_DESKTOP=24 preference_index=-2;;
-			"${aSOFTWARE_NAME[173]}") SELECTED_DESKTOP=173 preference_index=-3;;
-			"${aSOFTWARE_NAME[26]}") SELECTED_DESKTOP=26 preference_index=-4;;
-			*) SELECTED_DESKTOP=23 preference_index=0;;
-		esac
-
-		G_CONFIG_INJECT 'AUTO_SETUP_DESKTOP_INDEX=' "AUTO_SETUP_DESKTOP_INDEX=$preference_index" /boot/dietpi.txt
 		return 0
 	}
 
@@ -2100,7 +2024,7 @@ Available commands:
 		then
 			SELECTED_BROWSER=67; return 0
 
-		elif dpkg-query -s 'chromium' &> /dev/null || dpkg-query -s 'chromium-browser' &> /dev/null
+		elif dpkg-query -s 'chromium' &> /dev/null
 		then
 			SELECTED_BROWSER=113; return 0
 		fi
@@ -2151,12 +2075,6 @@ Available commands:
 			then
 				Select_Webserver_Dependency "$1" || continue
 				i=$SELECTED_WEBSERVER
-
-			# Resolve desktop dependency based on install state
-			elif [[ $i == 'desktop' ]]
-			then
-				Select_Desktop_Dependency "$1" || continue
-				i=$SELECTED_DESKTOP
 
 			# Resolve browser dependency based on install state
 			elif [[ $i == 'browser' ]]
@@ -2245,7 +2163,7 @@ Available commands:
 #!/bin/dash
 
 # Create desktop shortcuts
-set 'opentyrian' 'kodi' 'steam' 'dxx-rebirth' 'chromium' 'chromium-browser' 'htop' 'codium'
+set 'opentyrian' 'kodi' 'steam' 'dxx-rebirth' 'chromium' 'htop' 'codium'
 [ $USER = 'root' ] && set "$@" 'dietpi-launcher' 'dietpi-software' 'dietpi-config'
 [ -d ~/Desktop ] || mkdir -p ~/Desktop
 for i in "$@"
@@ -10292,16 +10210,13 @@ _EOF_
 
 		if To_Install 156 # Steam
 		then
-			# Allow non-interactive install
-			G_EXEC eval "debconf-set-selections <<< 'steam steam/question select I AGREE'"
-
 			# x86_64: Install Debian i386 package
 			if [[ $G_HW_ARCH == 10 ]]
 			then
-				# Add i386 arch: https://packages.debian.org/steam
+				# Add i386 arch: https://packages.debian.org/steam-installer
 				[[ $(dpkg --print-foreign-architectures) == *'i386'* ]] || { G_EXEC dpkg --add-architecture i386; G_AGUP; }
 
-				G_AGI steam
+				G_AGI steam-installer
 
 				# Reapply GPU drivers to install required i386 items
 				local gpu_current=$(sed -n '/^[[:blank:]]*CONFIG_GPU_DRIVER=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
@@ -10310,6 +10225,8 @@ _EOF_
 			# ARM: Install repacked Debian i386 package for armhf
 			elif [[ $G_HW_ARCH == 2 ]]
 			then
+				# Allow non-interactive install
+				G_EXEC eval 'debconf-set-selections <<< '\''steam steam/question select I AGREE'\'
 				Download_Install "https://dietpi.com/downloads/binaries/$G_DISTRO_NAME/steam_$G_HW_ARCH_NAME.deb"
 			fi
 
@@ -13561,7 +13478,7 @@ _EOF_
 
 		if To_Uninstall 156 # Steam
 		then
-			G_AGP steam
+			G_AGP steam-installer steam
 			G_EXEC rm -Rf /{root,home/*}/{.steam{,path,pid},Desktop/steam.desktop} /mnt/dietpi_userdata/steam
 		fi
 
@@ -14212,8 +14129,7 @@ _EOF_
 			# Files
 			[[ -d '/etc/chromium.d' ]] && G_EXEC rm -R /etc/chromium.d
 			[[ -d '/usr/lib/chromium' ]] && G_EXEC rm -R /usr/lib/chromium
-			[[ -d '/usr/lib/chromium-browser' ]] && G_EXEC rm -R /usr/lib/chromium-browser
-			G_EXEC rm -Rf /{root,home/*}/{.chromium-browser.init,.{cache,config}/chromium,Desktop/chromium{,-browser}.desktop}
+			G_EXEC rm -Rf /{root,home/*}/{.{cache,config}/chromium,Desktop/chromium.desktop}
 			[[ -f '/var/lib/dietpi/dietpi-software/installed/chromium-autostart.sh' ]] && G_EXEC rm /var/lib/dietpi/dietpi-software/installed/chromium-autostart.sh
 			# Autostart index: If currently Chromium, revert to console login
 			[[ -f '/boot/dietpi/.dietpi-autostart_index' && $(</boot/dietpi/.dietpi-autostart_index) == 11 ]] && /boot/dietpi/dietpi-autostart 0


### PR DESCRIPTION
* NoMachine can even work with DRM and EGL, not even an X11 server is strictly needed
* Steam can work with X11 alone
* While on it, remove obsolete chromium-browser package handling and files which might still be present on older systems
* `steam` is a transitional dummy package since Bookworm, `steam-installer` is the actual package needed, and it does not have the license debconf question anymore