### PR TITLE
dietpi-software: Immich: polishing

### DIFF
--- a/.update/patches
+++ b/.update/patches
@@ -2343,6 +2343,22 @@ Patch_10_2()
 	# Software updates, migrations and patches
 	if [[ -f '/boot/dietpi/.installed' ]]
 	then
+		# Immich directory migration for beta users
+		if grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[215\]=2' /boot/dietpi/.installed && grep -q '^[[:blank:]]*IMMICH_MEDIA_LOCATION=/mnt/dietpi_userdata/immich/upload' /mnt/dietpi_userdata/immich/immich.env
+		then
+			G_DIETPI-NOTIFY 2 'Moving Immich data dir from /mnt/dietpi_userdata/immich/upload to /mnt/dietpi_userdata/immich'
+			G_EXEC sed --follow-symlinks -i '/^Environment=/s|$| IMMICH_MEDIA_LOCATION=/mnt/dietpi_userdata/immich|' /etc/systemd/system/immich.service
+			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*IMMICH_MEDIA_LOCATION=/d' /mnt/dietpi_userdata/immich/immich.env
+			G_EXEC mv /mnt/dietpi_userdata/immich/upload/* /mnt/dietpi_userdata/immich/
+			G_EXEC rmdir /mnt/dietpi_userdata/immich/upload
+		fi
+		if grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[216\]=2' /boot/dietpi/.installed && grep -q '^[[:blank:]]*MACHINE_LEARNING_CACHE_FOLDER=/mnt/dietpi_userdata/immich-ml/model-cache' /mnt/dietpi_userdata/immich/immich-ml.env
+		then
+			G_DIETPI-NOTIFY 2 'Moving Immich Machine Learning cache dir from /mnt/dietpi_userdata/immich-ml/model-cache to /mnt/dietpi_userdata/immich-ml/cache'
+			G_CONFIG_INJECT 'MACHINE_LEARNING_CACHE_FOLDER=' 'MACHINE_LEARNING_CACHE_FOLDER=/mnt/dietpi_userdata/immich-ml/cache'
+			G_EXEC mv /mnt/dietpi_userdata/immich-ml/model-cache /mnt/dietpi_userdata/immich-ml/cache
+		fi
+
 		# Pi-hole v6 migration
 		# - /etc/pihole/pihole.toml indicates that Pi-hole has been upgraded to v6 already.
 		# - The /var/www/pihole symlink indicates that an instance installed via dietpi-software has not been migrated yet.

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -11971,15 +11971,15 @@ _EOF_
 		if To_Install 215 immich # Immich
 		then
 			# Install pgvector and VectorChord extensions: https://immich.app/docs/administration/postgres-standalone
-			local pg_version=$(find /etc/postgresql -mindepth 1 -maxdepth 1 -type d -name '[1-9][0-9]' -printf '%f\n' | sort -Vr | head -1)
-			aDEPS=("postgresql-$pg_version-pgvector")
+			local version=$(find /etc/postgresql -mindepth 1 -maxdepth 1 -type d -name '[1-9][0-9]' -printf '%f\n' | sort -Vr | head -1)
+			aDEPS=("postgresql-$version-pgvector")
 			local arch='amd64'
-			(( $G_HW_ARCH == 3 )) && local arch='arm64'
-			local fallback_url="https://github.com/tensorchord/VectorChord/releases/download/1.1.0/postgresql-$pg_version-vchord_1.1.0-1_$arch.deb"
-			Download_Install "$(curl -sSfL 'https://api.github.com/repos/tensorchord/VectorChord/releases/latest' | grep -Po "\"browser_download_url\": *\"\K[^\"]*-$pg_version-vchord_[^\"\/]*_$arch.deb")"
+			(( $G_HW_ARCH == 3 )) && arch='arm64'
+			local fallback_url="https://github.com/tensorchord/VectorChord/releases/download/1.1.0/postgresql-$version-vchord_1.1.0-1_$arch.deb"
+			Download_Install "$(curl -sSfL 'https://api.github.com/repos/tensorchord/VectorChord/releases/latest' | grep -Po "\"browser_download_url\": *\"\K[^\"]*-$version-vchord_[^\"\/]*_$arch.deb")"
 
 			# Download Immich source
-			local version=$(curl -sSfL 'https://api.github.com/repos/immich-app/immich/releases/latest' | grep -Po '"tag_name": *"\K[^"]+')
+			version=$(curl -sSfL 'https://api.github.com/repos/immich-app/immich/releases/latest' | grep -Po '"tag_name": *"\K[^"]+')
 			[[ $version ]] || { version='v2.5.6'; G_DIETPI-NOTIFY 1 "Automatic latest ${aSOFTWARE_NAME[$software_id]} version detection failed. Version \"$version\" will be installed as fallback, but a newer version might be available. Please report this at: https://github.com/MichaIng/DietPi/issues"; }
 			Download_Install "https://github.com/immich-app/immich/archive/$version.tar.gz"
 
@@ -11989,12 +11989,12 @@ _EOF_
 			G_EXEC mv "immich-${version#v}" "$immich_src"
 
 			# Install build-time tools
-			local arch='x86_64'
-			(( $G_HW_ARCH == 3 )) && local arch='aarch64'
-			local fallback_url="https://github.com/extism/js-pdk/releases/download/v1.5.1/extism-js-$arch-linux-v1.5.1.gz"
+			arch='x86_64'
+			(( $G_HW_ARCH == 3 )) && arch='aarch64'
+			fallback_url="https://github.com/extism/js-pdk/releases/download/v1.5.1/extism-js-$arch-linux-v1.5.1.gz"
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/extism/js-pdk/releases/latest' | grep -Po "\"browser_download_url\": *\"\K[^\"]*\/extism-js-$arch-linux-[^\"\/]*\.gz(?=\")")" /usr/local/bin/extism-js
 			G_EXEC chmod +x /usr/local/bin/extism-js
-			local fallback_url="https://github.com/WebAssembly/binaryen/releases/download/version_124/binaryen-version_124-$arch-linux.tar.gz"
+			fallback_url="https://github.com/WebAssembly/binaryen/releases/download/version_124/binaryen-version_124-$arch-linux.tar.gz"
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/WebAssembly/binaryen/releases/latest' | grep -Po "\"browser_download_url\": *\"\K[^\"]*\/binaryen-[^\"\/]*-$arch-linux\.tar\.gz(?=\")")"
 			G_EXEC mv binaryen-*/bin/wasm-merge binaryen-*/bin/wasm-opt /usr/local/bin/
 			G_EXEC rm -R binaryen-version_*
@@ -12009,8 +12009,8 @@ _EOF_
 			G_EXEC pnpm c set --location=project cacheDir "$immich_src/.pnpmCache"
 			G_EXEC pnpm c set --location=project stateDir "$immich_src/.pnpmState"
 
-			# Assure at least 5 GiB total memory (RAM + swap) for the build
-			Min_Total_Memory 5120
+			# Assure at least 4+256*cores GiB total memory (RAM + swap) for the build
+			Min_Total_Memory $(( 4096 + 256 * $G_HW_CPU_CORES ))
 
 			# Prevent JavaScript OOM during build
 			export NODE_OPTIONS='--max-old-space-size=4096'
@@ -12057,7 +12057,7 @@ _EOF_
 			Create_User -G redis -d /mnt/dietpi_userdata/immich immich
 
 			# Data directory
-			G_EXEC mkdir -p /mnt/dietpi_userdata/immich/upload
+			G_EXEC mkdir -p /mnt/dietpi_userdata/immich
 			G_EXEC chown -R immich:immich /mnt/dietpi_userdata/immich
 
 			# Configure PostgreSQL: load VectorChord and enable localhost TCP for the Node.js database driver
@@ -12095,9 +12095,6 @@ _EOF_
 # Immich web UI port and bind host
 IMMICH_PORT=2283
 IMMICH_HOST=0.0.0.0
-
-# Upload location for photos and videos
-IMMICH_MEDIA_LOCATION=/mnt/dietpi_userdata/immich/upload
 
 # Log level: verbose, debug, log, warn, error, fatal
 IMMICH_LOG_LEVEL=warn
@@ -12137,7 +12134,7 @@ After=network-online.target postgresql.service redis-server.service
 [Service]
 SyslogIdentifier=Immich
 User=immich
-Environment=NO_COLOR=true IMMICH_BUILD_DATA='/opt/immich'
+Environment=NO_COLOR=true IMMICH_BUILD_DATA=/opt/immich IMMICH_MEDIA_LOCATION=/mnt/dietpi_userdata/immich
 EnvironmentFile=/mnt/dietpi_userdata/immich/immich.env
 ExecStart=/usr/local/bin/node /opt/immich/dist/main
 
@@ -12152,7 +12149,7 @@ ProtectControlGroups=1
 ProtectKernelLogs=1
 ProtectClock=1
 NoNewPrivileges=1
-ReadWritePaths=-/mnt/dietpi_userdata/immich
+ReadWritePaths=-/mnt
 
 [Install]
 WantedBy=multi-user.target
@@ -12196,7 +12193,7 @@ _EOF_
 			Create_User -d /mnt/dietpi_userdata/immich-ml immich-ml
 
 			# Data directory
-			G_EXEC mkdir -p /mnt/dietpi_userdata/immich-ml/model-cache
+			G_EXEC mkdir -p /mnt/dietpi_userdata/immich-ml/cache
 			G_EXEC chown -R immich-ml:immich-ml /mnt/dietpi_userdata/immich-ml
 
 			# Env file
@@ -12209,7 +12206,7 @@ IMMICH_HOST=127.0.0.1
 IMMICH_LOG_LEVEL=warn
 
 # Cache directory for downloaded AI model files
-MACHINE_LEARNING_CACHE_FOLDER=/mnt/dietpi_userdata/immich-ml/model-cache
+MACHINE_LEARNING_CACHE_FOLDER=/mnt/dietpi_userdata/immich-ml/cache
 _EOF_
 			# Enable machine learning in Immich server config if present (no-op for standalone ML setups)
 			if [[ -f '/mnt/dietpi_userdata/immich/immich.env' ]]


### PR DESCRIPTION
* Tune needed memory size for build based on CPU cores
* Do not expose `IMMICH_MEDIA_LOCATION` in env file, this shall better not be changed, but instead symlinks for its subdirs
* Relax systemd sandboxing, allowing access to all `/mnt` (where the user has access to)
* Move Immich data dir from `/mnt/dietpi_userdata/immich/upload` to `/mnt/dietpi_userdata/immich`
* Move Immich-ML cache dir from `/mnt/dietpi_userdata/immich-ml/model-cache` to `/mnt/dietpi_userdata/immich-ml/cache`