### PR TITLE
dietpi-config: re-add Bluetooth state flag

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Enhancements:
 Bug fixes:
 - Odroid N2/HC4 | Support for petitboot has been fixed. Changes in our base boot script caused some petitboot workarounds to not be applied as intended. Many thanks to @vlix and @tigersky for reporting this issue: https://dietpi.com/forum/t/24902, https://dietpi.com/forum/t/25296
 - DietPi-Config | Resolved an issue where scanning for WiFi networks could result in an empty list, if a single hidden network (with an empty SSID) was in range. Many thanks to @miraz1300 for reporting this issue: https://github.com/MichaIng/DietPi/issues/8199
+- DietPi-Config | Resolved a v10.5 regression where Bluetooth was always shown as enabled, hence could not be actually enabled anymore. Many thanks to @z3huti for reporting this issue: https://github.com/MichaIng/DietPi/issues/8213
 - DietPi-Software | Immich: Resolved an issue where the installation failed due to breaking changes in the recent Immich v3 release. Our code has been updated to support Immich v3. As always, existing instances can apply the update via "dietpi-software reinstall 215 216", which includes Immich Machine Learning, (only) if installed.
 - DietPi-Software | BirdNET-Go: Resolved an issue where the installer did not detect recent releases, since the URLs got an additional date suffix. Many thanks to @oradke for reporting this issue: https://github.com/MichaIng/DietPi/discussions/8215
 

--- a/dietpi/func/dietpi-set_hardware
+++ b/dietpi/func/dietpi-set_hardware
@@ -1173,7 +1173,7 @@ _EOF_
 			[[ -f '/etc/modules-load.d/dietpi-enable_bluetooth.conf' ]] && G_EXEC rm /etc/modules-load.d/dietpi-enable_bluetooth.conf
 
 			# Unload and blacklist kernel modules
-			[[ -f '/etc/modprobe.d/dietpi-disable_bluetooth.conf' ]] && G_EXEC rm /etc/modprobe.d/dietpi-disable_bluetooth.conf
+			> /etc/modprobe.d/dietpi-disable_bluetooth.conf # keep as flag for dietpi-config, until we have a better idea
 			for i in "${aBLUETOOTH_MODULES[@]}"
 			do
 				G_EXEC eval "echo 'blacklist $i' >> /etc/modprobe.d/dietpi-disable_bluetooth.conf"


### PR DESCRIPTION
`dietpi-config` uses `/etc/modprobe.d/dietpi-disable_bluetooth.conf` as flag about whether Bluetooth is enabled or not. Since v10.5 we do not create it anymore on all systems, so that Bluetooth in those cases kept showing as enabled, hence could not be actually enabled anymore either.

This commit re-adds `/etc/modprobe.d/dietpi-disable_bluetooth.conf` in every case, it might just remain empty. It is no elegant solution, but works, until we have a better idea how to detect whether Bluetooth is enabled or not, like the `bluez` package, or service. Or use rfkill, to block Bluetooth on a lower level, no matter which adapter/driver is loaded (almost, `sprdbt_tty` on Allwinner does not support rfkill).