### PR TITLE
dietpi-software: Tor: Set AvoidDiskWrites

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5914,6 +5914,7 @@ _EOF_
 
 			G_EXEC eval 'echo '\''ControlPort 9051'\'' >> /etc/tor/torrc'
 			G_EXEC eval 'echo '\''CookieAuthentication 1'\'' >> /etc/tor/torrc'
+			G_EXEC eval 'echo '\''AvoidDiskWrites 1'\'' >> /etc/tor/torrc'
 			[[ $nickname ]] && G_EXEC eval "echo 'Nickname $nickname' >> /etc/tor/torrc"
 			[[ $email ]] && G_EXEC eval "echo 'ContactInfo $email' >> /etc/tor/torrc"
 			[[ $ipv6 ]] && G_EXEC eval "echo 'ORPort [$ipv6]:$orport' >> /etc/tor/torrc"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -8024,13 +8024,14 @@ _EOF_
 			Remove_SysV tor 1
 
 			# Tor config
-			cat << '_EOF_' > /etc/tor/torrc
+			cat << '_EOF_' > /etc/tor/torrc || exit 1
 Log notice stdout
 VirtualAddrNetwork 10.192.0.0/10
 AutomapHostsSuffixes .onion,.exit
 AutomapHostsOnResolve 1
 TransPort 192.168.42.1:9040
 DNSPort 192.168.42.1:53
+AvoidDiskWrites 1
 _EOF_
 			# Flush iptables
 			iptables -F


### PR DESCRIPTION
From the Tor manual: If non-zero, try to write to disk less frequently than we would otherwise. This is useful when running on flash memory or other media that support only a limited number of writes.