### PR TITLE
dietpi-software: Grafana: use official APT repo as well for ARMv6

### DIFF
--- a/.update/pre-patches
+++ b/.update/pre-patches
@@ -464,15 +464,6 @@ Pin-Priority: 500
 _EOF_'
 		fi
 	fi
-
-	# Update Grafana APT key, expired at 2025-08-23
-	if [[ -f '/etc/apt/trusted.gpg.d/dietpi-grafana.gpg' ]] && (( $(date -u '+%Y%m%d' -r '/etc/apt/trusted.gpg.d/dietpi-grafana.gpg') < 20250823 ))
-	then
-		G_DIETPI-NOTIFY 2 'Updating Grafana APT repo key'
-		G_EXEC curl -sSfLO 'https://apt.grafana.com/gpg.key'
-		G_EXEC gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-grafana.gpg --yes gpg.key
-		G_EXEC rm gpg.key
-	fi
 fi
 
 # v9.17
@@ -653,6 +644,33 @@ _EOF_'
 		G_EXEC rm -f /usr/share/keyrings/plexmediaserver.v2.gpg
 		G_EXEC rm -f /etc/apt/keyrings/plexmediaserver.v2.gpg
 		G_EXEC rm -f /etc/apt/keyrings/plexmediaserver.gpg
+	fi
+fi
+
+# v10.3
+if (( $G_DIETPI_VERSION_CORE < 10 || ( $G_DIETPI_VERSION_CORE == 10 && $G_DIETPI_VERSION_SUB < 3 ) ))
+then
+	if [[ -f '/boot/dietpi/.installed' ]] && grep -q '^[[:blank:]]*aSOFTWARE_INSTALL_STATE\[77\]=2' /boot/dietpi/.installed
+	then
+		if [[ $G_HW_ARCH == 1 || -f '/etc/apt/trusted.gpg.d/dietpi-grafana.gpg' ]]
+		then
+			G_DIETPI-NOTIFY 2 'Updating Grafana repo key'
+			G_EXEC mkdir -p /etc/apt/keyrings
+			G_EXEC curl -sSfLo /etc/apt/keyrings/dietpi-grafana.asc 'https://apt.grafana.com/gpg.key'
+			G_EXEC rm -f /etc/apt/trusted.gpg.d/dietpi-grafana.gpg
+		fi
+		if [[ $G_HW_ARCH == 1 || -f '/etc/apt/sources.list.d/grafana.list' ]]
+		then
+			G_DIETPI-NOTIFY 2 'Updating Grafana repo list'
+			G_EXEC eval 'cat << '\''_EOF_'\'' > /etc/apt/sources.list.d/dietpi-grafana.sources
+Types: deb
+URIs: https://apt.grafana.com
+Suites: stable
+Components: main
+Signed-By: /etc/apt/keyrings/dietpi-grafana.asc
+_EOF_'
+			G_EXEC rm -f /etc/apt/sources.list.d/grafana.list
+		fi
 	fi
 fi
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -7356,13 +7356,13 @@ _EOF_
 			G_EXEC curl -sSfLo /etc/apt/keyrings/dietpi-influxdb.asc 'https://repos.influxdata.com/influxdata-archive.key'
 
 			# APT source: Bookworm is the latest available suite
-			G_EXEC eval "cat << '_EOF_' > /etc/apt/sources.list.d/dietpi-influxdb.sources
+			G_EXEC eval 'cat << '\''_EOF_'\'' > /etc/apt/sources.list.d/dietpi-influxdb.sources
 Types: deb
 URIs: https://repos.influxdata.com/debian
 Suites: bookworm
 Components: stable
 Signed-By: /etc/apt/keyrings/dietpi-influxdb.asc
-_EOF_"
+_EOF_'
 			G_AGUP
 
 			# APT package
@@ -7387,21 +7387,26 @@ _EOF_"
 
 		if To_Install 77 grafana-server # Grafana: https://grafana.com/docs/grafana/latest/setup-grafana/installation/debian/#install-from-apt-repository
 		then
-			# ARMv6: Since Grafana repo is not compatible, install package from our repo, taken from here: https://grafana.com/grafana/download?platform=arm&edition=oss
+			# APT key: https://apt.grafana.com/
+			G_EXEC mkdir -p /etc/apt/keyrings
+			G_EXEC curl -sSfLo /etc/apt/keyrings/dietpi-grafana.asc 'https://apt.grafana.com/gpg.key'
+
+			# APT source
+			G_EXEC eval 'cat << '\''_EOF_'\'' > /etc/apt/sources.list.d/dietpi-grafana.sources
+Types: deb
+URIs: https://apt.grafana.com
+Suites: stable
+Components: main
+Signed-By: /etc/apt/keyrings/dietpi-grafana.asc
+_EOF_'
+			G_AGUP
+
+			# APT package
+			# - ARMv6 requires dedicated packages
 			if (( $G_HW_ARCH == 1 ))
 			then
 				G_AGI grafana-rpi
 			else
-				# APT key
-				local url='https://apt.grafana.com/gpg.key'
-				G_CHECK_URL "$url"
-				G_EXEC eval "curl -sSfL '$url' | gpg --dearmor -o /etc/apt/trusted.gpg.d/dietpi-grafana.gpg --yes"
-
-				# APT list
-				G_EXEC eval 'echo '\''deb https://apt.grafana.com stable main'\'' > /etc/apt/sources.list.d/grafana.list'
-				G_AGUP
-
-				# APT package
 				G_AGI grafana
 			fi
 			G_EXEC systemctl stop grafana-server
@@ -13128,8 +13133,8 @@ _EOF_
 				G_EXEC update-ca-certificates -f
 			fi
 			G_AGP mympd
-			[[ -f '/etc/apt/sources.list.d/dietpi-mympd.list' ]] && G_EXEC rm /etc/apt/sources.list.d/dietpi-mympd.list
-			[[ -f '/etc/apt/trusted.gpg.d/dietpi-mympd.asc' ]] && G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-mympd.asc
+			G_EXEC rm -f /etc/apt/sources.list.d/dietpi-mympd.list
+			G_EXEC rm -f /etc/apt/trusted.gpg.d/dietpi-mympd.asc
 			[[ -d '/var/lib/mympd' ]] && G_EXEC rm -R /var/lib/mympd
 			[[ -d '/var/lib/private/mympd' ]] && G_EXEC rm -R /var/lib/private/mympd
 			[[ -d '/var/cache/mympd' ]] && G_EXEC rm -R /var/cache/mympd
@@ -14266,8 +14271,8 @@ _EOF_
 		if To_Uninstall 167 # Raspotify
 		then
 			G_AGP raspotify
-			[[ -f '/etc/apt/sources.list.d/dietpi-raspotify.list' ]] && G_EXEC rm /etc/apt/sources.list.d/dietpi-raspotify.list
-			[[ -f '/etc/apt/trusted.gpg.d/dietpi-raspotify.asc' ]] && G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-raspotify.asc
+			G_EXEC rm -f /etc/apt/sources.list.d/dietpi-raspotify.list
+			G_EXEC rm -f /etc/apt/trusted.gpg.d/dietpi-raspotify.asc
 		fi
 
 		if To_Uninstall 100 # PiJuice
@@ -14421,9 +14426,9 @@ _EOF_
 		if To_Uninstall 77 # Grafana
 		then
 			Remove_Service grafana-server grafana grafana
-			G_AGP grafana
-			[[ -f '/etc/apt/sources.list.d/grafana.list' ]] && G_EXEC rm /etc/apt/sources.list.d/grafana.list
-			[[ -f '/etc/apt/trusted.gpg.d/dietpi-grafana.gpg' ]] && G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-grafana.gpg
+			G_AGP grafana grafana-rpi
+			G_EXEC rm -f /etc/apt/sources.list.d/dietpi-grafana.sources
+			G_EXEC rm -f /etc/apt/keyrings/dietpi-grafana.asc
 			G_EXEC rm -Rf /{mnt/dietpi_userdata,var/{lib,log},etc}/grafana
 		fi
 
@@ -14431,8 +14436,8 @@ _EOF_
 		then
 			Remove_Service influxdb 1 1
 			G_AGP influxdb
-			[[ -f '/etc/apt/sources.list.d/dietpi-influxdb.sources' ]] && G_EXEC rm /etc/apt/sources.list.d/dietpi-influxdb.sources
-			[[ -f '/etc/apt/trusted.gpg.d/dietpi-influxdb.asc' ]] && G_EXEC rm /etc/apt/trusted.gpg.d/dietpi-influxdb.asc
+			G_EXEC rm -f /etc/apt/sources.list.d/dietpi-influxdb.sources
+			G_EXEC rm -f /etc/apt/keyrings/dietpi-influxdb.asc
 			G_EXEC rm -Rf /{mnt/dietpi_userdata,var/{lib,log},etc}/influxdb
 		fi
 


### PR DESCRIPTION
It was probably an oversight, that while the "grafana" armhf packages from that repo are incompatible with ARMv6, the "grafana-rpi" packages are not, and are available. Hence we can and should use Grafana's own repo, and in the same turn migrate to DEB822 format.

Additionally, this aligns and fixes some uninstall code.

Test installs: https://github.com/MichaIng/DietPi/actions/runs/24403663562