### PR TITLE
dietpi-software: replace runuser with setpriv

### DIFF
--- a/.github/workflows/dietpi-software.bash
+++ b/.github/workflows/dietpi-software.bash
@@ -372,7 +372,12 @@ apackages=('xz-utils' 'parted' 'fdisk' 'systemd-container')
 G_AG_CHECK_INSTALL_PREREQ "${apackages[@]}"
 
 # Register QEMU binfmt configs
-(( $emulation )) && G_EXEC systemctl restart systemd-binfmt
+if (( $emulation ))
+then
+	# Add credentials flag to allow setuid/setgid flags to function, e.g. used by Koel to add its crontab
+	G_EXEC sed --follow-symlinks -i '1s|$|C|' /usr/lib/binfmt.d/qemu-*.conf
+	G_EXEC systemctl restart systemd-binfmt
+fi
 
 ##########################################
 # Prepare container
@@ -499,7 +504,7 @@ then
 		for i in ${aSERVICES[@]}
 		do
 			G_EXEC mkdir "rootfs/etc/systemd/system/$i.service.d"
-			G_EXEC eval "echo -e '[Service]\nPrivateUsers=0\nProtectSystem=0\nProtectHome=0\nPrivateTmp=0\nPrivateDevices=0\nProtectKernelModules=0\nProtectControlGroups=0\nProtectKernelTunables=0\nProtectKernelLogs=0\nReadWritePaths=' > 'rootfs/etc/systemd/system/$i.service.d/dietpi-container.conf'"
+			G_EXEC eval "echo -e '[Service]\nPrivateUsers=0\nProtectSystem=0\nProtectHome=0\nPrivateTmp=0\nPrivateDevices=0\nProtectKernelModules=0\nProtectControlGroups=0\nProtectKernelTunables=0\nProtectKernelLogs=0\nReadWritePaths=\nProtectProc=default\nNoExecPaths=\nExecPaths=' > 'rootfs/etc/systemd/system/$i.service.d/dietpi-container.conf'"
 		done
 
 		# /dev/console == /dev/pts/0 seen as "Inappropriate ioctl for device" leading to failing console-getty.service and StandardOutput=tty

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,9 @@ Enhancements:
 Bug fixes:
 - DietPi-Drive_Manager | Resolved a v10.3 regression where moving the rootfs on Raspberry Pi to a different drive caused an invalid /boot/firmware/cmdline.txt root entry, failing to boot. Many thanks to @TimH for reporting this issue: https://dietpi.com/forum/t/25154
 - DietPi-Software | Docker: Resolved a v10.3 regression where a fresh Docker installation failed, since "--no-reload" was used when unmasking docker.service, which prevents docker.socket from starting up as well. Many thanks to @peracchi for reporting this issue: https://github.com/MichaIng/DietPi/issues/8108
+- DietPi-Software | Home Assistant: Resolved an issue where the installation might have failed, when starting it from within a desktop session. As we used "runuser", environment variables were passed through to "uv", notably "XDG_DATA_HOME", which was then used as install dir for Python, instead of the intended service user's home directory. All runuser calls have now been replaced by "setpriv" with the "--reset-env" flag, to guarantee a clean environment. Many thanks to @btuerk89 for reporting this issue: https://github.com/MichaIng/DietPi/issues/8116
+- DietPi-Software | Synapse: Resolved an issue where the installation might have failed, since dependencies were not installed as intended.
+- DietPi-Software | ownCloud Infinite Scale: Resolved a v10.3 regression, where the service failed to start, as it does not have the permissions to "touch" its environment file, to trigger the systemd automount, if needed. Instead of "touch", automounts for environment files are now triggered with "test -e", which does not require write access.
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/ADDME
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -1093,6 +1093,8 @@ Available commands:
 		aSOFTWARE_DESC[$software_id]='Simple camera streaming tool with HTML plugin'
 		aSOFTWARE_CATX[$software_id]=7
 		aSOFTWARE_DOCS[$software_id]='https://dietpi.com/docs/software/camera/#mjpg-streamer'
+		# - Forky: "Compatibility with CMake < 3.5 has been removed from CMake."
+		(( $G_DISTRO > 8 )) && aSOFTWARE_AVAIL_G_DISTRO[$software_id,$G_DISTRO]=0
 		#------------------
 		software_id=127
 		aSOFTWARE_NAME[$software_id]='BirdNET-Go'
@@ -2594,10 +2596,10 @@ sudo sysctl -p /etc/sysctl.d/dietpi-$1.conf"
 					'greenlet-v113') (( $python_version > 311 || ( $G_HW_ARCH < 3 && ! $piwheels ) || $G_HW_ARCH == 11 )) && aDEPS+=('g++');;
 					'isal') (( ( $G_HW_ARCH < 3 && ! $piwheels ) || $G_HW_ARCH == 11 )) && aDEPS+=('make');;
 					'libsass') (( $piwheels || $G_HW_ARCH == 10 )) || aDEPS+=('g++');;
-					'lxml') (( $G_HW_ARCH == 1 && ( ! $piwheels || $python_version != 311 ) )) && aDEPS+=('libxslt1-dev');;
+					'lxml') (( $G_HW_ARCH == 1 && ! $piwheels )) && aDEPS+=('libxslt1-dev');;
 					'matrix-synapse')
-						(( ( $G_HW_ARCH < 3 && ! $piwheels ) || $G_HW_ARCH == 11 )) && rust=1
-						sed -- "$@" bcrypt cffi cryptography pillow pydantic pynacl
+						(( ( $G_HW_ARCH < 3 && ! $piwheels ) || $G_HW_ARCH == 11 )) && rust=1 aDEPS+=('gcc')
+						set -- "$@" bcrypt cffi cryptography pillow pydantic pynacl
 					;;
 					'netifaces') (( $piwheels )) || aDEPS+=('gcc');;
 					'numpy')
@@ -2611,8 +2613,8 @@ sudo sysctl -p /etc/sysctl.d/dietpi-$1.conf"
 						(( $piwheels )) && aDEPS+=('libgfortran5' 'libopenblas0-pthread')
 					;;
 					'pillow')
-						(( ( $G_HW_ARCH < 3 && ( ! $piwheels || $python_version != 311 ) ) || $G_HW_ARCH == 11 )) && aDEPS+=('gcc' 'libjpeg62-turbo-dev' 'zlib1g-dev')
-						(( $piwheels && $python_version == 311 )) && aDEPS+=('libopenjp2-7' 'libtiff6' 'libxcb1')
+						(( ( $G_HW_ARCH < 3 && ! $piwheels ) || $G_HW_ARCH == 11 )) && aDEPS+=('gcc' 'libjpeg62-turbo-dev' 'zlib1g-dev')
+						(( $piwheels )) && aDEPS+=('libopenjp2-7' 'libtiff6' 'libxcb1')
 					;;
 					'poetry')
 						# cryptography > SecretStorage > keyring > poetry
@@ -2637,7 +2639,7 @@ sudo sysctl -p /etc/sysctl.d/dietpi-$1.conf"
 						# Python < 3.12: https://dietpi.com/forum/t/24975/2
 						(( $python_version < 312 )) && aDEPS+=('patch')
 					;;
-					'pymicro-vad-v101') (( $python_version > 312 || $G_HW_ARCH < 3 || $G_HW_ARCH == 11 )) && aDEPS+=('g++');;
+					'pymicro-vad-v101') (( $python_version > 312 || ( $G_HW_ARCH < 3 && ! $piwheels ) || $G_HW_ARCH == 11 )) && aDEPS+=('g++');;
 					'pynacl')
 						(( ( $G_HW_ARCH < 3 && ! $piwheels ) || $G_HW_ARCH == 11 )) && aDEPS+=('make')
 						set -- "$@" cffi
@@ -2653,7 +2655,7 @@ sudo sysctl -p /etc/sysctl.d/dietpi-$1.conf"
 			then
 				G_EXEC curl -sSfo rustup-init.sh 'https://sh.rustup.rs'
 				G_EXEC chmod +x rustup-init.sh
-				G_EXEC_OUTPUT=1 G_EXEC ${user:+runuser -u "$user" --} ./rustup-init.sh -y --profile minimal
+				G_EXEC_OUTPUT=1 G_EXEC ${user:+setpriv --reuid="$user" --regid="$user" --clear-groups --reset-env --} ./rustup-init.sh -y --profile minimal
 				G_EXEC rm rustup-init.sh
 				[[ $user ]] || export PATH="/root/.cargo/bin:$PATH"
 			fi
@@ -3147,7 +3149,7 @@ _EOF_"
 			G_CONFIG_INJECT 'no-cache-dir[[:blank:]]*=' 'no-cache-dir=true' /etc/pip.conf '\[global\]'
 
 			# ARMv6/7: Add piwheels
-			(( $G_HW_ARCH < 3 )) && G_CONFIG_INJECT 'extra-index-url[[:blank:]]*=' 'extra-index-url=https://www.piwheels.org/simple/' /etc/pip.conf '\[global\]'
+			(( $G_HW_ARCH < 3 )) && G_CONFIG_INJECT 'extra-index-url[[:blank:]]*=' 'extra-index-url=https://www.piwheels.org/simple' /etc/pip.conf '\[global\]'
 
 			# Obtain Python version as global variable for use in venv creation and Python_Deps
 			PYTHON_VERSION=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
@@ -4022,7 +4024,7 @@ sudo sysctl -p /etc/sysctl.d/98-dietpi-redis.conf'
 				G_CONFIG_INJECT 'pm.min_spare_servers[[:blank:]=]' "pm.min_spare_servers = $G_HW_CPU_CORES" "/etc/php/$PHP_VERSION/fpm/pool.d/www.conf"
 				G_CONFIG_INJECT 'pm.max_spare_servers[[:blank:]=]' "pm.max_spare_servers = $G_HW_CPU_CORES" "/etc/php/$PHP_VERSION/fpm/pool.d/www.conf"
 				# Set static PATH, not passed by Lighttpd and Nginx by default but required by some web applications: https://github.com/MichaIng/DietPi/issues/5161#issuecomment-1013381362
-				G_CONFIG_INJECT 'env\[PATH\][[:blank:]=]' 'env[PATH] = /usr/local/bin:/usr/bin:/bin' "/etc/php/$PHP_VERSION/fpm/pool.d/www.conf"
+				G_CONFIG_INJECT 'env\[PATH\][[:blank:]=]' 'env[PATH] = /usr/local/bin:/usr/bin' "/etc/php/$PHP_VERSION/fpm/pool.d/www.conf"
 
 				# Force service to start after database servers
 				G_EXEC mkdir -p "/etc/systemd/system/php$PHP_VERSION-fpm.service.d"
@@ -4180,15 +4182,15 @@ _EOF_
 			# Database
 			G_EXEC systemctl start postgresql
 			local synapse_pass=$(tr -dc '[:alnum:]' < /dev/random | head -c30)
-			if [[ $(runuser -u postgres -- psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='synapse'") != 1 ]]
+			if [[ $(setpriv --re{u,g}id='postgres' --clear-groups --reset-env -- psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='synapse'") != 1 ]]
 			then
-				G_EXEC runuser -u postgres -- psql -c "CREATE ROLE synapse WITH LOGIN PASSWORD '$synapse_pass';"
+				G_EXEC setpriv --re{u,g}id='postgres' --clear-groups --reset-env -- psql -c "CREATE ROLE synapse WITH LOGIN PASSWORD '$synapse_pass';"
 			else
-				G_EXEC runuser -u postgres -- psql -c "ALTER ROLE synapse WITH PASSWORD '$synapse_pass';"
+				G_EXEC setpriv --re{u,g}id='postgres' --clear-groups --reset-env -- psql -c "ALTER ROLE synapse WITH PASSWORD '$synapse_pass';"
 			fi
-			if [[ $(runuser -u postgres -- psql -tAc "SELECT 1 FROM pg_database WHERE datname='synapse'") != 1 ]]
+			if [[ $(setpriv --re{u,g}id='postgres' --clear-groups --reset-env -- psql -tAc "SELECT 1 FROM pg_database WHERE datname='synapse'") != 1 ]]
 			then
-				G_EXEC runuser -u postgres -- createdb --encoding=UTF8 --locale=C --template=template0 --owner=synapse synapse
+				G_EXEC setpriv --re{u,g}id='postgres' --clear-groups --reset-env -- createdb --encoding=UTF8 --locale=C --template=template0 --owner=synapse synapse
 			fi
 
 			# Pre-create drop-in config for database access details
@@ -4501,7 +4503,7 @@ sudo sysctl -p /etc/sysctl.d/dietpi-ipfs.conf
 
 			# Configure Poetry
 			# - > The "poetry.dev-dependencies" section is deprecated and will be removed in a future version. Use "poetry.group.dev.dependencies" instead.
-			G_EXEC sed --follow-symlinks -i '/^\[poetry.dev-dependencies\]$/c\[poetry.group.dev.dependencies]' "$micro_data_dir/pyproject.toml"
+			G_EXEC sed --follow-symlinks -i 's/poetry\.dev-dependencies/poetry.group.dev.dependencies/' "$micro_data_dir/pyproject.toml"
 			# - Disable package mode to prevent: "Error: The current project could not be installed: No file/folder found for package microblogpub"
 			G_CONFIG_INJECT 'package-mode[[:blank:]]' 'package-mode = false' "$micro_data_dir/pyproject.toml" '\[tool.poetry\]'
 
@@ -4510,7 +4512,7 @@ sudo sysctl -p /etc/sysctl.d/dietpi-ipfs.conf
 			G_EXEC chown -R "$micro_name:$micro_name" "$micro_data_dir"
 
 			# Dependencies: https://git.sr.ht/~tsileo/microblog.pub/tree/v2/item/pyproject.toml
-			PYTHON_VERSION=$micro_python_version Python_Deps -u "$micro_name" -P pyenv poetry bcrypt brotli greenlet-v113 libsass lxml pillow
+			PYTHON_VERSION=$micro_python_version Python_Deps -P -u "$micro_name" pyenv poetry bcrypt brotli greenlet-v113 libsass lxml pillow
 
 			# Create a Python environment via pyenv
 			# - https://python-poetry.org/docs/managing-environments/
@@ -4532,21 +4534,21 @@ cd $micro_data_dir
 PS1=\"(microblog.pub) \$PS1\"" > "$micro_pyenv_activate_file"
 
 			G_EXEC_DESC="Compiling and installing Python $micro_python_version into pyenv, which will take a while ..."
-			G_EXEC_OUTPUT=1 G_EXEC runuser -u "$micro_name" -- dash -c ". $micro_pyenv_activate_file; exec pyenv install $micro_python_version"
+			G_EXEC_OUTPUT=1 G_EXEC setpriv --re{u,g}id="$micro_name" --clear-groups --reset-env -- dash -c ". $micro_pyenv_activate_file; exec pyenv install $micro_python_version"
 			G_EXEC_DESC="Setting Python $micro_python_version as global version for this pyenv instance"
-			G_EXEC_OUTPUT=1 G_EXEC runuser -u "$micro_name" -- dash -c ". $micro_pyenv_activate_file; exec pyenv global $micro_python_version"
+			G_EXEC_OUTPUT=1 G_EXEC setpriv --re{u,g}id="$micro_name" --clear-groups --reset-env -- dash -c ". $micro_pyenv_activate_file; exec pyenv global $micro_python_version"
 			G_EXEC_DESC='Upgrading base modules: pip setuptools wheel'
-			G_EXEC_OUTPUT=1 G_EXEC runuser -u "$micro_name" -- dash -c ". $micro_pyenv_activate_file; exec pip3 install -U pip setuptools wheel"
+			G_EXEC_OUTPUT=1 G_EXEC setpriv --re{u,g}id="$micro_name" --clear-groups --reset-env -- dash -c ". $micro_pyenv_activate_file; exec pip3 install -U pip setuptools wheel"
 			G_EXEC_DESC='Installing Poetry'
-			G_EXEC_OUTPUT=1 G_EXEC runuser -u "$micro_name" -- dash -c ". $micro_pyenv_activate_file; exec pip3 install poetry"
+			G_EXEC_OUTPUT=1 G_EXEC setpriv --re{u,g}id="$micro_name" --clear-groups --reset-env -- dash -c ". $micro_pyenv_activate_file; exec pip3 install poetry"
 			G_EXEC_DESC='Updating dependency locks'
-			G_EXEC_OUTPUT=1 G_EXEC runuser -u "$micro_name" -- dash -c ". $micro_pyenv_activate_file; exec poetry update --lock"
+			G_EXEC_OUTPUT=1 G_EXEC setpriv --re{u,g}id="$micro_name" --clear-groups --reset-env -- dash -c ". $micro_pyenv_activate_file; exec poetry update --lock"
 			G_EXEC_DESC='Adding setuptools dependency for Poetry needed for config wizard' # <81: /mnt/dietpi_userdata/microblog-pub/.cache/pypoetry/virtualenvs/microblogpub-qTlMHCqJ-py3.11/lib/python3.11/site-packages/boussole/__init__.py:7: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
-			G_EXEC_OUTPUT=1 G_EXEC runuser -u "$micro_name" -- dash -c ". $micro_pyenv_activate_file; exec poetry add --lock 'setuptools<81'"
-			G_EXEC_DESC='Installing microblog.pub'
-			G_EXEC_OUTPUT=1 G_EXEC runuser -u "$micro_name" -- dash -c ". $micro_pyenv_activate_file; exec poetry install"
+			G_EXEC_OUTPUT=1 G_EXEC setpriv --re{u,g}id="$micro_name" --clear-groups --reset-env -- dash -c ". $micro_pyenv_activate_file; exec poetry add --lock 'setuptools<81'"
+			G_EXEC_DESC='Installing microblog.pub' # /usr/sbin needed in PATH to compile pillow 9.5.0, as it otherwise fails to detect zlib: https://github.com/python-pillow/Pillow/commit/ca2bf04
+			G_EXEC_OUTPUT=1 G_EXEC setpriv --re{u,g}id="$micro_name" --clear-groups --reset-env -- dash -c ". $micro_pyenv_activate_file; PATH=\"\$PATH:/usr/sbin\" exec poetry install"
 			G_EXEC_DESC='Storing Poetry virtualenv path'
-			G_EXEC_OUTPUT=1 G_EXEC runuser -u "$micro_name" -- dash -c ". $micro_pyenv_activate_file; poetry env info | grep -Po '(?<=^Path:\s).*/virtualenvs/.*' > '$micro_virtualenv'"
+			G_EXEC_OUTPUT=1 G_EXEC setpriv --re{u,g}id="$micro_name" --clear-groups --reset-env -- dash -c ". $micro_pyenv_activate_file; poetry env info | grep -Po '(?<=^Path:\s).*/virtualenvs/.*' > '$micro_virtualenv'"
 			read -r VENV_DIR < "$micro_virtualenv"
 			# shellcheck disable=SC2016
 			G_EXEC_DESC='Checking Poetry virtualenv path' G_EXEC eval '[[ $VENV_DIR ]]'
@@ -4672,7 +4674,7 @@ _EOF_
 				# Replace password strings internally to avoid printing it to console
 				G_EXEC_PRE_FUNC(){ acommand[11]="$GLOBAL_PW"; }
 				G_EXEC_POST_FUNC(){ sed --follow-symlinks -i "/^ *password/s/:.*/: ${GLOBAL_PW//?/X}/" "$fp_log"; cat "$fp_log"; }
-				G_EXEC runuser -u ocis -- /opt/ocis/ocis init --config-path /mnt/dietpi_userdata/ocis --insecure yes --ap "${GLOBAL_PW//?/X}"
+				G_EXEC setpriv --re{u,g}id='ocis' --clear-groups --reset-env -- /opt/ocis/ocis init --config-path /mnt/dietpi_userdata/ocis --insecure yes --ap "${GLOBAL_PW//?/X}"
 			fi
 
 			# Env file
@@ -4708,7 +4710,7 @@ After=network-online.target
 User=ocis
 # Workaround for failing systemd.automount: https://dietpi.com/forum/t/17463/22
 EnvironmentFile=-/mnt/dietpi_userdata/ocis/ocis.env
-ExecStartPre=/bin/touch /mnt/dietpi_userdata/ocis/ocis.env
+ExecStartPre=/bin/test -e /mnt/dietpi_userdata/ocis/ocis.env
 ExecStart=/opt/ocis/ocis server
 
 # Hardening
@@ -4837,7 +4839,7 @@ location = /.well-known/caldav  { return 301 /nextcloud/remote.php/dav/; }' > /e
 			G_EXEC chown -R www-data:www-data /var/www/nextcloud "$datadir"
 
 			# Add occ command shortcut, added to interactive bash sessions as alias by /etc/bashrc.d/dietpi.bash if /var/www/nextcloud/occ exist
-			occ(){ runuser -u www-data -- php /var/www/nextcloud/occ "$@"; }
+			occ(){ setpriv --re{u,g}id='www-data' --init-groups --reset-env -- php /var/www/nextcloud/occ "$@"; }
 
 			# Adjusting config file
 			local config_php='/var/www/nextcloud/config/config.php'
@@ -6732,13 +6734,13 @@ _EOF_
 			# Install as local instance for "nodered" user
 			G_EXEC cd /mnt/dietpi_userdata/node-red
 			# - Disable cache
-			local cache=$(runuser -u nodered -- mktemp -d)
+			local cache=$(setpriv --re{u,g}id='nodered' --clear-groups --reset-env -- mktemp -d)
 			# - Reinstall: Remove all locally installed modules, to work around update issues, but preserve installed plugins from package.json: https://github.com/MichaIng/DietPi/issues/7128
 			[[ -f 'package.json' ]] && G_EXEC rm -Rf node_modules .npm/_cacache
 			# - Install v3 on ARMv6, since the @node-rs/bcrypt dependency does not support it: https://github.com/MichaIng/DietPi/issues/7252
 			local version='latest'
 			(( $G_HW_ARCH == 1 )) && version=3
-			G_EXEC_OUTPUT=1 G_EXEC runuser -u nodered -- npm i --cache "$cache" --no-audit "node-red@$version"
+			G_EXEC_OUTPUT=1 G_EXEC setpriv --re{u,g}id='nodered' --clear-groups --reset-env -- npm i --cache "$cache" --no-audit "node-red@$version"
 			G_EXEC rm -R "$cache"
 			G_EXEC cd "$G_WORKING_DIR"
 
@@ -7151,12 +7153,12 @@ _EOF_
 
 			# CLI install: https://github.com/FreshRSS/FreshRSS/blob/master/cli/README.md#commands
 			G_EXEC cd /opt/FreshRSS
-			runuser -u www-data -- php ./cli/prepare.php
-			runuser -u www-data -- php ./cli/do-install.php --default_user dietpi --auth_type form --environment production --title FreshRSS --db-type mysql --db-host localhost --db-user freshrss --db-password "$password" --db-base freshrss --db-prefix freshrss
+			setpriv --re{u,g}id='www-data' --clear-groups --reset-env -- php ./cli/prepare.php
+			setpriv --re{u,g}id='www-data' --clear-groups --reset-env -- php ./cli/do-install.php --default_user dietpi --auth_type form --environment production --title FreshRSS --db-type mysql --db-host localhost --db-user freshrss --db-password "$password" --db-base freshrss --db-prefix freshrss
 			unset -v password
-			runuser -u www-data -- php ./cli/create-user.php --user dietpi --password "$GLOBAL_PW" --api_password "$GLOBAL_PW"
-			runuser -u www-data -- php ./cli/actualize-user.php --user dietpi
-			runuser -u www-data -- php ./cli/db-optimize.php --user dietpi
+			setpriv --re{u,g}id='www-data' --clear-groups --reset-env -- php ./cli/create-user.php --user dietpi --password "$GLOBAL_PW" --api_password "$GLOBAL_PW"
+			setpriv --re{u,g}id='www-data' --clear-groups --reset-env -- php ./cli/actualize-user.php --user dietpi
+			setpriv --re{u,g}id='www-data' --clear-groups --reset-env -- php ./cli/db-optimize.php --user dietpi
 			G_EXEC cd "$G_WORKING_DIR"
 
 			# Link web interface to webroot
@@ -8944,7 +8946,7 @@ _EOF_
 				G_EXEC chmod 'g+rwx' /mnt/dietpi_userdata
 
 				# Generate config
-				G_EXEC_OUTPUT=1 G_EXEC runuser -u syncthing -- /opt/syncthing/syncthing generate --home=/mnt/dietpi_userdata/syncthing
+				G_EXEC_OUTPUT=1 G_EXEC setpriv --reuid='syncthing' --regid='dietpi' --clear-groups --reset-env -- /opt/syncthing/syncthing generate --home=/mnt/dietpi_userdata/syncthing
 
 				# Allow remote access: https://docs.syncthing.net/users/faq.html#how-do-i-access-the-web-gui-from-another-computer
 				G_EXEC sed --follow-symlinks -i '\|:8384</address>|c\        <address>0.0.0.0:8384</address>' /mnt/dietpi_userdata/syncthing/config.xml
@@ -9147,9 +9149,9 @@ _EOF_
 			if [[ ${aSOFTWARE_INSTALL_STATE[153]} == 2 && -f '/mnt/dietpi_userdata/octoprint/.octoprint/config.yaml' ]]
 			then
 				G_DIETPI-NOTIFY 2 'Configuring OctoPrint to use mjpg-streamer for webcam support'
-				G_EXEC runuser -u octoprint -- /mnt/dietpi_userdata/octoprint/venv/bin/octoprint config set webcam.stream "http://$(G_GET_NET ip):8082/?action=stream"
-				G_EXEC runuser -u octoprint -- /mnt/dietpi_userdata/octoprint/venv/bin/octoprint config set webcam.snapshot 'http://127.0.0.1:8082/?action=snapshot'
-				G_EXEC runuser -u octoprint -- /mnt/dietpi_userdata/octoprint/venv/bin/octoprint config set webcam.ffmpeg "$(command -v ffmpeg)"
+				G_EXEC setpriv --re{u,g}id='octoprint' --clear-groups --reset-env -- /mnt/dietpi_userdata/octoprint/venv/bin/octoprint config set webcam.stream "http://$(G_GET_NET ip):8082/?action=stream"
+				G_EXEC setpriv --re{u,g}id='octoprint' --clear-groups --reset-env -- /mnt/dietpi_userdata/octoprint/venv/bin/octoprint config set webcam.snapshot 'http://127.0.0.1:8082/?action=snapshot'
+				G_EXEC setpriv --re{u,g}id='octoprint' --clear-groups --reset-env -- /mnt/dietpi_userdata/octoprint/venv/bin/octoprint config set webcam.ffmpeg "$(command -v ffmpeg)"
 			fi
 		fi
 
@@ -9401,8 +9403,8 @@ _EOF_
 			Download_Test_Media
 
 			# Init
-			G_EXEC_OUTPUT=1 G_EXEC runuser -u koel -- "php$PHP_VERSION" artisan koel:init -n --no-assets
-			G_EXEC_OUTPUT=1 G_EXEC runuser -u koel -- "php$PHP_VERSION" artisan koel:sync
+			G_EXEC_OUTPUT=1 G_EXEC setpriv --reuid='koel' --regid='dietpi' --clear-groups --reset-env -- "php$PHP_VERSION" artisan koel:init -n --no-assets
+			G_EXEC_OUTPUT=1 G_EXEC setpriv --reuid='koel' --regid='dietpi' --clear-groups --reset-env -- "php$PHP_VERSION" artisan koel:sync
 			G_EXEC cd "$G_WORKING_DIR"
 
 			# Service: Run on port 8003 by default to avoid conflict with Icecast
@@ -10185,9 +10187,9 @@ _EOF_
 
 			# Install OctoPrint
 			Remove_old_venv /mnt/dietpi_userdata/octoprint/venv
-			G_EXEC runuser -u octoprint -- python3 -m venv --upgrade-deps /mnt/dietpi_userdata/octoprint/venv
+			G_EXEC setpriv --re{u,g}id='octoprint' --clear-groups --reset-env -- python3 -m venv --upgrade-deps /mnt/dietpi_userdata/octoprint/venv
 			# shellcheck disable=SC2016
-			G_EXEC_OUTPUT=1 G_EXEC runuser -u octoprint -- dash -c 'PATH="$HOME/.cargo/bin:$PATH" /mnt/dietpi_userdata/octoprint/venv/bin/pip3 install -U octoprint'
+			G_EXEC_OUTPUT=1 G_EXEC setpriv --re{u,g}id='octoprint' --clear-groups --reset-env -- dash -c 'PATH="$HOME/.cargo/bin:$PATH" /mnt/dietpi_userdata/octoprint/venv/bin/pip3 install -U octoprint'
 
 			# Service: https://github.com/OctoPrint/OctoPrint/blob/master/scripts/octoprint.service
 			cat << '_EOF_' > /etc/systemd/system/octoprint.service
@@ -10209,22 +10211,22 @@ _EOF_
 			echo "alias octoprint='sudo -u octoprint /mnt/dietpi_userdata/octoprint/venv/bin/octoprint'" > /etc/bashrc.d/dietpi-octoprint.sh
 
 			# On fresh installs, change listening port to 5001 to avoid conflict with Shairport Sync.
-			[[ -f '/mnt/dietpi_userdata/octoprint/.octoprint/config.yaml' ]] || G_EXEC runuser -u octoprint -- /mnt/dietpi_userdata/octoprint/venv/bin/octoprint config set server.port '5001'
+			[[ -f '/mnt/dietpi_userdata/octoprint/.octoprint/config.yaml' ]] || G_EXEC setpriv --re{u,g}id='octoprint' --clear-groups --reset-env -- /mnt/dietpi_userdata/octoprint/venv/bin/octoprint config set server.port '5001'
 
 			# Apply service and system commands: Allow execution via specific sudoers config, use "which" for "reboot" and "poweroff", since we create shell functions in dietpi-globals to bypass logind calls if logind is not running.
 			# shellcheck disable=SC2230
 			echo "octoprint ALL=NOPASSWD: $(command -v systemctl) restart octoprint, $(which reboot), $(which poweroff)" > /etc/sudoers.d/octoprint
-			G_EXEC runuser -u octoprint -- /mnt/dietpi_userdata/octoprint/venv/bin/octoprint config set server.commands.serverRestartCommand 'sudo systemctl restart octoprint'
-			G_EXEC runuser -u octoprint -- /mnt/dietpi_userdata/octoprint/venv/bin/octoprint config set server.commands.systemRestartCommand 'sudo reboot'
-			G_EXEC runuser -u octoprint -- /mnt/dietpi_userdata/octoprint/venv/bin/octoprint config set server.commands.systemShutdownCommand 'sudo poweroff'
+			G_EXEC setpriv --re{u,g}id='octoprint' --clear-groups --reset-env -- /mnt/dietpi_userdata/octoprint/venv/bin/octoprint config set server.commands.serverRestartCommand 'sudo systemctl restart octoprint'
+			G_EXEC setpriv --re{u,g}id='octoprint' --clear-groups --reset-env -- /mnt/dietpi_userdata/octoprint/venv/bin/octoprint config set server.commands.systemRestartCommand 'sudo reboot'
+			G_EXEC setpriv --re{u,g}id='octoprint' --clear-groups --reset-env -- /mnt/dietpi_userdata/octoprint/venv/bin/octoprint config set server.commands.systemShutdownCommand 'sudo poweroff'
 
 			# mjpg-streamer: Configure OctoPrint to use it if installed
 			if (( ${aSOFTWARE_INSTALL_STATE[137]} > 0 ))
 			then
 				G_DIETPI-NOTIFY 2 'Configuring OctoPrint to use mjpg-streamer for webcam support'
-				G_EXEC runuser -u octoprint -- /mnt/dietpi_userdata/octoprint/venv/bin/octoprint config set webcam.stream "http://$(G_GET_NET ip):8082/?action=stream"
-				G_EXEC runuser -u octoprint -- /mnt/dietpi_userdata/octoprint/venv/bin/octoprint config set webcam.snapshot 'http://127.0.0.1:8082/?action=snapshot'
-				G_EXEC runuser -u octoprint -- /mnt/dietpi_userdata/octoprint/venv/bin/octoprint config set webcam.ffmpeg "$(command -v ffmpeg)"
+				G_EXEC setpriv --re{u,g}id='octoprint' --clear-groups --reset-env -- /mnt/dietpi_userdata/octoprint/venv/bin/octoprint config set webcam.stream "http://$(G_GET_NET ip):8082/?action=stream"
+				G_EXEC setpriv --re{u,g}id='octoprint' --clear-groups --reset-env -- /mnt/dietpi_userdata/octoprint/venv/bin/octoprint config set webcam.snapshot 'http://127.0.0.1:8082/?action=snapshot'
+				G_EXEC setpriv --re{u,g}id='octoprint' --clear-groups --reset-env -- /mnt/dietpi_userdata/octoprint/venv/bin/octoprint config set webcam.ffmpeg "$(command -v ffmpeg)"
 			fi
 		fi
 
@@ -11253,7 +11255,7 @@ _EOF_'
 			# - Install isal compression library as faster drop-in replacement for zlib, to address a warning by aiohttp_fast_zlib: https://github.com/MichaIng/DietPi/issues/7525
 			local custom_pip_deps=()
 			read -ra custom_pip_deps < <(echo -n 'isal '; sed -n '/^[[:blank:]]*SOFTWARE_HOMEASSISTANT_PIP_DEPS=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-			PYTHON_VERSION=$ha_python_version Python_Deps -u "$ha_user" -i av bcrypt cryptography isal numpy pillow pycares pymicro-vad-v101
+			PYTHON_VERSION=$ha_python_version Python_Deps -P -u "$ha_user" -i av bcrypt cryptography isal numpy pillow pycares pymicro-vad-v101
 
 			# Configure uv
 			# - Disable cache
@@ -11265,11 +11267,11 @@ _EOF_'
 			do
 				[[ $i == .local/bin/python$ha_python_version || ! -f $i ]] && break
 				G_EXEC_DESC='Removing old Python'
-				G_EXEC_OUTPUT=1 G_EXEC runuser -u "$ha_user" -- uv python uninstall --all
+				G_EXEC_OUTPUT=1 G_EXEC setpriv --re{u,g}id="$ha_user" --clear-groups --reset-env -- uv python uninstall --all
 			done
 
 			G_EXEC_DESC='Installing Python'
-			G_EXEC_OUTPUT=1 G_EXEC runuser -u "$ha_user" -- uv python install -U "$ha_python_version"
+			G_EXEC_OUTPUT=1 G_EXEC setpriv --re{u,g}id="$ha_user" --clear-groups --reset-env -- uv python install -U "$ha_python_version"
 
 			# Remove old venv if Python version differs
 			if [[ -d '.venv' && ! -d .venv/lib/python$ha_python_version ]]
@@ -11279,29 +11281,25 @@ _EOF_'
 			fi
 
 			G_EXEC_DESC='Setting up venv'
-			G_EXEC_OUTPUT=1 G_EXEC runuser -u "$ha_user" -- uv venv --allow-existing
+			G_EXEC_OUTPUT=1 G_EXEC setpriv --re{u,g}id="$ha_user" --clear-groups --reset-env -- uv venv --allow-existing
 
 			# Add Rust compiler to PATH if present
-			[[ -d '.cargo/bin' ]] && export PATH="$ha_home/.cargo/bin:$PATH"
+			local ha_env=()
+			[[ -d '.cargo/bin' ]] && ha_env=("PATH=$ha_home/.cargo/bin:/usr/local/bin:/usr/bin")
 
 			G_EXEC_DESC="Installing additional dependencies: ${custom_pip_deps[*]}"
-			G_EXEC_OUTPUT=1 G_EXEC runuser -u "$ha_user" -- uv pip install -U "${custom_pip_deps[@]}"
+			G_EXEC_OUTPUT=1 G_EXEC setpriv --re{u,g}id="$ha_user" --clear-groups --reset-env -- ${ha_env[@]+env -- "${ha_env[@]}"} uv pip install -U "${custom_pip_deps[@]}"
 
 			# ARMv6/RISC-V: Prevent full /tmp, OOM, and extensive swap usage caused mainly by grpcio build
 			if (( $G_HW_ARCH == 1 || $G_HW_ARCH == 11 ))
 			then
-				export GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS=$(( $RAM_PHYS / 1024 ))
-				(( $GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS >= $G_HW_CPU_CORES )) && unset -v GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS
-				(( $(findmnt -nbo SIZE /tmp) < 6000*1024**2 )) && export TMPDIR='/var/tmp'
+				(( $RAM_PHYS / 1024 < $G_HW_CPU_CORES )) && ha_env+=("GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS=$(( $RAM_PHYS / 1024 ))")
+				(( $(findmnt -nbo SIZE /tmp) < 6000*1024**2 )) && ha_env+=('TMPDIR=/var/tmp')
 				Min_Total_Memory 2048
 			fi
 
 			G_EXEC_DESC='Installing Home Assistant core module'
-			G_EXEC_OUTPUT=1 G_EXEC runuser -u "$ha_user" -- uv pip install -U homeassistant
-
-			# Clean env
-			[[ -d '.cargo/bin' ]] && PATH=${PATH#"$ha_home/.cargo/bin:"}
-			(( $G_HW_ARCH == 1 || $G_HW_ARCH == 11 )) && unset -v GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS TMPDIR
+			G_EXEC_OUTPUT=1 G_EXEC setpriv --re{u,g}id="$ha_user" --clear-groups --reset-env -- ${ha_env[@]+env -- "${ha_env[@]}"} uv pip install -U homeassistant
 
 			G_DIETPI-NOTIFY 2 'Linking config and data to /mnt/dietpi_userdata/homeassistant'
 			if [[ ! -d '/mnt/dietpi_userdata/homeassistant' ]]
@@ -11317,9 +11315,7 @@ _EOF_'
 			G_EXEC ln -sf /mnt/dietpi_userdata/homeassistant .homeassistant
 
 			G_DIETPI-NOTIFY 2 'Generating Home Assistant update script'
-			local ha_env=''
-			[[ -d '.cargo/bin' ]] && ha_env=" PATH=\"$ha_home/.cargo/bin:\$PATH\""
-			G_EXEC eval "echo -e '#!/bin/dash\nexec sudo -u $ha_user$ha_env uv pip install --directory '$ha_home' -U homeassistant' > homeassistant-update.sh"
+			G_EXEC eval "echo -e '#!/bin/dash\nexec sudo -u $ha_user${ha_env[*]:+ ${ha_env[*]}} uv pip install --directory '$ha_home' -U homeassistant' > homeassistant-update.sh"
 			G_EXEC chmod +x homeassistant-update.sh
 
 			# Service
@@ -12030,7 +12026,7 @@ StartLimitBurst=3
 User=whodb
 # Workaround for failing systemd.automount: https://dietpi.com/forum/t/17463/22
 EnvironmentFile=-/mnt/dietpi_userdata/whodb/whodb.env
-ExecStartPre=/bin/touch /mnt/dietpi_userdata/whodb/whodb.env
+ExecStartPre=/bin/test -e /mnt/dietpi_userdata/whodb/whodb.env
 ExecStart=/opt/whodb/whodb
 Restart=on-failure
 RestartSec=5
@@ -12158,16 +12154,16 @@ _EOF_
 
 			# Database
 			local immich_pass=$(tr -dc '[:alnum:]' < /dev/random | head -c30)
-			if [[ $(runuser -u postgres -- psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='immich'") != 1 ]]
+			if [[ $(setpriv --re{u,g}id='postgres' --clear-groups --reset-env -- psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='immich'") != 1 ]]
 			then
-				G_EXEC runuser -u postgres -- psql -c "CREATE ROLE immich WITH LOGIN PASSWORD '$immich_pass';"
-				G_EXEC runuser -u postgres -- psql -c "ALTER ROLE immich SUPERUSER;"
+				G_EXEC setpriv --re{u,g}id='postgres' --clear-groups --reset-env -- psql -c "CREATE ROLE immich WITH LOGIN PASSWORD '$immich_pass';"
+				G_EXEC setpriv --re{u,g}id='postgres' --clear-groups --reset-env -- psql -c "ALTER ROLE immich SUPERUSER;"
 			else
-				G_EXEC runuser -u postgres -- psql -c "ALTER ROLE immich WITH PASSWORD '$immich_pass' SUPERUSER;"
+				G_EXEC setpriv --re{u,g}id='postgres' --clear-groups --reset-env -- psql -c "ALTER ROLE immich WITH PASSWORD '$immich_pass' SUPERUSER;"
 			fi
-			if [[ $(runuser -u postgres -- psql -tAc "SELECT 1 FROM pg_database WHERE datname='immich'") != 1 ]]
+			if [[ $(setpriv --re{u,g}id='postgres' --clear-groups --reset-env -- psql -tAc "SELECT 1 FROM pg_database WHERE datname='immich'") != 1 ]]
 			then
-				G_EXEC runuser -u postgres -- createdb --owner=immich immich
+				G_EXEC setpriv --re{u,g}id='postgres' --clear-groups --reset-env -- createdb --owner=immich immich
 			fi
 
 			# Env file
@@ -12222,7 +12218,7 @@ User=immich
 Environment=NO_COLOR=true IMMICH_BUILD_DATA=/opt/immich IMMICH_MEDIA_LOCATION=/mnt/dietpi_userdata/immich
 # Workaround for failing systemd.automount: https://dietpi.com/forum/t/17463/22
 EnvironmentFile=-/mnt/dietpi_userdata/immich/immich.env
-ExecStartPre=/bin/touch /mnt/dietpi_userdata/immich/immich.env
+ExecStartPre=/bin/test -e /mnt/dietpi_userdata/immich/immich.env
 ExecStart=/usr/local/bin/node /opt/immich/dist/main
 
 # Hardening
@@ -12312,10 +12308,10 @@ After=network-online.target
 [Service]
 SyslogIdentifier=Immich-ML
 User=immich-ml
-Environment=NO_COLOR=true PATH='/opt/immich-ml/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' GUNICORN_CMD_ARGS='--no-control-socket'
+Environment=NO_COLOR=true PATH='/opt/immich-ml/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin' GUNICORN_CMD_ARGS='--no-control-socket'
 # Workaround for failing systemd.automount: https://dietpi.com/forum/t/17463/22
 EnvironmentFile=-/mnt/dietpi_userdata/immich-ml/immich-ml.env
-ExecStartPre=/bin/touch /mnt/dietpi_userdata/immich-ml/immich-ml.env
+ExecStartPre=/bin/test -e /mnt/dietpi_userdata/immich-ml/immich-ml.env
 ExecStart=/opt/immich-ml/bin/python -m immich_ml
 
 # Hardening
@@ -12457,7 +12453,7 @@ _EOF_
 				# Initial call to generate ~/.config/birdnet-go/config.yaml
 				# - Needs to be done in $bnet_data to prevent logs dir generation failure in working dir.
 				G_EXEC cd "$bnet_data"
-				G_EXEC runuser -u "$bnet_user" -- "$bnet_inst/birdnet-go"
+				G_EXEC setpriv --re{u,g}id="$bnet_user" --clear-groups --reset-env -- "$bnet_inst/birdnet-go"
 				G_EXEC cd "$G_WORKING_DIR"
 				# Replace paths, otherwise defaults to the working directory
 				# Disable MQTT and CPU/memory/disk monitoring
@@ -12598,7 +12594,7 @@ User=rustdesk
 WorkingDirectory=$rd_data
 # Workaround for failing systemd.automount: https://dietpi.com/forum/t/17463/22
 EnvironmentFile=-$rd_data/signal.env
-ExecStartPre=/bin/touch $rd_data/signal.env
+ExecStartPre=/bin/test -e $rd_data/signal.env
 ExecStart=$rd_inst/hbbs
 Restart=on-failure
 RestartSec=5
@@ -12634,7 +12630,7 @@ User=rustdesk
 WorkingDirectory=$rd_data
 # Workaround for failing systemd.automount: https://dietpi.com/forum/t/17463/22
 EnvironmentFile=-$rd_data/relay.env
-ExecStartPre=/bin/touch $rd_data/relay.env
+ExecStartPre=/bin/test -e $rd_data/relay.env
 ExecStart=$rd_inst/hbbr
 Restart=on-failure
 RestartSec=5
@@ -12973,8 +12969,8 @@ _EOF_
 			systemctl start redis-server
 			if systemctl start mariadb
 			then
-				runuser -u www-data -- php /var/www/nextcloud/occ maintenance:mode --off
-				runuser -u www-data -- php /var/www/nextcloud/occ app:disable spreed
+				setpriv --re{u,g}id='www-data' --init-groups --reset-env -- php /var/www/nextcloud/occ maintenance:mode --off
+				setpriv --re{u,g}id='www-data' --init-groups --reset-env -- php /var/www/nextcloud/occ app:disable spreed
 			fi
 			G_DIETPI-NOTIFY 2 'Disabled Nextcloud Talk app, but you need to remove it manually from Nextcloud web UI if desired.'
 		fi
@@ -13244,8 +13240,8 @@ _EOF_
 			G_EXEC rm -Rf /opt/synapse
 			G_EXEC rm -Rf /mnt/dietpi_userdata/synapse
 
-			command -v dropdb > /dev/null && runuser -u postgres -- dropdb synapse
-			command -v dropuser > /dev/null && runuser -u postgres -- dropuser synapse
+			command -v dropdb > /dev/null && setpriv --re{u,g}id='postgres' --clear-groups --reset-env -- dropdb synapse
+			command -v dropuser > /dev/null && setpriv --re{u,g}id='postgres' --clear-groups --reset-env -- dropuser synapse
 		fi
 
 		if To_Uninstall 132 # Aria2
@@ -14855,8 +14851,8 @@ _EOF_
 			G_EXEC rm -f /etc/postgresql/*/main/conf.d/dietpi-immich.conf
 			G_AGP 'postgresql-*-vchord' 'postgresql-*-pgvector'
 			G_EXEC_NOHALT=1 G_EXEC systemctl restart postgresql
-			command -v dropdb > /dev/null && runuser -u postgres -- dropdb immich 2> /dev/null
-			command -v dropuser > /dev/null && runuser -u postgres -- dropuser immich 2> /dev/null
+			command -v dropdb > /dev/null && setpriv --re{u,g}id='postgres' --clear-groups --reset-env -- dropdb immich 2> /dev/null
+			command -v dropuser > /dev/null && setpriv --re{u,g}id='postgres' --clear-groups --reset-env -- dropuser immich 2> /dev/null
 			[[ -d '/mnt/dietpi_userdata/immich' ]] && G_WHIP_BUTTON_CANCEL_TEXT='Skip' G_WHIP_YESNO "Shall all ${aSOFTWARE_NAME[$software_id]} data at /mnt/dietpi_userdata/immich be removed as well?" && G_EXEC rm -R /mnt/dietpi_userdata/immich
 		fi
 


### PR DESCRIPTION
- `runuser` preserves the environment, and has no option to reset it without initializing a login shell (which fails for `nologin` users).

  This solves e.g. the issue that `runuser -u user -- uv python install` prefers `XDG_DATA_HOME` over the user's home dir as Python install target. It makes sense from security aspect, too, and `setpriv` performs faster than `runuser`, as it skips the PAM session. Call `env` explicitly to pass specific variables, and `--clear-groups` by default, or `--init-groups` if we know that we require a supplemental group, like `redis` for Nextcloud `occ` calls.

- Additionally, this fixes obtaining Synapse dependencies, and updates lxml and pillow dependencies, now available for Python 3.13 on piwheels.

- Disable mjpg-streamer for Forky, due to incompatibility with its cmake.

- Replace `/bin/touch` to trigger `x-systemd.automount` for `EnvironmentFile` in systemd units with `/bin/test -e`. The service user does not always have write permissions, and we do not want to bump the mtime of the file anyway.

- Add `ProtectProc=`, `NoExecPaths=`, and `ExecPaths=` to workaround for systemd sandboxing with QEMU on Forky.

- Allow setuid/setgid bits to function inside the container, required for recent Koel to add its cron job.

- `/sbin` and `/bin` are removed from PATH where we set it. All our images are usr-merged, enforeced by Debian since Bookworm.

Test installs: https://github.com/MichaIng/DietPi/actions/runs/25060637144