### PR TITLE
dietpi-config: display options rework

### DIFF
--- a/.build/images/RPi/config.txt
+++ b/.build/images/RPi/config.txt
@@ -2,16 +2,12 @@
 # Overlays: https://github.com/raspberrypi/firmware/blob/master/boot/overlays/README
 
 #-------Display---------
-# Max allocated framebuffers: Set to "0" in headless mode to reduce memory usage
-# - Defaults to "2" on RPi4 and "1" on earlier RPi models
-#max_framebuffers=0
-
 # If you get no picture, set the following to "1" to apply most compatible HDMI settings.
 #hdmi_safe=1
 
 # Uncomment to adjust the HDMI signal strength if you have interferences, blanking, or no display.
 # - Ranges from "0" to "11", use values above "7" only if required, e.g. with very long HDMI cable.
-# - Default on first RPi1 A/B is "2", else "5", on RPi4 this setting is ignored.
+# - Defaults to "2" on first RPi1 A/B, else "5". From RPi4 on, this setting is ignored.
 #config_hdmi_boost=5
 
 # Uncomment if HDMI display is not detected and composite is being outputted.
@@ -20,25 +16,14 @@
 # Uncomment to disable HDMI even if plugged, e.g. to force composite output.
 #hdmi_ignore_hotplug=1
 
-# Uncomment to force a console size. By default it will be display's size minus overscan.
-#framebuffer_width=1280
-#framebuffer_height=720
-
-# Uncomment to enable SDTV/composite output on RPi4. This has no effect on previous RPi models.
+# Uncomment to enable SDTV/composite output from RPi4 on. This has no effect on previous RPi models.
 #enable_tvout=1
-# SDTV mode
-#sdtv_mode=0
-
-# Uncomment to force a specific HDMI mode (this will force VGA).
-#hdmi_group=1
-#hdmi_mode=1
 
 # Uncomment to force an HDMI mode rather than DVI. This enables HDMI audio in DMT modes.
 #hdmi_drive=2
 
 # Set "hdmi_blanking=1" to allow the display going into standby after 10 minutes without input.
 # With default value "0", the display shows a blank screen instead, but will not go into standby.
-# NB: Some legacy OpenMAX applications (OMXPlayer) cannot wake screens from real standby.
 hdmi_blanking=1
 
 # Set to "1" if your display has a black border of unused pixels visible.
@@ -51,9 +36,12 @@ disable_overscan=1
 #overscan_top=16
 #overscan_bottom=16
 
-# Rotation
-#display_hdmi_rotate=0
+# LCD/OLED Rotation
 #lcd_rotate=0
+
+# Enable KMS/DRM display driver, recommended when a GUI application or desktop is used.
+# Remove ",noaudio" if HDMI audio is needed, or enable it via dietpi-config.
+#dtoverlay=vc4-kms-v3d,noaudio
 
 #-------RPi camera module-------
 #start_x=1

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,7 +2,9 @@ v10.5
 (2026-06-13)
 
 Enhancements:
-- RustDesk Client | It has been enabled for the ARMv7 architecture after the latest release fixed package compatibility with Debian time64 transitioned packages.
+- Raspberry Pi | KMS/DRM is now enabled by default whenever a GUI application or desktop environment is installed via dietpi-software, and it can be toggled with a new dedicated dietpi-config display options entry. After several libraries for the legacy GPU firmware driver have been removed, using it has almost only downsides. Any application which made use of its features, like OpenMAX, DispmanX, and MMAL, cannot work anymore on any supported Raspberry Pi repository version.
+- DietPi-Config | The display menu has been reworked: dietpi-display is now the standard tool to configure display resolution/mode and rotation, the device-specific resolution menus for Raspberry Pi and Odroids have been removed, along with other legacy and dysfunctional options, namely RPi headless mode, HDMI rotation (now included in dietpi-display), and PSU noise reduction. Like possible only on VMs before, it is now additionally possible on any system with GRUB bootloader, to configure the GRUB terminal and early boot console resolution, before the KMS video mode configured via dietpi-display applies.
+- DietPi-Software | RustDesk Client: It has been enabled for the ARMv7 architecture after the latest release fixed package compatibility with Debian time64 transitioned packages.
 
 Bug fixes:
 - DietPi-Config | Resolved an issue where the RTC mode option within Advanced Options was never shown, because the presence of /dev/rtc* was checked incorrectly. Many thanks to @TheRaven500 for reporting this issue: https://github.com/MichaIng/DietPi/issues/7721#issuecomment-4649733270

--- a/dietpi.txt
+++ b/dietpi.txt
@@ -59,9 +59,6 @@ AUTO_SETUP_SWAPFILE_SIZE=1
 # Swap space location: "zram" => swap space on /dev/zram0 (auto-size = 50% of RAM size) | /path/to/file => swap file at location (auto-size = 2 GiB minus RAM size)
 AUTO_SETUP_SWAPFILE_LOCATION=/var/swap
 
-# Set to "1" to disable HDMI/video output and framebuffers on Raspberry Pi, to reduce power consumption and memory usage: Works on RPi only!
-AUTO_SETUP_HEADLESS=0
-
 # Serial console: Set to "0" if you do not require a serial console. It will then be disabled automatically on first boot.
 # - If you leave it at "1", and first login does not happen on a serial console, a dialogue offers to disable it instead.
 CONFIG_SERIAL_CONSOLE_ENABLE=1

--- a/dietpi/dietpi-autostart
+++ b/dietpi/dietpi-autostart
@@ -103,7 +103,7 @@ _EOF_
 			command -v X > /dev/null || { G_WHIP_MSG '[FAILED] No X server has been found\n\nLightDM requires an X server. Please install a desktop or other X application first.'; return 1; }
 			G_AG_CHECK_INSTALL_PREREQ lightdm
 			# Raspberry Pi Trixie: Requires KMS/DRM: https://github.com/MichaIng/DietPi/issues/7644#issuecomment-3229785538
-			(( $G_DISTRO < 8 || $G_HW_MODEL > 9 )) || grep -Eq '^[[:blank:]]*dtoverlay=vc4-f?kms-v3d' /boot/firmware/config.txt || /boot/dietpi/func/dietpi-set_hardware rpi-opengl vc4-kms-v3d
+			(( $G_DISTRO < 8 || $G_HW_MODEL > 9 )) || /boot/dietpi/func/dietpi-set_hardware rpi-opengl 1
 			# graphical.target Wants=display-manager.service
 			G_EXEC ln -sf /lib/systemd/system/lightdm.service /etc/systemd/system/display-manager.service
 
@@ -154,7 +154,7 @@ _EOF_
 				command -v X > /dev/null || { G_WHIP_MSG '[FAILED] No X server has been found\n\nDesktop autologin requires an X server. Please install a desktop or other X application first.'; return 1; }
 				G_AG_CHECK_INSTALL_PREREQ lightdm
 				# Raspberry Pi Trixie: Requires KMS/DRM: https://github.com/MichaIng/DietPi/issues/7644#issuecomment-3229785538
-				(( $G_DISTRO < 8 || $G_HW_MODEL > 9 )) || grep -Eq '^[[:blank:]]*dtoverlay=vc4-f?kms-v3d' /boot/firmware/config.txt || /boot/dietpi/func/dietpi-set_hardware rpi-opengl vc4-kms-v3d
+				(( $G_DISTRO < 8 || $G_HW_MODEL > 9 )) || /boot/dietpi/func/dietpi-set_hardware rpi-opengl 1
 				# graphical.target Wants=display-manager.service
 				G_EXEC ln -sf /lib/systemd/system/lightdm.service /etc/systemd/system/display-manager.service
 

--- a/dietpi/dietpi-config
+++ b/dietpi/dietpi-config
@@ -90,76 +90,62 @@
 		esac
 	}
 
-	# $1: 0=landscape 1=portrait
-	Display_Rotation_Calc_XY_Invert()
-	{
-		local framebuffer_x=$(grep -m1 '^[[:blank:]]*framebuffer_width=' /boot/firmware/config.txt || vcgencmd get_config framebuffer_width)
-		framebuffer_x=${framebuffer_x#*=}; framebuffer_x=${framebuffer_x:-0}
-		local framebuffer_y=$(grep -m1 '^[[:blank:]]*framebuffer_height=' /boot/firmware/config.txt || vcgencmd get_config framebuffer_height)
-		framebuffer_y=${framebuffer_y#*=}; framebuffer_y=${framebuffer_y:-0}
-
-		# 0/180 landscape
-		if (( $1 == 0 && $framebuffer_x < $framebuffer_y ))
-		then
-			G_CONFIG_INJECT 'framebuffer_width=' "framebuffer_width=$framebuffer_y" /boot/firmware/config.txt
-			G_CONFIG_INJECT 'framebuffer_height=' "framebuffer_height=$framebuffer_x" /boot/firmware/config.txt
-
-		# 90/270 portrait
-		elif (( $1 == 1 && $framebuffer_x > $framebuffer_y ))
-		then
-			G_CONFIG_INJECT 'framebuffer_width=' "framebuffer_width=$framebuffer_y" /boot/firmware/config.txt
-			G_CONFIG_INJECT 'framebuffer_height=' "framebuffer_height=$framebuffer_x" /boot/firmware/config.txt
-		fi
-	}
-
 	# TARGETMENUID=1
 	Menu_DisplayOptions()
 	{
-		# DietPi-Display (beta)
-		G_WHIP_MENU_ARRAY=('0' ': DietPi-Display mode and rotation (beta)')
-		# Driver/Resolution
+		# DietPi-Display
+		G_WHIP_MENU_ARRAY=(0 ': Display Resolution and Rotation')
+
+		# GRUB terminal Resolution
+		if dpkg-query -s 'grub2-common' 2> /dev/null | grep -q '^Status: install ok installed$'
+		then
+			local grub_resolution=$(sed -n '/^[[:blank:]]*GRUB_GFXMODE=/{s/^[^=]*=//p;q}' /etc/default/grub)
+			G_WHIP_MENU_ARRAY+=(101 ": GRUB Terminal Resolution: [${grub_resolution:=System default}]")
+		fi
+
+		# GPU driver
 		if (( $G_HW_MODEL == 21 ))
 		then
-			G_WHIP_MENU_ARRAY+=('1' ': Display Driver')
-		else
-			G_WHIP_MENU_ARRAY+=('1' ': Display Resolution')
+			local gpu_driver=$(sed -n '/^[[:blank:]]*CONFIG_GPU_DRIVER=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+			G_WHIP_MENU_ARRAY+=(102 ": Display Driver: [${gpu_driver:=none}]")
 
-			if (( $G_HW_MODEL < 20 ))
-			then
-				local lcdpanel_text=$(sed -n '/^[[:blank:]]*CONFIG_LCDPANEL=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-				G_WHIP_MENU_ARRAY+=('3' ": LCD/OLED Panel addon: [${lcdpanel_text:=none}]")
-			fi
+		# LCD/OLED/DSI panels
+		elif (( $G_HW_MODEL < 20 ))
+		then
+			local lcdpanel_text=$(sed -n '/^[[:blank:]]*CONFIG_LCDPANEL=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+			G_WHIP_MENU_ARRAY+=(3 ": LCD/OLED Panel addon: [${lcdpanel_text:=none}]")
 		fi
 
 		# Brightness
-		G_WHIP_MENU_ARRAY+=('16' ': Display Brightness')
+		G_WHIP_MENU_ARRAY+=(16 ': Display Brightness')
 
 		# X11 DPI
 		local xorg_dpi_current=$(sed -n '/^[[:blank:]]*SOFTWARE_XORG_DPI=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-		G_WHIP_MENU_ARRAY+=('17' ": X.Org DPI: [${xorg_dpi_current:-N/A}]")
+		G_WHIP_MENU_ARRAY+=(17 ": X.Org DPI: [${xorg_dpi_current:-N/A}]")
 
 		# LED control: Hide on VM/container
-		(( $G_HW_MODEL == 20 || $G_HW_MODEL == 75 )) || G_WHIP_MENU_ARRAY+=('14' ': LED Control')
+		(( $G_HW_MODEL == 20 || $G_HW_MODEL == 75 )) || G_WHIP_MENU_ARRAY+=(14 ': LED Control')
 
 		# RPi only
 		if (( $G_HW_MODEL < 10 ))
 		then
-			# GPU memory split
-			G_WHIP_MENU_ARRAY+=('2' ': GPU/RAM memory split')
+			# DRM/KMS
+			local kmsdrm_enabled=0 kmsdrm_text='Off'
+			grep -Eq '^[[:blank:]]*dtoverlay=vc4-f?kms-v3d(-pi4)?(,|$)' /boot/firmware/config.txt && kmsdrm_enabled=1 kmsdrm_text='On'
+			G_WHIP_MENU_ARRAY+=(103 ": KMS/DRM             : [$kmsdrm_text]")
 
-			# HDMI rotation
-			local rotation_hdmi_current=$(sed -n '/^[[:blank:]]*display_hdmi_rotate=/{s/^[^=]*=//p;q}' /boot/firmware/config.txt)
-			G_WHIP_MENU_ARRAY+=('4' ": Rotation (HDMI)     : [${rotation_hdmi_current:=0}]")
+			# GPU memory split
+			G_WHIP_MENU_ARRAY+=(2 ': GPU/RAM memory split')
 
 			# LCD rotation
 			local rotation_lcd_current=$(sed -n '/^[[:blank:]]*lcd_rotate=/{s/^[^=]*=//p;q}' /boot/firmware/config.txt)
-			G_WHIP_MENU_ARRAY+=('5' ": Rotation (LCD)      : [${rotation_lcd_current:=0}]")
+			G_WHIP_MENU_ARRAY+=(5 ": LCD/OLED Rotation   : [${rotation_lcd_current:=0}]")
 
 			# Display overscan
 			local overscan_disabled=$(grep -cm1 '^[[:blank:]]*disable_overscan=1' /boot/firmware/config.txt)
 			local overscan_text='On'
 			(( $overscan_disabled )) && overscan_text='Off'
-			G_WHIP_MENU_ARRAY+=('6' ": Overscan            : [$overscan_text]")
+			G_WHIP_MENU_ARRAY+=(6 ": Overscan            : [$overscan_text]")
 			# - Overscan sizes
 			if (( ! $overscan_disabled ))
 			then
@@ -168,45 +154,45 @@
 				local overscan_right=$(grep -m1 '^[[:blank:]]*overscan_right=' /boot/firmware/config.txt || vcgencmd get_config overscan_right); overscan_right=${overscan_right#*=}
 				local overscan_top=$(grep -m1 '^[[:blank:]]*overscan_top=' /boot/firmware/config.txt || vcgencmd get_config overscan_top); overscan_top=${overscan_top#*=}
 				local overscan_bottom=$(grep -m1 '^[[:blank:]]*overscan_bottom=' /boot/firmware/config.txt || vcgencmd get_config overscan_bottom); overscan_bottom=${overscan_bottom#*=}
-				G_WHIP_MENU_ARRAY+=('15' ": Overscan Compensation [L:${overscan_left:-N/A}] [R:${overscan_right:-N/A}] [T:${overscan_top:-N/A}] [B:${overscan_bottom:-N/A}]")
+				G_WHIP_MENU_ARRAY+=(15 ": Overscan Compensation [L:${overscan_left:-N/A}] [R:${overscan_right:-N/A}] [T:${overscan_top:-N/A}] [B:${overscan_bottom:-N/A}]")
 			fi
 
 			# HDMI signal boost, RPi up to 3 only
 			if (( $G_HW_MODEL < 4 ))
 			then
 				local hdmi_boost_current=$(grep -m1 '^[[:blank:]]*config_hdmi_boost=' /boot/firmware/config.txt || vcgencmd get_config config_hdmi_boost); hdmi_boost_current=${hdmi_boost_current#*=}
-				G_WHIP_MENU_ARRAY+=('7'	": HDMI Boost          : [${hdmi_boost_current:-N/A}]")
+				G_WHIP_MENU_ARRAY+=(7 ": HDMI Boost          : [${hdmi_boost_current:-N/A}]")
 			fi
 
 			# RPi codecs
 			local rpi_codecs_enabled=0 rpi_codecs_text='Off'
 			[[ -f '/etc/modprobe.d/dietpi-disable_rpi_codec.conf' ]] || rpi_codecs_enabled=1 rpi_codecs_text='On'
-			G_WHIP_MENU_ARRAY+=('18' ": RPi Codecs          : [$rpi_codecs_text] V4L2 hardware video codecs")
+			G_WHIP_MENU_ARRAY+=(18 ": RPi Codecs          : [$rpi_codecs_text] V4L2 hardware video codecs")
 
 			# RPi camera module
 			local rpi_camera_module_enabled=$(grep -cm1 '^[[:blank:]]*start_x=1' /boot/firmware/config.txt)
 			local rpi_camera_module_text='Off'
 			(( $rpi_camera_module_enabled )) && rpi_camera_module_text='On'
-			G_WHIP_MENU_ARRAY+=('8' ": RPi Camera          : [$rpi_camera_module_text]")
+			G_WHIP_MENU_ARRAY+=(8 ": RPi Camera          : [$rpi_camera_module_text]")
 
 			# RPi camera LED
 			local rpi_camera_led_disabled=$(grep -cm1 '^[[:blank:]]*disable_camera_led=1' /boot/firmware/config.txt)
 			local rpi_camera_led_text='On'
 			(( $rpi_camera_led_disabled )) && rpi_camera_led_text='Off'
-			G_WHIP_MENU_ARRAY+=('9' ": RPi Camera LED      : [$rpi_camera_led_text]")
+			G_WHIP_MENU_ARRAY+=(9 ": RPi Camera LED      : [$rpi_camera_led_text]")
 
 			# JustBoom IR Remote
 			local justboom_ir_remote_text='Off' justboom_ir_remote_enabled=0
 			[[ -f '/etc/systemd/system/justboom-ir-mpd.service' ]] && justboom_ir_remote_text='On' justboom_ir_remote_enabled=1
-			G_WHIP_MENU_ARRAY+=('11' ": JustBoom IR remote  : [$justboom_ir_remote_text]")
+			G_WHIP_MENU_ARRAY+=(11 ": JustBoom IR remote  : [$justboom_ir_remote_text]")
 
 			# VC1 key
 			local vc1_key_current=$(sed -n '/^[[:blank:]]*decode_WVC1=/{s/^[^=]*=//p;q}' /boot/firmware/config.txt)
-			G_WHIP_MENU_ARRAY+=('12' ": VC1 Key             : [${vc1_key_current:-none}]")
+			G_WHIP_MENU_ARRAY+=(12 ": VC1 Key             : [${vc1_key_current:-none}]")
 
 			# MPEG2 key
 			local mpeg2_key_current=$(sed -n '/^[[:blank:]]*decode_MPG2=/{s/^[^=]*=//p;q}' /boot/firmware/config.txt)
-			G_WHIP_MENU_ARRAY+=('13' ": MPEG2 Key           : [${mpeg2_key_current:-none}]")
+			G_WHIP_MENU_ARRAY+=(13 ": MPEG2 Key           : [${mpeg2_key_current:-none}]")
 
 		# Odroids only
 		elif (( $G_HW_MODEL < 13 ))
@@ -219,503 +205,325 @@
 				odroid_remote_text='On'
 				odroid_remote_enabled=1
 			fi
-			G_WHIP_MENU_ARRAY+=('10' ": Odroid remote : [$odroid_remote_text]")
+			G_WHIP_MENU_ARRAY+=(10 ": Odroid remote : [$odroid_remote_text]")
 		fi
 
 		G_WHIP_DEFAULT_ITEM=$WHIP_SELECTION_PREVIOUS
 		G_WHIP_MENU 'Please select an option:' || { Back_or_Exit 0; return 0; } # Main menu
 		WHIP_SELECTION_PREVIOUS=$G_WHIP_RETURNED_VALUE
 
-		if (( $G_WHIP_RETURNED_VALUE == 0 ))
-		then
-			/boot/dietpi/dietpi-display
-
-		elif (( $G_WHIP_RETURNED_VALUE == 15 ))
-		then
-			for i in "${overscan_options[@]}"
-			do
-				G_WHIP_DEFAULT_ITEM=${!i}
-				G_WHIP_INPUTBOX "Please enter a value (pixel count) for $i\n - E.g.: 16" || break
-
-				G_CONFIG_INJECT "$i=" "$i=$G_WHIP_RETURNED_VALUE" /boot/firmware/config.txt
-				REBOOT_REQUIRED=1
-			done
-
-		elif (( $G_WHIP_RETURNED_VALUE == 1 ))
-		then
-			TARGETMENUID=2
-
-		elif (( $G_WHIP_RETURNED_VALUE == 3 ))
-		then
-			G_WHIP_MENU_ARRAY=('none' ': Uninstall all panels')
-			G_WHIP_MENU_ARRAY+=('waveshare32' ': 320x240 panel with touch input')
-
-			if (( $G_HW_MODEL < 10 ))
-			then
-				G_WHIP_MENU_ARRAY+=('esp01215e' ': Elecrow 1024x600 7" IPS HDMI panel with touch input')
-				G_WHIP_MENU_ARRAY+=('allo-boss2-oled' ': Allo Boss2 DAC OLED display')
-			else
-				G_WHIP_MENU_ARRAY+=('odroid-lcd35' ': 480x320 panel with touch input')
-				(( $G_HW_MODEL == 11 )) && G_WHIP_MENU_ARRAY+=('odroid-cloudshell' ': 320x240 panel' 'odroid-cloudshell2' ': Odroid XU4 CloudShell 2 LCD')
-			fi
-
-			G_WHIP_DEFAULT_ITEM=$lcdpanel_text
-			G_WHIP_MENU 'Please select an option:' || return 0
-
-			/boot/dietpi/func/dietpi-set_hardware lcdpanel "$G_WHIP_RETURNED_VALUE" && REBOOT_REQUIRED=1
-
-		elif (( $G_WHIP_RETURNED_VALUE == 2 ))
-		then
-			TARGETMENUID=6
-
-		elif (( $G_WHIP_RETURNED_VALUE == 6 ))
-		then
-			if (( $overscan_disabled ))
-			then
-				G_CONFIG_INJECT 'disable_overscan=' 'disable_overscan=0' /boot/firmware/config.txt
-			else
-				G_CONFIG_INJECT 'disable_overscan=' 'disable_overscan=1' /boot/firmware/config.txt
+		case $G_WHIP_RETURNED_VALUE in
+			0) /boot/dietpi/dietpi-display;;
+			15)
 				for i in "${overscan_options[@]}"
 				do
-					sed --follow-symlinks -i "/^[[:blank:]]*$i=/c\#$i=0" /boot/firmware/config.txt
+					G_WHIP_DEFAULT_ITEM=${!i}
+					G_WHIP_INPUTBOX "Please enter a value (pixel count) for $i\n - E.g.: 16" || break
+
+					G_CONFIG_INJECT "$i=" "$i=$G_WHIP_RETURNED_VALUE" /boot/firmware/config.txt
+					REBOOT_REQUIRED=1
 				done
-			fi
-			REBOOT_REQUIRED=1
+			;;
+			101) TARGETMENUID=101;;
+			102) TARGETMENUID=102;;
+			103) /boot/dietpi/func/dietpi-set_hardware rpi-opengl $(( ! $kmsdrm_enabled ));;
+			3)
+				G_WHIP_MENU_ARRAY=('none' ': Uninstall all panels')
+				G_WHIP_MENU_ARRAY+=('waveshare32' ': 320x240 panel with touch input')
 
-		elif (( $G_WHIP_RETURNED_VALUE == 7 ))
-		then
-			G_WHIP_MENU_ARRAY=(
-				'0' ': Disabled'
-				'2' ': RPi 1 A/B Default'
-				'5' ': RPi 1+/2/3 Default'
-				'6' ''
-				'7' ': High (May increase stability)'
-				'8' ''
-				'9' ''
-				'10' ''
-				'11' ': Max (Not recommended)'
-			)
+				if (( $G_HW_MODEL < 10 ))
+				then
+					G_WHIP_MENU_ARRAY+=('esp01215e' ': Elecrow 1024x600 7" IPS HDMI panel with touch input')
+					G_WHIP_MENU_ARRAY+=('allo-boss2-oled' ': Allo Boss2 DAC OLED display')
+				else
+					G_WHIP_MENU_ARRAY+=('odroid-lcd35' ': 480x320 panel with touch input')
+					(( $G_HW_MODEL == 11 )) && G_WHIP_MENU_ARRAY+=('odroid-cloudshell' ': 320x240 panel' 'odroid-cloudshell2' ': Odroid XU4 CloudShell 2 LCD')
+				fi
 
-			G_WHIP_DEFAULT_ITEM=$hdmi_boost_current
-			G_WHIP_MENU 'Please select a HDMI boost level.\n
+				G_WHIP_DEFAULT_ITEM=$lcdpanel_text
+				G_WHIP_MENU 'Please select an option:' || return 0
+
+				/boot/dietpi/func/dietpi-set_hardware lcdpanel "$G_WHIP_RETURNED_VALUE" && REBOOT_REQUIRED=1
+			;;
+			2) TARGETMENUID=6;;
+			6)
+				if (( $overscan_disabled ))
+				then
+					G_CONFIG_INJECT 'disable_overscan=' 'disable_overscan=0' /boot/firmware/config.txt
+					for i in "${overscan_options[@]}"
+					do
+						G_EXEC sed --follow-symlinks -i "s/^[[:blank:]#]*$i=/$i=/" /boot/firmware/config.txt
+					done
+				else
+					G_CONFIG_INJECT 'disable_overscan=' 'disable_overscan=1' /boot/firmware/config.txt
+					for i in "${overscan_options[@]}"
+					do
+						G_EXEC sed --follow-symlinks -i "s/^[[:blank:]]*$i=/#$i=/" /boot/firmware/config.txt
+					done
+				fi
+				REBOOT_REQUIRED=1
+			;;
+			7)
+				G_WHIP_MENU_ARRAY=(
+					'0' ': Disabled'
+					'2' ': RPi 1 A/B Default'
+					'5' ': RPi 1+/2/3 Default'
+					'6' ''
+					'7' ': High (May increase stability)'
+					'8' ''
+					'9' ''
+					'10' ''
+					'11' ': Max (Not recommended)'
+				)
+
+				G_WHIP_DEFAULT_ITEM=$hdmi_boost_current
+				G_WHIP_MENU 'Please select a HDMI boost level.\n
 A long (or insufficiently manufactured) cable may required a higher boost setting to achieve correct signal.' || return 0
 
-			G_CONFIG_INJECT 'config_hdmi_boost=' "config_hdmi_boost=$G_WHIP_RETURNED_VALUE" /boot/firmware/config.txt && REBOOT_REQUIRED=1
+				G_CONFIG_INJECT 'config_hdmi_boost=' "config_hdmi_boost=$G_WHIP_RETURNED_VALUE" /boot/firmware/config.txt && REBOOT_REQUIRED=1
+			;;
+			18) /boot/dietpi/func/dietpi-set_hardware rpi-codec $(( ! $rpi_codecs_enabled )) && REBOOT_REQUIRED=1;;
+			8) /boot/dietpi/func/dietpi-set_hardware rpi-camera $(( ! $rpi_camera_module_enabled )) && REBOOT_REQUIRED=1;;
+			9) G_CONFIG_INJECT 'disable_camera_led=' "disable_camera_led=$(( ! $rpi_camera_led_disabled ))" /boot/firmware/config.txt && REBOOT_REQUIRED=1;;
+			10)
+				if (( $odroid_remote_enabled ))
+				then
+					/boot/dietpi/func/dietpi-set_hardware remoteir none && REBOOT_REQUIRED=1
 
-		elif (( $G_WHIP_RETURNED_VALUE == 18 ))
-		then
-			/boot/dietpi/func/dietpi-set_hardware rpi-codec $(( ! $rpi_codecs_enabled )) && REBOOT_REQUIRED=1
-
-		elif (( $G_WHIP_RETURNED_VALUE == 8 ))
-		then
-			/boot/dietpi/func/dietpi-set_hardware rpi-camera $(( ! $rpi_camera_module_enabled )) && REBOOT_REQUIRED=1
-
-		elif (( $G_WHIP_RETURNED_VALUE == 9 ))
-		then
-			G_CONFIG_INJECT 'disable_camera_led=' "disable_camera_led=$(( ! $rpi_camera_led_disabled ))" /boot/firmware/config.txt && REBOOT_REQUIRED=1
-
-		elif (( $G_WHIP_RETURNED_VALUE == 10 ))
-		then
-			if (( $odroid_remote_enabled ))
-			then
-				/boot/dietpi/func/dietpi-set_hardware remoteir none && REBOOT_REQUIRED=1
-
-			elif G_WHIP_YESNO 'This will enable the IR modules, setup Lirc and the Odroid Remote for Odroid C1, C2 and XU4 CloudShell.
+				elif G_WHIP_YESNO 'This will enable the IR modules, setup Lirc and the Odroid Remote for Odroid C1, C2 and XU4 CloudShell.
 \nNB: Other remotes can be configured by running "irrecord" and applying the codes to "/etc/lirc/lircd.conf"\n\nDo you wish to continue?'
-			then
-				/boot/dietpi/func/dietpi-set_hardware remoteir odroid_remote && REBOOT_REQUIRED=1
-			fi
+				then
+					/boot/dietpi/func/dietpi-set_hardware remoteir odroid_remote && REBOOT_REQUIRED=1
+				fi
+			;;
+			11)
+				if (( $justboom_ir_remote_enabled ))
+				then
+					/boot/dietpi/func/dietpi-set_hardware remoteir none && REBOOT_REQUIRED=1
 
-		elif (( $G_WHIP_RETURNED_VALUE == 11 ))
-		then
-			if (( $justboom_ir_remote_enabled ))
-			then
-				/boot/dietpi/func/dietpi-set_hardware remoteir none && REBOOT_REQUIRED=1
-
-			elif G_WHIP_YESNO 'Got a JustBoom IR Remote? Excellent!
+				elif G_WHIP_YESNO 'Got a JustBoom IR Remote? Excellent!
 \nDietPi will enable the IR modules, setup Lirc and enable support for MPD controls by default:\n\nDo you wish to continue?'
-			then
-				/boot/dietpi/func/dietpi-set_hardware remoteir justboom_ir_remote && REBOOT_REQUIRED=1
-			fi
+				then
+					/boot/dietpi/func/dietpi-set_hardware remoteir justboom_ir_remote && REBOOT_REQUIRED=1
+				fi
+			;;
+			12)
+				G_WHIP_DEFAULT_ITEM=$vc1_key_current
+				if G_WHIP_INPUTBOX 'Please enter your key for VC1:\n - E.g.: 0x12345678'
+				then
+					G_CONFIG_INJECT 'decode_WVC1=' "decode_WVC1=$G_WHIP_RETURNED_VALUE" /boot/firmware/config.txt
 
-		elif (( $G_WHIP_RETURNED_VALUE == 12 ))
-		then
-			G_WHIP_DEFAULT_ITEM=$vc1_key_current
-			if G_WHIP_INPUTBOX 'Please enter your key for VC1:\n - EG: 0x00000000'
-			then
-				G_CONFIG_INJECT 'decode_WVC1=' "decode_WVC1=$G_WHIP_RETURNED_VALUE" /boot/firmware/config.txt
+					# https://github.com/MichaIng/DietPi/issues/1487
+					local current_gpu_mem=$(sed -n '/^[[:blank:]]*gpu_mem_1024=/{s/^[^=]*=//p;q}' /boot/firmware/config.txt)
+					(( ${current_gpu_mem:=76} < 96 )) && /boot/dietpi/func/dietpi-set_hardware gpumemsplit 96
 
-				# https://github.com/MichaIng/DietPi/issues/1487
-				local current_gpu_mem=$(sed -n '/^[[:blank:]]*gpu_mem_1024=/{s/^[^=]*=//p;q}' /boot/firmware/config.txt)
-				(( ${current_gpu_mem:=76} < 96 )) && /boot/dietpi/func/dietpi-set_hardware gpumemsplit 96
+					REBOOT_REQUIRED=1
+				fi
+			;;
+			13)
+				G_WHIP_DEFAULT_ITEM=$mpeg2_key_current
+				if G_WHIP_INPUTBOX 'Please enter your key for MPEG2:\n - E.g.: 0x12345678'
+				then
+					G_CONFIG_INJECT 'decode_MPG2=' "decode_MPG2=$G_WHIP_RETURNED_VALUE" /boot/firmware/config.txt
 
-				REBOOT_REQUIRED=1
-			fi
+					# https://github.com/MichaIng/DietPi/issues/1487
+					local current_gpu_mem=$(sed -n '/^[[:blank:]]*gpu_mem_1024=/{s/^[^=]*=//p;q}' /boot/firmware/config.txt)
+					(( ${current_gpu_mem:=76} < 96 )) && /boot/dietpi/func/dietpi-set_hardware gpumemsplit 96
 
-		elif (( $G_WHIP_RETURNED_VALUE == 13 ))
-		then
-			G_WHIP_DEFAULT_ITEM=$mpeg2_key_current
-			if G_WHIP_INPUTBOX 'Please enter your key for MPEG2:\n - EG: 0x00000000'
-			then
-				G_CONFIG_INJECT 'decode_MPG2=' "decode_MPG2=$G_WHIP_RETURNED_VALUE" /boot/firmware/config.txt
+					REBOOT_REQUIRED=1
+				fi
+			;;
+			5)
+				G_WHIP_MENU_ARRAY=(
 
-				# https://github.com/MichaIng/DietPi/issues/1487
-				local current_gpu_mem=$(sed -n '/^[[:blank:]]*gpu_mem_1024=/{s/^[^=]*=//p;q}' /boot/firmware/config.txt)
-				(( ${current_gpu_mem:=76} < 96 )) && /boot/dietpi/func/dietpi-set_hardware gpumemsplit 96
+					'0' ': Disabled (default)'
+					'2' ': 180 degrees'
+				)
 
-				REBOOT_REQUIRED=1
-			fi
-
-		elif (( $G_WHIP_RETURNED_VALUE == 4 ))
-		then
-			G_WHIP_MENU_ARRAY=(
-				'0' ': Disabled (default)'
-				'1' ': 90 degrees'
-				'2' ': 180 degrees'
-				'3' ': 270 degrees'
-				'0x10000' ': Horizontal flip'
-				'0x20000' ': Vertical flip'
-			)
-
-			G_WHIP_DEFAULT_ITEM=$rotation_hdmi_current
-			G_WHIP_MENU "Please select an option:
-\nNB: If you have the RPi touchscreen, please set this to 0 and use LCD rotation option." || return 0
-
-			G_CONFIG_INJECT 'display_hdmi_rotate=' "display_hdmi_rotate=$G_WHIP_RETURNED_VALUE" /boot/firmware/config.txt
-
-			# rotation 90/270 | invert x/y on framebuffer (Y > X)
-			if [[ $G_WHIP_RETURNED_VALUE == [13] ]]
-			then
-				Display_Rotation_Calc_XY_Invert 1
-
-			# X > Y
-			else
-				Display_Rotation_Calc_XY_Invert 0
-			fi
-			REBOOT_REQUIRED=1
-
-		elif (( $G_WHIP_RETURNED_VALUE == 5 ))
-		then
-			G_WHIP_MENU_ARRAY=(
-
-				'0' ': Disabled (default)'
-				'2' ': 180 degrees'
-			)
-
-			G_WHIP_DEFAULT_ITEM=$rotation_lcd_current
-			if G_WHIP_MENU 'Please select an option:\n\nNB: This option is for RPi touchscreen.'
-			then
-				G_CONFIG_INJECT 'lcd_rotate=' "lcd_rotate=$G_WHIP_RETURNED_VALUE" /boot/firmware/config.txt && REBOOT_REQUIRED=1
-			fi
-
-		elif (( $G_WHIP_RETURNED_VALUE == 14 ))
-		then
-			/boot/dietpi/dietpi-led_control
-
-		elif (( $G_WHIP_RETURNED_VALUE == 16 ))
-		then
-			# Find and obtain values for all backlight devices
-			local fp_brightness iTotalAvailable=0 aFp_Brightness_Available=() aBrightness_Name=() aBrightness_Current=() aBrightness_Max=()
-			for fp_brightness in /sys/class/backlight/*
-			do
-				(( iTotalAvailable++ ))
-				aFp_Brightness_Available+=("$fp_brightness")
-				aBrightness_Name+=("${fp_brightness##*/}")
-				aBrightness_Current+=("$(<"$fp_brightness/actual_brightness")")
-				aBrightness_Max+=("$(<"$fp_brightness/max_brightness")")
-			done
-
-			# Return if no backlist device has been found
-			if (( iTotalAvailable ))
-			then
-				# Convert current brightness to %
-				local i aBrightness_Percent=()
-				for (( i=0; i<$iTotalAvailable; i++ ))
+				G_WHIP_DEFAULT_ITEM=$rotation_lcd_current
+				if G_WHIP_MENU 'Please select an option:\n\nNB: This option is for RPi touchscreen.'
+				then
+					G_CONFIG_INJECT 'lcd_rotate=' "lcd_rotate=$G_WHIP_RETURNED_VALUE" /boot/firmware/config.txt && REBOOT_REQUIRED=1
+				fi
+			;;
+			14) /boot/dietpi/dietpi-led_control;;
+			16)
+				# Find and obtain values for all backlight devices
+				local fp_brightness iTotalAvailable=0 aFp_Brightness_Available=() aBrightness_Name=() aBrightness_Current=() aBrightness_Max=()
+				for fp_brightness in /sys/class/backlight/*
 				do
-					aBrightness_Percent+=("$(echo "${aBrightness_Current[i]} ${aBrightness_Max[i]}" | mawk '{printf "%.0f\n", $1*100/$2}')")
+					(( iTotalAvailable++ ))
+					aFp_Brightness_Available+=("$fp_brightness")
+					aBrightness_Name+=("${fp_brightness##*/}")
+					aBrightness_Current+=("$(<"$fp_brightness/actual_brightness")")
+					aBrightness_Max+=("$(<"$fp_brightness/max_brightness")")
 				done
 
-				# List backlight devices to selection if multiple were found, else select 1st/only one
-				local iIndex=0
-				if (( iTotalAvailable > 1 ))
+				# Return if no backlist device has been found
+				if (( iTotalAvailable ))
 				then
-					G_WHIP_MENU_ARRAY=()
+					# Convert current brightness to %
+					local i aBrightness_Percent=()
 					for (( i=0; i<$iTotalAvailable; i++ ))
 					do
-						G_WHIP_MENU_ARRAY+=("${aBrightness_Name[i]}" ": [${aBrightness_Percent[i]}%]")
+						aBrightness_Percent+=("$(echo "${aBrightness_Current[i]} ${aBrightness_Max[i]}" | mawk '{printf "%.0f\n", $1*100/$2}')")
 					done
-					G_WHIP_MENU 'Please select a Brightness item to change its value:' || return 0
 
-					# Obtain array index
-					for (( i=0; i<$iTotalAvailable; i++ ))
+					# List backlight devices to selection if multiple were found, else select 1st/only one
+					local iIndex=0
+					if (( iTotalAvailable > 1 ))
+					then
+						G_WHIP_MENU_ARRAY=()
+						for (( i=0; i<$iTotalAvailable; i++ ))
+						do
+							G_WHIP_MENU_ARRAY+=("${aBrightness_Name[i]}" ": [${aBrightness_Percent[i]}%]")
+						done
+						G_WHIP_MENU 'Please select a Brightness item to change its value:' || return 0
+
+						# Obtain array index
+						for (( i=0; i<$iTotalAvailable; i++ ))
+						do
+							[[ ${aBrightness_Name[i]} == "$G_WHIP_RETURNED_VALUE" ]] || continue
+							iIndex=$i
+							break
+						done
+					fi
+
+					# Generate % menu
+					G_WHIP_MENU_ARRAY=('Custom' ': Manually enter a value')
+					for i in {0..100..10}
 					do
-						[[ ${aBrightness_Name[i]} == "$G_WHIP_RETURNED_VALUE" ]] || continue
-						iIndex=$i
-						break
+						G_WHIP_MENU_ARRAY+=("$i" '%')
 					done
+
+					G_WHIP_DEFAULT_ITEM=${aBrightness_Percent[iIndex]}
+					G_WHIP_MENU "Please select a new Brightness level for [${aBrightness_Name[iIndex]}]:\n - Current Value = ${aBrightness_Percent[iIndex]}%" || return 0
+
+					# Handle custom
+					if [[ $G_WHIP_RETURNED_VALUE == 'Custom' ]]
+					then
+						local MIN_VALUE=0 MAX_VALUE=100
+						G_WHIP_INPUTBOX "Please enter a value between $MIN_VALUE and $MAX_VALUE:" || return 0
+						G_CHECK_VALIDINT "$G_WHIP_RETURNED_VALUE" "$MIN_VALUE" "$MAX_VALUE" || return 1
+					fi
+
+					# Convert % back and apply
+					echo "$G_WHIP_RETURNED_VALUE ${aBrightness_Max[iIndex]}" | mawk '{printf "%.0f\n", $1*$2/100}' > "${aFp_Brightness_Available[iIndex]}/brightness"
+				else
+					Info_HW_OptionNotSupported
 				fi
+			;;
+			17)
+				G_WHIP_MENU_ARRAY=(
+					'96' ': Default'
+					'120' ": +25% larger"
+					'144' ": +50% larger"
+					'168' ": +75% larger"
+					'192' ": +100% larger"
+				)
 
-				# Generate % menu
-				G_WHIP_MENU_ARRAY=('Custom' ': Manually enter a value')
-				for i in {0..100..10}
-				do
-					G_WHIP_MENU_ARRAY+=("$i" '%')
-				done
-
-				G_WHIP_DEFAULT_ITEM=${aBrightness_Percent[iIndex]}
-				G_WHIP_MENU "Please select a new Brightness level for [${aBrightness_Name[iIndex]}]:\n - Current Value = ${aBrightness_Percent[iIndex]}%" || return 0
-
-				# Handle custom
-				if [[ $G_WHIP_RETURNED_VALUE == 'Custom' ]]
+				G_WHIP_DEFAULT_ITEM=$xorg_dpi_current
+				if G_WHIP_MENU "Please select a DPI value for Xorg:
+- A higher value will make text and windows larger
+- Has no effect on local terminal (eg: no desktop installed)
+\nNB: Setting will only take effect, once system is restarted."
 				then
-					local MIN_VALUE=0 MAX_VALUE=100
-					G_WHIP_INPUTBOX "Please enter a value between $MIN_VALUE and $MAX_VALUE:" || return 0
-					G_CHECK_VALIDINT "$G_WHIP_RETURNED_VALUE" "$MIN_VALUE" "$MAX_VALUE" || return 1
+					G_CONFIG_INJECT 'SOFTWARE_XORG_DPI=' "SOFTWARE_XORG_DPI=$G_WHIP_RETURNED_VALUE" /boot/dietpi.txt
+					G_EXEC mkdir -p /etc/X11/Xsession.d
+					echo "xrandr --dpi $G_WHIP_RETURNED_VALUE" > /etc/X11/Xsession.d/99-dietpi-dpi
+					REBOOT_REQUIRED=1
 				fi
-
-				# Convert % back and apply
-				echo "$G_WHIP_RETURNED_VALUE ${aBrightness_Max[iIndex]}" | mawk '{printf "%.0f\n", $1*$2/100}' > "${aFp_Brightness_Available[iIndex]}/brightness"
-			else
-				Info_HW_OptionNotSupported
-			fi
-
-		elif (( $G_WHIP_RETURNED_VALUE == 17 ))
-		then
-			G_WHIP_MENU_ARRAY=(
-				'96' ': Default'
-				'120' ": +25% larger"
-				'144' ": +50% larger"
-				'168' ": +75% larger"
-				'192' ": +100% larger"
-			)
-
-			G_WHIP_DEFAULT_ITEM=$xorg_dpi_current
-			if G_WHIP_MENU "Please select a DPI value for Xorg:
- - A higher value will make text and windows larger
- - Has no effect on local terminal (eg: no desktop installed)
- \nNB: Setting will only take effect, once system is restarted."
-			then
-				G_CONFIG_INJECT 'SOFTWARE_XORG_DPI=' "SOFTWARE_XORG_DPI=$G_WHIP_RETURNED_VALUE" /boot/dietpi.txt
-				G_EXEC mkdir -p /etc/X11/Xsession.d
-				echo "xrandr --dpi $G_WHIP_RETURNED_VALUE" > /etc/X11/Xsession.d/99-dietpi-dpi
-				REBOOT_REQUIRED=1
-			fi
-		fi
+			;;
+			*) :;;
+		esac
 	}
 
-	# TARGETMENUID=2
-	Menu_DisplayOptions_Driver_Resolution()
+	# TARGETMENUID=101
+	Menu_DisplayOptions_GRUB_Resolution()
 	{
-		G_WHIP_BUTTON_CANCEL_TEXT='Cancel'
-
-		# VM
-		if (( $G_HW_MODEL == 20 ))
+		if [[ ! $grub_resolution ]]
 		then
-			local current=$(sed -n '/^[[:blank:]]*GRUB_GFXMODE=/{s/^[^=]*=//p;q}' /etc/default/grub)
-			[[ $current ]] || current='System default'
+			dpkg-query -s 'grub2-common' 2> /dev/null | grep -q '^Status: install ok installed$' || { Info_HW_OptionNotSupported; Back_or_Exit 1; return 1; }
+			local grub_resolution=$(sed -n '/^[[:blank:]]*GRUB_GFXMODE=/{s/^[^=]*=//p;q}' /etc/default/grub)
+		fi
 
-			G_WHIP_MENU_ARRAY=(
-				'System default' ''
-				'1600x1200' ''
-				'1280x1024' ''
-				'1152x864' ''
-				'1024x768' ''
-				'800x600' ''
-			)
+		G_WHIP_MENU_ARRAY=(
+			'System default' ''
+			'1600x1200' ''
+			'1280x1024' ''
+			'1152x864' ''
+			'1024x768' ''
+			'800x600' ''
+			'Custom' ''
+		)
 
-			G_WHIP_DEFAULT_ITEM=$current
-			G_WHIP_MENU "Please select a display resolution. Current: $current
-\nNB: This only affects the virtual screen resolution, not the SSH session.
-	You might need to increase the maximum guest screen resolution within your VM software." || { Back_or_Exit 1; return 0; } # Display Options
+		G_WHIP_DEFAULT_ITEM=${grub_resolution:=System default}
+		G_WHIP_MENU "Please select the GRUB terminal resolution. Current: $grub_resolution
+\nNB: This only affects the GRUB (bootloader) and early Linux console resolution during boot.
+To set the final Linux console resolution, please use dietpi-display, or the Display Resolution menu above." || { Back_or_Exit 1; return 0; } # Display Options
 
-			if [[ $G_WHIP_RETURNED_VALUE == 'System default' ]]
+		if [[ $G_WHIP_RETURNED_VALUE == 'System default' ]]
+		then
+			G_EXEC sed --follow-symlinks -i 's/^[[:blank:]]*GRUB_GFXMODE=/#GRUB_GFXMODE=/' /etc/default/grub
+			G_EXEC sed --follow-symlinks -i 's/^[[:blank:]]*GRUB_GFXPAYLOAD_LINUX=/#GRUB_GFXPAYLOAD_LINUX=/' /etc/default/grub
+		else
+			if [[ $G_WHIP_RETURNED_VALUE == 'Custom' ]]
 			then
-				sed --follow-symlinks -i 's/^[[:blank:]]*GRUB_GFXMODE=/#GRUB_GFXMODE=/' /etc/default/grub
-				sed --follow-symlinks -i 's/^[[:blank:]]*GRUB_GFXPAYLOAD_LINUX=/#GRUB_GFXPAYLOAD_LINUX=/' /etc/default/grub
-			else
-				G_CONFIG_INJECT 'GRUB_GFXMODE=' "GRUB_GFXMODE=$G_WHIP_RETURNED_VALUE" /etc/default/grub
-				G_CONFIG_INJECT 'GRUB_GFXPAYLOAD_LINUX=' 'GRUB_GFXPAYLOAD_LINUX=keep' /etc/default/grub 'GRUB_GFXMODE='
+				G_WHIP_INPUTBOX_REGEX='^[0-9]+x[0-9]+$'
+				G_WHIP_INPUTBOX_REGEX_TEXT='be a resolution in the format XxY, like "1920x1080"'
+				G_WHIP_INPUTBOX 'Please enter a custom resolution, e.g. "1920x1080":' || return 0
 			fi
+			G_CONFIG_INJECT 'GRUB_GFXMODE=' "GRUB_GFXMODE=$G_WHIP_RETURNED_VALUE" /etc/default/grub
+			G_CONFIG_INJECT 'GRUB_GFXPAYLOAD_LINUX=' 'GRUB_GFXPAYLOAD_LINUX=keep' /etc/default/grub 'GRUB_GFXMODE='
+		fi
+		grub_resolution=$G_WHIP_RETURNED_VALUE
 
-			update-grub
+		update-grub
+	}
 
-		# Native PC
-		elif (( $G_HW_MODEL == 21 ))
+	# TARGETMENUID=102
+	Menu_DisplayOptions_Driver()
+	{
+		if [[ ! $gpu_driver ]]
 		then
-			local gpu_current=$(sed -n '/^[[:blank:]]*CONFIG_GPU_DRIVER=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
-			gpu_current=${gpu_current,,}
+			(( $G_HW_MODEL == 21 )) || { Info_HW_OptionNotSupported; Back_or_Exit 1; return 1; }
+			local gpu_driver=$(sed -n '/^[[:blank:]]*CONFIG_GPU_DRIVER=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)
+		fi
 
-			local menu_index=0
-			case $gpu_current in
-				'nvidia') menu_index=1;;
-				'intel') menu_index=3;;
-				'amd') menu_index=5;;
-				'custom') menu_index=7;;
-				*) :;;
-			esac
+		local menu_index=0
+		gpu_driver=${gpu_driver,,}
+		case $gpu_driver in
+			'nvidia') menu_index=1;;
+			'intel') menu_index=3;;
+			'amd') menu_index=5;;
+			'custom') menu_index=7;;
+			*) :;;
+		esac
 
-			G_WHIP_MENU_ARRAY=(
-				'Nvidia' ': [ ] | Proprietary GPU driver'
-				'Intel' ': [ ] | Open-Source VA-API GPU drivers'
-				'AMD' ': [ ] | Open-Source GPU driver'
-				'Custom' ': [ ] | Manual User Install'
-				'None' ': Uninstall all GPU drivers'
-			)
-			(( $menu_index )) && G_WHIP_MENU_ARRAY[$menu_index]=${G_WHIP_MENU_ARRAY[$menu_index]/\[ \]/[X]}
+		G_WHIP_MENU_ARRAY=(
+			'Nvidia' ': [ ] | Proprietary GPU driver'
+			'Intel' ': [ ] | Open-Source VA-API GPU drivers'
+			'AMD' ': [ ] | Open-Source GPU driver'
+			'Custom' ': [ ] | Manual User Install'
+			'None' ': Uninstall all GPU drivers'
+		)
+		(( $menu_index )) && G_WHIP_MENU_ARRAY[$menu_index]=${G_WHIP_MENU_ARRAY[$menu_index]/\[ \]/[X]}
 
-			G_WHIP_BUTTON_CANCEL_TEXT='Back'
-			G_WHIP_DEFAULT_ITEM=${gpu_current^}
-			G_WHIP_MENU 'Please select an option:' || { Back_or_Exit 1; return 0; } # Display Options
+		G_WHIP_BUTTON_CANCEL_TEXT='Back'
+		G_WHIP_DEFAULT_ITEM=${gpu_driver^}
+		G_WHIP_MENU 'Please select an option:' || { Back_or_Exit 1; return 0; } # Display Options
 
-			local gpu_new=${G_WHIP_RETURNED_VALUE,,}
-			/boot/dietpi/func/dietpi-set_hardware gpudriver "$gpu_new"
+		gpu_driver=${G_WHIP_RETURNED_VALUE,,}
+		/boot/dietpi/func/dietpi-set_hardware gpudriver "$gpu_driver"
 
-			G_WHIP_YESNO 'X11 auto-configuration
+		G_WHIP_YESNO 'X11 auto-configuration
 \nThis feature generates a configuration for X11 at /etc/X11/xorg.conf based on available drivers. It is not always required, but helps to assure the right driver is used after one has been installed or uninstalled.
 \nNB: This feature will only work if an X server (desktop) is NOT currently running. If a desktop is running, please set "dietpi-autostart" to "Console", reboot the system, then run the auto-configuration manually:
 - Xorg -configure
 \nWould you like to auto-configure X11 now?' || return 0
 
-			G_EXEC Xorg -configure
-			[[ -f '/root/xorg.conf.new' ]] && G_EXEC mv /root/xorg.conf{.new,}
-
-		# RPi
-		elif (( $G_HW_MODEL < 10 ))
-		then
-			local framebuffer_x=$(grep -m1 '^[[:blank:]]*framebuffer_width=' /boot/firmware/config.txt || vcgencmd get_config framebuffer_width)
-			framebuffer_x=${framebuffer_x#*=}; framebuffer_x=${framebuffer_x:-0}
-			local framebuffer_y=$(grep -m1 '^[[:blank:]]*framebuffer_height=' /boot/firmware/config.txt || vcgencmd get_config framebuffer_height)
-			framebuffer_y=${framebuffer_y#*=}; framebuffer_y=${framebuffer_y:-0}
-			local current_value=$(sed -n '/^[[:blank:]]*dtoverlay=vc4-/{s/^[^=]*=//p;q}' /boot/firmware/config.txt) # OpenGL check 1st
-			if [[ ! $current_value ]]
-			then
-				# Framebuffer
-				current_value="$framebuffer_x X $framebuffer_y"
-
-				# Check for headless
-				grep -q '^[[:blank:]]*AUTO_SETUP_HEADLESS=1' /boot/dietpi.txt && current_value='Headless'
-			fi
-
-			G_WHIP_MENU_ARRAY=(
-				'vc4-kms-v3d' ': OpenGL | 1920 x 1080'
-				'vc4-fkms-v3d' ': OpenGL | 1920 x 1080'
-				'1080p' ': 1920 x 1080'
-				'720p' ': 1280 x 720'
-				'480p' ': 854 x 480'
-				'RPi Touchscreen' ': 800 x 480'
-				'PC1' ': 1024 x 768'
-				'PC2' ': 800 x 640'
-				'PC3' ': 640 x 480'
-				'DietPi-CloudShell' ': 320 x 240'
-				'sdtv_mode=0' ': Composite NTSC'
-				'sdtv_mode=1' ': Composite Japanese NTSC'
-				'sdtv_mode=2' ': Composite PAL'
-				'sdtv_mode=3' ': Composite Brazilian PAL'
-				'Headless' ': Disables HDMI & Composite Output'
-			)
-
-			G_WHIP_DEFAULT_ITEM=$current_value
-			G_WHIP_MENU "Hardware: $G_HW_MODEL_NAME\nCurrent resolution: $current_value" || { Back_or_Exit 1; return 0; } # Display Options
-
-			REBOOT_REQUIRED=1
-
-			# Enable headless if chosen, else always disable
-			if [[ $G_WHIP_RETURNED_VALUE == 'Headless' ]]
-			then
-				G_WHIP_YESNO 'Using the Headless option will:
- - Disable HDMI and composite output
- - Disable the framebuffer
- - Lower energy consumption by 0.1+ Watts
- - Improve RAM performance by 1-5% (VideoCore shares RAM bandwidth)
-   Source: https://forums.raspberrypi.com/viewtopic.php?p=105008#p105008\n
-Re-enabling HDMI requires a reboot. If you need emergency HDMI output, edit the following files on first partition of the SDcard from external system:
- - In config.txt, set "hdmi_ignore_hotplug=0" and comment/remove the "max_framebuffers=0" line.
- - In dietpi.txt, set "AUTO_SETUP_HEADLESS=0".' || { REBOOT_REQUIRED=0; return; }
-
-				/boot/dietpi/func/dietpi-set_hardware headless 1
-			else
-				/boot/dietpi/func/dietpi-set_hardware headless 0
-			fi
-
-			# Disable composite if not chosen
-			if [[ $G_WHIP_RETURNED_VALUE != 'sdtv_mode'* ]]
-			then
-				sed --follow-symlinks -i '/sdtv_mode=/c\#sdtv_mode=0' /boot/firmware/config.txt
-				sed --follow-symlinks -i '/enable_tvout=/c\#enable_tvout=0' /boot/firmware/config.txt
-			fi
-
-			# Disable OpenGL if not chosen
-			[[ $G_WHIP_RETURNED_VALUE == 'vc4-'* ]] || /boot/dietpi/func/dietpi-set_hardware rpi-opengl disable
-
-			if [[ $G_WHIP_RETURNED_VALUE == 'vc4-'* ]]
-			then
-				/boot/dietpi/func/dietpi-set_hardware rpi-opengl "$G_WHIP_RETURNED_VALUE"
-
-			elif [[ $G_WHIP_RETURNED_VALUE != 'Headless' ]]
-			then
-				case "$G_WHIP_RETURNED_VALUE" in
-					'sdtv_mode'*)
-						# Enable SDTV on RPi4, apply to all RPi to allow SD card switch
-						G_CONFIG_INJECT 'enable_tvout=' 'enable_tvout=1' /boot/firmware/config.txt
-						G_CONFIG_INJECT 'sdtv_mode=' "$G_WHIP_RETURNED_VALUE" /boot/firmware/config.txt
-						framebuffer_x=720 framebuffer_y=576
-					;;
-					'DietPi-CloudShell') framebuffer_x=320 framebuffer_y=240;;
-					'1080p') framebuffer_x=1920 framebuffer_y=1080;;
-					'720p') framebuffer_x=1280 framebuffer_y=720;;
-					'480p') framebuffer_x=854 framebuffer_y=480;;
-					'RPi Touchscreen') framebuffer_x=800 framebuffer_y=480;;
-					'PC1') framebuffer_x=1024 framebuffer_y=768;;
-					'PC2') framebuffer_x=800 framebuffer_y=640;;
-					'PC3') framebuffer_x=640 framebuffer_y=480;;
-					*) :;;
-				esac
-
-				# Apply framebuffer size and Chromium autostart resolution
-				G_CONFIG_INJECT 'framebuffer_width=' "framebuffer_width=$framebuffer_x" /boot/firmware/config.txt
-				G_CONFIG_INJECT 'framebuffer_height=' "framebuffer_height=$framebuffer_y" /boot/firmware/config.txt
-				G_CONFIG_INJECT 'SOFTWARE_CHROMIUM_RES_X=' "SOFTWARE_CHROMIUM_RES_X=$framebuffer_x" /boot/dietpi.txt
-				G_CONFIG_INJECT 'SOFTWARE_CHROMIUM_RES_Y=' "SOFTWARE_CHROMIUM_RES_Y=$framebuffer_y" /boot/dietpi.txt
-			fi
-
-		# Odroid XU4
-		elif (( $G_HW_MODEL == 11 ))
-		then
-			# Get Current Values
-			local current_resolution=$(grep -Em1 'setenv[[:blank:]]+videoconfig[[:blank:]]' /boot/boot.ini)
-			case $current_resolution in
-				*'1920x1080'*) current_resolution='1920x1080';;
-				*'1280x720'*) current_resolution='1280x720';;
-				*'720x480'*) current_resolution='720x480';;
-				*'1024x600'*) current_resolution='1024x600';;
-				*) :;;
-			esac
-
-			G_WHIP_MENU_ARRAY=(
-				'1920x1080' ': 1080p'
-				'1280x720' ': 720p'
-				'720x480' ': 480p'
-				'1024x600' ': VU7+'
-			)
-
-			G_WHIP_DEFAULT_ITEM=$current_resolution
-			G_WHIP_MENU "Hardware : $G_HW_MODEL_NAME\nCurrent: $current_resolution" || { Back_or_Exit 1; return 0; } # Display Options
-
-			# DVI or HDMI
-			if [[ $G_WHIP_RETURNED_VALUE == '1024x600' ]]
-			then
-				G_CONFIG_INJECT 'setenv[[:blank:]]+vout[[:blank:]]' 'setenv vout "dvi"' /boot/boot.ini 'ODROIDXU-UBOOT-CONFIG'
-			else
-				G_CONFIG_INJECT 'setenv[[:blank:]]+vout[[:blank:]]' 'setenv vout "hdmi"' /boot/boot.ini 'ODROIDXU-UBOOT-CONFIG'
-			fi
-
-			G_CONFIG_INJECT 'setenv[[:blank:]]+videoconfig[[:blank:]]' "setenv videoconfig \"drm_kms_helper.edid_firmware=edid/$G_WHIP_RETURNED_VALUE.bin\"" /boot/boot.ini 'ODROIDXU-UBOOT-CONFIG'
-
-			REBOOT_REQUIRED=1
-		else
-			Info_HW_OptionNotSupported
-			Back_or_Exit 1 # Display Options
-		fi
+		G_EXEC Xorg -configure
+		[[ -f '/root/xorg.conf.new' ]] && G_EXEC mv /root/xorg.conf{.new,}
 	}
 
 	# TARGETMENUID=19
@@ -3163,15 +2971,6 @@ This is mainly aimed at PINE A64 which may have a hardware issue that causes uns
 				'DietPi-JustBoom' ': Launches EQ and MPD audio options menu'
 			)
 
-			# RPi, low power mode (PSU noise ripple reduction): https://github.com/MichaIng/DietPi/issues/757
-			if (( $G_HW_MODEL < 10 )); then
-
-				local psu_noise_reduction='Off'
-				grep -q '^[[:blank:]]*CONFIG_CPU_GOVERNOR=powersave' /boot/dietpi.txt && grep -q '^[[:blank:]]*AUTO_SETUP_HEADLESS=1' /boot/dietpi.txt && psu_noise_reduction='On'
-				G_WHIP_MENU_ARRAY+=('PSU noise reduction' ": [$psu_noise_reduction]")
-
-			fi
-
 			G_WHIP_MENU_ARRAY+=('' '●─' 'Disable' ': Disable all audio capabilities')
 
 		fi
@@ -3189,27 +2988,6 @@ This is mainly aimed at PINE A64 which may have a hardware issue that causes uns
 
 			G_AG_CHECK_INSTALL_PREREQ alsa-utils
 			[[ -f '/boot/dietpi/.installed' ]] && G_CONFIG_INJECT 'aSOFTWARE_INSTALL_STATE\[5\]=' 'aSOFTWARE_INSTALL_STATE[5]=2' /boot/dietpi/.installed
-
-		elif [[ $G_WHIP_RETURNED_VALUE == 'PSU noise reduction' ]]; then
-
-			if [[ $psu_noise_reduction == 'Off' ]]; then
-
-				G_WHIP_YESNO 'PSU noise reduction:\n\nThis mode attempts to reduce power consumption on your SBC. In turn, this may reduce PSU inflicted noise, that may degrade audio output quality.
-\nThe following will now be applied:\n - CPU governor = powersave\n - Display output = disabled\n\nDo you want to continue?' || return
-
-				G_CONFIG_INJECT 'CONFIG_CPU_GOVERNOR=' 'CONFIG_CPU_GOVERNOR=powersave' /boot/dietpi.txt
-				/boot/dietpi/func/dietpi-set_cpu
-				/boot/dietpi/func/dietpi-set_hardware headless 1
-				tvservice -o
-
-			else
-
-				G_CONFIG_INJECT 'CONFIG_CPU_GOVERNOR=' 'CONFIG_CPU_GOVERNOR=schedutil' /boot/dietpi.txt
-				/boot/dietpi/func/dietpi-set_cpu
-				/boot/dietpi/func/dietpi-set_hardware headless 0
-				tvservice -p
-
-			fi
 
 		elif [[ $G_WHIP_RETURNED_VALUE == 'Sound card' ]]; then
 
@@ -3853,7 +3631,8 @@ NB: If you need to use *.pool.ntp.org servers, enter the base domain only. The s
 		case $TARGETMENUID in
 			0) Menu_Main;;
 			1) Menu_DisplayOptions;;
-			2) Menu_DisplayOptions_Driver_Resolution;;
+			101) Menu_DisplayOptions_GRUB_Resolution;;
+			102) Menu_DisplayOptions_Driver;;
 			3) Menu_AdvancedOptions;;
 			4) Menu_PerformanceOptions;;
 			5) Menu_SecurityOptions;;

--- a/dietpi/dietpi-display
+++ b/dietpi/dietpi-display
@@ -343,7 +343,7 @@ Menu_Display()
 		G_WHIP_MENU_ARRAY+=("$i" '')
 	done
 	G_WHIP_DEFAULT_ITEM=$DISPLAY
-	G_WHIP_MENU 'Select a display from the list below' || return 0
+	G_WHIP_MENU 'Please select a display from the list below' || return 0
 	DISPLAY=$G_WHIP_RETURNED_VALUE
 }
 
@@ -363,12 +363,12 @@ Menu_Mode()
 		G_WHIP_MENU_ARRAY+=("$mode" '')
 	done
 	G_WHIP_DEFAULT_ITEM=${aMODE[$DISPLAY]}
-	G_WHIP_MENU "Select a mode for the display $DISPLAY
+	G_WHIP_MENU "Please select a mode for the display $DISPLAY
 \nNB: The list can be incomplete, miss frequencies or resolutions above the current one. In case use \"Custom\" to define resolution, optionally frequency, and more explicitly." || return 0
 	if [[ $G_WHIP_RETURNED_VALUE == 'Custom' ]]
 	then
 		G_WHIP_DEFAULT_ITEM=${aMODE[$DISPLAY]}
-		G_WHIP_INPUTBOX 'Enter a custom display mode, e.g. "1920x1080@60".
+		G_WHIP_INPUTBOX 'Please enter a custom display mode, e.g. "1920x1080@60".
 \nMore info: https://docs.kernel.org/fb/modedb.html' || { Menu_Mode; return 0; }
 	fi
 	aMODE["$DISPLAY"]=$G_WHIP_RETURNED_VALUE
@@ -385,7 +385,7 @@ Menu_Rotation()
 		270 ''
 	)
 	G_WHIP_DEFAULT_ITEM=${aROTATION[$DISPLAY]}
-	G_WHIP_MENU "Select a rotation for the display $DISPLAY" || return 0
+	G_WHIP_MENU "Please select a rotation for the display $DISPLAY" || return 0
 	aROTATION["$DISPLAY"]=$G_WHIP_RETURNED_VALUE
 	Apply_Settings
 }
@@ -411,9 +411,7 @@ Main_Menu()
 		)
 		G_WHIP_BUTTON_CANCEL_TEXT='Exit'
 		G_WHIP_DEFAULT_ITEM=${G_WHIP_DEFAULT_ITEM_NEXT:-Display}
-		G_WHIP_MENU 'DietPi-Display is currently in beta status. Please report issues/suggestions:
-- https://github.com/MichaIng/DietPi/issues/7390
-\nSelect a display to change its mode and rotation' || return 1
+		G_WHIP_MENU 'Please select a display to change its mode and/or rotation:' || return 1
 		case $G_WHIP_RETURNED_VALUE in
 			'LCDs') while :; do Menu_LCDs || break; done;;
 			'Display') Menu_Display;;
@@ -429,7 +427,7 @@ Main_Menu()
 	then
 		G_WHIP_BUTTON_OK_TEXT='Yes' G_WHIP_BUTTON_CANCEL_TEXT='Exit'
 		G_WHIP_YESNO '[ INFO ] KMS/DRM driver is not enabled
-\nOn Raspberry Pi, you need to enable the KMS/DRM drive to use this tool. Do you want to enable it now?' && /boot/dietpi/func/dietpi-set_hardware rpi-opengl vc4-kms-v3d && REBOOT=1
+\nOn Raspberry Pi, you need to enable the KMS/DRM drive to use this tool. Do you want to enable it now?' && /boot/dietpi/func/dietpi-set_hardware rpi-opengl 1 && REBOOT=1
 		return 1
 
 	elif (( $G_HW_MODEL == 92 ))

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5347,7 +5347,7 @@ _EOF_
 		if To_Install 108 # Amiberry
 		then
 			# RPi: Enable KMS/DRM
-			(( $G_HW_MODEL < 10 )) && /boot/dietpi/func/dietpi-set_hardware rpi-opengl vc4-kms-v3d
+			(( $G_HW_MODEL > 9 )) || /boot/dietpi/func/dietpi-set_hardware rpi-opengl vc4-kms-v3d
 
 			G_AGI amiberry
 
@@ -5374,7 +5374,7 @@ _EOF_
 		if To_Install 10 # Amiberry-Lite
 		then
 			# RPi: Enable KMS/DRM
-			(( $G_HW_MODEL < 10 )) && /boot/dietpi/func/dietpi-set_hardware rpi-opengl vc4-kms-v3d
+			(( $G_HW_MODEL > 9 )) || /boot/dietpi/func/dietpi-set_hardware rpi-opengl vc4-kms-v3d
 
 			G_AGI amiberry-lite
 
@@ -8999,15 +8999,8 @@ sudo sysctl -p /etc/sysctl.d/dietpi-syncthing.confs
 			G_AGI chromium libpam-systemd
 			Create_Desktop_Shortcut chromium
 
-			# RPi
-			if (( $G_HW_MODEL < 10 ))
-			then
-				# Enable KMS
-				grep -Eq '^[[:blank:]]*dtoverlay=vc4-f?kms-v3d' /boot/firmware/config.txt || /boot/dietpi/func/dietpi-set_hardware rpi-opengl vc4-kms-v3d
-
-				# Enable hardware codecs
-				/boot/dietpi/func/dietpi-set_hardware rpi-codec 1
-			fi
+			# RPi: Enable hardware codecs
+			(( $G_HW_MODEL > 9 )) || /boot/dietpi/func/dietpi-set_hardware rpi-codec 1
 
 			# Flags: Allow root (disable sandbox) and minimise CPU usage: https://peter.sh/experiments/chromium-command-line-switches/
 			G_EXEC eval "echo 'export CHROMIUM_FLAGS=\"\$CHROMIUM_FLAGS --no-sandbox --test-type --disable-smooth-scrolling --disable-low-res-tiling --enable-low-end-device-mode --num-raster-threads=$G_HW_CPU_CORES --disable-composited-antialiasing\"' > /etc/chromium.d/dietpi"
@@ -12795,7 +12788,7 @@ _EOF_
 			[[ ${gpu_current,,} == 'none' ]] && G_WHIP_YESNO 'No GPU Driver is currently installed.\n\nWould you like to select a GPU driver for installation now?' && /boot/dietpi/dietpi-config 2
 		fi
 
-		# RPi: Disable headless mode and raise memory split to default for GUI applications
+		# RPi: Enable KMS/DRM and raise memory split to default for GUI applications
 		(( $G_HW_MODEL < 10 )) || return 0
 
 		# Kodi, Jellyfin, DXX-Rebirth, Amiberry, Amiberry-Lite, Chromium, Desktops, OpenTyrian, Moonlight (CLI), Moonlight (GUI), GZDoom
@@ -12815,8 +12808,8 @@ _EOF_
 		${aSOFTWARE_INSTALL_STATE[208]} == 1 ||
 		${aSOFTWARE_INSTALL_STATE[11]} == 1 )) || return 0
 
-		# Disable headless mode
-		/boot/dietpi/func/dietpi-set_hardware headless 0
+		# Enable KMS/DRM
+		/boot/dietpi/func/dietpi-set_hardware rpi-opengl 1
 
 		# Raise memory split to default
 		local default_gpu_mem=76

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -24,11 +24,10 @@ $FP_SCRIPT	spi			enable/disable
 $FP_SCRIPT	soundcard		target_card (non-matching name for reset to default). Add '-eq' to target_card string to enable ALSA equalizer on card. hw:x,y (specify target card and device index eg: hw:0,0)
 $FP_SCRIPT	remoteir		odroid_remote/justboom_ir_remote # Odroid/RPi only
 $FP_SCRIPT	lcdpanel		target_panel (\"none\" to remove all)
-$FP_SCRIPT	headless		enable/disable
 $FP_SCRIPT	gpumemsplit		64/128/256... Range: 16-944, RPi only
 $FP_SCRIPT	rpi-camera		enable/disable
 $FP_SCRIPT	rpi-codec		enable/disable
-$FP_SCRIPT	rpi-opengl		vc4-kms-v3d/vc4-fkms-v3d/disable
+$FP_SCRIPT	rpi-opengl		enable/disable/vc4-kms-v3d/vc4-fkms-v3d
 $FP_SCRIPT	rpi3_usb_boot		enable
 $FP_SCRIPT	rpi-eeprom		Update RPi 4/5 EEPROM bootloader and USB firmware
 $FP_SCRIPT	vf2-spi-update		Update StarFive VisionFive 2 SPI bootloader
@@ -293,41 +292,6 @@ _EOF_
 	}
 
 	#/////////////////////////////////////////////////////////////////////////////////////
-	# headless
-	#/////////////////////////////////////////////////////////////////////////////////////
-	Headless_Main()
-	{
-		(( $G_HW_MODEL > 9 )) && { Unsupported_Input_Name; return 1; } # Exit path for non-RPi
-
-		if [[ $INPUT_DEVICE_VALUE == 'enable' ]]
-		then
-			# Prevent any framebuffer from being allocated
-			G_CONFIG_INJECT 'max_framebuffers=' 'max_framebuffers=0' /boot/firmware/config.txt
-			# Splash cannot be seen anyway without video output
-			G_CONFIG_INJECT 'disable_splash=' 'disable_splash=1' /boot/firmware/config.txt
-			# hdmi_blanking should not play a role, however mode 1 should be generally preferred, which on idle disables HDMI output completely instead of just blanking the screen
-			G_CONFIG_INJECT 'hdmi_blanking=' 'hdmi_blanking=1' /boot/firmware/config.txt
-			# Disable HDMI hotplug detection, which requires it to be generally responsive/active
-			G_CONFIG_INJECT 'hdmi_ignore_hotplug=' 'hdmi_ignore_hotplug=1' /boot/firmware/config.txt
-			# Disable SDTV on RPi 4 (default)
-			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*enable_tvout=/c\#enable_tvout=0' /boot/firmware/config.txt
-			# dietpi.txt flag
-			G_CONFIG_INJECT 'AUTO_SETUP_HEADLESS=' 'AUTO_SETUP_HEADLESS=1' /boot/dietpi.txt
-
-		elif [[ $INPUT_DEVICE_VALUE == 'disable' ]]
-		then
-			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*max_framebuffers=/c\#max_framebuffers=2' /boot/firmware/config.txt
-			#G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*disable_splash=/c\#disable_splash=0' /boot/firmware/config.txt
-			#G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*hdmi_blanking=/c\#hdmi_blanking=0' /boot/firmware/config.txt
-			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*hdmi_ignore_hotplug=/c\#hdmi_ignore_hotplug=0' /boot/firmware/config.txt
-			G_EXEC sed --follow-symlinks -i '/^[[:blank:]]*enable_tvout=/c\#enable_tvout=0' /boot/firmware/config.txt
-			G_CONFIG_INJECT 'AUTO_SETUP_HEADLESS=' 'AUTO_SETUP_HEADLESS=0' /boot/dietpi.txt
-		else
-			Unknown_Input_Mode
-		fi
-	}
-
-	#/////////////////////////////////////////////////////////////////////////////////////
 	# remoteir
 	#/////////////////////////////////////////////////////////////////////////////////////
 	RemoteIR_Reset()
@@ -584,11 +548,18 @@ _EOF_
 	}
 
 	#/////////////////////////////////////////////////////////////////////////////////////
-	# RPi OpenGL
+	# rpi-opengl
 	#/////////////////////////////////////////////////////////////////////////////////////
 	RPi_OpenGL_Main()
 	{
 		(( $G_HW_MODEL > 9 )) && { Unsupported_Input_Name; return 1; } # Exit path for non-RPi
+
+		# "enable" means to keep the current KMS/DRM overlay untouched if enabled, else full KMS
+		if [[ $INPUT_DEVICE_VALUE == 'enable' ]]
+		then
+			grep -Eq '^[[:blank:]]*dtoverlay=vc4-f?kms-v3d(-pi4)?(,|$)' /boot/firmware/config.txt && return 0
+			INPUT_DEVICE_VALUE='vc4-kms-v3d'
+		fi
 
 		# Get overlay params
 		local params=$(sed -En '/^[[:blank:]]*dtoverlay=vc4-f?kms-v3d(-pi4)?,/{s/^[^,]*//p;q}' /boot/firmware/config.txt)
@@ -2329,7 +2300,6 @@ _EOF_
 		'rpi-eeprom') RPi_EEPROM;;
 		'vf2-spi-update') VF2_SPI_Update;;
 		'flash-u-boot-mmc'|'flash-uboot-mmc') Flash_U-Boot_MMC || EXIT_CODE=1;;
-		'headless') Headless_Main;;
 		'gpudriver') GPUDriver_Main;;
 		'qemu-guest-agent'|'qga') QEMU_Guest_Agent_Main;;
 		'keyboard') Keyboard_Main || EXIT_CODE=$?;;

--- a/rootfs/var/lib/dietpi/services/dietpi-firstboot.bash
+++ b/rootfs/var/lib/dietpi/services/dietpi-firstboot.bash
@@ -156,9 +156,6 @@
 		# Apply swap settings
 		/boot/dietpi/func/dietpi-set_swapfile
 
-		# Apply headless mode if set in dietpi.txt (RPi, Odroid C1/C2)
-		(( $G_HW_MODEL < 11 || $G_HW_MODEL == 12 )) && /boot/dietpi/func/dietpi-set_hardware headless "$(grep -cm1 '^[[:blank:]]*AUTO_SETUP_HEADLESS=1' /boot/dietpi.txt)"
-
 		# Set hostname
 		/boot/dietpi/func/change_hostname "$(sed -n '/^[[:blank:]]*AUTO_SETUP_NET_HOSTNAME=/{s/^[^=]*=//p;q}' /boot/dietpi.txt)"
 


### PR DESCRIPTION
* Move dietpi-display out of beta state, make it default way to set display mode and rotation. KMS/DRM is standard in the meantime, available also with all non-legacy VM display drivers.
* Keep the GRUB-based resolution menu, but rename it to make clear that this applies for the GRUB terminal and early kernel output only, before KMS/DRM video modes are applied. Enable the menu whenever GRUB is installed.
* Remove the prior RPi and Odroid specific display resolution menus, which are obsolete: The Odroid XU4 drm_kms_helper does not work anymore, but KMS/DRM video mode does. On RPi, with legacy display driver, its config.txt settings still work, but are deprecated, and superseded by KMS/DRM video modes.
* Keep the display driver menu for native PCs.
* Remove RPi headless mode and PSU noise reduction settings: After tvservice has been removed, and hdmi_ignore_composite a longer while ago, there is no way to fully turn of the RPi display stack without custom device tree overlays. That way, headless mode cannot reduce power consumption anymore. The only other setting with some effect on RAM usage is max_framebuffers, which however works with the legacy graphics driver only, and has no effect if no actual display is attached. Remove the respective config.txt and dietpi.txt entries as well.
* Remove the dedicated display_hdmi_rotate-based RPi HDMI rotation option, which does not work anymore, neither with DRM/KMS, nor with legacy GPU driver, but can be achieved with dietpi-display via KMS/DRM now.
* Enable KMS/DRM by default on RPi, whenever a GUI application or desktop environment is installed via dietpi-software, needed for 2D acceleration and more. Since there is still the CLI variant of Moonlight which requires fake KMS (really? needs testing!), keep whichever KMS/DRM variant previously enabled. Only enforce full KMS where we did so before. Add a new `dietpi-set_hardware rpi-opengl enable/1` option to achive this, which enables full KMS if none was enabled before, else leaves the respective overlay and paramter untouched.