### PR TITLE
Fix regex in dietpi-banner to also count bans created in CIDR notation

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ v10.7
 New images:
 
 Enhancements:
+- DietPi-Banner | The Fail2Ban status now also counts bans for whole subnets in CIDR notation, which can be applied manually via fail2ban-client. The banner message now accordingly refers to "ban(s)" instead of "banned IP(s)".
 
 Bug fixes:
 - DietPi-Software | Ampache: Resolved an issue where detecting the latest version failed, since Ampache 8 requires PHP 8.5+. The latest version is now searched among all releases, so that latest Ampache 7 is downloaded on all supported Debian versions at time of writing.

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -383,7 +383,7 @@ $CLI_LINE"
           state="${aCOLOUR[alert]}$count_banned_ips ban(s)"
 				else
 					# low number of bans
-					state="$count_banned_ips IP(s) banned"
+          state="$count_banned_ips ban(s)"
 				fi
 			;;
 			1) state="${aCOLOUR[alert]}fail2ban-client not available";;

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -380,7 +380,7 @@ $CLI_LINE"
 				elif (( $count_banned_ips > 20 ))
 				then
 					# high number of bans
-          state="${aCOLOUR[alert]}$count_banned_ips ban(s)"
+					state="${aCOLOUR[alert]}$count_banned_ips ban(s)"
 				else
 					# low number of bans
           state="$count_banned_ips ban(s)"

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -352,7 +352,7 @@ $CLI_LINE"
 			if command -v fail2ban-client > /dev/null
 			then
 				# IP address detection (very sloppy for IPv6) - avoid {m,n} to support mawk on Debian Bookworm
-				local IP_re='^([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(/[0-9]+)?|[0-9a-f:]*:[0-9a-f:]*(/[0-9]+)?)$'
+				local IP_re='^([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+|[0-9a-f:]*:[0-9a-f:]*)(/[0-9]+)?$'
 				if [[ $EUID == 0 ]]
 				then
 					fail2ban-client banned 2> /dev/null | mawk -F\' -v ip="$IP_re" '{for(i=2;i<NF;i+=2){if($i ~ ip) a[$i]=1}} END{print length(a)}'

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -383,7 +383,7 @@ $CLI_LINE"
 					state="${aCOLOUR[alert]}$count_banned_ips ban(s)"
 				else
 					# low number of bans
-          state="$count_banned_ips ban(s)"
+					state="$count_banned_ips ban(s)"
 				fi
 			;;
 			1) state="${aCOLOUR[alert]}fail2ban-client not available";;

--- a/dietpi/func/dietpi-banner
+++ b/dietpi/func/dietpi-banner
@@ -352,7 +352,7 @@ $CLI_LINE"
 			if command -v fail2ban-client > /dev/null
 			then
 				# IP address detection (very sloppy for IPv6) - avoid {m,n} to support mawk on Debian Bookworm
-				local IP_re='^([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+|[0-9a-f:]*:[0-9a-f:]*)$'
+				local IP_re='^([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(/[0-9]+)?|[0-9a-f:]*:[0-9a-f:]*(/[0-9]+)?)$'
 				if [[ $EUID == 0 ]]
 				then
 					fail2ban-client banned 2> /dev/null | mawk -F\' -v ip="$IP_re" '{for(i=2;i<NF;i+=2){if($i ~ ip) a[$i]=1}} END{print length(a)}'
@@ -375,12 +375,12 @@ $CLI_LINE"
 				if (( $count_banned_ips == 0 ))
 				then
 					# zero bans can be suspicious - something may not be working correctly
-					state="${aCOLOUR[highlight]}No IPs banned, check Fail2Ban state"
+					state="${aCOLOUR[highlight]}No bans, check Fail2Ban state"
 
 				elif (( $count_banned_ips > 20 ))
 				then
 					# high number of bans
-					state="${aCOLOUR[alert]}$count_banned_ips IP(s) banned"
+          state="${aCOLOUR[alert]}$count_banned_ips ban(s)"
 				else
 					# low number of bans
 					state="$count_banned_ips IP(s) banned"


### PR DESCRIPTION
For reference: [https://dietpi.com/forum/t/dietpi-v10-6-2-dietpi-banner-option-fail2ban-status-not-working-with-ip-cidr-addresses/25407](https://dietpi.com/forum/t/dietpi-v10-6-2-dietpi-banner-option-fail2ban-status-not-working-with-ip-cidr-addresses/25407)

This commit fixes the Fail2Ban regex pattern in dietpi-banner. Previously, it only counted bans for individual IPs, while bans created in CIDR notation were ignored.

The status messages were also adjusted, since we now count bans rather than individual IPs.

