### PR TITLE
dietpi-software: add missing Roon Bridge dependency

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,6 +24,7 @@ Bug fixes:
 - dietpi-banner | Resolved an issue where the number of failed systemd services could not be obtained when logging in as non-root user, if D-Bus was not installed. Many thanks to @CA_Lobo for reporting this issue: https://dietpi.com/forum/t/25413
 - dietpi-software | Ampache: Resolved an issue where detecting the latest version failed, since Ampache 8 requires PHP 8.5+. The latest version is now searched among all releases, so that latest Ampache 7 is downloaded on all supported Debian versions at time of writing.
 - dietpi-software | WiringPi: Resolved an issue where the installation failed on Odroid SBCs since Debian Trixie, since an outdated package was tried to be installed. Also, support for all recently added Orange Pi boards was added. Many thanks to @LJPCODESTUDIO for reporting this issue: https://github.com/MichaIng/DietPi/issues/8266
+- dietpi-software | Roon Bridge: Resolved an issue where the latest version failed to start, due to a missing new dependency. Many thanks to @aposcic for fixing this issue: https://github.com/MichaIng/DietPi/pull/8287
 
 As always, many smaller code performance and stability improvements, visual and spelling fixes have been done, too much to list all of them here. Check out all code changes of this release on GitHub: https://github.com/MichaIng/DietPi/pull/8265
 

--- a/dietpi/dietpi-software
+++ b/dietpi/dietpi-software
@@ -5090,6 +5090,13 @@ The install script will now exit. After applying one of the above, rerun dietpi-
 
 		if To_Install 121 roonbridge # Roon Bridge
 		then
+			# .NET 10 dependency
+			case $G_DISTRO in
+				7) aDEPS=('libicu72');;
+				8) aDEPS=('libicu76');;
+				*) aDEPS=('libicu78');;
+			esac
+
 			case $G_HW_ARCH in
 				2) local arch='armv7hf';;
 				3) local arch='armv8';;


### PR DESCRIPTION
Version `2.71 (build 1683)` of Roon Bridge has migrated to `.NET 10`, which in turn requires `libicu` to be installed. As it stands, the `DietPi-Software` entry for Roon Bridge results in a service that won't start.

See [here](https://community.roonlabs.com/t/roon-bridge-now-runs-on-net-10/324438) and [here](https://github.com/dotnet/core/blob/main/release-notes/10.0/dotnet-dependencies.md) for more info.

The fix is to install the appropriate `libicu` version: `libicu72` for Bookworm, `libicu76` for Trixie, and `libicu78` for Forky.
Users with existing installations will have to install the dependency manually or reinstall via `DietPi-Software`.

As an aside, all other dependencies (`glibc 2.27+` and `OpenSSL 1.1.1+`) are already satisfied, and Roon Bridge runs normally after `libicu` is installed.