### PR TITLE
dietpi-software: Immich: updates for v3 release

### DIFF
--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12031,7 +12031,7 @@ _EOF_
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/supervc-stack/VectorChord/releases/latest' | grep -Po "\"browser_download_url\": *\"\K[^\"]*-$version-vchord_[^\"\/]*_$arch\.deb(?=\")")"
 
 			# Download Immich source
-			version=$(curl -sSfL 'https://api.github.com/repos/immich-app/immich/releases' | grep -Po '"tag_name": *"\K[^"]+' | head -1)
+			version=$(curl -sSfL 'https://api.github.com/repos/immich-app/immich/releases/latest' | grep -Po '"tag_name": *"\K[^"]+')
 			[[ $version ]] || { version='v2.7.5'; G_DIETPI-NOTIFY 1 "Automatic latest ${aSOFTWARE_NAME[$software_id]} version detection failed. Version \"$version\" will be installed as fallback, but a newer version might be available. Please report this at: https://github.com/MichaIng/DietPi/issues"; }
 			Download_Install "https://github.com/immich-app/immich/archive/$version.tar.gz"
 
@@ -12225,7 +12225,7 @@ _EOF_
 				G_AGI "${aDEPS[@]}"
 				unset -v aDEPS
 			else
-				local version=$(curl -sSfL 'https://api.github.com/repos/immich-app/immich/releases' | grep -Po '"tag_name": *"\K[^"]+' | head -1)
+				local version=$(curl -sSfL 'https://api.github.com/repos/immich-app/immich/releases/latest' | grep -Po '"tag_name": *"\K[^"]+')
 				[[ $version ]] || { version='v2.7.5'; G_DIETPI-NOTIFY 1 "Automatic latest ${aSOFTWARE_NAME[$software_id]} version detection failed. Version \"$version\" will be installed as fallback, but a newer version might be available. Please report this at: https://github.com/MichaIng/DietPi/issues"; }
 				Download_Install "https://github.com/immich-app/immich/archive/$version.tar.gz"
 				immich_src="immich-${version#v}"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12031,7 +12031,7 @@ _EOF_
 			Download_Install "$(curl -sSfL 'https://api.github.com/repos/supervc-stack/VectorChord/releases/latest' | grep -Po "\"browser_download_url\": *\"\K[^\"]*-$version-vchord_[^\"\/]*_$arch\.deb(?=\")")"
 
 			# Download Immich source
-			version=$(curl -sSfL 'https://api.github.com/repos/immich-app/immich/releases/latest' | grep -Po '"tag_name": *"\K[^"]+')
+			version=$(curl -sSfL 'https://api.github.com/repos/immich-app/immich/releases' | grep -Po '"tag_name": *"\K[^"]+' | head -1)
 			[[ $version ]] || { version='v2.7.5'; G_DIETPI-NOTIFY 1 "Automatic latest ${aSOFTWARE_NAME[$software_id]} version detection failed. Version \"$version\" will be installed as fallback, but a newer version might be available. Please report this at: https://github.com/MichaIng/DietPi/issues"; }
 			Download_Install "https://github.com/immich-app/immich/archive/$version.tar.gz"
 
@@ -12225,7 +12225,7 @@ _EOF_
 				G_AGI "${aDEPS[@]}"
 				unset -v aDEPS
 			else
-				local version=$(curl -sSfL 'https://api.github.com/repos/immich-app/immich/releases/latest' | grep -Po '"tag_name": *"\K[^"]+')
+				local version=$(curl -sSfL 'https://api.github.com/repos/immich-app/immich/releases' | grep -Po '"tag_name": *"\K[^"]+' | head -1)
 				[[ $version ]] || { version='v2.7.5'; G_DIETPI-NOTIFY 1 "Automatic latest ${aSOFTWARE_NAME[$software_id]} version detection failed. Version \"$version\" will be installed as fallback, but a newer version might be available. Please report this at: https://github.com/MichaIng/DietPi/issues"; }
 				Download_Install "https://github.com/immich-app/immich/archive/$version.tar.gz"
 				immich_src="immich-${version#v}"

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -12068,10 +12068,10 @@ _EOF_
 			export NODE_OPTIONS='--max-old-space-size=4096'
 
 			# Install Node dependencies
-			G_EXEC_OUTPUT=1 G_EXEC pnpm --filter immich --filter @immich/sdk --filter immich-web --filter plugins i
+			G_EXEC_OUTPUT=1 G_EXEC pnpm --filter immich --filter @immich/sdk --filter immich-web --filter @immich/plugin-sdk --filter @immich/plugin-core i
 
 			# Build Immich server, web UI (requires Immich SDK), and WebAssembly workflow plugin
-			G_EXEC_OUTPUT=1 G_EXEC pnpm --filter immich --filter @immich/sdk --filter immich-web --filter plugins build
+			G_EXEC_OUTPUT=1 G_EXEC pnpm --filter immich --filter @immich/sdk --filter immich-web --filter @immich/plugin-sdk --filter @immich/plugin-core build
 
 			# Remove build-time tools
 			G_EXEC rm /usr/local/bin/extism-js /usr/local/bin/wasm-merge /usr/local/bin/wasm-opt
@@ -12083,9 +12083,9 @@ _EOF_
 
 			# Install web frontend and WebAssembly workflow plugin
 			G_EXEC mv web/build /opt/immich/www
-			G_EXEC mkdir /opt/immich/corePlugin
-			G_EXEC mv plugins/dist /opt/immich/corePlugin/
-			G_EXEC mv plugins/manifest.json /opt/immich/corePlugin/
+			G_EXEC mkdir -p /opt/immich/plugins/immich-plugin-core
+			G_EXEC mv packages/plugin-core/dist /opt/immich/plugins/immich-plugin-core/
+			G_EXEC mv packages/plugin-core/manifest.json /opt/immich/plugins/immich-plugin-core/
 
 			# Remove source directory if Immich Machine Learning won't be co-installed
 			G_EXEC cd "$G_WORKING_DIR"


### PR DESCRIPTION
Pulling latest v3 pre-release to test our setup:
- https://pr-558.dev.immich.app/blog/v3.0.0-release
- https://pr-558.dev.immich.app/blog/v3-migration

Test installs:
- Immich only: https://github.com/MichaIng/DietPi/actions/runs/27712965105
- Immich-ML: https://github.com/MichaIng/DietPi/actions/runs/27718003829
- Immich + ML: https://github.com/MichaIng/DietPi/actions/runs/27718270202