### PR TITLE
DietPi-Software | Immich Machine Learning: Add missing cache environment variables

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12291,6 +12291,10 @@ IMMICH_LOG_LEVEL=warn
 
 # Cache directory for downloaded AI model files
 MACHINE_LEARNING_CACHE_FOLDER=/mnt/dietpi_userdata/immich-ml/cache
+HF_HOME=/mnt/dietpi_userdata/immich-ml/cache
+TRANSFORMERS_CACHE=/mnt/dietpi_userdata/immich-ml/cache
+XDG_CACHE_HOME=/mnt/dietpi_userdata/immich-ml/cache
+
 _EOF_
 			# Enable machine learning in Immich server config if present (no-op for standalone ML setups)
 			if [[ -f '/mnt/dietpi_userdata/immich/immich.env' ]]


### PR DESCRIPTION
**Describe the bug/issue:**
Currently, when installing Immich natively via `dietpi-software`, the `immich-ml` service crashes on startup with a `TypeError: argument should be a str... not 'NoneType'` error. This happens because the native Python installation lacks the implicit environment variables for the HuggingFace and Transformers cache directories (which are normally present in Docker setups).

**Solution:**
Added `HF_HOME`, `TRANSFORMERS_CACHE`, and `XDG_CACHE_HOME` environment variables to the `immich-ml.env` creation block, pointing them to the software's cache folder. This allows the AI models to download successfully and prevents the service from crashing.