### PR TITLE
ci: dietpi-software build: remove obsolete workaround

### DIFF
--- a/.build/images/dietpi-build
+++ b/.build/images/dietpi-build
@@ -475,8 +475,6 @@ fi
 ##########################################
 # Create boot script and systemd unit to automate DietPi-Installer
 # - NB: WIFI_REQUIRED=1 is always passed here, but ignored by DietPi-Installer for VMs and containers.
-# - Prevent console-getty.service from stealing the controlling terminal
-G_EXEC ln -s /dev/null rootfs/etc/systemd/system/console-getty.service
 cat << _EOF_ > rootfs/dietpi-build.sh || exit 1
 #!/bin/dash -e
 {
@@ -484,17 +482,16 @@ infocmp "\$TERM" > /dev/null 2>&1 || { echo "[ WARN ] Unsupported TERM=\"\$TERM\
 export GITOWNER='$GITOWNER' GITBRANCH='$GITBRANCH' HW_MODEL='$HW_MODEL' IMAGE_CREATOR=0 PREIMAGE_INFO=0 WIFI_REQUIRED=1 DISTRO_TARGET=$DISTRO TEST_KERNEL=$TEST_KERNEL TEST_UBOOT=$TEST_UBOOT RK35XX_MAINLINE=$RK35XX_MAINLINE TMPDIR='/tmp'
 echo '[ INFO ] Running DietPi-Installer for $G_GITOWNER/$G_GITBRANCH'
 bash -c "\$(curl -sSf 'https://raw.githubusercontent.com/$G_GITOWNER/DietPi/$G_GITBRANCH/.build/images/dietpi-installer' || echo false)" || { echo '[FAILED] DietPi-Installer failed, shutting down ...'; journalctl -n 25; df -h; free -h; exit 1; }
-rm -v /etc/systemd/system/multi-user.target.wants/dietpi-build.service /etc/systemd/system/dietpi-build.service /dietpi-build.sh /etc/systemd/system/console-getty.service
+rm -v /etc/systemd/system/multi-user.target.wants/dietpi-build.service /etc/systemd/system/dietpi-build.service /dietpi-build.sh
 > /success
 exit 0
-} > /dev/console 2>&1
+}
 _EOF_
 G_EXEC chmod +x rootfs/dietpi-build.sh
 cat << '_EOF_' > rootfs/etc/systemd/system/dietpi-build.service || exit 1
 [Service]
 Type=idle
-# StandardOutput=tty fails in emulated containers
-StandardOutput=journal+console
+StandardOutput=tty
 ExecStart=-/dietpi-build.sh
 ExecStopPost=/usr/bin/systemctl --no-block start poweroff.target
 _EOF_

--- a/.build/software/dietpi-software-build.bash
+++ b/.build/software/dietpi-software-build.bash
@@ -147,14 +147,6 @@ then
 		G_EXEC mkdir "${i/lib/etc}.d"
 		G_EXEC eval "echo -e '[Service]\nImportCredential=\nLoadCredential=' > '${i/lib/etc}.d/dietpi-no-credentials.conf'"
 	done
-	# Forky
-	if (( $dist > 8 ))
-	then
-		# /dev/console == /dev/pts/0 seen as "Inappropriate ioctl for device" leading to failing console-getty.service and StandardOutput=tty
-		# - Define HOME, as it is not set in systemd unit, and needed for go to obtain a default GOPATH: "go: module cache not found: neither GOMODCACHE nor GOPATH is set"
-		G_EXEC eval 'echo -e '\''#!/bin/dash\nHOME=/root exec /boot/dietpi/dietpi-login > /dev/console 2>&1'\'' > rootfs/var/lib/dietpi/postboot.d/dietpi-login'
-		G_EXEC sed --follow-symlinks -i '/^StandardOutput=/c\StandardOutput=journal+console' rootfs/etc/systemd/system/dietpi-{first,post}boot.service
-	fi
 fi
 
 # ARMv6/7/RISC-V Trixie: Workaround failing chpasswd, which tries to access /proc/sys/vm/mmap_min_addr, but fails as of AppArmor on the host

--- a/.github/workflows/dietpi-software.bash
+++ b/.github/workflows/dietpi-software.bash
@@ -505,15 +505,6 @@ then
 		G_EXEC eval "echo -e '[Service]\nPrivateUsers=0\nProtectSystem=0\nProtectHome=0\nPrivateTmp=0\nPrivateDevices=0\nProtectKernelModules=0\nProtectControlGroups=0\nProtectKernelTunables=0\nProtectKernelLogs=0\nReadWritePaths=\nProtectProc=default\nProcSubset=all\nNoExecPaths=\nExecPaths=\nInaccessiblePaths=' > 'rootfs/etc/systemd/system/$i.service.d/dietpi-container.conf'"
 	done
 
-	# Forky
-	if (( $dist > 8 ))
-	then
-		# /dev/console == /dev/pts/0 seen as "Inappropriate ioctl for device" leading to failing console-getty.service and StandardOutput=tty
-		# - Define HOME, as it is not set in systemd unit, and needed for go to obtain a default GOPATH: "go: module cache not found: neither GOMODCACHE nor GOPATH is set"
-		G_EXEC eval 'echo -e '\''#!/bin/dash\nHOME=/root exec /boot/dietpi/dietpi-login > /dev/console 2>&1'\'' > rootfs/var/lib/dietpi/postboot.d/dietpi-login'
-		G_EXEC sed --follow-symlinks -i '/^StandardOutput=/c\StandardOutput=journal+console' rootfs/etc/systemd/system/dietpi-{first,post}boot.service
-	fi
-
 	# Failing 32-bit ARM Rust builds on ext4 with 64-bit host: https://github.com/rust-lang/cargo/issues/9545
 	if (( $arch < 3 ))
 	then


### PR DESCRIPTION
systemd v261 seems to have solved the "Inappropriate ioctl for device" issue on `/dev/console` == `/dev/pts/0` when QEMU-emulation is used.

Context about the underlying issue that was fixed:
- https://lists.nongnu.org/archive/html/qemu-devel/2026-01/msg03649.html
- https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/2133804
- https://gitlab.com/qemu-project/qemu/-/work_items/3065