### PR TITLE
Fix/ocis installation

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ v10.5
 Enhancements:
 
 Bug fixes:
+- DietPI-Software | ownCloud Infinite Scale: Resolved a v10.4 regression where on fresh installs, login via intended password failed, since the command argument was falsely added. Many thanks to @tonosama for reporting this issue, and @JappeHallunken for fixing it: https://dietpi.com/forum/t/25235
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/XXXX
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -4672,7 +4672,7 @@ _EOF_
 			if [[ ! -f '/mnt/dietpi_userdata/ocis/ocis.yaml' ]]
 			then
 				# Replace password strings internally to avoid printing it to console
-				G_EXEC_PRE_FUNC(){ acommand[11]="$GLOBAL_PW"; }
+				G_EXEC_PRE_FUNC(){ acommand[13]="$GLOBAL_PW"; }
 				G_EXEC_POST_FUNC(){ sed --follow-symlinks -i "/^ *password/s/:.*/: ${GLOBAL_PW//?/X}/" "$fp_log"; cat "$fp_log"; }
 				G_EXEC setpriv --re{u,g}id='ocis' --clear-groups --reset-env -- /opt/ocis/ocis init --config-path /mnt/dietpi_userdata/ocis --insecure yes --ap "${GLOBAL_PW//?/X}"
 			fi


### PR DESCRIPTION
This PR fixes a issue with the OwnCloud Infinite Scale installation reported by a user ([](https://dietpi.com/forum/t/ocis-owncloud-i-s-yields-invalid-credentials-error-post-fresh-instal-dietpis-pass-not-working/25235/2)

The installer masked the password in the command line and then restored the real value via `G_EXEC_PRE_FUNC`, but it replaced the wrong argument index. As a result, ocis init did not receive the intended admin password for` --ap`.